### PR TITLE
feat(executor): validation fix-cycle loop (Phase 1.5e)

### DIFF
--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -182,6 +182,26 @@ class WorkspaceExecutor:
         # and we fail with a specific reason rather than pushing nothing.
         worktree_host = self._config.worktrees_root / workspace_id
 
+        # ``base_commit`` is set by the provisioner before a workspace ever
+        # reaches ``ready`` — if it's missing here something went wrong
+        # upstream and every ``rev-list``/``merge-base`` below would
+        # inject the literal string "None" into a git command. Fail
+        # cleanly instead of passing "None..HEAD" to git
+        # (review feedback on #2: gemini, coderabbit).
+        if ws.base_commit is None:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "workspace has no base_commit — provisioning must set "
+                    "this before the agent run; cannot verify feature-branch "
+                    "commits without it"
+                ),
+            )
+            return
+        base_commit: str = ws.base_commit
+
         async def _git_in_worktree(args: list[str]):  # type: ignore[no-untyped-def]
             return await self._runner.run(["git", "-C", str(worktree_host), *args])
 
@@ -210,9 +230,9 @@ class WorkspaceExecutor:
                     )
             # Regardless of whether we just committed, verify HEAD has advanced
             # past the base commit. If not, the agent produced no change.
-            rev_count = await _git_in_worktree(["rev-list", "--count", f"{ws.base_commit}..HEAD"])
+            rev_count = await _git_in_worktree(["rev-list", "--count", f"{base_commit}..HEAD"])
             if not rev_count.ok or int(rev_count.stdout.strip() or "0") == 0:
-                base_short = ws.base_commit[:10] if ws.base_commit else "unknown"
+                base_short = base_commit[:10] if base_commit else "unknown"
                 message = (
                     f"agent exited without producing any commits on the feature branch "
                     f"(base={base_short})"
@@ -242,26 +262,23 @@ class WorkspaceExecutor:
             # cumulative diff, and the branch is reattached to a valid
             # ancestry so the PR can be opened normally.
             #
-            # Invariant: ``ws.base_commit`` is always populated by
+            # Invariant: ``base_commit`` is always populated by
             # ``_claim_ready`` before this block runs. The ``assert`` both
             # documents and satisfies mypy.
-            assert ws.base_commit is not None
-            ancestor = await _git_in_worktree(
-                ["merge-base", "--is-ancestor", ws.base_commit, "HEAD"]
-            )
+            ancestor = await _git_in_worktree(["merge-base", "--is-ancestor", base_commit, "HEAD"])
             if not ancestor.ok:
                 _log.warning(
                     "executor.orphan_history_detected",
                     workspace_id=workspace_id,
-                    base_commit=ws.base_commit,
+                    base_commit=base_commit,
                 )
-                reset = await _git_in_worktree(["reset", "--soft", ws.base_commit])
+                reset = await _git_in_worktree(["reset", "--soft", base_commit])
                 if reset.ok:
                     recovery_msg = f"awf: {ws.task_title} (recovered from orphan)"[:72]
                     recovery_body = (
                         f"AWF detected orphan history on workspace {workspace_id} "
                         f"(agent: {ws.agent}) and squashed the cumulative diff "
-                        f"onto base commit {ws.base_commit[:10]}.\n"
+                        f"onto base commit {base_commit[:10]}.\n"
                     )
                     recover_commit = await self._runner.run(
                         [
@@ -277,7 +294,7 @@ class WorkspaceExecutor:
                     )
                     if recover_commit.ok:
                         ancestor = await _git_in_worktree(
-                            ["merge-base", "--is-ancestor", ws.base_commit, "HEAD"]
+                            ["merge-base", "--is-ancestor", base_commit, "HEAD"]
                         )
                 if not ancestor.ok:
                     await self._mark_failed(
@@ -286,7 +303,7 @@ class WorkspaceExecutor:
                         failure_reason=FailureReason.agent_failure,
                         message=(
                             "agent severed git history — HEAD does not descend from "
-                            f"base commit {ws.base_commit[:10] if ws.base_commit else 'unknown'}, "
+                            f"base commit {base_commit[:10] if base_commit else 'unknown'}, "
                             "and automatic recovery (reset --soft + fresh commit) also failed. "
                             "The coding CLI likely ran `git checkout --orphan` or reinitialised "
                             "the repo; inspect the worktree manually."
@@ -296,7 +313,7 @@ class WorkspaceExecutor:
                 _log.info(
                     "executor.orphan_history_recovered",
                     workspace_id=workspace_id,
-                    base_commit=ws.base_commit,
+                    base_commit=base_commit,
                 )
         except Exception as exc:  # unexpected — mark infrastructure
             _log.exception("executor.commit_step_failed", workspace_id=workspace_id)

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -26,6 +26,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.adapters.base import AgentAdapter, AgentRunError, get_adapter
 from awf.common.commands import AsyncCommandRunner
 from awf.common.logging import get_logger
+from awf.control.validation_fix_cycle import (
+    ValidationFixContext,
+    build_fix_prompt,
+    read_output_tail,
+)
 from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
@@ -60,6 +65,13 @@ class ExecutorConfig:
 
     default_models: dict[AgentRuntime, str]
     """Default LLM model to pass each adapter when the request doesn't set one."""
+
+    max_validation_fix_passes: int = 5
+    """Maximum fix attempts on validation failure. After the initial agent
+    run + validation, if validation fails, the executor re-invokes the
+    coding CLI with a fix prompt (failing command + stdout/stderr tails)
+    and re-validates. ``0`` disables the loop (single-shot legacy
+    behaviour); the default mirrors the PR monitor's fix-cycle cap."""
 
 
 class WorkspaceExecutor:
@@ -296,34 +308,136 @@ class WorkspaceExecutor:
             )
             return
 
-        # ── Step 2: validation (tests + optional Alembic) ───────────────────
+        # ── Step 2: validation (tests + optional Alembic), with fix-cycle ──
         await self._transition(workspace_id, to=WorkspaceStatus.validating, reason="AGENT_RUN_OK")
 
-        val_result = await self._validation.run(
-            workspace_id=workspace_id,
-            compose_project=compose_project,
-            compose_file=compose_file,
-            test_commands=list(ws.test_commands),
-            requires_database=ws.requires_database,
-        )
-        if not val_result.all_passed:
+        max_fix_passes = self._config.max_validation_fix_passes
+        test_commands_tuple = tuple(ws.test_commands)
+        last_failure_message: str | None = None
+        for pass_number in range(max_fix_passes + 1):
+            # pass_number == 0 is the initial run (already-committed agent
+            # work). 1..N are fix attempts driven by the retry prompt.
+            val_result = await self._validation.run(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                test_commands=list(ws.test_commands),
+                requires_database=ws.requires_database,
+            )
+            if val_result.all_passed:
+                if pass_number > 0:
+                    _log.info(
+                        "executor.validation_recovered",
+                        workspace_id=workspace_id,
+                        fix_passes_used=pass_number,
+                    )
+                break
+
             first_fail = val_result.first_failure
             _log.info(
                 "executor.validation_failed",
                 workspace_id=workspace_id,
                 failed_command=first_fail.command if first_fail else None,
+                fix_pass=pass_number,
+                max_fix_passes=max_fix_passes,
             )
-            await self._mark_failed(
+            last_failure_message = (
+                f"validation failed: {first_fail.command}" if first_fail else "validation failed"
+            )
+
+            if pass_number >= max_fix_passes or first_fail is None:
+                # Exhausted our budget (or no failure details to anchor a
+                # fix prompt on) — mark failed and let the operator triage.
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.validating,
+                    failure_reason=FailureReason.validation_failure,
+                    message=(
+                        last_failure_message
+                        + (f" (after {max_fix_passes} fix attempts)" if max_fix_passes > 0 else "")
+                    )[:2000],
+                )
+                return
+
+            # Fire a fix pass: re-invoke the coding CLI with the failure
+            # context, then re-commit whatever it changed.
+            fix_context = ValidationFixContext(
+                failed_command=first_fail.command,
+                returncode=first_fail.returncode,
+                stdout_tail=read_output_tail(first_fail.stdout_path),
+                stderr_tail=read_output_tail(first_fail.stderr_path),
+                pass_number=pass_number + 1,
+                total_passes=max_fix_passes,
+                test_commands=test_commands_tuple,
+            )
+            fix_prompt = build_fix_prompt(fix_context)
+            _log.info(
+                "executor.fix_pass_start",
                 workspace_id=workspace_id,
-                from_status=WorkspaceStatus.validating,
-                failure_reason=FailureReason.validation_failure,
-                message=(
-                    f"validation failed: {first_fail.command}"
-                    if first_fail
-                    else "validation failed"
-                )[:2000],
+                pass_number=pass_number + 1,
+                max_fix_passes=max_fix_passes,
+                failed_command=first_fail.command,
             )
-            return
+            try:
+                await adapter.run(
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    prompt=fix_prompt,
+                    model=default_model,
+                )
+            except AgentRunError as exc:
+                # Coding CLI exited non-zero on the fix pass. Mirrors the
+                # initial-run behaviour: log, remember the note, fall
+                # through to commit any salvaged work, then continue the
+                # loop (next validation will tell us if it's pushable).
+                _log.warning(
+                    "executor.fix_pass_agent_nonzero_exit",
+                    workspace_id=workspace_id,
+                    pass_number=pass_number + 1,
+                    returncode=exc.result.returncode,
+                )
+
+            # Commit whatever the fix pass produced. Simpler than the
+            # initial post-agent commit block — orphan-history recovery
+            # isn't possible here (HEAD already descends from base after
+            # the initial run succeeded); zero-change fix passes are
+            # allowed (agent may think no change was needed, which next
+            # validation will confirm or refute).
+            fix_add = await _git_in_worktree(["add", "-A"])
+            if not fix_add.ok:
+                _log.warning(
+                    "executor.fix_pass_add_failed",
+                    workspace_id=workspace_id,
+                    stderr=fix_add.stderr[:400],
+                )
+            fix_cached = await _git_in_worktree(["diff", "--cached", "--name-only"])
+            if fix_cached.stdout.strip():
+                commit_msg = f"awf: fix pass {pass_number + 1} for {ws.task_title}"[:72]
+                commit_body = (
+                    f"AWF validation fix pass {pass_number + 1} of "
+                    f"{max_fix_passes} for workspace {workspace_id} "
+                    f"(agent: {ws.agent}). Failed command: "
+                    f"{first_fail.command}."
+                )
+                fix_commit = await self._runner.run(
+                    [
+                        "git",
+                        "-C",
+                        str(worktree_host),
+                        "commit",
+                        "-m",
+                        commit_msg,
+                        "-m",
+                        commit_body,
+                    ],
+                )
+                if not fix_commit.ok:
+                    _log.warning(
+                        "executor.fix_pass_commit_failed",
+                        workspace_id=workspace_id,
+                        stderr=fix_commit.stderr[:400],
+                    )
+            # Loop back to re-validate.
 
         # ── Step 3: push + open PR ──────────────────────────────────────────
         await self._transition(workspace_id, to=WorkspaceStatus.pushing, reason="VALIDATION_OK")

--- a/src/awf/control/validation_fix_cycle.py
+++ b/src/awf/control/validation_fix_cycle.py
@@ -1,0 +1,126 @@
+"""Fix-cycle helpers for the validation stage.
+
+When validation fails in ``WorkspaceExecutor``, the old behaviour was
+to mark the workspace ``failed`` and stop. That left many perfectly
+recoverable workspaces stuck on minor test bugs the coding CLI could
+have fixed on a second pass — the same capability the PR monitor
+already has via ``max_fix_cycle_passes`` + ``ReportCiFailure``.
+
+This module owns the *pure* pieces of the validation retry loop:
+
+  - ``ValidationFixContext`` — an immutable dataclass describing one
+    failed attempt. Carries the failing command, its exit code,
+    stdout/stderr tails, the attempt counter, and the full list of
+    validation commands the next pass will run against.
+  - ``build_fix_prompt`` — turns that context into a prompt the
+    coding CLI can act on. Pure string construction, trivially
+    testable.
+  - ``read_output_tail`` — truncates a validation-artifact file to
+    its last ``max_chars`` characters so tails don't blow the
+    context window.
+
+The *loop* lives in ``WorkspaceExecutor.execute`` — it's the part that
+touches the DB + adapter + validation runner, and belongs with the
+rest of the executor's wiring. Keeping pure helpers here makes each
+independently unit-testable without a FakeCommandRunner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+# The CLI needs enough context to diagnose but not so much that the
+# important signal scrolls off the top. 4 KB per stream is a practical
+# middle ground: long enough for a full pytest failure dump, short
+# enough that two streams (stdout + stderr) plus the rest of the
+# prompt fits comfortably under a 200 KB context budget.
+DEFAULT_TAIL_CHARS = 4000
+
+
+@dataclass(frozen=True)
+class ValidationFixContext:
+    """One validation failure, packaged for the retry prompt.
+
+    ``test_commands`` is stored as a tuple so the dataclass stays
+    hashable — structured-logging layers sometimes dedupe retry events
+    by context.
+    """
+
+    failed_command: str
+    returncode: int
+    stdout_tail: str
+    stderr_tail: str
+    pass_number: int
+    """1-indexed — "this is attempt 1 of N". Never 0."""
+
+    total_passes: int
+    """The configured ``max_validation_fix_passes``. The coding CLI
+    sees both counters so it can pace itself (conservative on attempt
+    1, more aggressive near the cap)."""
+
+    test_commands: tuple[str, ...]
+    """All validation commands that will run on the NEXT pass —
+    not only the one that just failed. Gives the CLI the full gate
+    list so a fix to one command doesn't accidentally break another."""
+
+
+def read_output_tail(path: Path, *, max_chars: int = DEFAULT_TAIL_CHARS) -> str:
+    """Return up to ``max_chars`` trailing characters from a file.
+
+    Used to extract the last N chars of a validation command's
+    stdout / stderr artifact for embedding in the fix prompt. Failure
+    signals live at the tail of test logs, hence "tail".
+
+    Defensive: missing files return ``""`` (a failed validation run
+    should always have written its artifact, but don't crash the
+    whole retry loop if there's a race); non-UTF-8 bytes fall back to
+    best-effort decode with lossy replacement.
+    """
+    if not path.exists():
+        return ""
+    # Read bytes then decode with replace — validation artifacts can
+    # contain terminal color codes and occasional binary garbage.
+    data = path.read_bytes()
+    if not data:
+        return ""
+    if len(data) > max_chars:
+        data = data[-max_chars:]
+    return data.decode("utf-8", errors="replace")
+
+
+def build_fix_prompt(context: ValidationFixContext) -> str:
+    """Compose the retry prompt the coding CLI sees on a fix pass.
+
+    Key contracts (asserted by tests):
+      - Mentions the failing command + returncode.
+      - Embeds stdout + stderr tails verbatim.
+      - Tells the CLI to FIX, not re-implement.
+      - Lists every validation command so fixes can be holistic.
+      - Shows "attempt N of M" so the CLI can pace itself.
+    """
+    stdout_block = context.stdout_tail.rstrip() or "(empty)"
+    stderr_block = context.stderr_tail.rstrip() or "(empty)"
+    test_cmds_block = "\n".join(f"  - {cmd}" for cmd in context.test_commands)
+
+    return (
+        f"Validation failed after your previous pass. This is attempt "
+        f"{context.pass_number} of {context.total_passes}.\n\n"
+        f"Failing command: {context.failed_command}\n"
+        f"Exit code: {context.returncode}\n\n"
+        f"── stdout (tail) ──\n"
+        f"{stdout_block}\n"
+        f"── stderr (tail) ──\n"
+        f"{stderr_block}\n\n"
+        f"All validation commands that will run on the next pass:\n"
+        f"{test_cmds_block}\n\n"
+        f"Your job: FIX the failure above. Inspect the tail output for "
+        f"concrete clues (assertion mismatches, missing fixtures, wrong "
+        f"test IDs, stale imports) and make the minimum change that will "
+        f"let validation pass. Do not re-implement the feature from "
+        f"scratch — the existing work is almost certainly fine except "
+        f"for the specific failure reported. Keep changes tight.\n\n"
+        f"After you exit, validation will run every command above "
+        f"again, in order. If any of them fail you'll get one more "
+        f"fix prompt until attempts are exhausted."
+    )

--- a/src/awf/control/validation_fix_cycle.py
+++ b/src/awf/control/validation_fix_cycle.py
@@ -72,6 +72,13 @@ def read_output_tail(path: Path, *, max_chars: int = DEFAULT_TAIL_CHARS) -> str:
     stdout / stderr artifact for embedding in the fix prompt. Failure
     signals live at the tail of test logs, hence "tail".
 
+    Implementation note: opens the file in binary mode and ``seek()``s
+    to ``-max_chars`` from the end rather than reading the whole file
+    into memory. A noisy failing test run can produce multi-MB
+    artifacts; every fix-cycle pass reads two of them (stdout +
+    stderr), so the naive ``read_bytes`` grows O(artifact_size) per
+    retry. Tail-seeking keeps it O(max_chars) regardless of file size.
+
     Defensive: missing files return ``""`` (a failed validation run
     should always have written its artifact, but don't crash the
     whole retry loop if there's a race); non-UTF-8 bytes fall back to
@@ -79,13 +86,18 @@ def read_output_tail(path: Path, *, max_chars: int = DEFAULT_TAIL_CHARS) -> str:
     """
     if not path.exists():
         return ""
-    # Read bytes then decode with replace — validation artifacts can
-    # contain terminal color codes and occasional binary garbage.
-    data = path.read_bytes()
-    if not data:
+    try:
+        size = path.stat().st_size
+    except OSError:
         return ""
-    if len(data) > max_chars:
-        data = data[-max_chars:]
+    if size == 0:
+        return ""
+    # Read only the trailing slice — bounded memory regardless of file size.
+    to_read = min(size, max_chars)
+    with path.open("rb") as f:
+        if size > to_read:
+            f.seek(-to_read, 2)  # 2 = SEEK_END
+        data = f.read(to_read)
     return data.decode("utf-8", errors="replace")
 
 

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -230,10 +230,34 @@ class TestFailurePaths:
     @pytest.mark.unit
     async def test_validation_failure_marks_failed_with_reason(
         self,
-        executor: WorkspaceExecutor,
         fake: FakeCommandRunner,
         factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
     ) -> None:
+        """With the fix-cycle loop disabled (``max_validation_fix_passes=0``),
+        a single validation failure still marks the workspace failed with
+        the ``validation_failure`` reason — the pre-fix-cycle contract
+        this test was originally written for."""
+        compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+        pr = PullRequestCreator(fake)
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=fake,
+            compose=compose,
+            validation=validation,
+            pr_creator=pr,
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "work" / "worktrees",
+                compose_projects_root=tmp_path / "work" / "compose",
+                default_models={
+                    AgentRuntime.codex: "gpt-5",
+                    AgentRuntime.claude_code: "sonnet",
+                    AgentRuntime.gemini: "gemini-2.5-pro",
+                },
+                max_validation_fix_passes=0,
+            ),
+        )
         ws_id = await _seed_ready_workspace(factory)
         fake.queue_result(returncode=0)  # adapter ok
         fake.queue_result(returncode=0)  # git add

--- a/tests/unit/control/test_executor_validation_fix_cycle.py
+++ b/tests/unit/control/test_executor_validation_fix_cycle.py
@@ -1,0 +1,397 @@
+"""Executor-level tests for the validation fix-cycle loop.
+
+The pure helpers (``build_fix_prompt``, ``read_output_tail``,
+``ValidationFixContext``) have their own unit tests in
+``test_validation_fix_cycle.py``. This file covers the loop semantics:
+
+  - A validation pass on first try → push + completed (no retry).
+  - Fail once, fix, pass → push + completed.
+  - Fail more times than the budget allows → ``validation_failure``.
+  - ``max_validation_fix_passes=0`` → legacy single-shot (covered in
+    ``test_executor.py``).
+  - The re-invocation of the agent on a fix pass embeds the failure
+    context (fix prompt actually flows to the adapter subprocess).
+
+The harness mirrors ``test_executor.py``: real in-memory SQLite,
+``FakeCommandRunner`` queued with explicit per-subprocess results.
+Every docker compose exec / git / gh invocation consumes exactly one
+queued result, in order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters import registry as _registry  # noqa: F401 - populates adapters
+from awf.common.commands import FakeCommandRunner
+from awf.control.executor import ExecutorConfig, WorkspaceExecutor
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.node.compose_manager import ComposeManager
+from awf.runtime.pr_creator import PullRequestCreator
+from awf.runtime.validation import ValidationRunner
+
+_TEMPLATE = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def fake() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+def _make_executor(
+    *,
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    max_fix_passes: int,
+) -> WorkspaceExecutor:
+    compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+    validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+    pr = PullRequestCreator(fake)
+    return WorkspaceExecutor(
+        session_factory=factory,
+        runner=fake,
+        compose=compose,
+        validation=validation,
+        pr_creator=pr,
+        config=ExecutorConfig(
+            worktrees_root=tmp_path / "work" / "worktrees",
+            compose_projects_root=tmp_path / "work" / "compose",
+            default_models={
+                AgentRuntime.codex: "gpt-5",
+                AgentRuntime.claude_code: "sonnet",
+                AgentRuntime.gemini: "gemini-2.5-pro",
+            },
+            max_validation_fix_passes=max_fix_passes,
+        ),
+    )
+
+
+async def _seed_ready_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> str:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-agent.git",
+            branch_base="development",
+            task_title="trivial",
+            task_prompt="Add a docstring.",
+            agent="codex",
+            test_commands=["pytest -q"],
+            requires_database=False,
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="X")
+        await s.commit()
+        return ws.id
+
+
+def _queue_initial_pass(fake: FakeCommandRunner) -> None:
+    """Queue the subprocess results for the initial agent-run + commit
+    block (through to just before validation). Shared prefix for every
+    test in this file."""
+    fake.queue_result(returncode=0)  # adapter.run (initial)
+    fake.queue_result(returncode=0)  # git add -A
+    fake.queue_result(returncode=0, stdout="f\n")  # diff --cached (non-empty)
+    fake.queue_result(returncode=0)  # git commit
+    fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+    fake.queue_result(returncode=0)  # merge-base --is-ancestor ok
+
+
+def _queue_fix_pass(fake: FakeCommandRunner, *, changed: bool = True) -> None:
+    """Queue the subprocess results for one fix-cycle iteration's
+    agent-run + commit block. ``changed=True`` means the agent made
+    file edits worth committing; ``False`` means no diff and the
+    commit is skipped."""
+    fake.queue_result(returncode=0)  # adapter.run (fix pass)
+    fake.queue_result(returncode=0)  # git add -A
+    if changed:
+        fake.queue_result(returncode=0, stdout="f\n")  # diff --cached
+        fake.queue_result(returncode=0)  # git commit
+    else:
+        fake.queue_result(returncode=0, stdout="")  # diff --cached empty
+
+
+def _queue_push_and_pr(
+    fake: FakeCommandRunner, *, pr_url: str = "https://github.com/x/y/pull/1"
+) -> None:
+    """Queue the subprocess results for push + gh pr create."""
+    fake.queue_result(returncode=0)  # git push
+    fake.queue_result(returncode=0, stdout=pr_url)  # gh pr create
+
+
+class TestValidationPassesOnFirstTry:
+    @pytest.mark.unit
+    async def test_no_fix_cycle_invoked_when_validation_green(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Green validation shouldn't spawn any retry work — the
+        subprocess queue should drain cleanly with no extras."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=0)  # validation passes
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.pr_url == "https://github.com/x/y/pull/1"
+
+
+class TestFixCycleRecoversAfterOneFailure:
+    @pytest.mark.unit
+    async def test_single_fix_pass_is_enough(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Validation fails once → fix pass runs → validation passes →
+        push + completed. This is the common case the user wants."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=1, stderr="pytest: 1 failed")  # validation fails
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=0)  # validation passes after fix
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.pr_url == "https://github.com/x/y/pull/1"
+
+    @pytest.mark.unit
+    async def test_fix_pass_invokes_adapter_a_second_time(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """The whole point of the loop: the coding CLI gets a second
+        ``docker compose exec`` invocation. Two adapter calls must
+        appear in the runner's history."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail")
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=0)  # validation passes after fix
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        # Count ``docker compose ... exec -T -w /workspace agent codex``
+        # invocations. Two of them = initial agent + fix-pass agent.
+        adapter_calls = [c for c in fake.calls if "codex" in c.args and "exec" in c.args]
+        assert len(adapter_calls) == 2
+
+    @pytest.mark.unit
+    async def test_fix_prompt_embeds_failure_context(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """The fix prompt — the payload handed to the CLI on the second
+        call — must carry the failing command + its tail output so the
+        CLI knows what to fix. The adapter passes the prompt as the
+        last CLI arg, so we can grep it out of the subprocess args."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(
+            returncode=1,
+            stderr="AssertionError: expected 'bulk-create-tasks' button",
+            stdout="FAILED tests/foo.py::test_it",
+        )
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=0)
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        # The 2nd adapter call's prompt arg is the fix prompt.
+        adapter_calls = [c for c in fake.calls if "codex" in c.args and "exec" in c.args]
+        assert len(adapter_calls) == 2
+        fix_prompt = " ".join(adapter_calls[1].args)
+        assert "Validation failed" in fix_prompt
+        assert "pytest -q" in fix_prompt  # the failing command
+        assert "attempt 1 of 5" in fix_prompt
+        assert "AssertionError" in fix_prompt or "FAILED tests/foo.py" in fix_prompt
+
+
+class TestFixCycleExhaustion:
+    @pytest.mark.unit
+    async def test_persistent_failure_hits_cap_and_marks_failed(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """If validation keeps failing beyond ``max_validation_fix_passes``,
+        the workspace is marked failed with the exhaustion message. This
+        is the worst-case outcome the loop is allowed to reach."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=2)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        # Initial validation + 2 fix-pass validations = 3 fails total.
+        fake.queue_result(returncode=1, stderr="fail 1")
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail 2")
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail 3")
+        # No push/PR queued — exhaustion should short-circuit before push.
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "validation_failure"
+            assert "2 fix attempts" in (ws.failure_message or "")
+
+    @pytest.mark.unit
+    async def test_two_fails_then_pass_still_wins(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Recovery after several fix passes — verifies the loop
+        correctly advances its pass counter."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail 1")  # initial validation
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail 2")  # fix pass 1 validation
+        _queue_fix_pass(fake)
+        fake.queue_result(returncode=0)  # fix pass 2 validation — PASS
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+
+
+class TestFixPassAgentFailure:
+    @pytest.mark.unit
+    async def test_agent_nonzero_on_fix_pass_does_not_abort_loop(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Coding CLI exiting non-zero on a fix pass mirrors the initial-
+        run salvage behaviour: log it, commit whatever's there, let
+        the next validation decide. If validation passes anyway, the
+        workspace completes. If not, the loop continues."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail")  # initial validation
+        # Fix-pass agent exits non-zero but edits are still on disk.
+        fake.queue_result(returncode=137, stderr="codex: killed")  # adapter.run non-zero
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="f\n")  # diff --cached
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0)  # validation passes anyway
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+
+
+class TestFixPassNoChanges:
+    @pytest.mark.unit
+    async def test_fix_pass_with_no_diff_skips_commit_and_continues(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """If the fix pass makes no edits (CLI decided nothing needed
+        changing), the loop must continue without trying to commit an
+        empty change. Validation simply re-runs; if it still fails,
+        the loop keeps going until either recovery or exhaustion."""
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=2)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        fake.queue_result(returncode=1, stderr="fail 1")  # initial validation
+        _queue_fix_pass(fake, changed=False)  # agent made no edits
+        fake.queue_result(returncode=0)  # validation passes anyway
+        _queue_push_and_pr(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+
+
+class TestFailureMessage:
+    @pytest.mark.unit
+    async def test_exhaustion_message_mentions_attempt_count(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=3)
+        ws_id = await _seed_ready_workspace(factory)
+        _queue_initial_pass(fake)
+        for _ in range(4):  # initial + 3 fix passes, all fail
+            fake.queue_result(returncode=1, stderr="fail")
+            if _ < 3:  # fix-pass subprocess block
+                _queue_fix_pass(fake)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.failure_reason == "validation_failure"
+            assert "3 fix attempts" in (ws.failure_message or "")
+            assert "pytest -q" in (ws.failure_message or "")

--- a/tests/unit/control/test_validation_fix_cycle.py
+++ b/tests/unit/control/test_validation_fix_cycle.py
@@ -1,0 +1,168 @@
+"""Tests for the validation fix-cycle helpers.
+
+Scope: the *pure* parts of the fix-cycle — prompt composition, output
+tailing, context dataclass. The executor-level loop that consumes these
+is covered in ``test_executor_validation_fix_cycle.py`` with the normal
+executor test harness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.control.validation_fix_cycle import (
+    ValidationFixContext,
+    build_fix_prompt,
+    read_output_tail,
+)
+
+
+class TestReadOutputTail:
+    """The fix prompt embeds tails of the failing command's stdout +
+    stderr. The tail length matters for context budget — too short and
+    the coding CLI lacks signal, too long and we burn tokens."""
+
+    @pytest.mark.unit
+    def test_short_file_returned_whole(self, tmp_path: Path) -> None:
+        path = tmp_path / "stderr"
+        path.write_text("line1\nline2\nline3\n")
+
+        assert read_output_tail(path, max_chars=1000) == "line1\nline2\nline3\n"
+
+    @pytest.mark.unit
+    def test_long_file_truncated_to_max_chars_from_end(self, tmp_path: Path) -> None:
+        """Tail — we keep the LAST max_chars, not the first. The failure
+        signal is almost always at the end of a test log."""
+        path = tmp_path / "stderr"
+        path.write_text("a" * 5000 + "TRAIL")
+
+        tail = read_output_tail(path, max_chars=100)
+
+        assert len(tail) == 100
+        assert tail.endswith("TRAIL")
+
+    @pytest.mark.unit
+    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
+        """A failed command should always produce its artifact, but
+        handle the race gracefully."""
+        path = tmp_path / "does-not-exist"
+
+        assert read_output_tail(path, max_chars=1000) == ""
+
+    @pytest.mark.unit
+    def test_empty_file_returns_empty_string(self, tmp_path: Path) -> None:
+        path = tmp_path / "empty"
+        path.write_text("")
+
+        assert read_output_tail(path, max_chars=1000) == ""
+
+    @pytest.mark.unit
+    def test_binary_garbage_falls_back_to_best_effort(self, tmp_path: Path) -> None:
+        """Test frameworks sometimes dump bytes that aren't valid UTF-8
+        (terminal escape codes, binary payloads). We tolerate those and
+        return something readable rather than crashing the fix loop."""
+        path = tmp_path / "stderr"
+        path.write_bytes(b"\xff\xfe\x00valid ascii tail")
+
+        tail = read_output_tail(path, max_chars=1000)
+
+        assert "valid ascii tail" in tail
+
+
+class TestBuildFixPrompt:
+    """The fix prompt is the whole reason the coding CLI gets a second
+    chance. Must be specific enough that it reviews the test output
+    before blindly editing, but short enough not to crowd the CLI's
+    context window."""
+
+    def _ctx(self, **overrides) -> ValidationFixContext:
+        defaults = {
+            "failed_command": "pytest -q",
+            "returncode": 1,
+            "stdout_tail": "FAILED tests/unit/foo.py::test_bar",
+            "stderr_tail": "AssertionError: assert 1 == 2",
+            "pass_number": 1,
+            "total_passes": 5,
+            "test_commands": ["pip install -e .", "pytest -q", "ruff check ."],
+        }
+        defaults.update(overrides)
+        return ValidationFixContext(**defaults)
+
+    @pytest.mark.unit
+    def test_mentions_the_failing_command(self) -> None:
+        prompt = build_fix_prompt(self._ctx())
+        assert "pytest -q" in prompt
+
+    @pytest.mark.unit
+    def test_includes_returncode(self) -> None:
+        prompt = build_fix_prompt(self._ctx(returncode=42))
+        assert "42" in prompt
+
+    @pytest.mark.unit
+    def test_embeds_stdout_and_stderr_tails(self) -> None:
+        prompt = build_fix_prompt(
+            self._ctx(
+                stdout_tail="MYSTDOUT_UNIQUE_MARKER",
+                stderr_tail="MYSTDERR_UNIQUE_MARKER",
+            )
+        )
+        assert "MYSTDOUT_UNIQUE_MARKER" in prompt
+        assert "MYSTDERR_UNIQUE_MARKER" in prompt
+
+    @pytest.mark.unit
+    def test_tells_agent_to_fix_not_re_implement(self) -> None:
+        """The single most important contract: the prompt must orient
+        the CLI toward fixing the reported failure, not wiping the
+        existing work to re-implement from scratch."""
+        prompt = build_fix_prompt(self._ctx()).lower()
+        assert "fix" in prompt
+        # Negation pressure — don't invite a rewrite.
+        assert "do not" in prompt or "don't" in prompt
+
+    @pytest.mark.unit
+    def test_lists_all_validation_commands(self) -> None:
+        """The agent needs to know which commands will run on the next
+        validation pass — otherwise it might fix only the one that
+        failed this pass and break another."""
+        prompt = build_fix_prompt(self._ctx())
+        assert "pip install -e ." in prompt
+        assert "pytest -q" in prompt
+        assert "ruff check ." in prompt
+
+    @pytest.mark.unit
+    def test_shows_attempt_counter(self) -> None:
+        """Telemetry for the CLI: "this is attempt 3 of 5" helps it
+        decide whether to be conservative or experimental."""
+        prompt = build_fix_prompt(self._ctx(pass_number=3, total_passes=5))
+        assert "3" in prompt
+        assert "5" in prompt
+
+    @pytest.mark.unit
+    def test_handles_empty_output_tails(self) -> None:
+        """A command can fail with no output (OOM kill, SIGTERM). The
+        prompt must still be well-formed and not crash."""
+        prompt = build_fix_prompt(self._ctx(stdout_tail="", stderr_tail=""))
+        assert "pytest -q" in prompt
+        # No stray empty-placeholder artifacts.
+        assert "None" not in prompt
+
+
+class TestValidationFixContext:
+    @pytest.mark.unit
+    def test_is_hashable_for_logging_structure(self) -> None:
+        """Structured-logging callers may compare contexts as dict keys
+        (dedupe retry events); frozen dataclass guarantees this."""
+        ctx = ValidationFixContext(
+            failed_command="pytest",
+            returncode=1,
+            stdout_tail="",
+            stderr_tail="",
+            pass_number=1,
+            total_passes=5,
+            test_commands=("pytest",),  # must be tuple for hashability
+        )
+        # Assignment keeps the lint rule happy (B018) while still
+        # asserting the dataclass can be used as a dict key.
+        _ = {ctx: "x"}


### PR DESCRIPTION
## Summary

When validation fails after the initial agent run, the executor now re-invokes the coding CLI with a fix prompt carrying the failure context, re-validates, and keeps iterating up to `max_validation_fix_passes` (default 5) before marking the workspace failed. Mirrors the PR monitor's existing `max_fix_cycle_passes` pattern — but kicks in *before* a PR exists, closing the gap that was killing workspaces for fixable failures.

## Why

T39 is the canonical case: Claude's implementation was correct, one Playwright test asserted a wrong project-seeding flow, and the workspace died immediately. With this loop, Claude would have gotten the failure output back as context and fixed its own test — no manual salvage needed.

## Behaviour

```
validate
  ├─ pass → push + PR
  ├─ fail with budget left → build fix prompt → re-invoke adapter
  │                          → re-commit → re-validate
  └─ budget exhausted → mark failed ("after N fix attempts")
```

- `max_validation_fix_passes: int = 5` added to `ExecutorConfig`. `0` disables (legacy single-shot).
- Fix prompt (built by `build_fix_prompt`) embeds: failing command, exit code, stdout/stderr tails (last 4 KB each), attempt counter (`attempt N of M`), full list of test_commands for the next pass, and explicit "fix, don't re-implement" instruction.
- Agent non-zero exit on a fix pass mirrors the initial-run salvage (log, commit, let next validation decide). Zero-change fix pass skips commit.

## Tests (TDD, 100% on pure helpers, 91% on executor)

- `tests/unit/control/test_validation_fix_cycle.py` — **13 cases** on the pure helpers (`ValidationFixContext`, `build_fix_prompt`, `read_output_tail`).
- `tests/unit/control/test_executor_validation_fix_cycle.py` — **9 cases** on the loop: green-first-try no-op, one-fix-pass recovery, adapter called twice, fix prompt actually embeds failure context at the subprocess layer, exhaustion with budget=2, recovery after 2 failures, agent-nonzero on fix-pass doesn't abort, zero-change fix-pass continues, exhaustion message mentions count.
- `tests/unit/control/test_executor.py` — legacy single-shot test updated to set `max_validation_fix_passes=0` explicitly so it keeps testing what it was meant to test.

**Full suite: 357/357 pass** (was 335 — 22 new cases). Ruff + format clean.

## Relationship to Phase 1.5d

Independent. Phase 1.5d (#1) is for attaching a monitor to an existing PR. Phase 1.5e is for making workspaces self-recover *before* they ever produce a PR. Both ship the same T39-class of failure out of existence, from different angles.

## Test plan

- [x] `pytest tests/unit/` → 357 pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Dogfood: re-launch T39 against this branch and observe the fix loop salvage Claude's test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated PR monitoring with comment/CI-driven fix cycles, optional auto-merge, and release-PR sync to open/maintain development→main PRs; new CLIs to schedule, watch, remonitor, salvage, and run these workflows
* **Bug Fixes**
  * Validation now retries with guided fix passes; improved recovery for severed/orphaned git history and push-rejection handling
* **Documentation**
  * New PR-monitor and release-sync design docs; updated runtime and Playwright/Chromium guidance
* **Chores**
  * Container includes system libraries for unprivileged Chromium install; DB schema extended to persist PR-monitoring state
* **Tests**
  * Extensive unit and integration tests for monitoring, sync, validation, and GitHub tooling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->