### PR TITLE
fix(awf): address all 14 pre-existing CodeRabbit review findings from PR #2

### DIFF
--- a/scripts/airaweb_issues_bulk_create_tasks.json
+++ b/scripts/airaweb_issues_bulk_create_tasks.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-agent/.env",
+        "env_file": "~/Projects/aira/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-web/.env.local",
+        "env_file": "~/Projects/aira/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/airaweb_only.json
+++ b/scripts/airaweb_only.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-agent/.env",
+        "env_file": "~/Projects/aira/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-web/.env.local",
+        "env_file": "~/Projects/aira/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/airaweb_vitest_bff.json
+++ b/scripts/airaweb_vitest_bff.json
@@ -18,7 +18,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-agent/.env",
+        "env_file": "~/Projects/aira/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -31,7 +31,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-web/.env.local",
+        "env_file": "~/Projects/aira/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/real_tasks.json
+++ b/scripts/real_tasks.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-agent/.env",
+        "env_file": "~/Projects/aira/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "/home/dimileeh/Projects/aira/aira-web/.env.local",
+        "env_file": "~/Projects/aira/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/release_pr_watcher.py
+++ b/scripts/release_pr_watcher.py
@@ -74,8 +74,6 @@ async def _tick_one(
     agent: str,
     companions_path: Path | None,
 ) -> None:
-    import subprocess
-
     repo = RepoRef.from_url(repo_url)
     try:
         result = await ensure_release_pr_open(
@@ -121,9 +119,8 @@ async def _tick_one(
         pr_number=result.pr_number,
     )
     scheduler = Path(__file__).resolve().parent / "schedule_release_pr.py"
-    python_bin = Path(__file__).resolve().parents[1] / ".venv" / "bin" / "python"
     args = [
-        str(python_bin),
+        sys.executable,
         str(scheduler),
         "--repo",
         repo_url,
@@ -139,7 +136,35 @@ async def _tick_one(
     ]
     if companions_path is not None:
         args.extend(["--companions", str(companions_path)])
-    subprocess.run(args, check=False)  # noqa: S603 - controlled args
+    # Run the scheduler via asyncio so we neither block the watcher's
+    # event loop nor silently drop the scheduler's exit status.
+    # ``subprocess.run`` on the sync path would pause every other
+    # repo's tick while this scheduler executed; ``asyncio.create_sub
+    # process_exec`` lets the loop continue servicing the other
+    # coroutines scheduled by ``gather()`` in ``_run``. Review
+    # feedback on PR #2 (CodeRabbit): "don't block the event loop or
+    # ignore scheduler launch failures".
+    proc = await asyncio.create_subprocess_exec(
+        *args,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    if proc.returncode != 0:
+        _log.warning(
+            "watcher.scheduler_launch_failed",
+            repo=repo.slug(),
+            pr_number=result.pr_number,
+            returncode=proc.returncode,
+            stderr=stderr.decode("utf-8", errors="replace")[:400],
+        )
+    else:
+        _log.info(
+            "watcher.scheduler_launched",
+            repo=repo.slug(),
+            pr_number=result.pr_number,
+            stdout_snippet=stdout.decode("utf-8", errors="replace")[:200],
+        )
 
 
 async def _run(

--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -72,14 +72,20 @@ async def _main(work_dir: Path, workspace_id: str) -> int:
             print("Workspace has no pr_number; nothing to re-monitor.", file=sys.stderr)
             return 2
         # Bypass state-machine: we're deliberately re-entering the monitor
-        # phase after a premature completion. Reset iter_count to give the
-        # "just finish merge" phase a fresh budget; KEEP
-        # monitor_threads_addressed so we don't re-poke CodeRabbit threads
-        # we already resolved.
+        # phase after a premature completion. Reset iter_count AND
+        # ``monitor_started_at`` so the wall-clock budget starts fresh
+        # from this remonitor call — otherwise ``decide()`` keeps
+        # comparing ``now()`` against the original entry timestamp and
+        # an old workspace re-entered after its wall-clock cap has
+        # already elapsed aborts on the first tick. KEEP
+        # ``monitor_threads_addressed`` so we don't re-poke CodeRabbit
+        # threads we already resolved. Review feedback on PR #2
+        # (CodeRabbit): flag the wall-clock-cap reset pattern.
         ws.status = WorkspaceStatus.monitoring_pr.value
         ws.failure_reason = None
         ws.failure_message = None
         ws.monitor_iter_count = 0
+        ws.monitor_started_at = None
         await s.commit()
         agent_runtime = AgentRuntime(ws.agent)
         compose_project = ws.compose_project_name or f"awf_{workspace_id}"

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -164,22 +164,36 @@ async def _materialize_companion(
     raw: dict[str, Any],
     *,
     git: GitManager,
+    owner_workspace_id: str,
 ) -> CompanionService:
     """Resolve one JSON companion block to a CompanionService.
 
     If ``repo_url`` is set, we clone it to a dedicated companion worktree
-    under ``<work_dir>/companions/<name>`` and use that as the build context.
-    Otherwise ``build_context`` is taken verbatim (must already exist).
+    under ``<work_dir>/companions/<workspace_id>__<name>`` and use that
+    as the build context. Otherwise ``build_context`` is taken verbatim
+    (must already exist).
+
+    ``owner_workspace_id`` scopes the companion's worktree ID so two
+    concurrent workspaces each materializing a companion with the same
+    NAME (e.g. both need a ``backend`` companion from aira-agent) don't
+    stomp on a shared ``companion__backend`` path. The previous naming
+    was ``companion__{name}`` — dangerous under ``asyncio.gather()``,
+    where two ``_run_task()`` coroutines race to ``remove_worktree`` +
+    ``add_worktree`` at the same filesystem path. Review feedback on
+    PR #2 (CodeRabbit, Critical): "Scope companion worktree IDs to
+    the owning workspace".
     """
     name = raw["name"]
     if raw.get("repo_url"):
         # Companion gets its own mirror + worktree, checked out at the base
         # branch (no feature branch — we don't edit companions). The
-        # companion_ws_id is deterministic, so a failed prior run can leave
-        # the worktree on disk; remove it first so add_worktree sees a clean
-        # slate. Companions are read-only build contexts — we don't commit
-        # back to them, so nothing is lost by re-creating them.
-        companion_ws_id = f"companion__{name}"
+        # companion_ws_id is deterministic per (owner_workspace, name)
+        # so a failed prior run's worktree can be removed cleanly; a
+        # concurrent workspace with a same-named companion lands in a
+        # different path. Companions are read-only build contexts — we
+        # don't commit back to them, so nothing is lost by re-creating
+        # them.
+        companion_ws_id = f"companion__{owner_workspace_id}__{name}"
         await git.remove_worktree(
             workspace_id=companion_ws_id,
             repo_url=raw["repo_url"],
@@ -188,7 +202,7 @@ async def _materialize_companion(
             workspace_id=companion_ws_id,
             repo_url=raw["repo_url"],
             base_branch=raw.get("branch", "development"),
-            new_branch=f"awf-companion/{name}-{os.getpid()}",
+            new_branch=f"awf-companion/{owner_workspace_id}-{name}",
         )
         build_context = str(layout.worktree_path)
     else:
@@ -207,6 +221,38 @@ async def _materialize_companion(
         ports=tuple((cp, hp) for cp, hp in (raw.get("ports") or [])),
         command=raw.get("command"),
     )
+
+
+async def _configure_branch_push_upstream(
+    *,
+    runner: AsyncioSubprocessRunner,
+    worktree_path: Path,
+    branch_name: str,
+    remote_branch: str,
+) -> None:
+    """Configure a per-workspace branch so ``git push`` writes back to
+    the *remote* branch it's tracking.
+
+    Used by the ``sync_release_pr`` and ``sync_feature_pr`` handlers,
+    which check out a local ref like ``release-sync/ws_<id>`` or
+    ``feature-sync/ws_<id>`` that should push to a specific remote
+    branch (``development``, the PR's head, etc.). Extracted from the
+    handlers so the three identical blocks can't drift out of sync.
+    Review feedback on PR #2 (CodeRabbit, generic CLI concern at
+    run_awf.py:487).
+
+    Sets three git configs on the worktree:
+      * ``branch.<branch>.remote = origin``
+      * ``branch.<branch>.merge = refs/heads/<remote_branch>``
+      * ``push.default = upstream`` — so bare ``git push`` writes
+        HEAD to whatever the two above specify.
+    """
+    for cfg_args in (
+        [f"branch.{branch_name}.remote", "origin"],
+        [f"branch.{branch_name}.merge", f"refs/heads/{remote_branch}"],
+        ["push.default", "upstream"],
+    ):
+        await runner.run(["git", "-C", str(worktree_path), "config", *cfg_args])
 
 
 def _expand_host_path(path: str) -> str:
@@ -321,7 +367,9 @@ async def _run_task(
                 k: (v.replace("${POSTGRES_URL}", postgres_url) if isinstance(v, str) else v)
                 for k, v in resolved["environment"].items()
             }
-        companion_services.append(await _materialize_companion(resolved, git=git))
+        companion_services.append(
+            await _materialize_companion(resolved, git=git, owner_workspace_id=ws_id)
+        )
 
     # Step 4: compose up with auth mounts + companions.
     # ── git-in-container ──────────────────────────────────────────────────
@@ -488,38 +536,11 @@ async def _run_sync_release_pr(
         base_branch=source_branch,
         new_branch=branch_name,
     )
-    # Configure the per-workspace branch to push to the source branch.
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            f"branch.{branch_name}.remote",
-            "origin",
-        ]
-    )
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            f"branch.{branch_name}.merge",
-            f"refs/heads/{source_branch}",
-        ]
-    )
-    # push.default = upstream makes ``git push`` (with no refspec) push
-    # HEAD to ``merge``-configured upstream — i.e. origin/<source_branch>.
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            "push.default",
-            "upstream",
-        ]
+    await _configure_branch_push_upstream(
+        runner=runner,
+        worktree_path=layout.worktree_path,
+        branch_name=branch_name,
+        remote_branch=source_branch,
     )
     base_commit = await git.head_sha(workspace_id=ws_id)
 
@@ -547,7 +568,9 @@ async def _run_sync_release_pr(
                 k: (v.replace("${POSTGRES_URL}", postgres_url) if isinstance(v, str) else v)
                 for k, v in resolved["environment"].items()
             }
-        companion_services.append(await _materialize_companion(resolved, git=git))
+        companion_services.append(
+            await _materialize_companion(resolved, git=git, owner_workspace_id=ws_id)
+        )
 
     # Step 4: compose up (agent container + postgres + companions).
     mirror_mount = AuthMount(
@@ -718,35 +741,11 @@ async def _run_sync_feature_pr(
         base_branch=source_branch,
         new_branch=branch_name,
     )
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            f"branch.{branch_name}.remote",
-            "origin",
-        ]
-    )
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            f"branch.{branch_name}.merge",
-            f"refs/heads/{source_branch}",
-        ]
-    )
-    await runner.run(
-        [
-            "git",
-            "-C",
-            str(layout.worktree_path),
-            "config",
-            "push.default",
-            "upstream",
-        ]
+    await _configure_branch_push_upstream(
+        runner=runner,
+        worktree_path=layout.worktree_path,
+        branch_name=branch_name,
+        remote_branch=source_branch,
     )
     base_commit = await git.head_sha(workspace_id=ws_id)
 
@@ -774,7 +773,9 @@ async def _run_sync_feature_pr(
                 k: (v.replace("${POSTGRES_URL}", postgres_url) if isinstance(v, str) else v)
                 for k, v in resolved["environment"].items()
             }
-        companion_services.append(await _materialize_companion(resolved, git=git))
+        companion_services.append(
+            await _materialize_companion(resolved, git=git, owner_workspace_id=ws_id)
+        )
 
     # Step 4: compose up.
     mirror_mount = AuthMount(

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -194,17 +194,37 @@ async def _materialize_companion(
     else:
         build_context = raw["build_context"]
 
+    env_file_raw = raw.get("env_file")
+    env_file = _expand_host_path(env_file_raw) if env_file_raw else None
     return CompanionService(
         name=name,
         build_context=build_context,
         dockerfile=raw.get("dockerfile", "Dockerfile"),
-        env_file=raw.get("env_file"),
+        env_file=env_file,
         environment=tuple((k, v) for k, v in (raw.get("environment") or {}).items()),
         depends_on=tuple(raw.get("depends_on") or ("postgres",)),
         healthcheck_cmd=raw.get("healthcheck_cmd"),
         ports=tuple((cp, hp) for cp, hp in (raw.get("ports") or [])),
         command=raw.get("command"),
     )
+
+
+def _expand_host_path(path: str) -> str:
+    """Expand ``~`` and ``$VAR`` / ``${VAR}`` in a host-side path string.
+
+    Companion specs reference host files by path (typically ``.env``
+    files on the operator's machine). Hardcoding absolute paths like
+    ``/home/dimileeh/Projects/aira/aira-agent/.env`` locks the spec to
+    one developer's filesystem; ``~/Projects/aira/aira-agent/.env`` and
+    ``${AWF_AIRA_CHECKOUT_ROOT}/aira-agent/.env`` both survive being
+    checked into the repo and run on someone else's machine.
+
+    Review feedback on PR #2 (CodeRabbit): "hardcoded absolute paths
+    are machine-specific". Fix here, at the loader seam, so every
+    companion spec gets the same treatment without each having to
+    duplicate the expansion logic.
+    """
+    return str(Path(os.path.expandvars(path)).expanduser())
 
 
 async def _run_task(

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -273,6 +273,91 @@ def _expand_host_path(path: str) -> str:
     return str(Path(os.path.expandvars(path)).expanduser())
 
 
+async def _run_task_with_failure_guard(
+    cfg: TaskConfig,
+    *,
+    work_dir: Path,
+    session_factory: async_sessionmaker[AsyncSession],
+    auth_mounts: list[AuthMount],
+    git_name: str,
+    git_email: str,
+) -> dict[str, Any]:
+    """Wrap ``_run_task`` so an unhandled exception in the handler
+    still transitions the workspace row to ``failed``.
+
+    Without this guard, a crash in compose-up / git-add-worktree / any
+    other provisioning step leaves the DB row stuck in a non-terminal
+    state forever (observed in production: runaway watcher spawned 122
+    workspaces, each crashed on ``all predefined address pools have
+    been fully subnetted``, none got marked failed, DB-based
+    idempotency checks downstream thought each was still running).
+
+    The guard identifies the stuck workspace by querying the DB for
+    the MOST RECENT row matching this task's ``repo_url`` + ``task_title``
+    that's in a non-terminal state. It's a heuristic — the ``_run_*``
+    handlers don't currently expose the workspace id they created to
+    the caller — but it's robust enough: each handler creates exactly
+    one workspace at task start, and by the time an exception
+    propagates up, that row is the latest non-terminal one for the
+    pair.
+    """
+    try:
+        return await _run_task(
+            cfg,
+            work_dir=work_dir,
+            session_factory=session_factory,
+            auth_mounts=auth_mounts,
+            git_name=git_name,
+            git_email=git_email,
+        )
+    except BaseException as exc:
+        # Any exception — compose failure, git error, KeyboardInterrupt.
+        # Mark the orphaned workspace row failed so downstream
+        # idempotency checks (the scheduler's DB-based
+        # ``_monitor_already_running``) don't see a phantom "active"
+        # workspace that will never transition on its own.
+        await _mark_orphan_workspace_failed(
+            session_factory=session_factory,
+            repo_url=cfg.repo_url,
+            task_title=cfg.task_title,
+            message=f"driver crashed mid-provision: {exc!r}"[:2000],
+        )
+        raise
+
+
+async def _mark_orphan_workspace_failed(
+    *,
+    session_factory: async_sessionmaker[AsyncSession],
+    repo_url: str,
+    task_title: str,
+    message: str,
+) -> None:
+    """Mark the most recent non-terminal workspace for this
+    (repo_url, task_title) as failed. No-op if none found."""
+    from sqlalchemy import select
+
+    from awf.db.models import Workspace
+
+    async with session_factory() as s:
+        result = await s.execute(
+            select(Workspace)
+            .where(
+                Workspace.repo_url == repo_url,
+                Workspace.task_title == task_title,
+                Workspace.status.notin_(("completed", "failed")),
+            )
+            .order_by(Workspace.created_at.desc())
+            .limit(1)
+        )
+        ws = result.scalar_one_or_none()
+        if ws is None:
+            return
+        ws.status = WorkspaceStatus.failed.value
+        ws.failure_reason = "infrastructure_failure"
+        ws.failure_message = message
+        await s.commit()
+
+
 async def _run_task(
     cfg: TaskConfig,
     *,
@@ -887,7 +972,7 @@ async def _main(config_path: Path, work_dir: Path, keep_state: bool) -> int:
     try:
         results = await asyncio.gather(
             *(
-                _run_task(
+                _run_task_with_failure_guard(
                     t,
                     work_dir=work_dir,
                     session_factory=factory,

--- a/scripts/salvage_workspace.py
+++ b/scripts/salvage_workspace.py
@@ -70,6 +70,52 @@ class _NoOpAdapter(AgentAdapter):
         )
 
 
+def _make_noop_factory(runtime_value: AgentRuntime) -> type[AgentAdapter]:
+    """Build a no-op adapter class bound to *this* runtime value.
+
+    Extracted from the registry-install loop specifically to sidestep
+    the classic Python closure-capture pitfall: classes defined inside
+    a ``for runtime in ...`` loop share the enclosing ``runtime``
+    variable by REFERENCE, so every class ends up pointing at whatever
+    runtime the loop variable last held — all three registered classes
+    would report the same ``name``. Review feedback on PR #2
+    (CodeRabbit): "closure capture in for-loop".
+
+    Returning a class from a function closes ``runtime_value`` by
+    value because it's a fresh local in this frame, one per call.
+    """
+
+    class _Factory(AgentAdapter):  # type: ignore[misc]
+        runtime = runtime_value  # type: ignore[assignment]
+
+        def __init__(self, *, runner: object = None, default_model: str | None = None) -> None:
+            # runner / default_model accepted for signature compat, unused.
+            self._runtime = runtime_value
+
+        @property
+        def name(self) -> AgentRuntime:
+            return self._runtime
+
+        def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+            return []
+
+        async def run(
+            self,
+            *,
+            compose_project: str,
+            compose_file: Path,
+            prompt: str,
+            model: str | None = None,
+        ) -> AgentRunResult:
+            return AgentRunResult(
+                returncode=0,
+                stdout="[salvage] skipping agent run — worktree already holds completed work",
+                stderr="",
+            )
+
+    return _Factory
+
+
 def _install_noop_adapter_factory() -> None:
     """Replace every entry in the adapter registry with a no-op factory.
 
@@ -78,37 +124,7 @@ def _install_noop_adapter_factory() -> None:
     regardless of which runtime was configured for the workspace.
     """
     for runtime in list(_adapter_base._REGISTRY.keys()):
-        captured = runtime
-
-        class _Factory(AgentAdapter):  # type: ignore[misc]
-            runtime = captured  # type: ignore[assignment]
-
-            def __init__(self, *, runner: object = None, default_model: str | None = None) -> None:
-                # runner / default_model accepted for signature compat, unused.
-                self._runtime = captured
-
-            @property
-            def name(self) -> AgentRuntime:
-                return self._runtime
-
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-                return []
-
-            async def run(
-                self,
-                *,
-                compose_project: str,
-                compose_file: Path,
-                prompt: str,
-                model: str | None = None,
-            ) -> AgentRunResult:
-                return AgentRunResult(
-                    returncode=0,
-                    stdout="[salvage] skipping agent run — worktree already holds completed work",
-                    stderr="",
-                )
-
-        _adapter_base._REGISTRY[runtime] = _Factory
+        _adapter_base._REGISTRY[runtime] = _make_noop_factory(runtime)
 
 
 async def _main(work_dir: Path, workspace_id: str) -> int:

--- a/scripts/schedule_release_pr.py
+++ b/scripts/schedule_release_pr.py
@@ -126,11 +126,16 @@ async def _main(
         # Fire-and-forget — run_awf.py is a long-running monitor; don't
         # block this scheduler tick on it.
         log_path = work_dir / f"release-monitor-{result.pr_number}.log"
-        python_bin = _ROOT / ".venv" / "bin" / "python"
+        # Spawn run_awf.py using whichever Python is currently running
+        # this scheduler. Hardcoding ``_ROOT / ".venv" / "bin" / "python"``
+        # only works when the caller's venv lives at exactly that path;
+        # ``uv``, system python, and operator-local virtualenvs would
+        # all break that assumption. Review feedback on PR #2
+        # (CodeRabbit): "use the current interpreter".
         run_awf = _ROOT / "scripts" / "run_awf.py"
         subprocess.Popen(  # noqa: S603 - deliberately spawning a long-running child
             [
-                str(python_bin),
+                sys.executable,
                 str(run_awf),
                 "--config",
                 str(spec_path),
@@ -147,15 +152,29 @@ async def _main(
 
 
 def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) -> bool:
-    """True iff a sync_release_pr workspace for this (repo, PR) is active.
+    """True iff a sync_release_pr workspace for this (repo, PR) is active
+    in the SAME ``work_dir``.
 
-    Active = status in one of the non-terminal states. Checked by
-    scanning process list for running ``run_awf.py`` invocations whose
-    config path matches our deterministic spec filename. A proper
-    implementation would query the AWF DB, but the scheduler runs
-    outside the driver's process so a file/process check is sufficient
-    for MVP — the scheduler's whole job is to avoid spawning duplicates."""
+    Scoped by ``work_dir`` (not just repo+PR) because two AWF installs
+    can legitimately run side-by-side on the same host — e.g. an
+    operator testing a local branch in ``/tmp/awf-dev`` while
+    production sits in ``/tmp/awf-realrun``. The old filename-only
+    match would have made one install's scheduler suppress the
+    other's launch. Review feedback on PR #2 (CodeRabbit): "use
+    work_dir in the duplicate-monitor check".
+
+    Active = ``run_awf.py`` process whose ``--config`` argument points
+    inside ``<work_dir>/release-pr-specs/`` with the deterministic
+    spec filename for this (repo, PR). A proper implementation would
+    query the AWF DB, but the scheduler runs outside the driver's
+    process so a file/process check is sufficient for MVP — the
+    scheduler's whole job is to avoid spawning duplicates."""
     spec_filename = f"{repo_slug.replace('/', '__')}-pr{pr_number}.json"
+    # Full config path the launcher passes to run_awf.py. Matching the
+    # full path (not just the filename) is what makes this work_dir-
+    # scoped: the same spec filename under a different work_dir won't
+    # match.
+    expected_arg = str(work_dir / "release-pr-specs" / spec_filename)
     try:
         # pgrep -af matches both the command and its args.
         out = subprocess.check_output(
@@ -166,7 +185,7 @@ def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) 
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
     for line in out.splitlines():
-        if spec_filename in line:
+        if expected_arg in line:
             return True
     return False
 

--- a/scripts/schedule_release_pr.py
+++ b/scripts/schedule_release_pr.py
@@ -152,42 +152,72 @@ async def _main(
 
 
 def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) -> bool:
-    """True iff a sync_release_pr workspace for this (repo, PR) is active
-    in the SAME ``work_dir``.
+    """True iff a sync_release_pr workspace for this (repo, PR) is
+    active in this ``work_dir``'s AWF DB.
 
-    Scoped by ``work_dir`` (not just repo+PR) because two AWF installs
-    can legitimately run side-by-side on the same host — e.g. an
-    operator testing a local branch in ``/tmp/awf-dev`` while
-    production sits in ``/tmp/awf-realrun``. The old filename-only
-    match would have made one install's scheduler suppress the
-    other's launch. Review feedback on PR #2 (CodeRabbit): "use
-    work_dir in the duplicate-monitor check".
+    Active = any workspace row where ``task_kind='sync_release_pr'``,
+    ``repo_url`` matches, ``pr_number`` matches, and ``status`` is
+    NOT terminal (not in ``{completed, failed}``).
 
-    Active = ``run_awf.py`` process whose ``--config`` argument points
-    inside ``<work_dir>/release-pr-specs/`` with the deterministic
-    spec filename for this (repo, PR). A proper implementation would
-    query the AWF DB, but the scheduler runs outside the driver's
-    process so a file/process check is sufficient for MVP — the
-    scheduler's whole job is to avoid spawning duplicates."""
-    spec_filename = f"{repo_slug.replace('/', '__')}-pr{pr_number}.json"
-    # Full config path the launcher passes to run_awf.py. Matching the
-    # full path (not just the filename) is what makes this work_dir-
-    # scoped: the same spec filename under a different work_dir won't
-    # match.
-    expected_arg = str(work_dir / "release-pr-specs" / spec_filename)
-    try:
-        # pgrep -af matches both the command and its args.
-        out = subprocess.check_output(
-            ["pgrep", "-af", "run_awf.py"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    Originally a process-based ``pgrep run_awf.py`` check. That was
+    fragile: a run_awf.py that crashes fast (e.g. docker network pool
+    exhausted at compose-up — we hit this in production) leaves a
+    ``provisioning`` workspace row behind but NO process. Next tick
+    the pgrep check finds nothing, spawns another workspace that
+    also dies, and the scheduler spins forever creating orphan rows.
+
+    DB-based check sees the stuck ``provisioning`` row and correctly
+    reports "already active" so the next tick skips re-spawning. When
+    combined with the driver's ``_run_task_with_failure_guard`` —
+    which marks orphaned rows failed on exception — the scheduler
+    spawns exactly one retry after each terminal failure, not a
+    retry-storm.
+    """
+    # SQLite DB lives at ``<work_dir>/awf.db``. The scheduler may run
+    # before any workspace has been provisioned (no DB yet) — treat
+    # that as "no monitor running" and let the launch proceed.
+    db_path = work_dir / "awf.db"
+    if not db_path.exists():
         return False
-    for line in out.splitlines():
-        if expected_arg in line:
-            return True
-    return False
+    # Use a plain sync sqlite3 connection — the scheduler isn't inside
+    # the async driver's event loop and doesn't need to pull in the
+    # whole SQLAlchemy stack for a single SELECT.
+    import sqlite3
+
+    repo_url_variants = _repo_url_variants(repo_slug)
+    placeholders = ",".join("?" for _ in repo_url_variants)
+    try:
+        with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as conn:
+            cur = conn.execute(
+                f"""SELECT 1 FROM workspaces
+                    WHERE task_kind = 'sync_release_pr'
+                      AND pr_number = ?
+                      AND repo_url IN ({placeholders})
+                      AND status NOT IN ('completed', 'failed')
+                    LIMIT 1""",
+                (pr_number, *repo_url_variants),
+            )
+            row = cur.fetchone()
+    except sqlite3.DatabaseError:
+        # Malformed / locked DB → don't let that stop the scheduler.
+        # Worst case we spawn a duplicate, which is what we had before.
+        return False
+    return row is not None
+
+
+def _repo_url_variants(repo_slug: str) -> tuple[str, ...]:
+    """Return the repo-URL forms the AWF DB might have stored.
+
+    The driver accepts SSH (``git@github.com:owner/name.git``) and
+    HTTPS (``https://github.com/owner/name``) forms. We check both so
+    the idempotency query doesn't miss a workspace that was recorded
+    with the other flavor."""
+    return (
+        f"git@github.com:{repo_slug}.git",
+        f"git@github.com:{repo_slug}",
+        f"https://github.com/{repo_slug}.git",
+        f"https://github.com/{repo_slug}",
+    )
 
 
 def _load_companions(companions_path: Path) -> list[dict]:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -371,6 +371,29 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     ):
         return NotifyHuman()
 
+    # 7.5. Deferred feedback still unresolved on GitHub → block auto-merge.
+    #
+    # "Defer" means the coding CLI decided a reviewer comment needs human
+    # follow-up (design question, out-of-scope, etc.) — NOT that the
+    # thread has been addressed. The previous code filtered such threads
+    # out of ``new_threads`` (step 2) AND let merge proceed at step 8,
+    # silently merging past feedback the maintainer never saw. Now we
+    # explicitly check: if any thread we marked ``defer`` is still
+    # unresolved on GitHub (i.e. the human hasn't resolved it either),
+    # hand off to NotifyHuman regardless of ``auto_merge`` so the
+    # deferred question can't slip through. Review feedback on PR #2
+    # (CodeRabbit, Major): "Deferred feedback still disappears from the
+    # merge gate".
+    deferred_still_open = any(
+        state.threads_addressed_ids.get(t.thread_id) == "defer"
+        for t in status.unresolved_inline_threads
+    ) or any(
+        state.threads_addressed_ids.get(c.comment_id) == "defer"
+        for c in status.unresolved_review_comments
+    )
+    if deferred_still_open:
+        return NotifyHuman()
+
     # 8. All green — terminal success action.
     if config.auto_merge:
         return Merge()

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -135,7 +135,20 @@ class PullRequestMonitorRunner:
             state = self._load_state(ws)
             repo = RepoRef.from_url(ws.repo_url)
             pr_number = ws.pr_number
-            assert pr_number is not None, "pr_number must be set before monitoring"
+            if pr_number is None:
+                # A workspace in ``monitoring_pr`` without a PR number is
+                # an upstream invariant violation (the executor/sync
+                # handlers set pr_number before transitioning here).
+                # Fail cleanly instead of crashing the background runner
+                # with AssertionError — review feedback on PR #2 (gemini).
+                await self._terminate_failed(
+                    workspace_id,
+                    message=(
+                        "monitor: workspace reached monitoring_pr without a "
+                        "pr_number — upstream provisioning must populate it"
+                    ),
+                )
+                return
 
             # Refresh the worktree's remote-tracking ref BEFORE counting
             # how far behind we are. Without this, origin/<base> is frozen

--- a/tests/integration/runtime/test_pr_monitor_runner.py
+++ b/tests/integration/runtime/test_pr_monitor_runner.py
@@ -523,7 +523,7 @@ class TestAddressComments:
             assert ws.monitor_threads_addressed["T_fp"] == "false_positive"
 
     @pytest.mark.unit
-    async def test_defer_verdict_does_not_resolve_thread(
+    async def test_defer_verdict_does_not_resolve_thread_and_blocks_merge(
         self,
         factory: async_sessionmaker[AsyncSession],
         cmd: FakeCommandRunner,
@@ -531,6 +531,19 @@ class TestAddressComments:
         sleep_fn: RecordedSleep,
         tmp_path: Path,
     ) -> None:
+        """Two contracts around ``DEFER``:
+
+        1. The thread is NOT resolved on GitHub — "defer" means the
+           agent couldn't decide, a human has to. Resolving would
+           sweep the question under the rug.
+        2. The merge gate MUST NOT fire while a deferred thread is
+           still unresolved on GitHub. Previously (the bug CodeRabbit
+           flagged on PR #2) the filter in ``decide()`` treated
+           deferred threads as "addressed" at step 2 and let step 8
+           merge silently. Now a dedicated gate at step 7.5 returns
+           NotifyHuman instead — the maintainer sees the "ready to
+           review" comment AND the deferred thread still standing.
+        """
         ws_id = await _seed_monitoring_workspace(factory)
         thread = {
             "id": "T_defer",
@@ -546,14 +559,15 @@ class TestAddressComments:
         adapter.queue(stdout="DEFER: need design input from maintainer")
         cmd.queue_result(returncode=0, stdout=_pr_payload())  # settle
         cmd.queue_result(returncode=0, stderr="Everything up-to-date")  # push
-        # No resolve_thread call queued — test checks we didn't hit it.
-        # After a second outer iteration the thread is "addressed" in state
-        # so decide() returns Merge; queue the merge.
+        # No resolve_thread call queued — contract #1.
+        # Second outer iteration: thread still unresolved on GitHub.
+        # decide() should now hit the deferred-still-open gate and
+        # return NotifyHuman — queue the ``gh pr comment`` call, NOT a
+        # merge.
         cmd.queue_result(returncode=0)  # git fetch origin <base>
         cmd.queue_result(returncode=0, stdout="0\n")
         cmd.queue_result(returncode=0, stdout=_pr_payload(threads=[thread]))  # still there
-        cmd.queue_result(returncode=0)  # merge (thread addressed in state, gate passes)
-        cmd.queue_result(returncode=0, stdout="M\n")
+        cmd.queue_result(returncode=0)  # gh pr comment (NotifyHuman terminal)
         runner = _make_runner(
             factory=factory,
             cmd=cmd,
@@ -566,12 +580,25 @@ class TestAddressComments:
             compose_project="proj",
             compose_file=tmp_path / "compose.yml",
         )
-        # Specifically assert no resolveReviewThread mutation fired.
+        # Contract #1: no resolveReviewThread mutation fired.
         for c in cmd.calls:
             query_args = [a for a in c.args if a.startswith("query=")]
             assert not any("resolveReviewThread" in q for q in query_args), (
                 "defer verdict must NOT resolve the thread"
             )
+        # Contract #2: no merge call fired. The merge would look like
+        # ``gh pr merge ...``; the NotifyHuman path is ``gh pr comment``.
+        assert not any(c.args[:3] == ["gh", "pr", "merge"] for c in cmd.calls), (
+            "deferred-still-open must block merge — maintainer-driven only"
+        )
+        # Workspace ended in a terminal state (NotifyHuman → completed-ish).
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status in (
+                WorkspaceStatus.completed.value,
+                WorkspaceStatus.failed.value,
+            ), "monitor must terminate the workspace after NotifyHuman, not loop forever"
 
 
 class TestFixCyclePasses:

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -495,6 +495,74 @@ class TestTerminalSuccess:
             )
 
 
+# ── Deferred feedback gate ─────────────────────────────────────────────────
+
+
+class TestDeferredFeedbackGate:
+    """Regression tests for the Major bug CodeRabbit flagged on PR #2:
+    the pre-fix filter treated threads marked ``"defer"`` as "addressed"
+    at step 2, so a PR with only-deferred unresolved threads looked
+    clean to the merge gate and auto-merged silently. The fix adds a
+    dedicated gate: if any deferred thread is still unresolved on
+    GitHub, return NotifyHuman regardless of ``auto_merge``."""
+
+    @pytest.mark.unit
+    def test_deferred_thread_still_open_blocks_merge(self) -> None:
+        """The exact scenario: CI green, nothing to merge against,
+        only thing left is a thread the agent deferred. Must NOT merge."""
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread(tid="T1"),))
+        action = decide(state=state, status=status, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_deferred_review_comment_still_open_blocks_merge(self) -> None:
+        """Same contract for top-level review comments (CodeRabbit posts
+        these as ``ReviewComment`` not ``ReviewThread`` — both paths
+        must honour defer)."""
+        state = MonitorState(threads_addressed_ids={"C1": "defer"})
+        status = _status(reviews=(_review(cid="C1"),))
+        action = decide(state=state, status=status, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_resolved_deferred_thread_unblocks_merge(self) -> None:
+        """Happy path: agent deferred T1; the maintainer then resolved
+        T1 on GitHub. Next poll GitHub reports T1 no longer in
+        ``unresolved_inline_threads`` → the defer gate finds no
+        deferred-still-open thread → Merge proceeds."""
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=())  # maintainer resolved it
+        action = decide(state=state, status=status, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge)
+
+    @pytest.mark.unit
+    def test_fix_committed_thread_does_not_trigger_defer_gate(self) -> None:
+        """Sanity: only ``defer`` should route through NotifyHuman. A
+        thread marked ``fix_committed`` would already have been
+        resolved on GitHub, but even if it somehow lingers
+        unresolved, it must not be treated as deferred."""
+        state = MonitorState(threads_addressed_ids={"T1": "fix_committed"})
+        # If it ever appeared unresolved — which would be a different
+        # bug — it must either re-trigger AddressComments OR merge,
+        # NEVER be confused with a defer.
+        status_gone = _status(inline=())
+        assert isinstance(
+            decide(status=status_gone, state=state, config=MonitorConfig(auto_merge=True)),
+            Merge,
+        )
+
+    @pytest.mark.unit
+    def test_release_variant_still_ends_in_notify_human(self) -> None:
+        """Release-PR variant (``auto_merge=False``) already returns
+        NotifyHuman unconditionally — the defer gate must not corrupt
+        that path (verifying no regression on the release-PR variant)."""
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread(tid="T1"),))
+        action = decide(state=state, status=status, config=MonitorConfig(auto_merge=False))
+        assert isinstance(action, NotifyHuman)
+
+
 # ── Iteration accounting — decide() doesn't mutate state ──────────────────
 
 

--- a/tests/unit/scripts/test_run_awf_companion.py
+++ b/tests/unit/scripts/test_run_awf_companion.py
@@ -1,0 +1,165 @@
+"""Tests for ``scripts.run_awf._materialize_companion`` companion-worktree
+ID scoping.
+
+Scope: the Critical fix from CodeRabbit feedback on PR #2 — two
+concurrent workspaces that both provision a companion with the same
+NAME used to race on a shared ``companion__{name}`` worktree path.
+After the fix the ID includes the owning workspace, so they live in
+distinct paths.
+
+We fake the ``GitManager`` so the test stays in-memory — we only care
+about which ``workspace_id`` the materializer hands it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.node.compose_manager import CompanionService
+from scripts.run_awf import _materialize_companion
+
+
+class _FakeWorktreeLayout:
+    """Mirror ``awf.node.git_manager.WorktreeLayout`` enough for the test."""
+
+    def __init__(self, worktree_path: Path, mirror_path: Path) -> None:
+        self.worktree_path = worktree_path
+        self.mirror_path = mirror_path
+
+
+class _FakeGitManager:
+    """Records every ``remove_worktree`` / ``add_worktree`` call so the
+    test can assert on the ``workspace_id`` parameter."""
+
+    def __init__(self, tmp_path: Path) -> None:
+        self.removed_ids: list[str] = []
+        self.added_ids: list[str] = []
+        self.added_new_branches: list[str] = []
+        self._tmp = tmp_path
+
+    async def remove_worktree(self, *, workspace_id: str, repo_url: str) -> None:
+        self.removed_ids.append(workspace_id)
+
+    async def add_worktree(
+        self,
+        *,
+        workspace_id: str,
+        repo_url: str,
+        base_branch: str,
+        new_branch: str,
+    ) -> _FakeWorktreeLayout:
+        self.added_ids.append(workspace_id)
+        self.added_new_branches.append(new_branch)
+        # Return paths that are at least plausible — the test doesn't
+        # read them, but the real return type has these attributes.
+        return _FakeWorktreeLayout(
+            worktree_path=self._tmp / workspace_id,
+            mirror_path=self._tmp / "mirrors" / workspace_id,
+        )
+
+
+_COMPANION_RAW = {
+    "name": "backend",
+    "repo_url": "git@github.com:dimileeh/aira-agent.git",
+    "branch": "development",
+}
+
+
+class TestCompanionWorktreeScoping:
+    @pytest.mark.unit
+    async def test_worktree_id_includes_owner_workspace(self, tmp_path: Path) -> None:
+        """The Critical bug: ``companion__{name}`` was unscoped. Now
+        the ID must carry the owning workspace so concurrent materializers
+        never collide."""
+        git = _FakeGitManager(tmp_path)
+
+        await _materialize_companion(
+            dict(_COMPANION_RAW),
+            git=git,  # type: ignore[arg-type]
+            owner_workspace_id="ws_aaaaaaaa",
+        )
+
+        assert git.added_ids == ["companion__ws_aaaaaaaa__backend"]
+        assert git.removed_ids == ["companion__ws_aaaaaaaa__backend"]
+
+    @pytest.mark.unit
+    async def test_two_workspaces_same_companion_get_distinct_paths(self, tmp_path: Path) -> None:
+        """Concurrent-run regression: two workspaces with same-named
+        companions must land in different worktree IDs — this is the
+        whole point of the fix."""
+        git1 = _FakeGitManager(tmp_path)
+        git2 = _FakeGitManager(tmp_path)
+
+        await _materialize_companion(
+            dict(_COMPANION_RAW), git=git1, owner_workspace_id="ws_aaaaaaaa"
+        )
+        await _materialize_companion(
+            dict(_COMPANION_RAW), git=git2, owner_workspace_id="ws_bbbbbbbb"
+        )
+
+        # Different workspace → different companion IDs → no collision.
+        assert git1.added_ids[0] == "companion__ws_aaaaaaaa__backend"
+        assert git2.added_ids[0] == "companion__ws_bbbbbbbb__backend"
+        assert git1.added_ids[0] != git2.added_ids[0]
+
+    @pytest.mark.unit
+    async def test_new_branch_name_also_scoped(self, tmp_path: Path) -> None:
+        """The per-companion local branch (``awf-companion/<something>``)
+        is created fresh each run. Previously used ``os.getpid()`` as a
+        uniqueness suffix, which only worked per-process and still
+        collided under ``asyncio.gather`` in the same process. Now uses
+        the owner workspace id — same scoping as the worktree ID."""
+        git = _FakeGitManager(tmp_path)
+
+        await _materialize_companion(
+            dict(_COMPANION_RAW),
+            git=git,
+            owner_workspace_id="ws_cafebabe",
+        )
+
+        assert git.added_new_branches == ["awf-companion/ws_cafebabe-backend"]
+
+    @pytest.mark.unit
+    async def test_local_build_context_still_supported(self, tmp_path: Path) -> None:
+        """Companions without ``repo_url`` use an on-disk build context
+        and don't touch git. Regression guard: the workspace-scoping
+        refactor must not break this path."""
+        git = _FakeGitManager(tmp_path)
+        build_ctx = tmp_path / "local-ctx"
+        build_ctx.mkdir()
+
+        svc = await _materialize_companion(
+            {"name": "local", "build_context": str(build_ctx)},
+            git=git,
+            owner_workspace_id="ws_abc",
+        )
+
+        assert isinstance(svc, CompanionService)
+        assert svc.name == "local"
+        # No git operations happened — no repo_url.
+        assert git.added_ids == []
+        assert git.removed_ids == []
+
+    @pytest.mark.unit
+    async def test_env_file_expansion_runs_on_companions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Companion loader still expands tilde/envvar on env_file
+        (from the earlier fix). Regression guard: the workspace-scoping
+        change shares the same function; don't break the env-file path."""
+        git = _FakeGitManager(tmp_path)
+        monkeypatch.setenv("AWF_TEST_AIRA_ROOT", str(tmp_path))
+
+        svc = await _materialize_companion(
+            {
+                "name": "local",
+                "build_context": str(tmp_path),
+                "env_file": "${AWF_TEST_AIRA_ROOT}/.env",
+            },
+            git=git,
+            owner_workspace_id="ws_ignored_here",
+        )
+
+        assert svc.env_file == str(tmp_path / ".env")

--- a/tests/unit/scripts/test_run_awf_failure_guard.py
+++ b/tests/unit/scripts/test_run_awf_failure_guard.py
@@ -1,0 +1,211 @@
+"""Tests for ``scripts.run_awf._run_task_with_failure_guard`` and
+``_mark_orphan_workspace_failed``.
+
+Scope: the runaway-watcher bug observed in production. When a handler
+crashed mid-provisioning (compose-up failure, git error, etc.), the
+DB row stayed stuck in ``provisioning`` forever. The downstream
+scheduler (``schedule_release_pr._monitor_already_running``) then saw
+the stuck row AND thought the monitor was still live — or, worse in
+the pre-fix world, the PROCESS-based check saw the crashed process
+gone and spawned another on top. Either way, orphans piled up.
+
+The guard wrapper and orphan-marker helper together turn those crashes
+into clean terminal ``failed`` transitions.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.base import Base
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from scripts.run_awf import (
+    TaskConfig,
+    _mark_orphan_workspace_failed,
+    _run_task_with_failure_guard,
+)
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_ws(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    status: WorkspaceStatus,
+    repo_url: str = "git@github.com:dimileeh/aira-web.git",
+    task_title: str = "release-monitor: dimileeh/aira-web#278",
+) -> str:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url=repo_url,
+            branch_base="main",
+            task_title=task_title,
+            task_prompt="x",
+            agent="codex",
+            test_commands=[],
+            requires_database=False,
+        )
+        if status != WorkspaceStatus.requested:
+            await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
+            if status not in (WorkspaceStatus.provisioning,):
+                # walk partway if the test asked for something downstream
+                for stage in (
+                    WorkspaceStatus.ready,
+                    WorkspaceStatus.running,
+                    WorkspaceStatus.validating,
+                    WorkspaceStatus.pushing,
+                    WorkspaceStatus.monitoring_pr,
+                    WorkspaceStatus.completed,
+                    WorkspaceStatus.failed,
+                ):
+                    await repo.transition(ws, to=stage, reason_code="X")
+                    if stage == status:
+                        break
+        await s.commit()
+        return ws.id
+
+
+class TestMarkOrphanWorkspaceFailed:
+    @pytest.mark.unit
+    async def test_transitions_latest_non_terminal_row(
+        self, factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        ws_id = await _seed_ws(factory, status=WorkspaceStatus.provisioning)
+
+        await _mark_orphan_workspace_failed(
+            session_factory=factory,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            task_title="release-monitor: dimileeh/aira-web#278",
+            message="compose up failed — test message",
+        )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert "compose up failed" in (ws.failure_message or "")
+
+    @pytest.mark.unit
+    async def test_no_matching_row_is_noop(self, factory: async_sessionmaker[AsyncSession]) -> None:
+        """Guard fires an orphan-mark call even for tasks that never
+        reached workspace creation. Must not crash on empty DB."""
+        await _mark_orphan_workspace_failed(
+            session_factory=factory,
+            repo_url="git@github.com:dimileeh/nothing-here.git",
+            task_title="ghost",
+            message="no such ws",
+        )  # just must not raise
+
+    @pytest.mark.unit
+    async def test_leaves_terminal_rows_untouched(
+        self, factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Guard must NOT retroactively flip a successful run to
+        failed — its only job is to recover stuck non-terminal rows."""
+        ws_id = await _seed_ws(factory, status=WorkspaceStatus.completed)
+
+        await _mark_orphan_workspace_failed(
+            session_factory=factory,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            task_title="release-monitor: dimileeh/aira-web#278",
+            message="would-be regression if applied",
+        )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.failure_reason is None
+
+
+class TestRunTaskWithFailureGuard:
+    @pytest.mark.unit
+    async def test_successful_handler_returns_result_unchanged(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The guard must be transparent for the happy path — it wraps
+        exception handling, nothing else."""
+        expected_result = {"workspace_id": "ws_123", "status": "completed"}
+
+        async def _fake_run_task(cfg, **kwargs):  # type: ignore[no-untyped-def]
+            return expected_result
+
+        monkeypatch.setattr("scripts.run_awf._run_task", _fake_run_task)
+
+        cfg = TaskConfig(
+            repo_url="git@github.com:x/y.git",
+            branch_base="development",
+            task_title="test",
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        result = await _run_task_with_failure_guard(
+            cfg,
+            work_dir=Path("/tmp"),
+            session_factory=factory,
+            auth_mounts=[],
+            git_name="x",
+            git_email="x@x",
+        )
+        assert result is expected_result
+
+    @pytest.mark.unit
+    async def test_exception_marks_orphan_failed_and_reraises(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Core contract: any exception from the inner handler →
+        orphan row marked failed, exception propagates (so the gather
+        in _main still reports the crash to the operator)."""
+        ws_id = await _seed_ws(factory, status=WorkspaceStatus.provisioning)
+
+        async def _boom(cfg, **kwargs):  # type: ignore[no-untyped-def]
+            raise RuntimeError("compose up failed")
+
+        monkeypatch.setattr("scripts.run_awf._run_task", _boom)
+
+        cfg = TaskConfig(
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            branch_base="main",
+            task_title="release-monitor: dimileeh/aira-web#278",
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+
+        with pytest.raises(RuntimeError, match="compose up failed"):
+            await _run_task_with_failure_guard(
+                cfg,
+                work_dir=Path("/tmp"),
+                session_factory=factory,
+                auth_mounts=[],
+                git_name="x",
+                git_email="x@x",
+            )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert "compose up failed" in (ws.failure_message or "")

--- a/tests/unit/scripts/test_run_awf_path_expansion.py
+++ b/tests/unit/scripts/test_run_awf_path_expansion.py
@@ -1,0 +1,65 @@
+"""Tests for ``scripts.run_awf._expand_host_path`` — the loader-side
+helper that turns portable companion-spec paths (``~/...``,
+``${VAR}/...``) into concrete absolute paths at runtime.
+
+Review feedback on PR #2 (CodeRabbit Major): companion specs checked
+into the repo used hardcoded absolute paths like
+``/home/dimileeh/Projects/aira/aira-agent/.env``. Those break on any
+other developer's machine. Spec authors can now use ``~`` /
+``$HOME`` / ``${AWF_AIRA_CHECKOUT_ROOT}`` variants; this test pins the
+expansion behaviour so future refactors don't silently disable it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scripts.run_awf import _expand_host_path
+
+
+class TestExpandHostPath:
+    @pytest.mark.unit
+    def test_tilde_expands_to_home(self) -> None:
+        expanded = _expand_host_path("~/Projects/aira/aira-agent/.env")
+        # ``~`` should become the actual HOME — not the literal string.
+        assert not expanded.startswith("~")
+        assert expanded.endswith("/Projects/aira/aira-agent/.env")
+
+    @pytest.mark.unit
+    def test_env_var_expands(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWF_AIRA_CHECKOUT_ROOT", "/opt/aira")
+        expanded = _expand_host_path("${AWF_AIRA_CHECKOUT_ROOT}/aira-agent/.env")
+        assert expanded == "/opt/aira/aira-agent/.env"
+
+    @pytest.mark.unit
+    def test_dollar_var_without_braces_expands(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWF_AIRA_CHECKOUT_ROOT", "/opt/aira")
+        expanded = _expand_host_path("$AWF_AIRA_CHECKOUT_ROOT/x.env")
+        assert expanded == "/opt/aira/x.env"
+
+    @pytest.mark.unit
+    def test_missing_env_var_leaves_literal_unchanged(self) -> None:
+        """``os.path.expandvars`` leaves ``$NOT_SET`` as-is when the var
+        isn't set. Confirm the loader doesn't silently swallow that —
+        the subsequent file-read will fail loudly, which is what we
+        want (don't mount a bogus ``/...$NOT_SET...`` path)."""
+        expanded = _expand_host_path("$AWF_NOT_SET_ENV_VAR_PLS/x.env")
+        assert "$AWF_NOT_SET_ENV_VAR_PLS" in expanded
+
+    @pytest.mark.unit
+    def test_absolute_path_passes_through(self) -> None:
+        # An already-concrete absolute path is a no-op.
+        path = "/opt/aira/aira-agent/.env"
+        assert _expand_host_path(path) == path
+
+    @pytest.mark.unit
+    def test_tilde_and_env_compose(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both expansions applied: ``$CHECKOUT`` then ``~``. ``~``
+        only expands at the START of a path, so this checks the common
+        case where the caller wrote ``~/x`` and we still handle it."""
+        monkeypatch.setenv("AIRA_SUBPATH", "Projects/aira")
+        assert _expand_host_path("~/${AIRA_SUBPATH}/x.env") == str(
+            Path("~/Projects/aira/x.env").expanduser()
+        )

--- a/tests/unit/scripts/test_salvage_workspace.py
+++ b/tests/unit/scripts/test_salvage_workspace.py
@@ -1,0 +1,53 @@
+"""Tests for ``scripts.salvage_workspace`` no-op adapter factory.
+
+Scope: the closure-capture fix (CodeRabbit PR #2 feedback). Classes
+defined inside a for-loop that reference the loop variable share it by
+reference, so every factory was bound to the SAME runtime (the last
+one the loop saw) — a silent bug that would only surface when
+salvaging a workspace whose runtime wasn't the registry's final key.
+
+We don't exercise the real adapter path; just verify every factory
+reports its OWN runtime after ``_install_noop_adapter_factory`` runs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.adapters import base as _adapter_base
+from awf.adapters import registry as _registry  # noqa: F401 - populates registry
+from awf.db.enums import AgentRuntime
+from scripts.salvage_workspace import _install_noop_adapter_factory, _make_noop_factory
+
+
+class TestClosureCapture:
+    @pytest.mark.unit
+    def test_each_factory_binds_its_own_runtime(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """After installation, each registry entry must return an
+        adapter whose ``.name`` matches ITS key. The closure-capture
+        bug made every entry report the last-iterated runtime instead."""
+        # Snapshot + restore registry so the test doesn't pollute.
+        original_registry = dict(_adapter_base._REGISTRY)
+        monkeypatch.setattr(_adapter_base, "_REGISTRY", dict(original_registry))
+
+        _install_noop_adapter_factory()
+
+        for registered_runtime, factory_cls in _adapter_base._REGISTRY.items():
+            instance = factory_cls(runner=None, default_model=None)
+            assert instance.name == registered_runtime, (
+                f"factory for {registered_runtime.value} reports "
+                f"{instance.name.value} — closure-capture regression"
+            )
+
+    @pytest.mark.unit
+    def test_factory_builder_isolation(self) -> None:
+        """``_make_noop_factory`` is the extraction that fixed the bug —
+        each call must produce a class bound to the argument value, not
+        to whatever state the caller's loop variable happens to hold
+        later. Build two factories back-to-back, mutate nothing, and
+        verify they keep their distinct runtimes."""
+        codex_factory = _make_noop_factory(AgentRuntime.codex)
+        claude_factory = _make_noop_factory(AgentRuntime.claude_code)
+
+        assert codex_factory().name == AgentRuntime.codex
+        assert claude_factory().name == AgentRuntime.claude_code

--- a/tests/unit/scripts/test_schedule_release_pr_idempotency.py
+++ b/tests/unit/scripts/test_schedule_release_pr_idempotency.py
@@ -1,0 +1,195 @@
+"""Tests for ``scripts.schedule_release_pr._monitor_already_running``
+DB-based idempotency check.
+
+Scope: the runaway-watcher bug observed in production — the old
+process-based pgrep check saw a crashed run_awf.py as "no monitor
+running" and re-spawned on every tick. This created 122+ orphan
+workspace rows over 10 hours before cleanup. The DB-based check sees
+the stuck ``provisioning`` row and correctly skips re-spawning until
+the workspace transitions to a terminal state.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from scripts.schedule_release_pr import _monitor_already_running, _repo_url_variants
+
+
+def _make_awf_db(tmp_path: Path) -> Path:
+    """Create a minimal ``awf.db`` SQLite file with just the column
+    subset the idempotency check reads. We don't need the full AWF
+    schema — the check is a narrow SELECT."""
+    db_path = tmp_path / "awf.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE workspaces (
+            id TEXT PRIMARY KEY,
+            status TEXT NOT NULL,
+            task_kind TEXT NOT NULL,
+            repo_url TEXT NOT NULL,
+            pr_number INTEGER
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_ws(
+    db_path: Path,
+    *,
+    ws_id: str,
+    status: str,
+    task_kind: str = "sync_release_pr",
+    repo_url: str = "git@github.com:dimileeh/aira-web.git",
+    pr_number: int = 278,
+) -> None:
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "INSERT INTO workspaces (id, status, task_kind, repo_url, pr_number) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (ws_id, status, task_kind, repo_url, pr_number),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestDbBasedIdempotency:
+    @pytest.mark.unit
+    def test_missing_db_returns_false(self, tmp_path: Path) -> None:
+        """Scheduler may run before the driver has ever provisioned
+        anything in this work_dir — no DB file yet. Don't treat that
+        as 'already active' or we'd block the first legitimate
+        launch."""
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    def test_no_matching_row_returns_false(self, tmp_path: Path) -> None:
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(db_path, ws_id="w1", status="provisioning", pr_number=999)
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "status",
+        ["provisioning", "ready", "running", "validating", "pushing", "monitoring_pr"],
+    )
+    def test_non_terminal_row_returns_true(self, tmp_path: Path, status: str) -> None:
+        """Any non-terminal status counts as "active" — we're checking
+        that a real production state gets honored. The old bug was
+        the ``provisioning`` case specifically (crashed run_awf left
+        workspaces stuck there), but every non-terminal state deserves
+        the same treatment."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(db_path, ws_id="w1", status=status)
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is True
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("status", ["completed", "failed"])
+    def test_terminal_row_returns_false(self, tmp_path: Path, status: str) -> None:
+        """Terminal statuses must NOT block a re-spawn. After a
+        transient failure, the scheduler's next tick must be allowed
+        to retry. Without this, a single failed monitor would block
+        the release-PR workflow forever."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(db_path, ws_id="w1", status=status)
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    def test_different_pr_number_returns_false(self, tmp_path: Path) -> None:
+        """Scoping by pr_number: an active monitor for #277 doesn't
+        block a launch for #278 in the same repo."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(db_path, ws_id="w1", status="provisioning", pr_number=277)
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    def test_different_repo_returns_false(self, tmp_path: Path) -> None:
+        """Scoping by repo_url: an active monitor for aira-agent#1
+        doesn't block a launch for aira-web#1 in the same work_dir."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(
+            db_path,
+            ws_id="w1",
+            status="provisioning",
+            repo_url="git@github.com:dimileeh/aira-agent.git",
+            pr_number=1,
+        )
+        assert (
+            _monitor_already_running(work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=1)
+            is False
+        )
+
+    @pytest.mark.unit
+    def test_https_repo_url_variant_matches(self, tmp_path: Path) -> None:
+        """The AWF DB may have recorded ``https://github.com/...`` or
+        SSH form; the idempotency check must find both variants for
+        the same logical repo."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(
+            db_path,
+            ws_id="w1",
+            status="provisioning",
+            repo_url="https://github.com/dimileeh/aira-web",
+        )
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is True
+        )
+
+    @pytest.mark.unit
+    def test_wrong_task_kind_returns_false(self, tmp_path: Path) -> None:
+        """A ``feature_branch_pr`` workspace for the same PR number is
+        a different monitor class and must not suppress a
+        ``sync_release_pr`` launch."""
+        db_path = _make_awf_db(tmp_path)
+        _insert_ws(db_path, ws_id="w1", status="provisioning", task_kind="feature_branch_pr")
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+
+class TestRepoUrlVariants:
+    @pytest.mark.unit
+    def test_returns_ssh_and_https_forms(self) -> None:
+        variants = _repo_url_variants("dimileeh/aira-web")
+        assert "git@github.com:dimileeh/aira-web.git" in variants
+        assert "git@github.com:dimileeh/aira-web" in variants
+        assert "https://github.com/dimileeh/aira-web" in variants
+        assert "https://github.com/dimileeh/aira-web.git" in variants


### PR DESCRIPTION
## Summary

Follow-up to [PR #2](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/2). That PR shipped Phase 1.5e (validation fix-cycle loop); CodeRabbit + Gemini flagged 14 unresolved issues on files **outside** Phase 1.5e's scope — they came along because local `main` had 15 commits ahead of `origin/main`. This PR addresses all 14 properly, with TDD where applicable.

## Commits

Three focused commits, each standalone reviewable:

### `1ca5cb7` — 6 simpler fixes (one commit for the batch)

| # | Issue | Fix |
|---|---|---|
| 1 | Companion specs hardcoded `/home/dimileeh/…/.env` paths | New `_expand_host_path` helper in `run_awf.py` expands `~` and `${VAR}` at load time; all 4 checked-in specs updated to `~/…` |
| 2 | `salvage_workspace.py` closure-capture bug | Extracted `_make_noop_factory(runtime_value)` so each call closes the runtime by value |
| 3 | `pr_monitor_runner.py:138` `assert pr_number` | Replaced with `_terminate_failed` — same pattern the executor's `base_commit` guard uses |
| 4 | `schedule_release_pr.py` hardcoded `.venv/bin/python` + work_dir-unaware idempotency | Use `sys.executable`; match the FULL config path (not just filename) so concurrent AWF installs don't suppress each other |
| 5 | `release_pr_watcher.py` sync `subprocess.run` in async tick | `asyncio.create_subprocess_exec` + `communicate`; exit code drives `watcher.scheduler_launch_failed` / `_launched` log lines |
| 6 | `remonitor_workspace.py` wall-clock-cap reset pattern | Also reset `monitor_started_at = None` so wall-clock budget starts fresh |

8 new unit tests: 6 for path-expansion, 2 for closure-capture.

### `9a1f2f3` — 🔴 Critical: companion worktree collision

`run_awf.py:182` used `companion__{name}` as the worktree ID, no workspace scoping. Under `asyncio.gather()`, two workspaces with same-named companions (the common case — both need a `backend` from aira-agent) race on the shared path. We hit this multiple times this session. Fix:

- `_materialize_companion` now takes required `owner_workspace_id`; IDs become `companion__{workspace_id}__{name}` and branches `awf-companion/{workspace_id}-{name}`.
- All 3 call sites in `run_awf.py` updated to pass `ws_id`.
- Bonus: extracted `_configure_branch_push_upstream` to dedupe the three-command git-config block the two sync handlers were copy-pasting (flagged as `run_awf.py:487` generic CLI concern).

5 new unit tests: scoping, distinct paths for concurrent same-named companions, branch-name scoping, local build_context regression, env_file expansion regression.

### `527916e` — 🟠 Major: deferred-feedback merge gate

`pr_monitor.decide()` treated threads marked `"defer"` as "addressed" at step 2, so a PR with only-deferred unresolved feedback looked clean to the merge gate and auto-merged silently. Now step 7.5 explicitly returns `NotifyHuman` when any deferred thread is still unresolved on GitHub — the maintainer sees a "ready to merge, but…" comment AND the deferred thread still standing.

Properties:
- If maintainer resolves the deferred thread on GH → next poll unblocks merge automatically (no deadlock).
- Release-PR variant (`auto_merge=False`) behaviour unchanged (already `NotifyHuman`).
- Doesn't re-prompt the CLI on deferred threads (step 2's filter still excludes them from `AddressComments`).

5 new unit tests in `test_pr_monitor.py::TestDeferredFeedbackGate`. Rewrote the integration test at `test_pr_monitor_runner.py:556` (which was BAKING THE BUG INTO THE ASSERTION) to verify: no `resolveReviewThread` mutation + no `gh pr merge` call + terminal workspace state after NotifyHuman.

## Totals

- **375/375** unit tests pass (was 357; +18 new)
- `ruff check` + `ruff format --check` clean
- `mypy` clean
- No schema migrations needed (all state lives in existing `monitor_threads_addressed` dict)

## Test plan

- [x] `pytest tests/unit/` → 375 pass
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy` clean
- [ ] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - Prevents auto-merging when previously deferred reviewer feedback remains unresolved
  - Avoids monitor crashes when a workspace is missing PR metadata
  - More reliable duplicate-monitor detection and clearer scheduler outcome logging

* **Chores**
  - Use home-directory (~) and env-var expansion for companion env file paths to improve portability

* **Tests**
  - Added extensive tests covering PR monitoring, companion worktree scoping, path expansion, and failure-guard behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->