### PR TITLE
fix(feature-pr-sync): gh pr view doesn't have 'merged'/'closed' fields — derive from state

### DIFF
--- a/scripts/airaweb_issues_bulk_create_tasks.json
+++ b/scripts/airaweb_issues_bulk_create_tasks.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-agent/.env",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-web/.env.local",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/airaweb_only.json
+++ b/scripts/airaweb_only.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-agent/.env",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-web/.env.local",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/airaweb_release_monitor_companions.json
+++ b/scripts/airaweb_release_monitor_companions.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "backend",
+    "repo_url": "git@github.com:dimileeh/aira-agent.git",
+    "branch": "development",
+    "dockerfile": "Dockerfile",
+    "env_file": "~/Projects/aira/aira-agent/.env",
+    "environment": {
+      "AIRA_DATABASE_URL": "${POSTGRES_URL}",
+      "AIRA_ENV": "development"
+    },
+    "depends_on": [
+      "postgres"
+    ],
+    "healthcheck_cmd": "python -c 'import urllib.request,sys; sys.exit(0 if urllib.request.urlopen(\"http://localhost:8000/api/v1/health\", timeout=2).status==200 else 1)'"
+  },
+  {
+    "name": "web",
+    "repo_url": "git@github.com:dimileeh/aira-web.git",
+    "branch": "development",
+    "dockerfile": "Dockerfile",
+    "env_file": "~/Projects/aira/aira-web/.env.local",
+    "environment": {
+      "AGENT_SERVICE_URL": "http://backend:8000",
+      "NODE_ENV": "production"
+    },
+    "depends_on": [
+      "backend"
+    ],
+    "healthcheck_cmd": "node -e 'require(\"http\").get(\"http://localhost:3000\",r=>process.exit(r.statusCode>=400?1:0)).on(\"error\",()=>process.exit(1))'"
+  }
+]

--- a/scripts/airaweb_release_monitor_companions.json
+++ b/scripts/airaweb_release_monitor_companions.json
@@ -4,7 +4,7 @@
     "repo_url": "git@github.com:dimileeh/aira-agent.git",
     "branch": "development",
     "dockerfile": "Dockerfile",
-    "env_file": "~/Projects/aira/aira-agent/.env",
+    "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env",
     "environment": {
       "AIRA_DATABASE_URL": "${POSTGRES_URL}",
       "AIRA_ENV": "development"
@@ -19,7 +19,7 @@
     "repo_url": "git@github.com:dimileeh/aira-web.git",
     "branch": "development",
     "dockerfile": "Dockerfile",
-    "env_file": "~/Projects/aira/aira-web/.env.local",
+    "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-web/.env.local",
     "environment": {
       "AGENT_SERVICE_URL": "http://backend:8000",
       "NODE_ENV": "production"

--- a/scripts/airaweb_vitest_bff.json
+++ b/scripts/airaweb_vitest_bff.json
@@ -18,7 +18,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-agent/.env",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -31,7 +31,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-web/.env.local",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/real_tasks.json
+++ b/scripts/real_tasks.json
@@ -19,7 +19,7 @@
         "repo_url": "git@github.com:dimileeh/aira-agent.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-agent/.env",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env",
         "environment": {
           "AIRA_DATABASE_URL": "${POSTGRES_URL}",
           "AIRA_ENV": "development"
@@ -32,7 +32,7 @@
         "repo_url": "git@github.com:dimileeh/aira-web.git",
         "branch": "development",
         "dockerfile": "Dockerfile",
-        "env_file": "~/Projects/aira/aira-web/.env.local",
+        "env_file": "${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-web/.env.local",
         "environment": {
           "AGENT_SERVICE_URL": "http://backend:8000",
           "NODE_ENV": "production"

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -31,6 +31,7 @@ import argparse
 import asyncio
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -255,22 +256,49 @@ async def _configure_branch_push_upstream(
         await runner.run(["git", "-C", str(worktree_path), "config", *cfg_args])
 
 
+_DEFAULT_FALLBACK_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*):-([^}]*)\}")
+
+
 def _expand_host_path(path: str) -> str:
-    """Expand ``~`` and ``$VAR`` / ``${VAR}`` in a host-side path string.
+    """Expand ``~``, ``$VAR`` / ``${VAR}``, and ``${VAR:-default}`` in a
+    host-side path string.
 
     Companion specs reference host files by path (typically ``.env``
-    files on the operator's machine). Hardcoding absolute paths like
-    ``/home/dimileeh/Projects/aira/aira-agent/.env`` locks the spec to
-    one developer's filesystem; ``~/Projects/aira/aira-agent/.env`` and
-    ``${AWF_AIRA_CHECKOUT_ROOT}/aira-agent/.env`` both survive being
-    checked into the repo and run on someone else's machine.
+    files on the operator's machine). The progression of portability
+    options:
 
-    Review feedback on PR #2 (CodeRabbit): "hardcoded absolute paths
-    are machine-specific". Fix here, at the loader seam, so every
-    companion spec gets the same treatment without each having to
-    duplicate the expansion logic.
+      * Hardcoded absolute — ``/home/dimileeh/Projects/aira/…`` —
+        locks the spec to one developer's filesystem.
+      * ``~/...`` — portable across Unix users but assumes the same
+        directory structure under each HOME.
+      * ``${VAR}/...`` — needs the operator to set VAR; silently
+        fails if unset (``expandvars`` leaves ``${VAR}`` literal and
+        we'd try to open a nonexistent file).
+      * ``${VAR:-default}/...`` — best of both worlds: operator can
+        override with VAR, spec works out of the box if VAR is unset.
+        Shell syntax, so spec authors already know it.
+
+    Review feedback on PRs #2, #4 (CodeRabbit + gemini, repeated):
+    the plain ``~/Projects/aira`` path wasn't fully portable. This
+    helper now understands the shell ``${VAR:-default}`` idiom, so
+    a spec can say ``${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/…``
+    and an operator on a machine without that env var + without the
+    exact directory gets a clear error ("no such file") instead of
+    a silent broken mount.
     """
-    return str(Path(os.path.expandvars(path)).expanduser())
+
+    # Pre-expand ``${VAR:-default}`` BEFORE ``os.path.expandvars`` runs,
+    # because expandvars doesn't understand the :- syntax and would
+    # leave it literal.
+    def _resolve_fallback(match: re.Match[str]) -> str:
+        var_name, default = match.group(1), match.group(2)
+        return os.environ.get(var_name, default)
+
+    with_fallbacks = _DEFAULT_FALLBACK_PATTERN.sub(_resolve_fallback, path)
+    # Then the standard ${VAR} / $VAR expansion (for specs that
+    # deliberately don't want a fallback).
+    expanded = os.path.expandvars(with_fallbacks)
+    return str(Path(expanded).expanduser())
 
 
 async def _run_task_with_failure_guard(

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -290,9 +290,18 @@ def _expand_host_path(path: str) -> str:
     # Pre-expand ``${VAR:-default}`` BEFORE ``os.path.expandvars`` runs,
     # because expandvars doesn't understand the :- syntax and would
     # leave it literal.
+    #
+    # Shell ``:-`` semantics: use ``default`` when VAR is UNSET *OR*
+    # SET-TO-EMPTY. ``os.environ.get(var, default)`` only handles the
+    # UNSET case — a VAR exported as empty would return ``""`` and we'd
+    # end up with a bogus path like ``"/aira-agent/.env"`` that
+    # silently bind-mounts the filesystem root. Use ``or`` to collapse
+    # both "missing" and "empty" to the default, matching bash. (The
+    # non-colon variant ``${VAR-default}`` IS unset-only, but callers
+    # who want that can use plain ``${VAR}`` + expandvars.)
     def _resolve_fallback(match: re.Match[str]) -> str:
         var_name, default = match.group(1), match.group(2)
-        return os.environ.get(var_name, default)
+        return os.environ.get(var_name) or default
 
     with_fallbacks = _DEFAULT_FALLBACK_PATTERN.sub(_resolve_fallback, path)
     # Then the standard ${VAR} / $VAR expansion (for specs that

--- a/src/awf/runtime/feature_pr_sync.py
+++ b/src/awf/runtime/feature_pr_sync.py
@@ -84,10 +84,12 @@ class FeaturePRSyncError(Exception):
         super().__init__(f"{operation} failed: {stderr.strip() or '<no output>'}")
 
 
-# The set of fields we pull from ``gh pr view``. Keep in sync with
-# ``_parse_metadata`` — adding a field here without a parser update is
+# The set of fields we pull from ``gh pr view``. ``gh pr view --json``
+# does NOT accept ``merged`` or ``closed`` as field names — derive
+# both from ``state`` (one of ``OPEN`` / ``CLOSED`` / ``MERGED``) in
+# ``_parse_metadata``. Adding a field here without a parser update is
 # a silent drop on the floor.
-_PR_VIEW_JSON_FIELDS = "number,headRefName,baseRefName,state,isDraft,closed,merged,author,url,title"
+_PR_VIEW_JSON_FIELDS = "number,headRefName,baseRefName,state,isDraft,author,url,title"
 
 
 async def fetch_pr_metadata(
@@ -144,8 +146,13 @@ def _parse_metadata(payload: dict[str, Any]) -> FeaturePRMetadata:
         base_branch = payload["baseRefName"]
         state = payload["state"]
         is_draft = bool(payload.get("isDraft", False))
-        closed = bool(payload.get("closed", False))
-        merged = bool(payload.get("merged", False))
+        # ``gh pr view --json`` doesn't expose ``closed`` / ``merged``
+        # as separate boolean fields — derive both from ``state``,
+        # which is the canonical one-of {OPEN, CLOSED, MERGED}. Tests
+        # that stub the gh payload with explicit ``closed`` / ``merged``
+        # keys still work because we honour them if present.
+        closed = bool(payload.get("closed", state == "CLOSED"))
+        merged = bool(payload.get("merged", state == "MERGED"))
         url = payload["url"]
         title = payload.get("title", "")
     except (KeyError, TypeError, ValueError) as exc:

--- a/src/awf/runtime/feature_pr_sync.py
+++ b/src/awf/runtime/feature_pr_sync.py
@@ -146,13 +146,18 @@ def _parse_metadata(payload: dict[str, Any]) -> FeaturePRMetadata:
         base_branch = payload["baseRefName"]
         state = payload["state"]
         is_draft = bool(payload.get("isDraft", False))
-        # ``gh pr view --json`` doesn't expose ``closed`` / ``merged``
-        # as separate boolean fields — derive both from ``state``,
-        # which is the canonical one-of {OPEN, CLOSED, MERGED}. Tests
-        # that stub the gh payload with explicit ``closed`` / ``merged``
-        # keys still work because we honour them if present.
-        closed = bool(payload.get("closed", state == "CLOSED"))
-        merged = bool(payload.get("merged", state == "MERGED"))
+        # ``state`` is the canonical terminal-check source — one of
+        # OPEN / CLOSED / MERGED. Earlier this derivation honoured
+        # explicit ``closed`` / ``merged`` payload keys as overrides,
+        # but that let a stubbed / legacy payload with ``state=MERGED``
+        # + ``merged=false`` slip past the refusal checks below and
+        # spin up a workspace for a PR that can't transition. Trust
+        # ``state`` authoritatively — it's what gh returns and what
+        # we've already built the rest of the parser around. Review
+        # feedback on PR #4 (CodeRabbit): "Keep terminal-state refusal
+        # canonical even when legacy keys are present".
+        closed = state == "CLOSED"
+        merged = state == "MERGED"
         url = payload["url"]
         title = payload.get("title", "")
     except (KeyError, TypeError, ValueError) as exc:

--- a/tests/unit/runtime/test_feature_pr_sync.py
+++ b/tests/unit/runtime/test_feature_pr_sync.py
@@ -209,6 +209,134 @@ class TestGhCliErrors:
         assert "baserefname" in str(excinfo.value).lower() or "base" in str(excinfo.value).lower()
 
 
+class TestStateOnlyPayload:
+    """``gh pr view --json`` doesn't expose ``merged`` or ``closed`` as
+    boolean fields — only ``state`` (one of OPEN, CLOSED, MERGED).
+    Phase 1.5d originally requested those fields in the projection and
+    hit ``Unknown JSON field: merged`` at runtime (fatal: blocked
+    ``attach_feature_pr_monitor.py`` from attaching to PR #277). These
+    tests pin the real-gh shape — no ``closed`` / ``merged`` keys —
+    and verify we derive both from ``state``.
+
+    Separate class so the helpers above that still pass explicit
+    ``closed``/``merged`` keys (covering the full parse surface) keep
+    working — the parser honours explicit keys if present, falls back
+    to the state-derivation otherwise."""
+
+    @pytest.mark.unit
+    async def test_open_pr_state_only(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 277,
+                    "headRefName": "fix/sprints-ai-plan-button-guard",
+                    "baseRefName": "development",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "author": {"login": "dimileeh"},
+                    "url": "https://github.com/dimileeh/aira-web/pull/277",
+                    "title": "fix: sprints",
+                }
+            ),
+        )
+
+        result = await fetch_pr_metadata(runner=fake, repo=_REPO, pr_number=277)
+
+        assert result.state == "OPEN"
+        assert result.closed is False
+        assert result.merged is False
+
+    @pytest.mark.unit
+    async def test_closed_state_raises(self) -> None:
+        """No ``closed`` key, only ``state=CLOSED``. Parser must still
+        refuse — otherwise the CLI spins up a workspace for a PR that
+        can't transition."""
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 277,
+                    "headRefName": "fix/x",
+                    "baseRefName": "development",
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "author": {"login": "a"},
+                    "url": "https://github.com/x/y/pull/277",
+                    "title": "t",
+                }
+            ),
+        )
+
+        with pytest.raises(FeaturePRSyncError) as excinfo:
+            await fetch_pr_metadata(runner=fake, repo=_REPO, pr_number=277)
+        assert "closed" in str(excinfo.value).lower()
+
+    @pytest.mark.unit
+    async def test_merged_state_raises(self) -> None:
+        """Same for MERGED — derived from ``state``, not a separate key."""
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 277,
+                    "headRefName": "fix/x",
+                    "baseRefName": "development",
+                    "state": "MERGED",
+                    "isDraft": False,
+                    "author": {"login": "a"},
+                    "url": "https://github.com/x/y/pull/277",
+                    "title": "t",
+                }
+            ),
+        )
+
+        with pytest.raises(FeaturePRSyncError) as excinfo:
+            await fetch_pr_metadata(runner=fake, repo=_REPO, pr_number=277)
+        assert "merged" in str(excinfo.value).lower()
+
+    @pytest.mark.unit
+    async def test_gh_command_does_not_request_nonexistent_fields(self) -> None:
+        """The JSON field projection string we pass to ``gh pr view``
+        must stick to fields gh recognizes. Regression guard for the
+        concrete fix: if someone adds ``merged`` or ``closed`` to the
+        field list again, gh exits 1 with ``Unknown JSON field: ...``
+        and the whole CLI breaks."""
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "number": 1,
+                    "headRefName": "h",
+                    "baseRefName": "b",
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "author": {"login": "a"},
+                    "url": "u",
+                    "title": "t",
+                }
+            ),
+        )
+
+        await fetch_pr_metadata(runner=fake, repo=_REPO, pr_number=1)
+
+        assert len(fake.calls) == 1
+        # Extract the --json arg value.
+        args = fake.calls[0].args
+        json_flag_index = args.index("--json")
+        fields = args[json_flag_index + 1].split(",")
+        assert "merged" not in fields
+        assert "closed" not in fields
+        # And the real gh fields we DO rely on are still requested.
+        assert "state" in fields
+        assert "headRefName" in fields
+        assert "baseRefName" in fields
+
+
 def _metadata(**overrides) -> FeaturePRMetadata:
     defaults = {
         "number": 277,

--- a/tests/unit/scripts/test_run_awf_path_expansion.py
+++ b/tests/unit/scripts/test_run_awf_path_expansion.py
@@ -63,3 +63,51 @@ class TestExpandHostPath:
         assert _expand_host_path("~/${AIRA_SUBPATH}/x.env") == str(
             Path("~/Projects/aira/x.env").expanduser()
         )
+
+
+class TestShellFallbackSyntax:
+    """``${VAR:-default}`` lets specs self-describe their default so
+    an operator without the env var set still gets a sensible path.
+    Review feedback on PR #4 (CodeRabbit + gemini): ``~/Projects/aira``
+    isn't fully portable; an operator whose monorepo lives elsewhere
+    needs to override cleanly without hacking the spec."""
+
+    @pytest.mark.unit
+    def test_fallback_used_when_env_var_unset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AWF_AIRA_CHECKOUT_ROOT", raising=False)
+        expanded = _expand_host_path("${AWF_AIRA_CHECKOUT_ROOT:-/opt/aira}/aira-agent/.env")
+        assert expanded == "/opt/aira/aira-agent/.env"
+
+    @pytest.mark.unit
+    def test_env_var_wins_over_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AWF_AIRA_CHECKOUT_ROOT", "/custom/aira")
+        expanded = _expand_host_path("${AWF_AIRA_CHECKOUT_ROOT:-/opt/aira}/aira-agent/.env")
+        assert expanded == "/custom/aira/aira-agent/.env"
+
+    @pytest.mark.unit
+    def test_fallback_itself_gets_tilde_expanded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The default value inside ``${VAR:-default}`` should also
+        go through ``~`` expansion — that's the whole point of
+        providing ``~/Projects/aira`` as the default: operators with
+        the standard layout get a valid path, no env var required."""
+        monkeypatch.delenv("AWF_AIRA_CHECKOUT_ROOT", raising=False)
+        expanded = _expand_host_path("${AWF_AIRA_CHECKOUT_ROOT:-~/Projects/aira}/aira-agent/.env")
+        assert expanded == str(Path("~/Projects/aira/aira-agent/.env").expanduser())
+        assert not expanded.startswith("~")
+
+    @pytest.mark.unit
+    def test_empty_fallback_stays_empty_when_var_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Edge case: ``${VAR:-}`` means "empty string if unset". The
+        resulting path would be bogus but we still parse cleanly
+        (shell semantics, not ours to second-guess)."""
+        monkeypatch.delenv("AWF_MISSING_ENV_VAR", raising=False)
+        assert _expand_host_path("${AWF_MISSING_ENV_VAR:-}/x") == "/x"
+
+    @pytest.mark.unit
+    def test_no_fallback_still_works(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pre-existing ``${VAR}/path`` without ``:-`` still expands
+        exactly as before — the fallback is optional."""
+        monkeypatch.setenv("AWF_PATH_ONLY", "/just/path")
+        assert _expand_host_path("${AWF_PATH_ONLY}/x.env") == "/just/path/x.env"

--- a/tests/unit/scripts/test_run_awf_path_expansion.py
+++ b/tests/unit/scripts/test_run_awf_path_expansion.py
@@ -85,6 +85,21 @@ class TestShellFallbackSyntax:
         assert expanded == "/custom/aira/aira-agent/.env"
 
     @pytest.mark.unit
+    def test_empty_env_var_falls_back_bash_semantics(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Shell ``${VAR:-default}`` uses the default when VAR is set
+        but EMPTY, not just when unset. Without this contract a docker
+        envfile that exported ``AWF_AIRA_CHECKOUT_ROOT=`` (for any
+        reason — pipeline bug, human typo) would make
+        ``_expand_host_path`` produce ``/aira-agent/.env`` and we'd
+        bind-mount filesystem root into the container. Regression
+        guard for PR #4 review feedback (CodeRabbit Major):
+        ``os.environ.get(var, default)`` was handling only the unset
+        case; replaced with ``or default`` to cover both."""
+        monkeypatch.setenv("AWF_AIRA_CHECKOUT_ROOT", "")
+        expanded = _expand_host_path("${AWF_AIRA_CHECKOUT_ROOT:-/opt/aira}/aira-agent/.env")
+        assert expanded == "/opt/aira/aira-agent/.env"
+
+    @pytest.mark.unit
     def test_fallback_itself_gets_tilde_expanded(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The default value inside ``${VAR:-default}`` should also
         go through ``~`` expansion — that's the whole point of


### PR DESCRIPTION
## Summary

Two things:

1. **Bug fix** in `src/awf/runtime/feature_pr_sync.py`: Phase 1.5d (PR #1) built the `gh pr view --json ...` field projection with `merged` and `closed` as assumed boolean fields — but the gh CLI doesn't expose those. Only `state` (one of OPEN, CLOSED, MERGED) is canonical. `attach_feature_pr_monitor.py` crashed with `Unknown JSON field: "merged"` the moment I tried to attach a monitor to real PR #277 just now.

2. **New file** `scripts/airaweb_release_monitor_companions.json`: a standalone companions-list file extracted from the task specs, so `attach_feature_pr_monitor.py --companions` and `schedule_release_pr.py --companions` can both reference it. Was being written + used ad-hoc during the watcher cleanup; checking it in so it's reusable and discoverable.

## Why the tests missed it originally

The Phase 1.5d tests stubbed `gh pr view` payloads with explicit `closed` / `merged` keys (via the `_gh_pr_view_json` helper). That exercised the parser's `.get(...)` fallback, never the real gh-CLI shape. The bug only surfaced against a live gh invocation.

## Fix

- Dropped `merged` + `closed` from `_PR_VIEW_JSON_FIELDS`.
- `_parse_metadata` derives both booleans from `state`: `closed = state == "CLOSED"`, `merged = state == "MERGED"`. Keeps backward compat with the existing test stubs that DO set explicit keys (fallback: `payload.get("closed", state == "CLOSED")`).

## Tests

4 new cases in `TestStateOnlyPayload`:

- `test_open_pr_state_only` — real gh shape (no `closed`/`merged` keys) parses correctly
- `test_closed_state_raises` — `state=CLOSED` alone triggers pre-spawn refusal
- `test_merged_state_raises` — same for `state=MERGED`
- `test_gh_command_does_not_request_nonexistent_fields` — **regression guard**: asserts the `--json` arg contains neither `merged` nor `closed`, and still contains `state`/`headRefName`/`baseRefName`. This is the test that would have caught the bug in Phase 1.5d.

Full suite: 399/399 pass. mypy + ruff + format clean.

## Verified live

After this fix, `attach_feature_pr_monitor.py --pr 277` successfully attached a monitor to aira-web PR #277, which is now running in the background (`ws_ba640d92…`, provisioning → compose-up). Same for `schedule_release_pr.py --attach-monitor` for PR #278 (`ws_6b8330a…`). Both companion worktrees use the PR #3 scoped naming (`companion__ws_…__web`) — no collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a release-monitoring companion configuration and made companion env-file paths configurable via a checkout-root fallback; companion services now include healthchecks and environment wiring.
  * Improved host-path expansion to support shell-style fallbacks (e.g., ${VAR:-default}).

* **Bug Fixes**
  * Tightened PR metadata parsing to derive closed/merged from the canonical state value only.

* **Tests**
  * Added/updated unit tests covering path expansion and PR metadata behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->