### PR TITLE
fix(executor): auto-recover from agent branch drift

### DIFF
--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -21,6 +21,31 @@ from awf.db.enums import AgentRuntime
 _log = get_logger(__name__)
 
 
+# Prepended to every agent prompt. Encodes contract invariants the
+# agent must honour inside an AWF workspace. Kept short — most agent
+# CLIs accept prompts as command-line args and some have length caps.
+_AWF_PROMPT_PREAMBLE = """\
+## AWF workspace contract (DO NOT VIOLATE)
+
+You are inside an AWF-managed Docker workspace at /workspace, on a git
+branch that AWF has already created for you. Your contract:
+
+1. **DO NOT switch git branches.** Do not run `git checkout -b <name>`,
+   `git switch -c <name>`, `git branch <name>`, `git checkout <name>`,
+   or any equivalent. Commit ALL work on the current branch. AWF owns
+   branch management. Drifting to a "properly named" feature branch
+   strands your commits and the PR ends up empty.
+2. **DO NOT push, rebase onto origin, or force-push.** AWF handles
+   push + PR creation after you exit.
+3. Commit your work locally as you go (`git add` + `git commit` is
+   fine). AWF's post-agent step will also capture any uncommitted
+   changes, but commits with good messages are preferred.
+
+---
+
+"""
+
+
 @dataclass(frozen=True)
 class AgentRunResult:
     """Structured result of one coding-CLI run."""
@@ -91,8 +116,19 @@ class AgentAdapter(ABC):
         """Invoke the coding CLI inside the workspace's agent container.
 
         Raises ``AgentRunError`` on non-zero exit.
+
+        The user-supplied ``prompt`` is wrapped with an AWF preamble
+        that encodes contract invariants the agent must honour — most
+        notably "do not switch git branches". Agent CLIs (Claude Code,
+        Codex) sometimes run ``git checkout -b <name>`` mid-session as
+        part of their own "good git hygiene" heuristics, but AWF has
+        already created the right branch on entry; drifting strands
+        the agent's commits on an orphan branch and the PR ends up
+        empty. Preamble + post-agent branch-drift recovery in
+        ``control/executor.py`` form a belt-and-braces defence.
         """
-        cli_args = self._cli_args(prompt=prompt, model=model or self._default_model)
+        wrapped_prompt = _AWF_PROMPT_PREAMBLE + prompt
+        cli_args = self._cli_args(prompt=wrapped_prompt, model=model or self._default_model)
         args = [
             "docker",
             "compose",

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -205,7 +205,72 @@ class WorkspaceExecutor:
         async def _git_in_worktree(args: list[str]):  # type: ignore[no-untyped-def]
             return await self._runner.run(["git", "-C", str(worktree_host), *args])
 
+        expected_branch = ws.branch_name or f"awf/{workspace_id}"
+
         try:
+            # ── Branch-drift recovery ──────────────────────────────────
+            # Agent CLIs (Claude Code, Codex) sometimes run
+            # ``git checkout -b <descriptive-name>`` mid-session as part
+            # of "good git hygiene" — they don't know AWF already
+            # created the right branch for them. If they commit on the
+            # drifted branch, ``pr_creator.push_and_open`` pushes the
+            # original (empty) AWF branch to origin and ``gh pr create``
+            # fails with "No commits between development and awf/ws_...".
+            #
+            # Incident 2026-04-24 (T41 Phase 3, ws_9ca6134a): agent
+            # switched to ``awf/t41-phase3-github-app-install-flow``
+            # and committed there. AWF's push of the empty
+            # ``awf/ws_9ca6134a...`` created a no-op PR. Agent's work
+            # stranded in the worktree.
+            #
+            # Recovery: if HEAD's branch diverged, fast-forward the
+            # expected branch to the agent's tip. Both branches share
+            # the same base commit (the worktree was created fresh
+            # from origin/<base>), so this is a safe pointer update.
+            current_branch_r = await _git_in_worktree(["rev-parse", "--abbrev-ref", "HEAD"])
+            current_branch = (current_branch_r.stdout or "").strip()
+            if current_branch and current_branch != expected_branch:
+                _log.warning(
+                    "executor.branch_drift_detected",
+                    workspace_id=workspace_id,
+                    current_branch=current_branch,
+                    expected_branch=expected_branch,
+                )
+                agent_head_r = await _git_in_worktree(["rev-parse", "HEAD"])
+                agent_head = (agent_head_r.stdout or "").strip()
+                if not agent_head_r.ok or not agent_head:
+                    raise RuntimeError(
+                        f"branch drift detected (current={current_branch} "
+                        f"expected={expected_branch}) but agent HEAD could not "
+                        f"be resolved: {agent_head_r.stderr!r}"
+                    )
+                # Switch to the expected branch. It should exist locally
+                # — AWF created it at worktree-add time. ``switch`` over
+                # ``checkout`` for clearer semantics.
+                switch_r = await _git_in_worktree(["switch", expected_branch])
+                if not switch_r.ok:
+                    raise RuntimeError(
+                        f"branch drift recovery: could not switch back to "
+                        f"{expected_branch}: {switch_r.stderr!r}"
+                    )
+                # Fast-forward to the agent's tip. ``reset --hard`` over
+                # ``merge --ff-only`` because both branches share the
+                # same base and the agent branch was linear work on
+                # top; ff-only would also work but reset is explicit.
+                reset_r = await _git_in_worktree(["reset", "--hard", agent_head])
+                if not reset_r.ok:
+                    raise RuntimeError(
+                        f"branch drift recovery: reset --hard {agent_head[:10]} "
+                        f"failed: {reset_r.stderr!r}"
+                    )
+                _log.info(
+                    "executor.branch_drift_recovered",
+                    workspace_id=workspace_id,
+                    recovered_from=current_branch,
+                    recovered_to=expected_branch,
+                    head_sha=agent_head,
+                )
+
             await _git_in_worktree(["add", "-A"])
             cached = await _git_in_worktree(["diff", "--cached", "--name-only"])
             if cached.stdout.strip():

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -228,6 +228,17 @@ class WorkspaceExecutor:
             # the same base commit (the worktree was created fresh
             # from origin/<base>), so this is a safe pointer update.
             current_branch_r = await _git_in_worktree(["rev-parse", "--abbrev-ref", "HEAD"])
+            # If rev-parse itself failed (corrupted git state, missing
+            # HEAD, etc.) we can't reliably detect drift. Fail loudly
+            # rather than silently skip — a working tree that can't
+            # resolve HEAD is broken enough that continuing to push
+            # would produce nonsense anyway.
+            if not current_branch_r.ok:
+                raise RuntimeError(
+                    "branch drift check: ``git rev-parse --abbrev-ref HEAD`` "
+                    f"failed with exit {current_branch_r.returncode}: "
+                    f"{current_branch_r.stderr!r}"
+                )
             current_branch = (current_branch_r.stdout or "").strip()
             if current_branch and current_branch != expected_branch:
                 _log.warning(
@@ -244,31 +255,96 @@ class WorkspaceExecutor:
                         f"expected={expected_branch}) but agent HEAD could not "
                         f"be resolved: {agent_head_r.stderr!r}"
                     )
-                # Switch to the expected branch. It should exist locally
-                # — AWF created it at worktree-add time. ``switch`` over
-                # ``checkout`` for clearer semantics.
+                # Preserve uncommitted changes. The executor's core
+                # contract is "salvage whatever the agent left on
+                # disk" — including edits not yet committed on the
+                # drifted branch. ``status --porcelain`` with
+                # ``--untracked-files=all`` catches both staged,
+                # unstaged, and untracked files. If any exist, stash
+                # them (with ``-u`` to include untracked) before the
+                # ``switch`` so they don't get lost. Pop after the
+                # fast-forward so they end up on top of the agent's
+                # commits on the expected branch.
+                status_r = await _git_in_worktree(
+                    ["status", "--porcelain=v1", "--untracked-files=all"]
+                )
+                if not status_r.ok:
+                    raise RuntimeError(
+                        f"branch drift recovery: ``git status`` failed: {status_r.stderr!r}"
+                    )
+                has_wip = bool(status_r.stdout.strip())
+                stash_created = False
+                if has_wip:
+                    stash_r = await _git_in_worktree(
+                        [
+                            "stash",
+                            "push",
+                            "--include-untracked",
+                            "--message",
+                            f"awf-drift-recovery-{workspace_id}",
+                        ]
+                    )
+                    if not stash_r.ok:
+                        raise RuntimeError(
+                            f"branch drift recovery: ``git stash push`` failed: "
+                            f"{stash_r.stderr!r} (refusing to switch with dirty "
+                            f"worktree that couldn't be stashed)"
+                        )
+                    stash_created = True
+
+                # Switch to the expected branch. It should exist
+                # locally — AWF created it at worktree-add time.
                 switch_r = await _git_in_worktree(["switch", expected_branch])
                 if not switch_r.ok:
+                    # Best-effort: try to restore stashed WIP so it's
+                    # not silently lost before bailing out.
+                    if stash_created:
+                        await _git_in_worktree(["stash", "pop"])
                     raise RuntimeError(
                         f"branch drift recovery: could not switch back to "
                         f"{expected_branch}: {switch_r.stderr!r}"
                     )
-                # Fast-forward to the agent's tip. ``reset --hard`` over
-                # ``merge --ff-only`` because both branches share the
-                # same base and the agent branch was linear work on
-                # top; ff-only would also work but reset is explicit.
-                reset_r = await _git_in_worktree(["reset", "--hard", agent_head])
-                if not reset_r.ok:
+                # Fast-forward the expected branch to the agent's tip
+                # using ``merge --ff-only``. The two branches share
+                # the same base (AWF created the worktree fresh from
+                # ``origin/<base>``) and the agent only added commits
+                # on top, so ff must succeed. ``merge --ff-only`` over
+                # ``reset --hard`` because the latter would also wipe
+                # any WIP the user has in the working tree if the
+                # stash step above silently did nothing (e.g. if
+                # ``status`` missed an edge case).
+                merge_r = await _git_in_worktree(["merge", "--ff-only", agent_head])
+                if not merge_r.ok:
+                    if stash_created:
+                        await _git_in_worktree(["stash", "pop"])
                     raise RuntimeError(
-                        f"branch drift recovery: reset --hard {agent_head[:10]} "
-                        f"failed: {reset_r.stderr!r}"
+                        f"branch drift recovery: ``merge --ff-only "
+                        f"{agent_head[:10]}`` failed: {merge_r.stderr!r}"
                     )
+
+                if stash_created:
+                    pop_r = await _git_in_worktree(["stash", "pop"])
+                    if not pop_r.ok:
+                        # A pop conflict means the agent's WIP and the
+                        # fast-forwarded commits touch the same
+                        # regions. That's a real problem for the
+                        # workspace — the WIP is left in the stash
+                        # under a named entry, but we can't auto-merge
+                        # it. Fail loudly so the operator knows to
+                        # inspect.
+                        raise RuntimeError(
+                            f"branch drift recovery: ``git stash pop`` failed "
+                            f"(WIP conflicts with recovered commits): "
+                            f"{pop_r.stderr!r}"
+                        )
+
                 _log.info(
                     "executor.branch_drift_recovered",
                     workspace_id=workspace_id,
                     recovered_from=current_branch,
                     recovered_to=expected_branch,
                     head_sha=agent_head,
+                    wip_stashed=has_wip,
                 )
 
             await _git_in_worktree(["add", "-A"])

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -64,7 +64,12 @@ class TestCodexAdapter:
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
         ]
-        assert args[-1] == _PROMPT
+        # AWF prepends a contract preamble ("do not switch branches")
+        # before the user-supplied prompt; the last argv element is
+        # therefore the wrapped form. Check the user prompt is the
+        # trailing substring so the assertion survives preamble edits.
+        assert args[-1].endswith(_PROMPT)
+        assert "AWF workspace contract" in args[-1]
         assert "--model" in args and "gpt-5" in args
         assert "-c" in args
         assert any(a.startswith("model_reasoning_effort=") for a in args)
@@ -120,7 +125,12 @@ class TestClaudeCodeAdapter:
         ]
         # -p signals non-interactive print mode.
         assert args[-2] == "-p"
-        assert args[-1] == _PROMPT
+        # AWF prepends a contract preamble ("do not switch branches")
+        # before the user-supplied prompt; the last argv element is
+        # therefore the wrapped form. Check the user prompt is the
+        # trailing substring so the assertion survives preamble edits.
+        assert args[-1].endswith(_PROMPT)
+        assert "AWF workspace contract" in args[-1]
         assert "--model" in args and "sonnet" in args
 
 
@@ -141,7 +151,12 @@ class TestGeminiAdapter:
         gemini_start = args.index("gemini")
         assert args[gemini_start : gemini_start + 2] == ["gemini", "--yolo"]
         assert args[-2] == "-p"
-        assert args[-1] == _PROMPT
+        # AWF prepends a contract preamble ("do not switch branches")
+        # before the user-supplied prompt; the last argv element is
+        # therefore the wrapped form. Check the user prompt is the
+        # trailing substring so the assertion survives preamble edits.
+        assert args[-1].endswith(_PROMPT)
+        assert "AWF workspace contract" in args[-1]
         assert "-m" in args and "gemini-2.5-pro" in args
 
 

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -200,9 +200,13 @@ class TestFailurePaths:
         # workspace fails with agent_failure before validation runs.
         ws_id = await _seed_ready_workspace(factory)
         fake.queue_result(returncode=2, stderr="codex: auth failed")  # adapter dies
+        # Executor checks branch drift before the commit block
+        # (rev-parse --abbrev-ref HEAD). Return the expected branch
+        # name (awf/<ws_id>) to skip the recovery path.
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # abbrev-ref
         fake.queue_result(returncode=0)  # git add -A (no-op)
-        fake.queue_result(returncode=0, stdout="")  # diff --cached is empty
-        fake.queue_result(returncode=0, stdout="0\n")  # rev-list base..HEAD = 0
+        fake.queue_result(returncode=0, stdout="")  # diff --cached empty
+        fake.queue_result(returncode=0, stdout="0\n")  # rev-list = 0
 
         await executor.execute(ws_id)
 
@@ -211,8 +215,9 @@ class TestFailurePaths:
             assert ws is not None
             assert ws.status == WorkspaceStatus.failed.value
             assert ws.failure_reason == "agent_failure"
-        # Validation + PR never ran.
-        assert len(fake.calls) == 4
+        # Validation + PR never ran; 5 subprocess calls total (adapter
+        # + drift-check + add + diff + rev-list).
+        assert len(fake.calls) == 5
 
     @pytest.mark.unit
     async def test_agent_killed_with_uncommitted_work_is_salvaged(

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -220,6 +220,109 @@ class TestUnexpectedErrorDuringAgentRun:
             assert "unexpected error" in (ws.failure_message or "")
 
 
+class TestBranchDriftRecovery:
+    """2026-04-24 incident (T41 Phase 3, ws_9ca6134a): agent CLI
+    switched to a custom branch and committed there. pr_creator
+    pushed the original empty branch → PR ended up empty.
+
+    Fix: executor detects branch drift before the commit step and
+    fast-forwards the expected branch to the agent's HEAD."""
+
+    @pytest.mark.unit
+    async def test_drift_to_named_branch_is_recovered(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")  # adapter
+        fake.queue_result(returncode=0, stdout="awf/feature-x\n")  # abbrev-ref → drifted
+        fake.queue_result(returncode=0, stdout="deadbeef12345\n")  # rev-parse HEAD
+        fake.queue_result(returncode=0)  # git switch awf/x
+        fake.queue_result(returncode=0)  # git reset --hard deadbeef12345
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="a.py\n")  # diff --cached
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="sha\n")  # pre-push rev-parse HEAD
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # pre-push abbrev-ref
+        fake.queue_result(returncode=0, stdout="ab commit\n")  # pre-push log
+        fake.queue_result(returncode=0)  # git push
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/1\n")
+
+        executor = _make_executor(fake, factory, tmp_path)
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+        argvs = [c.args for c in fake.calls]
+        switch_calls = [a for a in argvs if "switch" in a and "awf/x" in a]
+        assert len(switch_calls) == 1, f"expected one ``git switch awf/x``; got {argvs}"
+        reset_calls = [a for a in argvs if "reset" in a and "--hard" in a and "deadbeef12345" in a]
+        assert len(reset_calls) == 1
+
+    @pytest.mark.unit
+    async def test_no_drift_skips_recovery(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # current == expected
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="a.py\n")
+        fake.queue_result(returncode=0)  # commit
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="tests ok")
+        fake.queue_result(returncode=0, stdout="sha\n")
+        fake.queue_result(returncode=0, stdout="awf/x\n")
+        fake.queue_result(returncode=0, stdout="ab commit\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/1\n")
+
+        executor = _make_executor(fake, factory, tmp_path)
+        await executor.execute(ws_id)
+
+        argvs = [c.args for c in fake.calls]
+        switch_calls = [a for a in argvs if "switch" in a]
+        reset_hard_calls = [a for a in argvs if "reset" in a and "--hard" in a]
+        assert switch_calls == []
+        assert reset_hard_calls == []
+
+    @pytest.mark.unit
+    async def test_drift_recovery_switch_fails_marks_workspace_failed(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """If the recovery itself fails (expected branch missing,
+        corrupted refs), fail loudly rather than fall back to the
+        no-op push that created the original incident."""
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/something-else\n")
+        fake.queue_result(returncode=0, stdout="abc123\n")
+        fake.queue_result(returncode=1, stderr="fatal: invalid reference: awf/x")
+
+        executor = _make_executor(fake, factory, tmp_path)
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert "branch drift" in (ws.failure_message or "")
+
+
 class TestCommitStepRuntimeError:
     @pytest.mark.unit
     async def test_nonzero_git_commit_raises_and_marks_failed(
@@ -233,6 +336,7 @@ class TestCommitStepRuntimeError:
         by the generic except → mark infrastructure_failure."""
         ws_id = await _seed_ready(factory)
         fake.queue_result(returncode=0, stdout="adapter ok")  # agent
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # drift-check: on expected branch
         fake.queue_result(returncode=0)  # git add
         fake.queue_result(returncode=0, stdout="a.py\n")  # cached diff (non-empty)
         fake.queue_result(

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -229,18 +229,21 @@ class TestBranchDriftRecovery:
     fast-forwards the expected branch to the agent's HEAD."""
 
     @pytest.mark.unit
-    async def test_drift_to_named_branch_is_recovered(
+    async def test_drift_with_clean_worktree_is_recovered(
         self,
         fake: FakeCommandRunner,
         factory: async_sessionmaker[AsyncSession],
         tmp_path: Path,
     ) -> None:
+        """Clean-worktree drift path: agent switched and committed,
+        left nothing uncommitted. Recovery: switch back + ff-merge."""
         ws_id = await _seed_ready(factory)
         fake.queue_result(returncode=0, stdout="adapter ok")  # adapter
         fake.queue_result(returncode=0, stdout="awf/feature-x\n")  # abbrev-ref → drifted
         fake.queue_result(returncode=0, stdout="deadbeef12345\n")  # rev-parse HEAD
+        fake.queue_result(returncode=0, stdout="")  # status --porcelain (clean)
         fake.queue_result(returncode=0)  # git switch awf/x
-        fake.queue_result(returncode=0)  # git reset --hard deadbeef12345
+        fake.queue_result(returncode=0)  # git merge --ff-only deadbeef12345
         fake.queue_result(returncode=0)  # git add -A
         fake.queue_result(returncode=0, stdout="a.py\n")  # diff --cached
         fake.queue_result(returncode=0)  # git commit
@@ -261,10 +264,105 @@ class TestBranchDriftRecovery:
             assert ws is not None
             assert ws.status == WorkspaceStatus.completed.value
         argvs = [c.args for c in fake.calls]
-        switch_calls = [a for a in argvs if "switch" in a and "awf/x" in a]
-        assert len(switch_calls) == 1, f"expected one ``git switch awf/x``; got {argvs}"
+        # ff-only merge (not reset --hard) — preserves working tree.
+        merge_calls = [
+            a for a in argvs if "merge" in a and "--ff-only" in a and "deadbeef12345" in a
+        ]
+        assert len(merge_calls) == 1, f"expected one ``merge --ff-only``; got {argvs}"
+        # No ``reset --hard`` against the agent head — reset would wipe WIP.
         reset_calls = [a for a in argvs if "reset" in a and "--hard" in a and "deadbeef12345" in a]
-        assert len(reset_calls) == 1
+        assert reset_calls == [], (
+            f"drift recovery must not ``reset --hard`` the agent's HEAD — "
+            f"that would wipe any WIP the agent left. Use ``merge --ff-only``. "
+            f"Full argvs: {argvs}"
+        )
+        switch_calls = [a for a in argvs if "switch" in a and "awf/x" in a]
+        assert len(switch_calls) == 1
+        # No stash activity when the worktree was clean.
+        stash_calls = [a for a in argvs if "stash" in a]
+        assert stash_calls == []
+
+    @pytest.mark.unit
+    async def test_drift_with_uncommitted_wip_preserves_it(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """CodeRabbit + gemini feedback on PR #7: if the agent drifted
+        to ``feature-x``, committed some work, AND left other edits
+        uncommitted, the naive ``reset --hard`` would wipe the WIP.
+        Recovery must stash WIP → switch → ff-merge → pop."""
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")  # adapter
+        fake.queue_result(returncode=0, stdout="awf/feature-x\n")  # abbrev-ref
+        fake.queue_result(returncode=0, stdout="deadbeef12345\n")  # rev-parse HEAD
+        fake.queue_result(
+            returncode=0, stdout=" M src/wip.py\n?? new-untracked.txt\n"
+        )  # status: HAS WIP (both modified and untracked)
+        fake.queue_result(returncode=0, stdout="Saved working directory")  # stash push
+        fake.queue_result(returncode=0)  # git switch awf/x
+        fake.queue_result(returncode=0)  # git merge --ff-only deadbeef12345
+        fake.queue_result(returncode=0, stdout="On branch awf/x")  # stash pop
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="a.py\n")
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="tests ok")
+        fake.queue_result(returncode=0, stdout="sha\n")
+        fake.queue_result(returncode=0, stdout="awf/x\n")
+        fake.queue_result(returncode=0, stdout="ab commit\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/1\n")
+
+        executor = _make_executor(fake, factory, tmp_path)
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+        argvs = [c.args for c in fake.calls]
+        # Stash push BEFORE switch, pop AFTER merge.
+        stash_push_calls = [a for a in argvs if "stash" in a and "push" in a]
+        stash_pop_calls = [a for a in argvs if "stash" in a and "pop" in a]
+        assert len(stash_push_calls) == 1, f"WIP must be stashed before switch; got {argvs}"
+        assert len(stash_pop_calls) == 1, f"WIP must be popped after ff-merge; got {argvs}"
+        # stash push includes --include-untracked
+        assert "--include-untracked" in stash_push_calls[0]
+
+    @pytest.mark.unit
+    async def test_drift_stash_pop_conflict_surfaces(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """If ``git stash pop`` conflicts (agent's WIP and the
+        fast-forwarded commits touch the same regions), surface it as
+        a workspace failure rather than silently leave the operator
+        with a dirty tree and no signal."""
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/feature-x\n")
+        fake.queue_result(returncode=0, stdout="abc123\n")
+        fake.queue_result(returncode=0, stdout=" M conflicted.py\n")
+        fake.queue_result(returncode=0, stdout="Saved")  # stash push ok
+        fake.queue_result(returncode=0)  # switch ok
+        fake.queue_result(returncode=0)  # ff-merge ok
+        fake.queue_result(
+            returncode=1, stderr="CONFLICT (content): Merge conflict in conflicted.py"
+        )  # stash pop FAILS
+
+        executor = _make_executor(fake, factory, tmp_path)
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert "stash pop" in (ws.failure_message or "")
 
     @pytest.mark.unit
     async def test_no_drift_skips_recovery(
@@ -309,9 +407,10 @@ class TestBranchDriftRecovery:
         no-op push that created the original incident."""
         ws_id = await _seed_ready(factory)
         fake.queue_result(returncode=0, stdout="adapter ok")
-        fake.queue_result(returncode=0, stdout="awf/something-else\n")
-        fake.queue_result(returncode=0, stdout="abc123\n")
-        fake.queue_result(returncode=1, stderr="fatal: invalid reference: awf/x")
+        fake.queue_result(returncode=0, stdout="awf/something-else\n")  # abbrev-ref
+        fake.queue_result(returncode=0, stdout="abc123\n")  # rev-parse HEAD
+        fake.queue_result(returncode=0, stdout="")  # status (clean)
+        fake.queue_result(returncode=1, stderr="fatal: invalid reference: awf/x")  # switch FAILS
 
         executor = _make_executor(fake, factory, tmp_path)
         await executor.execute(ws_id)


### PR DESCRIPTION
## Summary

2026-04-24 incident (T41 Phase 3, ws_9ca6134a): Claude Code ran \`git checkout -b awf/t41-phase3-github-app-install-flow\` mid-session and committed there. AWF's \`pr_creator.push_and_open\` pushed the original (empty) \`awf/ws_9ca6134a...\` branch → \`gh pr create\` failed with "No commits between development and awf/ws_9ca6134a...". Agent work stranded.

## Root cause

Agent CLIs (Claude Code, Codex) have internal "good git hygiene" heuristics that favour descriptively-named branches. They don't know AWF already set up the right branch on entry. AWF's prompt never said "do not switch branches" and the post-agent pipeline never detected drift.

## Fix — two layers

**1. Preamble (prevention)** — \`src/awf/adapters/base.py\` prepends an AWF contract preamble to every agent prompt. Explicitly forbids \`git checkout -b\`, \`git switch -c\`, branch creation/switch. Inherited by every runtime (codex/claude_code/gemini).

**2. Auto-recovery (detection)** — \`src/awf/control/executor.py\` runs \`git rev-parse --abbrev-ref HEAD\` after the agent exits. If the current branch != \`ws.branch_name\`, it captures the drifted branch's HEAD SHA, \`git switch\`es back to the expected branch, and \`git reset --hard\`s to the SHA. Both branches share base so this is a safe pointer update. If recovery itself fails, workspace fails loudly with "branch drift" in the message rather than silently pushing empty.

## Regression tests

\`TestBranchDriftRecovery\`:
- \`test_drift_to_named_branch_is_recovered\` — full recovery path.
- \`test_no_drift_skips_recovery\` — happy path, no switch/reset fires.
- \`test_drift_recovery_switch_fails_marks_workspace_failed\` — recovery failure surfaces to the workspace.

## Test plan

- [x] 574 tests pass
- [x] ruff format + check clean
- [x] Adapter tests updated to assert the prompt preamble wrapping
- [x] Two existing executor tests got an extra rev-parse queue entry for the new drift check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Executor now automatically detects when the working directory branch deviates from the expected state and recovers by switching to the correct branch and synchronizing with the latest changes.

* **Tests**
  * Updated adapter tests to accommodate enhanced prompt formatting.
  * Added comprehensive test coverage for branch state detection, automatic recovery, and related failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->