### PR TITLE
fix(scheduler): cooldown after terminal workspace failures

### DIFF
--- a/scripts/schedule_release_pr.py
+++ b/scripts/schedule_release_pr.py
@@ -151,27 +151,38 @@ async def _main(
     return 0
 
 
-def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) -> bool:
-    """True iff a sync_release_pr workspace for this (repo, PR) is
-    active in this ``work_dir``'s AWF DB.
+# Cooldown: after a workspace for this PR terminates (completed or
+# failed), don't respawn for ``_MONITOR_COOLDOWN_SECONDS``. Prevents
+# retry storms when a deterministic failure (docker network pool
+# exhausted, stale secret, etc.) would otherwise cause the watcher to
+# burn a new workspace every tick.
+#
+# 2026-04-24 incident: ~180 failed sync_release_pr workspaces in 6h
+# because the compose-up fail-fast path created terminal rows
+# instantly, and the "non-terminal" idempotency check bypassed them.
+# The cooldown is 5 min so a transient issue gets one retry per
+# 5 min — enough to recover without spam.
+_MONITOR_COOLDOWN_SECONDS = 300
 
-    Active = any workspace row where ``task_kind='sync_release_pr'``,
-    ``repo_url`` matches, ``pr_number`` matches, and ``status`` is
-    NOT terminal (not in ``{completed, failed}``).
+
+def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) -> bool:
+    """True iff we should skip spawning a new monitor for this PR.
+
+    Skips when EITHER:
+      a) a non-terminal workspace row already exists (classic "already
+         running" case — another process is handling it), OR
+      b) the most-recent terminal workspace row for this PR is younger
+         than ``_MONITOR_COOLDOWN_SECONDS`` (cooldown after failure).
+
+    (b) is the 2026-04-24 fix. Without it, a deterministic failure
+    path (docker network pool full, auth expired, etc.) would let the
+    watcher spawn a new workspace every tick (~2 min), producing 30+
+    failed rows per hour and never recovering because each attempt
+    fails the same way.
 
     Originally a process-based ``pgrep run_awf.py`` check. That was
-    fragile: a run_awf.py that crashes fast (e.g. docker network pool
-    exhausted at compose-up — we hit this in production) leaves a
-    ``provisioning`` workspace row behind but NO process. Next tick
-    the pgrep check finds nothing, spawns another workspace that
-    also dies, and the scheduler spins forever creating orphan rows.
-
-    DB-based check sees the stuck ``provisioning`` row and correctly
-    reports "already active" so the next tick skips re-spawning. When
-    combined with the driver's ``_run_task_with_failure_guard`` —
-    which marks orphaned rows failed on exception — the scheduler
-    spawns exactly one retry after each terminal failure, not a
-    retry-storm.
+    fragile: a run_awf.py that crashes fast leaves a ``provisioning``
+    row but NO process. DB-based check catches both cases.
     """
     # SQLite DB lives at ``<work_dir>/awf.db``. The scheduler may run
     # before any workspace has been provisioned (no DB yet) — treat
@@ -188,6 +199,7 @@ def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) 
     placeholders = ",".join("?" for _ in repo_url_variants)
     try:
         with sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5) as conn:
+            # (a) Non-terminal row → classic "already running".
             cur = conn.execute(
                 f"""SELECT 1 FROM workspaces
                     WHERE task_kind = 'sync_release_pr'
@@ -196,6 +208,27 @@ def _monitor_already_running(*, work_dir: Path, repo_slug: str, pr_number: int) 
                       AND status NOT IN ('completed', 'failed')
                     LIMIT 1""",
                 (pr_number, *repo_url_variants),
+            )
+            if cur.fetchone() is not None:
+                return True
+            # (b) Terminal row within cooldown window → skip.
+            # Compare ``updated_at`` against ``now() - cooldown`` using
+            # SQLite's own time math so we don't depend on the
+            # timezone the row was written in.
+            cur = conn.execute(
+                f"""SELECT 1 FROM workspaces
+                    WHERE task_kind = 'sync_release_pr'
+                      AND pr_number = ?
+                      AND repo_url IN ({placeholders})
+                      AND status IN ('completed', 'failed')
+                      AND datetime(updated_at) >= datetime('now', ?)
+                    ORDER BY updated_at DESC
+                    LIMIT 1""",
+                (
+                    pr_number,
+                    *repo_url_variants,
+                    f"-{_MONITOR_COOLDOWN_SECONDS} seconds",
+                ),
             )
             row = cur.fetchone()
     except sqlite3.DatabaseError:

--- a/tests/unit/scripts/test_schedule_release_pr_idempotency.py
+++ b/tests/unit/scripts/test_schedule_release_pr_idempotency.py
@@ -32,7 +32,8 @@ def _make_awf_db(tmp_path: Path) -> Path:
             status TEXT NOT NULL,
             task_kind TEXT NOT NULL,
             repo_url TEXT NOT NULL,
-            pr_number INTEGER
+            pr_number INTEGER,
+            updated_at TEXT
         );
         """
     )
@@ -49,13 +50,23 @@ def _insert_ws(
     task_kind: str = "sync_release_pr",
     repo_url: str = "git@github.com:dimileeh/aira-web.git",
     pr_number: int = 278,
+    updated_at: str | None = None,
 ) -> None:
+    """``updated_at`` as ISO-8601 UTC — if None, uses SQLite's own
+    ``CURRENT_TIMESTAMP`` which is also UTC."""
     conn = sqlite3.connect(db_path)
-    conn.execute(
-        "INSERT INTO workspaces (id, status, task_kind, repo_url, pr_number) "
-        "VALUES (?, ?, ?, ?, ?)",
-        (ws_id, status, task_kind, repo_url, pr_number),
-    )
+    if updated_at is None:
+        conn.execute(
+            "INSERT INTO workspaces (id, status, task_kind, repo_url, pr_number, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)",
+            (ws_id, status, task_kind, repo_url, pr_number),
+        )
+    else:
+        conn.execute(
+            "INSERT INTO workspaces (id, status, task_kind, repo_url, pr_number, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (ws_id, status, task_kind, repo_url, pr_number, updated_at),
+        )
     conn.commit()
     conn.close()
 
@@ -107,13 +118,20 @@ class TestDbBasedIdempotency:
 
     @pytest.mark.unit
     @pytest.mark.parametrize("status", ["completed", "failed"])
-    def test_terminal_row_returns_false(self, tmp_path: Path, status: str) -> None:
-        """Terminal statuses must NOT block a re-spawn. After a
-        transient failure, the scheduler's next tick must be allowed
-        to retry. Without this, a single failed monitor would block
-        the release-PR workflow forever."""
+    def test_old_terminal_row_returns_false(self, tmp_path: Path, status: str) -> None:
+        """Terminal statuses OLDER THAN the cooldown window must NOT
+        block a re-spawn. After a transient failure, the scheduler
+        must be allowed to retry once the window has passed.
+
+        (The cooldown was added 2026-04-24 — see
+        ``TestCooldownAfterTerminalFailure`` for the inside-window
+        behaviour. This test pins the outside-window semantics.)"""
+        import datetime as _dt
+
         db_path = _make_awf_db(tmp_path)
-        _insert_ws(db_path, ws_id="w1", status=status)
+        # One hour ago: comfortably outside the 5-min cooldown window.
+        old_ts = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(hours=1)).strftime("%Y-%m-%d %H:%M:%S")
+        _insert_ws(db_path, ws_id="w1", status=status, updated_at=old_ts)
         assert (
             _monitor_already_running(
                 work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
@@ -177,6 +195,106 @@ class TestDbBasedIdempotency:
         ``sync_release_pr`` launch."""
         db_path = _make_awf_db(tmp_path)
         _insert_ws(db_path, ws_id="w1", status="provisioning", task_kind="feature_branch_pr")
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+
+class TestCooldownAfterTerminalFailure:
+    """2026-04-24 regression: when ``compose up`` fails fast (e.g.
+    Docker network pool exhausted), the workspace flips to ``failed``
+    immediately. The old "non-terminal row" idempotency check didn't
+    catch that, so the watcher spawned a new workspace every tick
+    (~2 min), producing 180+ failed rows over 6 hours. The cooldown
+    check prevents this: any terminal row younger than 5 min is
+    treated as "skip this tick"."""
+
+    @pytest.mark.unit
+    def test_recent_failure_blocks_respawn(self, tmp_path: Path) -> None:
+        """Row that failed 1 minute ago → cooldown fires → skip."""
+        import datetime as _dt
+
+        db_path = _make_awf_db(tmp_path)
+        one_min_ago = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(minutes=1)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        _insert_ws(
+            db_path,
+            ws_id="w_recent_fail",
+            status="failed",
+            updated_at=one_min_ago,
+        )
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is True
+        )
+
+    @pytest.mark.unit
+    def test_old_failure_allows_respawn(self, tmp_path: Path) -> None:
+        """Row that failed 10 minutes ago → cooldown expired → allow."""
+        import datetime as _dt
+
+        db_path = _make_awf_db(tmp_path)
+        ten_min_ago = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(minutes=10)).strftime(
+            "%Y-%m-%d %H:%M:%S"
+        )
+        _insert_ws(
+            db_path,
+            ws_id="w_old_fail",
+            status="failed",
+            updated_at=ten_min_ago,
+        )
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    def test_recent_completion_also_blocks_respawn(self, tmp_path: Path) -> None:
+        """Not just failures — a recent successful completion also
+        cools down, preventing redundant re-attachment to a PR that
+        just finished (or was short-circuited)."""
+        import datetime as _dt
+
+        db_path = _make_awf_db(tmp_path)
+        now = _dt.datetime.now(_dt.UTC).strftime("%Y-%m-%d %H:%M:%S")
+        _insert_ws(
+            db_path,
+            ws_id="w_recent_success",
+            status="completed",
+            updated_at=now,
+        )
+        assert (
+            _monitor_already_running(
+                work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278
+            )
+            is True
+        )
+
+    @pytest.mark.unit
+    def test_many_old_failures_do_not_block(self, tmp_path: Path) -> None:
+        """A PR with a long history of old failures must still be
+        respawnable when all are outside the cooldown window."""
+        import datetime as _dt
+
+        db_path = _make_awf_db(tmp_path)
+        for i in range(5):
+            old_ts = (_dt.datetime.now(_dt.UTC) - _dt.timedelta(minutes=30 + i)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+            _insert_ws(
+                db_path,
+                ws_id=f"w_old_{i}",
+                status="failed",
+                updated_at=old_ts,
+            )
         assert (
             _monitor_already_running(
                 work_dir=tmp_path, repo_slug="dimileeh/aira-web", pr_number=278


### PR DESCRIPTION
## Summary

2026-04-24 storm: release_pr_watcher spawned ~180 failed workspaces over 6 hours. Root cause was Docker network pool exhaustion (addressed in PR #6), but what amplified one failure into a storm was the idempotency check.

## The bug

\`_monitor_already_running\` only blocked re-spawn when a NON-terminal workspace row existed. A fast-fail compose error flipped rows to \`failed\` instantly, and the next 2-min watcher tick saw no non-terminal row → spawned another. Repeat ~30×/hr.

## Fix

Add a **5-minute cooldown** after any terminal workspace row (completed OR failed). After the window expires, retry is allowed. So a transient issue gets one retry per 5 minutes instead of one per 2 minutes.

Combined with PR #6 (compose teardown on completion), the storm class is now closed.

## Regression tests

- \`test_recent_failure_blocks_respawn\` — 1-min-old failed row blocks.
- \`test_old_failure_allows_respawn\` — 10-min-old failed row allows.
- \`test_recent_completion_also_blocks_respawn\` — cooldown applies to successful completions too.
- \`test_many_old_failures_do_not_block\` — ancient history doesn't sticky-block.

## Test plan

- [x] 571 tests pass
- [x] ruff clean
- [x] Existing \`test_terminal_row_returns_false\` updated to pin outside-window semantics (seeded with \`updated_at\` ≥ cooldown + buffer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Release monitoring now implements a 5-minute cooldown period after failed attempts to prevent redundant retries.
  * Monitoring checks are optimized to skip verification when a recent terminal status already exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->