### PR TITLE
feat(monitor): per-iteration action logging + bot-defer auto-merge with orchestrator signal

### DIFF
--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -110,6 +110,7 @@ async def _main(work_dir: Path, workspace_id: str) -> int:
         adapter=adapter,
         gh=gh,
         worktrees_root=worktrees_root,
+        artifacts_root=work_dir / "artifacts",
     )
 
     print("[remonitor] entering monitor loop ...", flush=True)

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -35,7 +35,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import IO, Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -561,6 +561,7 @@ async def _run_task(
             adapter=adapter,
             gh=gh,
             worktrees_root=work_dir / "git" / "worktrees",
+            artifacts_root=work_dir / "artifacts",
         )
 
     executor = WorkspaceExecutor(
@@ -766,6 +767,7 @@ async def _run_sync_release_pr(
         adapter=adapter,
         gh=gh,
         worktrees_root=work_dir / "git" / "worktrees",
+        artifacts_root=work_dir / "artifacts",
     )
     print(
         f"[{cfg.task_title[:40]}] release-monitor running for PR #{cfg.pr_number} ...",
@@ -976,6 +978,7 @@ async def _run_sync_feature_pr(
         adapter=adapter,
         gh=gh,
         worktrees_root=work_dir / "git" / "worktrees",
+        artifacts_root=work_dir / "artifacts",
     )
     print(
         f"[{cfg.task_title[:40]}] feature-pr-monitor running for PR "
@@ -1003,6 +1006,41 @@ async def _run_sync_feature_pr(
             "branch": persisted.branch_name,
             "base_commit": persisted.base_commit,
         }
+
+
+def print_defer_summary(*, artifacts_root: Path, out: IO[str]) -> None:
+    """Emit the orchestrator's bot-defer cue if any artifact has one.
+
+    Reads every ``<ws_id>.defer-signal.json`` under ``artifacts_root``
+    (written by ``PullRequestMonitorRunner`` on terminal transitions)
+    and prints a ``DEFERRED BOT FEEDBACK`` section listing every bot
+    defer. Silent when no artifacts contain bot defers — orchestrators
+    grep for the header and skip run_awf output otherwise. Missing
+    directory is a no-op (operators may run with artifacts disabled).
+    """
+    if not artifacts_root.is_dir():
+        return
+    rows: list[tuple[str, list[dict[str, Any]]]] = []
+    for path in sorted(artifacts_root.glob("*.defer-signal.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        items = data.get("deferred_bot_items") or []
+        if items:
+            rows.append((data.get("workspace_id", path.stem), items))
+    if not rows:
+        return
+    out.write("\nDEFERRED BOT FEEDBACK (orchestrator should spec follow-ups):\n")
+    for ws_id, items in rows:
+        sample = items[0]
+        author = sample.get("author") or "?"
+        path_str = sample.get("path") or "-"
+        line = sample.get("line")
+        locator = f"{path_str}:{line}" if line is not None else path_str
+        count = len(items)
+        noun = "item" if count == 1 else "items"
+        out.write(f"  {ws_id}: {count} {noun} — {author} on {locator}\n")
 
 
 _ADDITIVE_MIGRATIONS: tuple[tuple[str, str, str], ...] = (
@@ -1107,6 +1145,9 @@ async def _main(config_path: Path, work_dir: Path, keep_state: bool) -> int:
             all_ok = False
         elif result["status"] != "completed":
             all_ok = False
+
+    # Bot-defer callout — orchestrators grep for this.
+    print_defer_summary(artifacts_root=work_dir / "artifacts", out=sys.stdout)
 
     return 0 if all_ok else 1
 

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -411,18 +411,16 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # opens a thread expects their question answered before the merge
     # fires. Review feedback on PR #2 (CodeRabbit, Major): "Deferred
     # feedback still disappears from the merge gate".
-    deferred_blocking: list[tuple[str, str, str | None]] = []
-    for t in status.unresolved_inline_threads:
-        if state.threads_addressed_ids.get(t.thread_id) != "defer":
-            continue
-        if not _is_bot_author(t.author):
-            deferred_blocking.append(("thread", t.thread_id, t.author))
-    for c in status.unresolved_review_comments:
-        if state.threads_addressed_ids.get(c.comment_id) != "defer":
-            continue
-        if not _is_bot_author(c.author):
-            deferred_blocking.append(("review", c.comment_id, c.author))
-    if deferred_blocking:
+    has_human_defer = any(
+        state.threads_addressed_ids.get(t.thread_id) == "defer"
+        and not _is_bot_author(t.author)
+        for t in status.unresolved_inline_threads
+    ) or any(
+        state.threads_addressed_ids.get(c.comment_id) == "defer"
+        and not _is_bot_author(c.author)
+        for c in status.unresolved_review_comments
+    )
+    if has_human_defer:
         return NotifyHuman()
 
     # 8. All green — terminal success action.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -261,6 +261,31 @@ MonitorAction = (
 )
 
 
+# Known bot reviewer logins whose "defer" verdicts should not block the
+# merge — they only post advisory feedback and cannot themselves mark
+# threads resolved. Any GitHub App handle ending in "[bot]" (e.g.
+# dependabot[bot], renovate[bot]) is also treated as a bot. A
+# non-member in this set whose login we don't recognise is treated as
+# human — safer default: block the merge, let the operator triage.
+BOT_REVIEWER_LOGINS = frozenset(
+    {
+        "greptile-apps",
+        "coderabbitai",
+        "gemini-code-assist",
+        "chatgpt-codex-connector",
+        "cursor",
+        "codex",
+        "github-actions",
+    }
+)
+
+
+def _is_bot_author(login: str | None) -> bool:
+    if not login:
+        return False
+    return login in BOT_REVIEWER_LOGINS or login.endswith("[bot]")
+
+
 # ── The decision function ──────────────────────────────────────────────────
 
 
@@ -371,27 +396,33 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     ):
         return NotifyHuman()
 
-    # 7.5. Deferred feedback still unresolved on GitHub → block auto-merge.
+    # 7.5. Deferred HUMAN feedback still unresolved on GitHub → block
+    # auto-merge. Deferred BOT feedback does not block.
     #
-    # "Defer" means the coding CLI decided a reviewer comment needs human
-    # follow-up (design question, out-of-scope, etc.) — NOT that the
-    # thread has been addressed. The previous code filtered such threads
-    # out of ``new_threads`` (step 2) AND let merge proceed at step 8,
-    # silently merging past feedback the maintainer never saw. Now we
-    # explicitly check: if any thread we marked ``defer`` is still
-    # unresolved on GitHub (i.e. the human hasn't resolved it either),
-    # hand off to NotifyHuman regardless of ``auto_merge`` so the
-    # deferred question can't slip through. Review feedback on PR #2
-    # (CodeRabbit, Major): "Deferred feedback still disappears from the
-    # merge gate".
-    deferred_still_open = any(
-        state.threads_addressed_ids.get(t.thread_id) == "defer"
-        for t in status.unresolved_inline_threads
-    ) or any(
-        state.threads_addressed_ids.get(c.comment_id) == "defer"
-        for c in status.unresolved_review_comments
-    )
-    if deferred_still_open:
+    # "Defer" means the coding CLI decided a reviewer comment needs
+    # human follow-up (design question, out-of-scope, etc.) — NOT that
+    # the thread has been addressed. Originally this gate blocked the
+    # merge on ANY defer regardless of author, and PR 342 sat for 4
+    # hours because Greptile's P1 nit kept returning "defer" on every
+    # iteration. Bot reviewers (Greptile, CodeRabbit, Gemini, Cursor
+    # Bugbot, Codex-connector, etc.) post advisory feedback only —
+    # they cannot themselves mark threads resolved, so their deferred
+    # nits would linger forever. Humans still block: a maintainer who
+    # opens a thread expects their question answered before the merge
+    # fires. Review feedback on PR #2 (CodeRabbit, Major): "Deferred
+    # feedback still disappears from the merge gate".
+    deferred_blocking: list[tuple[str, str, str | None]] = []
+    for t in status.unresolved_inline_threads:
+        if state.threads_addressed_ids.get(t.thread_id) != "defer":
+            continue
+        if not _is_bot_author(t.author):
+            deferred_blocking.append(("thread", t.thread_id, t.author))
+    for c in status.unresolved_review_comments:
+        if state.threads_addressed_ids.get(c.comment_id) != "defer":
+            continue
+        if not _is_bot_author(c.author):
+            deferred_blocking.append(("review", c.comment_id, c.author))
+    if deferred_blocking:
         return NotifyHuman()
 
     # 8. All green — terminal success action.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -412,12 +412,10 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # fires. Review feedback on PR #2 (CodeRabbit, Major): "Deferred
     # feedback still disappears from the merge gate".
     has_human_defer = any(
-        state.threads_addressed_ids.get(t.thread_id) == "defer"
-        and not _is_bot_author(t.author)
+        state.threads_addressed_ids.get(t.thread_id) == "defer" and not _is_bot_author(t.author)
         for t in status.unresolved_inline_threads
     ) or any(
-        state.threads_addressed_ids.get(c.comment_id) == "defer"
-        and not _is_bot_author(c.author)
+        state.threads_addressed_ids.get(c.comment_id) == "defer" and not _is_bot_author(c.author)
         for c in status.unresolved_review_comments
     )
     if has_human_defer:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -846,7 +847,12 @@ class PullRequestMonitorRunner:
                 "deferred_human_items": human_items,
             }
             out_path = self._artifacts_root / f"{workspace_id}.defer-signal.json"
-            out_path.write_text(json.dumps(payload, indent=2))
+            # Atomic publish: write to a sibling temp file, then rename.
+            # Pollers treat presence of out_path as the terminal signal, so
+            # they must never observe a partially-written JSON payload.
+            tmp_path = out_path.with_suffix(f".json.{os.getpid()}.tmp")
+            tmp_path.write_text(json.dumps(payload, indent=2))
+            os.replace(tmp_path, out_path)
         except Exception as exc:
             _log.warning(
                 "monitor.defer_signal_write_failed",

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -836,13 +836,14 @@ class PullRequestMonitorRunner:
         """
         try:
             self._artifacts_root.mkdir(parents=True, exist_ok=True)
+            bot_items, human_items = _collect_defer_items(status, state)
             payload = {
                 "workspace_id": workspace_id,
                 "pr_number": pr_number,
                 "terminal_action": terminal_action,
                 "merged": merged,
-                "deferred_bot_items": _collect_defer_items(status, state, bot=True),
-                "deferred_human_items": _collect_defer_items(status, state, bot=False),
+                "deferred_bot_items": bot_items,
+                "deferred_human_items": human_items,
             }
             out_path = self._artifacts_root / f"{workspace_id}.defer-signal.json"
             out_path.write_text(json.dumps(payload, indent=2))
@@ -1046,24 +1047,23 @@ def _with_ci_failures(status: PRStatus, failures: tuple[CheckFailure, ...]) -> P
 
 
 def _collect_defer_items(
-    status: PRStatus, state: MonitorState, *, bot: bool
-) -> list[dict[str, object]]:
-    """Collect deferred threads/comments whose author matches the
-    requested kind (bot vs. human) for the defer-signal artifact.
+    status: PRStatus, state: MonitorState
+) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """Collect deferred threads/comments, partitioned by author kind.
 
-    ``bot=True`` selects items whose author classifies as a bot per
-    ``pr_monitor._is_bot_author``; ``bot=False`` selects the complement
-    (including unknown-author items, which the merge gate treats as
-    human for safety — the artifact mirrors that classification so
-    orchestrators see the same picture).
+    Returns ``(bot_items, human_items)``. Items whose author classifies
+    as a bot per ``pr_monitor._is_bot_author`` go into the first list;
+    the rest (including unknown-author items, which the merge gate
+    treats as human for safety) go into the second — the artifact
+    mirrors that classification so orchestrators see the same picture.
     """
-    items: list[dict[str, object]] = []
+    bot_items: list[dict[str, object]] = []
+    human_items: list[dict[str, object]] = []
     for t in status.unresolved_inline_threads:
         if state.threads_addressed_ids.get(t.thread_id) != "defer":
             continue
-        if _is_bot_author(t.author) is not bot:
-            continue
-        items.append(
+        bucket = bot_items if _is_bot_author(t.author) else human_items
+        bucket.append(
             {
                 "kind": "thread",
                 "id": t.thread_id,
@@ -1077,9 +1077,8 @@ def _collect_defer_items(
     for c in status.unresolved_review_comments:
         if state.threads_addressed_ids.get(c.comment_id) != "defer":
             continue
-        if _is_bot_author(c.author) is not bot:
-            continue
-        items.append(
+        bucket = bot_items if _is_bot_author(c.author) else human_items
+        bucket.append(
             {
                 "kind": "review",
                 "id": c.comment_id,
@@ -1090,4 +1089,4 @@ def _collect_defer_items(
                 "agent_verdict_reason": None,
             }
         )
-    return items
+    return bot_items, human_items

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -262,6 +262,27 @@ class PullRequestMonitorRunner:
         """Execute one action. Returns True iff the monitor has reached a
         terminal state (merged / notified / aborted / short-circuited)."""
 
+        # One structured log line per iteration, BEFORE any side effect —
+        # operators grepping logs need to see which arm the decision
+        # core chose without having to correlate gh / git calls
+        # downstream. Regression guard for PR 342: the monitor ran 200+
+        # iterations silently because only handoff_to_pr_monitor and
+        # compose_teardown_ok fired.
+        _log.info(
+            "monitor.action",
+            workspace_id=workspace_id,
+            pr_number=pr_number,
+            iter=state.iter_count,
+            action=type(action).__name__,
+            head_sha=status.head_sha[:10],
+            base_behind=status.base_behind_count,
+            merge_state=(
+                status.merge_state_status.value if status.merge_state_status else None
+            ),
+            unresolved_threads=len(status.unresolved_inline_threads),
+            unresolved_reviews=len(status.unresolved_review_comments),
+        )
+
         if isinstance(action, ShortCircuitCompleted):
             await self._terminate_completed(
                 workspace_id,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -22,6 +22,7 @@ The loop:
 from __future__ import annotations
 
 import asyncio
+import json
 import re
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
@@ -61,6 +62,7 @@ from awf.runtime.pr_monitor import (
     ShortCircuitCompleted,
     SyncBase,
     WaitForCI,
+    _is_bot_author,
     decide,
 )
 
@@ -109,6 +111,7 @@ class PullRequestMonitorRunner:
         runner_config: MonitorRunnerConfig | None = None,
         sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
         worktrees_root: Path,
+        artifacts_root: Path | None = None,
     ) -> None:
         self._deps = _RunnerDeps(
             session_factory=session_factory,
@@ -120,6 +123,10 @@ class PullRequestMonitorRunner:
         self._config = monitor_config or MonitorConfig()
         self._runner_config = runner_config or MonitorRunnerConfig()
         self._worktrees_root = worktrees_root
+        # Orchestrator-facing JSON drops — one ``<ws_id>.defer-signal.json``
+        # per terminal transition. Default layout matches ``run_awf.py``'s
+        # ``<work_dir>/artifacts`` directory.
+        self._artifacts_root = artifacts_root or (worktrees_root.parent / "artifacts")
 
     # ── Entry point ────────────────────────────────────────────────────────
 
@@ -276,14 +283,20 @@ class PullRequestMonitorRunner:
             action=type(action).__name__,
             head_sha=status.head_sha[:10],
             base_behind=status.base_behind_count,
-            merge_state=(
-                status.merge_state_status.value if status.merge_state_status else None
-            ),
+            merge_state=(status.merge_state_status.value if status.merge_state_status else None),
             unresolved_threads=len(status.unresolved_inline_threads),
             unresolved_reviews=len(status.unresolved_review_comments),
         )
 
         if isinstance(action, ShortCircuitCompleted):
+            self._write_defer_signal(
+                workspace_id=workspace_id,
+                pr_number=pr_number,
+                terminal_action="ShortCircuitCompleted",
+                merged=True,
+                status=status,
+                state=state,
+            )
             await self._terminate_completed(
                 workspace_id,
                 pr_merge_sha=None,
@@ -293,6 +306,14 @@ class PullRequestMonitorRunner:
             return True
 
         if isinstance(action, Abort):
+            self._write_defer_signal(
+                workspace_id=workspace_id,
+                pr_number=pr_number,
+                terminal_action="Abort",
+                merged=False,
+                status=status,
+                state=state,
+            )
             await self._terminate_failed(
                 workspace_id,
                 message=f"monitor: abort ({action.reason.value})",
@@ -361,6 +382,14 @@ class PullRequestMonitorRunner:
                     pr_number=pr_number,
                     body=ready_to_merge_comment(pr_number=pr_number, head_sha=status.head_sha),
                 )
+                self._write_defer_signal(
+                    workspace_id=workspace_id,
+                    pr_number=pr_number,
+                    terminal_action="Merge",
+                    merged=False,
+                    status=status,
+                    state=state,
+                )
                 await self._terminate_completed(
                     workspace_id,
                     pr_merge_sha=None,
@@ -368,6 +397,14 @@ class PullRequestMonitorRunner:
                     compose_file=compose_file,
                 )
                 return True
+            self._write_defer_signal(
+                workspace_id=workspace_id,
+                pr_number=pr_number,
+                terminal_action="Merge",
+                merged=True,
+                status=status,
+                state=state,
+            )
             await self._terminate_completed(
                 workspace_id,
                 pr_merge_sha=merge_sha,
@@ -381,6 +418,14 @@ class PullRequestMonitorRunner:
                 repo=repo,
                 pr_number=pr_number,
                 body=ready_to_merge_comment(pr_number=pr_number, head_sha=status.head_sha),
+            )
+            self._write_defer_signal(
+                workspace_id=workspace_id,
+                pr_number=pr_number,
+                terminal_action="NotifyHuman",
+                merged=False,
+                status=status,
+                state=state,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -764,6 +809,49 @@ class PullRequestMonitorRunner:
         )
         return False
 
+    # ── Defer-signal artifact ─────────────────────────────────────────────
+
+    def _write_defer_signal(
+        self,
+        *,
+        workspace_id: str,
+        pr_number: int,
+        terminal_action: str,
+        merged: bool,
+        status: PRStatus,
+        state: MonitorState,
+    ) -> None:
+        """Persist a machine-readable drop of the workspace's terminal
+        state for an orchestrator to consume.
+
+        The file always exists when the runner reaches a terminal
+        action — empty ``deferred_*_items`` lists when nothing was
+        deferred. Downstream tooling can therefore poll for the file's
+        presence as the authoritative "monitor is done" signal without
+        also having to handle a missing-file case.
+
+        Called with a best-effort contract: a failure to write MUST NOT
+        stop the state-machine transition (the DB write has priority).
+        """
+        try:
+            self._artifacts_root.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "workspace_id": workspace_id,
+                "pr_number": pr_number,
+                "terminal_action": terminal_action,
+                "merged": merged,
+                "deferred_bot_items": _collect_defer_items(status, state, bot=True),
+                "deferred_human_items": _collect_defer_items(status, state, bot=False),
+            }
+            out_path = self._artifacts_root / f"{workspace_id}.defer-signal.json"
+            out_path.write_text(json.dumps(payload, indent=2))
+        except Exception as exc:
+            _log.warning(
+                "monitor.defer_signal_write_failed",
+                workspace_id=workspace_id,
+                error=repr(exc)[:400],
+            )
+
     # ── DB state management ───────────────────────────────────────────────
 
     async def _load_workspace(self, workspace_id: str) -> Workspace:
@@ -954,3 +1042,51 @@ def _with_ci_failures(status: PRStatus, failures: tuple[CheckFailure, ...]) -> P
     from dataclasses import replace
 
     return replace(status, ci_failures=failures)
+
+
+def _collect_defer_items(
+    status: PRStatus, state: MonitorState, *, bot: bool
+) -> list[dict[str, object]]:
+    """Collect deferred threads/comments whose author matches the
+    requested kind (bot vs. human) for the defer-signal artifact.
+
+    ``bot=True`` selects items whose author classifies as a bot per
+    ``pr_monitor._is_bot_author``; ``bot=False`` selects the complement
+    (including unknown-author items, which the merge gate treats as
+    human for safety — the artifact mirrors that classification so
+    orchestrators see the same picture).
+    """
+    items: list[dict[str, object]] = []
+    for t in status.unresolved_inline_threads:
+        if state.threads_addressed_ids.get(t.thread_id) != "defer":
+            continue
+        if _is_bot_author(t.author) is not bot:
+            continue
+        items.append(
+            {
+                "kind": "thread",
+                "id": t.thread_id,
+                "author": t.author,
+                "path": t.path,
+                "line": t.line,
+                "body": t.body_excerpt,
+                "agent_verdict_reason": None,
+            }
+        )
+    for c in status.unresolved_review_comments:
+        if state.threads_addressed_ids.get(c.comment_id) != "defer":
+            continue
+        if _is_bot_author(c.author) is not bot:
+            continue
+        items.append(
+            {
+                "kind": "review",
+                "id": c.comment_id,
+                "author": c.author,
+                "path": None,
+                "line": None,
+                "body": c.body_excerpt,
+                "agent_verdict_reason": None,
+            }
+        )
+    return items

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -125,8 +125,9 @@ class PullRequestMonitorRunner:
         self._worktrees_root = worktrees_root
         # Orchestrator-facing JSON drops — one ``<ws_id>.defer-signal.json``
         # per terminal transition. Default layout matches ``run_awf.py``'s
-        # ``<work_dir>/artifacts`` directory.
-        self._artifacts_root = artifacts_root or (worktrees_root.parent / "artifacts")
+        # ``<work_dir>/artifacts`` directory; since ``worktrees_root`` there
+        # is ``<work_dir>/git/worktrees``, go up two levels.
+        self._artifacts_root = artifacts_root or (worktrees_root.parents[1] / "artifacts")
 
     # ── Entry point ────────────────────────────────────────────────────────
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -852,7 +852,7 @@ class PullRequestMonitorRunner:
             # they must never observe a partially-written JSON payload.
             tmp_path = out_path.with_suffix(f".json.{os.getpid()}.tmp")
             tmp_path.write_text(json.dumps(payload, indent=2))
-            os.replace(tmp_path, out_path)
+            tmp_path.replace(out_path)
         except Exception as exc:
             _log.warning(
                 "monitor.defer_signal_write_failed",

--- a/src/awf/runtime/release_pr_monitor.py
+++ b/src/awf/runtime/release_pr_monitor.py
@@ -41,6 +41,7 @@ def build_release_pr_monitor(
     adapter: AgentAdapter,
     gh: GitHubClient,
     worktrees_root: Path,
+    artifacts_root: Path | None = None,
     iter_cap: int = 10,
     wall_clock_cap_seconds: float = 6 * 3600,
     poll_interval_seconds: float = 60.0,
@@ -68,6 +69,7 @@ def build_release_pr_monitor(
             max_fix_cycle_passes=max_fix_cycle_passes,
         ),
         worktrees_root=worktrees_root,
+        artifacts_root=artifacts_root,
     )
 
 
@@ -78,6 +80,7 @@ def build_feature_pr_monitor(
     adapter: AgentAdapter,
     gh: GitHubClient,
     worktrees_root: Path,
+    artifacts_root: Path | None = None,
     iter_cap: int = 10,
     wall_clock_cap_seconds: float = 6 * 3600,
     poll_interval_seconds: float = 60.0,
@@ -105,4 +108,5 @@ def build_feature_pr_monitor(
             max_fix_cycle_passes=max_fix_cycle_passes,
         ),
         worktrees_root=worktrees_root,
+        artifacts_root=artifacts_root,
     )

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -1,0 +1,202 @@
+"""Shared helpers for the new PR-monitor runner unit tests.
+
+The action-logging, bot-defer, and defer-signal-artifact tests all need
+the same setup: a real in-memory SQLite, a ``FakeCommandRunner``, a
+``FakeAdapter`` returning canned verdicts, and a workspace row already in
+``monitoring_pr``. Reuse the same shapes as
+``tests/integration/runtime/test_pr_monitor_runner.py`` (which is where
+the baseline end-to-end flows live) but keep the helpers local to the
+new suites so the integration file doesn't become a cross-test import
+surface.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters.base import AgentAdapter, AgentRunError, AgentRunResult
+from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.common.github_client import GitHubClient
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.runtime.pr_monitor import MonitorConfig
+from awf.runtime.pr_monitor_runner import (
+    MonitorRunnerConfig,
+    PullRequestMonitorRunner,
+)
+
+
+@dataclass
+class FakeAdapter(AgentAdapter):
+    runtime = AgentRuntime.claude_code
+    _queued: list[AgentRunResult] = field(default_factory=list)
+    calls: list[str] = field(default_factory=list)
+
+    def __init__(self) -> None:  # type: ignore[override]
+        super().__init__(runner=None)  # type: ignore[arg-type]
+        self._queued = []
+        self.calls = []
+
+    @property
+    def name(self) -> AgentRuntime:  # type: ignore[override]
+        return AgentRuntime.claude_code
+
+    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+        return []
+
+    def queue(self, *, stdout: str = "", returncode: int = 0) -> None:
+        self._queued.append(AgentRunResult(returncode=returncode, stdout=stdout, stderr=""))
+
+    async def run(  # type: ignore[override]
+        self, *, compose_project: str, compose_file: Path, prompt: str, model: str | None = None
+    ) -> AgentRunResult:
+        self.calls.append(prompt)
+        if not self._queued:
+            return AgentRunResult(returncode=0, stdout="fixed it", stderr="")
+        r = self._queued.pop(0)
+        if r.returncode != 0:
+            raise AgentRunError(
+                agent=AgentRuntime.claude_code,
+                result=CommandResult(returncode=r.returncode, stdout=r.stdout, stderr=r.stderr),
+            )
+        return r
+
+
+class RecordedSleep:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+def pr_payload(
+    *,
+    closed: bool = False,
+    merged: bool = False,
+    mergeable: str = "MERGEABLE",
+    merge_state_status: str = "CLEAN",
+    check_state: str = "SUCCESS",
+    threads: list[dict] | None = None,
+    reviews: list[dict] | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 42,
+                        "headRefOid": "abc1234567890def",
+                        "mergeable": mergeable,
+                        "mergeStateStatus": merge_state_status,
+                        "isDraft": False,
+                        "closed": closed,
+                        "merged": merged,
+                        "baseRef": {"name": "development", "target": {"oid": "base0"}},
+                        "commits": {
+                            "nodes": [{"commit": {"statusCheckRollup": {"state": check_state}}}]
+                        },
+                        "reviewThreads": {"nodes": threads or []},
+                        "reviews": {"nodes": reviews or []},
+                    }
+                }
+            }
+        }
+    )
+
+
+def thread_node(
+    *,
+    tid: str,
+    author: str,
+    path: str = "src/foo.py",
+    line: int = 42,
+    body: str = "tiny nit",
+) -> dict:
+    return {
+        "id": tid,
+        "isResolved": False,
+        "isOutdated": False,
+        "path": path,
+        "line": line,
+        "comments": {"nodes": [{"bodyText": body, "author": {"login": author}}]},
+    }
+
+
+def review_node(*, cid: int, author: str, body: str = "see below") -> dict:
+    return {
+        "databaseId": cid,
+        "body": body,
+        "state": "COMMENTED",
+        "author": {"login": author},
+    }
+
+
+async def seed_monitoring_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    pr_number: int = 42,
+) -> str:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            branch_base="development",
+            task_title="monitor test",
+            task_prompt="x",
+            agent="claude_code",
+            test_commands=["pytest -q"],
+            requires_database=False,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+            WorkspaceStatus.monitoring_pr,
+        ):
+            await repo.transition(ws, to=target, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.remote_push_branch = ws.branch_name
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.pr_url = f"https://github.com/dimileeh/aira-web/pull/{pr_number}"
+        ws.pr_number = pr_number
+        await s.commit()
+        return ws.id
+
+
+def make_runner(
+    *,
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    worktrees_root: Path,
+    auto_merge: bool = True,
+    iter_cap: int = 10,
+    artifacts_root: Path | None = None,
+) -> PullRequestMonitorRunner:
+    kwargs: dict = dict(
+        session_factory=factory,
+        runner=cmd,
+        adapter=adapter,
+        gh=GitHubClient(cmd),
+        monitor_config=MonitorConfig(
+            iter_cap=iter_cap,
+            auto_merge=auto_merge,
+            poll_interval_seconds=60,
+            settle_interval_seconds=30,
+        ),
+        runner_config=MonitorRunnerConfig(max_outer_iterations=20, max_fix_cycle_passes=3),
+        sleep=sleep_fn,
+        worktrees_root=worktrees_root,
+    )
+    if artifacts_root is not None:
+        kwargs["artifacts_root"] = artifacts_root
+    return PullRequestMonitorRunner(**kwargs)

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -182,21 +182,21 @@ def make_runner(
     iter_cap: int = 10,
     artifacts_root: Path | None = None,
 ) -> PullRequestMonitorRunner:
-    kwargs: dict = dict(
-        session_factory=factory,
-        runner=cmd,
-        adapter=adapter,
-        gh=GitHubClient(cmd),
-        monitor_config=MonitorConfig(
+    kwargs: dict = {
+        "session_factory": factory,
+        "runner": cmd,
+        "adapter": adapter,
+        "gh": GitHubClient(cmd),
+        "monitor_config": MonitorConfig(
             iter_cap=iter_cap,
             auto_merge=auto_merge,
             poll_interval_seconds=60,
             settle_interval_seconds=30,
         ),
-        runner_config=MonitorRunnerConfig(max_outer_iterations=20, max_fix_cycle_passes=3),
-        sleep=sleep_fn,
-        worktrees_root=worktrees_root,
-    )
+        "runner_config": MonitorRunnerConfig(max_outer_iterations=20, max_fix_cycle_passes=3),
+        "sleep": sleep_fn,
+        "worktrees_root": worktrees_root,
+    }
     if artifacts_root is not None:
         kwargs["artifacts_root"] = artifacts_root
     return PullRequestMonitorRunner(**kwargs)

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -56,7 +56,10 @@ class FakeAdapter(AgentAdapter):
     ) -> AgentRunResult:
         self.calls.append(prompt)
         if not self._queued:
-            return AgentRunResult(returncode=0, stdout="fixed it", stderr="")
+            raise AssertionError(
+                "FakeAdapter.run called with empty queue; queue() a result "
+                "in the test before this dispatch to avoid masking setup bugs"
+            )
         r = self._queued.pop(0)
         if r.returncode != 0:
             raise AgentRunError(

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -1,0 +1,289 @@
+"""Defer-signal artifact at terminal transitions.
+
+On each terminal ``MonitorAction`` dispatch (``Merge`` / ``NotifyHuman`` /
+``ShortCircuitCompleted`` / ``Abort``) the runner writes a JSON file
+under ``<artifacts_root>/<workspace_id>.defer-signal.json``. The file
+tells an orchestrator outside AWF:
+
+  * what terminal action fired (did we actually merge?),
+  * which bot-authored threads were deferred (orchestrator should spec
+    follow-ups for these),
+  * which human-authored threads were deferred (maintainer-owned).
+
+Every terminal transition writes, even when both defer lists are empty —
+downstream tooling shouldn't have to distinguish "no file" from "no
+defers". See PR 342 Phase 3 plan.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.base import Base
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    review_node,
+    seed_monitoring_workspace,
+    thread_node,
+)
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+def _artifact_for(artifacts_root: Path, ws_id: str) -> dict:
+    path = artifacts_root / f"{ws_id}.defer-signal.json"
+    assert path.exists(), f"expected artifact at {path}"
+    return json.loads(path.read_text())
+
+
+class TestDeferSignalArtifact:
+    @pytest.mark.unit
+    async def test_artifact_written_on_merge_with_bot_defers(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        """Bot defers do NOT block the merge; artifact captures them so
+        the orchestrator can spec follow-up workspaces."""
+        ws_id = await seed_monitoring_workspace(factory)
+        artifacts_root = tmp_path / "artifacts"
+        bot_thread = thread_node(
+            tid="T_bot",
+            author="greptile-apps",
+            path="src/foo.py",
+            line=42,
+            body="consider renaming",
+        )
+        # Outer iter 1: AddressComments fires; adapter defers.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))
+        adapter.queue(stdout="DEFER: advisory nit, skipping")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))  # settle
+        cmd.queue_result(returncode=0, stderr="Everything up-to-date")  # push
+        # Outer iter 2: bot-defer → gate passes → Merge.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))
+        cmd.queue_result(returncode=0)  # gh pr merge
+        cmd.queue_result(returncode=0, stdout="MERGESHA\n")
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            artifacts_root=artifacts_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        data = _artifact_for(artifacts_root, ws_id)
+        assert data["workspace_id"] == ws_id
+        assert data["pr_number"] == 42
+        assert data["terminal_action"] == "Merge"
+        assert data["merged"] is True
+        assert len(data["deferred_bot_items"]) == 1
+        item = data["deferred_bot_items"][0]
+        assert item["kind"] == "thread"
+        assert item["id"] == "T_bot"
+        assert item["author"] == "greptile-apps"
+        assert item["path"] == "src/foo.py"
+        assert item["line"] == 42
+        assert data["deferred_human_items"] == []
+
+    @pytest.mark.unit
+    async def test_artifact_written_on_notify_human_with_human_defers(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        artifacts_root = tmp_path / "artifacts"
+        human_thread = thread_node(
+            tid="T_human",
+            author="alice-human",
+            path="src/bar.py",
+            line=7,
+            body="design question",
+        )
+        # Outer iter 1: AddressComments; agent defers.
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[human_thread]))
+        adapter.queue(stdout="DEFER: needs maintainer input")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[human_thread]))
+        cmd.queue_result(returncode=0, stderr="Everything up-to-date")
+        # Outer iter 2: human-defer → gate blocks → NotifyHuman.
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[human_thread]))
+        cmd.queue_result(returncode=0)  # gh pr comment (NotifyHuman)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            artifacts_root=artifacts_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        data = _artifact_for(artifacts_root, ws_id)
+        assert data["terminal_action"] == "NotifyHuman"
+        assert data["merged"] is False
+        assert data["deferred_bot_items"] == []
+        assert len(data["deferred_human_items"]) == 1
+        item = data["deferred_human_items"][0]
+        assert item["id"] == "T_human"
+        assert item["author"] == "alice-human"
+        assert item["path"] == "src/bar.py"
+
+    @pytest.mark.unit
+    async def test_artifact_written_on_abort(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        artifacts_root = tmp_path / "artifacts"
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(closed=True))  # Abort path
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            artifacts_root=artifacts_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        data = _artifact_for(artifacts_root, ws_id)
+        assert data["terminal_action"] == "Abort"
+        assert data["merged"] is False
+        assert data["deferred_bot_items"] == []
+        assert data["deferred_human_items"] == []
+
+    @pytest.mark.unit
+    async def test_artifact_written_on_short_circuit_already_merged(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        """Even on ShortCircuitCompleted (PR merged externally), write
+        the artifact. Orchestrator shouldn't have to handle missing
+        files when polling for terminal signals."""
+        ws_id = await seed_monitoring_workspace(factory)
+        artifacts_root = tmp_path / "artifacts"
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            artifacts_root=artifacts_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        data = _artifact_for(artifacts_root, ws_id)
+        assert data["terminal_action"] == "ShortCircuitCompleted"
+        assert data["deferred_bot_items"] == []
+        assert data["deferred_human_items"] == []
+
+    @pytest.mark.unit
+    async def test_artifact_default_path_under_worktrees_parent(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        """When ``artifacts_root`` is not passed to the runner, it
+        defaults to ``worktrees_root.parent / "artifacts"`` — matches
+        the layout ``run_awf.py`` uses for ``<work_dir>/artifacts``."""
+        ws_id = await seed_monitoring_workspace(factory)
+        worktrees_root = tmp_path / "work" / "git" / "worktrees"
+        default_artifacts_root = tmp_path / "work" / "git" / "artifacts"
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=worktrees_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        path = default_artifacts_root / f"{ws_id}.defer-signal.json"
+        assert path.exists(), f"expected default artifact at {path}"

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -26,16 +26,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.db.base import Base
-from awf.db.enums import WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
     make_runner,
     pr_payload,
-    review_node,
     seed_monitoring_workspace,
     thread_node,
 )

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -261,11 +261,13 @@ class TestDeferSignalArtifact:
         tmp_path: Path,
     ) -> None:
         """When ``artifacts_root`` is not passed to the runner, it
-        defaults to ``worktrees_root.parent / "artifacts"`` — matches
-        the layout ``run_awf.py`` uses for ``<work_dir>/artifacts``."""
+        defaults to ``worktrees_root.parents[1] / "artifacts"`` — matches
+        the layout ``run_awf.py`` uses where ``worktrees_root`` is
+        ``<work_dir>/git/worktrees`` and artifacts live at
+        ``<work_dir>/artifacts``."""
         ws_id = await seed_monitoring_workspace(factory)
         worktrees_root = tmp_path / "work" / "git" / "worktrees"
-        default_artifacts_root = tmp_path / "work" / "git" / "artifacts"
+        default_artifacts_root = tmp_path / "work" / "artifacts"
         cmd.queue_result(returncode=0)
         cmd.queue_result(returncode=0, stdout="0\n")
         cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -131,6 +131,69 @@ class TestDeferSignalArtifact:
         assert data["deferred_human_items"] == []
 
     @pytest.mark.unit
+    async def test_artifact_written_on_merge_blocked_downgrade(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        """``gh pr merge`` can be rejected by branch protection. The
+        runner falls back to posting a "ready to merge" comment and
+        still writes the artifact, but with ``merged=False`` so the
+        orchestrator knows no squash actually landed."""
+        ws_id = await seed_monitoring_workspace(factory)
+        artifacts_root = tmp_path / "artifacts"
+        bot_thread = thread_node(
+            tid="T_bot",
+            author="greptile-apps",
+            path="src/foo.py",
+            line=42,
+            body="consider renaming",
+        )
+        # Outer iter 1: AddressComments fires; adapter defers.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))
+        adapter.queue(stdout="DEFER: advisory nit, skipping")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))  # settle
+        cmd.queue_result(returncode=0, stderr="Everything up-to-date")  # push
+        # Outer iter 2: bot-defer → gate passes → Merge dispatched, but
+        # gh pr merge is blocked by branch protection → downgrade path.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[bot_thread]))
+        cmd.queue_result(
+            returncode=1,
+            stderr="pull request not mergeable: required status checks pending",
+        )  # gh pr merge — blocked
+        cmd.queue_result(returncode=0)  # gh pr comment (ready-to-merge fallback)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            artifacts_root=artifacts_root,
+        )
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+        data = _artifact_for(artifacts_root, ws_id)
+        assert data["terminal_action"] == "Merge"
+        assert data["merged"] is False
+        assert len(data["deferred_bot_items"]) == 1
+        item = data["deferred_bot_items"][0]
+        assert item["id"] == "T_bot"
+        assert item["author"] == "greptile-apps"
+        assert item["path"] == "src/foo.py"
+        assert item["line"] == 42
+        assert data["deferred_human_items"] == []
+
+    @pytest.mark.unit
     async def test_artifact_written_on_notify_human_with_human_defers(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -1,0 +1,345 @@
+"""Action-decision logging for the PR monitor runner.
+
+Regression guard for PR 342: the monitor ran 200+ iterations silently,
+with no way to tell from the logs whether it was looping on
+``AddressComments``, ``NotifyHuman``, or ``Merge``. We now emit a
+``monitor.action`` structlog line BEFORE each dispatch so operators
+grepping ``/tmp/awf-realrun/logs/*.log`` can trace the decision sequence.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.base import Base
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    review_node,
+    seed_monitoring_workspace,
+    thread_node,
+)
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+def _action_entries(records: list[dict]) -> list[dict]:
+    return [r for r in records if r.get("event") == "monitor.action"]
+
+
+class TestMonitorActionLogging:
+    @pytest.mark.unit
+    async def test_merge_action_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload())  # PR state
+        cmd.queue_result(returncode=0)  # gh pr merge
+        cmd.queue_result(returncode=0, stdout="MERGESHA\n")  # sha lookup
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        entries = _action_entries(captured)
+        assert len(entries) == 1, f"expected one monitor.action; got {entries}"
+        entry = entries[0]
+        assert entry["action"] == "Merge"
+        assert entry["workspace_id"] == ws_id
+        assert entry["pr_number"] == 42
+        assert entry["iter"] == 0
+        assert entry["merge_state"] == "CLEAN"
+        assert entry["unresolved_threads"] == 0
+        assert entry["unresolved_reviews"] == 0
+        assert entry["head_sha"].startswith("abc1234567")
+
+    @pytest.mark.unit
+    async def test_notify_human_action_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload())
+        cmd.queue_result(returncode=0)  # gh pr comment
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            auto_merge=False,
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        entries = _action_entries(captured)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "NotifyHuman"
+
+    @pytest.mark.unit
+    async def test_short_circuit_completed_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        entries = _action_entries(captured)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "ShortCircuitCompleted"
+
+    @pytest.mark.unit
+    async def test_abort_action_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload(closed=True))  # closed → Abort
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        entries = _action_entries(captured)
+        assert len(entries) == 1
+        assert entries[0]["action"] == "Abort"
+
+    @pytest.mark.unit
+    async def test_address_comments_action_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        thread = thread_node(tid="T1", author="cr")
+        # Outer iter 1: AddressComments.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(threads=[thread]))
+        adapter.queue(stdout="fixed it")
+        cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
+        cmd.queue_result(returncode=0)  # push
+        cmd.queue_result(returncode=0, stdout="head2\n")  # rev-parse
+        cmd.queue_result(returncode=0, stdout=json.dumps({"data": {}}))  # resolve
+        # Outer iter 2: clean → Merge.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload())
+        cmd.queue_result(returncode=0)  # merge
+        cmd.queue_result(returncode=0, stdout="M\n")
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        entries = _action_entries(captured)
+        actions = [e["action"] for e in entries]
+        assert actions == ["AddressComments", "Merge"], actions
+        ac_entry = entries[0]
+        assert ac_entry["unresolved_threads"] == 1
+        assert ac_entry["iter"] == 0  # iter_count bumped AFTER dispatch
+
+    @pytest.mark.unit
+    async def test_wait_for_ci_action_emits_log_line(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        # Outer iter 1: PENDING → WaitForCI; outer iter 2: CLEAN → Merge.
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(check_state="PENDING"))
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload())
+        cmd.queue_result(returncode=0)  # merge
+        cmd.queue_result(returncode=0, stdout="M\n")
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+        actions = [e["action"] for e in _action_entries(captured)]
+        assert actions == ["WaitForCI", "Merge"]
+
+    @pytest.mark.unit
+    async def test_action_log_fires_before_dispatch_side_effects(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        """The log line must land BEFORE the side effects it narrates —
+        if the merge call crashes, the operator's log grep still shows
+        which action was chosen. We verify by checking the log appears
+        before the ``gh pr merge`` command recorded by FakeCommandRunner."""
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload())
+        cmd.queue_result(returncode=0)  # gh pr merge
+        cmd.queue_result(returncode=0, stdout="M\n")  # sha
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+
+        # Wrap FakeCommandRunner.run to interleave with log capture order:
+        # each recorded call happens-after the log that narrates the
+        # action. We check this by asserting the "monitor.action" log
+        # with action=Merge appears in captured_logs BEFORE the ``gh pr
+        # merge`` FakeCommandRunner call does any recording via a
+        # counter-based interleaving check.
+        merge_cmd_index: list[int] = []
+        original_run = cmd.run
+
+        async def tracking_run(args, **kwargs):  # type: ignore[no-untyped-def]
+            if args[:3] == ["gh", "pr", "merge"]:
+                merge_cmd_index.append(len(cmd.calls))
+            return await original_run(args, **kwargs)
+
+        cmd.run = tracking_run  # type: ignore[method-assign]
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        action_events = [
+            i for i, r in enumerate(captured) if r.get("event") == "monitor.action"
+        ]
+        assert action_events, "expected a monitor.action log"
+        # The Merge action log should appear somewhere BEFORE the
+        # ``gh pr merge`` command is invoked. capture_logs records in
+        # order, and FakeCommandRunner records in order, so asserting
+        # the log entry index predates the recorded-call index is
+        # sufficient: the very next thing we did after logging was to
+        # invoke the gh merge call, and capture_logs records the log
+        # synchronously at the moment it is made.
+        merge_actions = [r for r in captured if r.get("event") == "monitor.action"
+                         and r.get("action") == "Merge"]
+        assert merge_actions, "expected a Merge action log"
+        assert merge_cmd_index, "expected gh pr merge to have been called"

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -339,6 +339,5 @@ class TestMonitorActionLogging:
         # [False] and the test would fail — which is the regression we
         # guard against.
         assert saw_merge_log_before_call == [True], (
-            "expected the Merge monitor.action log to be emitted before "
-            "`gh pr merge` was invoked"
+            "expected the Merge monitor.action log to be emitted before `gh pr merge` was invoked"
         )

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -19,16 +19,12 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.db.base import Base
-from awf.db.enums import WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
     make_runner,
     pr_payload,
-    review_node,
     seed_monitoring_workspace,
     thread_node,
 )
@@ -328,9 +324,7 @@ class TestMonitorActionLogging:
                 compose_file=tmp_path / "compose.yml",
             )
 
-        action_events = [
-            i for i, r in enumerate(captured) if r.get("event") == "monitor.action"
-        ]
+        action_events = [i for i, r in enumerate(captured) if r.get("event") == "monitor.action"]
         assert action_events, "expected a monitor.action log"
         # The Merge action log should appear somewhere BEFORE the
         # ``gh pr merge`` command is invoked. capture_logs records in
@@ -339,7 +333,8 @@ class TestMonitorActionLogging:
         # sufficient: the very next thing we did after logging was to
         # invoke the gh merge call, and capture_logs records the log
         # synchronously at the moment it is made.
-        merge_actions = [r for r in captured if r.get("event") == "monitor.action"
-                         and r.get("action") == "Merge"]
+        merge_actions = [
+            r for r in captured if r.get("event") == "monitor.action" and r.get("action") == "Merge"
+        ]
         assert merge_actions, "expected a Merge action log"
         assert merge_cmd_index, "expected gh pr merge to have been called"

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -301,23 +301,28 @@ class TestMonitorActionLogging:
             worktrees_root=tmp_path / "worktrees",
         )
 
-        # Wrap FakeCommandRunner.run to interleave with log capture order:
-        # each recorded call happens-after the log that narrates the
-        # action. We check this by asserting the "monitor.action" log
-        # with action=Merge appears in captured_logs BEFORE the ``gh pr
-        # merge`` FakeCommandRunner call does any recording via a
-        # counter-based interleaving check.
-        merge_cmd_index: list[int] = []
+        # Wrap FakeCommandRunner.run so that when ``gh pr merge`` is
+        # invoked, we snapshot whether the Merge action log has already
+        # been emitted. capture_logs' list is appended to synchronously
+        # by structlog, so peeking at it inside tracking_run observes
+        # exactly the logs that existed at dispatch time.
+        saw_merge_log_before_call: list[bool] = []
         original_run = cmd.run
 
-        async def tracking_run(args, **kwargs):  # type: ignore[no-untyped-def]
-            if args[:3] == ["gh", "pr", "merge"]:
-                merge_cmd_index.append(len(cmd.calls))
-            return await original_run(args, **kwargs)
-
-        cmd.run = tracking_run  # type: ignore[method-assign]
-
         with structlog.testing.capture_logs() as captured:
+
+            async def tracking_run(args, **kwargs):  # type: ignore[no-untyped-def]
+                if args[:3] == ["gh", "pr", "merge"]:
+                    saw_merge_log_before_call.append(
+                        any(
+                            r.get("event") == "monitor.action" and r.get("action") == "Merge"
+                            for r in captured
+                        )
+                    )
+                return await original_run(args, **kwargs)
+
+            cmd.run = tracking_run  # type: ignore[method-assign]
+
             await runner.run(
                 workspace_id=ws_id,
                 compose_project="proj",
@@ -326,15 +331,14 @@ class TestMonitorActionLogging:
 
         action_events = [i for i, r in enumerate(captured) if r.get("event") == "monitor.action"]
         assert action_events, "expected a monitor.action log"
-        # The Merge action log should appear somewhere BEFORE the
-        # ``gh pr merge`` command is invoked. capture_logs records in
-        # order, and FakeCommandRunner records in order, so asserting
-        # the log entry index predates the recorded-call index is
-        # sufficient: the very next thing we did after logging was to
-        # invoke the gh merge call, and capture_logs records the log
-        # synchronously at the moment it is made.
         merge_actions = [
             r for r in captured if r.get("event") == "monitor.action" and r.get("action") == "Merge"
         ]
         assert merge_actions, "expected a Merge action log"
-        assert merge_cmd_index, "expected gh pr merge to have been called"
+        # If monitor.action moved below the dispatch, this would be
+        # [False] and the test would fail — which is the regression we
+        # guard against.
+        assert saw_merge_log_before_call == [True], (
+            "expected the Merge monitor.action log to be emitted before "
+            "`gh pr merge` was invoked"
+        )

--- a/tests/unit/runtime/test_pr_monitor_bot_defer.py
+++ b/tests/unit/runtime/test_pr_monitor_bot_defer.py
@@ -1,0 +1,157 @@
+"""Bot-defer-aware merge gate for ``pr_monitor.decide``.
+
+Regression for PR 342: every bot reviewer's advisory nit was blocking
+the auto-merge because ``state.threads_addressed_ids[t.thread_id] ==
+"defer"`` plus "still unresolved on GitHub" was a hard stop. Bots
+(Greptile, CodeRabbit, Gemini, Cursor Bugbot, Codex-connector, etc.)
+post advisory feedback only — they cannot themselves resolve threads,
+so their unresolved nits linger forever. Humans must still block.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.runtime.pr_monitor import (
+    Merge,
+    MonitorConfig,
+    MonitorState,
+    NotifyHuman,
+    PRStatus,
+    ReviewComment,
+    ReviewThread,
+    decide,
+)
+from awf.runtime.pr_monitor import (
+    MergeableState,
+    MergeStateStatus,
+    CheckState,
+)
+
+
+def _status(
+    *,
+    inline: tuple[ReviewThread, ...] = (),
+    reviews: tuple[ReviewComment, ...] = (),
+) -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha="abc123",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=inline,
+        unresolved_review_comments=reviews,
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+
+def _thread(tid: str, author: str) -> ReviewThread:
+    return ReviewThread(
+        thread_id=tid,
+        path="src/foo.py",
+        line=42,
+        body_excerpt="nit",
+        author=author,
+    )
+
+
+def _review(cid: str, author: str) -> ReviewComment:
+    return ReviewComment(
+        comment_id=cid,
+        body_excerpt="nit",
+        author=author,
+    )
+
+
+class TestBotDeferUnblocksMerge:
+    @pytest.mark.unit
+    def test_bot_defer_does_not_block_merge(self) -> None:
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread("T1", "greptile-apps"),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge), f"expected Merge; got {action!r}"
+
+    @pytest.mark.unit
+    def test_human_defer_blocks_merge(self) -> None:
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread("T1", "alice-human"),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_mixed_defers_block_if_any_human(self) -> None:
+        state = MonitorState(
+            threads_addressed_ids={"T_bot": "defer", "T_human": "defer"}
+        )
+        status = _status(
+            inline=(
+                _thread("T_bot", "greptile-apps"),
+                _thread("T_human", "alice"),
+            )
+        )
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_bot_suffix_login_classified_as_bot(self) -> None:
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread("T1", "dependabot[bot]"),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "login",
+        [
+            "greptile-apps",
+            "coderabbitai",
+            "gemini-code-assist",
+            "chatgpt-codex-connector",
+            "cursor",
+            "codex",
+            "github-actions",
+        ],
+    )
+    def test_known_bot_logins_all_classified(self, login: str) -> None:
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread("T1", login),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge), f"{login} should be classified as bot"
+
+    @pytest.mark.unit
+    def test_bot_defer_review_comment_does_not_block_merge(self) -> None:
+        state = MonitorState(threads_addressed_ids={"C1": "defer"})
+        status = _status(reviews=(_review("C1", "coderabbitai"),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge)
+
+    @pytest.mark.unit
+    def test_human_defer_review_comment_blocks_merge(self) -> None:
+        state = MonitorState(threads_addressed_ids={"C1": "defer"})
+        status = _status(reviews=(_review("C1", "alice"),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_addressed_without_defer_does_not_block(self) -> None:
+        """A thread marked ``fix_committed`` that lingers unresolved on
+        GitHub (maintainer just hasn't clicked Resolve yet) flows through
+        the normal gates — the defer block only triggers on ``defer``."""
+        state = MonitorState(threads_addressed_ids={"T1": "fix_committed"})
+        # Thread resolved upstream — the decide() gate sees no unresolved
+        # thread at all, so Merge.
+        status = _status(inline=())
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, Merge)
+
+    @pytest.mark.unit
+    def test_unknown_author_treated_as_human(self) -> None:
+        """If the author field is unset (GraphQL returned null), we must
+        NOT silently assume "bot" and merge — that would let a merge
+        slip through on deferred unknown-author feedback. Default to
+        human (block the merge)."""
+        state = MonitorState(threads_addressed_ids={"T1": "defer"})
+        status = _status(inline=(_thread("T1", ""),))
+        action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+        assert isinstance(action, NotifyHuman)

--- a/tests/unit/runtime/test_pr_monitor_bot_defer.py
+++ b/tests/unit/runtime/test_pr_monitor_bot_defer.py
@@ -44,7 +44,7 @@ def _status(
     )
 
 
-def _thread(tid: str, author: str) -> ReviewThread:
+def _thread(tid: str, author: str | None) -> ReviewThread:
     return ReviewThread(
         thread_id=tid,
         path="src/foo.py",
@@ -148,6 +148,6 @@ class TestBotDeferUnblocksMerge:
         slip through on deferred unknown-author feedback. Default to
         human (block the merge)."""
         state = MonitorState(threads_addressed_ids={"T1": "defer"})
-        status = _status(inline=(_thread("T1", ""),))
+        status = _status(inline=(_thread("T1", None),))
         action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
         assert isinstance(action, NotifyHuman)

--- a/tests/unit/runtime/test_pr_monitor_bot_defer.py
+++ b/tests/unit/runtime/test_pr_monitor_bot_defer.py
@@ -13,7 +13,10 @@ from __future__ import annotations
 import pytest
 
 from awf.runtime.pr_monitor import (
+    CheckState,
     Merge,
+    MergeableState,
+    MergeStateStatus,
     MonitorConfig,
     MonitorState,
     NotifyHuman,
@@ -21,11 +24,6 @@ from awf.runtime.pr_monitor import (
     ReviewComment,
     ReviewThread,
     decide,
-)
-from awf.runtime.pr_monitor import (
-    MergeableState,
-    MergeStateStatus,
-    CheckState,
 )
 
 
@@ -81,9 +79,7 @@ class TestBotDeferUnblocksMerge:
 
     @pytest.mark.unit
     def test_mixed_defers_block_if_any_human(self) -> None:
-        state = MonitorState(
-            threads_addressed_ids={"T_bot": "defer", "T_human": "defer"}
-        )
+        state = MonitorState(threads_addressed_ids={"T_bot": "defer", "T_human": "defer"})
         status = _status(
             inline=(
                 _thread("T_bot", "greptile-apps"),

--- a/tests/unit/scripts/test_run_awf_defer_summary.py
+++ b/tests/unit/scripts/test_run_awf_defer_summary.py
@@ -1,0 +1,137 @@
+"""``run_awf.py`` prints a bot-defer summary after its result header.
+
+If any workspace's artifact JSON has non-empty ``deferred_bot_items``,
+the summary section is emitted so the orchestrator launching ``run_awf``
+has a machine-readable cue to spec follow-up work. An empty artifact
+(every task was clean) must NOT add the section.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts import run_awf
+
+
+def _write_artifact(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload))
+
+
+class TestDeferSummary:
+    @pytest.mark.unit
+    def test_summary_includes_defer_section_when_bot_items_present(
+        self, tmp_path: Path
+    ) -> None:
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root / "ws_1.defer-signal.json",
+            {
+                "workspace_id": "ws_1",
+                "pr_number": 342,
+                "terminal_action": "Merge",
+                "merged": True,
+                "deferred_bot_items": [
+                    {
+                        "kind": "thread",
+                        "id": "PRRT_xyz",
+                        "author": "greptile-apps",
+                        "path": "src/foo.py",
+                        "line": 42,
+                        "body": "rename foo",
+                    }
+                ],
+                "deferred_human_items": [],
+            },
+        )
+        buf = io.StringIO()
+        run_awf.print_defer_summary(artifacts_root=artifacts_root, out=buf)
+        out = buf.getvalue()
+        assert "DEFERRED BOT FEEDBACK" in out
+        assert "ws_1" in out
+        assert "greptile-apps" in out
+        assert "src/foo.py" in out
+        assert "42" in out
+
+    @pytest.mark.unit
+    def test_summary_omits_defer_section_when_no_items(self, tmp_path: Path) -> None:
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root / "ws_clean.defer-signal.json",
+            {
+                "workspace_id": "ws_clean",
+                "pr_number": 1,
+                "terminal_action": "Merge",
+                "merged": True,
+                "deferred_bot_items": [],
+                "deferred_human_items": [],
+            },
+        )
+        buf = io.StringIO()
+        run_awf.print_defer_summary(artifacts_root=artifacts_root, out=buf)
+        assert buf.getvalue() == ""
+
+    @pytest.mark.unit
+    def test_summary_skips_missing_artifacts_root(self, tmp_path: Path) -> None:
+        """An orchestrator may run with artifacts disabled / the directory
+        never created. Don't crash."""
+        buf = io.StringIO()
+        run_awf.print_defer_summary(
+            artifacts_root=tmp_path / "does-not-exist", out=buf
+        )
+        assert buf.getvalue() == ""
+
+    @pytest.mark.unit
+    def test_summary_aggregates_across_multiple_workspaces(self, tmp_path: Path) -> None:
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root / "ws_1.defer-signal.json",
+            {
+                "workspace_id": "ws_1",
+                "pr_number": 100,
+                "terminal_action": "Merge",
+                "merged": True,
+                "deferred_bot_items": [
+                    {
+                        "kind": "thread",
+                        "id": "T1",
+                        "author": "greptile-apps",
+                        "path": "a.py",
+                        "line": 1,
+                        "body": "",
+                    }
+                ],
+                "deferred_human_items": [],
+            },
+        )
+        _write_artifact(
+            artifacts_root / "ws_2.defer-signal.json",
+            {
+                "workspace_id": "ws_2",
+                "pr_number": 101,
+                "terminal_action": "Merge",
+                "merged": True,
+                "deferred_bot_items": [
+                    {
+                        "kind": "review",
+                        "id": "C2",
+                        "author": "coderabbitai",
+                        "path": None,
+                        "line": None,
+                        "body": "",
+                    }
+                ],
+                "deferred_human_items": [],
+            },
+        )
+        buf = io.StringIO()
+        run_awf.print_defer_summary(artifacts_root=artifacts_root, out=buf)
+        out = buf.getvalue()
+        assert "ws_1" in out
+        assert "ws_2" in out
+        assert "greptile-apps" in out
+        assert "coderabbitai" in out

--- a/tests/unit/scripts/test_run_awf_defer_summary.py
+++ b/tests/unit/scripts/test_run_awf_defer_summary.py
@@ -24,9 +24,7 @@ def _write_artifact(path: Path, payload: dict) -> None:
 
 class TestDeferSummary:
     @pytest.mark.unit
-    def test_summary_includes_defer_section_when_bot_items_present(
-        self, tmp_path: Path
-    ) -> None:
+    def test_summary_includes_defer_section_when_bot_items_present(self, tmp_path: Path) -> None:
         artifacts_root = tmp_path / "artifacts"
         _write_artifact(
             artifacts_root / "ws_1.defer-signal.json",
@@ -80,9 +78,7 @@ class TestDeferSummary:
         """An orchestrator may run with artifacts disabled / the directory
         never created. Don't crash."""
         buf = io.StringIO()
-        run_awf.print_defer_summary(
-            artifacts_root=tmp_path / "does-not-exist", out=buf
-        )
+        run_awf.print_defer_summary(artifacts_root=tmp_path / "does-not-exist", out=buf)
         assert buf.getvalue() == ""
 
     @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_347a66fa1ab44c7387221f46` (agent: `claude_code`).


### Task
## Context — PR 342 (T41 Phase 3) hung silently for 4 hours

The AWF `PullRequestMonitorRunner` ran 200+ agent iterations against Greptile's P1 nit on PR 342, then silently downgraded to `NotifyHuman` at `pr_monitor.py:394` because the coding CLI returned `verdict="defer"` on one bot thread. The monitor posts the `ready_to_merge_comment` and exits — fine in principle, except:

1. The log emits ZERO action-decision lines. You can't tell from `/tmp/awf-realrun/logs/*.log` whether the monitor reached `Merge`, `NotifyHuman`, or `AddressComments` on any given iteration. Only `handoff_to_pr_monitor` + `compose_teardown_ok` appear.
2. Bot comments (Greptile, CodeRabbit, Gemini, Codex, Cursor Bugbot, chatgpt-codex-connector) should never block auto-merge — they're advisory. Human reviews DO block. Today, any defer regardless of author stops the merge.
3. When a defer DOES block, the orchestrator that launched the AWF run has no machine-readable signal telling it "there's deferred feedback at thread X, please spec a follow-up." It has to grep logs.

This PR fixes all three.

## Environment

AWF workspace, aira-agent-workspace-fabric at `/workspace`, fresh feature branch off `main` (this repo uses `main`, not `development`). Python 3.12 + uv. First setup: `uv pip install -e ".[dev]" --quiet`.

## Strict TDD workflow

Tests FIRST. Commit order:

1. Red-commit: failing tests for (a) action-logging emission, (b) bot-author classification, (c) defer signal artifact.
2. Green-commit: (a) action-logging.
3. Green-commit: (b) bot-defer-aware merge gate.
4. Green-commit: (c) defer signal artifact at terminal transitions.

## Scope

### 1. Per-iteration action logging — `src/awf/runtime/pr_monitor_runner.py`

At the top of `_dispatch_action` (or wherever each iteration's chosen action fires — grep for `if isinstance(action, AddressComments)`), emit a structured log line BEFORE each dispatch:

```python
_log.info(
    "monitor.action",
    workspace_id=workspace_id,
    pr_number=pr_number,
    iter=state.iter_count,
    action=type(action).__name__,
    head_sha=status.head_sha[:10],
    base_behind=status.base_behind_count,
    merge_state=status.merge_state_status.value if status.merge_state_status else None,
    unresolved_threads=len(status.unresolved_inline_threads),
    unresolved_reviews=len(status.unresolved_review_comments),
)
```

Every decision arm the runner dispatches — `AddressComments`, `SyncBase`, `Merge`, `NotifyHuman`, `ShortCircuitCompleted`, `Abort`, `WaitForCI`, `ReportCiFailure` — must emit this line. A single call at the top covers them all; don't scatter per-arm.

### 2. Bot-defer-aware merge gate — `src/awf/runtime/pr_monitor.py`

At `decide()` step 7.5 (lines 387–395), split the check by author kind:

```python
BOT_REVIEWER_LOGINS = frozenset({
    "greptile-apps", "coderabbitai", "gemini-code-assist",
    "chatgpt-codex-connector", "cursor", "codex",
    "github-actions",
})

def _is_bot_author(login: str | None) -> bool:
    if not login:
        return False
    return login in BOT_REVIEWER_LOGINS or login.endswith("[bot]")

# step 7.5 rewritten:
deferred_blocking = []
for t in status.unresolved_inline_threads:
    if state.threads_addressed_ids.get(t.thread_id) != "defer":
        continue
    author = t.comments[0].author_login if t.comments else None
    if not _is_bot_author(author):
        deferred_blocking.append(("thread", t.thread_id, author))

for c in status.unresolved_review_comments:
    if state.threads_addressed_ids.get(c.comment_id) != "defer":
        continue
    if not _is_bot_author(c.author_login):
        deferred_blocking.append(("review", c.comment_id, c.author_login))

if deferred_blocking:
    return NotifyHuman()  # at least one HUMAN defer still open
```

Bot defers no longer block the merge. But they ARE captured and reported (see section 3) so the orchestrator can spec a follow-up workspace for each bot-defer item.

**If `ReviewThread` / `ReviewComment` dataclasses don't currently expose `author_login` on their comments, add the field and plumb it through the GitHub client's `fetch_pr_status`.** Grep for `ReviewThread` and `ReviewComment` to find their definitions; inspect `gh.fetch_pr_status` to see the data coming from the GraphQL query.

### 3. Defer signal artifact — `src/awf/runtime/pr_monitor_runner.py` + `src/awf/runtime/monitor_state.py`

When `_terminate_completed` fires, write a JSON artifact to `<work_dir>/artifacts/<workspace_id>.defer-signal.json`:

```json
{
  "workspace_id": "ws_eef84687af304fc1a93f5396",
  "pr_number": 342,
  "terminal_action": "Merge" | "NotifyHuman" | "ShortCircuitCompleted" | "Abort",
  "merged": true,
  "deferred_bot_items": [
    {
      "kind": "thread",
      "id": "PRRT_...",
      "author": "greptile-apps",
      "path": "src/.../foo.py",
      "line": 42,
      "body": "<snippet>",
      "agent_verdict_reason": "<if captured>"
    }
  ],
  "deferred_human_items": [/* same shape */]
}
```

Read the base path from the same `worktrees_root` or a new `artifacts_root` attribute on the runner (add if missing, default `worktrees_root.parent / "artifacts"`).

Write ONCE at terminal transition. Empty lists if no defers. The orchestrator consumes this file after `run_awf.py` exits.

### 4. `run_awf.py` surface — append defer signals to the summary

At the end of `run_awf.py`, after "AWF RUN RESULTS", if any artifact has non-empty `deferred_bot_items`, append a section:

```
DEFERRED BOT FEEDBACK (orchestrator should spec follow-ups):
  ws_...: 1 item — greptile-apps on src/.../foo.py:42
```

This is the orchestrator's machine-readable cue. Don't try to auto-spec the follow-up inside AWF — that's orchestrator policy, lives outside AWF.

## Tests (required — write first)

### `tests/unit/runtime/test_monitor_action_logging.py` (new)

1. `test_each_action_emits_monitor_action_log_line`: drive the runner's `_dispatch_action` through each `MonitorAction` variant; assert a single `monitor.action` structlog line per call, with fields `workspace_id`, `pr_number`, `iter`, `action`, `head_sha`, `merge_state`.
2. `test_action_log_fires_before_dispatch_side_effects`: using a mock GitHub client, assert the log line precedes `gh.merge_pr` / `gh.post_comment` calls (verify via call-order on the capture mock).

### `tests/unit/runtime/test_pr_monitor_bot_defer.py` (new)

1. `test_bot_defer_does_not_block_merge`: `decide()` with auto_merge=True, a single unresolved inline thread marked `defer`, author=`greptile-apps`. Assert returns `Merge()`.
2. `test_human_defer_blocks_merge`: same state but author=`alice@company.com` → `NotifyHuman()`.
3. `test_mixed_defers_block_if_any_human`: 1 bot-defer + 1 human-defer → `NotifyHuman()`.
4. `test_bot_suffix_login_classified_as_bot`: author=`dependabot[bot]` → merge goes through.
5. `test_known_bot_logins_all_classified`: each login in the `BOT_REVIEWER_LOGINS` frozenset round-trips as bot.
6. `test_addressed_without_defer_does_not_block`: thread marked `"addressed"` but still unresolved on GitHub → same as today (addressed threads flow through normal gate, don't block).

### `tests/unit/runtime/test_defer_signal_artifact.py` (new)

1. `test_artifact_written_on_merge_with_bot_defers`: drive runner to `Merge()` with 1 bot-defer. Assert `<artifacts_root>/<ws_id>.defer-signal.json` exists with `terminal_action="Merge"`, `merged=true`, `deferred_bot_items` length 1, `deferred_human_items` empty.
2. `test_artifact_written_on_notify_human_with_human_defers`: drive runner to `NotifyHuman()` with 1 human-defer. Assert `terminal_action="NotifyHuman"`, `merged=false`, `deferred_human_items` length 1.
3. `test_artifact_written_on_abort`: drive runner to `Abort()`. Assert artifact exists with empty defer lists.
4. `test_artifact_absent_on_short_circuit_already_merged`: if PR was merged externally (ShortCircuitCompleted), still write artifact with empty defer lists — orchestrator shouldn't have to handle missing files.

### `tests/unit/scripts/test_run_awf_defer_summary.py` (new)

1. `test_summary_includes_defer_section_when_bot_items_present`: set up an artifact file with 1 bot-defer, invoke `run_awf.py`'s summary-printer (extract it to a testable function if needed), capture stdout, assert "DEFERRED BOT FEEDBACK" section appears.
2. `test_summary_omits_defer_section_when_no_items`: empty artifact → no defer section.

## Verification checklist

- `ruff check .` clean.
- `ruff format --check .` clean.
- `pytest tests/unit/runtime/test_monitor_action_logging.py -v` green.
- `pytest tests/unit/runtime/test_pr_monitor_bot_defer.py -v` green.
- `pytest tests/unit/runtime/test_defer_signal_artifact.py -v` green.
- `pytest tests/unit/scripts/test_run_awf_defer_summary.py -v` green.
- Existing monitor tests (`pytest tests/unit/runtime/test_pr_monitor.py tests/unit/runtime/test_pr_monitor_runner.py -v`) still pass.

## Do NOT

- Do NOT change the 5-gate logic itself (steps 1–6 of `decide()`).
- Do NOT auto-spec follow-up workspaces inside AWF — orchestrator owns that.
- Do NOT change `auto_merge=True/False` defaults on the two monitor builders.
- Do NOT remove the `ready_to_merge_comment` — it still fires on human-defer NotifyHuman paths.
- Do NOT couple the defer artifact to any specific orchestrator. Flat JSON on disk, that's it.

---
Validation: 4 test command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bot reviewer deferrals no longer block auto-merge—only human-authored defer comments prevent merging
  * Deferred feedback summaries now generated and reported with structured artifacts for external monitoring
  * Enhanced monitor action logging for improved visibility into merge decisions and state transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->