### PR TITLE
fix(validation): skip alembic upgrade when repo has no alembic.ini

### DIFF
--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -481,6 +481,7 @@ class WorkspaceExecutor:
                 compose_file=compose_file,
                 test_commands=list(ws.test_commands),
                 requires_database=ws.requires_database,
+                workspace_worktree=worktree_path,
             )
             if val_result.all_passed:
                 if pass_number > 0:

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -107,6 +107,7 @@ class ValidationRunner:
         compose_file: Path,
         test_commands: list[str],
         requires_database: bool = False,
+        workspace_worktree: Path | None = None,
     ) -> ValidationResult:
         workspace_artifacts = self._artifacts_dir / workspace_id
         workspace_artifacts.mkdir(parents=True, exist_ok=True)
@@ -145,6 +146,28 @@ class ValidationRunner:
             # migration fails, skip remaining test commands: they'd run against
             # a broken schema and the output would be noise.
             if index == 1 and requires_database:
+                # ``requires_database=True`` means "the companion stack needs
+                # Postgres running" — not "run Alembic here." Non-Python
+                # workspaces (aira-web, etc.) have no ``alembic.ini`` at the
+                # worktree root; their companion backend handles its own
+                # migrations via its own entrypoint. Skip the workspace-side
+                # step for them rather than burn fix-passes on a shell error.
+                # When ``workspace_worktree`` is not provided (e.g. legacy
+                # unit tests that assert the historical migration behavior)
+                # we fall back to the old "just run it" path.
+                if (
+                    workspace_worktree is not None
+                    and not (workspace_worktree / "alembic.ini").is_file()
+                ):
+                    _log.info(
+                        "validation.migration_skipped_no_alembic_ini",
+                        workspace_id=workspace_id,
+                        reason=(
+                            "requires_database=True but workspace has no "
+                            "alembic.ini — skipping migration step"
+                        ),
+                    )
+                    continue
                 migration = await self._exec(
                     compose_project=compose_project,
                     compose_file=compose_file,

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -1,12 +1,18 @@
 """Validation runner — executes test commands inside the workspace container.
 
 Contract:
-    1. If ``requires_database`` is True, run ``alembic upgrade head`` AFTER
-       the first test command (which is the convention for dep-install).
-       This is deliberate: dep install must happen first so Alembic + the
-       app package are importable. If the app doesn't need this pattern,
-       set ``requires_database=False`` and put migration in test_commands
-       yourself.
+    1. If ``requires_database`` is True AND the workspace has an
+       ``alembic.ini`` at its worktree root, run ``alembic upgrade head``
+       AFTER the first test command (which is the convention for
+       dep-install). This is deliberate: dep install must happen first so
+       Alembic + the app package are importable. For Node.js or other
+       non-Python workspaces, set ``requires_database=True`` when the
+       COMPANION stack needs a DB — the Postgres companion will apply its
+       own migrations via its own entrypoint, and AWF will skip the
+       workspace-side alembic step silently (no ``alembic.ini`` ⇒ no
+       Alembic to run). If the app has a custom migration command,
+       leave ``requires_database=False`` and put the migration line in
+       test_commands yourself.
     2. Run each command in ``test_commands`` sequentially via ``docker
        compose exec -T -w /workspace agent sh -lc <command>``.
     3. Capture stdout + stderr for each command to per-workspace artifact

--- a/tests/unit/runtime/test_validation_skip_alembic.py
+++ b/tests/unit/runtime/test_validation_skip_alembic.py
@@ -1,0 +1,186 @@
+"""ValidationRunner: skip ``alembic upgrade head`` when workspace has no ``alembic.ini``.
+
+Regression guard for the incident where AWF blocked a valid aira-web
+(Node.js) workspace for 10+ minutes because the executor tried to run
+``alembic upgrade head`` against a repo that has no Alembic config —
+aira-web is pure Node and doesn't ship Python migrations.
+
+The semantic of ``requires_database=True`` is "the companion stack needs
+Postgres running" — not "run Alembic on the workspace repo." For non-Python
+workspaces the companion backend applies its own migrations via its own
+entrypoint; AWF must skip the workspace-side Alembic step silently.
+
+Gating rule: if ``workspace_worktree / alembic.ini`` does NOT exist,
+skip the migration even when ``requires_database=True``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+
+from awf.common.commands import FakeCommandRunner
+from awf.runtime.validation import ValidationRunner
+
+_COMPOSE_PROJECT = "awf_ws_val_skip"
+_COMPOSE_FILE = Path("/fake/compose.yml")
+
+
+@pytest.fixture
+def runner(tmp_path: Path) -> tuple[FakeCommandRunner, ValidationRunner]:
+    fake = FakeCommandRunner()
+    return fake, ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+
+def _make_worktree(tmp_path: Path, *, with_alembic_ini: bool) -> Path:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    if with_alembic_ini:
+        (worktree / "alembic.ini").write_text("[alembic]\n")
+    return worktree
+
+
+def _shell_of(call_args: list[str]) -> str:
+    """Return the `sh -lc` payload (the last argv entry) for a fake call."""
+    return call_args[-1]
+
+
+class TestSkipAlembicWhenNoIni:
+    @pytest.mark.unit
+    async def test_migration_skipped_when_no_alembic_ini(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        tmp_path: Path,
+    ) -> None:
+        """requires_database=True + no ``alembic.ini`` → migration skipped, run continues.
+
+        Asserts:
+          (a) No subprocess invocation for ``alembic upgrade head`` (the
+              migration shell payload never hits FakeCommandRunner).
+          (b) ``validation.migration_skipped_no_alembic_ini`` log fires.
+          (c) Validation continues and runs the next test_command.
+        """
+        fake, val = runner
+        worktree = _make_worktree(tmp_path, with_alembic_ini=False)
+
+        fake.queue_result(returncode=0, stdout="deps installed")  # cmd_01
+        fake.queue_result(returncode=0, stdout="tests ok")  # cmd_02 (pytest)
+
+        with structlog.testing.capture_logs() as captured:
+            result = await val.run(
+                workspace_id="ws_node",
+                compose_project=_COMPOSE_PROJECT,
+                compose_file=_COMPOSE_FILE,
+                test_commands=['uv pip install -e ".[dev]"', "pytest -q"],
+                requires_database=True,
+                workspace_worktree=worktree,
+            )
+
+        # (a) No alembic invocation anywhere in the recorded calls.
+        for call in fake.calls:
+            assert "alembic upgrade head" not in _shell_of(call.args), (
+                f"migration was invoked but workspace has no alembic.ini: {call.args!r}"
+            )
+        assert result.migration is None
+
+        # (b) Skip log line fired with the expected structured fields.
+        skip_events = [
+            e for e in captured if e.get("event") == "validation.migration_skipped_no_alembic_ini"
+        ]
+        assert len(skip_events) == 1, f"expected one skip log; got {skip_events}"
+        assert skip_events[0]["workspace_id"] == "ws_node"
+
+        # (c) Validation ran BOTH test commands; both passed.
+        assert result.all_passed
+        assert len(result.commands) == 2
+        assert result.commands[0].command == 'uv pip install -e ".[dev]"'
+        assert result.commands[1].command == "pytest -q"
+        # Exactly two subprocess calls: cmd_01 and cmd_02. No migration.
+        assert len(fake.calls) == 2
+
+    @pytest.mark.unit
+    async def test_migration_runs_when_alembic_ini_present(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        tmp_path: Path,
+    ) -> None:
+        """requires_database=True + alembic.ini present → migration runs as before."""
+        fake, val = runner
+        worktree = _make_worktree(tmp_path, with_alembic_ini=True)
+
+        fake.queue_result(returncode=0, stdout="deps installed")  # cmd_01
+        fake.queue_result(returncode=0, stdout="migrated")  # migration
+        fake.queue_result(returncode=0, stdout="tests ok")  # cmd_02
+
+        result = await val.run(
+            workspace_id="ws_py",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            test_commands=['uv pip install -e ".[dev]"', "pytest -q"],
+            requires_database=True,
+            workspace_worktree=worktree,
+        )
+
+        assert result.all_passed
+        assert result.migration is not None
+        assert result.migration.ok
+        # Three calls: cmd_01, migration, cmd_02.
+        assert len(fake.calls) == 3
+        # Migration invocation contains the alembic shell.
+        migration_shell = _shell_of(fake.calls[1].args)
+        assert "alembic upgrade head" in migration_shell
+
+    @pytest.mark.unit
+    async def test_migration_skipped_when_requires_database_false(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        tmp_path: Path,
+    ) -> None:
+        """requires_database=False + alembic.ini present → still skipped.
+
+        Preserves existing behavior: requires_database is the gate for
+        opting into the migration step at all.
+        """
+        fake, val = runner
+        worktree = _make_worktree(tmp_path, with_alembic_ini=True)
+        fake.queue_result(returncode=0, stdout="tests ok")
+
+        result = await val.run(
+            workspace_id="ws_nomig_alembic",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            test_commands=["pytest -q"],
+            requires_database=False,
+            workspace_worktree=worktree,
+        )
+
+        assert result.migration is None
+        assert len(fake.calls) == 1
+        # No alembic was invoked.
+        assert "alembic upgrade head" not in _shell_of(fake.calls[0].args)
+
+    @pytest.mark.unit
+    async def test_migration_skipped_when_requires_database_false_no_alembic(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        tmp_path: Path,
+    ) -> None:
+        """requires_database=False + no alembic.ini → skipped (existing behavior)."""
+        fake, val = runner
+        worktree = _make_worktree(tmp_path, with_alembic_ini=False)
+        fake.queue_result(returncode=0, stdout="tests ok")
+
+        result = await val.run(
+            workspace_id="ws_node_nomig",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            test_commands=["pytest -q"],
+            requires_database=False,
+            workspace_worktree=worktree,
+        )
+
+        assert result.migration is None
+        assert len(fake.calls) == 1
+        assert "alembic upgrade head" not in _shell_of(fake.calls[0].args)


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e1b2799a7757487294b3ba3f` (agent: `claude_code`).


### Task
## Context — AWF blocked a valid aira-web workspace for 10+ min

Workspace `ws_791958d015cd42428cdb9b8c` ran the button-coverage e2e task against aira-web (a Next.js/Node.js repo). AWF's executor ran `alembic upgrade head` as part of validation because the spec set `requires_database: true`. The aira-web repo has no alembic (alembic is a Python SQLAlchemy tool; aira-web is pure Node). All 5 fix passes failed on the same command; the agent had no way to "fix" a missing Python migration tool in a Node.js project. The task was aborted and the agent's legitimate work (button-inventory.json + spec + helpers) had to be rescued manually.

The spec's `requires_database: true` was semantically meaning "the companion BACKEND needs Postgres running" — not "run alembic on the workspace repo." AWF conflated these.

Fix: AWF should only run `alembic upgrade head` when the workspace repo has an `alembic.ini` file at its root. If absent, skip the migration step silently and continue validation.

## Environment

AWF workspace, aira-agent-workspace-fabric at `/workspace`, fresh feature branch off `main`. Python 3.12 + uv. First setup: `uv pip install -e ".[dev]" --quiet`.

## Strict TDD workflow

Tests FIRST. Commit order:

1. Red-commit: failing tests for (a) skip-when-no-alembic-ini and (b) still-run-when-alembic-ini-present.
2. Green-commit: implementation change in `src/awf/runtime/validation.py`.
3. Green-commit: update docstring + any spec file that set `requires_database: true` incorrectly.

Paste the failing-test output into the red-commit body.

## Scope

### 1. `src/awf/runtime/validation.py`

At line 147 (the `if index == 1 and requires_database` guard), add a second check — only run the migration shell if `workspace_worktree / "alembic.ini"` exists:

```python
if index == 1 and requires_database:
    alembic_ini = workspace_worktree / "alembic.ini"
    if not alembic_ini.is_file():
        _log.info(
            "validation.migration_skipped_no_alembic_ini",
            workspace_id=ws.id,
            reason="requires_database=True but workspace has no alembic.ini — skipping migration step",
        )
        continue  # or break out of the migration branch cleanly
    # existing migration logic follows
```

Don't change the existing behavior when `alembic.ini` IS present (that branch stays identical).

### 2. Docstring update

At `validation.py:4–8`, update the module docstring to reflect the new semantic:

> "If `requires_database` is True AND the workspace has an `alembic.ini`, run `alembic upgrade head` after venv is ready. For Node.js or other non-Python workspaces, set `requires_database=True` when the COMPANION stack needs a DB (Postgres companion will apply its own migrations via its own entrypoint) — AWF will skip the workspace-side alembic step."

### 3. DO NOT

- Do NOT change the DB helpers in `src/awf/db/`.
- Do NOT change the default value of `requires_database`.
- Do NOT touch existing spec files in `scripts/` — the existing ones already use `requires_database` correctly for Python workspaces; no behavior change for them.
- Do NOT remove the `_MIGRATION_SHELL` constant — it's still used for Python workspaces.

## Tests (required — write first)

### `tests/unit/runtime/test_validation_skip_alembic.py` (new file)

Use the existing test fixtures in `tests/unit/runtime/`. Grep for `test_validation*.py` to find the style.

1. `test_migration_skipped_when_no_alembic_ini`: build a workspace with `requires_database=True` but NO `alembic.ini` in the worktree. Run the validator. Assert (a) no subprocess invocation for `alembic upgrade head`, (b) log line `validation.migration_skipped_no_alembic_ini` fires, (c) validation continues to the next command.
2. `test_migration_runs_when_alembic_ini_present`: build a workspace with `requires_database=True` AND a touched `alembic.ini` in the worktree. Run the validator. Assert the existing `_MIGRATION_SHELL` subprocess fires (mock the subprocess call; assert it was called with the right shell string).
3. `test_migration_skipped_when_requires_database_false`: requires_database=False, alembic.ini present — still skipped (matches existing behavior).
4. `test_migration_skipped_when_requires_database_false_no_alembic`: requires_database=False, no alembic.ini — skipped (existing behavior preserved).

## Verification checklist

- `ruff check .` clean.
- `ruff format --check .` clean.
- `pytest tests/unit/runtime/test_validation_skip_alembic.py -v` green.
- `pytest tests/unit/runtime/test_validation.py -v` (existing) green — behavior preserved for Python workspaces.
- `pytest tests/unit/runtime/ -v` — no other validator test regressions.

---
Validation: 4 test command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved database migration handling during workspace setup: initialization now validates that required database configuration files exist before attempting to run migrations. Migrations only execute when both enabled in workspace settings and the configuration file is present at the workspace root. This prevents common initialization errors and ensures more reliable workspace setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->