### PR TITLE
fix(monitor): resolve unresolved review comments from PR #11

### DIFF
--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -311,9 +311,13 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     4.  CI FAILURE → ReportCiFailure.
     5.  CI PENDING (or mergeable UNKNOWN with no other blocker) →
         WaitForCI (does not consume an iteration).
-    6.  Mergeable == CONFLICTING after addressing everything → Abort (the
-        coding CLI can't fix a structural conflict it doesn't know about).
-    7.  All green → Merge (or NotifyHuman if auto_merge=False).
+    6.  Legacy ``mergeable == CONFLICTING`` (without richer
+        mergeStateStatus) → SyncBase, same treatment as DIRTY.
+    7.  ``merge_state_status`` BLOCKED / HAS_HOOKS (branch protection or
+        required-review) → NotifyHuman regardless of auto_merge.
+    7.5. Deferred HUMAN feedback still unresolved on GitHub →
+        NotifyHuman. Deferred BOT feedback does not block.
+    8.  All green → Merge (or NotifyHuman if auto_merge=False).
     """
 
     # 0. Terminal upstream states short-circuit everything.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -357,7 +357,7 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     if new_threads or new_reviews:
         return AddressComments(threads=new_threads, review_comments=new_reviews)
 
-    # 3. CI failures.
+    # 4. CI failures.
     if status.check_state == CheckState.FAILURE:
         if not status.ci_failures:
             # Failure reported by GraphQL but no per-check log available.
@@ -367,7 +367,7 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
             return ReportCiFailure(failures=())
         return ReportCiFailure(failures=status.ci_failures)
 
-    # 4. CI still running, or GitHub is still computing state → passive wait.
+    # 5. CI still running, or GitHub is still computing state → passive wait.
     if status.check_state == CheckState.PENDING:
         return WaitForCI(reason="pending_checks")
     if (
@@ -385,7 +385,7 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # aborted. The PR #335/#336 stale-rev-list bug lived here too —
     # that fix (base_behind_count fallback) is preserved above.
 
-    # Legacy ``mergeable == CONFLICTING`` without the richer
+    # 6. Legacy ``mergeable == CONFLICTING`` without the richer
     # mergeStateStatus signal — same treatment as DIRTY: let SyncBase
     # attempt to reproduce + resolve.
     if status.mergeable == MergeableState.CONFLICTING:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ec3438a8b842413588b73dc5` (agent: `claude_code`).


### Task
## Context — cleanup after a human bulldozed PR #11

PR #11 ("fix(monitor): SyncBase runs BEFORE AddressComments on BEHIND/DIRTY") was merged to main with two unresolved review comments. Both are legitimate. This task addresses them.

## Environment

AWF workspace, aira-agent-workspace-fabric at `/workspace`, fresh feature branch off `main`. Python 3.12 + uv. First setup: `uv pip install -e ".[dev]" --quiet`.

## Scope — two small fixes

### 1. `src/awf/runtime/pr_monitor.py` — in-code step numbering inconsistent with docstring

PR #11 renumbered the gate list in `decide()`'s docstring (lines 311-312 area). The NEW order is:

```
0. Terminal
1. Budget (iter_cap / wall_clock)
2. Base behind → SyncBase  ← moved up
3. Unresolved comments → AddressComments  ← moved down
4. CI FAILURE → ReportCiFailure
5. CI PENDING → WaitForCI
6. CONFLICTING → (legacy)
7. All green → Merge / NotifyHuman
```

BUT the in-code section comments (lines ~355-400) still have the OLD numbering — `# 3. CI failures.`, `# 4. CI still running...`, etc. Update them to match the docstring:

- Rename `# 3. CI failures.` → `# 4. CI failures.`
- Rename `# 4. CI still running, or GitHub is still computing state` → `# 5. CI still running...`
- Rename `# 6. Legacy ``mergeable == CONFLICTING``` → `# 6. Legacy CONFLICTING...` (keep as 6)
- Rename `# 7. Branch protection / required-review blocker` → `# 7. Branch protection / required-review blocker` (stays)
- Rename `# 7.5. Deferred feedback still unresolved on GitHub` → `# 7.5. Deferred feedback...` (stays)
- Rename `# 8. All green — terminal success action.` → `# 8. All green — terminal success action.` (stays)

Actually — re-read the file yourself to see EXACT current numbering after PR #11's changes. Make the in-code numbers match the docstring. Line numbers may have shifted.

The CodeRabbit review comment URL: `https://github.com/dimileeh/aira-agent-workspace-fabric/pull/11#discussion_r...`. The exact comment said: "The docstring at lines 311-312 lists CI FAILURE as step 4, but the in-code comment at line 360 still uses the old numbering."

### 2. Do NOT revert the scope-creep spec JSONs

PR #11 also swept 3 AWF spec JSONs into the main tree: `awf_monitor_unbounded_iterations.json`, `awf_validation_skip_alembic_when_absent.json`, `airaweb_button_coverage_e2e_v2.json`. Gemini correctly flagged this as scope-creep for PR #11.

HOWEVER, these spec files belong in `scripts/` — they are the AWF task prompt archive, same as `airaagent_deprecate_cerebras.json`, `airaweb_issues_bulk_create_tasks.json`, and the 5 others committed in commit 489ba14 ("chore(scripts): archive AWF task specs from 2026-04-24 session"). Their placement is correct; only their bundling into PR #11 was wrong.

**DO NOT delete these files.** They are valid repository artifacts. The scope-creep complaint was about PR discipline, not file correctness. In THIS follow-up PR's description, acknowledge Gemini's comment with: "PR #11 mixed the gate-order fix with spec-archive commits. The specs themselves are valid artifacts (matching the existing archive pattern — see commit 489ba14); the mistake was bundling them into an unrelated PR. This cleanup addresses CodeRabbit's numbering issue; the scope-mixing is a process lesson, not a file to revert."

## Strict TDD workflow

This is a documentation-only code change (comments only, no behavior change). No new test file required. Run the existing runtime test suite to confirm zero regression:

1. Read `src/awf/runtime/pr_monitor.py` to find the current in-code `# N.` comments.
2. Make one commit: `fix(monitor): sync in-code step numbering with docstring after PR #11 reorder`.
3. Run `pytest tests/unit/runtime/ -v --timeout 30` — all 161 tests must pass.

## Verification checklist

- `ruff check .` clean.
- `ruff format --check .` clean.
- `pytest tests/unit/runtime/ -v --timeout 30` — 161 passing.
- In-code numeric step comments in `decide()` match the docstring.
- No files removed from `scripts/`.
- PR description acknowledges Gemini's scope comment with the wording above.

## Do NOT

- Do NOT revert any files committed in PR #11.
- Do NOT change the gate-order logic itself (it's correct).
- Do NOT add new tests; this is a comment-only fix.
- Do NOT touch any files outside `src/awf/runtime/pr_monitor.py`.
- Do NOT rename the function, decorators, or public API of `decide()`.

---
Validation: 4 test command(s) passed inside the workspace container.
