### PR TITLE
fix(tribunal): batch nine bugs from hunter/validator/judge review

### DIFF
--- a/scripts/attach_feature_pr_monitor.py
+++ b/scripts/attach_feature_pr_monitor.py
@@ -236,12 +236,16 @@ async def orchestrate_attach(
 
         # Spawn run_awf.py detached. We pass --keep-state so the shared
         # SQLite DB in work_dir isn't wiped on startup.
+        #
+        # ``sys.executable`` (not a hardcoded ``.venv/bin/python``) so the
+        # script works under ``uv run``, system python, or a venv rooted
+        # anywhere other than ``<repo>/.venv`` — sibling scheduler scripts
+        # already follow this pattern.
         log_path = work_dir / f"feature-pr-monitor-{pr_number}.log"
-        python_bin = _ROOT / ".venv" / "bin" / "python"
         run_awf = _ROOT / "scripts" / "run_awf.py"
         handle = spawn(
             [
-                str(python_bin),
+                sys.executable,
                 str(run_awf),
                 "--config",
                 str(spec_path),

--- a/scripts/release_pr_watcher.py
+++ b/scripts/release_pr_watcher.py
@@ -181,13 +181,30 @@ async def _run(
     runner = AsyncioSubprocessRunner()
     stop = asyncio.Event()
 
-    def _handle_signal(signum: int, _frame: object) -> None:  # type: ignore[no-untyped-def]
-        _log.info("watcher.shutdown_signal", signum=signum)
+    def _handle_signal(sig: signal.Signals) -> None:
+        _log.info("watcher.shutdown_signal", signum=int(sig))
         stop.set()
 
-    # SIGTERM from orchestrators, SIGINT from Ctrl+C.
-    signal.signal(signal.SIGTERM, _handle_signal)
-    signal.signal(signal.SIGINT, _handle_signal)
+    # SIGTERM from orchestrators, SIGINT from Ctrl+C. Use the asyncio-native
+    # registration path so the handler runs on the event loop (safe to call
+    # ``stop.set()``) rather than from a C-level signal handler, where the
+    # scheduling hop to the loop can be delayed by whatever coroutine is
+    # currently holding the thread — per CPython asyncio docs.
+    #
+    # ``loop.add_signal_handler`` raises ``NotImplementedError`` on
+    # Windows event loops per the asyncio docs. The watcher is Linux-only
+    # in production, but the fallback keeps dev-on-Windows usable: drop
+    # back to ``signal.signal`` + ``call_soon_threadsafe`` so the C-level
+    # handler hops to the loop safely.
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, _handle_signal, sig)
+        except NotImplementedError:
+            signal.signal(
+                sig,
+                lambda _signum, _frame, s=sig: loop.call_soon_threadsafe(_handle_signal, s),
+            )
 
     _log.info(
         "watcher.start",

--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -37,7 +37,9 @@ import awf.adapters.gemini  # noqa: E402, F401
 from awf.adapters.base import get_adapter  # noqa: E402
 from awf.common.commands import AsyncioSubprocessRunner  # noqa: E402
 from awf.common.github_client import GitHubClient  # noqa: E402
+from awf.common.ids import new_event_id  # noqa: E402
 from awf.db.enums import AgentRuntime, WorkspaceStatus  # noqa: E402
+from awf.db.models import WorkspaceEvent  # noqa: E402
 from awf.db.repositories import WorkspaceRepository  # noqa: E402
 from awf.db.session import make_session_factory  # noqa: E402
 from awf.runtime.release_pr_monitor import build_feature_pr_monitor  # noqa: E402
@@ -81,11 +83,27 @@ async def _main(work_dir: Path, workspace_id: str) -> int:
         # ``monitor_threads_addressed`` so we don't re-poke CodeRabbit
         # threads we already resolved. Review feedback on PR #2
         # (CodeRabbit): flag the wall-clock-cap reset pattern.
+        #
+        # We append a ``WorkspaceEvent`` by hand because the state-machine
+        # assert_transition refuses ``completed → monitoring_pr``. Without
+        # this, the workspace_events log has a gap between the original
+        # MONITOR_DONE entry and whatever the re-attached monitor emits
+        # next — operators auditing lifecycle would not see the reset.
+        old_state = ws.status
         ws.status = WorkspaceStatus.monitoring_pr.value
         ws.failure_reason = None
         ws.failure_message = None
         ws.monitor_iter_count = 0
         ws.monitor_started_at = None
+        ws.events.append(
+            WorkspaceEvent(
+                id=new_event_id(),
+                event_type="workspace.remonitor_reset",
+                old_state=old_state,
+                new_state=WorkspaceStatus.monitoring_pr.value,
+                reason_code="OPERATOR_REMONITOR",
+            )
+        )
         await s.commit()
         agent_runtime = AgentRuntime(ws.agent)
         compose_project = ws.compose_project_name or f"awf_{workspace_id}"

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import re
+import weakref
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -76,15 +77,46 @@ class WorktreeLayout:
 class GitManager:
     """Manages bare mirrors and per-workspace worktrees on the local filesystem."""
 
+    # Lock registry scoped by event loop. Must be class-level, not
+    # instance-level: ``scripts/run_awf.py`` constructs one ``GitManager``
+    # per task inside ``asyncio.gather(...)``. If the dict were an
+    # instance attribute, two concurrent tasks targeting the same repo
+    # would get INDEPENDENT locks and race on ``git clone --mirror`` /
+    # ``worktree add`` / ``worktree prune`` — the exact corruption the
+    # lock exists to prevent.
+    #
+    # We key first by running loop, then by resolved mirror path, rather
+    # than keeping a flat ``{path → Lock}`` dict, because ``asyncio.Lock``
+    # binds to its creating loop on first acquire and re-acquiring from a
+    # different loop raises ``RuntimeError``. Production runs one
+    # ``asyncio.run``, but pytest-asyncio creates a fresh loop per test —
+    # a flat registry would hand the second test a stale lock from the
+    # first. The WeakKeyDictionary drops the inner dict automatically
+    # when a loop is garbage-collected. ``mirror_path.resolve()`` as the
+    # inner key ensures symlinks / relative-vs-absolute forms of the
+    # same physical path share a lock.
+    _mirror_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, dict[str, asyncio.Lock]] = (
+        weakref.WeakKeyDictionary()
+    )
+
     def __init__(self, work_dir: Path) -> None:
         self._work_dir = work_dir
         self._mirrors_dir = work_dir / "mirrors"
         self._worktrees_dir = work_dir / "worktrees"
-        # Per-repo-URL lock so two concurrent ``ensure_mirror`` calls for the same
-        # repo serialize (the first clones; the second sees the mirror already
-        # present and only fetches). Without this, parallel provisioning of
-        # workspaces against the same repo races on the initial clone.
-        self._mirror_locks: dict[str, asyncio.Lock] = {}
+
+    @classmethod
+    def _lock_for_mirror(cls, mirror_path: Path) -> asyncio.Lock:
+        """Return the per-loop lock for ``mirror_path``, creating it on
+        first use. Safe across multiple ``asyncio.run`` invocations
+        (tests, multi-loop callers) because each loop gets its own
+        inner dict and the inner dict + its Locks are GC'd when the
+        loop goes away."""
+        loop = asyncio.get_running_loop()
+        loop_locks = cls._mirror_locks.get(loop)
+        if loop_locks is None:
+            loop_locks = {}
+            cls._mirror_locks[loop] = loop_locks
+        return loop_locks.setdefault(str(mirror_path.resolve()), asyncio.Lock())
 
     @property
     def work_dir(self) -> Path:
@@ -101,7 +133,7 @@ class GitManager:
         """
         self._mirrors_dir.mkdir(parents=True, exist_ok=True)
         mirror_path = self._mirror_path(repo_url)
-        lock = self._mirror_locks.setdefault(repo_url, asyncio.Lock())
+        lock = self._lock_for_mirror(mirror_path)
 
         async with lock:
             if mirror_path.exists():
@@ -238,7 +270,7 @@ class GitManager:
         # under the new refspec) never targets the worktree's own branch.
         tracking_ref = f"origin/{base_branch}"
 
-        lock = self._mirror_locks.setdefault(repo_url, asyncio.Lock())
+        lock = self._lock_for_mirror(mirror_path)
         async with lock:
             try:
                 await self._run(
@@ -287,30 +319,39 @@ class GitManager:
 
         We also run ``worktree prune`` so metadata is cleaned up even if the
         directory was deleted out-of-band.
+
+        The per-mirror lock is held for both operations because the mirror's
+        ``$GIT_DIR/worktrees/`` admin dir is a single file git mutates on
+        every worktree add / remove / prune. Without the lock, a concurrent
+        ``add_worktree`` (e.g. one workspace tearing down while another
+        provisions against the same mirror) can see a half-pruned registry
+        and end up with a dangling worktree entry or a corrupted HEAD ref.
         """
         mirror_path = self._mirror_path(repo_url)
         worktree_path = self._worktrees_dir / workspace_id
 
-        if worktree_path.exists():
-            # ``--force`` because a failed task may leave dirty state.
-            await self._run(
-                [
-                    "git",
-                    "--git-dir",
-                    str(mirror_path),
-                    "worktree",
-                    "remove",
-                    "--force",
-                    str(worktree_path),
-                ],
-                operation="worktree.remove",
-            )
+        lock = self._lock_for_mirror(mirror_path)
+        async with lock:
+            if worktree_path.exists():
+                # ``--force`` because a failed task may leave dirty state.
+                await self._run(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_path),
+                        "worktree",
+                        "remove",
+                        "--force",
+                        str(worktree_path),
+                    ],
+                    operation="worktree.remove",
+                )
 
-        if mirror_path.exists():
-            await self._run(
-                ["git", "--git-dir", str(mirror_path), "worktree", "prune"],
-                operation="worktree.prune",
-            )
+            if mirror_path.exists():
+                await self._run(
+                    ["git", "--git-dir", str(mirror_path), "worktree", "prune"],
+                    operation="worktree.prune",
+                )
 
     async def head_sha(self, *, workspace_id: str) -> str:
         """Return the current HEAD SHA of the workspace's worktree.

--- a/src/awf/runtime/feature_pr_sync.py
+++ b/src/awf/runtime/feature_pr_sync.py
@@ -184,7 +184,7 @@ def _parse_metadata(payload: dict[str, Any]) -> FeaturePRMetadata:
             operation="fetch_pr_metadata",
             stderr=f"PR #{number} is already merged — no monitor to attach",
         )
-    if closed or state == "CLOSED":
+    if closed:
         raise FeaturePRSyncError(
             operation="fetch_pr_metadata",
             stderr=f"PR #{number} is closed — no monitor to attach",

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -949,16 +949,21 @@ class PullRequestMonitorRunner:
         compose_file: Path,
     ) -> None:
         """Run ``docker compose down --remove-orphans --volumes`` for a
-        terminated workspace. Truly never raises.
+        terminated workspace. Never raises a regular ``Exception``.
 
-        The entire call is wrapped in a blanket ``except Exception``
-        because the failure modes here include ``FileNotFoundError``
-        (no ``docker`` on PATH — happens on dev laptops without the
-        daemon), ``asyncio.CancelledError`` during shutdown, and
-        transient I/O errors from the subprocess runner itself. None
-        of those are reasons to fail a workspace that already merged
-        its PR — the completion signal has already landed in the DB
-        before this method runs."""
+        The call is wrapped in ``except Exception`` so the failure modes
+        that routinely bubble up — ``FileNotFoundError`` (no ``docker``
+        on PATH, common on dev laptops without the daemon), transient
+        I/O errors from the subprocess runner, compose returning junk
+        stderr — don't fail a workspace that already merged its PR. The
+        DB completion transition has already landed before this method
+        runs.
+
+        ``asyncio.CancelledError`` is intentionally NOT caught here
+        (since Python 3.8 it inherits from ``BaseException``, so the
+        ``except Exception`` clause does not match it). Cancellation
+        must propagate cleanly — swallowing it would defeat the loop
+        runner's shutdown path."""
         try:
             r = await self._deps.runner.run(
                 [
@@ -974,10 +979,11 @@ class PullRequestMonitorRunner:
                 ]
             )
         except Exception as exc:
-            # docker binary missing, transient I/O, cancellation — any of
-            # these would otherwise propagate and crash the monitor
-            # runner. Log and swallow; the DB transition already
-            # completed.
+            # docker binary missing, transient I/O, subprocess-runner
+            # hiccup — any of these would otherwise propagate and crash
+            # the monitor runner. Log and swallow; the DB transition
+            # already completed. Cancellation (BaseException) is not in
+            # this branch by design — it flows through.
             _log.warning(
                 "monitor.compose_teardown_raised",
                 workspace_id=workspace_id,

--- a/tests/unit/scripts/test_release_pr_watcher.py
+++ b/tests/unit/scripts/test_release_pr_watcher.py
@@ -460,21 +460,35 @@ class TestRunLoop:
     async def test_signal_handler_sets_stop_event(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Covers the signal-handler body (lines 185-186). We capture
-        the handler that ``_run`` registers via ``signal.signal``, then
-        invoke it with a fake signum and assert it sets the stop event.
+        """Covers the signal-handler body. We capture the handler that
+        ``_run`` registers via ``loop.add_signal_handler`` (the
+        asyncio-native path — the earlier ``signal.signal`` call chain
+        was racy against the event loop per the asyncio docs), then
+        invoke it and assert it sets the stop event.
         """
         import signal
 
-        captured: dict[str, Any] = {}
-        real_signal = signal.signal
+        captured: dict[signal.Signals, tuple[Any, tuple[Any, ...]]] = {}
 
-        def _capture(signum: int, handler: Any) -> Any:
-            if signum in (signal.SIGTERM, signal.SIGINT):
-                captured[signum] = handler
-            return real_signal(signum, handler)
+        # Patch on the concrete loop class that pytest-asyncio actually
+        # constructs — ``BaseEventLoop`` has a stub that the Unix loop
+        # overrides, so patching the base class is invisible.
+        loop = asyncio.get_running_loop()
 
-        monkeypatch.setattr(signal, "signal", _capture)
+        def _capture_add(
+            self_loop: asyncio.AbstractEventLoop,
+            sig: signal.Signals,
+            callback: Any,
+            *args: Any,
+        ) -> None:
+            if sig in (signal.SIGTERM, signal.SIGINT):
+                captured[sig] = (callback, args)
+
+        monkeypatch.setattr(
+            type(loop),
+            "add_signal_handler",
+            _capture_add,
+        )
 
         stop_from_outside: asyncio.Event | None = None
         orig_event = asyncio.Event
@@ -486,12 +500,13 @@ class TestRunLoop:
             return e
 
         async def _tick_once_then_verify_and_stop(**kwargs: Any) -> None:
-            # By now the handler has been registered. Call it with a
-            # fake signum — the handler should set stop.
+            # By now the handler has been registered on the loop. Invoke
+            # it directly (bypassing the real signal delivery) — it
+            # should set stop.
             assert stop_from_outside is not None
             assert not stop_from_outside.is_set()
-            handler = captured[signal.SIGTERM]
-            handler(signal.SIGTERM, None)
+            callback, args = captured[signal.SIGTERM]
+            callback(*args)
             assert stop_from_outside.is_set()
 
         monkeypatch.setattr(release_pr_watcher.asyncio, "Event", _capture_event)


### PR DESCRIPTION
## Summary

Bundled fix PR for the nine bugs confirmed by the three-stage review (bug-hunter → bug-validator → bug-judge). Six dismissed findings were not touched.

## Confirmed bugs addressed

| # | Sev | Where | Fix |
|---|-----|-------|-----|
| 1 | High | `src/awf/node/git_manager.py` | `_mirror_locks` hoisted to class-level dict keyed on `mirror_path`. Prior per-instance dict meant concurrent per-task `GitManager`s in `run_awf.py` raced on clone/worktree-add for the same repo. |
| 3 | High | `scripts/attach_feature_pr_monitor.py:190` | Replaces hardcoded `.venv/bin/python` with `sys.executable` (matches sibling scripts; works under `uv run` / system python). |
| 6 | Med | `src/awf/node/git_manager.py:remove_worktree` | Acquires the per-mirror lock around `worktree remove` + `prune`. Concurrent add+remove could corrupt the mirror's shared worktree registry. |
| 7 | Med | `scripts/release_pr_watcher.py` | Uses `loop.add_signal_handler` instead of `signal.signal + Event.set` — the asyncio-documented pattern. |
| 8 | Med | `src/awf/runtime/feature_pr_sync.py:187` | Drops redundant `or state == "CLOSED"` tail that duplicated the variable it was OR-ing with. |
| 9 | Med | `src/awf/runtime/pr_monitor_runner.py` | `max_outer_iterations` default `10_000` → `1_000`. At `poll_interval=60s` the old value left ~7 days of `WaitForCI` spin pinning docker subnets; 1000 ≈ 16h, still comfortably past the 6h wall-clock cap. |
| 10 | Med | `scripts/remonitor_workspace.py` | Appends a `workspace_events` row for the intentional `completed→monitoring_pr` reset. State-machine bypass is intentional; missing audit entry was not. |
| 13 | Min | `src/awf/runtime/pr_monitor.py` | Gate comments `# 3.` / `# 4.` renumbered to `# 4.` / `# 5.` to match the `decide()` docstring after PR #11's reorder. Docstring extended to cover the existing-but-undocumented gates 6, 7, and 7.5. |
| 15 | Min | `src/awf/runtime/pr_monitor_runner.py:_teardown_compose_stack` | Docstring corrected — `CancelledError` is `BaseException` since Py3.8 and is NOT caught by `except Exception`; documents that cancellation is allowed to propagate. |

## Dismissed findings (not touched)

- #2 review-level comment resolution — GitHub GraphQL has no `resolveReviewThread` equivalent for review-summary bodies; current state-dedup is the right option.
- #4 `_run_sync_base` push after conflict — HEAD doesn't advance on conflict, push is a no-op; `merge --abort` already runs first on next iteration.
- #5 defer-on-empty-stdout — the conservative default; human defers still route to `NotifyHuman` which posts a PR comment.
- #11 `state.last_push_sha` — field has no readers anywhere in the code; no decision depends on its freshness.
- #12 alembic.ini host-path check — worktree is bind-mounted at identical paths host/container; purely speculative future concern.
- #14 pid-suffixed tmpfile — filename scopes by `{workspace_id}`; pid-recycle collision implausible.

## Test plan

- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `pytest tests/unit/` — 559 passed, 1 skipped
- [x] `pytest tests/integration/` (excluding docker/postgres-heavy suites) — 56 passed
- [x] `tests/unit/scripts/test_release_pr_watcher.py::test_signal_handler_sets_stop_event` updated to patch `loop.add_signal_handler` instead of `signal.signal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent git operation handling to prevent race conditions.
  * Enhanced signal termination handling for more reliable shutdown.

* **Improvements**
  * Better interpreter compatibility across different Python environments.
  * Added workspace event tracking for remonitoring operations.
  * Adjusted monitoring safety parameters for optimal performance.

* **Documentation**
  * Clarified monitoring decision logic and error handling flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->