### PR TITLE
feat(cli): add awf node status

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Preview profile resolution for a local checkout:
 awf profile preview ~/Projects/example-repo --profile auto
 ```
 
+Check local node readiness for workspace execution:
+
+```bash
+awf node status
+awf node status --format pretty
+```
+
 Create a v2 workspace:
 
 ```bash

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from enum import StrEnum
 from typing import Any
@@ -30,8 +31,10 @@ app = typer.Typer(
 
 workspace_app = typer.Typer(help="Workspace lifecycle (create/inspect/destroy).")
 profile_app = typer.Typer(help="Workspace profile inspection.")
+node_app = typer.Typer(help="Local node operator health.")
 app.add_typer(workspace_app, name="workspace")
 app.add_typer(profile_app, name="profile")
+app.add_typer(node_app, name="node")
 
 
 class OutputFormat(StrEnum):
@@ -40,6 +43,7 @@ class OutputFormat(StrEnum):
 
 
 _DEFAULT_BASE_URL = "http://localhost:8000"
+_AGENT_RUNTIME_IMAGE = "awf-agent-runtime:latest"
 
 
 def _base_url(override: str | None) -> str:
@@ -90,6 +94,57 @@ def _handle_response(response: httpx.Response, fmt: OutputFormat) -> None:
     _emit(response.json(), fmt)
 
 
+def _run_local_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603
+        command,
+        capture_output=True,
+        check=False,
+        text=True,
+        timeout=10,
+    )
+
+
+def _command_error(result: subprocess.CompletedProcess[str]) -> str | None:
+    message = (result.stderr or result.stdout).strip()
+    if message:
+        return message
+    return f"exited with code {result.returncode}"
+
+
+def _inspect_command(command: list[str]) -> dict[str, object]:
+    try:
+        result = _run_local_command(command)
+    except FileNotFoundError as exc:
+        return {"available": False, "error": str(exc)}
+    except subprocess.TimeoutExpired as exc:
+        return {"available": False, "error": f"timed out after {exc.timeout} seconds"}
+
+    if result.returncode == 0:
+        return {"available": True, "error": None}
+    return {"available": False, "error": _command_error(result)}
+
+
+def _node_status_payload() -> dict[str, object]:
+    docker_cli = _inspect_command(["docker", "--version"])
+    docker_daemon = _inspect_command(["docker", "info"])
+    docker_compose = _inspect_command(["docker", "compose", "version"])
+    runtime_image = _inspect_command(["docker", "image", "inspect", _AGENT_RUNTIME_IMAGE])
+
+    return {
+        "docker_cli": docker_cli,
+        "docker_daemon": {
+            "reachable": docker_daemon["available"],
+            "error": docker_daemon["error"],
+        },
+        "docker_compose_plugin": docker_compose,
+        "agent_runtime_image": {
+            "name": _AGENT_RUNTIME_IMAGE,
+            "exists": runtime_image["available"],
+            "error": runtime_image["error"],
+        },
+    }
+
+
 # ── Commands ─────────────────────────────────────────────────────────────
 
 
@@ -109,6 +164,14 @@ def serve(
         port=port,
         reload=reload,
     )
+
+
+@node_app.command("status")
+def node_status(
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Inspect local Docker prerequisites for running AWF workspaces."""
+    _emit(_node_status_payload(), fmt)
 
 
 @workspace_app.command("create")

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -8,6 +8,7 @@ End-to-end testing against a real server lives in tests/e2e/ (future).
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -205,3 +206,81 @@ class TestConnectionErrors:
 
         assert result.exit_code == 2
         assert "could not reach" in result.stderr
+
+
+class TestNodeStatus:
+    @pytest.mark.unit
+    def test_emits_json_status_for_available_node(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["docker"],
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+        with patch("awf.cli.main._run_local_command", return_value=completed) as mock:
+            result = _runner.invoke(app, ["node", "status"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload == {
+            "docker_cli": {"available": True, "error": None},
+            "docker_daemon": {"reachable": True, "error": None},
+            "docker_compose_plugin": {"available": True, "error": None},
+            "agent_runtime_image": {
+                "name": "awf-agent-runtime:latest",
+                "exists": True,
+                "error": None,
+            },
+        }
+        assert [call.args[0] for call in mock.call_args_list] == [
+            ["docker", "--version"],
+            ["docker", "info"],
+            ["docker", "compose", "version"],
+            ["docker", "image", "inspect", "awf-agent-runtime:latest"],
+        ]
+
+    @pytest.mark.unit
+    def test_reports_docker_errors_without_crashing(self) -> None:
+        def fake_run(command: list[str]) -> subprocess.CompletedProcess[str]:
+            if command == ["docker", "--version"]:
+                raise FileNotFoundError("docker")
+            return subprocess.CompletedProcess(
+                args=command,
+                returncode=1,
+                stdout="",
+                stderr="cannot connect to docker daemon",
+            )
+
+        with patch("awf.cli.main._run_local_command", side_effect=fake_run):
+            result = _runner.invoke(app, ["node", "status"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.stdout)
+        assert payload["docker_cli"] == {"available": False, "error": "docker"}
+        assert payload["docker_daemon"] == {
+            "reachable": False,
+            "error": "cannot connect to docker daemon",
+        }
+        assert payload["docker_compose_plugin"] == {
+            "available": False,
+            "error": "cannot connect to docker daemon",
+        }
+        assert payload["agent_runtime_image"]["exists"] is False
+        assert payload["agent_runtime_image"]["error"] == "cannot connect to docker daemon"
+
+    @pytest.mark.unit
+    def test_pretty_format_uses_existing_pretty_output(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["docker"],
+            returncode=0,
+            stdout="ok",
+            stderr="",
+        )
+
+        with patch("awf.cli.main._run_local_command", return_value=completed):
+            result = _runner.invoke(app, ["node", "status", "--format", "pretty"])
+
+        assert result.exit_code == 0
+        assert "agent_runtime_image:" in result.stdout
+        assert "docker_cli:" in result.stdout


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_375197c9e6fe4b9b881f68f3` (agent: `codex`).


### Task
Implement the first tiny PRD operator-health slice: add an `awf node status` CLI command.

Context:
- You are working in the AWF repo on a branch already created by AWF.
- The repo has a local `.awf/workspace.yml`; AWF owns setup and validation phases.
- Keep the change narrowly scoped to CLI/operator health.

Required behavior:
1. Add a `node` Typer command group and a `status` command.
2. Default output must stay JSON, matching existing CLI output conventions. `--format pretty` must also work.
3. The status payload must report:
   - Docker CLI availability.
   - Docker daemon reachability.
   - Docker Compose plugin availability.
   - Whether `awf-agent-runtime:latest` exists locally.
4. The command must return actionable structured fields instead of crashing when Docker is unavailable.
5. Add focused unit tests with mocked subprocess results. Do not require a real Docker daemon in unit tests.
6. Update README with a short example for `awf node status`.

Implementation guidance:
- Prefer a small helper in `src/awf/cli/main.py` or a nearby CLI-local module if that keeps tests cleaner.
- Preserve current CLI behavior for workspace/profile commands.
- Use only stdlib subprocess helpers for local node inspection; do not add dependencies.
- Commit your work locally with a conventional commit message.

Validation expected by the AWF profile:
- `uv run ruff check src/awf/cli tests/unit/cli`
- `uv run mypy src/awf/cli`
- `uv run pytest tests/unit/cli -q`

Do not push. AWF handles push, PR creation, monitoring, and merge.

---
Validation: 3 profile command(s) passed inside the workspace container.
