### PR TITLE
docs(monitor): document pre-merge review gate

### DIFF
--- a/docs/PLAN_PR_MONITOR.md
+++ b/docs/PLAN_PR_MONITOR.md
@@ -109,6 +109,8 @@ while True:
         continue
 
     # All 5 gates green — merge.
+    # First, recheck a final quiet window. Do not auto-merge if a review bot
+    # says review was skipped or leaves a trigger-review checklist unresolved.
     gh_pr_merge(--squash --delete-branch)
     transition_workspace(completed)
     return


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ef8492d5ed20454fa491917a` (agent: `codex`).


### Task
Implement a tiny docs-only follow-up for AWF's PR monitor: add a concise note to docs/PLAN_PR_MONITOR.md explaining that the monitor performs a final pre-merge quiet-window recheck and must not auto-merge when a review bot reports that review was skipped or leaves a trigger-review checklist unresolved. Keep the change minimal. Run the profile validation commands. Commit the change locally. Do not push; AWF will push and create the PR.

---
Validation: 3 profile command(s) passed inside the workspace container.
