### PR TITLE
feat(api): add workspace events endpoint

### DIFF
--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -20,7 +20,7 @@ from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf import __version__
-from awf.api.routes import health, workspaces
+from awf.api.routes import events, health, workspaces
 from awf.common.config import Settings, get_settings
 from awf.db.base import Base
 from awf.db.session import make_engine, make_session_factory
@@ -76,6 +76,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     )
 
     app.include_router(health.router)
+    app.include_router(events.router)
     app.include_router(workspaces.router)
     app.include_router(workspaces.router_v2)
 

--- a/src/awf/api/routes/events.py
+++ b/src/awf/api/routes/events.py
@@ -1,0 +1,29 @@
+"""Workspace event observability endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.deps import get_db_session
+from awf.api.schemas import WorkspaceEventListResponse, WorkspaceEventResponse
+from awf.db.repositories import WorkspaceRepository
+
+router = APIRouter(prefix="/v1/events", tags=["events"])
+
+
+@router.get("", response_model=WorkspaceEventListResponse)
+async def list_events(
+    workspace_id: Annotated[str | None, Query()] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceEventListResponse:
+    repo = WorkspaceRepository(session)
+    rows = await repo.list_events(workspace_id=workspace_id, limit=limit)
+    return WorkspaceEventListResponse(
+        items=[WorkspaceEventResponse.model_validate(row) for row in rows],
+        next_cursor=None,
+        has_more=False,
+    )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -145,6 +145,33 @@ class WorkspaceAcceptedResponse(BaseModel):
     accepted_at: datetime
 
 
+class WorkspaceEventResponse(BaseModel):
+    """Representation of one workspace audit event in API responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    workspace_id: str
+    event_type: str
+    old_state: WorkspaceStatus | None
+    new_state: WorkspaceStatus | None
+    reason_code: str | None
+    payload: dict[str, Any] | None
+    occurred_at: datetime
+
+
+class WorkspaceEventListResponse(BaseModel):
+    """Cursor-compatible event list envelope.
+
+    Cursor pagination is intentionally deferred; keep the envelope stable so
+    callers do not need a breaking response-shape change when it is added.
+    """
+
+    items: list[WorkspaceEventResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
 class ErrorResponse(BaseModel):
     """Uniform error envelope.
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -10,6 +10,7 @@ SQLAlchemy calls everywhere. Rules:
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import select
@@ -96,6 +97,17 @@ class WorkspaceRepository:
 
     async def list(self, *, limit: int = 50) -> list[Workspace]:
         stmt = select(Workspace).order_by(Workspace.created_at.desc()).limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def list_events(
+        self, *, workspace_id: str | None = None, limit: int = 50
+    ) -> Sequence[WorkspaceEvent]:
+        stmt = select(WorkspaceEvent).order_by(
+            WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc()
+        )
+        if workspace_id is not None:
+            stmt = stmt.where(WorkspaceEvent.workspace_id == workspace_id)
+        stmt = stmt.limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
     async def transition(

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -1,0 +1,103 @@
+"""Event observability API contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+_MINIMAL_BODY = {
+    "repo_url": "git@github.com:dimileeh/aira-agent.git",
+    "branch_base": "development",
+    "task_title": "Add module docstring",
+    "task_prompt": "Add a one-line docstring to src/aira_agent/api/main.py.",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+async def _create_workspace(client: AsyncClient, title: str) -> str:
+    response = await client.post("/v1/workspaces", json={**_MINIMAL_BODY, "task_title": title})
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+class TestListEvents:
+    @pytest.mark.unit
+    async def test_returns_empty_page_when_no_events(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events")
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "next_cursor": None, "has_more": False}
+
+    @pytest.mark.unit
+    async def test_lists_all_events_newest_first(self, client: AsyncClient) -> None:
+        ids = [
+            await _create_workspace(client, "first"),
+            await _create_workspace(client, "second"),
+            await _create_workspace(client, "third"),
+        ]
+
+        response = await client.get("/v1/events")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+        assert [item["workspace_id"] for item in body["items"]] == list(reversed(ids))
+
+        first = body["items"][0]
+        assert set(first) == {
+            "id",
+            "workspace_id",
+            "event_type",
+            "old_state",
+            "new_state",
+            "reason_code",
+            "payload",
+            "occurred_at",
+        }
+        assert first["id"].startswith("evt_")
+        assert first["event_type"] == "workspace.created"
+        assert first["old_state"] is None
+        assert first["new_state"] == "requested"
+        assert first["reason_code"] == "CREATED"
+        assert first["payload"] is None
+
+    @pytest.mark.unit
+    async def test_filters_events_by_workspace_id(self, client: AsyncClient) -> None:
+        first_id = await _create_workspace(client, "first")
+        second_id = await _create_workspace(client, "second")
+
+        response = await client.get("/v1/events", params={"workspace_id": first_id})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [item["workspace_id"] for item in body["items"]] == [first_id]
+        assert second_id not in {item["workspace_id"] for item in body["items"]}
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+
+    @pytest.mark.unit
+    async def test_limit_caps_returned_events(self, client: AsyncClient) -> None:
+        ids = [
+            await _create_workspace(client, "first"),
+            await _create_workspace(client, "second"),
+            await _create_workspace(client, "third"),
+        ]
+
+        response = await client.get("/v1/events", params={"limit": 2})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [item["workspace_id"] for item in body["items"]] == list(reversed(ids))[:2]
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("limit", [0, 501])
+    async def test_rejects_limit_outside_supported_bounds(
+        self, client: AsyncClient, limit: int
+    ) -> None:
+        response = await client.get("/v1/events", params={"limit": limit})
+
+        assert response.status_code == 422


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_6f87fb12f5c5473e8637102e` (agent: `codex`).


### Task
Implement the PRD's basic event observability endpoint: `GET /v1/events`.

## Required behavior
- Add `GET /v1/events` to the FastAPI app.
- Return workspace events newest-first to match workspace list behavior.
- Support query params: `workspace_id: str | None` and `limit: int = 50` bounded to `1..500`.
- Response shape must be `{ "items": [...], "next_cursor": null, "has_more": false }`.
- Event item fields: event id, workspace id, event type, old state, new state, reason code, payload, occurred_at.
- Wire the route into the FastAPI app.
- Do not implement SSE or cursor pagination yet; keep the response shape compatible with adding it later.

## Strict TDD workflow
1. Write focused failing API tests first under `tests/unit/api`. Cover list all events, filter by workspace, limit-bound validation, and empty result.
2. Run the narrow failing tests and paste the failing output into the red commit body.
3. Implement until green.
4. Run all validation commands below.
5. Commit with conventional commits. Do not push; AWF owns push, PR creation, monitoring, and merge.

## Validation commands
- `uv run ruff check src/awf/api src/awf/db tests/unit/api`
- `uv run mypy src/awf/api src/awf/db`
- `uv run pytest tests/unit/api -q`

## Constraints
- Do not switch branches. AWF already created the branch.
- Keep this API-only; do not add CLI or dashboard code.
- Do not change existing workspace create/list/show semantics.

---
Validation: 6 profile command(s) passed inside the workspace container.
