### PR TITLE
feat(profiles): add profile linting core

### DIFF
--- a/src/awf/profiles/__init__.py
+++ b/src/awf/profiles/__init__.py
@@ -5,6 +5,7 @@ generic; profiles describe runtime services, Docker requirements, setup and
 validation phases, and project-specific environment.
 """
 
+from awf.profiles.lint import LintIssue, LintSeverity, lint_profile
 from awf.profiles.models import (
     DockerMode,
     ProfileCommand,
@@ -19,6 +20,8 @@ from awf.profiles.resolver import ProfileResolver, resolve_workspace_profile
 
 __all__ = [
     "DockerMode",
+    "LintIssue",
+    "LintSeverity",
     "ProfileCommand",
     "ProfileDocker",
     "ProfilePhaseSet",
@@ -27,5 +30,6 @@ __all__ = [
     "ProfileResolver",
     "ProfileService",
     "WorkspaceProfile",
+    "lint_profile",
     "resolve_workspace_profile",
 ]

--- a/src/awf/profiles/lint.py
+++ b/src/awf/profiles/lint.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from .models import DockerMode
-
-if TYPE_CHECKING:
-    from .models import WorkspaceProfile
+from .models import DockerMode, WorkspaceProfile
 
 
 class LintSeverity(StrEnum):

--- a/src/awf/profiles/lint.py
+++ b/src/awf/profiles/lint.py
@@ -39,7 +39,7 @@ def lint_profile(profile: WorkspaceProfile) -> list[LintIssue]:
     # 2. Service names must not include reserved names agent or docker
     reserved_names = {"agent", "docker"}
     for i, service in enumerate(profile.services):
-        if service.name in reserved_names:
+        if service.name.casefold() in reserved_names:
             issues.append(
                 LintIssue(
                     code="reserved-service-name",

--- a/src/awf/profiles/lint.py
+++ b/src/awf/profiles/lint.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 
 from pydantic import BaseModel
 
-from .models import DockerMode, WorkspaceProfile
+from .models import DockerMode, ProfilePhaseSet, WorkspaceProfile
 
 
 class LintSeverity(StrEnum):
@@ -50,11 +50,9 @@ def lint_profile(profile: WorkspaceProfile) -> list[LintIssue]:
             )
 
     # 3. Profile phase commands should have explicit timeout_seconds and should warn when missing
-    for phase_name in ["setup", "pre_agent", "post_agent", "validate_commands", "cleanup"]:
+    for phase_name, phase_field in ProfilePhaseSet.model_fields.items():
         commands = getattr(profile.phases, phase_name)
-        # validate_commands is aliased to 'validate' in some places,
-        # but the attribute on ProfilePhaseSet is validate_commands.
-        field_alias = "validate" if phase_name == "validate_commands" else phase_name
+        field_alias = phase_field.alias or phase_name
         for i, cmd in enumerate(commands):
             if cmd.timeout_seconds is None:
                 issues.append(

--- a/src/awf/profiles/lint.py
+++ b/src/awf/profiles/lint.py
@@ -81,14 +81,14 @@ def lint_profile(profile: WorkspaceProfile) -> list[LintIssue]:
     # 5. Services with depends_on should depend only on declared services
     service_names = {s.name for s in profile.services}
     for i, service in enumerate(profile.services):
-        for dep in service.depends_on:
+        for j, dep in enumerate(service.depends_on):
             if dep not in service_names:
                 issues.append(
                     LintIssue(
                         code="unresolved-service-dependency",
                         severity=LintSeverity.error,
                         message=f"Service '{service.name}' depends on unknown service '{dep}'",
-                        field_path=f"services.{i}.depends_on",
+                        field_path=f"services.{i}.depends_on.{j}",
                     )
                 )
 

--- a/src/awf/profiles/lint.py
+++ b/src/awf/profiles/lint.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel
+
+from .models import DockerMode
+
+if TYPE_CHECKING:
+    from .models import WorkspaceProfile
+
+
+class LintSeverity(StrEnum):
+    error = "error"
+    warning = "warning"
+
+
+class LintIssue(BaseModel):
+    code: str
+    severity: LintSeverity
+    message: str
+    field_path: str
+
+
+def lint_profile(profile: WorkspaceProfile) -> list[LintIssue]:
+    """Validate a WorkspaceProfile and return structured issues."""
+    issues: list[LintIssue] = []
+
+    # 1. DinD profiles should expose DOCKER_HOST=tcp://docker:2375 in runtime.environment
+    if profile.docker.mode == DockerMode.dind:
+        docker_host = profile.runtime.environment.get("DOCKER_HOST")
+        if docker_host != "tcp://docker:2375":
+            issues.append(
+                LintIssue(
+                    code="dind-docker-host-mismatch",
+                    severity=LintSeverity.error,
+                    message="DinD profiles must set DOCKER_HOST=tcp://docker:2375 in runtime.environment",
+                    field_path="runtime.environment",
+                )
+            )
+
+    # 2. Service names must not include reserved names agent or docker
+    reserved_names = {"agent", "docker"}
+    for i, service in enumerate(profile.services):
+        if service.name in reserved_names:
+            issues.append(
+                LintIssue(
+                    code="reserved-service-name",
+                    severity=LintSeverity.error,
+                    message=f"Service name '{service.name}' is reserved and cannot be used",
+                    field_path=f"services.{i}.name",
+                )
+            )
+
+    # 3. Profile phase commands should have explicit timeout_seconds and should warn when missing
+    for phase_name in ["setup", "pre_agent", "post_agent", "validate_commands", "cleanup"]:
+        commands = getattr(profile.phases, phase_name)
+        # validate_commands is aliased to 'validate' in some places,
+        # but the attribute on ProfilePhaseSet is validate_commands.
+        field_alias = "validate" if phase_name == "validate_commands" else phase_name
+        for i, cmd in enumerate(commands):
+            if cmd.timeout_seconds is None:
+                issues.append(
+                    LintIssue(
+                        code="missing-command-timeout",
+                        severity=LintSeverity.warning,
+                        message=f"Command in phase '{field_alias}' is missing explicit timeout_seconds",
+                        field_path=f"phases.{field_alias}.{i}.timeout_seconds",
+                    )
+                )
+
+    # 4. Secret declarations must not target broad host-home/workspace paths
+    dangerous_paths = ["/home/agent", "/root", "/workspace"]
+    for i, secret in enumerate(profile.secrets):
+        target = secret.target
+        if any(target == p or target.startswith(f"{p}/") for p in dangerous_paths):
+            issues.append(
+                LintIssue(
+                    code="dangerous-secret-target",
+                    severity=LintSeverity.error,
+                    message=f"Secret target '{target}' uses a protected path prefix",
+                    field_path=f"secrets.{i}.target",
+                )
+            )
+
+    # 5. Services with depends_on should depend only on declared services
+    service_names = {s.name for s in profile.services}
+    for i, service in enumerate(profile.services):
+        for dep in service.depends_on:
+            if dep not in service_names:
+                issues.append(
+                    LintIssue(
+                        code="unresolved-service-dependency",
+                        severity=LintSeverity.error,
+                        message=f"Service '{service.name}' depends on unknown service '{dep}'",
+                        field_path=f"services.{i}.depends_on",
+                    )
+                )
+
+    return issues

--- a/tests/unit/profiles/test_lint.py
+++ b/tests/unit/profiles/test_lint.py
@@ -79,6 +79,23 @@ def test_lint_missing_timeout_warning() -> None:
 
 
 @pytest.mark.unit
+def test_lint_missing_timeout_uses_phase_alias() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        phases={
+            "validate": [ProfileCommand(command="test", timeout_seconds=None)],
+        },
+    )
+    issues = lint_profile(profile)
+    assert any(
+        i.code == "missing-command-timeout"
+        and i.message == "Command in phase 'validate' is missing explicit timeout_seconds"
+        and i.field_path == "phases.validate.0.timeout_seconds"
+        for i in issues
+    )
+
+
+@pytest.mark.unit
 def test_lint_dangerous_secret_target() -> None:
     profile = WorkspaceProfile(
         name="test",

--- a/tests/unit/profiles/test_lint.py
+++ b/tests/unit/profiles/test_lint.py
@@ -46,14 +46,18 @@ def test_lint_reserved_service_names() -> None:
         services=[
             ProfileService(name="agent", image="busybox"),
             ProfileService(name="docker", image="busybox"),
+            ProfileService(name="Agent", image="busybox"),
+            ProfileService(name="DOCKER", image="busybox"),
             ProfileService(name="valid", image="busybox"),
         ],
     )
     issues = lint_profile(profile)
     reserved_issues = [i for i in issues if i.code == "reserved-service-name"]
-    assert len(reserved_issues) == 2
+    assert len(reserved_issues) == 4
     assert any(i.field_path == "services.0.name" for i in reserved_issues)
     assert any(i.field_path == "services.1.name" for i in reserved_issues)
+    assert any(i.field_path == "services.2.name" for i in reserved_issues)
+    assert any(i.field_path == "services.3.name" for i in reserved_issues)
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_lint.py
+++ b/tests/unit/profiles/test_lint.py
@@ -126,7 +126,7 @@ def test_lint_unresolved_service_dependency() -> None:
     issues = lint_profile(profile)
     unresolved = [i for i in issues if i.code == "unresolved-service-dependency"]
     assert len(unresolved) == 1
-    assert unresolved[0].field_path == "services.0.depends_on"
+    assert unresolved[0].field_path == "services.0.depends_on.1"
     assert "redis" in unresolved[0].message
 
 

--- a/tests/unit/profiles/test_lint.py
+++ b/tests/unit/profiles/test_lint.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from awf.profiles.lint import lint_profile
+from awf.profiles.models import (
+    DockerMode,
+    ProfileCommand,
+    ProfileSecret,
+    ProfileService,
+    WorkspaceProfile,
+)
+
+
+@pytest.mark.unit
+def test_lint_dind_missing_docker_host() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        docker={"mode": DockerMode.dind},
+        runtime={"environment": {}},
+    )
+    issues = lint_profile(profile)
+    assert any(
+        i.code == "dind-docker-host-mismatch"
+        and i.severity == "error"
+        and i.field_path == "runtime.environment"
+        for i in issues
+    )
+
+
+@pytest.mark.unit
+def test_lint_dind_wrong_docker_host() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        docker={"mode": DockerMode.dind},
+        runtime={"environment": {"DOCKER_HOST": "localhost"}},
+    )
+    issues = lint_profile(profile)
+    assert any(i.code == "dind-docker-host-mismatch" for i in issues)
+
+
+@pytest.mark.unit
+def test_lint_reserved_service_names() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        services=[
+            ProfileService(name="agent", image="busybox"),
+            ProfileService(name="docker", image="busybox"),
+            ProfileService(name="valid", image="busybox"),
+        ],
+    )
+    issues = lint_profile(profile)
+    reserved_issues = [i for i in issues if i.code == "reserved-service-name"]
+    assert len(reserved_issues) == 2
+    assert any(i.field_path == "services.0.name" for i in reserved_issues)
+    assert any(i.field_path == "services.1.name" for i in reserved_issues)
+
+
+@pytest.mark.unit
+def test_lint_missing_timeout_warning() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        phases={
+            "setup": [ProfileCommand(command="echo hi", timeout_seconds=None)],
+            "validate": [ProfileCommand(command="test", timeout_seconds=60)],
+        },
+    )
+    issues = lint_profile(profile)
+    assert any(
+        i.code == "missing-command-timeout"
+        and i.severity == "warning"
+        and i.field_path == "phases.setup.0.timeout_seconds"
+        for i in issues
+    )
+
+
+@pytest.mark.unit
+def test_lint_dangerous_secret_target() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        secrets=[
+            ProfileSecret(name="s1", target="/home/agent/.ssh"),
+            ProfileSecret(name="s2", target="/root/secret"),
+            ProfileSecret(name="s3", target="/workspace/config"),
+            ProfileSecret(name="s4", target="/etc/safe"),
+        ],
+    )
+    issues = lint_profile(profile)
+    dangerous_issues = [i for i in issues if i.code == "dangerous-secret-target"]
+    assert len(dangerous_issues) == 3
+    assert any(i.field_path == "secrets.0.target" for i in dangerous_issues)
+    assert any(i.field_path == "secrets.1.target" for i in dangerous_issues)
+    assert any(i.field_path == "secrets.2.target" for i in dangerous_issues)
+
+
+@pytest.mark.unit
+def test_lint_unresolved_service_dependency() -> None:
+    profile = WorkspaceProfile(
+        name="test",
+        services=[
+            ProfileService(name="s1", image="busybox", depends_on=["db", "redis"]),
+            ProfileService(name="db", image="postgres"),
+        ],
+    )
+    issues = lint_profile(profile)
+    unresolved = [i for i in issues if i.code == "unresolved-service-dependency"]
+    assert len(unresolved) == 1
+    assert unresolved[0].field_path == "services.0.depends_on"
+    assert "redis" in unresolved[0].message
+
+
+@pytest.mark.unit
+def test_lint_valid_profile_returns_no_issues() -> None:
+    profile = WorkspaceProfile(
+        name="valid",
+        docker={"mode": DockerMode.dind},
+        runtime={"environment": {"DOCKER_HOST": "tcp://docker:2375"}},
+        services=[
+            ProfileService(name="db", image="postgres"),
+            ProfileService(name="app", image="node", depends_on=["db"]),
+        ],
+        phases={
+            "setup": [ProfileCommand(command="init", timeout_seconds=30)],
+        },
+        secrets=[
+            ProfileSecret(name="cert", target="/etc/certs/cert.pem"),
+        ],
+    )
+    issues = lint_profile(profile)
+    assert issues == []


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_2ee38c62f3b6400f8f97654a` (agent: `gemini`).


### Task
Implement the PRD industrial-hardening slice: workspace profile linting core. Strict TDD: first add failing tests under tests/unit/profiles for the lint API, run the narrow test command and capture the red failure in your commit body, then implement until green. Add a module in src/awf/profiles that validates a WorkspaceProfile and returns structured issues, not exceptions. Issue shape: code, severity ('error' or 'warning'), message, field_path. Required checks: DinD profiles should expose DOCKER_HOST=tcp://docker:2375 in runtime.environment; service names must not include reserved names agent or docker; profile phase commands should have explicit timeout_seconds and should warn when missing; secret declarations must not target broad host-home/workspace paths such as /home/agent, /root, or /workspace; services with depends_on should depend only on declared services. Export the core API from src/awf/profiles/__init__.py. Keep this slice core-only: no CLI changes. Run the validation commands before finishing. Commit with a conventional commit. Do not push; AWF owns push, PR creation, monitoring, and merge. Do not switch branches; AWF owns branch lifecycle.

---
Validation: 6 profile command(s) passed inside the workspace container.
