### PR TITLE
feat(api): add workspace events endpoint

### DIFF
--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -20,7 +20,7 @@ from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf import __version__
-from awf.api.routes import health, workspaces
+from awf.api.routes import events, health, workspaces
 from awf.common.config import Settings, get_settings
 from awf.db.base import Base
 from awf.db.session import make_engine, make_session_factory
@@ -78,5 +78,6 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     app.include_router(health.router)
     app.include_router(workspaces.router)
     app.include_router(workspaces.router_v2)
+    app.include_router(events.router)
 
     return app

--- a/src/awf/api/routes/events.py
+++ b/src/awf/api/routes/events.py
@@ -1,0 +1,38 @@
+"""Workspace event observability endpoint.
+
+Exposes ``GET /v1/events`` — the minimal read-side of the append-only audit
+log. Events are returned newest-first with an optional ``workspace_id``
+filter and a bounded ``limit``.
+
+This is the "basic slice" of event observability: no SSE stream, no
+cursor-based pagination. The response envelope already carries the
+``next_cursor`` / ``has_more`` fields called out in the PRD so clients can
+adopt the shape now, but both are constants (``None`` / ``False``) until
+cursor pagination is wired in a later slice.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.deps import get_db_session
+from awf.api.schemas import WorkspaceEventListResponse, WorkspaceEventResponse
+from awf.db.repositories import WorkspaceRepository
+
+router = APIRouter(prefix="/v1/events", tags=["events"])
+
+
+@router.get("", response_model=WorkspaceEventListResponse)
+async def list_events(
+    workspace_id: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceEventListResponse:
+    repo = WorkspaceRepository(session)
+    rows = await repo.list_events(workspace_id=workspace_id, limit=limit)
+    return WorkspaceEventListResponse(
+        items=[WorkspaceEventResponse.model_validate(r) for r in rows],
+        next_cursor=None,
+        has_more=False,
+    )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -130,6 +130,40 @@ class WorkspaceResponse(BaseModel):
     updated_at: datetime
 
 
+class WorkspaceEventResponse(BaseModel):
+    """Single append-only audit event.
+
+    See docs/awf_prd_v2.2.md §14.1 — the shape matches the ``workspace_event``
+    entity: event id, workspace id, typed event + optional state transition,
+    structured reason code, free-form payload, occurrence timestamp.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    workspace_id: str
+    event_type: str
+    old_state: str | None
+    new_state: str | None
+    reason_code: str | None
+    payload: dict[str, Any] | None
+    occurred_at: datetime
+
+
+class WorkspaceEventListResponse(BaseModel):
+    """Paginated envelope for ``GET /v1/events``.
+
+    The envelope follows the PRD-mandated ``items`` / ``next_cursor`` /
+    ``has_more`` shape (docs/awf_prd_v2.2.md §14.1 Pagination). Cursor
+    pagination isn't wired yet — this slice always returns
+    ``next_cursor=None`` and ``has_more=False``.
+    """
+
+    items: list[WorkspaceEventResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
 class WorkspaceAcceptedResponse(BaseModel):
     """202 Accepted payload for workspace creation.
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -94,6 +94,26 @@ class WorkspaceRepository:
         stmt = select(Workspace).where(Workspace.idempotency_key == key)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
+    async def list_events(
+        self,
+        *,
+        workspace_id: str | None = None,
+        limit: int = 50,
+    ) -> list[WorkspaceEvent]:
+        """Return events newest-first, optionally filtered by ``workspace_id``.
+
+        ``occurred_at`` is the canonical ordering key; ``id`` is the tiebreaker
+        so events recorded in the same transaction (identical server-side
+        default timestamp on SQLite) have a stable, deterministic order.
+        """
+        stmt = select(WorkspaceEvent)
+        if workspace_id is not None:
+            stmt = stmt.where(WorkspaceEvent.workspace_id == workspace_id)
+        stmt = stmt.order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc()).limit(
+            limit
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
     async def list(self, *, limit: int = 50) -> list[Workspace]:
         stmt = select(Workspace).order_by(Workspace.created_at.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -1,0 +1,129 @@
+"""Event observability API contract tests.
+
+GET /v1/events returns workspace events newest-first with optional
+``workspace_id`` filtering and a bounded ``limit``. The response
+envelope mirrors the pagination shape called out in the PRD
+(``items`` + ``next_cursor`` + ``has_more``), but this slice doesn't
+wire up cursor-based pagination yet — ``next_cursor`` is always
+``null`` and ``has_more`` always ``false``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+_MINIMAL_BODY = {
+    "repo_url": "git@github.com:dimileeh/aira-agent.git",
+    "branch_base": "development",
+    "task_title": "Add module docstring",
+    "task_prompt": "Add a one-line docstring.",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+async def _create_workspace(client: AsyncClient, **overrides: object) -> str:
+    body = {**_MINIMAL_BODY, **overrides}
+    response = await client.post("/v1/workspaces", json=body)
+    assert response.status_code == 202
+    return response.json()["workspace_id"]
+
+
+class TestListEvents:
+    @pytest.mark.unit
+    async def test_returns_empty_envelope_when_no_events(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events")
+        assert response.status_code == 200
+        body = response.json()
+        assert body == {"items": [], "next_cursor": None, "has_more": False}
+
+    @pytest.mark.unit
+    async def test_returns_creation_event_shape(self, client: AsyncClient) -> None:
+        ws_id = await _create_workspace(client, task_title="event-shape")
+
+        response = await client.get("/v1/events")
+        assert response.status_code == 200
+
+        body = response.json()
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+        assert len(body["items"]) == 1
+
+        event = body["items"][0]
+        assert event["id"].startswith("evt_")
+        assert event["workspace_id"] == ws_id
+        assert event["event_type"] == "workspace.created"
+        assert event["old_state"] is None
+        assert event["new_state"] == "requested"
+        assert event["reason_code"] == "CREATED"
+        assert event["payload"] is None
+        assert "occurred_at" in event
+
+    @pytest.mark.unit
+    async def test_newest_first_across_workspaces(self, client: AsyncClient) -> None:
+        ids: list[str] = []
+        for title in ["first", "second", "third"]:
+            ids.append(await _create_workspace(client, task_title=title))
+
+        response = await client.get("/v1/events")
+        assert response.status_code == 200
+
+        body = response.json()
+        returned_ws_ids = [e["workspace_id"] for e in body["items"]]
+        # Each create emits exactly one event; newest creation first.
+        assert returned_ws_ids == list(reversed(ids))
+
+    @pytest.mark.unit
+    async def test_workspace_id_filter(self, client: AsyncClient) -> None:
+        keep_id = await _create_workspace(client, task_title="keep")
+        await _create_workspace(client, task_title="drop")
+
+        response = await client.get("/v1/events", params={"workspace_id": keep_id})
+        assert response.status_code == 200
+
+        body = response.json()
+        assert len(body["items"]) == 1
+        assert body["items"][0]["workspace_id"] == keep_id
+
+    @pytest.mark.unit
+    async def test_workspace_id_filter_unknown_id_returns_empty(self, client: AsyncClient) -> None:
+        await _create_workspace(client)
+
+        response = await client.get("/v1/events", params={"workspace_id": "ws_nope"})
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "next_cursor": None, "has_more": False}
+
+    @pytest.mark.unit
+    async def test_default_limit_is_50(self, client: AsyncClient) -> None:
+        # Each creation emits a single event, so 60 workspaces == 60 events.
+        for i in range(60):
+            await _create_workspace(client, task_title=f"n-{i}")
+
+        response = await client.get("/v1/events")
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == 50
+
+    @pytest.mark.unit
+    async def test_custom_limit_is_respected(self, client: AsyncClient) -> None:
+        for i in range(5):
+            await _create_workspace(client, task_title=f"n-{i}")
+
+        response = await client.get("/v1/events", params={"limit": 3})
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == 3
+
+    @pytest.mark.unit
+    async def test_limit_zero_is_rejected(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events", params={"limit": 0})
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_limit_over_max_is_rejected(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events", params={"limit": 501})
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_limit_at_max_is_accepted(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events", params={"limit": 500})
+        assert response.status_code == 200


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_4c2fdea24b1946159e804f42` (agent: `claude_code`).


### Task
Implement the PRD basic event observability slice. Strict TDD: add failing API tests under tests/unit/api first, run the narrow test and include the red failure output in your commit body, then implement until green. Add GET /v1/events. Return events newest-first. Support query params workspace_id: str | None and limit: int = 50 bounded 1..500. Response shape: {items: list[WorkspaceEventResponse], next_cursor: null, has_more: false}. Include event id, workspace id, event type, old/new state, reason code, payload, occurred_at. Wire the route into the FastAPI app. Do not implement SSE or cursor pagination yet. Keep changes scoped to src/awf/api, src/awf/db if needed, and tests/unit/api. Run validation commands before finishing. Commit with a conventional commit. Do not push; AWF owns push, PR creation, monitoring, and merge. Do not switch branches; AWF owns branch lifecycle.

---
Validation: 6 profile command(s) passed inside the workspace container.
