### PR TITLE
Add workspace events API for operator console

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ awf workspace create \
   --test "pytest -q"
 ```
 
+Operators can poll immutable workspace events for dashboard or console timelines:
+
+```bash
+curl "http://localhost:8000/v1/events?workspace_id=ws_123&limit=50"
+```
+
+The response is shaped for future pagination:
+`{"items": [...], "next_cursor": null, "has_more": false}`.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -20,7 +20,7 @@ from fastapi import FastAPI
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf import __version__
-from awf.api.routes import health, workspaces
+from awf.api.routes import events, health, workspaces
 from awf.common.config import Settings, get_settings
 from awf.db.base import Base
 from awf.db.session import make_engine, make_session_factory
@@ -78,5 +78,6 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     app.include_router(health.router)
     app.include_router(workspaces.router)
     app.include_router(workspaces.router_v2)
+    app.include_router(events.router)
 
     return app

--- a/src/awf/api/routes/events.py
+++ b/src/awf/api/routes/events.py
@@ -1,0 +1,27 @@
+"""Workspace event listing endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.deps import get_db_session
+from awf.api.schemas import WorkspaceEventListResponse, WorkspaceEventResponse
+from awf.db.repositories import WorkspaceEventRepository
+
+router = APIRouter(prefix="/v1/events", tags=["events"])
+
+
+@router.get("", response_model=WorkspaceEventListResponse)
+async def list_events(
+    workspace_id: str | None = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceEventListResponse:
+    repo = WorkspaceEventRepository(session)
+    rows = await repo.list(workspace_id=workspace_id, limit=limit)
+    return WorkspaceEventListResponse(
+        items=[WorkspaceEventResponse.model_validate(row) for row in rows]
+    )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -145,6 +145,29 @@ class WorkspaceAcceptedResponse(BaseModel):
     accepted_at: datetime
 
 
+class WorkspaceEventResponse(BaseModel):
+    """Representation of an immutable workspace event."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    workspace_id: str
+    event_type: str
+    old_state: str | None
+    new_state: str | None
+    reason_code: str | None
+    payload: dict[str, Any] | None
+    occurred_at: datetime
+
+
+class WorkspaceEventListResponse(BaseModel):
+    """List envelope reserved for cursor pagination in a later slice."""
+
+    items: list[WorkspaceEventResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
 class ErrorResponse(BaseModel):
     """Uniform error envelope.
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -147,5 +147,8 @@ class WorkspaceEventRepository:
         stmt = select(WorkspaceEvent)
         if workspace_id is not None:
             stmt = stmt.where(WorkspaceEvent.workspace_id == workspace_id)
-        stmt = stmt.order_by(WorkspaceEvent.occurred_at.desc()).limit(limit)
+        stmt = stmt.order_by(
+            WorkspaceEvent.occurred_at.desc(),
+            WorkspaceEvent.id.desc(),
+        ).limit(limit)
         return list((await self._session.execute(stmt)).scalars())

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -130,3 +130,22 @@ class WorkspaceRepository:
             )
         )
         return workspace
+
+
+class WorkspaceEventRepository:
+    """Read-only queries for immutable workspace events."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list(
+        self,
+        *,
+        workspace_id: str | None = None,
+        limit: int = 50,
+    ) -> list[WorkspaceEvent]:
+        stmt = select(WorkspaceEvent)
+        if workspace_id is not None:
+            stmt = stmt.where(WorkspaceEvent.workspace_id == workspace_id)
+        stmt = stmt.order_by(WorkspaceEvent.occurred_at.desc()).limit(limit)
+        return list((await self._session.execute(stmt)).scalars())

--- a/tests/unit/api/test_events.py
+++ b/tests/unit/api/test_events.py
@@ -1,0 +1,88 @@
+"""Workspace event API contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+
+_MINIMAL_BODY = {
+    "repo_url": "git@github.com:dimileeh/aira-agent.git",
+    "branch_base": "development",
+    "task_title": "Add module docstring",
+    "task_prompt": "Add a one-line docstring to src/aira_agent/api/main.py.",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+async def _create_workspace(client: AsyncClient, title: str) -> str:
+    response = await client.post("/v1/workspaces", json={**_MINIMAL_BODY, "task_title": title})
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+class TestListEvents:
+    @pytest.mark.unit
+    async def test_lists_all_events_newest_first(self, client: AsyncClient) -> None:
+        first_id = await _create_workspace(client, "first")
+        second_id = await _create_workspace(client, "second")
+
+        response = await client.get("/v1/events")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+        assert [item["workspace_id"] for item in body["items"]] == [second_id, first_id]
+        assert set(body["items"][0]) == {
+            "id",
+            "workspace_id",
+            "event_type",
+            "old_state",
+            "new_state",
+            "reason_code",
+            "payload",
+            "occurred_at",
+        }
+        assert body["items"][0]["event_type"] == "workspace.created"
+        assert body["items"][0]["new_state"] == "requested"
+        assert body["items"][0]["reason_code"] == "CREATED"
+
+    @pytest.mark.unit
+    async def test_filters_by_workspace_id(self, client: AsyncClient) -> None:
+        first_id = await _create_workspace(client, "first")
+        second_id = await _create_workspace(client, "second")
+
+        response = await client.get("/v1/events", params={"workspace_id": first_id})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [item["workspace_id"] for item in body["items"]] == [first_id]
+        assert second_id not in {item["workspace_id"] for item in body["items"]}
+
+    @pytest.mark.unit
+    async def test_applies_limit(self, client: AsyncClient) -> None:
+        await _create_workspace(client, "first")
+        second_id = await _create_workspace(client, "second")
+
+        response = await client.get("/v1/events", params={"limit": 1})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert [item["workspace_id"] for item in body["items"]] == [second_id]
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("limit", [0, 501])
+    async def test_validates_limit_bounds(self, client: AsyncClient, limit: int) -> None:
+        response = await client.get("/v1/events", params={"limit": limit})
+
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_returns_empty_items_for_no_matches(self, client: AsyncClient) -> None:
+        response = await client.get("/v1/events", params={"workspace_id": "ws_missing"})
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "next_cursor": None, "has_more": False}

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -9,6 +9,7 @@ under tests/integration/ with testcontainers.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,7 +17,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awf.control.state_machine import InvalidWorkspaceTransitionError
 from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.models import WorkspaceEvent
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 
 
@@ -174,3 +176,49 @@ class TestTransition:
         # Nothing changed.
         assert ws.status == WorkspaceStatus.requested.value
         assert ws.version == 1
+
+
+class TestListEvents:
+    @pytest.mark.unit
+    async def test_uses_event_id_as_stable_timestamp_tie_breaker(
+        self, session: AsyncSession
+    ) -> None:
+        workspace_repo = WorkspaceRepository(session)
+        workspace = await workspace_repo.create(
+            repo_url="git@github.com:example/a.git",
+            branch_base="development",
+            task_title="t",
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        await session.flush()
+
+        occurred_at = datetime(2100, 1, 1, tzinfo=UTC)
+        session.add_all(
+            [
+                WorkspaceEvent(
+                    id="evt_aaa",
+                    workspace_id=workspace.id,
+                    event_type="workspace.state_changed",
+                    old_state=WorkspaceStatus.requested.value,
+                    new_state=WorkspaceStatus.provisioning.value,
+                    reason_code="A",
+                    occurred_at=occurred_at,
+                ),
+                WorkspaceEvent(
+                    id="evt_zzz",
+                    workspace_id=workspace.id,
+                    event_type="workspace.state_changed",
+                    old_state=WorkspaceStatus.provisioning.value,
+                    new_state=WorkspaceStatus.ready.value,
+                    reason_code="B",
+                    occurred_at=occurred_at,
+                ),
+            ]
+        )
+        await session.commit()
+
+        events = await WorkspaceEventRepository(session).list(workspace_id=workspace.id, limit=2)
+
+        assert [event.id for event in events] == ["evt_zzz", "evt_aaa"]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_17be88ecb4804d34a7d9b205` (agent: `codex`).


### Task
Implement a small PRD-backed observability slice for AWF: add a GET /v1/events endpoint that exposes immutable workspace events for future operator dashboard/console timelines. Context: docs/PLAN_MVP.md lists /v1/events as the event stream endpoint, and docs/awf_prd_v2.2 requires structured events and an events stream for local dashboard/operator UX.

Required behavior:
- Add GET /v1/events and wire it into the FastAPI app.
- Default order should be newest-first, consistent with workspace listing. If you add an order param, keep default desc and support asc only if it stays small and tested.
- Support query params: workspace_id: str | None, limit: int = 50 bounded 1..500.
- Response shape should be future-pagination compatible: {"items": [...], "next_cursor": null, "has_more": false}.
- Each event item must include id, workspace_id, event_type, old_state, new_state, reason_code, payload, occurred_at.
- Return an empty items list for no matches; do not crash.
- Keep this as a polling/list endpoint only. Do not implement SSE or cursor pagination in this slice.
- Update README briefly so operators can discover the endpoint.

TDD requirements:
- Write failing API tests first under tests/unit/api.
- Cover list all events, filter by workspace_id, limit bound validation, and empty result.
- Implement until green.
- Run the validation commands below and ensure they pass.
- Commit with a conventional commit message.
- Do not push, do not open a PR, and do not switch branches; AWF owns branch lifecycle, PR creation, monitoring, and merge.

Validation commands:
uv run ruff check src/awf/api src/awf/db tests/unit/api
uv run mypy src/awf/api src/awf/db
uv run pytest tests/unit/api -q

---
Validation: 6 profile command(s) passed inside the workspace container.
