### PR TITLE
Add workspace list filters for operator console

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ curl "http://localhost:8000/v1/events?workspace_id=ws_123&limit=50"
 The response is shaped for future pagination:
 `{"items": [...], "next_cursor": null, "has_more": false}`.
 
+Operators can also list recent workspaces for dashboard views. Results are newest
+first, `limit` defaults to 50 and accepts 1-500, and filters are exact matches:
+
+```bash
+curl "http://localhost:8000/v1/workspaces?status=running&agent=codex&repo_url=git@github.com:example/app.git&limit=25"
+```
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -11,8 +11,9 @@ returns 409 ``IDEMPOTENCY_CONFLICT`` per docs/PLAN_MVP.md § Error code taxonomy
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Annotated
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -24,7 +25,7 @@ from awf.api.schemas import (
     WorkspaceCreateV2Request,
     WorkspaceResponse,
 )
-from awf.db.enums import WorkspaceStatus
+from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
 from awf.profiles.resolver import ProfileResolutionError, resolve_workspace_profile
@@ -170,11 +171,19 @@ async def get_workspace(
 
 @router.get("", response_model=list[WorkspaceResponse])
 async def list_workspaces(
-    limit: int = 50,
+    workspace_status: Annotated[WorkspaceStatus | None, Query(alias="status")] = None,
+    agent: AgentRuntime | None = None,
+    repo_url: Annotated[str | None, Query(min_length=1, max_length=512)] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
     session: AsyncSession = Depends(get_db_session),
 ) -> list[WorkspaceResponse]:
     repo = WorkspaceRepository(session)
-    rows = await repo.list(limit=limit)
+    rows = await repo.list(
+        status=workspace_status,
+        agent=agent,
+        repo_url=repo_url,
+        limit=limit,
+    )
     return [WorkspaceResponse.model_validate(r) for r in rows]
 
 

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -172,7 +172,7 @@ async def get_workspace(
 @router.get("", response_model=list[WorkspaceResponse])
 async def list_workspaces(
     workspace_status: Annotated[WorkspaceStatus | None, Query(alias="status")] = None,
-    agent: AgentRuntime | None = None,
+    agent: Annotated[AgentRuntime | None, Query()] = None,
     repo_url: Annotated[str | None, Query(min_length=1, max_length=512)] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
     session: AsyncSession = Depends(get_db_session),

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -98,19 +98,19 @@ class WorkspaceRepository:
     async def list(
         self,
         *,
-        status: WorkspaceStatus | None = None,
-        agent: AgentRuntime | None = None,
+        status: WorkspaceStatus | str | None = None,
+        agent: AgentRuntime | str | None = None,
         repo_url: str | None = None,
         limit: int = 50,
     ) -> list[Workspace]:
         stmt = select(Workspace)
         if status is not None:
-            stmt = stmt.where(Workspace.status == status.value)
+            stmt = stmt.where(Workspace.status == status)
         if agent is not None:
-            stmt = stmt.where(Workspace.agent == agent.value)
+            stmt = stmt.where(Workspace.agent == agent)
         if repo_url is not None:
             stmt = stmt.where(Workspace.repo_url == repo_url)
-        stmt = stmt.order_by(Workspace.created_at.desc()).limit(limit)
+        stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
     async def transition(

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -18,7 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.ids import new_event_id, new_workspace_id
 from awf.control.state_machine import WorkspaceStateMachine
-from awf.db.enums import WorkspaceStatus
+from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace, WorkspaceEvent
 
 
@@ -95,8 +95,22 @@ class WorkspaceRepository:
         stmt = select(Workspace).where(Workspace.idempotency_key == key)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
-    async def list(self, *, limit: int = 50) -> list[Workspace]:
-        stmt = select(Workspace).order_by(Workspace.created_at.desc()).limit(limit)
+    async def list(
+        self,
+        *,
+        status: WorkspaceStatus | None = None,
+        agent: AgentRuntime | None = None,
+        repo_url: str | None = None,
+        limit: int = 50,
+    ) -> list[Workspace]:
+        stmt = select(Workspace)
+        if status is not None:
+            stmt = stmt.where(Workspace.status == status.value)
+        if agent is not None:
+            stmt = stmt.where(Workspace.agent == agent.value)
+        if repo_url is not None:
+            stmt = stmt.where(Workspace.repo_url == repo_url)
+        stmt = stmt.order_by(Workspace.created_at.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
     async def transition(

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
 
 _MINIMAL_BODY = {
     "repo_url": "git@github.com:dimileeh/aira-agent.git",
@@ -18,6 +23,28 @@ _MINIMAL_BODY = {
     "agent": "codex",
     "test_commands": ["pytest -q"],
 }
+
+
+async def _create_workspace(client: AsyncClient, **overrides: object) -> str:
+    body = {**_MINIMAL_BODY, **overrides}
+    response = await client.post("/v1/workspaces", json=body)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _transition_workspace(
+    engine: AsyncEngine,
+    workspace_id: str,
+    *targets: WorkspaceStatus,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        for target in targets:
+            await repo.transition(ws, to=target, reason_code="TEST")
+        await session.commit()
 
 
 class TestCreateWorkspace:
@@ -120,3 +147,159 @@ class TestListWorkspaces:
         assert len(results) == 3
         # Newest first.
         assert [r["id"] for r in results] == list(reversed(ids))
+
+    @pytest.mark.unit
+    async def test_filters_by_status(
+        self, client: AsyncClient, engine: AsyncEngine
+    ) -> None:
+        ready_id = await _create_workspace(client, task_title="ready")
+        await _create_workspace(client, task_title="still requested")
+        await _transition_workspace(
+            engine,
+            ready_id,
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+        )
+
+        response = await client.get("/v1/workspaces", params={"status": "ready"})
+
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["id"] for r in results] == [ready_id]
+        assert {r["status"] for r in results} == {"ready"}
+
+    @pytest.mark.unit
+    async def test_filters_by_agent(self, client: AsyncClient) -> None:
+        await _create_workspace(client, task_title="codex", agent="codex")
+        claude_id = await _create_workspace(
+            client,
+            task_title="claude",
+            agent="claude_code",
+        )
+
+        response = await client.get("/v1/workspaces", params={"agent": "claude_code"})
+
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["id"] for r in results] == [claude_id]
+        assert {r["agent"] for r in results} == {"claude_code"}
+
+    @pytest.mark.unit
+    async def test_filters_by_exact_repo_url(self, client: AsyncClient) -> None:
+        repo_url = "git@github.com:example/app.git"
+        matching_id = await _create_workspace(
+            client,
+            task_title="matching repo",
+            repo_url=repo_url,
+        )
+        await _create_workspace(
+            client,
+            task_title="similar repo",
+            repo_url="git@github.com:example/app-extra.git",
+        )
+
+        response = await client.get("/v1/workspaces", params={"repo_url": repo_url})
+
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["id"] for r in results] == [matching_id]
+        assert {r["repo_url"] for r in results} == {repo_url}
+
+    @pytest.mark.unit
+    async def test_combines_filters(
+        self, client: AsyncClient, engine: AsyncEngine
+    ) -> None:
+        repo_url = "git@github.com:example/combined.git"
+        matching_id = await _create_workspace(
+            client,
+            task_title="matching",
+            repo_url=repo_url,
+            agent="gemini",
+        )
+        wrong_status_id = await _create_workspace(
+            client,
+            task_title="wrong status",
+            repo_url=repo_url,
+            agent="gemini",
+        )
+        wrong_agent_id = await _create_workspace(
+            client,
+            task_title="wrong agent",
+            repo_url=repo_url,
+            agent="codex",
+        )
+        wrong_repo_id = await _create_workspace(
+            client,
+            task_title="wrong repo",
+            repo_url="git@github.com:example/other.git",
+            agent="gemini",
+        )
+        for workspace_id in [matching_id, wrong_agent_id, wrong_repo_id]:
+            await _transition_workspace(
+                engine,
+                workspace_id,
+                WorkspaceStatus.provisioning,
+                WorkspaceStatus.ready,
+            )
+
+        response = await client.get(
+            "/v1/workspaces",
+            params={"status": "ready", "agent": "gemini", "repo_url": repo_url},
+        )
+
+        assert response.status_code == 200
+        assert [r["id"] for r in response.json()] == [matching_id]
+        assert wrong_status_id not in [r["id"] for r in response.json()]
+
+    @pytest.mark.unit
+    async def test_limit_defaults_to_50(self, client: AsyncClient) -> None:
+        for idx in range(51):
+            await _create_workspace(client, task_title=f"workspace {idx}")
+
+        response = await client.get("/v1/workspaces")
+
+        assert response.status_code == 200
+        assert len(response.json()) == 50
+
+    @pytest.mark.unit
+    async def test_limit_bounds_newest_first(self, client: AsyncClient) -> None:
+        first_id = await _create_workspace(client, task_title="first")
+        second_id = await _create_workspace(client, task_title="second")
+
+        response = await client.get("/v1/workspaces", params={"limit": 1})
+
+        assert response.status_code == 200
+        assert [r["id"] for r in response.json()] == [second_id]
+        assert first_id not in [r["id"] for r in response.json()]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("limit", [0, 501])
+    async def test_rejects_limit_outside_bounds(
+        self, client: AsyncClient, limit: int
+    ) -> None:
+        response = await client.get("/v1/workspaces", params={"limit": limit})
+
+        assert response.status_code == 422
+
+    @pytest.mark.unit
+    async def test_returns_empty_list_when_filters_match_nothing(
+        self, client: AsyncClient
+    ) -> None:
+        await _create_workspace(client, task_title="not completed")
+
+        response = await client.get("/v1/workspaces", params={"status": "completed"})
+
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("param", "value"),
+        [("status", "not-a-status"), ("agent", "not-an-agent")],
+    )
+    async def test_rejects_unknown_filter_enums(
+        self, client: AsyncClient, param: str, value: str
+    ) -> None:
+        response = await client.get("/v1/workspaces", params={param: value})
+
+        assert response.status_code == 422

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -142,6 +142,34 @@ class TestListWorkspaces:
         assert [row.id for row in rows] == [matching.id]
 
     @pytest.mark.unit
+    async def test_accepts_string_status_and_agent_filters(self, session: AsyncSession) -> None:
+        repo = WorkspaceRepository(session)
+        matching = await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="matching",
+            task_prompt="p",
+            agent=AgentRuntime.gemini.value,
+            test_commands=[],
+        )
+        await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="wrong agent",
+            task_prompt="p",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+        )
+
+        rows = await repo.list(
+            status=WorkspaceStatus.requested.value,
+            agent=AgentRuntime.gemini.value,
+            limit=10,
+        )
+
+        assert [row.id for row in rows] == [matching.id]
+
+    @pytest.mark.unit
     async def test_applies_filters_before_limit(self, session: AsyncSession) -> None:
         repo = WorkspaceRepository(session)
         matching = await repo.create(
@@ -169,6 +197,29 @@ class TestListWorkspaces:
         rows = await repo.list(status=WorkspaceStatus.ready, limit=1)
 
         assert [row.id for row in rows] == [matching.id]
+
+    @pytest.mark.unit
+    async def test_orders_created_at_ties_by_id_desc(self, session: AsyncSession) -> None:
+        repo = WorkspaceRepository(session)
+        rows = [
+            await repo.create(
+                repo_url=f"git@github.com:example/app-{index}.git",
+                branch_base="development",
+                task_title=f"workspace {index}",
+                task_prompt="p",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            for index in range(3)
+        ]
+        tied_created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        for row in rows:
+            row.created_at = tied_created_at
+        await session.commit()
+
+        listed = await repo.list(limit=3)
+
+        assert [row.id for row in listed] == sorted((row.id for row in rows), reverse=True)
 
 
 class TestTransition:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.control.state_machine import InvalidWorkspaceTransitionError
 from awf.db.base import Base
-from awf.db.enums import WorkspaceStatus
+from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import WorkspaceEvent
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
@@ -101,6 +101,74 @@ class TestIdempotency:
     ) -> None:
         repo = WorkspaceRepository(session)
         assert await repo.get_by_idempotency_key("never-used") is None
+
+
+class TestListWorkspaces:
+    @pytest.mark.unit
+    async def test_combines_status_agent_and_repo_filters(self, session: AsyncSession) -> None:
+        repo = WorkspaceRepository(session)
+        matching = await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="matching",
+            task_prompt="p",
+            agent=AgentRuntime.gemini.value,
+            test_commands=[],
+        )
+        await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="wrong agent",
+            task_prompt="p",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+        )
+        await repo.create(
+            repo_url="git@github.com:example/other.git",
+            branch_base="development",
+            task_title="wrong repo",
+            task_prompt="p",
+            agent=AgentRuntime.gemini.value,
+            test_commands=[],
+        )
+
+        rows = await repo.list(
+            status=WorkspaceStatus.requested,
+            agent=AgentRuntime.gemini,
+            repo_url="git@github.com:example/app.git",
+            limit=10,
+        )
+
+        assert [row.id for row in rows] == [matching.id]
+
+    @pytest.mark.unit
+    async def test_applies_filters_before_limit(self, session: AsyncSession) -> None:
+        repo = WorkspaceRepository(session)
+        matching = await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="older matching",
+            task_prompt="p",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+        )
+        newer_non_matching = await repo.create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            task_title="newer non-matching",
+            task_prompt="p",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+        )
+        await repo.transition(matching, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        await repo.transition(matching, to=WorkspaceStatus.ready, reason_code="TEST")
+        matching.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        newer_non_matching.created_at = datetime(2026, 1, 2, tzinfo=UTC)
+        await session.commit()
+
+        rows = await repo.list(status=WorkspaceStatus.ready, limit=1)
+
+        assert [row.id for row in rows] == [matching.id]
 
 
 class TestTransition:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_05cd48b16168492286fce562` (agent: `codex`).


### Task
Implement a small PRD-backed observability slice for AWF: make GET /v1/workspaces more useful for the future operator dashboard by adding query filters and safe limit validation.

PRD context:
- docs/PLAN_MVP.md lists GET /v1/workspaces as the workspace list endpoint for lifecycle observability.
- docs/awf_prd_v2.2 says the CLI/dashboard must expose filters by repository, workspace state, agent, failure taxonomy, node, and related operator dimensions.

Required behavior:
- Extend GET /v1/workspaces with optional query params: status, agent, repo_url, limit.
- status should use WorkspaceStatus validation.
- agent should use AgentRuntime validation.
- repo_url should be an exact match filter for now.
- limit should default to 50 and be bounded 1..500.
- Preserve newest-first ordering by created_at desc.
- Keep the response shape as list[WorkspaceResponse] for this slice; do not introduce pagination envelopes yet.
- Add repository-layer support for these filters rather than filtering in the route after fetching.
- Update README briefly so operators can discover the filters.

TDD requirements:
- Write failing unit tests first.
- Add API tests under tests/unit/api covering status filter, agent filter, repo_url filter, combined filters, limit bounds, and empty result.
- Add repository tests if needed to pin query behavior.
- Implement until green.
- Run all validation commands below and make sure they pass.
- Commit with a conventional commit message.
- Do not push, do not open a PR, and do not switch branches; AWF owns branch lifecycle, PR creation, PR monitoring, reviewer-comment fixes, and merge.

Validation commands:
uv run ruff check src/awf/api src/awf/db tests/unit/api tests/unit/db
uv run mypy src/awf/api src/awf/db
uv run pytest tests/unit/api tests/unit/db/test_workspace_repository.py -q

---
Validation: 6 profile command(s) passed inside the workspace container.
