### PR TITLE
feat(api): expose workspace artifact metadata

### DIFF
--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf import __version__
 from awf.api.routes import (
+    artifacts,
     controls,
     events,
     health,
@@ -91,6 +92,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     app.include_router(events.router)
     app.include_router(tasks.router)
     app.include_router(runtime.router)
+    app.include_router(artifacts.router)
     app.include_router(logs.router)
     app.include_router(operations.router)
     app.include_router(controls.router)

--- a/src/awf/api/routes/artifacts.py
+++ b/src/awf/api/routes/artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from hashlib import sha256
 from pathlib import Path
@@ -45,7 +46,8 @@ async def list_workspace_artifacts(
 ) -> WorkspaceArtifactListResponse:
     await _require_workspace(session, workspace_id)
     artifact_dir = _workspace_artifact_dir(workspace_id)
-    return WorkspaceArtifactListResponse(items=_list_artifacts(workspace_id, artifact_dir))
+    items = await asyncio.to_thread(_list_artifacts, workspace_id, artifact_dir)
+    return WorkspaceArtifactListResponse(items=items)
 
 
 async def _require_workspace(session: AsyncSession, workspace_id: str) -> None:

--- a/src/awf/api/routes/artifacts.py
+++ b/src/awf/api/routes/artifacts.py
@@ -63,24 +63,27 @@ def _workspace_artifact_dir(workspace_id: str) -> Path:
 
 
 def _list_artifacts(workspace_id: str, artifact_dir: Path) -> list[WorkspaceArtifactResponse]:
-    if not artifact_dir.is_dir() or artifact_dir.is_symlink():
+    try:
+        if not artifact_dir.is_dir() or artifact_dir.is_symlink():
+            return []
+        root = artifact_dir.resolve(strict=True)
+    except OSError:
         return []
 
-    root = artifact_dir.resolve(strict=True)
     items: list[WorkspaceArtifactResponse] = []
     for directory, dirnames, filenames in artifact_dir.walk(follow_symlinks=False):
         dirnames.sort()
         for filename in sorted(filenames):
             candidate = directory / filename
-            if candidate.is_symlink():
-                continue
             try:
+                if candidate.is_symlink():
+                    continue
                 resolved = candidate.resolve(strict=True)
+                if not resolved.is_file() or not resolved.is_relative_to(root):
+                    continue
+                stat = resolved.stat()
             except OSError:
                 continue
-            if not resolved.is_file() or not resolved.is_relative_to(root):
-                continue
-            stat = resolved.stat()
             relative_path = candidate.relative_to(artifact_dir).as_posix()
             items.append(
                 WorkspaceArtifactResponse(

--- a/src/awf/api/routes/artifacts.py
+++ b/src/awf/api/routes/artifacts.py
@@ -1,0 +1,105 @@
+"""Workspace artifact metadata endpoints."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from hashlib import sha256
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.deps import get_db_session, require_api_token
+from awf.common.config import get_settings
+from awf.db.repositories import WorkspaceRepository
+
+router = APIRouter(prefix="/v1/workspaces/{workspace_id}/artifacts", tags=["artifacts"])
+
+
+class WorkspaceArtifactResponse(BaseModel):
+    artifact_id: str
+    workspace_id: str
+    name: str
+    relative_path: str
+    path: str
+    kind: str
+    size_bytes: int
+    modified_at: datetime
+
+
+class WorkspaceArtifactListResponse(BaseModel):
+    items: list[WorkspaceArtifactResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+@router.get(
+    "",
+    response_model=WorkspaceArtifactListResponse,
+    dependencies=[Depends(require_api_token)],
+)
+async def list_workspace_artifacts(
+    workspace_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceArtifactListResponse:
+    await _require_workspace(session, workspace_id)
+    artifact_dir = _workspace_artifact_dir(workspace_id)
+    return WorkspaceArtifactListResponse(items=_list_artifacts(workspace_id, artifact_dir))
+
+
+async def _require_workspace(session: AsyncSession, workspace_id: str) -> None:
+    if not await WorkspaceRepository(session).exists(workspace_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
+        )
+
+
+def _workspace_artifact_dir(workspace_id: str) -> Path:
+    return Path(get_settings().work_dir) / "artifacts" / workspace_id
+
+
+def _list_artifacts(workspace_id: str, artifact_dir: Path) -> list[WorkspaceArtifactResponse]:
+    if not artifact_dir.is_dir() or artifact_dir.is_symlink():
+        return []
+
+    root = artifact_dir.resolve(strict=True)
+    items: list[WorkspaceArtifactResponse] = []
+    for directory, dirnames, filenames in artifact_dir.walk(follow_symlinks=False):
+        dirnames.sort()
+        for filename in sorted(filenames):
+            candidate = directory / filename
+            if candidate.is_symlink():
+                continue
+            try:
+                resolved = candidate.resolve(strict=True)
+            except OSError:
+                continue
+            if not resolved.is_file() or not resolved.is_relative_to(root):
+                continue
+            stat = resolved.stat()
+            relative_path = candidate.relative_to(artifact_dir).as_posix()
+            items.append(
+                WorkspaceArtifactResponse(
+                    artifact_id=_artifact_id(workspace_id, relative_path),
+                    workspace_id=workspace_id,
+                    name=candidate.name,
+                    relative_path=relative_path,
+                    path=str(resolved),
+                    kind=_artifact_kind(candidate),
+                    size_bytes=stat.st_size,
+                    modified_at=datetime.fromtimestamp(stat.st_mtime, UTC),
+                )
+            )
+    return sorted(items, key=lambda item: item.relative_path)
+
+
+def _artifact_id(workspace_id: str, relative_path: str) -> str:
+    digest = sha256(f"{workspace_id}\0{relative_path}".encode()).hexdigest()[:24]
+    return f"art_{digest}"
+
+
+def _artifact_kind(path: Path) -> str:
+    suffix = path.suffix.lower().lstrip(".")
+    return suffix or "file"

--- a/tests/unit/api/test_artifacts.py
+++ b/tests/unit/api/test_artifacts.py
@@ -1,0 +1,144 @@
+"""Workspace artifact metadata API tests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from httpx import AsyncClient
+
+from awf.common.config import get_settings
+
+_MINIMAL_BODY = {
+    "repo_url": "git@github.com:example/artifacts.git",
+    "branch_base": "main",
+    "task_title": "List artifacts",
+    "task_prompt": "Expose workspace artifact metadata.",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> None:
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+async def _create_workspace(client: AsyncClient) -> str:
+    response = await client.post("/v1/workspaces", json=_MINIMAL_BODY)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+def _configure_artifact_api(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> tuple[Path, dict[str, str]]:
+    work_dir = tmp_path / "awf-state"
+    monkeypatch.setenv("AWF_API_TOKEN", "secret")
+    monkeypatch.setenv("AWF_WORK_DIR", str(work_dir))
+    get_settings.cache_clear()
+    return work_dir, {"Authorization": "Bearer secret"}
+
+
+class TestWorkspaceArtifacts:
+    @pytest.mark.unit
+    async def test_requires_local_bearer_token_when_configured(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        workspace_id = await _create_workspace(client)
+        _configure_artifact_api(monkeypatch, tmp_path)
+
+        response = await client.get(f"/v1/workspaces/{workspace_id}/artifacts")
+
+        assert response.status_code == 401
+        assert response.json()["detail"]["error_code"] == "UNAUTHORIZED"
+
+    @pytest.mark.unit
+    async def test_missing_workspace_returns_not_found(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        _, headers = _configure_artifact_api(monkeypatch, tmp_path)
+
+        response = await client.get(
+            "/v1/workspaces/ws_missing/artifacts",
+            headers=headers,
+        )
+
+        assert response.status_code == 404
+        assert response.json()["detail"]["error_code"] == "NOT_FOUND"
+
+    @pytest.mark.unit
+    async def test_existing_workspace_without_artifact_directory_returns_empty_list(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        workspace_id = await _create_workspace(client)
+        _, headers = _configure_artifact_api(monkeypatch, tmp_path)
+
+        response = await client.get(
+            f"/v1/workspaces/{workspace_id}/artifacts",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "next_cursor": None, "has_more": False}
+
+    @pytest.mark.unit
+    async def test_lists_recursive_file_metadata_and_skips_escaping_symlinks(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        workspace_id = await _create_workspace(client)
+        work_dir, headers = _configure_artifact_api(monkeypatch, tmp_path)
+        artifact_dir = work_dir / "artifacts" / workspace_id
+        nested = artifact_dir / "logs"
+        nested.mkdir(parents=True)
+        stdout_path = nested / "stdout.txt"
+        stdout_path.write_text("alpha\n", encoding="utf-8")
+        screenshot_path = artifact_dir / "screenshot.png"
+        screenshot_path.write_bytes(b"\x89PNG\r\n")
+        (artifact_dir / "empty-dir").mkdir()
+        outside_path = tmp_path / "outside.txt"
+        outside_path.write_text("secret\n", encoding="utf-8")
+        (artifact_dir / "outside-link.txt").symlink_to(outside_path)
+
+        response = await client.get(
+            f"/v1/workspaces/{workspace_id}/artifacts",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["next_cursor"] is None
+        assert body["has_more"] is False
+        assert [item["relative_path"] for item in body["items"]] == [
+            "logs/stdout.txt",
+            "screenshot.png",
+        ]
+
+        stdout_item = body["items"][0]
+        second_read = await client.get(
+            f"/v1/workspaces/{workspace_id}/artifacts",
+            headers=headers,
+        )
+        assert stdout_item["artifact_id"] == second_read.json()["items"][0]["artifact_id"]
+        assert stdout_item["workspace_id"] == workspace_id
+        assert stdout_item["name"] == "stdout.txt"
+        assert stdout_item["path"] == str(stdout_path.resolve())
+        assert stdout_item["kind"] == "txt"
+        assert stdout_item["size_bytes"] == len("alpha\n")
+        datetime.fromisoformat(stdout_item["modified_at"])

--- a/tests/unit/api/test_artifacts.py
+++ b/tests/unit/api/test_artifacts.py
@@ -147,6 +147,47 @@ class TestWorkspaceArtifacts:
         datetime.fromisoformat(stdout_item["modified_at"])
 
     @pytest.mark.unit
+    def test_listing_skips_file_deleted_during_metadata_read(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        workspace_id = "ws_artifact_race"
+        artifact_dir = tmp_path / "artifacts" / workspace_id
+        artifact_dir.mkdir(parents=True)
+        stable_path = artifact_dir / "stable.txt"
+        stable_path.write_text("kept\n", encoding="utf-8")
+        deleted_path = artifact_dir / "deleted.txt"
+        deleted_path.write_text("removed\n", encoding="utf-8")
+        deleted_resolved = deleted_path.resolve()
+        original_resolve = Path.resolve
+        original_is_file = Path.is_file
+        original_stat = Path.stat
+
+        def resolve_candidate(self: Path, *args: Any, **kwargs: Any) -> Path:
+            if self == deleted_path:
+                return deleted_resolved
+            return original_resolve(self, *args, **kwargs)
+
+        def is_file_candidate(self: Path, *args: Any, **kwargs: Any) -> bool:
+            if self == deleted_resolved:
+                return True
+            return original_is_file(self, *args, **kwargs)
+
+        def stat_candidate(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if self == deleted_resolved:
+                raise FileNotFoundError(str(self))
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", resolve_candidate)
+        monkeypatch.setattr(Path, "is_file", is_file_candidate)
+        monkeypatch.setattr(Path, "stat", stat_candidate)
+
+        items = artifacts._list_artifacts(workspace_id, artifact_dir)
+
+        assert [item.relative_path for item in items] == ["stable.txt"]
+
+    @pytest.mark.unit
     async def test_artifact_listing_offloads_filesystem_scan(
         self,
         client: AsyncClient,

--- a/tests/unit/api/test_artifacts.py
+++ b/tests/unit/api/test_artifacts.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 import pytest
 from httpx import AsyncClient
 
+from awf.api.routes import artifacts
 from awf.common.config import get_settings
 
 _MINIMAL_BODY = {
@@ -142,3 +145,34 @@ class TestWorkspaceArtifacts:
         assert stdout_item["kind"] == "txt"
         assert stdout_item["size_bytes"] == len("alpha\n")
         datetime.fromisoformat(stdout_item["modified_at"])
+
+    @pytest.mark.unit
+    async def test_artifact_listing_offloads_filesystem_scan(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        workspace_id = await _create_workspace(client)
+        _, headers = _configure_artifact_api(monkeypatch, tmp_path)
+        calls: list[tuple[Callable[..., object], tuple[Any, ...]]] = []
+
+        async def fake_to_thread(func: Callable[..., object], /, *args: Any) -> object:
+            calls.append((func, args))
+            return func(*args)
+
+        monkeypatch.setattr(artifacts.asyncio, "to_thread", fake_to_thread)
+
+        response = await client.get(
+            f"/v1/workspaces/{workspace_id}/artifacts",
+            headers=headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"items": [], "next_cursor": None, "has_more": False}
+        assert calls == [
+            (
+                artifacts._list_artifacts,
+                (workspace_id, artifacts._workspace_artifact_dir(workspace_id)),
+            )
+        ]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e8b7e6fe5197400bbdac68eb` (agent: `codex`).


### Task
Strict TDD requirements:
- Start by adding focused failing tests for the requested behavior.
- Run the narrow tests and include the red failure output in the first commit body.
- Implement only the requested slice until the tests are green.
- Run the validation commands listed below before final response.
- Commit locally with a conventional commit message.
- Do not push, open PRs, switch branches, rebase, or force-push; AWF owns branch and PR lifecycle.
- Keep changes tightly scoped to the listed files/areas and avoid unrelated refactors.

PRD backing: docs/awf_prd_v2.2.md sections 14.2 and 18.2 require workspace artifact visibility for operator tooling.

Implement a small read-only artifact metadata API.

Expected behavior:
- Add GET /v1/workspaces/{workspace_id}/artifacts.
- Require the same local bearer-token guard used for sensitive log APIs.
- Return { items, next_cursor: null, has_more: false }.
- For each file under <AWF work_dir>/artifacts/{workspace_id}, return stable metadata: artifact_id, workspace_id, name, relative_path, path, kind, size_bytes, modified_at.
- Existing workspace with no artifact directory returns an empty list.
- Missing workspace returns 404 with error_code NOT_FOUND.
- Do not implement artifact download in this slice.
- Keep path handling safe: list files recursively, skip directories, and do not follow/report files that resolve outside the workspace artifact directory.
- Prefer route-local Pydantic response models if that avoids broad schema churn.

Validation commands to run:
uv run ruff check src/awf/api src/awf/common tests/unit/api
uv run mypy src/awf/api src/awf/common
uv run pytest tests/unit/api -q

---
Validation: 6 profile command(s) passed inside the workspace container.
