### PR TITLE
feat(health): add dependency readiness endpoint

### DIFF
--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -142,143 +142,98 @@ async def _run_bounded(runner: AsyncCommandRunner, args: list[str]) -> CommandRe
         return exc
 
 
-async def _check_docker_cli(runner: AsyncCommandRunner) -> CheckResult:
-    outcome = await _run_bounded(runner, ["docker", "--version"])
+async def _docker_check(
+    runner: AsyncCommandRunner,
+    *,
+    args: list[str],
+    description: str,
+    fail_reason: str,
+    timeout_reason: str,
+    detail_prefix: str = "",
+    cli_missing_detail: str = "docker binary not found on PATH",
+) -> CheckResult:
+    """Run a docker subprocess and map its outcome to a stable CheckResult.
+
+    Every docker dependency follows the same outcome → reason mapping: missing
+    binary, timeout, transport/permission failure, non-zero exit. ``description``
+    is the human-readable command shown in the timeout message; ``detail_prefix``
+    lets per-image checks tag detail strings (e.g. ``"<image>: ..."``) so the
+    operator sees which image was missing without parsing.
+    """
+    outcome = await _run_bounded(runner, args)
     if isinstance(outcome, FileNotFoundError):
         return CheckResult(
             ok=False,
             status="fail",
             reason="DOCKER_CLI_NOT_FOUND",
-            detail="docker binary not found on PATH",
+            detail=cli_missing_detail,
         )
     if isinstance(outcome, TimeoutError):
         return CheckResult(
             ok=False,
             status="fail",
-            reason="DOCKER_CLI_TIMEOUT",
-            detail=f"docker --version exceeded {_CHECK_TIMEOUT_SECONDS}s",
+            reason=timeout_reason,
+            detail=f"{description} exceeded {_CHECK_TIMEOUT_SECONDS}s",
         )
     if isinstance(outcome, Exception):
         return CheckResult(
             ok=False,
             status="fail",
-            reason="DOCKER_CLI_ERROR",
-            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
+            reason=fail_reason,
+            detail=_truncate(f"{detail_prefix}{type(outcome).__name__}: {outcome}"),
         )
     if outcome.returncode != 0:
         return CheckResult(
             ok=False,
             status="fail",
-            reason="DOCKER_CLI_ERROR",
-            detail=_truncate(outcome.stderr or outcome.stdout),
+            reason=fail_reason,
+            detail=_truncate(f"{detail_prefix}{outcome.stderr or outcome.stdout}"),
         )
-    version = outcome.stdout.strip() or None
-    return CheckResult(ok=True, status="ok", version=version)
+    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
+
+
+async def _check_docker_cli(runner: AsyncCommandRunner) -> CheckResult:
+    return await _docker_check(
+        runner,
+        args=["docker", "--version"],
+        description="docker --version",
+        fail_reason="DOCKER_CLI_ERROR",
+        timeout_reason="DOCKER_CLI_TIMEOUT",
+    )
 
 
 async def _check_docker_daemon(runner: AsyncCommandRunner) -> CheckResult:
     # ``--format`` keeps output to just the server version (one short line) so we
     # don't have to parse the verbose default ``docker info`` output.
-    outcome = await _run_bounded(
-        runner, ["docker", "info", "--format", "{{.ServerVersion}}"]
+    return await _docker_check(
+        runner,
+        args=["docker", "info", "--format", "{{.ServerVersion}}"],
+        description="docker info",
+        fail_reason="DOCKER_DAEMON_UNREACHABLE",
+        timeout_reason="DOCKER_DAEMON_TIMEOUT",
     )
-    if isinstance(outcome, FileNotFoundError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_CLI_NOT_FOUND",
-            detail="docker binary not found on PATH",
-        )
-    if isinstance(outcome, TimeoutError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_DAEMON_TIMEOUT",
-            detail=f"docker info exceeded {_CHECK_TIMEOUT_SECONDS}s",
-        )
-    if isinstance(outcome, Exception):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_DAEMON_UNREACHABLE",
-            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
-        )
-    if outcome.returncode != 0:
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_DAEMON_UNREACHABLE",
-            detail=_truncate(outcome.stderr or outcome.stdout),
-        )
-    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
 
 
 async def _check_docker_compose(runner: AsyncCommandRunner) -> CheckResult:
-    outcome = await _run_bounded(runner, ["docker", "compose", "version", "--short"])
-    if isinstance(outcome, FileNotFoundError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_CLI_NOT_FOUND",
-            detail="docker binary not found on PATH",
-        )
-    if isinstance(outcome, TimeoutError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_COMPOSE_TIMEOUT",
-            detail=f"docker compose version exceeded {_CHECK_TIMEOUT_SECONDS}s",
-        )
-    if isinstance(outcome, Exception):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_COMPOSE_NOT_AVAILABLE",
-            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
-        )
-    if outcome.returncode != 0:
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_COMPOSE_NOT_AVAILABLE",
-            detail=_truncate(outcome.stderr or outcome.stdout),
-        )
-    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
+    return await _docker_check(
+        runner,
+        args=["docker", "compose", "version", "--short"],
+        description="docker compose version",
+        fail_reason="DOCKER_COMPOSE_NOT_AVAILABLE",
+        timeout_reason="DOCKER_COMPOSE_TIMEOUT",
+    )
 
 
 async def _check_agent_runtime_image(runner: AsyncCommandRunner, image: str) -> CheckResult:
-    outcome = await _run_bounded(
-        runner, ["docker", "image", "inspect", image, "--format", "{{.Id}}"]
+    return await _docker_check(
+        runner,
+        args=["docker", "image", "inspect", image, "--format", "{{.Id}}"],
+        description=f"docker image inspect {image}",
+        fail_reason="AGENT_RUNTIME_IMAGE_MISSING",
+        timeout_reason="AGENT_RUNTIME_IMAGE_TIMEOUT",
+        detail_prefix=f"{image}: ",
+        cli_missing_detail=f"docker binary not found on PATH (cannot inspect {image})",
     )
-    if isinstance(outcome, FileNotFoundError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="DOCKER_CLI_NOT_FOUND",
-            detail=f"docker binary not found on PATH (cannot inspect {image})",
-        )
-    if isinstance(outcome, TimeoutError):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="AGENT_RUNTIME_IMAGE_TIMEOUT",
-            detail=f"docker image inspect {image} exceeded {_CHECK_TIMEOUT_SECONDS}s",
-        )
-    if isinstance(outcome, Exception):
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="AGENT_RUNTIME_IMAGE_MISSING",
-            detail=_truncate(f"{image}: {type(outcome).__name__}: {outcome}"),
-        )
-    if outcome.returncode != 0:
-        return CheckResult(
-            ok=False,
-            status="fail",
-            reason="AGENT_RUNTIME_IMAGE_MISSING",
-            detail=_truncate(f"{image}: {outcome.stderr or outcome.stdout}"),
-        )
-    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
 
 
 @router.get("/readyz", response_model=ReadyResponse)

--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -1,19 +1,30 @@
-"""Liveness/health endpoint.
+"""Liveness + readiness endpoints.
 
-Kept intentionally dependency-free: no DB query, no Docker daemon check, no secrets
-read. Its job is to report that the HTTP stack itself is up so external probes can
-distinguish "AWF process is alive" from "AWF depends on X which is down."
+``/healthz`` is intentionally dependency-free: no DB query, no Docker daemon
+check, no secrets read. Its job is to report that the HTTP stack itself is up
+so external probes can distinguish "AWF process is alive" from "AWF depends on
+X which is down."
 
-Separate readiness/dependency checks will live under /readyz (Phase 1.5+) and will
-verify DB + Docker reachability.
+``/readyz`` (PRD v2.2 §12, §18.2, §18.3) reports per-dependency readiness:
+control-plane DB connectivity, Docker CLI + daemon + Compose plugin, and
+presence of the configured agent runtime image. Each check has a stable
+``reason`` code so dashboards and operators can route alerts on the *specific*
+failing dependency rather than a generic 503.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+import asyncio
+import contextlib
+from typing import Any
+
+from fastapi import APIRouter, Request, Response, status
 from pydantic import BaseModel
+from sqlalchemy import text
 
 from awf import __version__
+from awf.common.commands import AsyncCommandRunner, AsyncioSubprocessRunner, CommandResult
+from awf.common.config import get_settings
 
 router = APIRouter(tags=["system"])
 
@@ -30,6 +41,272 @@ class HealthResponse(BaseModel):
     version: str
 
 
+class CheckResult(BaseModel):
+    """One readiness sub-check result.
+
+    ``reason`` is a stable uppercase code (e.g. ``DOCKER_DAEMON_UNREACHABLE``)
+    intended for routing alerts and dashboards; ``detail`` carries the raw
+    error text for human eyes.
+    """
+
+    ok: bool
+    status: str
+    reason: str | None = None
+    detail: str | None = None
+    version: str | None = None
+
+
+class ReadyResponse(BaseModel):
+    service: str
+    version: str
+    status: str
+    checks: dict[str, CheckResult]
+
+
 @router.get("/healthz", response_model=HealthResponse)
 async def healthz() -> HealthResponse:
     return HealthResponse(status="ok", service="awf", version=__version__)
+
+
+# Bound every subprocess call so a hung docker daemon can't wedge readiness probes
+# behind the default uvicorn worker. 5s is generous for local docker calls; tune
+# down once we have latency telemetry.
+_CHECK_TIMEOUT_SECONDS = 5.0
+
+
+def _get_command_runner_for_request(request: Request) -> AsyncCommandRunner:
+    """Resolve the command runner for the request.
+
+    Tests inject a ``FakeCommandRunner`` via ``app.state.command_runner``;
+    production falls back to the real asyncio subprocess runner.
+    """
+    runner: AsyncCommandRunner | None = getattr(request.app.state, "command_runner", None)
+    if runner is None:
+        return AsyncioSubprocessRunner()
+    return runner
+
+
+def _truncate(value: str, *, limit: int = 240) -> str:
+    """Cap detail strings so a verbose docker error can't bloat the response body."""
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+async def _check_db(factory: Any) -> CheckResult:
+    if factory is None:
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DB_NOT_CONFIGURED",
+            detail="db_session_factory is not attached to app.state",
+        )
+    session = factory()
+    try:
+        try:
+            await asyncio.wait_for(
+                session.execute(text("SELECT 1")), timeout=_CHECK_TIMEOUT_SECONDS
+            )
+        except TimeoutError:
+            return CheckResult(
+                ok=False,
+                status="fail",
+                reason="DB_TIMEOUT",
+                detail=f"SELECT 1 exceeded {_CHECK_TIMEOUT_SECONDS}s",
+            )
+        except Exception as exc:
+            return CheckResult(
+                ok=False,
+                status="fail",
+                reason="DB_CONNECTION_FAILED",
+                detail=_truncate(f"{type(exc).__name__}: {exc}"),
+            )
+    finally:
+        close = getattr(session, "close", None)
+        if close is not None:
+            # Close-time errors aren't actionable for a probe.
+            with contextlib.suppress(Exception):
+                await close()
+    return CheckResult(ok=True, status="ok")
+
+
+async def _run_bounded(runner: AsyncCommandRunner, args: list[str]) -> CommandResult | Exception:
+    """Run a subprocess with a timeout. Returns the exception object on failure
+    so the caller can map it to a structured reason code."""
+    try:
+        return await asyncio.wait_for(runner.run(args), timeout=_CHECK_TIMEOUT_SECONDS)
+    except TimeoutError as exc:
+        return exc
+    except Exception as exc:
+        return exc
+
+
+async def _check_docker_cli(runner: AsyncCommandRunner) -> CheckResult:
+    outcome = await _run_bounded(runner, ["docker", "--version"])
+    if isinstance(outcome, FileNotFoundError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_NOT_FOUND",
+            detail="docker binary not found on PATH",
+        )
+    if isinstance(outcome, TimeoutError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_TIMEOUT",
+            detail=f"docker --version exceeded {_CHECK_TIMEOUT_SECONDS}s",
+        )
+    if isinstance(outcome, Exception):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_ERROR",
+            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
+        )
+    if outcome.returncode != 0:
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_ERROR",
+            detail=_truncate(outcome.stderr or outcome.stdout),
+        )
+    version = outcome.stdout.strip() or None
+    return CheckResult(ok=True, status="ok", version=version)
+
+
+async def _check_docker_daemon(runner: AsyncCommandRunner) -> CheckResult:
+    # ``--format`` keeps output to just the server version (one short line) so we
+    # don't have to parse the verbose default ``docker info`` output.
+    outcome = await _run_bounded(
+        runner, ["docker", "info", "--format", "{{.ServerVersion}}"]
+    )
+    if isinstance(outcome, FileNotFoundError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_NOT_FOUND",
+            detail="docker binary not found on PATH",
+        )
+    if isinstance(outcome, TimeoutError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_DAEMON_TIMEOUT",
+            detail=f"docker info exceeded {_CHECK_TIMEOUT_SECONDS}s",
+        )
+    if isinstance(outcome, Exception):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_DAEMON_UNREACHABLE",
+            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
+        )
+    if outcome.returncode != 0:
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_DAEMON_UNREACHABLE",
+            detail=_truncate(outcome.stderr or outcome.stdout),
+        )
+    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
+
+
+async def _check_docker_compose(runner: AsyncCommandRunner) -> CheckResult:
+    outcome = await _run_bounded(runner, ["docker", "compose", "version", "--short"])
+    if isinstance(outcome, FileNotFoundError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_NOT_FOUND",
+            detail="docker binary not found on PATH",
+        )
+    if isinstance(outcome, TimeoutError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_COMPOSE_TIMEOUT",
+            detail=f"docker compose version exceeded {_CHECK_TIMEOUT_SECONDS}s",
+        )
+    if isinstance(outcome, Exception):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_COMPOSE_NOT_AVAILABLE",
+            detail=_truncate(f"{type(outcome).__name__}: {outcome}"),
+        )
+    if outcome.returncode != 0:
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_COMPOSE_NOT_AVAILABLE",
+            detail=_truncate(outcome.stderr or outcome.stdout),
+        )
+    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
+
+
+async def _check_agent_runtime_image(runner: AsyncCommandRunner, image: str) -> CheckResult:
+    outcome = await _run_bounded(
+        runner, ["docker", "image", "inspect", image, "--format", "{{.Id}}"]
+    )
+    if isinstance(outcome, FileNotFoundError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DOCKER_CLI_NOT_FOUND",
+            detail=f"docker binary not found on PATH (cannot inspect {image})",
+        )
+    if isinstance(outcome, TimeoutError):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="AGENT_RUNTIME_IMAGE_TIMEOUT",
+            detail=f"docker image inspect {image} exceeded {_CHECK_TIMEOUT_SECONDS}s",
+        )
+    if isinstance(outcome, Exception):
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="AGENT_RUNTIME_IMAGE_MISSING",
+            detail=_truncate(f"{image}: {type(outcome).__name__}: {outcome}"),
+        )
+    if outcome.returncode != 0:
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="AGENT_RUNTIME_IMAGE_MISSING",
+            detail=_truncate(f"{image}: {outcome.stderr or outcome.stdout}"),
+        )
+    return CheckResult(ok=True, status="ok", version=outcome.stdout.strip() or None)
+
+
+@router.get("/readyz", response_model=ReadyResponse)
+async def readyz(request: Request, response: Response) -> ReadyResponse:
+    settings = get_settings()
+    runner = _get_command_runner_for_request(request)
+    factory = getattr(request.app.state, "db_session_factory", None)
+
+    # Sequential checks: keeps the FakeCommandRunner contract simple and the
+    # latency floor is dominated by docker info anyway, so concurrency wouldn't
+    # buy much for a probe endpoint.
+    checks = {
+        "db": await _check_db(factory),
+        "docker_cli": await _check_docker_cli(runner),
+        "docker_daemon": await _check_docker_daemon(runner),
+        "docker_compose": await _check_docker_compose(runner),
+        "agent_runtime_image": await _check_agent_runtime_image(
+            runner, settings.agent_runtime_image
+        ),
+    }
+
+    overall_ok = all(check.ok for check in checks.values())
+    if not overall_ok:
+        response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
+
+    return ReadyResponse(
+        service="awf",
+        version=__version__,
+        status="ok" if overall_ok else "fail",
+        checks=checks,
+    )

--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -287,17 +287,24 @@ async def readyz(request: Request, response: Response) -> ReadyResponse:
     runner = _get_command_runner_for_request(request)
     factory = getattr(request.app.state, "db_session_factory", None)
 
-    # Sequential checks: keeps the FakeCommandRunner contract simple and the
-    # latency floor is dominated by docker info anyway, so concurrency wouldn't
-    # buy much for a probe endpoint.
+    # Run checks concurrently so the worst-case latency stays bounded by the
+    # single _CHECK_TIMEOUT_SECONDS rather than summing across all five (a
+    # k8s/uptime probe with multiple slow deps would otherwise hit 25s and
+    # time out at the orchestrator). Each check already returns a structured
+    # CheckResult on failure, so gather() never sees an exception.
+    db_check, cli_check, daemon_check, compose_check, image_check = await asyncio.gather(
+        _check_db(factory),
+        _check_docker_cli(runner),
+        _check_docker_daemon(runner),
+        _check_docker_compose(runner),
+        _check_agent_runtime_image(runner, settings.agent_runtime_image),
+    )
     checks = {
-        "db": await _check_db(factory),
-        "docker_cli": await _check_docker_cli(runner),
-        "docker_daemon": await _check_docker_daemon(runner),
-        "docker_compose": await _check_docker_compose(runner),
-        "agent_runtime_image": await _check_agent_runtime_image(
-            runner, settings.agent_runtime_image
-        ),
+        "db": db_check,
+        "docker_cli": cli_check,
+        "docker_daemon": daemon_check,
+        "docker_compose": compose_check,
+        "agent_runtime_image": image_check,
     }
 
     overall_ok = all(check.ok for check in checks.values())

--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -102,7 +102,18 @@ async def _check_db(factory: Any) -> CheckResult:
             reason="DB_NOT_CONFIGURED",
             detail="db_session_factory is not attached to app.state",
         )
-    session = factory()
+    try:
+        session = factory()
+    except Exception as exc:
+        # factory() can raise before we ever get a session — e.g. pool exhausted,
+        # bad DSN, engine misconfig. Surface it as a structured DB failure so
+        # /readyz returns 503 instead of an unhandled 500.
+        return CheckResult(
+            ok=False,
+            status="fail",
+            reason="DB_CONNECTION_FAILED",
+            detail=_truncate(f"{type(exc).__name__}: {exc}"),
+        )
     try:
         try:
             await asyncio.wait_for(

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -196,6 +196,29 @@ async def test_readyz_db_query_failure_returns_503(
     assert "connection refused" in (db_check["detail"] or "")
 
 
+@pytest.mark.unit
+async def test_readyz_db_factory_raises_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """Factory failure (pool exhausted, bad DSN) must surface as 503, not 500."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    def _exploding_factory() -> Any:
+        raise RuntimeError("QueuePool limit of size 5 overflow 10 reached")
+
+    app.state.db_session_factory = _exploding_factory
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    db_check = response.json()["checks"]["db"]
+    assert db_check["ok"] is False
+    assert db_check["reason"] == "DB_CONNECTION_FAILED"
+    assert "QueuePool" in (db_check["detail"] or "")
+
+
 # ---- /readyz: Docker CLI / daemon failures ----------------------------------
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -1,23 +1,30 @@
-"""Health endpoint — the first contract AWF guarantees to operators and uptime probes.
+"""Health + readiness endpoint contracts.
 
-The contract under test:
-    GET /healthz returns 200 with a JSON body shaped as:
-        {"status": "ok", "service": "awf", "version": "<semver>"}
+``/healthz`` is the liveness probe — dependency-free, must never depend on DB or
+Docker. See module docstring in ``awf.api.routes.health`` for rationale.
 
-Rationale:
-    - Operators (and k8s/Cloud Run) need a liveness probe that never depends on
-      external services (DB, Docker daemon) so a single dependency outage doesn't
-      flap the whole control plane.
-    - The version field is non-optional so deploys can verify the rolled-out build
-      matches expectations.
+``/readyz`` is the readiness probe required by PRD v2.2 §12 and §18.2/§18.3 — it
+reports per-dependency status (DB + Docker stack + configured agent runtime
+image) so an operator can see *which* dependency is down rather than just "AWF
+unhealthy". The response shape lets dashboards and uptime probes alert on the
+specific failing check rather than a generic 503.
 """
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from typing import Any
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf import __version__
+from awf.api.app import configure_database, create_app
+from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.db.session import make_session_factory
+
+# ---- /healthz ---------------------------------------------------------------
 
 
 @pytest.mark.unit
@@ -44,3 +51,312 @@ async def test_healthz_does_not_require_auth(client: AsyncClient) -> None:
     response = await client.get("/healthz")
     assert response.status_code != 401
     assert response.status_code != 403
+
+
+# ---- /readyz fixtures -------------------------------------------------------
+
+
+def _queue_all_ok(runner: FakeCommandRunner) -> None:
+    """Queue successful results for the four docker-related subprocess calls.
+
+    Order matches the readiness handler's sequential check order:
+    docker --version → docker info → docker compose version → docker image inspect.
+    """
+    runner.queue_result(stdout="Docker version 27.0.3, build abc1234\n")
+    runner.queue_result(stdout="27.0.3\n")
+    runner.queue_result(stdout="v2.29.2\n")
+    runner.queue_result(stdout="sha256:deadbeef\n")
+
+
+@pytest.fixture
+async def ready_app_and_client(engine: AsyncEngine) -> AsyncIterator[tuple[Any, AsyncClient]]:
+    """App + client pair so tests can mutate ``app.state`` (inject command runner)."""
+    app = create_app(use_lifespan=False)
+    configure_database(app, make_session_factory(engine))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield app, c
+
+
+# ---- /readyz: happy path ----------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_readyz_all_ok_returns_200(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+async def test_readyz_response_shape_matches_contract(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """Operators need a stable shape: service / version / status + per-check map."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    body = response.json()
+
+    assert body["service"] == "awf"
+    assert body["version"] == __version__
+    assert body["status"] == "ok"
+
+    checks = body["checks"]
+    assert set(checks.keys()) == {
+        "db",
+        "docker_cli",
+        "docker_daemon",
+        "docker_compose",
+        "agent_runtime_image",
+    }
+    for name, check in checks.items():
+        assert check["ok"] is True, f"{name} should be ok"
+        assert check["status"] == "ok"
+        assert check.get("reason") is None
+
+
+@pytest.mark.unit
+async def test_readyz_reports_versions_when_available(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """Surfacing versions helps operators verify the right Docker / image is rolled out."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    checks = response.json()["checks"]
+
+    assert "27.0.3" in checks["docker_cli"]["version"]
+    assert checks["docker_daemon"]["version"] == "27.0.3"
+    assert checks["docker_compose"]["version"] == "v2.29.2"
+    assert checks["agent_runtime_image"]["version"] == "sha256:deadbeef"
+
+
+# ---- /readyz: DB failures ---------------------------------------------------
+
+
+@pytest.mark.unit
+async def test_readyz_db_not_configured_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """If the session factory wasn't wired, the DB check must fail loudly."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+    app.state.db_session_factory = None  # Simulate misconfigured deploy.
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "fail"
+    db_check = body["checks"]["db"]
+    assert db_check["ok"] is False
+    assert db_check["reason"] == "DB_NOT_CONFIGURED"
+
+
+@pytest.mark.unit
+async def test_readyz_db_query_failure_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """A live DB outage should be surfaced as a structured failure, not a 500."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    class _ExplodingSession:
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("connection refused: control-plane DB is down")
+
+        async def close(self) -> None:
+            return None
+
+    def _factory() -> _ExplodingSession:
+        return _ExplodingSession()
+
+    app.state.db_session_factory = _factory
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    db_check = response.json()["checks"]["db"]
+    assert db_check["ok"] is False
+    assert db_check["reason"] == "DB_CONNECTION_FAILED"
+    assert "connection refused" in (db_check["detail"] or "")
+
+
+# ---- /readyz: Docker CLI / daemon failures ----------------------------------
+
+
+@pytest.mark.unit
+async def test_readyz_docker_cli_missing_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """When the docker binary is absent, asyncio raises FileNotFoundError —
+    the readiness check must catch it and report an actionable reason."""
+    app, client = ready_app_and_client
+
+    class _DockerMissingRunner:
+        def __init__(self) -> None:
+            self.calls: list[list[str]] = []
+
+        async def run(
+            self,
+            args: list[str],
+            *,
+            input_bytes: bytes | None = None,
+            cwd: str | None = None,
+        ) -> CommandResult:
+            self.calls.append(list(args))
+            if args and args[0] == "docker":
+                raise FileNotFoundError(args[0])
+            return CommandResult(returncode=0, stdout="", stderr="")
+
+    app.state.command_runner = _DockerMissingRunner()
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    body = response.json()
+
+    cli_check = body["checks"]["docker_cli"]
+    assert cli_check["ok"] is False
+    assert cli_check["reason"] == "DOCKER_CLI_NOT_FOUND"
+
+    # Daemon, compose, and image checks all depend on docker — they should also fail
+    # (gracefully) rather than crash the request.
+    assert body["checks"]["docker_daemon"]["ok"] is False
+    assert body["checks"]["docker_compose"]["ok"] is False
+    assert body["checks"]["agent_runtime_image"]["ok"] is False
+
+
+@pytest.mark.unit
+async def test_readyz_docker_daemon_unreachable_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    runner.queue_result(stdout="Docker version 27.0.3, build abc\n")  # docker --version
+    runner.queue_result(  # docker info
+        returncode=1,
+        stderr="Cannot connect to the Docker daemon at unix:///var/run/docker.sock\n",
+    )
+    runner.queue_result(stdout="v2.29.2\n")
+    runner.queue_result(stdout="sha256:deadbeef\n")
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    daemon = response.json()["checks"]["docker_daemon"]
+    assert daemon["ok"] is False
+    assert daemon["reason"] == "DOCKER_DAEMON_UNREACHABLE"
+    assert "Cannot connect" in (daemon["detail"] or "")
+
+
+@pytest.mark.unit
+async def test_readyz_docker_compose_missing_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    runner.queue_result(stdout="Docker version 27.0.3\n")
+    runner.queue_result(stdout="27.0.3\n")
+    runner.queue_result(  # docker compose version
+        returncode=1,
+        stderr="docker: 'compose' is not a docker command.\n",
+    )
+    runner.queue_result(stdout="sha256:deadbeef\n")
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    compose = response.json()["checks"]["docker_compose"]
+    assert compose["ok"] is False
+    assert compose["reason"] == "DOCKER_COMPOSE_NOT_AVAILABLE"
+
+
+@pytest.mark.unit
+async def test_readyz_agent_runtime_image_missing_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    runner.queue_result(stdout="Docker version 27.0.3\n")
+    runner.queue_result(stdout="27.0.3\n")
+    runner.queue_result(stdout="v2.29.2\n")
+    runner.queue_result(  # docker image inspect
+        returncode=1,
+        stderr="Error: No such image: awf-agent-runtime:latest\n",
+    )
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    image_check = response.json()["checks"]["agent_runtime_image"]
+    assert image_check["ok"] is False
+    assert image_check["reason"] == "AGENT_RUNTIME_IMAGE_MISSING"
+    # The configured image name must show up in the detail so the operator knows
+    # which tag was expected — "image missing" with no name is unactionable.
+    assert "awf-agent-runtime:latest" in (image_check["detail"] or "")
+
+
+@pytest.mark.unit
+async def test_readyz_uses_configured_agent_runtime_image(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """The image inspect call must reference the runtime image from settings."""
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    await client.get("/readyz")
+
+    image_inspect_call = runner.calls[3]  # 4th call: docker image inspect ...
+    assert image_inspect_call.args[:3] == ["docker", "image", "inspect"]
+    assert "awf-agent-runtime:latest" in image_inspect_call.args
+
+
+# ---- /readyz: never-crash contract ------------------------------------------
+
+
+@pytest.mark.unit
+async def test_readyz_never_crashes_when_docker_completely_unavailable(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    """Even with every docker call exploding, /readyz must return a structured
+    response (503 with per-check reasons) rather than a 500."""
+    app, client = ready_app_and_client
+
+    class _AlwaysExplodingRunner:
+        async def run(
+            self,
+            args: list[str],
+            *,
+            input_bytes: bytes | None = None,
+            cwd: str | None = None,
+        ) -> CommandResult:
+            raise OSError("no such file or directory")
+
+    app.state.command_runner = _AlwaysExplodingRunner()
+
+    response = await client.get("/readyz")
+    assert response.status_code == 503
+    body = response.json()
+    # DB check should still report OK (it doesn't touch docker).
+    assert body["checks"]["db"]["ok"] is True
+    # All docker-related checks fail with structured reasons, not tracebacks.
+    for name in ("docker_cli", "docker_daemon", "docker_compose", "agent_runtime_image"):
+        check = body["checks"][name]
+        assert check["ok"] is False
+        assert check["reason"] is not None


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_524abe06dbad446c8f8497cb` (agent: `claude_code`).


### Task
Strict TDD requirements:
- Start by adding focused failing tests for the requested behavior.
- Run the narrow tests and include the red failure output in the first commit body.
- Implement only the requested slice until the tests are green.
- Run the validation commands listed below before final response.
- Commit locally with a conventional commit message.
- Do not push, open PRs, switch branches, rebase, or force-push; AWF owns branch and PR lifecycle.
- Keep changes tightly scoped to the listed files/areas and avoid unrelated refactors.

PRD backing: docs/awf_prd_v2.2.md sections 12, 18.2, and 18.3 require health, dependency visibility, and actionable operator diagnostics.

Implement GET /readyz without changing /healthz semantics.

Expected behavior:
- /healthz remains dependency-free and always reports the HTTP stack liveness.
- /readyz returns structured dependency checks for: control-plane DB connectivity, Docker CLI availability, Docker daemon reachability, Docker Compose plugin availability, and configured AWF agent runtime image presence.
- Response includes service, version, status, and a checks array/object with ok, status, reason, and optional detail/version fields.
- Return 200 when all checks pass and 503 when one or more required checks fail.
- Never crash when Docker is unavailable; surface actionable reasons.
- Keep subprocess calls bounded and mockable in tests.

Validation commands to run:
uv run ruff check src/awf/api/routes/health.py tests/unit/api/test_health.py tests/unit/api
uv run mypy src/awf/api
uv run pytest tests/unit/api/test_health.py -q tests/unit/api -q

---
Validation: 6 profile command(s) passed inside the workspace container.
