### PR TITLE
feat(service): add local Postgres-backed AWF service foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ AWF_LOG_LEVEL=INFO
 # API
 AWF_API_HOST=0.0.0.0
 AWF_API_PORT=8000
+AWF_API_BASE_URL=http://localhost:8000
 AWF_API_TOKEN=
 
 # Database (control-plane Postgres)
@@ -22,6 +23,15 @@ AWF_DOCKER_HOST=unix:///var/run/docker.sock
 
 # Agent runtime image (built from docker/agent-runtime.Dockerfile)
 AWF_AGENT_RUNTIME_IMAGE=awf-agent-runtime:latest
+
+# Local AWF state root. The Compose stack overrides this to /awf-work.
+AWF_WORK_DIR=.awf
+
+# Worker
+AWF_WORKER_POLL_INTERVAL_SECONDS=1
+AWF_WORKER_MAX_CONCURRENT_PROVISIONS=3
+AWF_WORKER_NODE_ID=
+AWF_WORKER_BRANCH_PREFIX=awf
 
 # Workspace resource defaults (overridable per-request)
 AWF_WORKSPACE_STEADY_CPU=3

--- a/README.md
+++ b/README.md
@@ -398,8 +398,9 @@ curl -X POST http://localhost:8000/v2/workspaces \
 ```
 
 Current MVP note: the REST API persists workspace requests and exposes state.
-The full local end-to-end executor is `scripts/run_awf.py` until the dedicated
-worker/scheduler path is promoted.
+The always-on worker path currently proves provisioning only
+(`requested -> provisioning -> ready`). The full local end-to-end executor is
+still `scripts/run_awf.py` until API-backed full execution lands.
 
 Get one workspace:
 
@@ -445,6 +446,20 @@ Start the API:
 uv run --python 3.12 --extra dev awf serve --host 127.0.0.1 --port 8000
 ```
 
+Run the provisioning worker:
+
+```bash
+uv run --python 3.12 --extra dev awf worker
+```
+
+Inspect local service settings and dependency status:
+
+```bash
+uv run --python 3.12 --extra dev awf service config
+uv run --python 3.12 --extra dev awf service status
+uv run --python 3.12 --extra dev awf service status --format pretty
+```
+
 Create a workspace:
 
 ```bash
@@ -482,6 +497,43 @@ Preview profile resolution:
 uv run --python 3.12 --extra dev awf profile preview ~/Projects/example-repo --profile auto
 ```
 
+## Local Service Stack
+
+Docker Compose is the default local runtime for the always-on AWF control
+plane. The stack runs:
+
+- Postgres for the AWF control-plane database.
+- A one-shot `migrate` service that runs Alembic before API/worker startup.
+- The AWF API service.
+- The AWF worker service.
+
+Both the API and worker containers mount `/var/run/docker.sock` so AWF can
+create and manage per-workspace Compose stacks on the host Docker daemon.
+
+Start from a clean checkout:
+
+```bash
+cp .env.example .env
+docker build -t awf-agent-runtime:latest -f docker/agent-runtime.Dockerfile .
+docker compose -f docker/compose/local-service.yml up --build
+```
+
+Check the service from another terminal:
+
+```bash
+uv run --python 3.12 --extra dev awf service status
+```
+
+The service-mode default database URL is local Postgres
+(`postgresql+asyncpg://awf:...@localhost:5433/awf`). SQLite remains supported
+for tests and throwaway script runs, but the always-on service should run
+against Postgres.
+
+The AWF Postgres database is only the control-plane database. Project and
+workspace databases remain separate and profile-isolated; if a workspace
+profile needs Postgres or another datastore, that service belongs to the
+per-workspace Compose stack, not the AWF control-plane DB.
+
 ## MCP Surface
 
 AWF also exposes MCP tools for clients that want typed tool calls instead of
@@ -501,7 +553,8 @@ MCP is a straightforward next slice.
 ## Local Dogfood Runner
 
 The fastest way to exercise the full local pipeline today is
-`scripts/run_awf.py`. It creates a local SQLite control-plane database under a
+`scripts/run_awf.py`. It is a compatibility dogfood runner until API-backed
+full execution lands. It creates a local SQLite control-plane database under a
 run directory, provisions workspaces, launches Docker Compose, runs the agent,
 creates a PR, and runs the PR monitor.
 
@@ -626,23 +679,26 @@ docker image inspect awf-agent-runtime:latest
 
 ### Configure Environment
 
-Local API development can use the default SQLite database:
-
-```bash
-export AWF_DATABASE_URL="sqlite+aiosqlite:///./awf.db"
-```
-
-For Postgres control-plane development, copy `.env.example`:
+Local service development should use Postgres via the Compose stack:
 
 ```bash
 cp .env.example .env
+docker compose -f docker/compose/local-service.yml up --build
 ```
 
-Then edit:
+For API-only throwaway development, SQLite remains supported:
+
+```bash
+export AWF_DATABASE_URL="sqlite+aiosqlite:///./awf.db"
+uv run --python 3.12 --extra dev awf serve --host 127.0.0.1 --port 8000
+```
+
+Key local service values:
 
 ```text
 AWF_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf
 AWF_AGENT_RUNTIME_IMAGE=awf-agent-runtime:latest
+AWF_WORK_DIR=.awf
 AWF_GITHUB_TOKEN=
 ```
 
@@ -680,7 +736,14 @@ dogfood tests can use a Flash preview model when Pro is unavailable.
 ### Database Migrations
 
 SQLite local API runs create tables automatically at startup. For Postgres,
-apply migrations before starting the API:
+apply migrations before starting the API and worker. The Compose stack does
+this through its `migrate` service:
+
+```bash
+docker compose -f docker/compose/local-service.yml up migrate
+```
+
+Manual Postgres migration:
 
 ```bash
 AWF_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf \

--- a/docker/compose/local-service.yml
+++ b/docker/compose/local-service.yml
@@ -13,7 +13,7 @@ x-awf-service: &awf-service
     AWF_LOG_LEVEL: INFO
     AWF_API_HOST: 0.0.0.0
     AWF_API_PORT: "8000"
-    AWF_API_BASE_URL: http://localhost:8000
+    AWF_API_BASE_URL: http://api:8000
     AWF_DATABASE_URL: postgresql+asyncpg://awf:awf_dev@postgres:5432/awf
     AWF_DOCKER_HOST: unix:///var/run/docker.sock
     AWF_AGENT_RUNTIME_IMAGE: awf-agent-runtime:latest

--- a/docker/compose/local-service.yml
+++ b/docker/compose/local-service.yml
@@ -1,0 +1,71 @@
+name: awf-local-service
+
+x-awf-service: &awf-service
+  image: ghcr.io/astral-sh/uv:python3.12-bookworm
+  working_dir: /app
+  volumes:
+    - ../..:/app
+    - /var/run/docker.sock:/var/run/docker.sock
+    - awf-work:/awf-work
+  environment: &awf-environment
+    AWF_SERVICE_NAME: awf
+    AWF_ENV: local
+    AWF_LOG_LEVEL: INFO
+    AWF_API_HOST: 0.0.0.0
+    AWF_API_PORT: "8000"
+    AWF_API_BASE_URL: http://localhost:8000
+    AWF_DATABASE_URL: postgresql+asyncpg://awf:awf_dev@postgres:5432/awf
+    AWF_DOCKER_HOST: unix:///var/run/docker.sock
+    AWF_AGENT_RUNTIME_IMAGE: awf-agent-runtime:latest
+    AWF_WORK_DIR: /awf-work
+    AWF_WORKER_POLL_INTERVAL_SECONDS: "1.0"
+    AWF_WORKER_MAX_CONCURRENT_PROVISIONS: "3"
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: awf
+      POSTGRES_PASSWORD: awf_dev
+      POSTGRES_DB: awf
+    ports:
+      - "5433:5432"
+    volumes:
+      - awf-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U awf -d awf"]
+      interval: 2s
+      timeout: 5s
+      retries: 20
+
+  migrate:
+    <<: *awf-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+    command: sh -c "uv run --python 3.12 --extra dev alembic upgrade head"
+    restart: "no"
+
+  api:
+    <<: *awf-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8000:8000"
+    command: sh -c "uv run --python 3.12 --extra dev awf serve --host 0.0.0.0 --port 8000"
+
+  worker:
+    <<: *awf-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    command: sh -c "uv run --python 3.12 --extra dev awf worker"
+
+volumes:
+  awf-postgres-data:
+  awf-work:

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -12,6 +12,7 @@ friendly formatting is opt-in via ``--format pretty``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import sys
@@ -30,8 +31,10 @@ app = typer.Typer(
 
 workspace_app = typer.Typer(help="Workspace lifecycle (create/inspect/destroy).")
 profile_app = typer.Typer(help="Workspace profile inspection.")
+service_app = typer.Typer(help="Local service operations.")
 app.add_typer(workspace_app, name="workspace")
 app.add_typer(profile_app, name="profile")
+app.add_typer(service_app, name="service")
 
 
 class OutputFormat(StrEnum):
@@ -109,6 +112,46 @@ def serve(
         port=port,
         reload=reload,
     )
+
+
+@app.command("worker")
+def worker(
+    once: bool = typer.Option(
+        False,
+        "--once",
+        help="Run one poll batch and exit.",
+        hidden=True,
+    ),
+) -> None:
+    """Run the AWF control worker."""
+    from awf.service.config import resolve_service_settings
+    from awf.service.worker import run_worker
+
+    asyncio.run(run_worker(resolve_service_settings(), once=once))
+
+
+@service_app.command("status")
+def service_status(
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Check local AWF service dependencies."""
+    from awf.service.config import resolve_service_settings
+    from awf.service.status import collect_service_status
+
+    payload = asyncio.run(collect_service_status(resolve_service_settings()))
+    _emit(payload, fmt)
+    if payload.get("status") != "ok":
+        raise typer.Exit(code=1)
+
+
+@service_app.command("config")
+def service_config(
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Print resolved local service settings with secrets redacted."""
+    from awf.service.config import resolve_service_settings, service_config_payload
+
+    _emit(service_config_payload(resolve_service_settings()), fmt)
 
 
 @workspace_app.command("create")

--- a/src/awf/common/config.py
+++ b/src/awf/common/config.py
@@ -44,6 +44,7 @@ class Settings(BaseSettings):
     # API
     api_host: str = Field(default="0.0.0.0")  # noqa: S104 (intentional in containers)
     api_port: int = Field(default=8000, ge=1, le=65535)
+    api_base_url: str = Field(default="http://localhost:8000")
     api_token: str | None = Field(
         default=None,
         description=(
@@ -73,6 +74,12 @@ class Settings(BaseSettings):
         default=".awf",
         description="Local AWF state root. Log streams live under <work_dir>/logs.",
     )
+
+    # Worker
+    worker_poll_interval_seconds: float = Field(default=1.0, gt=0)
+    worker_max_concurrent_provisions: int = Field(default=3, gt=0)
+    worker_node_id: str | None = Field(default=None)
+    worker_branch_prefix: str = Field(default="awf")
 
     # Workspace resource defaults (overridable per-request)
     workspace_steady_cpu: float = Field(default=3.0, gt=0)

--- a/src/awf/service/__init__.py
+++ b/src/awf/service/__init__.py
@@ -1,0 +1,6 @@
+"""Local always-on AWF service helpers.
+
+This package keeps the Typer CLI thin: CLI commands resolve settings, call the
+service helper, and print the returned payload.
+"""
+

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -1,0 +1,101 @@
+"""Resolved settings for the local AWF service runtime."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+from sqlalchemy.engine import make_url
+
+from awf.common.config import Settings
+
+DEFAULT_LOCAL_SERVICE_DATABASE_URL = "postgresql+asyncpg://awf:awf_dev@localhost:5433/awf"
+
+
+@dataclass(frozen=True, kw_only=True)
+class ServiceSettings:
+    """Settings used by local service commands and containers."""
+
+    service_name: str
+    env: str
+    api_base_url: str
+    database_url: str
+    docker_host: str
+    agent_runtime_image: str
+    work_dir: str
+    api_token: str | None
+    github_token: str | None
+    worker_poll_interval_seconds: float
+    worker_max_concurrent_provisions: int
+    node_id: str | None = None
+    branch_prefix: str = "awf"
+
+
+def resolve_service_settings(
+    base: Settings | None = None,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> ServiceSettings:
+    """Resolve settings for service mode.
+
+    ``Settings`` intentionally keeps SQLite as its default so tests and
+    compatibility scripts can run without a service stack. Service mode promotes
+    the default to local Postgres unless ``AWF_DATABASE_URL`` is explicitly set.
+    When ``environ`` is ``None``, values loaded from ``.env`` by pydantic-settings
+    count as explicit.
+    """
+
+    settings = base or Settings()
+    env = os.environ if environ is None else environ
+    database_url = settings.database_url
+
+    database_url_explicit = _has_env_key(env, "AWF_DATABASE_URL")
+    if environ is None:
+        database_url_explicit = database_url_explicit or "database_url" in settings.model_fields_set
+
+    if not database_url_explicit:
+        database_url = DEFAULT_LOCAL_SERVICE_DATABASE_URL
+
+    return ServiceSettings(
+        service_name=settings.service_name,
+        env=settings.env,
+        api_base_url=settings.api_base_url,
+        database_url=database_url,
+        docker_host=settings.docker_host,
+        agent_runtime_image=settings.agent_runtime_image,
+        work_dir=settings.work_dir,
+        api_token=_empty_to_none(settings.api_token),
+        github_token=_empty_to_none(settings.github_token),
+        worker_poll_interval_seconds=settings.worker_poll_interval_seconds,
+        worker_max_concurrent_provisions=settings.worker_max_concurrent_provisions,
+        node_id=settings.worker_node_id,
+        branch_prefix=settings.worker_branch_prefix,
+    )
+
+
+def service_config_payload(settings: ServiceSettings) -> dict[str, object]:
+    """Return JSON-serializable service settings with secrets redacted."""
+
+    payload: dict[str, object] = asdict(settings)
+    payload["database_url"] = _redact_database_url(settings.database_url)
+    for key in ("api_token", "github_token"):
+        if payload.get(key):
+            payload[key] = "<redacted>"
+    return payload
+
+
+def _has_env_key(environ: Mapping[str, str], key: str) -> bool:
+    wanted = key.upper()
+    return any(existing.upper() == wanted for existing in environ)
+
+
+def _empty_to_none(value: str | None) -> str | None:
+    return value or None
+
+
+def _redact_database_url(value: str) -> str:
+    try:
+        return make_url(value).render_as_string(hide_password=True)
+    except Exception:
+        return "<redacted>" if value else value

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -1,0 +1,241 @@
+"""Local service status checks for the CLI."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+import httpx
+from sqlalchemy import text
+
+from awf.db.session import make_engine
+from awf.service.config import ServiceSettings
+
+_CHECK_TIMEOUT_SECONDS = 5.0
+
+CheckPayload = dict[str, object]
+DbProbe = Callable[[str], Awaitable[CheckPayload]]
+SocketExists = Callable[[Path], bool]
+
+
+class HttpResponse(Protocol):
+    status_code: int
+
+    def json(self) -> Any: ...
+
+    def raise_for_status(self) -> Any: ...
+
+
+class HttpGet(Protocol):
+    def __call__(self, url: str, *, timeout: float) -> HttpResponse: ...
+
+
+class CompletedProcessLike(Protocol):
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class SubprocessRun(Protocol):
+    def __call__(
+        self,
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: Literal[True],
+        timeout: float,
+        env: Mapping[str, str],
+    ) -> CompletedProcessLike: ...
+
+
+async def collect_service_status(
+    settings: ServiceSettings,
+    *,
+    api_get: HttpGet | None = None,
+    db_probe: DbProbe | None = None,
+    run_subprocess: SubprocessRun | None = None,
+    socket_exists: SocketExists | None = None,
+) -> dict[str, object]:
+    """Collect service dependency status without requiring Docker in tests."""
+
+    resolved_api_get = api_get or _http_get
+    resolved_db_probe = db_probe or check_database
+    resolved_run = run_subprocess or _run_subprocess
+    resolved_socket_exists = socket_exists or Path.exists
+
+    checks = {
+        "api": _check_api(settings, resolved_api_get),
+        "db": await resolved_db_probe(settings.database_url),
+        "docker": _check_docker(settings, resolved_run, resolved_socket_exists),
+        "agent_runtime_image": _check_agent_runtime_image(settings, resolved_run),
+    }
+    overall_ok = all(bool(check["ok"]) for check in checks.values())
+    return {
+        "service": settings.service_name,
+        "status": "ok" if overall_ok else "fail",
+        "checks": checks,
+    }
+
+
+async def check_database(database_url: str) -> CheckPayload:
+    engine = make_engine(database_url)
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+    except Exception as exc:
+        return _fail("DB_CONNECTION_FAILED", _truncate(f"{type(exc).__name__}: {exc}"))
+    finally:
+        await engine.dispose()
+    return _ok()
+
+
+def _check_api(settings: ServiceSettings, api_get: HttpGet) -> CheckPayload:
+    url = f"{settings.api_base_url.rstrip('/')}/healthz"
+    try:
+        response = api_get(url, timeout=_CHECK_TIMEOUT_SECONDS)
+        response.raise_for_status()
+    except Exception as exc:
+        return _fail("API_UNREACHABLE", _truncate(f"{type(exc).__name__}: {exc}"))
+
+    version: object | None = None
+    try:
+        body = response.json()
+    except ValueError:
+        body = {}
+    if isinstance(body, dict):
+        version = body.get("version")
+    return _ok(version=version if isinstance(version, str) else None)
+
+
+def _check_docker(
+    settings: ServiceSettings,
+    run_subprocess: SubprocessRun,
+    socket_exists: SocketExists,
+) -> CheckPayload:
+    socket_path = _docker_socket_path(settings.docker_host)
+    if socket_path is not None and not socket_exists(socket_path):
+        return _fail(
+            "DOCKER_SOCKET_UNREACHABLE",
+            f"Docker socket is not reachable at {socket_path}",
+        )
+    result = _run_docker_command(
+        ["docker", "info", "--format", "{{.ServerVersion}}"],
+        settings=settings,
+        run_subprocess=run_subprocess,
+    )
+    return _docker_result_to_check(result, fail_reason="DOCKER_DAEMON_UNREACHABLE")
+
+
+def _check_agent_runtime_image(
+    settings: ServiceSettings,
+    run_subprocess: SubprocessRun,
+) -> CheckPayload:
+    result = _run_docker_command(
+        [
+            "docker",
+            "image",
+            "inspect",
+            settings.agent_runtime_image,
+            "--format",
+            "{{.Id}}",
+        ],
+        settings=settings,
+        run_subprocess=run_subprocess,
+    )
+    return _docker_result_to_check(
+        result,
+        fail_reason="AGENT_RUNTIME_IMAGE_MISSING",
+        detail_prefix=f"{settings.agent_runtime_image}: ",
+    )
+
+
+def _http_get(url: str, *, timeout: float) -> HttpResponse:
+    return httpx.get(url, timeout=timeout)
+
+
+def _run_subprocess(
+    args: list[str],
+    *,
+    check: bool,
+    capture_output: bool,
+    text: Literal[True],
+    timeout: float,
+    env: Mapping[str, str],
+) -> CompletedProcessLike:
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _run_docker_command(
+    args: list[str],
+    *,
+    settings: ServiceSettings,
+    run_subprocess: SubprocessRun,
+) -> CompletedProcessLike | Exception:
+    env = {**os.environ, "DOCKER_HOST": settings.docker_host}
+    try:
+        return run_subprocess(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_CHECK_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except Exception as exc:
+        return exc
+
+
+def _docker_result_to_check(
+    result: CompletedProcessLike | Exception,
+    *,
+    fail_reason: str,
+    detail_prefix: str = "",
+) -> CheckPayload:
+    if isinstance(result, FileNotFoundError):
+        return _fail("DOCKER_CLI_NOT_FOUND", "docker binary not found on PATH")
+    if isinstance(result, subprocess.TimeoutExpired):
+        return _fail(fail_reason, _truncate(f"{detail_prefix}{result}"))
+    if isinstance(result, Exception):
+        return _fail(fail_reason, _truncate(f"{detail_prefix}{type(result).__name__}: {result}"))
+    if result.returncode != 0:
+        return _fail(fail_reason, _truncate(f"{detail_prefix}{result.stderr or result.stdout}"))
+    return _ok(version=result.stdout.strip() or None)
+
+
+def _docker_socket_path(docker_host: str) -> Path | None:
+    prefix = "unix://"
+    if not docker_host.startswith(prefix):
+        return None
+    return Path(docker_host.removeprefix(prefix))
+
+
+def _ok(*, version: str | None = None) -> CheckPayload:
+    payload: CheckPayload = {"ok": True, "status": "ok"}
+    if version is not None:
+        payload["version"] = version
+    return payload
+
+
+def _fail(reason: str, detail: str | None = None) -> CheckPayload:
+    payload: CheckPayload = {"ok": False, "status": "fail", "reason": reason}
+    if detail:
+        payload["detail"] = detail
+    return payload
+
+
+def _truncate(value: str, *, limit: int = 240) -> str:
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
 from collections.abc import Awaitable, Callable, Mapping
@@ -67,11 +68,17 @@ async def collect_service_status(
     resolved_run = run_subprocess or _run_subprocess
     resolved_socket_exists = socket_exists or Path.exists
 
+    api_check, db_check, docker_check, image_check = await asyncio.gather(
+        asyncio.to_thread(_check_api, settings, resolved_api_get),
+        resolved_db_probe(settings.database_url),
+        asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
+        asyncio.to_thread(_check_agent_runtime_image, settings, resolved_run),
+    )
     checks = {
-        "api": _check_api(settings, resolved_api_get),
-        "db": await resolved_db_probe(settings.database_url),
-        "docker": _check_docker(settings, resolved_run, resolved_socket_exists),
-        "agent_runtime_image": _check_agent_runtime_image(settings, resolved_run),
+        "api": api_check,
+        "db": db_check,
+        "docker": docker_check,
+        "agent_runtime_image": image_check,
     }
     overall_ok = all(bool(check["ok"]) for check in checks.values())
     return {

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -31,7 +31,7 @@ class HttpResponse(Protocol):
 
 
 class HttpGet(Protocol):
-    def __call__(self, url: str, *, timeout: float) -> HttpResponse: ...
+    def __call__(self, url: str, *, timeout: float) -> Awaitable[HttpResponse]: ...
 
 
 class CompletedProcessLike(Protocol):
@@ -69,7 +69,7 @@ async def collect_service_status(
     resolved_socket_exists = socket_exists or Path.exists
 
     api_check, db_check, docker_check, image_check = await asyncio.gather(
-        asyncio.to_thread(_check_api, settings, resolved_api_get),
+        _check_api(settings, resolved_api_get),
         resolved_db_probe(settings.database_url),
         asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
         asyncio.to_thread(_check_agent_runtime_image, settings, resolved_run),
@@ -100,10 +100,10 @@ async def check_database(database_url: str) -> CheckPayload:
     return _ok()
 
 
-def _check_api(settings: ServiceSettings, api_get: HttpGet) -> CheckPayload:
+async def _check_api(settings: ServiceSettings, api_get: HttpGet) -> CheckPayload:
     url = f"{settings.api_base_url.rstrip('/')}/healthz"
     try:
-        response = api_get(url, timeout=_CHECK_TIMEOUT_SECONDS)
+        response = await api_get(url, timeout=_CHECK_TIMEOUT_SECONDS)
         response.raise_for_status()
     except Exception as exc:
         return _fail("API_UNREACHABLE", _truncate(f"{type(exc).__name__}: {exc}"))
@@ -160,8 +160,9 @@ def _check_agent_runtime_image(
     )
 
 
-def _http_get(url: str, *, timeout: float) -> HttpResponse:
-    return httpx.get(url, timeout=timeout)
+async def _http_get(url: str, *, timeout: float) -> HttpResponse:
+    async with httpx.AsyncClient() as client:
+        return await client.get(url, timeout=timeout)
 
 
 def _run_subprocess(

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -1,0 +1,60 @@
+"""Worker runtime wiring for the local AWF service."""
+
+from __future__ import annotations
+
+import socket
+from dataclasses import dataclass
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.control.worker import ControlWorker, WorkerConfig
+from awf.db.session import make_engine, make_session_factory
+from awf.node.git_manager import GitManager
+from awf.node.provisioner import Provisioner, ProvisionerConfig
+from awf.service.config import ServiceSettings
+
+
+@dataclass(frozen=True)
+class WorkerRuntime:
+    engine: AsyncEngine
+    worker: ControlWorker
+
+
+def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
+    """Construct the DB/session, git manager, provisioner, and worker."""
+
+    engine = make_engine(settings.database_url)
+    session_factory = make_session_factory(engine)
+    work_dir = Path(settings.work_dir).expanduser().resolve()
+    git = GitManager(work_dir)
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git,
+        config=ProvisionerConfig(
+            node_id=settings.node_id or socket.gethostname(),
+            branch_prefix=settings.branch_prefix,
+        ),
+    )
+    worker = ControlWorker(
+        session_factory=session_factory,
+        provisioner=provisioner,
+        config=WorkerConfig(
+            poll_interval_seconds=settings.worker_poll_interval_seconds,
+            max_concurrent_provisions=settings.worker_max_concurrent_provisions,
+        ),
+    )
+    return WorkerRuntime(engine=engine, worker=worker)
+
+
+async def run_worker(settings: ServiceSettings, *, once: bool = False) -> None:
+    """Run the control worker, disposing the DB engine on exit."""
+
+    runtime = build_worker_runtime(settings)
+    try:
+        if once:
+            await runtime.worker.run_once()
+            return
+        await runtime.worker.run_forever()
+    finally:
+        await runtime.engine.dispose()

--- a/tests/integration/test_local_service_compose.py
+++ b/tests/integration/test_local_service_compose.py
@@ -1,0 +1,34 @@
+"""Static contract tests for the local AWF service Docker Compose stack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+@pytest.mark.integration
+def test_local_service_compose_declares_control_plane_stack() -> None:
+    compose_path = Path("docker/compose/local-service.yml")
+
+    assert compose_path.exists()
+    data = yaml.safe_load(compose_path.read_text())
+    services = data["services"]
+
+    assert {"postgres", "migrate", "api", "worker"}.issubset(services)
+
+    for service_name in ("api", "worker"):
+        volumes = services[service_name]["volumes"]
+        assert "/var/run/docker.sock:/var/run/docker.sock" in volumes
+        environment = services[service_name]["environment"]
+        assert environment["AWF_DATABASE_URL"].startswith("postgresql+asyncpg://")
+        assert "@postgres:5432/" in environment["AWF_DATABASE_URL"]
+
+    migrate_command = services["migrate"]["command"]
+    assert "alembic upgrade head" in migrate_command
+
+    for service_name in ("api", "worker"):
+        depends_on = services[service_name]["depends_on"]
+        assert depends_on["postgres"]["condition"] == "service_healthy"
+        assert depends_on["migrate"]["condition"] == "service_completed_successfully"

--- a/tests/integration/test_local_service_compose.py
+++ b/tests/integration/test_local_service_compose.py
@@ -22,6 +22,7 @@ def test_local_service_compose_declares_control_plane_stack() -> None:
         volumes = services[service_name]["volumes"]
         assert "/var/run/docker.sock:/var/run/docker.sock" in volumes
         environment = services[service_name]["environment"]
+        assert environment["AWF_API_BASE_URL"] == "http://api:8000"
         assert environment["AWF_DATABASE_URL"].startswith("postgresql+asyncpg://")
         assert "@postgres:5432/" in environment["AWF_DATABASE_URL"]
 

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -1,0 +1,290 @@
+"""Service-oriented CLI and local service runtime tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from awf.cli.main import app
+from awf.common.config import Settings
+
+_runner = CliRunner()
+
+
+@pytest.mark.unit
+def test_service_config_uses_postgres_default_and_redacts_secrets() -> None:
+    from awf.service.config import (
+        DEFAULT_LOCAL_SERVICE_DATABASE_URL,
+        resolve_service_settings,
+        service_config_payload,
+    )
+
+    base = Settings(
+        _env_file=None,
+        api_token="api-secret",
+        github_token="ghp_secret",
+        database_url="sqlite+aiosqlite:///./awf.db",
+    )
+
+    settings = resolve_service_settings(base, environ={})
+    payload = service_config_payload(settings)
+    rendered = json.dumps(payload)
+
+    assert settings.database_url == DEFAULT_LOCAL_SERVICE_DATABASE_URL
+    assert payload["database_url"].startswith("postgresql+asyncpg://awf:")
+    assert "awf_dev" not in payload["database_url"]
+    assert payload["api_token"] == "<redacted>"
+    assert payload["github_token"] == "<redacted>"
+    assert "api-secret" not in rendered
+    assert "ghp_secret" not in rendered
+
+
+@pytest.mark.unit
+def test_service_mode_uses_postgres_when_database_env_unset() -> None:
+    from awf.service.config import DEFAULT_LOCAL_SERVICE_DATABASE_URL, resolve_service_settings
+
+    base = Settings(_env_file=None)
+
+    service_settings = resolve_service_settings(base, environ={})
+
+    assert base.database_url.startswith("sqlite+aiosqlite")
+    assert service_settings.database_url == DEFAULT_LOCAL_SERVICE_DATABASE_URL
+    assert service_settings.database_url.startswith("postgresql+asyncpg://")
+
+
+@pytest.mark.unit
+def test_service_mode_preserves_explicit_sqlite_for_throwaway_runs(tmp_path: Path) -> None:
+    from awf.service.config import resolve_service_settings
+
+    sqlite_url = f"sqlite+aiosqlite:///{tmp_path / 'throwaway.db'}"
+    base = Settings(_env_file=None, database_url=sqlite_url)
+
+    service_settings = resolve_service_settings(base, environ={"AWF_DATABASE_URL": sqlite_url})
+
+    assert service_settings.database_url == sqlite_url
+
+
+@pytest.mark.unit
+def test_service_config_command_prints_redacted_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AWF_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AWF_API_TOKEN", "api-secret")
+    monkeypatch.setenv("AWF_GITHUB_TOKEN", "ghp_secret")
+
+    result = _runner.invoke(app, ["service", "config"])
+
+    assert result.exit_code == 0, result.output
+    body = json.loads(result.stdout)
+    assert body["database_url"].startswith("postgresql+asyncpg://")
+    assert body["api_token"] == "<redacted>"
+    assert body["github_token"] == "<redacted>"
+    assert "api-secret" not in result.stdout
+    assert "ghp_secret" not in result.stdout
+
+
+@pytest.mark.unit
+def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Path) -> None:
+    from awf.service.config import ServiceSettings
+    from awf.service.status import collect_service_status
+
+    api_calls: list[str] = []
+    subprocess_calls: list[list[str]] = []
+
+    class _Response:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"status": "ok", "version": "test-version"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _api_get(url: str, *, timeout: float) -> _Response:
+        api_calls.append(url)
+        return _Response()
+
+    async def _db_probe(database_url: str) -> dict[str, Any]:
+        assert database_url == "postgresql+asyncpg://awf:pw@localhost:5433/awf"
+        return {"ok": True, "status": "ok"}
+
+    def _run_subprocess(args: list[str], **_kwargs: object) -> Any:
+        subprocess_calls.append(args)
+        if args[:2] == ["docker", "info"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "27.0.3\n", "stderr": ""})()
+        if args[:3] == ["docker", "image", "inspect"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""},
+            )()
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    settings = ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
+        docker_host=f"unix://{tmp_path / 'docker.sock'}",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "work"),
+        api_token=None,
+        github_token=None,
+        worker_poll_interval_seconds=0.1,
+        worker_max_concurrent_provisions=1,
+    )
+
+    status = asyncio.run(
+        collect_service_status(
+            settings,
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess,
+            socket_exists=lambda _path: True,
+        )
+    )
+
+    assert status["status"] == "ok"
+    assert api_calls == ["http://localhost:8000/healthz"]
+    assert ["docker", "info", "--format", "{{.ServerVersion}}"] in subprocess_calls
+    assert [
+        "docker",
+        "image",
+        "inspect",
+        "awf-agent-runtime:latest",
+        "--format",
+        "{{.Id}}",
+    ] in subprocess_calls
+
+
+@pytest.mark.unit
+def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> None:
+    from awf.service.config import ServiceSettings
+    from awf.service.status import collect_service_status
+
+    def _api_get(url: str, *, timeout: float) -> Any:
+        raise httpx.ConnectError("connection refused")
+
+    async def _db_probe(database_url: str) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "status": "fail",
+            "reason": "DB_CONNECTION_FAILED",
+            "detail": "connection refused",
+        }
+
+    def _run_subprocess(args: list[str], **_kwargs: object) -> Any:
+        return type(
+            "Completed",
+            (),
+            {"returncode": 1, "stdout": "", "stderr": "Cannot connect to Docker\n"},
+        )()
+
+    settings = ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
+        docker_host=f"unix://{tmp_path / 'missing.sock'}",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "work"),
+        api_token=None,
+        github_token=None,
+        worker_poll_interval_seconds=0.1,
+        worker_max_concurrent_provisions=1,
+    )
+
+    status = asyncio.run(
+        collect_service_status(
+            settings,
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess,
+            socket_exists=lambda _path: False,
+        )
+    )
+
+    assert status["status"] == "fail"
+    assert status["checks"]["api"]["reason"] == "API_UNREACHABLE"
+    assert status["checks"]["db"]["reason"] == "DB_CONNECTION_FAILED"
+    assert status["checks"]["docker"]["reason"] == "DOCKER_SOCKET_UNREACHABLE"
+    assert status["checks"]["agent_runtime_image"]["reason"] == "AGENT_RUNTIME_IMAGE_MISSING"
+
+
+@pytest.mark.unit
+def test_worker_entrypoint_wires_control_worker_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from awf.service.config import ServiceSettings
+    from awf.service import worker as worker_mod
+
+    created: dict[str, Any] = {}
+
+    class _Engine:
+        async def dispose(self) -> None:
+            created["disposed"] = True
+
+    class _GitManager:
+        def __init__(self, work_dir: Path) -> None:
+            created["git_work_dir"] = work_dir
+
+    class _Provisioner:
+        def __init__(self, *, session_factory: object, git: object, config: object) -> None:
+            created["provisioner_session_factory"] = session_factory
+            created["provisioner_git"] = git
+            created["provisioner_config"] = config
+
+    class _ControlWorker:
+        def __init__(self, *, session_factory: object, provisioner: object, config: object) -> None:
+            created["worker_session_factory"] = session_factory
+            created["worker_provisioner"] = provisioner
+            created["worker_config"] = config
+
+        async def run_once(self) -> int:
+            created["run_once"] = True
+            return 0
+
+    engine = _Engine()
+    session_factory = object()
+    monkeypatch.setattr(worker_mod, "make_engine", lambda url: created.setdefault("db_url", url) or engine)
+    monkeypatch.setattr(
+        worker_mod,
+        "make_session_factory",
+        lambda eng: created.setdefault("session_engine", eng) or session_factory,
+    )
+    monkeypatch.setattr(worker_mod, "GitManager", _GitManager)
+    monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+
+    settings = ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
+        docker_host="unix:///var/run/docker.sock",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "awf-work"),
+        api_token=None,
+        github_token=None,
+        worker_poll_interval_seconds=0.25,
+        worker_max_concurrent_provisions=2,
+        node_id="node-1",
+    )
+
+    asyncio.run(worker_mod.run_worker(settings, once=True))
+
+    assert created["db_url"] == settings.database_url
+    assert created["session_engine"] is engine
+    assert created["git_work_dir"] == (tmp_path / "awf-work").resolve()
+    assert created["provisioner_session_factory"] is session_factory
+    assert created["worker_session_factory"] is session_factory
+    assert created["provisioner_config"].node_id == "node-1"
+    assert created["worker_config"].poll_interval_seconds == 0.25
+    assert created["worker_config"].max_concurrent_provisions == 2
+    assert created["run_once"] is True
+    assert created["disposed"] is True

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -159,6 +160,87 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
         "--format",
         "{{.Id}}",
     ] in subprocess_calls
+
+
+@pytest.mark.unit
+def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> None:
+    from awf.service.config import ServiceSettings
+    from awf.service.status import collect_service_status
+
+    started = {
+        "api": threading.Event(),
+        "docker": threading.Event(),
+        "image": threading.Event(),
+    }
+    release = threading.Event()
+
+    class _Response:
+        status_code = 200
+
+        def json(self) -> dict[str, str]:
+            return {"status": "ok"}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _wait_for_release(name: str) -> None:
+        started[name].set()
+        if not release.wait(timeout=2):
+            raise AssertionError(f"{name} check was not released")
+
+    def _api_get(url: str, *, timeout: float) -> _Response:
+        _wait_for_release("api")
+        return _Response()
+
+    async def _db_probe(database_url: str) -> dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 2
+        while not all(event.is_set() for event in started.values()):
+            if loop.time() >= deadline:
+                missing = sorted(name for name, event in started.items() if not event.is_set())
+                raise AssertionError(f"checks did not run concurrently: {missing}")
+            await asyncio.sleep(0.01)
+        release.set()
+        return {"ok": True, "status": "ok"}
+
+    def _run_subprocess(args: list[str], **_kwargs: object) -> Any:
+        if args[:2] == ["docker", "info"]:
+            _wait_for_release("docker")
+            return type("Completed", (), {"returncode": 0, "stdout": "27.0.3\n", "stderr": ""})()
+        if args[:3] == ["docker", "image", "inspect"]:
+            _wait_for_release("image")
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""},
+            )()
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    settings = ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
+        docker_host=f"unix://{tmp_path / 'docker.sock'}",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "work"),
+        api_token=None,
+        github_token=None,
+        worker_poll_interval_seconds=0.1,
+        worker_max_concurrent_provisions=1,
+    )
+
+    status = asyncio.run(
+        collect_service_status(
+            settings,
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess,
+            socket_exists=lambda _path: True,
+        )
+    )
+
+    assert status["status"] == "ok"
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -220,8 +220,8 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    from awf.service.config import ServiceSettings
     from awf.service import worker as worker_mod
+    from awf.service.config import ServiceSettings
 
     created: dict[str, Any] = {}
 
@@ -251,11 +251,20 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
 
     engine = _Engine()
     session_factory = object()
-    monkeypatch.setattr(worker_mod, "make_engine", lambda url: created.setdefault("db_url", url) or engine)
+
+    def _make_engine(url: str) -> _Engine:
+        created["db_url"] = url
+        return engine
+
+    def _make_session_factory(eng: _Engine) -> object:
+        created["session_engine"] = eng
+        return session_factory
+
+    monkeypatch.setattr(worker_mod, "make_engine", _make_engine)
     monkeypatch.setattr(
         worker_mod,
         "make_session_factory",
-        lambda eng: created.setdefault("session_engine", eng) or session_factory,
+        _make_session_factory,
     )
     monkeypatch.setattr(worker_mod, "GitManager", _GitManager)
     monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -105,7 +105,7 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
         def raise_for_status(self) -> None:
             return None
 
-    def _api_get(url: str, *, timeout: float) -> _Response:
+    async def _api_get(url: str, *, timeout: float) -> _Response:
         api_calls.append(url)
         return _Response()
 
@@ -188,8 +188,10 @@ def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> N
         if not release.wait(timeout=2):
             raise AssertionError(f"{name} check was not released")
 
-    def _api_get(url: str, *, timeout: float) -> _Response:
-        _wait_for_release("api")
+    async def _api_get(url: str, *, timeout: float) -> _Response:
+        started["api"].set()
+        if not await asyncio.to_thread(release.wait, 2):
+            raise AssertionError("api check was not released")
         return _Response()
 
     async def _db_probe(database_url: str) -> dict[str, Any]:
@@ -248,7 +250,7 @@ def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> N
     from awf.service.config import ServiceSettings
     from awf.service.status import collect_service_status
 
-    def _api_get(url: str, *, timeout: float) -> Any:
+    async def _api_get(url: str, *, timeout: float) -> Any:
         raise httpx.ConnectError("connection refused")
 
     async def _db_probe(database_url: str) -> dict[str, Any]:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_20982d536f6f41d8a9864768` (agent: `codex`).


### Task
Implement the first slice of moving AWF from script-first local runner into an always-on local service backed by Postgres. Strict TDD: write failing tests first, commit them with the red output in the body, then implement until green. Do not push; AWF owns push, PR creation, and monitoring. Do not switch branches; AWF owns branch lifecycle.

Scope for this slice:
- Add a local AWF Docker Compose stack for the control plane with Postgres, API, and worker services. Use Docker Compose as the default local service runtime. The AWF API/worker containers must be able to control the host Docker daemon via /var/run/docker.sock so they can create per-workspace compose stacks.
- Add service-oriented CLI entrypoints: `awf worker`, `awf service status`, and `awf service config`. Keep `awf serve`. The CLI should remain thin and service-oriented.
- Use Postgres as the documented local service default, while keeping SQLite supported for tests and throwaway script runs. Add a bootstrap path for migrations before API/worker start in the compose stack.
- Worker behavior for this first slice should prove the always-on service skeleton only: worker claims requested workspaces using the existing ControlWorker + Provisioner path and can move requested -> provisioning -> ready. Do not rewrite the full agent/validation/PR execution pipeline in this slice.
- Keep project/workspace databases separate and profile-isolated. The AWF Postgres is only the control-plane DB.
- Update README/.env docs so operators can run the local service and understand that scripts/run_awf.py is a compatibility dogfood runner until API-backed full execution lands.

Expected implementation details:
- Add a Docker Compose file under docker/compose for the local AWF service stack.
- Add a small worker CLI command that constructs the configured DB engine/session factory, GitManager, Provisioner, and ControlWorker, then runs forever.
- Add a service status command that checks API reachability, DB readiness, Docker daemon/socket reachability, and agent runtime image presence, returning JSON by default and pretty output when requested.
- Add a service config command that prints resolved service settings with secrets redacted.
- Ensure local service docs instruct running Alembic migrations against Postgres before API/worker start, or include that in the service startup command.

Tests required:
- Unit tests for service config redaction and defaults.
- Unit tests that `awf worker` wires ControlWorker with configured DB/work dir dependencies without running forever.
- Unit tests for `awf service status` with mocked subprocess/API/DB checks.
- Tests confirming SQLite remains usable for tests and Postgres URL is used in service mode.
- Add any focused integration coverage that can run without requiring a live Docker daemon by mocking subprocesses.

Validation commands to run before final response:
- uv run --python 3.12 --extra dev ruff check src/awf scripts tests/unit tests/integration
- uv run --python 3.12 --extra dev mypy src/awf
- uv run --python 3.12 --extra dev pytest tests/unit tests/integration -q

Commit style: conventional commits. Keep the final response concise and include files changed plus validation run results.

---
Validation: 6 profile command(s) passed inside the workspace container.
