### PR TITLE
feat(service): provision workspace compose stacks from worker

### DIFF
--- a/migrations/versions/e5f6a1b2c3d4_store_compose_file_path.py
+++ b/migrations/versions/e5f6a1b2c3d4_store_compose_file_path.py
@@ -1,0 +1,29 @@
+"""Store rendered compose file path.
+
+Revision ID: e5f6a1b2c3d4
+Revises: 7a8b9c0d1e2f
+Create Date: 2026-04-25 00:00:00.000000+00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e5f6a1b2c3d4"
+down_revision: str | Sequence[str] | None = "7a8b9c0d1e2f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.add_column(sa.Column("compose_file_path", sa.String(length=1024), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.drop_column("compose_file_path")

--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -131,7 +131,11 @@ async def _main(
             return 2
 
     # Re-use the container + worktree that the original run set up.
-    compose_file = work_dir / "compose" / "compose" / workspace_id / "compose.yml"
+    compose_file = (
+        Path(ws.compose_file_path)
+        if ws.compose_file_path
+        else work_dir / "compose" / "compose" / workspace_id / "compose.yml"
+    )
     worktrees_root = work_dir / "git" / "worktrees"
     if not compose_file.exists():
         print(

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -788,6 +788,7 @@ async def _run_task(
             repo = WorkspaceRepository(s)
             persisted = await repo.get(ws_id)
             assert persisted is not None
+            persisted.compose_file_path = str(compose_file)
             await repo.transition(persisted, to=WorkspaceStatus.ready, reason_code="STACK_READY")
             await s.commit()
 
@@ -999,7 +1000,12 @@ async def _run_sync_release_pr(
         companions=tuple(companion_services),
     )
     print(f"[{cfg.task_title[:40]}] compose up ...", flush=True)
-    await compose.up(spec, wait=True)
+    compose_paths = await compose.up(spec, wait=True)
+    compose_file = getattr(
+        compose_paths,
+        "compose_file",
+        work_dir / "compose" / "compose" / ws_id / "compose.yml",
+    )
     print(f"[{cfg.task_title[:40]}] compose up OK", flush=True)
 
     # Step 5: walk the state machine directly to monitoring_pr —
@@ -1008,6 +1014,7 @@ async def _run_sync_release_pr(
         repo = WorkspaceRepository(s)
         persisted = await repo.get(ws_id)
         assert persisted is not None
+        persisted.compose_file_path = str(compose_file)
         for to_state, reason in [
             (WorkspaceStatus.ready, "SYNC_STACK_READY"),
             (WorkspaceStatus.running, "SYNC_SKIP_AGENT"),
@@ -1043,7 +1050,6 @@ async def _run_sync_release_pr(
         f"[{cfg.task_title[:40]}] release-monitor running for PR #{cfg.pr_number} ...",
         flush=True,
     )
-    compose_file = work_dir / "compose" / "compose" / ws_id / "compose.yml"
     await monitor.run(
         workspace_id=ws_id,
         compose_project=f"awf_{ws_id}",
@@ -1229,7 +1235,12 @@ async def _run_sync_feature_pr(
         companions=tuple(companion_services),
     )
     print(f"[{cfg.task_title[:40]}] compose up ...", flush=True)
-    await compose.up(spec, wait=True)
+    compose_paths = await compose.up(spec, wait=True)
+    compose_file = getattr(
+        compose_paths,
+        "compose_file",
+        work_dir / "compose" / "compose" / ws_id / "compose.yml",
+    )
     print(f"[{cfg.task_title[:40]}] compose up OK", flush=True)
 
     # Step 5: walk the state machine directly to monitoring_pr — the
@@ -1238,6 +1249,7 @@ async def _run_sync_feature_pr(
         repo = WorkspaceRepository(s)
         persisted = await repo.get(ws_id)
         assert persisted is not None
+        persisted.compose_file_path = str(compose_file)
         for to_state, reason in [
             (WorkspaceStatus.ready, "SYNC_STACK_READY"),
             (WorkspaceStatus.running, "SYNC_SKIP_AGENT"),
@@ -1275,7 +1287,6 @@ async def _run_sync_feature_pr(
         f"#{cfg.pr_number} (auto_merge={cfg.auto_merge}) ...",
         flush=True,
     )
-    compose_file = work_dir / "compose" / "compose" / ws_id / "compose.yml"
     await monitor.run(
         workspace_id=ws_id,
         compose_project=f"awf_{ws_id}",

--- a/src/awf/api/routes/controls.py
+++ b/src/awf/api/routes/controls.py
@@ -165,6 +165,10 @@ async def destroy_workspace(
     failures = await cleaner.cleanup(
         workspace_id=workspace_id,
         repo_url=workspace.repo_url,
+        compose_project_name=workspace.compose_project_name,
+        compose_file_path=(
+            Path(workspace.compose_file_path) if workspace.compose_file_path else None
+        ),
         worktree_host_path=None,
     )
     if failures:

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -121,6 +121,7 @@ class WorkspaceResponse(BaseModel):
 
     node_id: str | None
     compose_project_name: str | None
+    compose_file_path: str | None
 
     pr_url: str | None
     failure_reason: str | None

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -134,7 +134,11 @@ class WorkspaceExecutor:
         if ws is None:
             return
 
-        compose_file = self._config.compose_projects_root / workspace_id / "compose.yml"
+        compose_file = (
+            Path(ws.compose_file_path)
+            if ws.compose_file_path
+            else self._config.compose_projects_root / workspace_id / "compose.yml"
+        )
         compose_project = ws.compose_project_name or f"awf_{workspace_id}"
         worktree_path = self._config.worktrees_root / workspace_id
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -91,6 +91,7 @@ class Workspace(Base):
     # Runtime placement + compose project
     node_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     compose_project_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    compose_file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
 
     # Terminal-state metadata
     pr_url: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/src/awf/node/cleanup.py
+++ b/src/awf/node/cleanup.py
@@ -29,6 +29,8 @@ class WorkspaceCleaner:
         *,
         workspace_id: str,
         repo_url: str,
+        compose_project_name: str | None = None,
+        compose_file_path: Path | None = None,
         worktree_host_path: Path | None = None,
     ) -> list[str]:
         """Best-effort cleanup. Returns list of failure-step names, empty on full success.
@@ -45,7 +47,15 @@ class WorkspaceCleaner:
             worktree_host_path=worktree_host_path or Path("/dev/null"),
         )
         try:
-            await self._compose.down(spec, remove_volumes=True)
+            if compose_file_path is not None:
+                await self._compose.down_project(
+                    project_name=compose_project_name or spec.project_name(),
+                    compose_file=compose_file_path,
+                    workspace_id=workspace_id,
+                    remove_volumes=True,
+                )
+            else:
+                await self._compose.down(spec, remove_volumes=True)
         except ComposeOperationError as exc:
             _log.warning(
                 "cleanup.compose_down_failed",

--- a/src/awf/node/compose_manager.py
+++ b/src/awf/node/compose_manager.py
@@ -270,15 +270,31 @@ class ComposeManager:
     async def down(self, spec: WorkspaceComposeSpec, *, remove_volumes: bool = True) -> None:
         """Stop + remove the stack. Idempotent — absent projects are not errors."""
         paths = self._paths_for(spec)
-        if not paths.compose_file.exists():
+        await self.down_project(
+            project_name=spec.project_name(),
+            compose_file=paths.compose_file,
+            workspace_id=spec.workspace_id,
+            remove_volumes=remove_volumes,
+        )
+
+    async def down_project(
+        self,
+        *,
+        project_name: str,
+        compose_file: Path,
+        workspace_id: str,
+        remove_volumes: bool = True,
+    ) -> None:
+        """Stop + remove a stack using an already-rendered compose file path."""
+        if not compose_file.exists():
             # Nothing rendered; assume never launched.
-            _log.info("compose.down.noop", workspace_id=spec.workspace_id)
+            _log.info("compose.down.noop", workspace_id=workspace_id)
             return
 
         args = ["down"]
         if remove_volumes:
             args.append("-v")
-        await self._compose(spec.project_name(), paths.compose_file, args, operation="down")
+        await self._compose(project_name, compose_file, args, operation="down")
 
     # ── Internals ──────────────────────────────────────────────────────────
 

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -24,7 +24,7 @@ from awf.common.logging import get_logger
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
-from awf.node.compose_manager import ComposeOperationError
+from awf.node.compose_manager import ComposeOperationError, ComposeProjectPaths
 from awf.node.git_manager import GitManager, GitOperationError
 from awf.node.stack_launcher import WorkspaceStackLauncher, WorkspaceStackLaunchRequest
 from awf.profiles.models import WorkspaceProfile
@@ -97,8 +97,9 @@ class Provisioner:
                 profile = profile_resolution.profile
             else:
                 profile = WorkspaceProfile.model_validate(ws.resolved_profile)
+            stack_paths: ComposeProjectPaths | None = None
             if self._stack_launcher is not None:
-                await self._stack_launcher.launch(
+                stack_paths = await self._stack_launcher.launch(
                     WorkspaceStackLaunchRequest(
                         workspace_id=workspace_id,
                         layout=layout,
@@ -158,6 +159,8 @@ class Provisioner:
             persisted.branch_name = layout.branch_name
             persisted.base_commit = base_commit
             persisted.compose_project_name = f"awf_{workspace_id}"
+            if stack_paths is not None:
+                persisted.compose_file_path = str(stack_paths.compose_file)
             if profile_resolution is not None:
                 persisted.resolved_profile = profile_resolution.profile.model_dump(
                     mode="json", by_alias=True

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -1,12 +1,13 @@
 """Workspace provisioner.
 
-Bridges the control-plane state machine to the node-local git manager.
+Bridges the control-plane state machine to node-local git and stack launchers.
 Given a workspace row in ``requested``, this module:
 
     1. Transitions it to ``provisioning`` and commits.
     2. Creates/updates the repo mirror, then adds a worktree at a fresh branch.
-    3. Records the assigned node, compose project name, branch, and base commit.
-    4. Transitions to ``ready`` and commits.
+    3. Resolves the workspace profile and starts the outer workspace stack.
+    4. Records the assigned node, compose project name, branch, and base commit.
+    5. Transitions to ``ready`` and commits.
 
 On any failure, the workspace is transitioned to ``failed`` with the most
 specific ``FailureReason`` we can derive, and the raised exception is
@@ -23,7 +24,10 @@ from awf.common.logging import get_logger
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
+from awf.node.compose_manager import ComposeOperationError
 from awf.node.git_manager import GitManager, GitOperationError
+from awf.node.stack_launcher import WorkspaceStackLauncher, WorkspaceStackLaunchRequest
+from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import ProfileResolutionError, resolve_workspace_profile
 
 _log = get_logger(__name__)
@@ -53,10 +57,12 @@ class Provisioner:
         session_factory: async_sessionmaker[AsyncSession],
         git: GitManager,
         config: ProvisionerConfig,
+        stack_launcher: WorkspaceStackLauncher | None = None,
     ) -> None:
         self._session_factory = session_factory
         self._git = git
         self._config = config
+        self._stack_launcher = stack_launcher
 
     async def provision(self, workspace_id: str) -> None:
         """Drive a workspace from ``requested`` to ``ready`` (or ``failed``).
@@ -88,6 +94,17 @@ class Provisioner:
                     profile_ref=ws.profile_ref or ws.env_profile or "auto",
                     validation_commands=list(ws.test_commands),
                 )
+                profile = profile_resolution.profile
+            else:
+                profile = WorkspaceProfile.model_validate(ws.resolved_profile)
+            if self._stack_launcher is not None:
+                await self._stack_launcher.launch(
+                    WorkspaceStackLaunchRequest(
+                        workspace_id=workspace_id,
+                        layout=layout,
+                        profile=profile,
+                    )
+                )
         except GitOperationError as exc:
             _log.error(
                 "provisioner.git_failed",
@@ -111,6 +128,20 @@ class Provisioner:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 failure_reason=FailureReason.profile_resolution_failure,
+                message=str(exc)[:2000],
+                from_status=WorkspaceStatus.provisioning,
+            )
+            raise
+        except ComposeOperationError as exc:
+            _log.error(
+                "provisioner.stack_startup_failed",
+                workspace_id=workspace_id,
+                reason_code=exc.reason_code,
+                stderr=exc.stderr[:2000],
+            )
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                failure_reason=FailureReason.service_startup_failure,
                 message=str(exc)[:2000],
                 from_status=WorkspaceStatus.provisioning,
             )

--- a/src/awf/node/stack_launcher.py
+++ b/src/awf/node/stack_launcher.py
@@ -1,0 +1,58 @@
+"""Launch per-workspace service stacks from resolved workspace profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from awf.node.compose_manager import (
+    AuthMount,
+    ComposeManager,
+    ComposeProjectPaths,
+    WorkspaceComposeSpec,
+)
+from awf.node.git_manager import WorktreeLayout
+from awf.profiles.compose import profile_agent_environment, profile_services
+from awf.profiles.models import WorkspaceProfile
+
+
+@dataclass(frozen=True)
+class WorkspaceStackLaunchRequest:
+    """Inputs required to launch a workspace's outer Compose stack."""
+
+    workspace_id: str
+    layout: WorktreeLayout
+    profile: WorkspaceProfile
+
+
+class WorkspaceStackLauncher(Protocol):
+    """Small seam for provisioning tests to avoid requiring Docker."""
+
+    async def launch(self, request: WorkspaceStackLaunchRequest) -> ComposeProjectPaths: ...
+
+
+class ComposeStackLauncher:
+    """Render and start the profile-driven outer workspace Compose stack."""
+
+    def __init__(self, *, compose: ComposeManager, agent_runtime_image: str) -> None:
+        self._compose = compose
+        self._agent_runtime_image = agent_runtime_image
+
+    async def launch(self, request: WorkspaceStackLaunchRequest) -> ComposeProjectPaths:
+        layout = request.layout
+        profile = request.profile
+        mirror_mount = AuthMount(
+            source=str(layout.mirror_path),
+            target=str(layout.mirror_path),
+            mode="rw",
+        )
+        spec = WorkspaceComposeSpec(
+            workspace_id=request.workspace_id,
+            worktree_host_path=layout.worktree_path,
+            agent_runtime_image=self._agent_runtime_image,
+            agent_environment=profile_agent_environment(profile),
+            docker_mode=profile.docker.mode.value,
+            services=profile_services(profile),
+            auth_mounts=(mirror_mount,),
+        )
+        return await self._compose.up(spec, wait=True)

--- a/src/awf/node/stack_launcher.py
+++ b/src/awf/node/stack_launcher.py
@@ -44,7 +44,6 @@ class ComposeStackLauncher:
         mirror_mount = AuthMount(
             source=str(layout.mirror_path),
             target=str(layout.mirror_path),
-            mode="rw",
         )
         spec = WorkspaceComposeSpec(
             workspace_id=request.workspace_id,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -10,8 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.control.worker import ControlWorker, WorkerConfig
 from awf.db.session import make_engine, make_session_factory
+from awf.node.compose_manager import ComposeManager
 from awf.node.git_manager import GitManager
 from awf.node.provisioner import Provisioner, ProvisionerConfig
+from awf.node.stack_launcher import ComposeStackLauncher
 from awf.service.config import ServiceSettings
 
 
@@ -27,10 +29,17 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     engine = make_engine(settings.database_url)
     session_factory = make_session_factory(engine)
     work_dir = Path(settings.work_dir).expanduser().resolve()
-    git = GitManager(work_dir)
+    template = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
+    git = GitManager(work_dir / "git")
+    compose = ComposeManager(work_dir=work_dir / "compose", template_path=template)
+    stack_launcher = ComposeStackLauncher(
+        compose=compose,
+        agent_runtime_image=settings.agent_runtime_image,
+    )
     provisioner = Provisioner(
         session_factory=session_factory,
         git=git,
+        stack_launcher=stack_launcher,
         config=ProvisionerConfig(
             node_id=settings.node_id or socket.gethostname(),
             branch_prefix=settings.branch_prefix,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -31,7 +31,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     work_dir = Path(settings.work_dir).expanduser().resolve()
     template = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
     git = GitManager(work_dir / "git")
-    compose = ComposeManager(work_dir=work_dir / "compose", template_path=template)
+    compose = ComposeManager(work_dir=work_dir, template_path=template)
     stack_launcher = ComposeStackLauncher(
         compose=compose,
         agent_runtime_image=settings.agent_runtime_image,

--- a/tests/unit/api/test_observability_api.py
+++ b/tests/unit/api/test_observability_api.py
@@ -436,12 +436,16 @@ class TestOperationsAndControls:
                 *,
                 workspace_id: str,
                 repo_url: str,
+                compose_project_name: str | None = None,
+                compose_file_path: Path | None = None,
                 worktree_host_path: Path | None = None,
             ) -> list[str]:
                 calls.append(
                     {
                         "workspace_id": workspace_id,
                         "repo_url": repo_url,
+                        "compose_project_name": compose_project_name,
+                        "compose_file_path": compose_file_path,
                         "worktree_host_path": worktree_host_path,
                     }
                 )
@@ -462,6 +466,8 @@ class TestOperationsAndControls:
             {
                 "workspace_id": workspace_id,
                 "repo_url": _BODY["repo_url"],
+                "compose_project_name": None,
+                "compose_file_path": None,
                 "worktree_host_path": None,
             }
         ]

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -317,10 +317,28 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
         def __init__(self, work_dir: Path) -> None:
             created["git_work_dir"] = work_dir
 
+    class _ComposeManager:
+        def __init__(self, *, work_dir: Path, template_path: Path) -> None:
+            created["compose_work_dir"] = work_dir
+            created["compose_template_path"] = template_path
+
+    class _ComposeStackLauncher:
+        def __init__(self, *, compose: object, agent_runtime_image: str) -> None:
+            created["stack_compose"] = compose
+            created["stack_agent_runtime_image"] = agent_runtime_image
+
     class _Provisioner:
-        def __init__(self, *, session_factory: object, git: object, config: object) -> None:
+        def __init__(
+            self,
+            *,
+            session_factory: object,
+            git: object,
+            stack_launcher: object,
+            config: object,
+        ) -> None:
             created["provisioner_session_factory"] = session_factory
             created["provisioner_git"] = git
+            created["provisioner_stack_launcher"] = stack_launcher
             created["provisioner_config"] = config
 
     class _ControlWorker:
@@ -351,17 +369,20 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
         _make_session_factory,
     )
     monkeypatch.setattr(worker_mod, "GitManager", _GitManager)
+    monkeypatch.setattr(worker_mod, "ComposeManager", _ComposeManager, raising=False)
+    monkeypatch.setattr(worker_mod, "ComposeStackLauncher", _ComposeStackLauncher, raising=False)
     monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)
     monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
 
+    host_work_dir = (tmp_path / "awf-work").resolve()
     settings = ServiceSettings(
         service_name="awf",
         env="local",
         api_base_url="http://localhost:8000",
         database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
         docker_host="unix:///var/run/docker.sock",
-        agent_runtime_image="awf-agent-runtime:latest",
-        work_dir=str(tmp_path / "awf-work"),
+        agent_runtime_image="custom-agent-runtime:dev",
+        work_dir=str(host_work_dir),
         api_token=None,
         github_token=None,
         worker_poll_interval_seconds=0.25,
@@ -373,9 +394,14 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
 
     assert created["db_url"] == settings.database_url
     assert created["session_engine"] is engine
-    assert created["git_work_dir"] == (tmp_path / "awf-work").resolve()
+    assert created["git_work_dir"] == host_work_dir / "git"
+    assert created["compose_work_dir"] == host_work_dir / "compose"
+    assert created["compose_template_path"].name == "workspace.base.yml.j2"
+    assert created["stack_compose"].__class__ is _ComposeManager
+    assert created["stack_agent_runtime_image"] == "custom-agent-runtime:dev"
     assert created["provisioner_session_factory"] is session_factory
     assert created["worker_session_factory"] is session_factory
+    assert created["provisioner_stack_launcher"].__class__ is _ComposeStackLauncher
     assert created["provisioner_config"].node_id == "node-1"
     assert created["worker_config"].poll_interval_seconds == 0.25
     assert created["worker_config"].max_concurrent_provisions == 2

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -395,7 +395,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     assert created["db_url"] == settings.database_url
     assert created["session_engine"] is engine
     assert created["git_work_dir"] == host_work_dir / "git"
-    assert created["compose_work_dir"] == host_work_dir / "compose"
+    assert created["compose_work_dir"] == host_work_dir
     assert created["compose_template_path"].name == "workspace.base.yml.j2"
     assert created["stack_compose"].__class__ is _ComposeManager
     assert created["stack_agent_runtime_image"] == "custom-agent-runtime:dev"

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -96,6 +96,7 @@ async def _seed_ready_workspace(
     agent: str = "codex",
     test_commands: list[str] | None = None,
     requires_database: bool = False,
+    compose_file_path: str | None = None,
 ) -> str:
     """Insert a workspace already in the ``ready`` state for the executor to pick up."""
     async with factory() as s:
@@ -114,6 +115,7 @@ async def _seed_ready_workspace(
         ws.branch_name = f"awf/{ws.id}"
         ws.base_commit = "a" * 40
         ws.compose_project_name = f"awf_{ws.id}"
+        ws.compose_file_path = compose_file_path
         await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="X")
         await s.commit()
         return ws.id
@@ -500,7 +502,11 @@ class TestMonitorHandoff:
             pr_monitor=monitor,
         )
 
-        ws_id = await _seed_ready_workspace(factory)
+        stored_compose_file = tmp_path / "rendered-compose" / "ws" / "compose.yml"
+        ws_id = await _seed_ready_workspace(
+            factory,
+            compose_file_path=str(stored_compose_file),
+        )
         # 9-step sequence (same as happy path).
         fake.queue_result(returncode=0)  # adapter
         fake.queue_result(returncode=0)  # git add
@@ -531,6 +537,7 @@ class TestMonitorHandoff:
         # Monitor received the hand-off call with the right IDs.
         assert len(monitor.calls) == 1
         assert monitor.calls[0]["workspace_id"] == ws_id
+        assert monitor.calls[0]["compose_file"] == stored_compose_file
 
 
 class TestPrNumberExtraction:

--- a/tests/unit/node/test_cleanup.py
+++ b/tests/unit/node/test_cleanup.py
@@ -39,6 +39,30 @@ class TestCleanup:
         )
 
     @pytest.mark.unit
+    async def test_uses_stored_compose_file_path_for_compose_down(
+        self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
+    ) -> None:
+        git, compose, wc = cleaner
+        compose_file = Path("/var/lib/awf/compose/ws_stored/compose.yml")
+
+        failures = await wc.cleanup(
+            workspace_id="ws_stored",
+            repo_url="git@x:y.git",
+            compose_project_name="awf_ws_stored",
+            compose_file_path=compose_file,
+        )
+
+        assert failures == []
+        compose.down_project.assert_awaited_once_with(
+            project_name="awf_ws_stored",
+            compose_file=compose_file,
+            workspace_id="ws_stored",
+            remove_volumes=True,
+        )
+        compose.down.assert_not_awaited()
+        git.remove_worktree.assert_awaited_once()
+
+    @pytest.mark.unit
     async def test_compose_failure_does_not_block_worktree_removal(
         self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
     ) -> None:

--- a/tests/unit/node/test_compose_manager_subprocess.py
+++ b/tests/unit/node/test_compose_manager_subprocess.py
@@ -139,6 +139,29 @@ class TestDown:
         assert "down" in cmd and "-v" in cmd
 
     @pytest.mark.unit
+    async def test_down_project_uses_supplied_compose_file_path(
+        self, manager: ComposeManager, tmp_path: Path
+    ) -> None:
+        compose_file = tmp_path / "custom-compose.yml"
+        compose_file.write_text("services: {}\n", encoding="utf-8")
+
+        with patch(
+            "awf.node.compose_manager.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(),
+        ) as mock_exec:
+            await manager.down_project(
+                project_name="awf_ws_custom",
+                compose_file=compose_file,
+                workspace_id="ws_custom",
+                remove_volumes=True,
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert "--project-name" in cmd and "awf_ws_custom" in cmd
+        assert "--file" in cmd and str(compose_file) in cmd
+        assert "down" in cmd and "-v" in cmd
+
+    @pytest.mark.unit
     async def test_down_without_volumes_omits_v(
         self, manager: ComposeManager, tmp_path: Path
     ) -> None:

--- a/tests/unit/node/test_provisioner.py
+++ b/tests/unit/node/test_provisioner.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -17,6 +18,7 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
+from awf.node.compose_manager import ComposeOperationError
 from awf.node.git_manager import GitManager, GitOperationError
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 
@@ -69,6 +71,61 @@ def provisioner(
 
 
 class TestSuccess:
+    @pytest.mark.unit
+    async def test_transitions_to_ready_only_after_stack_launch_succeeds(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        git_manager: GitManager,
+        origin_repo: Path,
+    ) -> None:
+        class _RecordingStackLauncher:
+            def __init__(self) -> None:
+                self.requests: list[Any] = []
+                self.statuses_seen: list[str] = []
+
+            async def launch(self, request: Any) -> object:
+                self.requests.append(request)
+                async with session_factory() as s:
+                    persisted = await WorkspaceRepository(s).get(request.workspace_id)
+                    assert persisted is not None
+                    self.statuses_seen.append(persisted.status)
+                return object()
+
+        launcher = _RecordingStackLauncher()
+        provisioner = Provisioner(
+            session_factory=session_factory,
+            git=git_manager,
+            stack_launcher=launcher,
+            config=ProvisionerConfig(node_id="test-node-01"),
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).create(
+                repo_url=str(origin_repo),
+                branch_base="development",
+                task_title="t",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+            )
+            await s.commit()
+            ws_id = ws.id
+
+        await provisioner.provision(ws_id)
+
+        assert len(launcher.requests) == 1
+        request = launcher.requests[0]
+        assert request.workspace_id == ws_id
+        assert request.layout.worktree_path == git_manager.work_dir / "worktrees" / ws_id
+        assert request.layout.branch_name == f"awf/{ws_id}"
+        assert request.profile.name == "generic"
+        assert launcher.statuses_seen == [WorkspaceStatus.provisioning.value]
+
+        async with session_factory() as s:
+            reloaded = await WorkspaceRepository(s).get(ws_id)
+            assert reloaded is not None
+            assert reloaded.status == WorkspaceStatus.ready.value
+            assert reloaded.compose_project_name == f"awf_{ws_id}"
+
     @pytest.mark.unit
     async def test_transitions_requested_to_ready(
         self,
@@ -131,6 +188,52 @@ class TestSuccess:
 
 
 class TestFailureHandling:
+    @pytest.mark.unit
+    async def test_stack_startup_failure_marks_workspace_failed_with_actionable_message(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        git_manager: GitManager,
+        origin_repo: Path,
+    ) -> None:
+        class _FailingStackLauncher:
+            async def launch(self, request: Any) -> object:
+                raise ComposeOperationError(
+                    operation="up",
+                    returncode=17,
+                    stdout="",
+                    stderr="pull access denied for awf-agent-runtime:test",
+                )
+
+        provisioner = Provisioner(
+            session_factory=session_factory,
+            git=git_manager,
+            stack_launcher=_FailingStackLauncher(),
+            config=ProvisionerConfig(node_id="test-node-01"),
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).create(
+                repo_url=str(origin_repo),
+                branch_base="development",
+                task_title="t",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+            )
+            await s.commit()
+            ws_id = ws.id
+
+        with pytest.raises(ComposeOperationError):
+            await provisioner.provision(ws_id)
+
+        async with session_factory() as s:
+            reloaded = await WorkspaceRepository(s).get(ws_id)
+            assert reloaded is not None
+            assert reloaded.status == WorkspaceStatus.failed.value
+            assert reloaded.failure_reason == "service_startup_failure"
+            assert reloaded.failure_message is not None
+            assert "docker compose up failed" in reloaded.failure_message
+            assert "pull access denied for awf-agent-runtime:test" in reloaded.failure_message
+
     @pytest.mark.unit
     async def test_missing_base_branch_marks_workspace_failed(
         self,

--- a/tests/unit/node/test_provisioner.py
+++ b/tests/unit/node/test_provisioner.py
@@ -18,7 +18,7 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-from awf.node.compose_manager import ComposeOperationError
+from awf.node.compose_manager import ComposeOperationError, ComposeProjectPaths
 from awf.node.git_manager import GitManager, GitOperationError
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 
@@ -89,7 +89,10 @@ class TestSuccess:
                     persisted = await WorkspaceRepository(s).get(request.workspace_id)
                     assert persisted is not None
                     self.statuses_seen.append(persisted.status)
-                return object()
+                return ComposeProjectPaths(
+                    project_dir=Path("/tmp/awf-compose/ws_launcher"),
+                    compose_file=Path("/tmp/awf-compose/ws_launcher/compose.yml"),
+                )
 
         launcher = _RecordingStackLauncher()
         provisioner = Provisioner(
@@ -125,6 +128,7 @@ class TestSuccess:
             assert reloaded is not None
             assert reloaded.status == WorkspaceStatus.ready.value
             assert reloaded.compose_project_name == f"awf_{ws_id}"
+            assert reloaded.compose_file_path == "/tmp/awf-compose/ws_launcher/compose.yml"
 
     @pytest.mark.unit
     async def test_transitions_requested_to_ready(

--- a/tests/unit/node/test_stack_launcher.py
+++ b/tests/unit/node/test_stack_launcher.py
@@ -77,4 +77,4 @@ async def test_compose_stack_launcher_builds_profile_driven_spec() -> None:
     assert [service.name for service in spec.services] == ["postgres"]
     assert spec.auth_mounts[0].source == str(layout.mirror_path)
     assert spec.auth_mounts[0].target == str(layout.mirror_path)
-    assert spec.auth_mounts[0].mode == "rw"
+    assert spec.auth_mounts[0].mode == "ro"

--- a/tests/unit/node/test_stack_launcher.py
+++ b/tests/unit/node/test_stack_launcher.py
@@ -1,0 +1,80 @@
+"""Stack launcher tests that avoid a Docker daemon."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.node.compose_manager import ComposeProjectPaths, WorkspaceComposeSpec
+from awf.node.git_manager import WorktreeLayout
+from awf.node.stack_launcher import ComposeStackLauncher, WorkspaceStackLaunchRequest
+from awf.profiles.models import (
+    DockerMode,
+    ProfileDocker,
+    ProfileRuntime,
+    ProfileService,
+    WorkspaceProfile,
+)
+
+
+class _RecordingCompose:
+    def __init__(self) -> None:
+        self.specs: list[WorkspaceComposeSpec] = []
+        self.waits: list[bool] = []
+
+    async def up(self, spec: WorkspaceComposeSpec, *, wait: bool = True) -> ComposeProjectPaths:
+        self.specs.append(spec)
+        self.waits.append(wait)
+        return ComposeProjectPaths(
+            project_dir=Path("/tmp/awf-compose/ws_launcher"),
+            compose_file=Path("/tmp/awf-compose/ws_launcher/compose.yml"),
+        )
+
+
+@pytest.mark.unit
+async def test_compose_stack_launcher_builds_profile_driven_spec() -> None:
+    compose = _RecordingCompose()
+    launcher = ComposeStackLauncher(
+        compose=compose,  # type: ignore[arg-type]
+        agent_runtime_image="custom-agent-runtime:dev",
+    )
+    layout = WorktreeLayout(
+        mirror_path=Path("/host/awf/git/mirrors/repo.git"),
+        worktree_path=Path("/host/awf/git/worktrees/ws_launcher"),
+        branch_name="awf/ws_launcher",
+    )
+    profile = WorkspaceProfile(
+        name="serviceful",
+        runtime=ProfileRuntime(environment={"DATABASE_URL": "postgresql://awf@postgres/awf"}),
+        docker=ProfileDocker(mode=DockerMode.dind),
+        services=[
+            ProfileService(
+                name="postgres",
+                image="postgres:16-alpine",
+                healthcheck_cmd="pg_isready -U awf",
+            )
+        ],
+    )
+
+    paths = await launcher.launch(
+        WorkspaceStackLaunchRequest(
+            workspace_id="ws_launcher",
+            layout=layout,
+            profile=profile,
+        )
+    )
+
+    assert paths.compose_file.name == "compose.yml"
+    assert compose.waits == [True]
+    assert len(compose.specs) == 1
+    spec = compose.specs[0]
+    assert spec.workspace_id == "ws_launcher"
+    assert spec.worktree_host_path == layout.worktree_path
+    assert spec.agent_runtime_image == "custom-agent-runtime:dev"
+    assert spec.agent_environment == (("DATABASE_URL", "postgresql://awf@postgres/awf"),)
+    assert spec.docker_mode == "dind"
+    assert [service.name for service in spec.services] == ["postgres"]
+    assert spec.auth_mounts[0].source == str(layout.mirror_path)
+    assert spec.auth_mounts[0].target == str(layout.mirror_path)
+    assert spec.auth_mounts[0].mode == "rw"

--- a/tests/unit/scripts/test_run_awf_handlers.py
+++ b/tests/unit/scripts/test_run_awf_handlers.py
@@ -378,6 +378,9 @@ class TestFeatureBranchPrHandler:
             assert ws.status == WorkspaceStatus.completed.value
             assert ws.base_commit == "a" * 40
             assert ws.compose_project_name == f"awf_{ws_id}"
+            assert ws.compose_file_path == str(
+                tmp_path / "compose" / "compose" / ws_id / "compose.yml"
+            )
 
         # The FakeExecutor was constructed exactly once and drove one
         # workspace to completion.


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_fedc65458e1b4214aabc60af` (agent: `codex`).


### Task
Implement the next focused slice of the always-on AWF service plan: service-mode workers should create a real profile-driven workspace Compose stack before marking a workspace ready. Today the API-backed worker only creates the git worktree and marks ready, so /runtime shows a stopped/missing stack. Goal: for API-created workspaces handled by awf worker, provisioning should render and start the outer workspace stack far enough that /runtime can see the agent service/container. Keep this slice intentionally bounded: do not run the coding agent, validation, push, or PR monitor from the service worker yet. Strict TDD: first add failing tests that prove a requested workspace reaches ready only after the stack launcher/Compose manager succeeds, compose startup failures transition the workspace to failed with an actionable failure reason/message, and service worker wiring uses the host-visible AWF work dir and agent runtime image. Prefer a small abstraction if needed so tests can mock stack startup without requiring Docker. Preserve existing script-runner behavior. Do not switch branches; AWF owns branch lifecycle. Do not push manually; AWF owns push, PR creation, and monitoring. Commit with conventional commits.

---
Validation: 6 profile command(s) passed inside the workspace container.
