### PR TITLE
fix(monitor): preserve initial review grace across remonitor

### DIFF
--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
+import time
+from datetime import UTC, datetime
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -48,6 +50,10 @@ from awf.db.models import WorkspaceEvent  # noqa: E402
 from awf.db.repositories import WorkspaceRepository  # noqa: E402
 from awf.db.session import make_session_factory  # noqa: E402
 from awf.runtime.logs import LogStore  # noqa: E402
+from awf.runtime.pr_monitor_runner import (  # noqa: E402
+    _initial_review_grace_done_key,
+    _initial_review_grace_started_key,
+)
 from awf.runtime.release_pr_monitor import (  # noqa: E402
     build_feature_pr_monitor,
     build_release_pr_monitor,
@@ -109,6 +115,11 @@ async def _main(
         ws.failure_reason = None
         ws.failure_message = None
         ws.monitor_iter_count = 0
+        ws.monitor_threads_addressed = _preserve_initial_review_grace_state(
+            ws.monitor_threads_addressed,
+            pr_number=ws.pr_number,
+            monitor_started_at=ws.monitor_started_at,
+        )
         ws.monitor_started_at = None
         ws.events.append(
             WorkspaceEvent(
@@ -194,6 +205,26 @@ async def _main(
         )
     await engine.dispose()
     return 0 if final.status == WorkspaceStatus.completed.value else 1
+
+
+def _preserve_initial_review_grace_state(
+    monitor_threads_addressed: dict[str, str] | None,
+    *,
+    pr_number: int,
+    monitor_started_at: datetime | None,
+) -> dict[str, str]:
+    threads = dict(monitor_threads_addressed or {})
+    started_key = _initial_review_grace_started_key(pr_number)
+    done_key = _initial_review_grace_done_key(pr_number)
+    if threads.get(done_key) == "elapsed" or started_key in threads or monitor_started_at is None:
+        return threads
+
+    started_dt = monitor_started_at
+    if started_dt.tzinfo is None:
+        started_dt = started_dt.replace(tzinfo=UTC)
+    elapsed_seconds = max((datetime.now(UTC) - started_dt).total_seconds(), 0.0)
+    threads[started_key] = f"{time.monotonic() - elapsed_seconds:.6f}"
+    return threads
 
 
 async def _push_pending_head(

--- a/scripts/remonitor_workspace.py
+++ b/scripts/remonitor_workspace.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import sys
-import time
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -53,6 +52,8 @@ from awf.runtime.logs import LogStore  # noqa: E402
 from awf.runtime.pr_monitor_runner import (  # noqa: E402
     _initial_review_grace_done_key,
     _initial_review_grace_started_key,
+    _initial_review_grace_wall_seconds,
+    _initial_review_grace_wall_started_value_from_datetime,
 )
 from awf.runtime.release_pr_monitor import (  # noqa: E402
     build_feature_pr_monitor,
@@ -216,14 +217,18 @@ def _preserve_initial_review_grace_state(
     threads = dict(monitor_threads_addressed or {})
     started_key = _initial_review_grace_started_key(pr_number)
     done_key = _initial_review_grace_done_key(pr_number)
-    if threads.get(done_key) == "elapsed" or started_key in threads or monitor_started_at is None:
+    if threads.get(done_key) == "elapsed" or monitor_started_at is None:
         return threads
 
     started_dt = monitor_started_at
     if started_dt.tzinfo is None:
         started_dt = started_dt.replace(tzinfo=UTC)
-    elapsed_seconds = max((datetime.now(UTC) - started_dt).total_seconds(), 0.0)
-    threads[started_key] = f"{time.monotonic() - elapsed_seconds:.6f}"
+    if (
+        started_key in threads
+        and _initial_review_grace_wall_seconds(threads[started_key]) is not None
+    ):
+        return threads
+    threads[started_key] = _initial_review_grace_wall_started_value_from_datetime(started_dt)
     return threads
 
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1103,18 +1103,29 @@ class PullRequestMonitorRunner:
         # persists it before actions that can sleep.
         import time as _time  # local to avoid confusion with datetime above
 
+        now_monotonic = _time.monotonic()
+        now_wall = datetime.now(UTC)
         if started_raw is None:
-            started_at = _time.monotonic()
+            started_at = now_monotonic
         else:
             started_dt = started_raw
             if started_dt.tzinfo is None:
                 started_dt = started_dt.replace(tzinfo=UTC)
-            elapsed = (datetime.now(UTC) - started_dt).total_seconds()
-            started_at = _time.monotonic() - max(elapsed, 0.0)
+            elapsed = (now_wall - started_dt).total_seconds()
+            started_at = now_monotonic - max(elapsed, 0.0)
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        if ws.pr_number is not None:
+            threads_addressed = _initial_review_grace_state_for_runtime(
+                threads_addressed,
+                pr_number=ws.pr_number,
+                now_monotonic=now_monotonic,
+                now_wall_seconds=now_wall.timestamp(),
+                legacy_monotonic_fallback=started_at if started_raw is not None else None,
+            )
         return MonitorState(
             iter_count=ws.monitor_iter_count,
             last_push_sha=ws.monitor_last_commit_sha,
-            threads_addressed_ids=dict(ws.monitor_threads_addressed or {}),
+            threads_addressed_ids=threads_addressed,
             started_at=started_at,
         )
 
@@ -1123,13 +1134,23 @@ class PullRequestMonitorRunner:
             ws = await WorkspaceRepository(s).get(workspace_id)
             if ws is None:
                 return
+            now_monotonic = time.monotonic()
+            now_wall = datetime.now(UTC)
+            threads_addressed = dict(state.threads_addressed_ids)
+            if ws.pr_number is not None:
+                threads_addressed = _initial_review_grace_state_for_persistence(
+                    threads_addressed,
+                    pr_number=ws.pr_number,
+                    now_monotonic=now_monotonic,
+                    now_wall_seconds=now_wall.timestamp(),
+                )
             ws.monitor_iter_count = state.iter_count
-            ws.monitor_threads_addressed = dict(state.threads_addressed_ids)
+            ws.monitor_threads_addressed = threads_addressed
             if state.last_push_sha is not None:
                 ws.monitor_last_commit_sha = state.last_push_sha
             if ws.monitor_started_at is None:
-                elapsed_seconds = max(time.monotonic() - state.started_at, 0.0)
-                ws.monitor_started_at = datetime.now(UTC) - timedelta(seconds=elapsed_seconds)
+                elapsed_seconds = max(now_monotonic - state.started_at, 0.0)
+                ws.monitor_started_at = now_wall - timedelta(seconds=elapsed_seconds)
             await s.commit()
 
     async def _terminate_completed(
@@ -1321,6 +1342,81 @@ def _initial_review_grace_started_key(pr_number: int) -> str:
 
 def _initial_review_grace_done_key(pr_number: int) -> str:
     return f"__awf_initial_review_grace_done__:{pr_number}"
+
+
+def _initial_review_grace_wall_started_value(started_wall_seconds: float) -> str:
+    return f"{started_wall_seconds:.6f}"
+
+
+def _initial_review_grace_wall_started_value_from_datetime(started_at: datetime) -> str:
+    started_dt = started_at
+    if started_dt.tzinfo is None:
+        started_dt = started_dt.replace(tzinfo=UTC)
+    return _initial_review_grace_wall_started_value(started_dt.timestamp())
+
+
+def _initial_review_grace_wall_seconds(raw: object) -> float | None:
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return None
+    # Values at or above 2001-09-09T01:46:40Z are epoch seconds. Smaller
+    # values are legacy process-local ``time.monotonic()`` markers.
+    if value >= 1_000_000_000:
+        return value
+    return None
+
+
+def _initial_review_grace_state_for_runtime(
+    threads_addressed: dict[str, str],
+    *,
+    pr_number: int,
+    now_monotonic: float,
+    now_wall_seconds: float,
+    legacy_monotonic_fallback: float | None = None,
+) -> dict[str, str]:
+    started_key = _initial_review_grace_started_key(pr_number)
+    started_raw = threads_addressed.get(started_key)
+    started_wall_seconds = _initial_review_grace_wall_seconds(started_raw)
+    if started_wall_seconds is None:
+        if started_raw is not None and legacy_monotonic_fallback is not None:
+            threads_addressed[started_key] = f"{legacy_monotonic_fallback:.6f}"
+        return threads_addressed
+
+    elapsed_seconds = max(now_wall_seconds - started_wall_seconds, 0.0)
+    threads_addressed[started_key] = f"{now_monotonic - elapsed_seconds:.6f}"
+    return threads_addressed
+
+
+def _initial_review_grace_state_for_persistence(
+    threads_addressed: dict[str, str],
+    *,
+    pr_number: int,
+    now_monotonic: float,
+    now_wall_seconds: float,
+) -> dict[str, str]:
+    started_key = _initial_review_grace_started_key(pr_number)
+    started_raw = threads_addressed.get(started_key)
+    if started_raw is None:
+        return threads_addressed
+
+    started_wall_seconds = _initial_review_grace_wall_seconds(started_raw)
+    if started_wall_seconds is not None:
+        threads_addressed[started_key] = _initial_review_grace_wall_started_value(
+            started_wall_seconds
+        )
+        return threads_addressed
+
+    try:
+        started_monotonic = float(started_raw)
+    except (TypeError, ValueError):
+        return threads_addressed
+
+    elapsed_seconds = max(now_monotonic - started_monotonic, 0.0)
+    threads_addressed[started_key] = _initial_review_grace_wall_started_value(
+        now_wall_seconds - elapsed_seconds
+    )
+    return threads_addressed
 
 
 def _initial_review_grace_wait_seconds(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1346,9 +1346,16 @@ def _initial_review_grace_wait_seconds(
         return 0.0
 
     started_key = _initial_review_grace_started_key(pr_number)
-    started_at = state.started_at
-    if started_key not in state.threads_addressed_ids:
+    started_raw = state.threads_addressed_ids.get(started_key)
+    if started_raw is None:
+        started_at = state.started_at
         state.mark_addressed(started_key, f"{started_at:.6f}")
+    else:
+        try:
+            started_at = float(started_raw)
+        except (TypeError, ValueError):
+            started_at = state.started_at
+            state.mark_addressed(started_key, f"{started_at:.6f}")
 
     remaining_seconds = grace_seconds - max(now - started_at, 0.0)
     if remaining_seconds <= 0:

--- a/tests/integration/runtime/test_pr_monitor_runner.py
+++ b/tests/integration/runtime/test_pr_monitor_runner.py
@@ -9,6 +9,7 @@ adapter so no subprocesses spawn. Tests drive full loops end-to-end.
 from __future__ import annotations
 
 import json
+import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,10 +24,11 @@ from awf.db.base import Base
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-from awf.runtime.pr_monitor import MonitorConfig
+from awf.runtime.pr_monitor import MonitorConfig, MonitorState
 from awf.runtime.pr_monitor_runner import (
     MonitorRunnerConfig,
     PullRequestMonitorRunner,
+    _initial_review_grace_started_key,
     _parse_verdict,
 )
 
@@ -1818,6 +1820,114 @@ class TestMonitorDbHelpers:
             # If tzinfo wasn't applied, we'd have gotten a naive/aware
             # subtract TypeError — reaching here proves the branch ran.
             assert state.iter_count == 0
+
+    @pytest.mark.unit
+    async def test_load_state_converts_wall_clock_grace_marker_to_monotonic(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+        from datetime import timedelta
+
+        ws_id = await _seed_monitoring_workspace(factory)
+        started_wall = _dt.now(_UTC) - timedelta(minutes=10)
+        started_key = _initial_review_grace_started_key(42)
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_threads_addressed = {started_key: f"{started_wall.timestamp():.6f}"}
+            await s.commit()
+
+        runner = _make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            state = runner._load_state(ws)
+
+        started_monotonic = float(state.threads_addressed_ids[started_key])
+        assert time.monotonic() - started_monotonic == pytest.approx(600, abs=2)
+
+    @pytest.mark.unit
+    async def test_load_state_rebases_legacy_grace_marker_from_monitor_started_at(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+        from datetime import timedelta
+
+        ws_id = await _seed_monitoring_workspace(factory)
+        started_wall = _dt.now(_UTC) - timedelta(minutes=10)
+        started_key = _initial_review_grace_started_key(42)
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_started_at = started_wall
+            ws.monitor_threads_addressed = {started_key: "1000.000000"}
+            await s.commit()
+
+        runner = _make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            state = runner._load_state(ws)
+
+        started_monotonic = float(state.threads_addressed_ids[started_key])
+        assert time.monotonic() - started_monotonic == pytest.approx(600, abs=2)
+
+    @pytest.mark.unit
+    async def test_persist_state_writes_wall_clock_grace_marker(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_monitoring_workspace(factory)
+        started_key = _initial_review_grace_started_key(42)
+        started_monotonic = time.monotonic() - 300
+        state = MonitorState(
+            threads_addressed_ids={started_key: f"{started_monotonic:.6f}"},
+            started_at=time.monotonic(),
+        )
+        runner = _make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+        )
+
+        await runner._persist_state(ws_id, state)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            started_wall = float(ws.monitor_threads_addressed[started_key])
+        assert started_wall > 1_000_000_000
+        assert time.time() - started_wall == pytest.approx(300, abs=2)
 
 
 class TestCompleteWorkspaceTearsDownComposeStack:

--- a/tests/unit/runtime/test_pr_monitor_initial_review_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_initial_review_grace.py
@@ -83,6 +83,40 @@ def test_initial_grace_uses_remaining_time_not_a_fresh_window() -> None:
 
 
 @pytest.mark.unit
+def test_existing_pr_scoped_started_key_survives_remonitor_reset() -> None:
+    state = MonitorState(started_at=1_500)
+    state.mark_addressed(_initial_review_grace_started_key(42), "1000.000000")
+
+    wait = _initial_review_grace_wait_seconds(
+        state,
+        pr_number=42,
+        now=1_500,
+        grace_seconds=900,
+        poll_interval_seconds=600,
+    )
+
+    assert wait == 400
+    assert state.threads_addressed_ids[_initial_review_grace_started_key(42)] == "1000.000000"
+
+
+@pytest.mark.unit
+def test_existing_pr_scoped_done_key_survives_remonitor_reset() -> None:
+    state = MonitorState(started_at=1_500)
+    state.mark_addressed(_initial_review_grace_done_key(42), "elapsed")
+
+    wait = _initial_review_grace_wait_seconds(
+        state,
+        pr_number=42,
+        now=1_500,
+        grace_seconds=900,
+        poll_interval_seconds=60,
+    )
+
+    assert wait == 0
+    assert _initial_review_grace_started_key(42) not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
 def test_grace_does_not_restart_after_it_elapsed_once() -> None:
     state = MonitorState(started_at=1_000)
     first = _initial_review_grace_wait_seconds(

--- a/tests/unit/scripts/test_remonitor_workspace.py
+++ b/tests/unit/scripts/test_remonitor_workspace.py
@@ -204,10 +204,8 @@ class TestRemonitor:
             # Monitor transitioned it forward; before the monitor ran,
             # iter_count would be 0. We can't prove the reset here, but
             # can prove the threads dict was preserved.
-            assert ws.monitor_threads_addressed == {
-                "T1": "fix_committed",
-                "T2": "false_positive",
-            }
+            assert ws.monitor_threads_addressed["T1"] == "fix_committed"
+            assert ws.monitor_threads_addressed["T2"] == "false_positive"
         await engine.dispose()
 
     @pytest.mark.unit

--- a/tests/unit/scripts/test_remonitor_workspace.py
+++ b/tests/unit/scripts/test_remonitor_workspace.py
@@ -11,6 +11,7 @@ on the observable state transitions + the CLI's exit code."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -22,6 +23,10 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor_runner import (
+    _initial_review_grace_done_key,
+    _initial_review_grace_started_key,
+)
 from scripts import remonitor_workspace
 
 
@@ -32,6 +37,7 @@ async def _seed_workspace(
     pr_number: int | None = 123,
     compose_project_name: str | None = "awf_ws_x",
     monitor_threads_addressed: dict[str, str] | None = None,
+    monitor_started_at: datetime | None = None,
 ) -> str:
     engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
     async with engine.begin() as conn:
@@ -65,6 +71,8 @@ async def _seed_workspace(
         ws.pr_url = "https://github.com/dimileeh/aira-web/pull/123"
         ws.monitor_iter_count = 7
         ws.monitor_threads_addressed = monitor_threads_addressed or {}
+        if monitor_started_at is not None:
+            ws.monitor_started_at = monitor_started_at
         if status != "completed":
             # Flip manually (status transitions in AWF don't cleanly go
             # completed → failed / completed → monitoring_pr).
@@ -82,6 +90,7 @@ class _FakeMonitor:
     def __init__(self, *, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._factory = session_factory
         self.calls: list[dict[str, Any]] = []
+        self.observed_states: list[dict[str, Any]] = []
 
     async def run(self, *, workspace_id: str, compose_project: str, compose_file: Path) -> None:
         self.calls.append(
@@ -95,6 +104,13 @@ class _FakeMonitor:
             repo = WorkspaceRepository(s)
             ws = await repo.get(workspace_id)
             assert ws is not None
+            self.observed_states.append(
+                {
+                    "monitor_iter_count": ws.monitor_iter_count,
+                    "monitor_started_at": ws.monitor_started_at,
+                    "monitor_threads_addressed": dict(ws.monitor_threads_addressed or {}),
+                }
+            )
             await repo.transition(ws, to=WorkspaceStatus.completed, reason_code="FAKE_MON")
             await s.commit()
 
@@ -193,6 +209,52 @@ class TestRemonitor:
                 "T2": "false_positive",
             }
         await engine.dispose()
+
+    @pytest.mark.unit
+    async def test_remonitor_preserves_initial_grace_start_while_resetting_budget(
+        self,
+        tmp_path: Path,
+        patch_monitor_builder: list[_FakeMonitor],
+    ) -> None:
+        original_monitor_start = datetime.now(UTC) - timedelta(minutes=10)
+        ws_id = await _seed_workspace(
+            tmp_path / "awf.db",
+            monitor_started_at=original_monitor_start,
+            monitor_threads_addressed={"T1": "fix_committed"},
+        )
+        (tmp_path / "compose" / "compose" / ws_id).mkdir(parents=True)
+        (tmp_path / "compose" / "compose" / ws_id / "compose.yml").write_text("x")
+
+        rc = await remonitor_workspace._main(tmp_path, ws_id)
+
+        assert rc == 0
+        observed = patch_monitor_builder[0].observed_states[0]
+        assert observed["monitor_iter_count"] == 0
+        assert observed["monitor_started_at"] is None
+        assert observed["monitor_threads_addressed"]["T1"] == "fix_committed"
+        assert _initial_review_grace_started_key(123) in observed["monitor_threads_addressed"]
+
+    @pytest.mark.unit
+    async def test_remonitor_preserves_existing_initial_grace_done_key(
+        self,
+        tmp_path: Path,
+        patch_monitor_builder: list[_FakeMonitor],
+    ) -> None:
+        done_key = _initial_review_grace_done_key(123)
+        ws_id = await _seed_workspace(
+            tmp_path / "awf.db",
+            monitor_started_at=datetime.now(UTC) - timedelta(hours=2),
+            monitor_threads_addressed={done_key: "elapsed"},
+        )
+        (tmp_path / "compose" / "compose" / ws_id).mkdir(parents=True)
+        (tmp_path / "compose" / "compose" / ws_id / "compose.yml").write_text("x")
+
+        rc = await remonitor_workspace._main(tmp_path, ws_id)
+
+        assert rc == 0
+        observed = patch_monitor_builder[0].observed_states[0]
+        assert observed["monitor_started_at"] is None
+        assert observed["monitor_threads_addressed"] == {done_key: "elapsed"}
 
     @pytest.mark.unit
     async def test_missing_db_returns_two(self, tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_remonitor_workspace.py
+++ b/tests/unit/scripts/test_remonitor_workspace.py
@@ -230,7 +230,10 @@ class TestRemonitor:
         assert observed["monitor_iter_count"] == 0
         assert observed["monitor_started_at"] is None
         assert observed["monitor_threads_addressed"]["T1"] == "fix_committed"
-        assert _initial_review_grace_started_key(123) in observed["monitor_threads_addressed"]
+        started_value = float(
+            observed["monitor_threads_addressed"][_initial_review_grace_started_key(123)]
+        )
+        assert started_value == pytest.approx(original_monitor_start.timestamp(), abs=1)
 
     @pytest.mark.unit
     async def test_remonitor_preserves_existing_initial_grace_done_key(
@@ -253,6 +256,29 @@ class TestRemonitor:
         observed = patch_monitor_builder[0].observed_states[0]
         assert observed["monitor_started_at"] is None
         assert observed["monitor_threads_addressed"] == {done_key: "elapsed"}
+
+    @pytest.mark.unit
+    async def test_remonitor_normalizes_existing_legacy_initial_grace_start(
+        self,
+        tmp_path: Path,
+        patch_monitor_builder: list[_FakeMonitor],
+    ) -> None:
+        original_monitor_start = datetime.now(UTC) - timedelta(minutes=10)
+        started_key = _initial_review_grace_started_key(123)
+        ws_id = await _seed_workspace(
+            tmp_path / "awf.db",
+            monitor_started_at=original_monitor_start,
+            monitor_threads_addressed={started_key: "1000.000000"},
+        )
+        (tmp_path / "compose" / "compose" / ws_id).mkdir(parents=True)
+        (tmp_path / "compose" / "compose" / ws_id / "compose.yml").write_text("x")
+
+        rc = await remonitor_workspace._main(tmp_path, ws_id)
+
+        assert rc == 0
+        observed = patch_monitor_builder[0].observed_states[0]
+        started_value = float(observed["monitor_threads_addressed"][started_key])
+        assert started_value == pytest.approx(original_monitor_start.timestamp(), abs=1)
 
     @pytest.mark.unit
     async def test_missing_db_returns_two(self, tmp_path: Path) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ed5496b652ff4d99a84fb4a2` (agent: `codex`).


### Task
Fix the PR monitor bug surfaced during PR #29 dogfood: reattaching/remonitoring an existing PR must not restart the one-time initial review grace window. The grace window starts when the PR first enters monitoring_pr after PR creation; remonitor/recovery should preserve that history. Strict TDD: write failing tests first for _initial_review_grace_wait_seconds using an existing started/done PR-scoped key, and for scripts/remonitor_workspace.py preserving grace state while still resetting the wall-clock monitor budget as intended. Implement the smallest safe fix. Do not manually touch GitHub PRs. Do not switch branches or push; AWF owns branch lifecycle, push, PR creation, comment handling, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
