### PR TITLE
feat(mcp): add v2 submission and observability tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,13 +579,37 @@ shelling out to the REST API:
 | Tool | Purpose |
 | --- | --- |
 | `awf_create_workspace` | Create a legacy v1 workspace request. |
+| `awf_create_workspace_v2` | Create a profile-driven v2 workspace request. |
 | `awf_get_workspace` | Fetch one workspace by id. |
 | `awf_list_workspaces` | List recent workspaces newest-first. |
 | `awf_wait_for_workspace` | Poll until a workspace reaches a terminal state or times out. |
+| `awf_list_workspace_events` | List one workspace's immutable events newest-first, with optional event-type filtering. |
+| `awf_list_workspace_logs` | List indexed durable log streams for one workspace. |
+| `awf_read_workspace_log` | Read a bounded log chunk by stream id and byte offset. |
 
-The MCP surface is intentionally small today. The v2 profile-driven create
-shape is available through REST and the local dogfood runner; promoting it into
-MCP is a straightforward next slice.
+The observability tools return `null` for a missing workspace or log stream
+rather than surfacing raw storage errors. MCP remains read-only beyond create;
+operator controls such as cancel/destroy stay on the authenticated REST API.
+
+Example `awf_create_workspace_v2` arguments:
+
+```json
+{
+  "repo_url": "git@github.com:example/app.git",
+  "base_branch": "main",
+  "task_title": "Implement feature",
+  "task_prompt": "Build the requested feature and commit the result.",
+  "task_kind": "feature_branch_pr",
+  "agent": "codex",
+  "task_external_id": "AIRA-123",
+  "profile_ref": "auto",
+  "profile": null,
+  "validation_commands": ["pytest -q"],
+  "requested_tier": 1,
+  "auto_merge": true,
+  "initial_review_grace_period_seconds": null
+}
+```
 
 ## Local Dogfood Runner
 

--- a/docs/PLAN_MVP.md
+++ b/docs/PLAN_MVP.md
@@ -123,10 +123,16 @@ Same underlying service, exposed as MCP tools so Codex / Claude Code can invoke 
 | Tool | Description |
 |---|---|
 | `awf_create_workspace` | Identical body to `POST /v1/workspaces`. Returns `workspace_id`. |
+| `awf_create_workspace_v2` | Clean v2 submission shape for profile-driven workspaces. |
 | `awf_get_workspace` | Fetch current state by `workspace_id`. |
 | `awf_wait_for_workspace` | Blocking helper: polls until terminal state or `timeout_seconds`. Useful for agents that want synchronous behavior. |
-| `awf_cancel_workspace` | Cancel. |
 | `awf_list_workspaces` | List with filters. |
+| `awf_list_workspace_events` | List one workspace's immutable events newest-first. |
+| `awf_list_workspace_logs` | List indexed durable log streams for one workspace. |
+| `awf_read_workspace_log` | Read a bounded log chunk by stream id and byte offset. |
+
+MCP stays read-only beyond create in the always-on service. Destructive controls
+remain on the authenticated REST/operator surface.
 
 ### Workspace lifecycle (MVP)
 

--- a/src/awf/api/routes/logs.py
+++ b/src/awf/api/routes/logs.py
@@ -15,7 +15,7 @@ from awf.api.schemas import (
     WorkspaceLogStreamResponse,
 )
 from awf.db.repositories import WorkspaceLogStreamRepository, WorkspaceRepository
-from awf.runtime.logs import LogStore
+from awf.runtime.logs import read_log_chunk
 
 router = APIRouter(prefix="/v1/workspaces/{workspace_id}/logs", tags=["logs"])
 
@@ -67,7 +67,7 @@ async def read_workspace_log(
                 "message": f"Log file is missing for stream {stream_id}",
             },
         )
-    data, next_offset, eof = await LogStore(root=path.parent).read(
+    data, next_offset, eof = await read_log_chunk(
         path=path,
         offset=offset,
         limit_bytes=limit_bytes,

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -32,7 +32,8 @@ from awf.api.schemas import (
 from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
-from awf.profiles.resolver import ProfileResolutionError, resolve_workspace_profile
+from awf.profiles.resolver import ProfileResolutionError
+from awf.service.workspaces import create_workspace_v2_row
 
 router = APIRouter(prefix="/v1/workspaces", tags=["workspaces"])
 router_v2 = APIRouter(prefix="/v2/workspaces", tags=["workspaces-v2"])
@@ -112,50 +113,20 @@ async def create_workspace_v2(
                 )
             return _accepted(existing.id, existing.status, existing.version, existing.created_at)
 
-    requested_profile = (
-        payload.workspace.profile.model_dump(mode="json", by_alias=True)
-        if payload.workspace.profile is not None
-        else None
-    )
-    resolved_profile = None
-    if payload.workspace.profile is not None or (
-        payload.workspace.profile_ref and payload.workspace.profile_ref != "auto"
-    ):
-        try:
-            resolved = resolve_workspace_profile(
-                worktree_path=None,
-                inline_profile=payload.workspace.profile,
-                profile_ref=payload.workspace.profile_ref,
-                validation_commands=payload.validation.commands,
-            )
-        except ProfileResolutionError as exc:
-            return JSONResponse(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                content=ErrorResponse(
-                    error_code="INVALID_PROFILE",
-                    message=str(exc),
-                ).model_dump(),
-            )
-        resolved_profile = resolved.profile.model_dump(mode="json", by_alias=True)
-
-    ws = await repo.create(
-        repo_url=payload.repo.url,
-        branch_base=payload.repo.base_branch,
-        task_title=payload.task.title,
-        task_prompt=payload.task.prompt,
-        task_external_id=payload.task.external_id,
-        auto_merge=payload.task.auto_merge,
-        initial_review_grace_period_seconds=payload.task.initial_review_grace_period_seconds,
-        agent=payload.task.agent.value,
-        env_profile=None,
-        profile_ref=payload.workspace.profile_ref,
-        requested_profile=requested_profile,
-        resolved_profile=resolved_profile,
-        test_commands=payload.validation.commands,
-        requires_database=False,
-        idempotency_key=idempotency_key,
-    )
-    ws.task_kind = payload.task.kind
+    try:
+        ws = await create_workspace_v2_row(
+            session,
+            payload,
+            idempotency_key=idempotency_key,
+        )
+    except ProfileResolutionError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            content=ErrorResponse(
+                error_code="INVALID_PROFILE",
+                message=str(exc),
+            ).model_dump(),
+        )
 
     return _accepted(ws.id, ws.status, ws.version, ws.created_at)
 
@@ -323,5 +294,20 @@ def _payloads_match_v2(existing: Workspace, payload: WorkspaceCreateV2Request) -
         and existing.task_kind == payload.task.kind
         and existing.profile_ref == payload.workspace.profile_ref
         and existing.requested_profile == requested_profile
+        and (
+            existing.resolved_profile is None
+            or _resolved_profile_requested_tier(existing) == payload.validation.requested_tier
+        )
         and list(existing.test_commands) == list(payload.validation.commands)
     )
+
+
+def _resolved_profile_requested_tier(existing: Workspace) -> int | None:
+    profile = existing.resolved_profile
+    if profile is None:
+        return None
+    validation = profile.get("validation")
+    if not isinstance(validation, dict):
+        return None
+    tier = validation.get("requested_tier")
+    return tier if isinstance(tier, int) else None

--- a/src/awf/api/routes/ws.py
+++ b/src/awf/api/routes/ws.py
@@ -18,7 +18,7 @@ from awf.db.repositories import (
     WorkspaceRepository,
 )
 from awf.runtime.events import WORKSPACE_EVENT_BROADCASTER, WorkspaceEventFrame
-from awf.runtime.logs import LOG_BROADCASTER, LogFrame, LogStore
+from awf.runtime.logs import LOG_BROADCASTER, LogFrame, read_log_chunk
 
 router = APIRouter(tags=["workspace-streams"])
 
@@ -132,7 +132,7 @@ async def _send_initial_state(
                 if not path.is_file():
                     continue
                 offset = max(stream.byte_count - tail_bytes, 0)
-                data, next_offset, _eof = await LogStore(root=path.parent).read(
+                data, next_offset, _eof = await read_log_chunk(
                     path=path,
                     offset=offset,
                     limit_bytes=tail_bytes,

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -12,13 +12,15 @@ cleanly when they show up alongside other MCP servers.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import CallToolResult, TextContent
 from pydantic import Field
 
-from awf.api.schemas import WorkspaceCreateRequest, WorkspaceCreateV2Request
+from awf.api.schemas import ErrorResponse, WorkspaceCreateRequest, WorkspaceCreateV2Request
 from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.profiles.resolver import ProfileResolutionError
 from awf.service.workspaces import WorkspaceService
 
 # ── MCP tool registration ─────────────────────────────────────────────────
@@ -152,7 +154,19 @@ def build_mcp_server(
             workspace={"profile_ref": profile_ref, "profile": profile},
             validation={"commands": validation_commands, "requested_tier": requested_tier},
         )
-        return (await service.create_v2(req)).model_dump(mode="json")
+        try:
+            ws = await service.create_v2(req)
+        except ProfileResolutionError as exc:
+            error = ErrorResponse(error_code="INVALID_PROFILE", message=str(exc))
+            return cast(
+                dict[str, Any],
+                CallToolResult(
+                    content=[TextContent(type="text", text=error.model_dump_json())],
+                    structuredContent=error.model_dump(mode="json"),
+                    isError=True,
+                ),
+            )
+        return ws.model_dump(mode="json")
 
     @mcp.tool(name="awf_get_workspace")
     async def awf_get_workspace(

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -1,6 +1,7 @@
 """MCP server surface for AWF.
 
-Builds a ``FastMCP`` instance with five tools that mirror the REST API.
+Builds a ``FastMCP`` instance with create, read, wait, and observability
+tools that mirror the REST API.
 Because both the MCP tools and the REST handlers want the same underlying
 logic (create workspace in DB, fetch by id, etc.) we expose a small
 ``WorkspaceService`` façade that both can call.
@@ -15,51 +16,10 @@ from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import Field
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.api.schemas import WorkspaceCreateRequest, WorkspaceResponse
+from awf.api.schemas import WorkspaceCreateRequest, WorkspaceCreateV2Request
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
-
-# ── Service layer: shared by REST + MCP ───────────────────────────────────
-
-
-class WorkspaceService:
-    """Domain operations shared across the REST router and MCP tools.
-
-    The router + tools stay thin (shape parsing only); the business logic
-    lives here so we don't duplicate the repository-and-commit dance.
-    """
-
-    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
-        self._factory = session_factory
-
-    async def create(self, req: WorkspaceCreateRequest) -> WorkspaceResponse:
-        async with self._factory() as s:
-            ws = await WorkspaceRepository(s).create(
-                repo_url=req.repo_url,
-                branch_base=req.branch_base,
-                task_title=req.task_title,
-                task_prompt=req.task_prompt,
-                task_external_id=req.task_external_id,
-                agent=req.agent.value,
-                env_profile=req.env_profile,
-                test_commands=req.test_commands,
-                requires_database=req.requires_database,
-            )
-            await s.commit()
-            return WorkspaceResponse.model_validate(ws)
-
-    async def get(self, workspace_id: str) -> WorkspaceResponse | None:
-        async with self._factory() as s:
-            ws = await WorkspaceRepository(s).get(workspace_id)
-            return WorkspaceResponse.model_validate(ws) if ws is not None else None
-
-    async def list(self, *, limit: int = 50) -> list[WorkspaceResponse]:
-        async with self._factory() as s:
-            rows = await WorkspaceRepository(s).list(limit=limit)
-            return [WorkspaceResponse.model_validate(r) for r in rows]
-
+from awf.service.workspaces import WorkspaceService
 
 # ── MCP tool registration ─────────────────────────────────────────────────
 
@@ -128,6 +88,72 @@ def build_mcp_server(
         )
         return (await service.create(req)).model_dump(mode="json")
 
+    @mcp.tool(name="awf_create_workspace_v2")
+    async def awf_create_workspace_v2(
+        repo_url: str = Field(..., description="Git URL the workspace should check out."),
+        base_branch: str = Field(
+            default="main",
+            description="Branch to branch FROM; feature branch is created off it.",
+        ),
+        task_title: str = Field(..., description="Short title of the task (≤ 512 chars)."),
+        task_prompt: str = Field(..., description="Full prompt to hand to the coding CLI."),
+        task_kind: str = Field(
+            default="feature_branch_pr",
+            description="Task kind for scheduling/monitor behavior.",
+        ),
+        agent: AgentRuntime = Field(
+            default=AgentRuntime.codex,
+            description="Which coding CLI to run inside the container.",
+        ),
+        task_external_id: str | None = Field(
+            default=None, description="Optional caller-side task ID for correlation."
+        ),
+        profile_ref: str | None = Field(
+            default="auto",
+            description="Workspace profile reference, e.g. auto, python, node, aira.",
+        ),
+        profile: dict[str, Any] | None = Field(
+            default=None,
+            description="Optional inline workspace profile dictionary.",
+        ),
+        validation_commands: list[str] = Field(
+            default_factory=list,
+            description="Shell commands to validate the change.",
+        ),
+        requested_tier: int = Field(
+            default=1,
+            ge=1,
+            le=3,
+            description="Requested validation tier hint.",
+        ),
+        auto_merge: bool = Field(
+            default=True,
+            description="Whether AWF may merge once gates are green.",
+        ),
+        initial_review_grace_period_seconds: float | None = Field(
+            default=None,
+            ge=0,
+            le=86400,
+            description="Optional monitor grace override before auto-merge.",
+        ),
+    ) -> dict[str, Any]:
+        """Create a new AWF workspace using the clean v2 contract."""
+        req = WorkspaceCreateV2Request(
+            repo={"url": repo_url, "base_branch": base_branch},
+            task={
+                "title": task_title,
+                "prompt": task_prompt,
+                "kind": task_kind,
+                "agent": agent,
+                "external_id": task_external_id,
+                "auto_merge": auto_merge,
+                "initial_review_grace_period_seconds": initial_review_grace_period_seconds,
+            },
+            workspace={"profile_ref": profile_ref, "profile": profile},
+            validation={"commands": validation_commands, "requested_tier": requested_tier},
+        )
+        return (await service.create_v2(req)).model_dump(mode="json")
+
     @mcp.tool(name="awf_get_workspace")
     async def awf_get_workspace(
         workspace_id: str = Field(..., description="ID returned by awf_create_workspace."),
@@ -177,5 +203,47 @@ def build_mcp_server(
             if time.monotonic() >= deadline:
                 return ws.model_dump(mode="json")
             await asyncio.sleep(poll_interval_seconds)
+
+    @mcp.tool(name="awf_list_workspace_events")
+    async def awf_list_workspace_events(
+        workspace_id: str = Field(..., description="Workspace ID to inspect."),
+        limit: int = Field(default=50, ge=1, le=500),
+        event_type: str | None = Field(default=None, description="Optional event-type filter."),
+    ) -> list[dict[str, Any]] | None:
+        """List immutable workspace events newest-first."""
+        rows = await service.list_events(
+            workspace_id,
+            limit=limit,
+            event_type=event_type,
+        )
+        return [row.model_dump(mode="json") for row in rows] if rows is not None else None
+
+    @mcp.tool(name="awf_list_workspace_logs")
+    async def awf_list_workspace_logs(
+        workspace_id: str = Field(..., description="Workspace ID to inspect."),
+    ) -> list[dict[str, Any]] | None:
+        """List indexed durable log streams for one workspace."""
+        rows = await service.list_logs(workspace_id)
+        return [row.model_dump(mode="json") for row in rows] if rows is not None else None
+
+    @mcp.tool(name="awf_read_workspace_log")
+    async def awf_read_workspace_log(
+        workspace_id: str = Field(..., description="Workspace ID to inspect."),
+        stream_id: str = Field(..., description="Stream ID from awf_list_workspace_logs."),
+        offset: int = Field(default=0, ge=0, description="Byte offset to start reading from."),
+        limit_bytes: int = Field(
+            default=65_536,
+            ge=1,
+            le=1_048_576,
+            description="Maximum bytes to read.",
+        ),
+    ) -> dict[str, Any] | None:
+        """Read a bounded chunk from an indexed durable log stream."""
+        return await service.read_log(
+            workspace_id,
+            stream_id,
+            offset=offset,
+            limit_bytes=limit_bytes,
+        )
 
     return mcp

--- a/src/awf/runtime/logs.py
+++ b/src/awf/runtime/logs.py
@@ -167,7 +167,30 @@ class LogStore:
         offset: int,
         limit_bytes: int,
     ) -> tuple[str, int, bool]:
-        return await asyncio.to_thread(_read_log_chunk, path, offset, limit_bytes)
+        return await read_log_chunk(
+            path=self._resolve_read_path(path),
+            offset=offset,
+            limit_bytes=limit_bytes,
+        )
+
+    def _resolve_read_path(self, path: Path) -> Path:
+        read_path = path if path.is_absolute() else self._root / path
+        root = self._root.resolve()
+        resolved = read_path.resolve()
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            raise ValueError("LogStore.read path must be within root") from None
+        return resolved
+
+
+async def read_log_chunk(
+    *,
+    path: Path,
+    offset: int,
+    limit_bytes: int,
+) -> tuple[str, int, bool]:
+    return await asyncio.to_thread(_read_log_chunk, path, offset, limit_bytes)
 
 
 def _read_log_chunk(path: Path, offset: int, limit_bytes: int) -> tuple[str, int, bool]:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1,0 +1,207 @@
+"""Workspace service operations shared by REST routes and MCP tools."""
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import (
+    WorkspaceCreateRequest,
+    WorkspaceCreateV2Request,
+    WorkspaceEventResponse,
+    WorkspaceLogStreamResponse,
+    WorkspaceResponse,
+)
+from awf.db.models import Workspace
+from awf.db.repositories import (
+    WorkspaceEventRepository,
+    WorkspaceLogStreamRepository,
+    WorkspaceRepository,
+)
+from awf.profiles.models import WorkspaceProfile
+from awf.profiles.resolver import resolve_workspace_profile
+from awf.runtime.logs import LogStore
+
+
+class WorkspaceService:
+    """Domain operations shared across REST routes and MCP tools."""
+
+    def __init__(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        *,
+        log_root: Path | str | None = None,
+    ) -> None:
+        self._factory = session_factory
+        self._log_root = Path(log_root) if log_root is not None else None
+
+    async def create(self, req: WorkspaceCreateRequest) -> WorkspaceResponse:
+        async with self._factory() as s:
+            ws = await WorkspaceRepository(s).create(
+                repo_url=req.repo_url,
+                branch_base=req.branch_base,
+                task_title=req.task_title,
+                task_prompt=req.task_prompt,
+                task_external_id=req.task_external_id,
+                agent=req.agent.value,
+                env_profile=req.env_profile,
+                test_commands=req.test_commands,
+                requires_database=req.requires_database,
+            )
+            await s.commit()
+            return WorkspaceResponse.model_validate(ws)
+
+    async def create_v2(self, req: WorkspaceCreateV2Request) -> WorkspaceResponse:
+        async with self._factory() as s:
+            ws = await create_workspace_v2_row(s, req)
+            await s.commit()
+            return WorkspaceResponse.model_validate(ws)
+
+    async def get(self, workspace_id: str) -> WorkspaceResponse | None:
+        async with self._factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            return WorkspaceResponse.model_validate(ws) if ws is not None else None
+
+    async def list(self, *, limit: int = 50) -> list[WorkspaceResponse]:
+        async with self._factory() as s:
+            rows = await WorkspaceRepository(s).list(limit=limit)
+            return [WorkspaceResponse.model_validate(r) for r in rows]
+
+    async def list_events(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+        event_type: str | None = None,
+    ) -> builtins.list[WorkspaceEventResponse] | None:
+        async with self._factory() as s:
+            workspace_repo = WorkspaceRepository(s)
+            if not await workspace_repo.exists(workspace_id):
+                return None
+            rows = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=event_type,
+                limit=limit,
+            )
+            return [WorkspaceEventResponse.model_validate(row) for row in rows]
+
+    async def list_logs(
+        self, workspace_id: str
+    ) -> builtins.list[WorkspaceLogStreamResponse] | None:
+        async with self._factory() as s:
+            workspace_repo = WorkspaceRepository(s)
+            if not await workspace_repo.exists(workspace_id):
+                return None
+            rows = await WorkspaceLogStreamRepository(s).list_for_workspace(workspace_id)
+            return [WorkspaceLogStreamResponse.model_validate(row) for row in rows]
+
+    async def read_log(
+        self,
+        workspace_id: str,
+        stream_id: str,
+        *,
+        offset: int = 0,
+        limit_bytes: int = 65_536,
+    ) -> dict[str, Any] | None:
+        async with self._factory() as s:
+            workspace_repo = WorkspaceRepository(s)
+            if not await workspace_repo.exists(workspace_id):
+                return None
+            stream = await WorkspaceLogStreamRepository(s).get(
+                workspace_id=workspace_id,
+                stream_id=stream_id,
+            )
+            if stream is None:
+                return None
+            path = Path(stream.path)
+
+        if not path.is_file():
+            return None
+        data, next_offset, eof = await LogStore(root=self._log_root or path.parent).read(
+            path=path,
+            offset=offset,
+            limit_bytes=limit_bytes,
+        )
+        return {
+            "stream_id": stream_id,
+            "offset": offset,
+            "next_offset": next_offset,
+            "eof": eof,
+            "text": data,
+        }
+
+
+async def create_workspace_v2_row(
+    session: AsyncSession,
+    payload: WorkspaceCreateV2Request,
+    *,
+    idempotency_key: str | None = None,
+) -> Workspace:
+    """Persist one v2 workspace request without committing the session."""
+    requested_profile, resolved_profile = v2_profile_snapshots(payload)
+    ws = await WorkspaceRepository(session).create(
+        repo_url=payload.repo.url,
+        branch_base=payload.repo.base_branch,
+        task_title=payload.task.title,
+        task_prompt=payload.task.prompt,
+        task_external_id=payload.task.external_id,
+        auto_merge=payload.task.auto_merge,
+        initial_review_grace_period_seconds=(
+            payload.task.initial_review_grace_period_seconds
+        ),
+        agent=payload.task.agent.value,
+        env_profile=None,
+        profile_ref=payload.workspace.profile_ref,
+        requested_profile=requested_profile,
+        resolved_profile=resolved_profile,
+        test_commands=payload.validation.commands,
+        requires_database=False,
+        idempotency_key=idempotency_key,
+    )
+    ws.task_kind = payload.task.kind
+    await session.flush()
+    return ws
+
+
+def v2_profile_snapshots(
+    payload: WorkspaceCreateV2Request,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    requested_profile = (
+        payload.workspace.profile.model_dump(mode="json", by_alias=True)
+        if payload.workspace.profile is not None
+        else None
+    )
+    resolved_profile = None
+    if payload.workspace.profile is not None or (
+        payload.workspace.profile_ref and payload.workspace.profile_ref != "auto"
+    ):
+        resolved = resolve_workspace_profile(
+            worktree_path=None,
+            inline_profile=payload.workspace.profile,
+            profile_ref=payload.workspace.profile_ref,
+            validation_commands=payload.validation.commands,
+        )
+        profile = profile_with_requested_tier(
+            resolved.profile,
+            payload.validation.requested_tier,
+        )
+        resolved_profile = profile.model_dump(mode="json", by_alias=True)
+    return requested_profile, resolved_profile
+
+
+def profile_with_requested_tier(
+    profile: WorkspaceProfile,
+    requested_tier: int,
+) -> WorkspaceProfile:
+    if profile.validation.requested_tier == requested_tier:
+        return profile
+    return profile.model_copy(
+        update={
+            "validation": profile.validation.model_copy(
+                update={"requested_tier": requested_tier}
+            )
+        }
+    )

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -23,7 +23,7 @@ from awf.db.repositories import (
 )
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
-from awf.runtime.logs import LogStore
+from awf.runtime.logs import read_log_chunk
 
 
 class WorkspaceService:
@@ -36,7 +36,7 @@ class WorkspaceService:
         log_root: Path | str | None = None,
     ) -> None:
         self._factory = session_factory
-        self._log_root = Path(log_root) if log_root is not None else None
+        self._log_root = Path(log_root).resolve() if log_root is not None else None
 
     async def create(self, req: WorkspaceCreateRequest) -> WorkspaceResponse:
         async with self._factory() as s:
@@ -118,9 +118,14 @@ class WorkspaceService:
                 return None
             path = Path(stream.path)
 
+        if (
+            self._log_root is not None
+            and not path.resolve().is_relative_to(self._log_root)
+        ):
+            return None
         if not path.is_file():
             return None
-        data, next_offset, eof = await LogStore(root=self._log_root or path.parent).read(
+        data, next_offset, eof = await read_log_chunk(
             path=path,
             offset=offset,
             limit_bytes=limit_bytes,

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -10,13 +10,17 @@ harness) against a throwaway in-memory SQLite. This validates:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.db.base import Base
+from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.mcp.server import WorkspaceService, build_mcp_server
+from awf.runtime.logs import LogStore
 
 
 @pytest.fixture
@@ -62,15 +66,23 @@ async def _call(mcp, name, args) -> object:  # type: ignore[no-untyped-def]
 
 class TestToolRegistration:
     @pytest.mark.unit
-    async def test_all_five_tools_registered(self, mcp) -> None:  # type: ignore[no-untyped-def]
+    async def test_existing_and_observability_tools_registered(
+        self, mcp
+    ) -> None:  # type: ignore[no-untyped-def]
         tools = await mcp.list_tools()
         names = {t.name for t in tools}
-        assert names == {
+        assert {
             "awf_create_workspace",
             "awf_get_workspace",
             "awf_list_workspaces",
             "awf_wait_for_workspace",
-        } | ({"awf_cancel_workspace"} & names)  # cancel deferred to Task 9 surface
+        } <= names
+        assert {
+            "awf_create_workspace_v2",
+            "awf_list_workspace_events",
+            "awf_list_workspace_logs",
+            "awf_read_workspace_log",
+        } <= names
 
 
 class TestCreateWorkspace:
@@ -92,6 +104,63 @@ class TestCreateWorkspace:
 
         with pytest.raises((McpError, Exception)):
             await _call(mcp, "awf_create_workspace", bad)
+
+
+class TestCreateWorkspaceV2:
+    @pytest.mark.unit
+    async def test_persists_clean_v2_contract_fields(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        payload = await _call(
+            mcp,
+            "awf_create_workspace_v2",
+            {
+                "repo_url": "git@github.com:example/app.git",
+                "base_branch": "main",
+                "task_title": "Add planner hook",
+                "task_prompt": "Implement the planner hook.",
+                "task_kind": "refactor_task",
+                "agent": "claude_code",
+                "task_external_id": "AIRA-42",
+                "profile_ref": "python",
+                "profile": {
+                    "name": "inline-python",
+                    "validation": {"requested_tier": 2},
+                    "monitor": {"initial_review_grace_period_seconds": 333},
+                },
+                "validation_commands": ["uv run pytest tests/unit -q"],
+                "requested_tier": 2,
+                "auto_merge": False,
+                "initial_review_grace_period_seconds": 12.5,
+            },
+        )
+
+        assert isinstance(payload, dict)
+        ws_id = payload["id"]
+        async with factory() as session:
+            ws = await WorkspaceRepository(session).get(str(ws_id))
+
+        assert ws is not None
+        assert ws.repo_url == "git@github.com:example/app.git"
+        assert ws.branch_base == "main"
+        assert ws.task_title == "Add planner hook"
+        assert ws.task_prompt == "Implement the planner hook."
+        assert ws.task_external_id == "AIRA-42"
+        assert ws.task_kind == "refactor_task"
+        assert ws.agent == "claude_code"
+        assert ws.profile_ref == "python"
+        assert ws.requested_profile is not None
+        assert ws.requested_profile["name"] == "inline-python"
+        assert ws.resolved_profile is not None
+        assert ws.resolved_profile["validation"]["requested_tier"] == 2
+        assert [
+            item["command"] for item in ws.resolved_profile["phases"]["validate"]
+        ] == ["uv run pytest tests/unit -q"]
+        assert ws.test_commands == ["uv run pytest tests/unit -q"]
+        assert ws.auto_merge is False
+        assert ws.initial_review_grace_period_seconds == 12.5
 
 
 class TestGetAndList:
@@ -176,3 +245,195 @@ class TestWaitForWorkspace:
             },
         )
         assert result is None
+
+
+class TestWorkspaceEvents:
+    @pytest.mark.unit
+    async def test_lists_requested_workspace_events_with_limit_and_type(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        first = await _call(mcp, "awf_create_workspace", {**_CREATE_ARGS, "task_title": "first"})
+        second = await _call(
+            mcp,
+            "awf_create_workspace",
+            {**_CREATE_ARGS, "task_title": "second"},
+        )
+        first_id = str(first["id"])  # type: ignore[index]
+        second_id = str(second["id"])  # type: ignore[index]
+        base = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+
+        async with factory() as session:
+            repo = WorkspaceRepository(session)
+            first_ws = await repo.get(first_id)
+            second_ws = await repo.get(second_id)
+            assert first_ws is not None
+            assert second_ws is not None
+            first_old = await repo.add_event(
+                first_ws,
+                event_type="workspace.phase_started",
+                reason_code="OLD",
+                payload={"phase": "agent"},
+            )
+            first_new = await repo.add_event(
+                first_ws,
+                event_type="workspace.phase_started",
+                reason_code="NEW",
+                payload={"phase": "validation"},
+            )
+            wrong_workspace = await repo.add_event(
+                second_ws,
+                event_type="workspace.phase_started",
+                reason_code="OTHER",
+                payload={"phase": "validation"},
+            )
+            ignored_type = await repo.add_event(
+                first_ws,
+                event_type="workspace.log",
+                reason_code="IGNORED",
+                payload={"stream": "agent.stdout"},
+            )
+            first_old.occurred_at = base
+            first_new.occurred_at = base + timedelta(seconds=2)
+            wrong_workspace.occurred_at = base + timedelta(seconds=3)
+            ignored_type.occurred_at = base + timedelta(seconds=4)
+            await session.commit()
+
+        events = await _call(
+            mcp,
+            "awf_list_workspace_events",
+            {
+                "workspace_id": first_id,
+                "event_type": "workspace.phase_started",
+                "limit": 1,
+            },
+        )
+
+        assert isinstance(events, list)
+        assert [event["workspace_id"] for event in events] == [first_id]
+        assert [event["reason_code"] for event in events] == ["NEW"]
+        assert [event["payload"] for event in events] == [{"phase": "validation"}]
+
+    @pytest.mark.unit
+    async def test_missing_workspace_events_return_none(
+        self, mcp
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = await _call(
+            mcp,
+            "awf_list_workspace_events",
+            {"workspace_id": "ws_missing"},
+        )
+
+        assert result is None
+
+
+class TestWorkspaceLogs:
+    @pytest.mark.unit
+    async def test_lists_and_reads_indexed_log_streams(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        service = WorkspaceService(factory, log_root=tmp_path / "logs")
+        mcp = build_mcp_server(service=service)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/app.git",
+                branch_base="main",
+                task_title="Observe logs",
+                task_prompt="Write logs.",
+                agent="codex",
+                test_commands=[],
+            )
+            await session.commit()
+
+        store = LogStore(root=tmp_path / "logs", session_factory=factory)
+        sink = await store.open_stream(
+            workspace_id=workspace.id,
+            stream_id="agent.stdout",
+            source="agent",
+            name="Agent stdout",
+            kind="stdout",
+        )
+        await sink.write("alpha\nbeta\n")
+        await sink.close()
+
+        listed = await _call(
+            mcp,
+            "awf_list_workspace_logs",
+            {"workspace_id": workspace.id},
+        )
+        assert isinstance(listed, list)
+        assert [stream["stream_id"] for stream in listed] == ["agent.stdout"]
+        assert listed[0]["byte_count"] == len("alpha\nbeta\n")
+        assert listed[0]["line_count"] == 2
+
+        chunk = await _call(
+            mcp,
+            "awf_read_workspace_log",
+            {
+                "workspace_id": workspace.id,
+                "stream_id": "agent.stdout",
+                "offset": 6,
+                "limit_bytes": 4,
+            },
+        )
+        assert chunk == {
+            "stream_id": "agent.stdout",
+            "offset": 6,
+            "next_offset": 10,
+            "eof": False,
+            "text": "beta",
+        }
+
+        eof = await _call(
+            mcp,
+            "awf_read_workspace_log",
+            {
+                "workspace_id": workspace.id,
+                "stream_id": "agent.stdout",
+                "offset": len("alpha\nbeta\n"),
+                "limit_bytes": 16,
+            },
+        )
+        assert eof == {
+            "stream_id": "agent.stdout",
+            "offset": len("alpha\nbeta\n"),
+            "next_offset": len("alpha\nbeta\n"),
+            "eof": True,
+            "text": "",
+        }
+
+    @pytest.mark.unit
+    async def test_missing_workspace_or_stream_returns_none(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        service = WorkspaceService(factory, log_root=tmp_path / "logs")
+        mcp = build_mcp_server(service=service)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/app.git",
+                branch_base="main",
+                task_title="Observe logs",
+                task_prompt="Write logs.",
+                agent="codex",
+                test_commands=[],
+            )
+            await session.commit()
+
+        missing_workspace = await _call(
+            mcp,
+            "awf_list_workspace_logs",
+            {"workspace_id": "ws_missing"},
+        )
+        missing_stream = await _call(
+            mcp,
+            "awf_read_workspace_log",
+            {"workspace_id": workspace.id, "stream_id": "agent.stderr"},
+        )
+
+        assert missing_workspace is None
+        assert missing_stream is None

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -162,6 +162,34 @@ class TestCreateWorkspaceV2:
         assert ws.auto_merge is False
         assert ws.initial_review_grace_period_seconds == 12.5
 
+    @pytest.mark.unit
+    async def test_unknown_profile_ref_returns_structured_invalid_profile_error(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        from mcp.types import CallToolResult
+
+        result = await mcp.call_tool(
+            "awf_create_workspace_v2",
+            {
+                "repo_url": "git@github.com:example/app.git",
+                "base_branch": "main",
+                "task_title": "Add planner hook",
+                "task_prompt": "Implement the planner hook.",
+                "profile_ref": "missing-profile",
+            },
+        )
+
+        message = "unknown workspace profile_ref: missing-profile"
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert result.structuredContent == {
+            "error_code": "INVALID_PROFILE",
+            "message": message,
+            "detail": None,
+        }
+        assert result.content[0].type == "text"
+
 
 class TestGetAndList:
     @pytest.mark.unit

--- a/tests/unit/runtime/test_logs.py
+++ b/tests/unit/runtime/test_logs.py
@@ -98,6 +98,21 @@ async def test_log_store_read_uses_threaded_bounded_file_read(
 
 
 @pytest.mark.unit
+async def test_log_store_read_rejects_paths_outside_root(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    root.mkdir()
+    outside = tmp_path / "outside.log"
+    outside.write_text("outside\n")
+
+    with pytest.raises(ValueError, match="within root"):
+        await LogStore(root=root).read(
+            path=outside,
+            offset=0,
+            limit_bytes=16,
+        )
+
+
+@pytest.mark.unit
 async def test_log_sink_write_uses_threaded_file_append(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_83b6f20aa5144233b1781d53` (agent: `codex`).


### Task
Implement the next MCP slice for AWF's always-on service: v2 task submission plus read-only observability tools that an Aira planner, Codex, or Claude Code MCP client can use without shelling out.

Strict TDD contract:
- Write failing MCP/service tests first and run the narrow tests to capture the red failure.
- Commit the red tests first with the failure output summarized in the commit body.
- Implement until green, run validation, and commit with conventional commits.
- Do not push; AWF owns push, PR creation, monitor, comments, sync, and merge.
- Do not switch branches.

Required behavior:
- Keep all existing MCP tools backward-compatible.
- Add `awf_create_workspace_v2` using the clean v2 contract fields:
  - repo_url, base_branch
  - task_title, task_prompt, task_kind, agent, task_external_id
  - profile_ref, optional inline profile dict
  - validation_commands, requested_tier
  - auto_merge, initial_review_grace_period_seconds
  It should persist the same fields as `POST /v2/workspaces`, including monitor policy from PR 33.
- Add read-only observability MCP tools:
  - `awf_list_workspace_events(workspace_id, limit=50, event_type=None)` returning newest-first event payloads.
  - `awf_list_workspace_logs(workspace_id)` returning indexed log streams.
  - `awf_read_workspace_log(workspace_id, stream_id, offset=0, limit_bytes=65536)` returning text, offsets, EOF.
- If a workspace is missing, return `None` or a structured empty/missing response consistently; do not crash with raw SQL errors.
- Add `WorkspaceService` methods behind the tools so route/tool logic stays thin and unit-testable.
- For logs, allow `WorkspaceService` to be constructed with a log root path; tests should use a temp path and real `LogStore`/repository rows.
- Update README/MCP docs with the new tools and an example v2 submission.
- Do not add destructive MCP controls in this slice; keep it read-only beyond create.

Suggested tests:
- Tool registry includes the new tools while old five tools remain.
- `awf_create_workspace_v2` persists profile ref, validation commands, auto_merge=false, grace override, and task kind.
- `awf_list_workspace_events` returns only the requested workspace and honors limit/event_type.
- `awf_list_workspace_logs` and `awf_read_workspace_log` work with a temp log stream, offsets, and EOF.
- Missing workspace/log stream behavior is structured and non-crashing.

Validation commands:
```bash
uv run --python 3.12 --extra dev ruff check src/awf/mcp src/awf/api src/awf/db src/awf/runtime tests/unit/mcp tests/unit/api tests/unit/db
uv run --python 3.12 --extra dev mypy src/awf/mcp src/awf/api src/awf/db src/awf/runtime
uv run --python 3.12 --extra dev pytest tests/unit/mcp tests/unit/api tests/unit/db -q
```

---
Validation: 6 profile command(s) passed inside the workspace container.
