### PR TITLE
feat(service): add service log inspection command

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,19 @@ uv run --python 3.12 --extra dev awf service status
 uv run --python 3.12 --extra dev awf service status --format pretty
 ```
 
+Inspect the local service Compose logs without writing Docker commands:
+
+```bash
+uv run --python 3.12 --extra dev awf service logs
+uv run --python 3.12 --extra dev awf service logs --tail 200 --service worker
+uv run --python 3.12 --extra dev awf service logs --follow --service api --service worker
+```
+
+`awf service logs` is a read-only wrapper around
+`docker compose -f docker/compose/local-service.yml logs`. By default it tails
+the `api` and `worker` services. Repeat `--service` to select `api`, `worker`,
+`migrate`, or `postgres`.
+
 Create a workspace:
 
 ```bash
@@ -559,6 +572,7 @@ Check the service from another terminal:
 
 ```bash
 uv run --python 3.12 --extra dev awf service status
+uv run --python 3.12 --extra dev awf service logs --follow --service worker
 ```
 
 The service-mode default database URL is local Postgres

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -180,6 +180,8 @@ def service_logs(
 
     try:
         result = run_service_logs(services=service, tail=tail, follow=follow)
+    except KeyboardInterrupt:
+        raise typer.Exit(code=130) from None
     except ServiceLogsError as exc:
         typer.echo(
             f"error: docker compose logs failed (exit {exc.returncode}): {exc.detail}",

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -22,6 +22,8 @@ from typing import Any
 import httpx
 import typer
 
+from awf.service.logs import DEFAULT_LOG_TAIL, ServiceLogName
+
 app = typer.Typer(
     name="awf",
     help="Aira Agent Workspace Fabric — CLI operator surface.",
@@ -152,6 +154,43 @@ def service_config(
     from awf.service.config import resolve_service_settings, service_config_payload
 
     _emit(service_config_payload(resolve_service_settings()), fmt)
+
+
+@service_app.command("logs")
+def service_logs(
+    tail: int = typer.Option(
+        DEFAULT_LOG_TAIL,
+        "--tail",
+        min=0,
+        help="Number of log lines to show per service.",
+    ),
+    service: list[ServiceLogName] = typer.Option(
+        [],
+        "--service",
+        help="Repeatable service filter.",
+    ),
+    follow: bool = typer.Option(
+        False,
+        "--follow/--no-follow",
+        help="Stream logs until interrupted.",
+    ),
+) -> None:
+    """Tail local AWF service Compose logs."""
+    from awf.service.logs import ServiceLogsError, run_service_logs
+
+    try:
+        result = run_service_logs(services=service, tail=tail, follow=follow)
+    except ServiceLogsError as exc:
+        typer.echo(
+            f"error: docker compose logs failed (exit {exc.returncode}): {exc.detail}",
+            err=True,
+        )
+        raise typer.Exit(code=1) from None
+
+    if result.stdout:
+        typer.echo(result.stdout, nl=False)
+    if result.stderr:
+        typer.echo(result.stderr, err=True, nl=False)
 
 
 @workspace_app.command("create")

--- a/src/awf/service/logs.py
+++ b/src/awf/service/logs.py
@@ -1,0 +1,137 @@
+"""Read-only local service log helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Literal, Protocol
+
+LOCAL_SERVICE_COMPOSE_FILE = Path("docker/compose/local-service.yml")
+DEFAULT_LOG_TAIL = 100
+DEFAULT_LOG_SERVICES = ("api", "worker")
+
+
+class ServiceLogName(StrEnum):
+    api = "api"
+    worker = "worker"
+    migrate = "migrate"
+    postgres = "postgres"
+
+
+class CompletedProcessLike(Protocol):
+    @property
+    def returncode(self) -> int: ...
+
+    @property
+    def stdout(self) -> str | None: ...
+
+    @property
+    def stderr(self) -> str | None: ...
+
+
+class SubprocessRun(Protocol):
+    def __call__(
+        self,
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: Literal[True],
+    ) -> CompletedProcessLike: ...
+
+
+@dataclass(frozen=True)
+class ServiceLogsResult:
+    stdout: str
+    stderr: str
+
+
+class ServiceLogsError(RuntimeError):
+    def __init__(self, *, returncode: int, detail: str) -> None:
+        super().__init__(detail)
+        self.returncode = returncode
+        self.detail = detail
+
+
+def service_logs_command(
+    *,
+    services: Sequence[ServiceLogName],
+    tail: int = DEFAULT_LOG_TAIL,
+    follow: bool = False,
+    compose_file: Path = LOCAL_SERVICE_COMPOSE_FILE,
+) -> list[str]:
+    selected_services = [service.value for service in services] or list(DEFAULT_LOG_SERVICES)
+    args = [
+        "docker",
+        "compose",
+        "-f",
+        str(compose_file),
+        "logs",
+        "--tail",
+        str(tail),
+    ]
+    if follow:
+        args.append("--follow")
+    args.extend(selected_services)
+    return args
+
+
+def run_service_logs(
+    *,
+    services: Sequence[ServiceLogName],
+    tail: int = DEFAULT_LOG_TAIL,
+    follow: bool = False,
+    compose_file: Path = LOCAL_SERVICE_COMPOSE_FILE,
+    run_subprocess: SubprocessRun | None = None,
+) -> ServiceLogsResult:
+    """Run ``docker compose logs`` for the local service stack."""
+
+    runner = run_subprocess or _run_subprocess
+    capture_output = not follow
+    try:
+        result = runner(
+            service_logs_command(
+                services=services,
+                tail=tail,
+                follow=follow,
+                compose_file=compose_file,
+            ),
+            check=False,
+            capture_output=capture_output,
+            text=True,
+        )
+    except FileNotFoundError as exc:
+        raise ServiceLogsError(returncode=127, detail="docker binary not found on PATH") from exc
+    except OSError as exc:
+        raise ServiceLogsError(returncode=1, detail=f"{type(exc).__name__}: {exc}") from exc
+
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
+    if result.returncode != 0:
+        raise ServiceLogsError(
+            returncode=result.returncode,
+            detail=_failure_detail(stdout=stdout, stderr=stderr),
+        )
+    if follow:
+        return ServiceLogsResult(stdout="", stderr="")
+    return ServiceLogsResult(stdout=stdout, stderr=stderr)
+
+
+def _run_subprocess(
+    args: list[str],
+    *,
+    check: bool,
+    capture_output: bool,
+    text: Literal[True],
+) -> CompletedProcessLike:
+    return subprocess.run(args, check=check, capture_output=capture_output, text=text)
+
+
+def _failure_detail(*, stdout: str, stderr: str) -> str:
+    detail = (stderr or stdout).strip()
+    if detail:
+        return detail
+    return "docker compose returned a non-zero exit status"

--- a/src/awf/service/logs.py
+++ b/src/awf/service/logs.py
@@ -117,7 +117,7 @@ def run_service_logs(
     if result.returncode != 0:
         raise ServiceLogsError(
             returncode=result.returncode,
-            detail=_failure_detail(stdout=stdout, stderr=stderr),
+            detail=_failure_detail(stdout=stdout, stderr=stderr, follow=follow),
         )
     if follow:
         return ServiceLogsResult(stdout="", stderr="")
@@ -134,8 +134,13 @@ def _run_subprocess(
     return subprocess.run(args, check=check, capture_output=capture_output, text=text)
 
 
-def _failure_detail(*, stdout: str, stderr: str) -> str:
+def _failure_detail(*, stdout: str, stderr: str, follow: bool = False) -> str:
     detail = (stderr or stdout).strip()
     if detail:
         return detail
+    if follow:
+        return (
+            "docker compose logs --follow exited with a non-zero status; "
+            "docker output was already written directly to the terminal"
+        )
     return "docker compose returned a non-zero exit status"

--- a/src/awf/service/logs.py
+++ b/src/awf/service/logs.py
@@ -107,6 +107,10 @@ def run_service_logs(
         raise ServiceLogsError(returncode=127, detail="docker binary not found on PATH") from exc
     except OSError as exc:
         raise ServiceLogsError(returncode=1, detail=f"{type(exc).__name__}: {exc}") from exc
+    except KeyboardInterrupt:
+        if follow:
+            return ServiceLogsResult(stdout="", stderr="")
+        raise
 
     stdout = result.stdout or ""
     stderr = result.stderr or ""

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -109,7 +109,7 @@ def test_service_logs_follow_streams_without_capturing_subprocess_output(
 
     def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         calls.append((args, kwargs))
-        return subprocess.CompletedProcess(args, returncode=0, stdout="not replayed\n", stderr="")
+        return subprocess.CompletedProcess(args, returncode=0, stdout=None, stderr=None)
 
     monkeypatch.setattr(subprocess, "run", _run)
 

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -11,8 +11,10 @@ from typing import Any
 
 import httpx
 import pytest
+import typer
 from typer.testing import CliRunner
 
+from awf.cli import main as cli_main
 from awf.cli.main import app
 from awf.common.config import Settings
 
@@ -133,6 +135,21 @@ def test_service_logs_follow_streams_without_capturing_subprocess_output(
             {"check": False, "capture_output": False, "text": True},
         )
     ]
+
+
+@pytest.mark.unit
+def test_service_logs_follow_keyboard_interrupt_exits_cleanly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    with pytest.raises(typer.Exit) as exc_info:
+        cli_main.service_logs(tail=100, service=[], follow=True)
+
+    assert exc_info.value.exit_code == 130
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -11,10 +11,8 @@ from typing import Any
 
 import httpx
 import pytest
-import typer
 from typer.testing import CliRunner
 
-from awf.cli import main as cli_main
 from awf.cli.main import app
 from awf.common.config import Settings
 
@@ -146,10 +144,10 @@ def test_service_logs_follow_keyboard_interrupt_exits_cleanly(
 
     monkeypatch.setattr(subprocess, "run", _run)
 
-    with pytest.raises(typer.Exit) as exc_info:
-        cli_main.service_logs(tail=100, service=[], follow=True)
+    result = _runner.invoke(app, ["service", "logs", "--follow"])
 
-    assert exc_info.value.exit_code == 130
+    assert result.exit_code == 0, result.output
+    assert _combined_output(result) == ""
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 import threading
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,155 @@ from awf.cli.main import app
 from awf.common.config import Settings
 
 _runner = CliRunner()
+
+
+def _combined_output(result: Any) -> str:
+    return f"{result.stdout}{getattr(result, 'stderr', '')}"
+
+
+@pytest.mark.unit
+def test_service_logs_defaults_to_tail_api_and_worker_logs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(
+            args, returncode=0, stdout="api log\nworker log\n", stderr=""
+        )
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    result = _runner.invoke(app, ["service", "logs"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == "api log\nworker log\n"
+    assert calls == [
+        (
+            [
+                "docker",
+                "compose",
+                "-f",
+                "docker/compose/local-service.yml",
+                "logs",
+                "--tail",
+                "100",
+                "api",
+                "worker",
+            ],
+            {"check": False, "capture_output": True, "text": True},
+        )
+    ]
+
+
+@pytest.mark.unit
+def test_service_logs_accepts_repeated_service_filters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[list[str]] = []
+
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append(args)
+        return subprocess.CompletedProcess(args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    result = _runner.invoke(
+        app,
+        [
+            "service",
+            "logs",
+            "--tail",
+            "25",
+            "--service",
+            "postgres",
+            "--service",
+            "migrate",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        [
+            "docker",
+            "compose",
+            "-f",
+            "docker/compose/local-service.yml",
+            "logs",
+            "--tail",
+            "25",
+            "postgres",
+            "migrate",
+        ]
+    ]
+
+
+@pytest.mark.unit
+def test_service_logs_follow_streams_without_capturing_subprocess_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[list[str], dict[str, object]]] = []
+
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls.append((args, kwargs))
+        return subprocess.CompletedProcess(args, returncode=0, stdout="not replayed\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    result = _runner.invoke(app, ["service", "logs", "--follow", "--service", "worker"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert calls == [
+        (
+            [
+                "docker",
+                "compose",
+                "-f",
+                "docker/compose/local-service.yml",
+                "logs",
+                "--tail",
+                "100",
+                "--follow",
+                "worker",
+            ],
+            {"check": False, "capture_output": False, "text": True},
+        )
+    ]
+
+
+@pytest.mark.unit
+def test_service_logs_docker_compose_failure_is_clean_typer_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args,
+            returncode=17,
+            stdout="",
+            stderr='service "api" is not running\n',
+        )
+
+    monkeypatch.setattr(subprocess, "run", _run)
+
+    result = _runner.invoke(app, ["service", "logs"])
+
+    output = _combined_output(result)
+    assert result.exit_code == 1
+    assert 'error: docker compose logs failed (exit 17): service "api" is not running' in output
+    assert "Traceback" not in output
+
+
+@pytest.mark.unit
+def test_readme_documents_service_logs_command() -> None:
+    readme = Path("README.md").read_text()
+
+    assert "awf service logs" in readme
+    assert "docker/compose/local-service.yml" in readme
+    assert "--tail" in readme
+    assert "--service worker" in readme
+    assert "--follow" in readme
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -478,8 +478,9 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
             created["disposed"] = True
 
     class _GitManager:
-        def __init__(self, work_dir: Path) -> None:
+        def __init__(self, work_dir: Path, *, env: dict[str, str]) -> None:
             created["git_work_dir"] = work_dir
+            created["git_env"] = env
 
     class _ComposeManager:
         def __init__(self, *, work_dir: Path, template_path: Path) -> None:
@@ -579,6 +580,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     assert created["db_url"] == settings.database_url
     assert created["session_engine"] is engine
     assert created["git_work_dir"] == host_work_dir / "git"
+    assert created["git_env"]["HOME"] == str((tmp_path / "host-home").resolve())
     assert created["compose_work_dir"] == host_work_dir
     assert created["compose_template_path"].name == "workspace.base.yml.j2"
     assert created["stack_compose"].__class__ is _ComposeManager

--- a/tests/unit/service/test_logs.py
+++ b/tests/unit/service/test_logs.py
@@ -1,0 +1,29 @@
+"""Local service log helper tests."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from awf.service.logs import ServiceLogName, ServiceLogsError, run_service_logs
+
+
+@pytest.mark.unit
+def test_service_logs_follow_failure_mentions_terminal_output() -> None:
+    def _run(args: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert kwargs == {"check": False, "capture_output": False, "text": True}
+        return subprocess.CompletedProcess(args, returncode=17, stdout=None, stderr=None)
+
+    with pytest.raises(ServiceLogsError) as exc_info:
+        run_service_logs(
+            services=[ServiceLogName.api],
+            follow=True,
+            run_subprocess=_run,
+        )
+
+    assert exc_info.value.returncode == 17
+    assert exc_info.value.detail == (
+        "docker compose logs --follow exited with a non-zero status; "
+        "docker output was already written directly to the terminal"
+    )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_6b2ee029343f48c69f91e1c7` (agent: `codex`).

**External task ID**: service-logs-helper-20260426-v12

### Task
Implement a small service-mode operator feature from the AWF roadmap: add `awf service logs` so local operators can inspect the always-on AWF compose stack logs without remembering docker compose syntax. Strict TDD. First add focused failing tests under tests/unit/cli for: default command tails api and worker logs, repeated --service filters to selected services, --follow enabling streaming, docker compose failure producing a clean Typer error without a Python traceback, and README documentation. Then implement. Keep the command read-only. It should use the local service compose file by default (`docker/compose/local-service.yml`), support `--tail` default 100, repeatable `--service` choices for api, worker, migrate, postgres, and `--follow/--no-follow`. Commit red tests first with failure output in the commit body, then implementation. Do not push; AWF owns push, PR creation, monitoring, comments, and merge. Do not rewrite `.git`, `.git-local`, worktree metadata, or mirror metadata; the AWF workspace is already configured so normal git commit commands work on the current branch.

---
Validation: 6 profile command(s) passed inside the workspace container.
