### PR TITLE
feat(cli): add workspace observability commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,10 +511,26 @@ List workspaces:
 uv run --python 3.12 --extra dev awf workspace list --limit 25
 ```
 
+Inspect workspace observability data:
+
+```bash
+uv run --python 3.12 --extra dev awf workspace events ws_123 --limit 50
+uv run --python 3.12 --extra dev awf workspace events ws_123 --event-type workspace.created
+uv run --python 3.12 --extra dev awf workspace runtime ws_123
+uv run --python 3.12 --extra dev awf workspace operations ws_123 --limit 25
+uv run --python 3.12 --extra dev awf workspace logs ws_123
+uv run --python 3.12 --extra dev awf workspace log ws_123 agent.stdout --offset 0 --limit-bytes 65536
+```
+
+For protected observability endpoints, set `AWF_API_TOKEN` or pass
+`--api-token` on the command. The CLI sends it as a bearer token and never
+prints it.
+
 Pretty output:
 
 ```bash
 uv run --python 3.12 --extra dev awf workspace show ws_123 --format pretty
+uv run --python 3.12 --extra dev awf workspace events ws_123 --format pretty
 ```
 
 Preview profile resolution:

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -53,7 +53,7 @@ def _base_url(override: str | None) -> str:
 
 
 def _api_token_headers(override: str | None) -> dict[str, str]:
-    token = override or os.environ.get("AWF_API_TOKEN")
+    token = override if override is not None else os.environ.get("AWF_API_TOKEN")
     if not token:
         return {}
     return {"Authorization": f"Bearer {token}"}

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -59,6 +59,14 @@ def _api_token_headers(override: str | None) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _api_token_option() -> Any:
+    return typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    )
+
+
 def _emit(payload: object, fmt: OutputFormat) -> None:
     if fmt == OutputFormat.json:
         typer.echo(json.dumps(payload, indent=2, default=str))
@@ -291,11 +299,7 @@ def workspace_events(
     workspace_id: str = typer.Argument(...),
     limit: int = typer.Option(50, "--limit", min=1, max=500),
     event_type: str | None = typer.Option(None, "--event-type"),
-    api_token: str | None = typer.Option(
-        None,
-        "--api-token",
-        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
-    ),
+    api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
@@ -316,11 +320,7 @@ def workspace_events(
 @workspace_app.command("runtime")
 def workspace_runtime(
     workspace_id: str = typer.Argument(...),
-    api_token: str | None = typer.Option(
-        None,
-        "--api-token",
-        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
-    ),
+    api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
@@ -338,11 +338,7 @@ def workspace_runtime(
 def workspace_operations(
     workspace_id: str = typer.Argument(...),
     limit: int = typer.Option(50, "--limit", min=1, max=500),
-    api_token: str | None = typer.Option(
-        None,
-        "--api-token",
-        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
-    ),
+    api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
@@ -360,11 +356,7 @@ def workspace_operations(
 @workspace_app.command("logs")
 def workspace_logs(
     workspace_id: str = typer.Argument(...),
-    api_token: str | None = typer.Option(
-        None,
-        "--api-token",
-        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
-    ),
+    api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
@@ -384,11 +376,7 @@ def workspace_log(
     stream_id: str = typer.Argument(...),
     offset: int = typer.Option(0, "--offset", min=0),
     limit_bytes: int = typer.Option(65_536, "--limit-bytes", min=1, max=1_048_576),
-    api_token: str | None = typer.Option(
-        None,
-        "--api-token",
-        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
-    ),
+    api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -23,6 +23,7 @@ from typing import Any
 import httpx
 import typer
 
+from awf.db.enums import OperationStatus, OperationType
 from awf.service.logs import DEFAULT_LOG_TAIL, ServiceLogName
 
 app = typer.Typer(
@@ -338,16 +339,23 @@ def workspace_runtime(
 def workspace_operations(
     workspace_id: str = typer.Argument(...),
     limit: int = typer.Option(50, "--limit", min=1, max=500),
+    status: OperationStatus | None = typer.Option(None, "--status"),
+    operation_type: OperationType | None = typer.Option(None, "--type"),
     api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
     """List operations for one workspace."""
+    params: dict[str, Any] = {"limit": limit}
+    if status is not None:
+        params["status"] = status.value
+    if operation_type is not None:
+        params["type"] = operation_type.value
     response = _call(
         "GET",
         f"/v1/workspaces/{workspace_id}/operations",
         base_url=_base_url(base_url),
-        params={"limit": limit},
+        params=params,
         headers=_api_token_headers(api_token),
     )
     _handle_response(response, fmt)

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -16,6 +16,7 @@ import asyncio
 import json
 import os
 import sys
+import urllib.parse
 from enum import StrEnum
 from typing import Any
 
@@ -392,9 +393,10 @@ def workspace_log(
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
     """Read a bounded durable log chunk for one stream."""
+    encoded_stream_id = urllib.parse.quote(stream_id, safe="")
     response = _call(
         "GET",
-        f"/v1/workspaces/{workspace_id}/logs/{stream_id}",
+        f"/v1/workspaces/{workspace_id}/logs/{encoded_stream_id}",
         base_url=_base_url(base_url),
         params={"offset": offset, "limit_bytes": limit_bytes},
         headers=_api_token_headers(api_token),

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -51,6 +51,13 @@ def _base_url(override: str | None) -> str:
     return override or os.environ.get("AWF_CLI_BASE_URL", _DEFAULT_BASE_URL)
 
 
+def _api_token_headers(override: str | None) -> dict[str, str]:
+    token = override or os.environ.get("AWF_API_TOKEN")
+    if not token:
+        return {}
+    return {"Authorization": f"Bearer {token}"}
+
+
 def _emit(payload: object, fmt: OutputFormat) -> None:
     if fmt == OutputFormat.json:
         typer.echo(json.dumps(payload, indent=2, default=str))
@@ -274,6 +281,123 @@ def workspace_list(
         "/v1/workspaces",
         base_url=_base_url(base_url),
         params={"limit": limit},
+    )
+    _handle_response(response, fmt)
+
+
+@workspace_app.command("events")
+def workspace_events(
+    workspace_id: str = typer.Argument(...),
+    limit: int = typer.Option(50, "--limit", min=1, max=500),
+    event_type: str | None = typer.Option(None, "--event-type"),
+    api_token: str | None = typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    ),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """List immutable events for one workspace."""
+    params: dict[str, Any] = {"limit": limit}
+    if event_type is not None:
+        params["event_type"] = event_type
+    response = _call(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/events",
+        base_url=_base_url(base_url),
+        params=params,
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt)
+
+
+@workspace_app.command("runtime")
+def workspace_runtime(
+    workspace_id: str = typer.Argument(...),
+    api_token: str | None = typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    ),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Fetch runtime/container state for one workspace."""
+    response = _call(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/runtime",
+        base_url=_base_url(base_url),
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt)
+
+
+@workspace_app.command("operations")
+def workspace_operations(
+    workspace_id: str = typer.Argument(...),
+    limit: int = typer.Option(50, "--limit", min=1, max=500),
+    api_token: str | None = typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    ),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """List operations for one workspace."""
+    response = _call(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/operations",
+        base_url=_base_url(base_url),
+        params={"limit": limit},
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt)
+
+
+@workspace_app.command("logs")
+def workspace_logs(
+    workspace_id: str = typer.Argument(...),
+    api_token: str | None = typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    ),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """List durable log streams for one workspace."""
+    response = _call(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/logs",
+        base_url=_base_url(base_url),
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt)
+
+
+@workspace_app.command("log")
+def workspace_log(
+    workspace_id: str = typer.Argument(...),
+    stream_id: str = typer.Argument(...),
+    offset: int = typer.Option(0, "--offset", min=0),
+    limit_bytes: int = typer.Option(65_536, "--limit-bytes", min=1, max=1_048_576),
+    api_token: str | None = typer.Option(
+        None,
+        "--api-token",
+        help="Bearer token override; defaults to AWF_API_TOKEN when set.",
+    ),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Read a bounded durable log chunk for one stream."""
+    response = _call(
+        "GET",
+        f"/v1/workspaces/{workspace_id}/logs/{stream_id}",
+        base_url=_base_url(base_url),
+        params={"offset": offset, "limit_bytes": limit_bytes},
+        headers=_api_token_headers(api_token),
     )
     _handle_response(response, fmt)
 

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -225,6 +225,139 @@ class TestWorkspaceList:
         assert "--- #2 ---" in result.stdout
 
 
+class TestWorkspaceObservability:
+    @pytest.mark.unit
+    def test_events_fetches_workspace_timeline_with_filters(self) -> None:
+        response = _mock_response(
+            status_code=200,
+            payload={"items": [{"event_type": "workspace.created", "workspace_id": "ws_obs"}]},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "events",
+                    "ws_obs",
+                    "--limit",
+                    "12",
+                    "--event-type",
+                    "workspace.created",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "workspace.created" in result.stdout
+        assert mock.call_args[0] == ("GET", "http://localhost:8000/v1/workspaces/ws_obs/events")
+        assert mock.call_args.kwargs["params"] == {
+            "limit": 12,
+            "event_type": "workspace.created",
+        }
+
+    @pytest.mark.unit
+    def test_runtime_fetches_without_token_header_when_unset(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AWF_API_TOKEN", raising=False)
+        response = _mock_response(
+            status_code=200,
+            payload={"workspace_id": "ws_obs", "stack_state": "running", "services": []},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(app, ["workspace", "runtime", "ws_obs"])
+
+        assert result.exit_code == 0
+        assert "running" in result.stdout
+        headers = mock.call_args.kwargs.get("headers", {})
+        assert "Authorization" not in headers
+
+    @pytest.mark.unit
+    def test_operations_fetches_workspace_operations_with_limit(self) -> None:
+        response = _mock_response(
+            status_code=200,
+            payload={"items": [{"id": "op_1", "type": "validate", "status": "succeeded"}]},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(app, ["workspace", "operations", "ws_obs", "--limit", "5"])
+
+        assert result.exit_code == 0
+        assert "validate" in result.stdout
+        assert mock.call_args[0] == (
+            "GET",
+            "http://localhost:8000/v1/workspaces/ws_obs/operations",
+        )
+        assert mock.call_args.kwargs["params"] == {"limit": 5}
+
+    @pytest.mark.unit
+    def test_logs_injects_env_api_token_without_printing_it(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AWF_API_TOKEN", "env-secret")
+        response = _mock_response(
+            status_code=200,
+            payload={"items": [{"stream_id": "agent.stdout", "size_bytes": 42}]},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(app, ["workspace", "logs", "ws_obs"])
+
+        assert result.exit_code == 0
+        assert "agent.stdout" in result.stdout
+        assert "env-secret" not in result.stdout
+        assert "env-secret" not in result.stderr
+        assert mock.call_args[0] == ("GET", "http://localhost:8000/v1/workspaces/ws_obs/logs")
+        assert mock.call_args.kwargs["headers"] == {"Authorization": "Bearer env-secret"}
+
+    @pytest.mark.unit
+    def test_log_reads_stream_with_cli_token_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AWF_API_TOKEN", "env-secret")
+        response = _mock_response(
+            status_code=200,
+            payload={"stream_id": "agent.stdout", "offset": 64, "data": "tail"},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "log",
+                    "ws_obs",
+                    "agent.stdout",
+                    "--offset",
+                    "64",
+                    "--limit-bytes",
+                    "1024",
+                    "--api-token",
+                    "cli-secret",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "tail" in result.stdout
+        assert "cli-secret" not in result.stdout
+        assert "cli-secret" not in result.stderr
+        assert mock.call_args[0] == (
+            "GET",
+            "http://localhost:8000/v1/workspaces/ws_obs/logs/agent.stdout",
+        )
+        assert mock.call_args.kwargs["params"] == {"offset": 64, "limit_bytes": 1024}
+        assert mock.call_args.kwargs["headers"] == {"Authorization": "Bearer cli-secret"}
+
+    @pytest.mark.unit
+    def test_non_json_upstream_errors_are_printed_as_text(self) -> None:
+        response = _mock_response(status_code=502, text="upstream failed")
+        response.json.side_effect = ValueError("not json")
+        with patch("awf.cli.main.httpx.request", return_value=response):
+            result = _runner.invoke(app, ["workspace", "operations", "ws_obs"])
+
+        assert result.exit_code == 1
+        assert "upstream failed" in result.stderr
+
+
 class TestBaseUrlResolution:
     @pytest.mark.unit
     def test_cli_flag_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -290,6 +290,36 @@ class TestWorkspaceObservability:
         assert mock.call_args.kwargs["params"] == {"limit": 5}
 
     @pytest.mark.unit
+    def test_operations_forwards_status_and_type_filters(self) -> None:
+        response = _mock_response(
+            status_code=200,
+            payload={"items": [{"id": "op_1", "type": "validate", "status": "succeeded"}]},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "operations",
+                    "ws_obs",
+                    "--status",
+                    "succeeded",
+                    "--type",
+                    "validate",
+                    "--limit",
+                    "5",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "validate" in result.stdout
+        assert mock.call_args.kwargs["params"] == {
+            "limit": 5,
+            "status": "succeeded",
+            "type": "validate",
+        }
+
+    @pytest.mark.unit
     def test_logs_injects_env_api_token_without_printing_it(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -348,6 +348,33 @@ class TestWorkspaceObservability:
         assert mock.call_args.kwargs["headers"] == {"Authorization": "Bearer cli-secret"}
 
     @pytest.mark.unit
+    def test_log_encodes_stream_id_path_segment(self) -> None:
+        response = _mock_response(
+            status_code=200,
+            payload={
+                "stream_id": "namespace/agent.stdout?tail#chunk",
+                "offset": 0,
+                "data": "tail",
+            },
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "log",
+                    "ws_obs",
+                    "namespace/agent.stdout?tail#chunk",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock.call_args[0] == (
+            "GET",
+            "http://localhost:8000/v1/workspaces/ws_obs/logs/namespace%2Fagent.stdout%3Ftail%23chunk",
+        )
+
+    @pytest.mark.unit
     def test_non_json_upstream_errors_are_printed_as_text(self) -> None:
         response = _mock_response(status_code=502, text="upstream failed")
         response.json.side_effect = ValueError("not json")

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -348,6 +348,32 @@ class TestWorkspaceObservability:
         assert mock.call_args.kwargs["headers"] == {"Authorization": "Bearer cli-secret"}
 
     @pytest.mark.unit
+    def test_empty_cli_token_suppresses_env_api_token(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AWF_API_TOKEN", "env-secret")
+        response = _mock_response(
+            status_code=200,
+            payload={"stream_id": "agent.stdout", "offset": 0, "data": "tail"},
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "log",
+                    "ws_obs",
+                    "agent.stdout",
+                    "--api-token",
+                    "",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock.call_args.kwargs["headers"] == {}
+
+    @pytest.mark.unit
     def test_log_encodes_stream_id_path_segment(self) -> None:
         response = _mock_response(
             status_code=200,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8e69b759eee147d286071ce9` (agent: `codex`).


### Task
Strict TDD task: add workspace observability commands to the AWF CLI.

Problem:
The REST API already exposes workspace events, runtime, operations, and durable logs, but the Typer CLI only covers create/show/list plus local service commands. Operators and Aira-side automation need API-backed workspace observability without using curl.

Required behavior:
- Add these read-only commands under `awf workspace`:
  - `awf workspace events WORKSPACE_ID` -> GET `/v1/workspaces/{id}/events`, with `--limit` and optional `--event-type` if the API supports it.
  - `awf workspace runtime WORKSPACE_ID` -> GET `/v1/workspaces/{id}/runtime`.
  - `awf workspace operations WORKSPACE_ID` -> GET `/v1/workspaces/{id}/operations`, with `--limit` if supported.
  - `awf workspace logs WORKSPACE_ID` -> GET `/v1/workspaces/{id}/logs`.
  - `awf workspace log WORKSPACE_ID STREAM_ID` -> GET `/v1/workspaces/{id}/logs/{stream_id}`, with `--offset` and `--limit-bytes`.
- Preserve JSON as the default output and `--format pretty` as for existing commands.
- Sensitive endpoints must pass `Authorization: Bearer <token>` when `AWF_API_TOKEN` is set, and should also support `--api-token` override. Do not print tokens.
- Keep create/list/show compatibility unchanged.
- Update README CLI docs.

TDD requirements:
- Write mocked CLI tests first, commit the red tests with failure output in the commit body.
- Cover token header injection, no-token behavior, non-JSON upstream errors, and at least one happy path for each command family.
- Then implement until green.
- Commit with conventional commits. Do not push, open PRs, or switch branches; AWF owns that.

Validation:
uv run --python 3.12 --extra dev ruff check src/awf/cli tests/unit/cli
uv run --python 3.12 --extra dev mypy src/awf/cli
uv run --python 3.12 --extra dev pytest tests/unit/cli -q

---
Validation: 6 profile command(s) passed inside the workspace container.
