### PR TITLE
feat(mcp): expose runtime and operation observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,9 +634,13 @@ Example `awf_create_workspace_v2` arguments:
 
 Example runtime and operation observability calls:
 
+`awf_get_workspace_runtime` arguments:
+
 ```json
 {"workspace_id": "ws_abc123"}
 ```
+
+`awf_list_workspace_operations` arguments:
 
 ```json
 {"workspace_id": "ws_abc123", "limit": 25}

--- a/README.md
+++ b/README.md
@@ -601,13 +601,16 @@ shelling out to the REST API:
 | `awf_get_workspace` | Fetch one workspace by id. |
 | `awf_list_workspaces` | List recent workspaces newest-first. |
 | `awf_wait_for_workspace` | Poll until a workspace reaches a terminal state or times out. |
+| `awf_get_workspace_runtime` | Fetch one workspace's compose/container runtime snapshot. |
+| `awf_list_workspace_operations` | List one workspace's active and completed operations newest-first. |
 | `awf_list_workspace_events` | List one workspace's immutable events newest-first, with optional event-type filtering. |
 | `awf_list_workspace_logs` | List indexed durable log streams for one workspace. |
 | `awf_read_workspace_log` | Read a bounded log chunk by stream id and byte offset. |
 
 The observability tools return `null` for a missing workspace or log stream
-rather than surfacing raw storage errors. MCP remains read-only beyond create;
-operator controls such as cancel/destroy stay on the authenticated REST API.
+rather than surfacing raw storage errors. Runtime and operation tools are
+read-only; operator controls such as cancel/destroy stay on the authenticated
+REST API.
 
 Example `awf_create_workspace_v2` arguments:
 
@@ -627,6 +630,16 @@ Example `awf_create_workspace_v2` arguments:
   "auto_merge": true,
   "initial_review_grace_period_seconds": null
 }
+```
+
+Example runtime and operation observability calls:
+
+```json
+{"workspace_id": "ws_abc123"}
+```
+
+```json
+{"workspace_id": "ws_abc123", "limit": 25}
 ```
 
 ## Local Dogfood Runner

--- a/src/awf/api/deps.py
+++ b/src/awf/api/deps.py
@@ -82,6 +82,11 @@ async def _ensure_live_session_factory(request: Request) -> async_sessionmaker[A
         return new_factory
 
 
+async def get_db_session_factory(request: Request) -> async_sessionmaker[AsyncSession]:
+    """Return the current per-app async session factory."""
+    return await _ensure_live_session_factory(request)
+
+
 async def get_db_session(request: Request) -> AsyncIterator[AsyncSession]:
     """Yield a per-request async DB session, committing on success and rolling back on error."""
     factory = await _ensure_live_session_factory(request)

--- a/src/awf/api/routes/operations.py
+++ b/src/awf/api/routes/operations.py
@@ -6,12 +6,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as fastapi_status
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.api.deps import get_db_session
+from awf.api.deps import get_db_session, get_db_session_factory
 from awf.api.schemas import OperationListResponse, OperationResponse
 from awf.db.enums import OperationStatus, OperationType
-from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.repositories import OperationRepository
+from awf.service.workspaces import WorkspaceService
 
 router = APIRouter(tags=["operations"])
 
@@ -57,21 +58,21 @@ async def list_workspace_operations(
     status: OperationStatus | None = None,
     operation_type: Annotated[OperationType | None, Query(alias="type")] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
-    session: AsyncSession = Depends(get_db_session),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> OperationListResponse:
-    if not await WorkspaceRepository(session).exists(workspace_id):
-        raise HTTPException(
-            status_code=fastapi_status.HTTP_404_NOT_FOUND,
-            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
-        )
-    rows = await OperationRepository(session).list_for_workspace(
+    rows = await WorkspaceService(session_factory).list_operations(
         workspace_id,
         status=status,
         operation_type=operation_type,
         limit=limit,
     )
+    if rows is None:
+        raise HTTPException(
+            status_code=fastapi_status.HTTP_404_NOT_FOUND,
+            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
+        )
     return OperationListResponse(
-        items=[OperationResponse.model_validate(row) for row in rows],
+        items=rows,
         next_cursor=None,
         has_more=False,
     )

--- a/src/awf/api/routes/operations.py
+++ b/src/awf/api/routes/operations.py
@@ -8,10 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as fastapi_status
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.api.deps import get_db_session, get_db_session_factory
+from awf.api.deps import get_db_session_factory
 from awf.api.schemas import OperationListResponse, OperationResponse
 from awf.db.enums import OperationStatus, OperationType
-from awf.db.repositories import OperationRepository
 from awf.service.workspaces import WorkspaceService
 
 router = APIRouter(tags=["operations"])
@@ -23,9 +22,9 @@ async def list_operations(
     status: OperationStatus | None = None,
     operation_type: Annotated[OperationType | None, Query(alias="type")] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
-    session: AsyncSession = Depends(get_db_session),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> OperationListResponse:
-    rows = await OperationRepository(session).list_all(
+    rows = await WorkspaceService(session_factory).list_all_operations(
         workspace_id=workspace_id,
         status=status,
         operation_type=operation_type,
@@ -41,15 +40,15 @@ async def list_operations(
 @router.get("/v1/operations/{operation_id}", response_model=OperationResponse)
 async def get_operation(
     operation_id: str,
-    session: AsyncSession = Depends(get_db_session),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> OperationResponse:
-    operation = await OperationRepository(session).get(operation_id)
+    operation = await WorkspaceService(session_factory).get_operation(operation_id)
     if operation is None:
         raise HTTPException(
             status_code=fastapi_status.HTTP_404_NOT_FOUND,
             detail={"error_code": "NOT_FOUND", "message": f"No operation with id {operation_id}"},
         )
-    return OperationResponse.model_validate(operation)
+    return operation
 
 
 @router.get("/v1/workspaces/{workspace_id}/operations", response_model=OperationListResponse)

--- a/src/awf/api/routes/runtime.py
+++ b/src/awf/api/routes/runtime.py
@@ -7,7 +7,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.deps import get_db_session_factory
 from awf.api.schemas import WorkspaceRuntimeResponse
-from awf.runtime.inspection import RuntimeInspector
 from awf.service.workspaces import WorkspaceService
 
 router = APIRouter(prefix="/v1/workspaces/{workspace_id}/runtime", tags=["runtime"])
@@ -18,10 +17,7 @@ async def get_workspace_runtime(
     workspace_id: str,
     session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> WorkspaceRuntimeResponse:
-    result = await WorkspaceService(
-        session_factory,
-        runtime_inspector=RuntimeInspector(),
-    ).get_runtime(workspace_id)
+    result = await WorkspaceService(session_factory).get_runtime(workspace_id)
     if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/src/awf/api/routes/runtime.py
+++ b/src/awf/api/routes/runtime.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, status
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.api.deps import get_db_session
-from awf.api.schemas import RuntimeServiceResponse, WorkspaceRuntimeResponse
-from awf.db.repositories import WorkspaceRepository
+from awf.api.deps import get_db_session_factory
+from awf.api.schemas import WorkspaceRuntimeResponse
 from awf.runtime.inspection import RuntimeInspector
+from awf.service.workspaces import WorkspaceService
 
 router = APIRouter(prefix="/v1/workspaces/{workspace_id}/runtime", tags=["runtime"])
 
@@ -16,33 +16,15 @@ router = APIRouter(prefix="/v1/workspaces/{workspace_id}/runtime", tags=["runtim
 @router.get("", response_model=WorkspaceRuntimeResponse)
 async def get_workspace_runtime(
     workspace_id: str,
-    session: AsyncSession = Depends(get_db_session),
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> WorkspaceRuntimeResponse:
-    workspace = await WorkspaceRepository(session).get(workspace_id)
-    if workspace is None:
+    result = await WorkspaceService(
+        session_factory,
+        runtime_inspector=RuntimeInspector(),
+    ).get_runtime(workspace_id)
+    if result is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
         )
-    snapshot = await RuntimeInspector().inspect(workspace.compose_project_name)
-    return WorkspaceRuntimeResponse(
-        workspace_id=workspace_id,
-        compose_project_name=workspace.compose_project_name,
-        stack_state=snapshot.stack_state,
-        services=[
-            RuntimeServiceResponse(
-                name=s.name,
-                container_id=s.container_id,
-                image=s.image,
-                state=s.state,
-                status=s.status,
-                health=s.health,
-                ports=s.ports,
-                started_at=s.started_at,
-            )
-            for s in snapshot.services
-        ],
-        logs_available=True,
-        control_available=True,
-        reason=snapshot.reason,
-    )
+    return result

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -232,6 +232,23 @@ def build_mcp_server(
         )
         return [row.model_dump(mode="json") for row in rows] if rows is not None else None
 
+    @mcp.tool(name="awf_get_workspace_runtime")
+    async def awf_get_workspace_runtime(
+        workspace_id: str = Field(..., description="Workspace ID to inspect."),
+    ) -> dict[str, Any] | None:
+        """Fetch compose/container runtime state for one workspace."""
+        result = await service.get_runtime(workspace_id)
+        return result.model_dump(mode="json") if result is not None else None
+
+    @mcp.tool(name="awf_list_workspace_operations")
+    async def awf_list_workspace_operations(
+        workspace_id: str = Field(..., description="Workspace ID to inspect."),
+        limit: int = Field(default=50, ge=1, le=500),
+    ) -> list[dict[str, Any]] | None:
+        """List one workspace's operations newest-first."""
+        rows = await service.list_operations(workspace_id, limit=limit)
+        return [row.model_dump(mode="json") for row in rows] if rows is not None else None
+
     @mcp.tool(name="awf_list_workspace_logs")
     async def awf_list_workspace_logs(
         workspace_id: str = Field(..., description="Workspace ID to inspect."),

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -132,6 +132,32 @@ class WorkspaceService:
             )
             return [OperationResponse.model_validate(row) for row in rows]
 
+    async def list_all_operations(
+        self,
+        *,
+        workspace_id: str | None = None,
+        status: OperationStatus | str | None = None,
+        operation_type: OperationType | str | None = None,
+        limit: int = 50,
+    ) -> builtins.list[OperationResponse]:
+        async with self._factory() as s:
+            rows = await OperationRepository(s).list_all(
+                workspace_id=workspace_id,
+                status=status,
+                operation_type=operation_type,
+                limit=limit,
+            )
+            return [OperationResponse.model_validate(row) for row in rows]
+
+    async def get_operation(self, operation_id: str) -> OperationResponse | None:
+        async with self._factory() as s:
+            operation = await OperationRepository(s).get(operation_id)
+            return (
+                OperationResponse.model_validate(operation)
+                if operation is not None
+                else None
+            )
+
     async def list_events(
         self,
         workspace_id: str,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -4,26 +4,36 @@ from __future__ import annotations
 
 import builtins
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.schemas import (
+    OperationResponse,
+    RuntimeServiceResponse,
     WorkspaceCreateRequest,
     WorkspaceCreateV2Request,
     WorkspaceEventResponse,
     WorkspaceLogStreamResponse,
     WorkspaceResponse,
+    WorkspaceRuntimeResponse,
 )
+from awf.db.enums import OperationStatus, OperationType
 from awf.db.models import Workspace
 from awf.db.repositories import (
+    OperationRepository,
     WorkspaceEventRepository,
     WorkspaceLogStreamRepository,
     WorkspaceRepository,
 )
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
+from awf.runtime.inspection import RuntimeInspector, RuntimeSnapshot
 from awf.runtime.logs import read_log_chunk
+
+
+class RuntimeInspection(Protocol):
+    async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot: ...
 
 
 class WorkspaceService:
@@ -34,9 +44,11 @@ class WorkspaceService:
         session_factory: async_sessionmaker[AsyncSession],
         *,
         log_root: Path | str | None = None,
+        runtime_inspector: RuntimeInspection | None = None,
     ) -> None:
         self._factory = session_factory
         self._log_root = Path(log_root).resolve() if log_root is not None else None
+        self._runtime_inspector = runtime_inspector or RuntimeInspector()
 
     async def create(self, req: WorkspaceCreateRequest) -> WorkspaceResponse:
         async with self._factory() as s:
@@ -69,6 +81,56 @@ class WorkspaceService:
         async with self._factory() as s:
             rows = await WorkspaceRepository(s).list(limit=limit)
             return [WorkspaceResponse.model_validate(r) for r in rows]
+
+    async def get_runtime(self, workspace_id: str) -> WorkspaceRuntimeResponse | None:
+        async with self._factory() as s:
+            workspace = await WorkspaceRepository(s).get(workspace_id)
+            if workspace is None:
+                return None
+            compose_project_name = workspace.compose_project_name
+
+        snapshot = await self._runtime_inspector.inspect(compose_project_name)
+        return WorkspaceRuntimeResponse(
+            workspace_id=workspace_id,
+            compose_project_name=compose_project_name,
+            stack_state=snapshot.stack_state,
+            services=[
+                RuntimeServiceResponse(
+                    name=s.name,
+                    container_id=s.container_id,
+                    image=s.image,
+                    state=s.state,
+                    status=s.status,
+                    health=s.health,
+                    ports=s.ports,
+                    started_at=s.started_at,
+                )
+                for s in snapshot.services
+            ],
+            logs_available=True,
+            control_available=True,
+            reason=snapshot.reason,
+        )
+
+    async def list_operations(
+        self,
+        workspace_id: str,
+        *,
+        status: OperationStatus | str | None = None,
+        operation_type: OperationType | str | None = None,
+        limit: int = 50,
+    ) -> builtins.list[OperationResponse] | None:
+        async with self._factory() as s:
+            workspace_repo = WorkspaceRepository(s)
+            if not await workspace_repo.exists(workspace_id):
+                return None
+            rows = await OperationRepository(s).list_for_workspace(
+                workspace_id,
+                status=status,
+                operation_type=operation_type,
+                limit=limit,
+            )
+            return [OperationResponse.model_validate(row) for row in rows]
 
     async def list_events(
         self,

--- a/tests/unit/api/test_observability_api.py
+++ b/tests/unit/api/test_observability_api.py
@@ -14,8 +14,8 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from starlette.testclient import WebSocketDenialResponse
 
 import awf.api.routes.controls as controls_route
-import awf.api.routes.runtime as runtime_route
 import awf.api.routes.ws as ws_route
+import awf.service.workspaces as workspace_service
 from awf.api.app import configure_database, create_app
 from awf.common.config import get_settings
 from awf.db.base import Base
@@ -149,7 +149,7 @@ class TestConsoleViews:
                     ],
                 )
 
-        monkeypatch.setattr(runtime_route, "RuntimeInspector", FakeRuntimeInspector)
+        monkeypatch.setattr(workspace_service, "RuntimeInspector", FakeRuntimeInspector)
 
         response = await client.get(f"/v1/workspaces/{workspace_id}/runtime")
 

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -17,9 +17,11 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.db.base import Base
-from awf.db.repositories import WorkspaceRepository
+from awf.db.enums import OperationStatus, OperationType
+from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.mcp.server import WorkspaceService, build_mcp_server
+from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
 from awf.runtime.logs import LogStore
 
 
@@ -79,6 +81,8 @@ class TestToolRegistration:
         } <= names
         assert {
             "awf_create_workspace_v2",
+            "awf_get_workspace_runtime",
+            "awf_list_workspace_operations",
             "awf_list_workspace_events",
             "awf_list_workspace_logs",
             "awf_read_workspace_log",
@@ -350,6 +354,149 @@ class TestWorkspaceEvents:
         result = await _call(
             mcp,
             "awf_list_workspace_events",
+            {"workspace_id": "ws_missing"},
+        )
+
+        assert result is None
+
+
+class TestWorkspaceRuntime:
+    @pytest.mark.unit
+    async def test_get_workspace_runtime_returns_container_snapshot(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        class FakeRuntimeInspector:
+            async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
+                assert compose_project_name == "awf_ws_mcp_runtime"
+                return RuntimeSnapshot(
+                    stack_state="running",
+                    services=[
+                        RuntimeService(
+                            name="agent",
+                            container_id="abc123",
+                            image="awf-agent-runtime:latest",
+                            state="running",
+                            status="Up 1 minute",
+                            health="healthy",
+                            ports=["127.0.0.1:8000->8000/tcp"],
+                            started_at="2026-04-25T10:00:00Z",
+                        )
+                    ],
+                )
+
+        service = WorkspaceService(factory, runtime_inspector=FakeRuntimeInspector())
+        mcp = build_mcp_server(service=service)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/app.git",
+                branch_base="main",
+                task_title="Observe runtime",
+                task_prompt="Inspect runtime.",
+                agent="codex",
+                test_commands=[],
+            )
+            workspace.compose_project_name = "awf_ws_mcp_runtime"
+            await session.commit()
+
+        runtime = await _call(
+            mcp,
+            "awf_get_workspace_runtime",
+            {"workspace_id": workspace.id},
+        )
+
+        assert runtime == {
+            "workspace_id": workspace.id,
+            "compose_project_name": "awf_ws_mcp_runtime",
+            "stack_state": "running",
+            "services": [
+                {
+                    "name": "agent",
+                    "container_id": "abc123",
+                    "image": "awf-agent-runtime:latest",
+                    "state": "running",
+                    "status": "Up 1 minute",
+                    "health": "healthy",
+                    "ports": ["127.0.0.1:8000->8000/tcp"],
+                    "started_at": "2026-04-25T10:00:00Z",
+                }
+            ],
+            "logs_available": True,
+            "control_available": True,
+            "reason": None,
+        }
+
+    @pytest.mark.unit
+    async def test_get_workspace_runtime_missing_workspace_returns_none(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = await _call(
+            mcp,
+            "awf_get_workspace_runtime",
+            {"workspace_id": "ws_missing"},
+        )
+
+        assert result is None
+
+
+class TestWorkspaceOperations:
+    @pytest.mark.unit
+    async def test_list_workspace_operations_respects_limit(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        base = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/app.git",
+                branch_base="main",
+                task_title="Observe operations",
+                task_prompt="List operations.",
+                agent="codex",
+                test_commands=[],
+            )
+            repo = OperationRepository(session)
+            create = await repo.create(
+                workspace_id=workspace.id,
+                operation_type=OperationType.create,
+                status=OperationStatus.succeeded,
+            )
+            validate = await repo.create(
+                workspace_id=workspace.id,
+                operation_type=OperationType.validate,
+                status=OperationStatus.running,
+            )
+            stop = await repo.create(
+                workspace_id=workspace.id,
+                operation_type=OperationType.stop,
+                status=OperationStatus.pending,
+            )
+            create.created_at = base
+            validate.created_at = base + timedelta(seconds=1)
+            stop.created_at = base + timedelta(seconds=2)
+            await session.commit()
+
+        operations = await _call(
+            mcp,
+            "awf_list_workspace_operations",
+            {"workspace_id": workspace.id, "limit": 2},
+        )
+
+        assert isinstance(operations, list)
+        assert [item["id"] for item in operations] == [stop.id, validate.id]
+        assert [item["type"] for item in operations] == ["stop", "validate"]
+        assert [item["status"] for item in operations] == ["pending", "running"]
+
+    @pytest.mark.unit
+    async def test_list_workspace_operations_missing_workspace_returns_none(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        result = await _call(
+            mcp,
+            "awf_list_workspace_operations",
             {"workspace_id": "ws_missing"},
         )
 

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -123,3 +123,54 @@ async def test_list_operations_respects_limit_and_none_for_missing_workspace(
     assert [row.type for row in rows] == ["stop", "validate"]
     assert [row.status for row in rows] == ["pending", "running"]
     assert missing is None
+
+
+@pytest.mark.unit
+async def test_global_operation_helpers_filter_and_get(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    base = datetime(2026, 4, 25, 13, 0, tzinfo=UTC)
+    async with factory() as session:
+        ws_repo = WorkspaceRepository(session)
+        first_workspace = await ws_repo.create(
+            repo_url="git@github.com:example/first.git",
+            branch_base="main",
+            task_title="First operations",
+            task_prompt="List first operations.",
+            agent="codex",
+            test_commands=[],
+        )
+        second_workspace = await ws_repo.create(
+            repo_url="git@github.com:example/second.git",
+            branch_base="main",
+            task_title="Second operations",
+            task_prompt="List second operations.",
+            agent="codex",
+            test_commands=[],
+        )
+        repo = OperationRepository(session)
+        first_operation = await repo.create(
+            workspace_id=first_workspace.id,
+            operation_type=OperationType.create,
+            status=OperationStatus.succeeded,
+        )
+        second_operation = await repo.create(
+            workspace_id=second_workspace.id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.running,
+        )
+        first_operation.created_at = base
+        second_operation.created_at = base + timedelta(seconds=1)
+        await session.commit()
+
+    rows = await service.list_all_operations(status=OperationStatus.running)
+    operation = await service.get_operation(first_operation.id)
+    missing = await service.get_operation("op_missing")
+
+    assert [row.id for row in rows] == [second_operation.id]
+    assert rows[0].workspace_id == second_workspace.id
+    assert operation is not None
+    assert operation.id == first_operation.id
+    assert operation.type == "create"
+    assert missing is None

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -1,0 +1,125 @@
+"""Workspace service observability helpers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.base import Base
+from awf.db.enums import OperationStatus, OperationType
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
+from awf.service.workspaces import WorkspaceService
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.unit
+async def test_get_runtime_returns_snapshot_and_none_for_missing_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    class FakeRuntimeInspector:
+        async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
+            assert compose_project_name == "awf_ws_service_runtime"
+            return RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="abc123",
+                        image="awf-agent-runtime:latest",
+                        state="running",
+                        status="Up 1 minute",
+                        health="healthy",
+                        ports=["127.0.0.1:8000->8000/tcp"],
+                        started_at="2026-04-25T10:00:00Z",
+                    )
+                ],
+            )
+
+    service = WorkspaceService(factory, runtime_inspector=FakeRuntimeInspector())
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="main",
+            task_title="Observe runtime",
+            task_prompt="Inspect runtime.",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.compose_project_name = "awf_ws_service_runtime"
+        await session.commit()
+
+    snapshot = await service.get_runtime(workspace.id)
+    missing = await service.get_runtime("ws_missing")
+
+    assert snapshot is not None
+    assert snapshot.workspace_id == workspace.id
+    assert snapshot.compose_project_name == "awf_ws_service_runtime"
+    assert snapshot.stack_state == "running"
+    assert snapshot.logs_available is True
+    assert snapshot.control_available is True
+    assert snapshot.reason is None
+    assert len(snapshot.services) == 1
+    assert snapshot.services[0].name == "agent"
+    assert snapshot.services[0].health == "healthy"
+    assert missing is None
+
+
+@pytest.mark.unit
+async def test_list_operations_respects_limit_and_none_for_missing_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    base = datetime(2026, 4, 25, 12, 0, tzinfo=UTC)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/app.git",
+            branch_base="main",
+            task_title="Observe operations",
+            task_prompt="List operations.",
+            agent="codex",
+            test_commands=[],
+        )
+        repo = OperationRepository(session)
+        create = await repo.create(
+            workspace_id=workspace.id,
+            operation_type=OperationType.create,
+            status=OperationStatus.succeeded,
+        )
+        validate = await repo.create(
+            workspace_id=workspace.id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.running,
+        )
+        stop = await repo.create(
+            workspace_id=workspace.id,
+            operation_type=OperationType.stop,
+            status=OperationStatus.pending,
+        )
+        create.created_at = base
+        validate.created_at = base + timedelta(seconds=1)
+        stop.created_at = base + timedelta(seconds=2)
+        await session.commit()
+
+    rows = await service.list_operations(workspace.id, limit=2)
+    missing = await service.list_operations("ws_missing")
+
+    assert rows is not None
+    assert [row.id for row in rows] == [stop.id, validate.id]
+    assert [row.type for row in rows] == ["stop", "validate"]
+    assert [row.status for row in rows] == ["pending", "running"]
+    assert missing is None


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_403019d55e4c4affb4ef1d88` (agent: `codex`).


### Task
Strict TDD task: extend the AWF MCP surface with runtime and operation observability.

Problem:
AWF's always-on service should be usable by agents and Aira through MCP, not only REST/CLI. MCP already supports create/get/list/events/logs, but it does not expose runtime/container state or operations, which the PRD calls out as core observability for a console and agent supervisors.

Required behavior:
- Add shared service-layer methods where appropriate so MCP can fetch:
  - runtime snapshot equivalent to GET `/v1/workspaces/{id}/runtime`.
  - operations equivalent to GET `/v1/workspaces/{id}/operations`.
- Add MCP tools:
  - `awf_get_workspace_runtime(workspace_id)` returning the runtime snapshot or null for missing workspace.
  - `awf_list_workspace_operations(workspace_id, limit=50)` returning operation rows or null for missing workspace.
- Keep this slice read-only; do not add cancel/stop/delete MCP tools yet.
- Preserve existing MCP tool names and behavior.
- Update README's MCP surface table and examples.

TDD requirements:
- Write failing MCP/service tests first, commit the red tests with failure output in the commit body.
- Cover missing workspace returns null, runtime payload shape, operation list limit, and existing tools still registered.
- Then implement until green.
- Commit with conventional commits. Do not push, open PRs, or switch branches; AWF owns that.

Validation:
uv run --python 3.12 --extra dev ruff check src/awf/mcp src/awf/service src/awf/api tests/unit/mcp tests/unit/api tests/unit/service
uv run --python 3.12 --extra dev mypy src/awf/mcp src/awf/service src/awf/api
uv run --python 3.12 --extra dev pytest tests/unit/mcp tests/unit/api tests/unit/service -q

---
Validation: 6 profile command(s) passed inside the workspace container.
