### PR TITLE
feat(service): resume PR monitors after worker restart

### DIFF
--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -761,7 +761,15 @@ class WorkspaceExecutor:
         happened before the workspace entered ``monitoring_pr``.
         """
         ws = await self._load_workspace(workspace_id)
-        if ws is None or ws.status != WorkspaceStatus.monitoring_pr.value:
+        if ws is None:
+            _log.warning("executor.resume_skip_unknown", workspace_id=workspace_id)
+            return
+        if ws.status != WorkspaceStatus.monitoring_pr.value:
+            _log.info(
+                "executor.resume_skip_not_monitoring_pr",
+                workspace_id=workspace_id,
+                status=ws.status,
+            )
             return
 
         missing = _missing_monitor_recovery_metadata(ws)

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -753,7 +753,95 @@ class WorkspaceExecutor:
             pr_url=pr.url,
         )
 
+    async def resume_pr_monitor(self, workspace_id: str) -> None:
+        """Resume the PR monitor for a workspace already in ``monitoring_pr``.
+
+        This is the service-worker restart path. It intentionally skips setup,
+        agent execution, validation, push, and PR creation; those have already
+        happened before the workspace entered ``monitoring_pr``.
+        """
+        ws = await self._load_workspace(workspace_id)
+        if ws is None or ws.status != WorkspaceStatus.monitoring_pr.value:
+            return
+
+        missing = _missing_monitor_recovery_metadata(ws)
+        if missing:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.monitoring_pr,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "monitor recovery: missing required persisted metadata: "
+                    + ", ".join(missing)
+                )[:2000],
+                reason_code="MONITOR_RECOVERY_METADATA_MISSING",
+            )
+            return
+
+        compose_project = ws.compose_project_name
+        compose_file_path = ws.compose_file_path
+        assert compose_project is not None
+        assert compose_file_path is not None
+
+        monitor: _MonitorRunnerProto | None = self._pr_monitor
+        try:
+            if monitor is None and self._pr_monitor_factory is not None:
+                agent = AgentRuntime(ws.agent)
+                defaults = self._defaults_for(agent)
+                adapter = get_adapter(
+                    agent,
+                    runner=self._runner,
+                    defaults=defaults,
+                    log_store=self._log_store,
+                )
+                profile = _profile_for_workspace(
+                    ws,
+                    worktree_path=self._config.worktrees_root / workspace_id,
+                )
+                monitor = _call_pr_monitor_factory(
+                    self._pr_monitor_factory,
+                    adapter=adapter,
+                    profile=profile,
+                    workspace=ws,
+                )
+        except Exception as exc:
+            _log.exception("executor.pr_monitor_resume_build_failed", workspace_id=workspace_id)
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.monitoring_pr,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=f"monitor recovery: failed to build PR monitor: {exc!r}"[:2000],
+                reason_code="MONITOR_RECOVERY_FAILED",
+            )
+            return
+
+        if monitor is None:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.monitoring_pr,
+                failure_reason=FailureReason.infrastructure_failure,
+                message="monitor recovery: no PR monitor configured",
+                reason_code="MONITOR_RECOVERY_FAILED",
+            )
+            return
+
+        _log.info(
+            "executor.resume_pr_monitor",
+            workspace_id=workspace_id,
+            pr_url=ws.pr_url,
+            pr_number=ws.pr_number,
+        )
+        await monitor.run(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=Path(compose_file_path),
+        )
+
     # ── Internals ──────────────────────────────────────────────────────────
+
+    async def _load_workspace(self, workspace_id: str) -> Workspace | None:
+        async with self._session_factory() as session:
+            return await WorkspaceRepository(session).get(workspace_id)
 
     def _defaults_for(self, agent: AgentRuntime) -> AgentDefaults | None:
         defaults = defaults_with_model_overrides(
@@ -797,6 +885,7 @@ class WorkspaceExecutor:
         from_status: WorkspaceStatus,
         failure_reason: FailureReason,
         message: str,
+        reason_code: str | None = None,
     ) -> None:
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
@@ -811,7 +900,7 @@ class WorkspaceExecutor:
             await repo.transition(
                 ws,
                 to=WorkspaceStatus.failed,
-                reason_code=failure_reason.value.upper(),
+                reason_code=reason_code or failure_reason.value.upper(),
             )
             await session.commit()
 
@@ -830,6 +919,21 @@ def _extract_pr_number(pr_url: str) -> int | None:
     """
     match = _PR_NUMBER_RE.search(pr_url)
     return int(match.group(1)) if match else None
+
+
+def _missing_monitor_recovery_metadata(ws: Workspace) -> list[str]:
+    missing: list[str] = []
+    if ws.pr_number is None:
+        missing.append("pr_number")
+    if not ws.pr_url:
+        missing.append("pr_url")
+    if not ws.remote_push_branch:
+        missing.append("remote_push_branch")
+    if not ws.compose_project_name:
+        missing.append("compose_project_name")
+    if not ws.compose_file_path:
+        missing.append("compose_file_path")
+    return missing
 
 
 def _call_pr_monitor_factory(

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -83,8 +83,10 @@ class ControlWorker:
         if self._executor is not None:
             execution_slots = self._available_execution_slots()
             if execution_slots > 0:
+                active_execution_ids = set(self._execution_tasks)
                 monitoring_ids = await self._list_monitoring_pr(
-                    limit=self._config.max_concurrent_executions
+                    limit=execution_slots,
+                    exclude_ids=active_execution_ids,
                 )
                 dispatched_ids.update(
                     self._dispatch_monitor_resumes(monitoring_ids, limit=execution_slots)
@@ -92,7 +94,10 @@ class ControlWorker:
 
             execution_slots = self._available_execution_slots()
             if execution_slots > 0:
-                ready_ids = await self._list_ready(limit=self._config.max_concurrent_executions)
+                ready_ids = await self._list_ready(
+                    limit=execution_slots,
+                    exclude_ids=set(self._execution_tasks),
+                )
                 dispatched_ids.update(
                     self._dispatch_ready_executions(ready_ids, limit=execution_slots)
                 )
@@ -131,27 +136,49 @@ class ControlWorker:
             limit=self._config.max_concurrent_provisions,
         )
 
-    async def _list_ready(self, *, limit: int | None = None) -> list[str]:
+    async def _list_ready(
+        self,
+        *,
+        limit: int | None = None,
+        exclude_ids: set[str] | None = None,
+    ) -> list[str]:
         """Return up to ``max_concurrent_executions`` workspace IDs in ``ready``."""
         row_limit = self._config.max_concurrent_executions if limit is None else limit
-        return await self._list_by_status(WorkspaceStatus.ready, limit=row_limit)
+        return await self._list_by_status(
+            WorkspaceStatus.ready,
+            limit=row_limit,
+            exclude_ids=exclude_ids,
+        )
 
-    async def _list_monitoring_pr(self, *, limit: int | None = None) -> list[str]:
+    async def _list_monitoring_pr(
+        self,
+        *,
+        limit: int | None = None,
+        exclude_ids: set[str] | None = None,
+    ) -> list[str]:
         """Return up to ``max_concurrent_executions`` IDs in ``monitoring_pr``."""
         row_limit = self._config.max_concurrent_executions if limit is None else limit
-        return await self._list_by_status(WorkspaceStatus.monitoring_pr, limit=row_limit)
+        return await self._list_by_status(
+            WorkspaceStatus.monitoring_pr,
+            limit=row_limit,
+            exclude_ids=exclude_ids,
+        )
 
-    async def _list_by_status(self, status: WorkspaceStatus, *, limit: int) -> list[str]:
+    async def _list_by_status(
+        self,
+        status: WorkspaceStatus,
+        *,
+        limit: int,
+        exclude_ids: set[str] | None = None,
+    ) -> list[str]:
         if limit <= 0:
             return []
 
         async with self._session_factory() as session:
-            stmt = (
-                select(Workspace.id)
-                .where(Workspace.status == status.value)
-                .order_by(Workspace.created_at)
-                .limit(limit)
-            )
+            stmt = select(Workspace.id).where(Workspace.status == status.value)
+            if exclude_ids:
+                stmt = stmt.where(~Workspace.id.in_(exclude_ids))
+            stmt = stmt.order_by(Workspace.created_at).limit(limit)
             result = await session.execute(stmt)
             return [row[0] for row in result.all()]
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -38,6 +38,7 @@ class WorkerConfig:
 
 class WorkspaceExecutorProtocol(Protocol):
     async def execute(self, workspace_id: str) -> None: ...
+    async def resume_pr_monitor(self, workspace_id: str) -> None: ...
 
 
 class ControlWorker:
@@ -63,7 +64,7 @@ class ControlWorker:
         self._stopped.set()
 
     async def run_once(self) -> int:
-        """Claim + dispatch requested provisioning and ready execution workspaces.
+        """Claim + dispatch requested provisioning and workspace runtime tasks.
 
         Returns the number of workspaces dispatched. A zero return is a signal
         for ``run_forever`` to sleep; non-zero means we may be throughput-bound
@@ -81,13 +82,25 @@ class ControlWorker:
 
         if self._executor is not None:
             execution_slots = self._available_execution_slots()
-            ready_ids = await self._list_ready(limit=execution_slots)
-            dispatched_ids.update(self._dispatch_ready_executions(ready_ids))
+            if execution_slots > 0:
+                monitoring_ids = await self._list_monitoring_pr(
+                    limit=self._config.max_concurrent_executions
+                )
+                dispatched_ids.update(
+                    self._dispatch_monitor_resumes(monitoring_ids, limit=execution_slots)
+                )
+
+            execution_slots = self._available_execution_slots()
+            if execution_slots > 0:
+                ready_ids = await self._list_ready(limit=self._config.max_concurrent_executions)
+                dispatched_ids.update(
+                    self._dispatch_ready_executions(ready_ids, limit=execution_slots)
+                )
 
         return len(dispatched_ids)
 
     async def wait_for_execution_tasks(self) -> None:
-        """Wait for ready-workspace execution tasks started by this worker."""
+        """Wait for ready execution or monitor-resume tasks started by this worker."""
         while self._execution_tasks:
             await asyncio.gather(*tuple(self._execution_tasks.values()))
 
@@ -123,6 +136,11 @@ class ControlWorker:
         row_limit = self._config.max_concurrent_executions if limit is None else limit
         return await self._list_by_status(WorkspaceStatus.ready, limit=row_limit)
 
+    async def _list_monitoring_pr(self, *, limit: int | None = None) -> list[str]:
+        """Return up to ``max_concurrent_executions`` IDs in ``monitoring_pr``."""
+        row_limit = self._config.max_concurrent_executions if limit is None else limit
+        return await self._list_by_status(WorkspaceStatus.monitoring_pr, limit=row_limit)
+
     async def _list_by_status(self, status: WorkspaceStatus, *, limit: int) -> list[str]:
         if limit <= 0:
             return []
@@ -140,15 +158,34 @@ class ControlWorker:
     def _available_execution_slots(self) -> int:
         return max(0, self._config.max_concurrent_executions - len(self._execution_tasks))
 
-    def _dispatch_ready_executions(self, workspace_ids: list[str]) -> set[str]:
+    def _dispatch_ready_executions(self, workspace_ids: list[str], *, limit: int) -> set[str]:
         dispatched: set[str] = set()
         for workspace_id in workspace_ids:
+            if len(dispatched) >= limit:
+                break
             if workspace_id in self._execution_tasks:
                 continue
 
             task = asyncio.create_task(
                 self._safely_execute(workspace_id),
                 name=f"awf-execute-{workspace_id}",
+            )
+            self._execution_tasks[workspace_id] = task
+            task.add_done_callback(partial(self._forget_execution_task, workspace_id))
+            dispatched.add(workspace_id)
+        return dispatched
+
+    def _dispatch_monitor_resumes(self, workspace_ids: list[str], *, limit: int) -> set[str]:
+        dispatched: set[str] = set()
+        for workspace_id in workspace_ids:
+            if len(dispatched) >= limit:
+                break
+            if workspace_id in self._execution_tasks:
+                continue
+
+            task = asyncio.create_task(
+                self._safely_resume_pr_monitor(workspace_id),
+                name=f"awf-monitor-{workspace_id}",
             )
             self._execution_tasks[workspace_id] = task
             task.add_done_callback(partial(self._forget_execution_task, workspace_id))
@@ -176,3 +213,14 @@ class ControlWorker:
             # skip-if-no-longer-ready semantics. The worker must keep polling
             # even if one execution path crashes before it can mark a failure.
             _log.exception("worker.execute_failed", workspace_id=workspace_id)
+
+    async def _safely_resume_pr_monitor(self, workspace_id: str) -> None:
+        if self._executor is None:
+            return
+        try:
+            await self._executor.resume_pr_monitor(workspace_id)
+        except Exception:
+            # The monitor runner owns normal terminal transitions. Recovery
+            # dispatch still must not take the service worker down if a single
+            # workspace hits an unexpected runtime error.
+            _log.exception("worker.pr_monitor_resume_failed", workspace_id=workspace_id)

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -838,8 +838,17 @@ class TestPrMonitorResume:
         ]
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("field", ["pr_number", "pr_url", "remote_push_branch"])
-    async def test_missing_pr_or_branch_metadata_fails_cleanly(
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "pr_number",
+            "pr_url",
+            "remote_push_branch",
+            "compose_project_name",
+            "compose_file_path",
+        ],
+    )
+    async def test_missing_monitor_recovery_metadata_fails_cleanly(
         self,
         field: str,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -32,6 +32,7 @@ from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.node.compose_manager import ComposeManager
+from awf.profiles.models import ProfileMonitor, WorkspaceProfile
 from awf.runtime.pr_creator import PullRequestCreator
 from awf.runtime.validation import ValidationRunner
 
@@ -109,6 +110,49 @@ async def _seed_ready(
         if auto_merge is not None:
             ws.auto_merge = auto_merge
         await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="SEED")
+        await s.commit()
+        return ws.id
+
+
+async def _seed_monitoring_pr(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    pr_number: int | None = 42,
+    pr_url: str | None = "https://github.com/x/y/pull/42",
+    remote_push_branch: str | None = "awf/x",
+    compose_project_name: str | None = "awf_x",
+    compose_file_path: str | None = "/tmp/awf/x/compose.yml",
+    resolved_profile: dict[str, Any] | None = None,
+    auto_merge: bool = True,
+    initial_review_grace_period_seconds: float | None = None,
+) -> str:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:x/y.git",
+            branch_base="development",
+            task_title="monitor-resume",
+            task_prompt="p",
+            agent="codex",
+            test_commands=["pytest -q"],
+            requires_database=False,
+            resolved_profile=resolved_profile,
+            auto_merge=auto_merge,
+            initial_review_grace_period_seconds=initial_review_grace_period_seconds,
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        ws.branch_name = "awf/x"
+        ws.remote_push_branch = remote_push_branch
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = compose_project_name
+        ws.compose_file_path = compose_file_path
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="SEED")
+        ws.pr_url = pr_url
+        ws.pr_number = pr_number
+        await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="SEED")
         await s.commit()
         return ws.id
 
@@ -716,3 +760,107 @@ class TestPrMonitorFactoryPath:
         assert len(factory_workspaces) == 1
         assert factory_workspaces[0].id == ws_id
         assert factory_workspaces[0].auto_merge is False
+
+
+class TestPrMonitorResume:
+    @pytest.mark.unit
+    async def test_resume_pr_monitor_uses_persisted_workspace_metadata(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        compose_file = tmp_path / "persisted-compose" / "compose.yml"
+        resolved_profile = WorkspaceProfile(
+            name="persisted",
+            monitor=ProfileMonitor(initial_review_grace_period_seconds=321),
+        ).model_dump(mode="json")
+        factory_calls: list[dict[str, Any]] = []
+        monitor_calls: list[dict[str, Any]] = []
+
+        class _FakeMonitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                monitor_calls.append(
+                    {
+                        "workspace_id": workspace_id,
+                        "compose_project": compose_project,
+                        "compose_file": compose_file,
+                    }
+                )
+
+        def _monitor_factory(adapter: Any, profile: Any, workspace: Any) -> _FakeMonitor:
+            factory_calls.append(
+                {
+                    "adapter": adapter,
+                    "profile_name": profile.name,
+                    "profile_grace": profile.monitor.initial_review_grace_period_seconds,
+                    "auto_merge": workspace.auto_merge,
+                    "workspace_grace": workspace.initial_review_grace_period_seconds,
+                    "pr_number": workspace.pr_number,
+                    "pr_url": workspace.pr_url,
+                    "remote_push_branch": workspace.remote_push_branch,
+                }
+            )
+            return _FakeMonitor()
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            pr_number=77,
+            pr_url="https://github.com/x/y/pull/77",
+            remote_push_branch="awf/persisted",
+            compose_project_name="persisted_project",
+            compose_file_path=str(compose_file),
+            resolved_profile=resolved_profile,
+            auto_merge=False,
+            initial_review_grace_period_seconds=12.5,
+        )
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.resume_pr_monitor(ws_id)
+
+        assert fake.calls == []
+        assert len(factory_calls) == 1
+        assert factory_calls[0]["profile_name"] == "persisted"
+        assert factory_calls[0]["profile_grace"] == 321
+        assert factory_calls[0]["auto_merge"] is False
+        assert factory_calls[0]["workspace_grace"] == 12.5
+        assert factory_calls[0]["pr_number"] == 77
+        assert factory_calls[0]["pr_url"] == "https://github.com/x/y/pull/77"
+        assert factory_calls[0]["remote_push_branch"] == "awf/persisted"
+        assert monitor_calls == [
+            {
+                "workspace_id": ws_id,
+                "compose_project": "persisted_project",
+                "compose_file": compose_file,
+            }
+        ]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("field", ["pr_number", "pr_url", "remote_push_branch"])
+    async def test_missing_pr_or_branch_metadata_fails_cleanly(
+        self,
+        field: str,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        kwargs: dict[str, Any] = {field: None}
+        ws_id = await _seed_monitoring_pr(factory, **kwargs)
+
+        def _monitor_factory(*_args: Any) -> object:
+            raise AssertionError("monitor factory must not run for invalid recovery rows")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.resume_pr_monitor(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert field in (ws.failure_message or "")
+            assert "monitor recovery" in (ws.failure_message or "")
+            assert ws.events[-1].reason_code == "MONITOR_RECOVERY_METADATA_MISSING"

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -21,6 +21,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import awf.control.executor as executor_module
@@ -763,6 +764,50 @@ class TestPrMonitorFactoryPath:
 
 
 class TestPrMonitorResume:
+    @pytest.mark.unit
+    async def test_resume_pr_monitor_logs_unknown_workspace(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        executor = _make_executor(fake, factory, tmp_path)
+
+        with structlog.testing.capture_logs() as captured:
+            await executor.resume_pr_monitor("ws_never_existed")
+
+        assert fake.calls == []
+        assert any(
+            event.get("event") == "executor.resume_skip_unknown"
+            and event.get("workspace_id") == "ws_never_existed"
+            for event in captured
+        )
+
+    @pytest.mark.unit
+    async def test_resume_pr_monitor_logs_unexpected_status(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_ready(factory)
+
+        def _monitor_factory(*_args: Any) -> object:
+            raise AssertionError("monitor factory must not run for non-monitoring workspaces")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        with structlog.testing.capture_logs() as captured:
+            await executor.resume_pr_monitor(ws_id)
+
+        assert fake.calls == []
+        assert any(
+            event.get("event") == "executor.resume_skip_not_monitoring_pr"
+            and event.get("workspace_id") == ws_id
+            and event.get("status") == WorkspaceStatus.ready.value
+            for event in captured
+        )
+
     @pytest.mark.unit
     async def test_resume_pr_monitor_uses_persisted_workspace_metadata(
         self,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -347,6 +347,85 @@ class TestRunOnceExecution:
         assert set(executor.calls) == set(ready_ids[:3])
 
     @pytest.mark.unit
+    async def test_execution_queries_are_limited_to_available_slots(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=3,
+            ),
+        )
+        release = asyncio.Event()
+
+        async def _busy() -> None:
+            await release.wait()
+
+        active_task = asyncio.create_task(_busy())
+        worker._execution_tasks["busy"] = active_task
+
+        limits: dict[str, int | None] = {}
+        exclusions: dict[str, set[str]] = {}
+
+        async def _list_monitoring_pr(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            limits["monitoring"] = limit
+            exclusions["monitoring"] = set(exclude_ids or set())
+            return []
+
+        async def _list_ready(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            limits["ready"] = limit
+            exclusions["ready"] = set(exclude_ids or set())
+            return []
+
+        worker._list_monitoring_pr = _list_monitoring_pr  # type: ignore[method-assign]
+        worker._list_ready = _list_ready  # type: ignore[method-assign]
+
+        try:
+            assert await worker.run_once() == 0
+            assert limits == {"monitoring": 2, "ready": 2}
+            assert exclusions == {"monitoring": {"busy"}, "ready": {"busy"}}
+        finally:
+            release.set()
+            await asyncio.wait_for(active_task, timeout=0.2)
+            worker._execution_tasks.pop("busy", None)
+
+    @pytest.mark.unit
+    async def test_monitor_query_excludes_active_ids_before_limiting(
+        self,
+        worker: ControlWorker,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_ids = [
+            await _create_monitoring_pr(
+                session_factory,
+                origin_repo,
+                f"needs-monitor-resume-{i}",
+                pr_number=100 + i,
+            )
+            for i in range(3)
+        ]
+
+        assert await worker._list_monitoring_pr(
+            limit=2,
+            exclude_ids={monitor_ids[0]},
+        ) == monitor_ids[1:]
+
+    @pytest.mark.unit
     async def test_ready_workspace_is_noop_when_no_executor_is_wired(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -472,6 +472,14 @@ class TestRunOnceMonitorRecovery:
                 self.resume_calls.append(workspace_id)
                 monitor_started.set()
                 await release_monitor.wait()
+                async with session_factory() as s:
+                    repo = WorkspaceRepository(s)
+                    ws = await repo.get(workspace_id)
+                    assert ws is not None
+                    await repo.transition(
+                        ws, to=WorkspaceStatus.completed, reason_code="TEST_MONITOR_DONE"
+                    )
+                    await s.commit()
 
         executor = _BlockingExecutor()
         worker = ControlWorker(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -108,6 +108,40 @@ async def _create_ready(
         return ws.id
 
 
+async def _create_monitoring_pr(
+    session_factory: async_sessionmaker[AsyncSession],
+    origin: Path,
+    title: str,
+    *,
+    pr_number: int = 123,
+) -> str:
+    async with session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url=str(origin),
+            branch_base="development",
+            task_title=title,
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.remote_push_branch = ws.branch_name
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.compose_file_path = f"/tmp/awf/{ws.id}/compose.yml"
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="SEED")
+        ws.pr_url = f"https://github.com/example/repo/pull/{pr_number}"
+        ws.pr_number = pr_number
+        await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="SEED")
+        await s.commit()
+        return ws.id
+
+
 class _TransitioningProvisioner:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
@@ -131,9 +165,13 @@ class _TransitioningProvisioner:
 class _RecordingExecutor:
     def __init__(self) -> None:
         self.calls: list[str] = []
+        self.resume_calls: list[str] = []
 
     async def execute(self, workspace_id: str) -> None:
         self.calls.append(workspace_id)
+
+    async def resume_pr_monitor(self, workspace_id: str) -> None:
+        self.resume_calls.append(workspace_id)
 
 
 class TestRunOnce:
@@ -390,3 +428,113 @@ class TestRunOnceExecution:
         assert await worker.run_once() == 2
         await worker.wait_for_execution_tasks()
         assert set(executor.calls) == {first_id, second_id}
+
+
+class TestRunOnceMonitorRecovery:
+    @pytest.mark.unit
+    async def test_fresh_worker_resumes_monitoring_pr_workspace(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "needs-monitor-resume"
+        )
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=3),
+        )
+
+        assert await worker.run_once() == 1
+        await worker.wait_for_execution_tasks()
+
+        assert executor.calls == []
+        assert executor.resume_calls == [monitor_id]
+
+    @pytest.mark.unit
+    async def test_monitor_resume_and_ready_execution_share_execution_limit(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "needs-monitor-resume"
+        )
+        ready_id = await _create_ready(session_factory, origin_repo, "already-ready")
+        monitor_started = asyncio.Event()
+        release_monitor = asyncio.Event()
+
+        class _BlockingExecutor(_RecordingExecutor):
+            async def resume_pr_monitor(self, workspace_id: str) -> None:
+                self.resume_calls.append(workspace_id)
+                monitor_started.set()
+                await release_monitor.wait()
+
+        executor = _BlockingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=1,
+            ),
+        )
+
+        assert await asyncio.wait_for(worker.run_once(), timeout=0.2) == 1
+        await asyncio.wait_for(monitor_started.wait(), timeout=0.2)
+        assert executor.resume_calls == [monitor_id]
+        assert executor.calls == []
+
+        assert await asyncio.wait_for(worker.run_once(), timeout=0.2) == 0
+        assert executor.calls == []
+
+        release_monitor.set()
+        await asyncio.wait_for(worker.wait_for_execution_tasks(), timeout=0.2)
+
+        assert await worker.run_once() == 1
+        await worker.wait_for_execution_tasks()
+        assert executor.calls == [ready_id]
+
+    @pytest.mark.unit
+    async def test_monitor_resume_does_not_duplicate_active_task(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "needs-monitor-resume"
+        )
+        monitor_started = asyncio.Event()
+        release_monitor = asyncio.Event()
+
+        class _BlockingExecutor(_RecordingExecutor):
+            async def resume_pr_monitor(self, workspace_id: str) -> None:
+                self.resume_calls.append(workspace_id)
+                monitor_started.set()
+                await release_monitor.wait()
+
+        executor = _BlockingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=2,
+            ),
+        )
+
+        assert await asyncio.wait_for(worker.run_once(), timeout=0.2) == 1
+        await asyncio.wait_for(monitor_started.wait(), timeout=0.2)
+
+        assert await asyncio.wait_for(worker.run_once(), timeout=0.2) == 0
+        assert executor.resume_calls == [monitor_id]
+
+        release_monitor.set()
+        await asyncio.wait_for(worker.wait_for_execution_tasks(), timeout=0.2)


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_66d7faf6ef014dea9dcb7939` (agent: `codex`).


### Task
Strict TDD task: implement service-worker recovery for PR monitors after worker/API restarts.

Problem:
The always-on AWF service worker currently dispatches requested workspaces for provisioning and ready workspaces for execution. If the worker process dies or the service is rebuilt while a workspace is already in monitoring_pr, the in-memory PR monitor task disappears and the workspace/PR can be stranded. This is not acceptable for AWF as an always-on agent workspace fabric.

Required behavior:
- On worker run_once/run_forever, detect monitoring_pr workspaces that still need an active PR monitor.
- Resume the existing PR monitor without rerunning setup, agent execution, validation, push, or PR creation.
- Respect max_concurrent_executions and avoid duplicate in-memory monitor tasks for the same workspace.
- Use the workspace's persisted pr_number/pr_url, remote_push_branch, compose_project_name, compose_file_path, resolved profile, agent, auto_merge, and monitor grace settings.
- If a monitoring_pr workspace is missing required persisted PR/branch metadata, fail it with a structured monitor/service failure instead of crashing the worker.
- Do not change completed, failed, cancelled, or destroyed workspaces.
- Keep the implementation small and consistent with existing ControlWorker, WorkspaceExecutor, and service worker factory patterns.

TDD requirements:
- Write failing unit tests first, commit the red tests with the failure snippet in the commit body.
- Add tests that prove monitoring_pr workspaces are resumed after a fresh worker instance starts.
- Add tests that prove ready execution and monitor resume share the configured concurrency limit and do not duplicate tasks.
- Add tests for missing PR metadata failing cleanly.
- Then implement until green.
- Commit with conventional commits. Do not push, open PRs, or switch branches; AWF owns that.

Validation:
uv run --python 3.12 --extra dev ruff check src/awf/control src/awf/service tests/unit/control tests/unit/service
uv run --python 3.12 --extra dev mypy src/awf/control src/awf/service
uv run --python 3.12 --extra dev pytest tests/unit/control tests/unit/service -q

---
Validation: 6 profile command(s) passed inside the workspace container.
