### PR TITLE
feat(mcp): expose workspace control tools

### DIFF
--- a/src/awf/api/routes/controls.py
+++ b/src/awf/api/routes/controls.py
@@ -2,22 +2,19 @@
 
 from __future__ import annotations
 
-import asyncio
-from pathlib import Path
-
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.deps import get_db_session, require_api_token
 from awf.api.schemas import WorkspaceControlRequest, WorkspaceControlResponse
-from awf.common.config import get_settings
-from awf.control.state_machine import WorkspaceStateMachine
-from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
-from awf.db.models import Workspace
-from awf.db.repositories import OperationRepository, WorkspaceRepository
-from awf.node.cleanup import WorkspaceCleaner
-from awf.node.compose_manager import ComposeManager
-from awf.node.git_manager import GitManager
+from awf.service.controls import (
+    ActiveWorkspaceDestroyError,
+    WorkspaceControlError,
+    WorkspaceControlService,
+    WorkspaceNotFoundError,
+    default_cleaner,
+    stop_project_containers,
+)
 
 router = APIRouter(
     prefix="/v1/workspaces/{workspace_id}",
@@ -32,42 +29,14 @@ async def cancel_workspace(
     payload: WorkspaceControlRequest,
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkspaceControlResponse:
-    repo = WorkspaceRepository(session)
-    operations = OperationRepository(session)
-    workspace = await _require_workspace(repo, workspace_id)
-    operation = await operations.create(
-        workspace_id=workspace_id,
-        operation_type=OperationType.cancel,
-        status=OperationStatus.running,
-        payload=payload.model_dump(),
-    )
-    if payload.stop_stack:
-        await _stop_project(workspace.compose_project_name)
-    if workspace.status != WorkspaceStatus.cancelled.value and WorkspaceStateMachine.can_transition(
-        WorkspaceStatus(workspace.status),
-        WorkspaceStatus.cancelled,
-    ):
-        await repo.transition(
-            workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_CANCEL"
+    try:
+        return await _controls(session).cancel_workspace(
+            workspace_id,
+            reason=payload.reason,
+            stop_stack=payload.stop_stack,
         )
-    else:
-        await repo.add_event(
-            workspace,
-            event_type="workspace.cancel_requested",
-            reason_code="OPERATOR_CANCEL",
-            payload=payload.model_dump(),
-        )
-    await operations.finish(
-        operation,
-        status=OperationStatus.succeeded,
-        result={"status": workspace.status},
-    )
-    return WorkspaceControlResponse(
-        workspace_id=workspace_id,
-        operation_id=operation.id,
-        status=WorkspaceStatus(workspace.status),
-        message="workspace cancellation requested",
-    )
+    except WorkspaceControlError as exc:
+        raise _http_error(exc) from exc
 
 
 @router.post("/stop", response_model=WorkspaceControlResponse)
@@ -76,39 +45,13 @@ async def stop_workspace(
     payload: WorkspaceControlRequest,
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkspaceControlResponse:
-    repo = WorkspaceRepository(session)
-    operations = OperationRepository(session)
-    workspace = await _require_workspace(repo, workspace_id)
-    operation = await operations.create(
-        workspace_id=workspace_id,
-        operation_type=OperationType.stop,
-        status=OperationStatus.running,
-        payload=payload.model_dump(),
-    )
-    await _stop_project(workspace.compose_project_name)
-    if _is_active(WorkspaceStatus(workspace.status)) and WorkspaceStateMachine.can_transition(
-        WorkspaceStatus(workspace.status),
-        WorkspaceStatus.cancelled,
-    ):
-        await repo.transition(workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_STOP")
-    else:
-        await repo.add_event(
-            workspace,
-            event_type="workspace.stack_stopped",
-            reason_code="OPERATOR_STOP",
-            payload=payload.model_dump(),
+    try:
+        return await _controls(session).stop_workspace(
+            workspace_id,
+            reason=payload.reason,
         )
-    await operations.finish(
-        operation,
-        status=OperationStatus.succeeded,
-        result={"status": workspace.status},
-    )
-    return WorkspaceControlResponse(
-        workspace_id=workspace_id,
-        operation_id=operation.id,
-        status=WorkspaceStatus(workspace.status),
-        message="workspace stack stopped",
-    )
+    except WorkspaceControlError as exc:
+        raise _http_error(exc) from exc
 
 
 @router.delete("", response_model=WorkspaceControlResponse)
@@ -119,140 +62,37 @@ async def destroy_workspace(
     remove_worktree: bool = True,
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkspaceControlResponse:
-    del (
-        remove_volumes,
-        remove_worktree,
-    )  # cleanup currently removes both; flags reserve the API contract.
-    repo = WorkspaceRepository(session)
-    operations = OperationRepository(session)
-    workspace = await _require_workspace(repo, workspace_id)
-    current = WorkspaceStatus(workspace.status)
-    if _is_active(current) and not force:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "error_code": "WORKSPACE_ACTIVE",
-                "message": "Active workspaces require force=true before destroy.",
-            },
+    try:
+        return await _controls(session).destroy_workspace(
+            workspace_id,
+            force=force,
+            remove_volumes=remove_volumes,
+            remove_worktree=remove_worktree,
         )
-    operation = await operations.create(
-        workspace_id=workspace_id,
-        operation_type=OperationType.destroy,
-        status=OperationStatus.running,
-        payload={"force": force},
-    )
-    if current == WorkspaceStatus.destroyed:
-        await operations.finish(operation, status=OperationStatus.succeeded)
-        return WorkspaceControlResponse(
-            workspace_id=workspace_id,
-            operation_id=operation.id,
-            status=WorkspaceStatus.destroyed,
-            message="workspace already destroyed",
-        )
-    if _is_active(current) and WorkspaceStateMachine.can_transition(
-        current, WorkspaceStatus.cancelled
-    ):
-        await repo.transition(
-            workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_DESTROY"
-        )
-        current = WorkspaceStatus.cancelled
-    if WorkspaceStateMachine.can_transition(current, WorkspaceStatus.destroying):
-        await repo.transition(
-            workspace, to=WorkspaceStatus.destroying, reason_code="OPERATOR_DESTROY"
-        )
-    await session.flush()
-    cleaner = _cleaner()
-    failures = await cleaner.cleanup(
-        workspace_id=workspace_id,
-        repo_url=workspace.repo_url,
-        compose_project_name=workspace.compose_project_name,
-        compose_file_path=(
-            Path(workspace.compose_file_path) if workspace.compose_file_path else None
-        ),
-        worktree_host_path=None,
-    )
-    if failures:
-        workspace.failure_reason = "cleanup_failure"
-        workspace.failure_message = ", ".join(failures)
-        if WorkspaceStateMachine.can_transition(
-            WorkspaceStatus(workspace.status), WorkspaceStatus.failed
-        ):
-            await repo.transition(
-                workspace, to=WorkspaceStatus.failed, reason_code="CLEANUP_FAILED"
-            )
-        await operations.finish(
-            operation,
-            status=OperationStatus.failed,
-            error_code="CLEANUP_FAILED",
-            error_message=", ".join(failures),
-        )
-    else:
-        if WorkspaceStateMachine.can_transition(
-            WorkspaceStatus(workspace.status), WorkspaceStatus.destroyed
-        ):
-            await repo.transition(workspace, to=WorkspaceStatus.destroyed, reason_code="DESTROYED")
-        await operations.finish(operation, status=OperationStatus.succeeded)
-    return WorkspaceControlResponse(
-        workspace_id=workspace_id,
-        operation_id=operation.id,
-        status=WorkspaceStatus(workspace.status),
-        message="workspace destroyed" if not failures else "workspace cleanup failed",
+    except WorkspaceControlError as exc:
+        raise _http_error(exc) from exc
+
+
+def _controls(session: AsyncSession) -> WorkspaceControlService:
+    return WorkspaceControlService(
+        session,
+        project_stopper=_stop_project,
+        cleaner_factory=_cleaner,
     )
 
 
-async def _require_workspace(repo: WorkspaceRepository, workspace_id: str) -> Workspace:
-    workspace = await repo.get(workspace_id)
-    if workspace is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
-        )
-    return workspace
-
-
-async def _stop_project(compose_project_name: str | None) -> None:
-    if not compose_project_name:
-        return
-    proc = await asyncio.create_subprocess_exec(
-        "docker",
-        "ps",
-        "-q",
-        "--filter",
-        f"label=com.docker.compose.project={compose_project_name}",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, _stderr = await proc.communicate()
-    ids = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line]
-    if not ids:
-        return
-    stop = await asyncio.create_subprocess_exec(
-        "docker",
-        "stop",
-        *ids,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    await stop.communicate()
-
-
-def _cleaner() -> WorkspaceCleaner:
-    settings = get_settings()
-    work_dir = Path(settings.work_dir)
-    template = Path(__file__).resolve().parents[4] / "docker" / "compose" / "workspace.base.yml.j2"
-    return WorkspaceCleaner(
-        git=GitManager(work_dir / "git"),
-        compose=ComposeManager(work_dir=work_dir / "compose", template_path=template),
+def _http_error(exc: WorkspaceControlError) -> HTTPException:
+    if isinstance(exc, WorkspaceNotFoundError):
+        status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, ActiveWorkspaceDestroyError):
+        status_code = status.HTTP_409_CONFLICT
+    else:  # pragma: no cover - future control error subclasses
+        status_code = status.HTTP_409_CONFLICT
+    return HTTPException(
+        status_code=status_code,
+        detail={"error_code": exc.error_code, "message": exc.message},
     )
 
 
-def _is_active(status_value: WorkspaceStatus) -> bool:
-    return status_value in {
-        WorkspaceStatus.requested,
-        WorkspaceStatus.provisioning,
-        WorkspaceStatus.ready,
-        WorkspaceStatus.running,
-        WorkspaceStatus.validating,
-        WorkspaceStatus.pushing,
-        WorkspaceStatus.monitoring_pr,
-    }
+_stop_project = stop_project_containers
+_cleaner = default_cleaner

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -12,7 +12,8 @@ cleanly when they show up alongside other MCP servers.
 
 from __future__ import annotations
 
-from typing import Any, cast
+import json
+from typing import Annotated, Any
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import CallToolResult, TextContent
@@ -28,6 +29,8 @@ from awf.db.enums import AgentRuntime, TaskClass, WorkspaceStatus
 from awf.profiles.resolver import ProfileResolutionError
 from awf.service.controls import WorkspaceControlError
 from awf.service.workspaces import WorkspaceService
+
+StructuredToolResult = Annotated[CallToolResult, dict[str, Any]]
 
 # ── MCP tool registration ─────────────────────────────────────────────────
 
@@ -155,7 +158,7 @@ def build_mcp_server(
             le=86400,
             description="Optional monitor grace override before auto-merge.",
         ),
-    ) -> dict[str, Any]:
+    ) -> StructuredToolResult:
         """Create a new AWF workspace using the clean v2 contract."""
         req = WorkspaceCreateV2Request(
             repo={"url": repo_url, "base_branch": base_branch},
@@ -177,15 +180,8 @@ def build_mcp_server(
             ws = await service.create_v2(req)
         except ProfileResolutionError as exc:
             error = ErrorResponse(error_code="INVALID_PROFILE", message=str(exc))
-            return cast(
-                dict[str, Any],
-                CallToolResult(
-                    content=[TextContent(type="text", text=error.model_dump_json())],
-                    structuredContent=error.model_dump(mode="json"),
-                    isError=True,
-                ),
-            )
-        return ws.model_dump(mode="json")
+            return _tool_result(error.model_dump(mode="json"), is_error=True)
+        return _tool_result(ws.model_dump(mode="json"))
 
     @mcp.tool(name="awf_get_workspace")
     async def awf_get_workspace(
@@ -248,7 +244,7 @@ def build_mcp_server(
             default=True,
             description="Also stop the workspace compose stack after requesting cancellation.",
         ),
-    ) -> dict[str, Any]:
+    ) -> StructuredToolResult:
         """Operator control: cancel a workspace; this is not shell access."""
         try:
             result = await service.cancel_workspace(
@@ -258,7 +254,7 @@ def build_mcp_server(
             )
         except WorkspaceControlError as exc:
             return _tool_error(exc)
-        return result.model_dump(mode="json")
+        return _tool_result(result.model_dump(mode="json"))
 
     @mcp.tool(name="awf_stop_workspace")
     async def awf_stop_workspace(
@@ -267,13 +263,13 @@ def build_mcp_server(
             default=None,
             description="Optional operator reason to record with the stop request.",
         ),
-    ) -> dict[str, Any]:
+    ) -> StructuredToolResult:
         """Operator control: stop a workspace stack; this is not shell access."""
         try:
             result = await service.stop_workspace(workspace_id, reason=reason)
         except WorkspaceControlError as exc:
             return _tool_error(exc)
-        return result.model_dump(mode="json")
+        return _tool_result(result.model_dump(mode="json"))
 
     @mcp.tool(name="awf_destroy_workspace")
     async def awf_destroy_workspace(
@@ -290,7 +286,7 @@ def build_mcp_server(
             default=True,
             description="Reserve REST-compatible intent to remove the workspace worktree.",
         ),
-    ) -> dict[str, Any]:
+    ) -> StructuredToolResult:
         """Operator control: destroy workspace resources; this is not shell access."""
         try:
             result = await service.destroy_workspace(
@@ -301,7 +297,7 @@ def build_mcp_server(
             )
         except WorkspaceControlError as exc:
             return _tool_error(exc)
-        return result.model_dump(mode="json")
+        return _tool_result(result.model_dump(mode="json"))
 
     @mcp.tool(name="awf_list_workspace_events")
     async def awf_list_workspace_events(
@@ -365,13 +361,14 @@ def build_mcp_server(
     return mcp
 
 
-def _tool_error(exc: WorkspaceControlError) -> dict[str, Any]:
+def _tool_error(exc: WorkspaceControlError) -> CallToolResult:
     error = ErrorResponse(error_code=exc.error_code, message=exc.message)
-    return cast(
-        dict[str, Any],
-        CallToolResult(
-            content=[TextContent(type="text", text=error.model_dump_json())],
-            structuredContent=error.model_dump(mode="json"),
-            isError=True,
-        ),
+    return _tool_result(error.model_dump(mode="json"), is_error=True)
+
+
+def _tool_result(payload: dict[str, Any], *, is_error: bool = False) -> CallToolResult:
+    return CallToolResult(
+        content=[TextContent(type="text", text=json.dumps(payload, indent=2))],
+        structuredContent=payload,
+        isError=is_error,
     )

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -1,7 +1,7 @@
 """MCP server surface for AWF.
 
-Builds a ``FastMCP`` instance with create, read, wait, and observability
-tools that mirror the REST API.
+Builds a ``FastMCP`` instance with create, read, wait, observability, and
+operator-control tools that mirror the REST API.
 Because both the MCP tools and the REST handlers want the same underlying
 logic (create workspace in DB, fetch by id, etc.) we expose a small
 ``WorkspaceService`` façade that both can call.
@@ -26,6 +26,7 @@ from awf.api.schemas import (
 )
 from awf.db.enums import AgentRuntime, TaskClass, WorkspaceStatus
 from awf.profiles.resolver import ProfileResolutionError
+from awf.service.controls import WorkspaceControlError
 from awf.service.workspaces import WorkspaceService
 
 # ── MCP tool registration ─────────────────────────────────────────────────
@@ -49,7 +50,9 @@ def build_mcp_server(
             instructions
             or "AWF: isolated Docker execution substrate for coding agents. "
             "Create a workspace to run one coding task end-to-end "
-            "(checkout → agent CLI → tests → PR). Poll via awf_get_workspace."
+            "(checkout → agent CLI → tests → PR). Poll via awf_get_workspace. "
+            "Operator controls cancel, stop, or destroy AWF-managed workspaces; "
+            "they are not shell access to workspace containers."
         ),
     )
 
@@ -234,6 +237,72 @@ def build_mcp_server(
                 return ws.model_dump(mode="json")
             await asyncio.sleep(poll_interval_seconds)
 
+    @mcp.tool(name="awf_cancel_workspace")
+    async def awf_cancel_workspace(
+        workspace_id: str = Field(..., description="Workspace ID to cancel."),
+        reason: str | None = Field(
+            default=None,
+            description="Optional operator reason to record with the cancellation request.",
+        ),
+        stop_stack: bool = Field(
+            default=True,
+            description="Also stop the workspace compose stack after requesting cancellation.",
+        ),
+    ) -> dict[str, Any]:
+        """Operator control: cancel a workspace; this is not shell access."""
+        try:
+            result = await service.cancel_workspace(
+                workspace_id,
+                reason=reason,
+                stop_stack=stop_stack,
+            )
+        except WorkspaceControlError as exc:
+            return _tool_error(exc)
+        return result.model_dump(mode="json")
+
+    @mcp.tool(name="awf_stop_workspace")
+    async def awf_stop_workspace(
+        workspace_id: str = Field(..., description="Workspace ID whose stack should stop."),
+        reason: str | None = Field(
+            default=None,
+            description="Optional operator reason to record with the stop request.",
+        ),
+    ) -> dict[str, Any]:
+        """Operator control: stop a workspace stack; this is not shell access."""
+        try:
+            result = await service.stop_workspace(workspace_id, reason=reason)
+        except WorkspaceControlError as exc:
+            return _tool_error(exc)
+        return result.model_dump(mode="json")
+
+    @mcp.tool(name="awf_destroy_workspace")
+    async def awf_destroy_workspace(
+        workspace_id: str = Field(..., description="Workspace ID to destroy."),
+        force: bool = Field(
+            default=False,
+            description="Required when the workspace is still active.",
+        ),
+        remove_volumes: bool = Field(
+            default=True,
+            description="Reserve REST-compatible intent to remove workspace volumes.",
+        ),
+        remove_worktree: bool = Field(
+            default=True,
+            description="Reserve REST-compatible intent to remove the workspace worktree.",
+        ),
+    ) -> dict[str, Any]:
+        """Operator control: destroy workspace resources; this is not shell access."""
+        try:
+            result = await service.destroy_workspace(
+                workspace_id,
+                force=force,
+                remove_volumes=remove_volumes,
+                remove_worktree=remove_worktree,
+            )
+        except WorkspaceControlError as exc:
+            return _tool_error(exc)
+        return result.model_dump(mode="json")
+
     @mcp.tool(name="awf_list_workspace_events")
     async def awf_list_workspace_events(
         workspace_id: str = Field(..., description="Workspace ID to inspect."),
@@ -294,3 +363,15 @@ def build_mcp_server(
         )
 
     return mcp
+
+
+def _tool_error(exc: WorkspaceControlError) -> dict[str, Any]:
+    error = ErrorResponse(error_code=exc.error_code, message=exc.message)
+    return cast(
+        dict[str, Any],
+        CallToolResult(
+            content=[TextContent(type="text", text=error.model_dump_json())],
+            structuredContent=error.model_dump(mode="json"),
+            isError=True,
+        ),
+    )

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -280,11 +280,11 @@ def build_mcp_server(
         ),
         remove_volumes: bool = Field(
             default=True,
-            description="Reserve REST-compatible intent to remove workspace volumes.",
+            description="Remove workspace volumes during compose cleanup.",
         ),
         remove_worktree: bool = Field(
             default=True,
-            description="Reserve REST-compatible intent to remove the workspace worktree.",
+            description="Remove the workspace git worktree during cleanup.",
         ),
     ) -> StructuredToolResult:
         """Operator control: destroy workspace resources; this is not shell access."""

--- a/src/awf/node/cleanup.py
+++ b/src/awf/node/cleanup.py
@@ -32,6 +32,8 @@ class WorkspaceCleaner:
         compose_project_name: str | None = None,
         compose_file_path: Path | None = None,
         worktree_host_path: Path | None = None,
+        remove_volumes: bool = True,
+        remove_worktree: bool = True,
     ) -> list[str]:
         """Best-effort cleanup. Returns list of failure-step names, empty on full success.
 
@@ -41,7 +43,7 @@ class WorkspaceCleaner:
         """
         failures: list[str] = []
 
-        # Step 1: compose down -v (stops containers, removes volumes + network).
+        # Step 1: compose down (stops containers, optionally removes volumes).
         spec = WorkspaceComposeSpec(
             workspace_id=workspace_id,
             worktree_host_path=worktree_host_path or Path("/dev/null"),
@@ -52,10 +54,10 @@ class WorkspaceCleaner:
                     project_name=compose_project_name or spec.project_name(),
                     compose_file=compose_file_path,
                     workspace_id=workspace_id,
-                    remove_volumes=True,
+                    remove_volumes=remove_volumes,
                 )
             else:
-                await self._compose.down(spec, remove_volumes=True)
+                await self._compose.down(spec, remove_volumes=remove_volumes)
         except ComposeOperationError as exc:
             _log.warning(
                 "cleanup.compose_down_failed",
@@ -66,15 +68,16 @@ class WorkspaceCleaner:
             failures.append("compose_down")
 
         # Step 2: git worktree remove (idempotent already per GitManager).
-        try:
-            await self._git.remove_worktree(workspace_id=workspace_id, repo_url=repo_url)
-        except GitOperationError as exc:
-            _log.warning(
-                "cleanup.git_remove_failed",
-                workspace_id=workspace_id,
-                reason_code=exc.reason_code,
-                stderr=exc.stderr[:1000],
-            )
-            failures.append("worktree_remove")
+        if remove_worktree:
+            try:
+                await self._git.remove_worktree(workspace_id=workspace_id, repo_url=repo_url)
+            except GitOperationError as exc:
+                _log.warning(
+                    "cleanup.git_remove_failed",
+                    workspace_id=workspace_id,
+                    reason_code=exc.reason_code,
+                    stderr=exc.stderr[:1000],
+                )
+                failures.append("worktree_remove")
 
         return failures

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -32,6 +32,8 @@ class WorkspaceCleanerProtocol(Protocol):
         compose_project_name: str | None = None,
         compose_file_path: Path | None = None,
         worktree_host_path: Path | None = None,
+        remove_volumes: bool = True,
+        remove_worktree: bool = True,
     ) -> list[str]: ...
 
 
@@ -245,6 +247,8 @@ class WorkspaceControlService:
                 Path(workspace.compose_file_path) if workspace.compose_file_path else None
             ),
             worktree_host_path=None,
+            remove_volumes=remove_volumes,
+            remove_worktree=remove_worktree,
         )
         if failures:
             workspace.failure_reason = "cleanup_failure"

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -1,0 +1,323 @@
+"""Shared workspace control operations for REST and MCP adapters."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Protocol
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.schemas import WorkspaceControlResponse
+from awf.common.config import get_settings
+from awf.control.state_machine import WorkspaceStateMachine
+from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.models import Workspace
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.node.cleanup import WorkspaceCleaner
+from awf.node.compose_manager import ComposeManager
+from awf.node.git_manager import GitManager
+
+ProjectStopper = Callable[[str | None], Awaitable[None]]
+CleanerFactory = Callable[[], "WorkspaceCleanerProtocol"]
+
+
+class WorkspaceCleanerProtocol(Protocol):
+    async def cleanup(
+        self,
+        *,
+        workspace_id: str,
+        repo_url: str,
+        compose_project_name: str | None = None,
+        compose_file_path: Path | None = None,
+        worktree_host_path: Path | None = None,
+    ) -> list[str]: ...
+
+
+class WorkspaceControlError(Exception):
+    """Base error for framework adapters to map into HTTP/MCP errors."""
+
+    def __init__(self, *, error_code: str, message: str) -> None:
+        self.error_code = error_code
+        self.message = message
+        super().__init__(message)
+
+
+class WorkspaceNotFoundError(WorkspaceControlError):
+    def __init__(self, workspace_id: str) -> None:
+        super().__init__(
+            error_code="NOT_FOUND",
+            message=f"No workspace with id {workspace_id}",
+        )
+
+
+class ActiveWorkspaceDestroyError(WorkspaceControlError):
+    def __init__(self) -> None:
+        super().__init__(
+            error_code="WORKSPACE_ACTIVE",
+            message="Active workspaces require force=true before destroy.",
+        )
+
+
+class WorkspaceControlService:
+    """Business logic for sensitive workspace lifecycle controls."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        project_stopper: ProjectStopper,
+        cleaner_factory: CleanerFactory,
+    ) -> None:
+        self._session = session
+        self._project_stopper = project_stopper
+        self._cleaner_factory = cleaner_factory
+
+    async def cancel_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None,
+        stop_stack: bool,
+    ) -> WorkspaceControlResponse:
+        repo = WorkspaceRepository(self._session)
+        operations = OperationRepository(self._session)
+        workspace = await self._require_workspace(repo, workspace_id)
+        payload = {"reason": reason, "stop_stack": stop_stack}
+        operation = await operations.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.cancel,
+            status=OperationStatus.running,
+            payload=payload,
+        )
+        if stop_stack:
+            await self._project_stopper(workspace.compose_project_name)
+        if (
+            workspace.status != WorkspaceStatus.cancelled.value
+            and WorkspaceStateMachine.can_transition(
+                WorkspaceStatus(workspace.status),
+                WorkspaceStatus.cancelled,
+            )
+        ):
+            await repo.transition(
+                workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_CANCEL"
+            )
+        else:
+            await repo.add_event(
+                workspace,
+                event_type="workspace.cancel_requested",
+                reason_code="OPERATOR_CANCEL",
+                payload=payload,
+            )
+        await operations.finish(
+            operation,
+            status=OperationStatus.succeeded,
+            result={"status": workspace.status},
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id=operation.id,
+            status=WorkspaceStatus(workspace.status),
+            message="workspace cancellation requested",
+        )
+
+    async def stop_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None,
+    ) -> WorkspaceControlResponse:
+        repo = WorkspaceRepository(self._session)
+        operations = OperationRepository(self._session)
+        workspace = await self._require_workspace(repo, workspace_id)
+        payload = {"reason": reason}
+        operation = await operations.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.stop,
+            status=OperationStatus.running,
+            payload=payload,
+        )
+        await self._project_stopper(workspace.compose_project_name)
+        if _is_active(WorkspaceStatus(workspace.status)) and WorkspaceStateMachine.can_transition(
+            WorkspaceStatus(workspace.status),
+            WorkspaceStatus.cancelled,
+        ):
+            await repo.transition(
+                workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_STOP"
+            )
+        else:
+            await repo.add_event(
+                workspace,
+                event_type="workspace.stack_stopped",
+                reason_code="OPERATOR_STOP",
+                payload=payload,
+            )
+        await operations.finish(
+            operation,
+            status=OperationStatus.succeeded,
+            result={"status": workspace.status},
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id=operation.id,
+            status=WorkspaceStatus(workspace.status),
+            message="workspace stack stopped",
+        )
+
+    async def destroy_workspace(
+        self,
+        workspace_id: str,
+        *,
+        force: bool,
+        remove_volumes: bool,
+        remove_worktree: bool,
+    ) -> WorkspaceControlResponse:
+        repo = WorkspaceRepository(self._session)
+        operations = OperationRepository(self._session)
+        workspace = await self._require_workspace(repo, workspace_id)
+        current = WorkspaceStatus(workspace.status)
+        if _is_active(current) and not force:
+            raise ActiveWorkspaceDestroyError()
+
+        operation = await operations.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.destroy,
+            status=OperationStatus.running,
+            payload={
+                "force": force,
+                "remove_volumes": remove_volumes,
+                "remove_worktree": remove_worktree,
+            },
+        )
+        if current == WorkspaceStatus.destroyed:
+            await operations.finish(
+                operation,
+                status=OperationStatus.succeeded,
+                result={"status": WorkspaceStatus.destroyed.value},
+            )
+            return WorkspaceControlResponse(
+                workspace_id=workspace_id,
+                operation_id=operation.id,
+                status=WorkspaceStatus.destroyed,
+                message="workspace already destroyed",
+            )
+
+        if _is_active(current) and WorkspaceStateMachine.can_transition(
+            current, WorkspaceStatus.cancelled
+        ):
+            await repo.transition(
+                workspace, to=WorkspaceStatus.cancelled, reason_code="OPERATOR_DESTROY"
+            )
+            current = WorkspaceStatus.cancelled
+        if WorkspaceStateMachine.can_transition(current, WorkspaceStatus.destroying):
+            await repo.transition(
+                workspace, to=WorkspaceStatus.destroying, reason_code="OPERATOR_DESTROY"
+            )
+
+        await self._session.flush()
+        cleaner = self._cleaner_factory()
+        failures = await cleaner.cleanup(
+            workspace_id=workspace_id,
+            repo_url=workspace.repo_url,
+            compose_project_name=workspace.compose_project_name,
+            compose_file_path=(
+                Path(workspace.compose_file_path) if workspace.compose_file_path else None
+            ),
+            worktree_host_path=None,
+        )
+        if failures:
+            workspace.failure_reason = "cleanup_failure"
+            workspace.failure_message = ", ".join(failures)
+            if WorkspaceStateMachine.can_transition(
+                WorkspaceStatus(workspace.status), WorkspaceStatus.failed
+            ):
+                await repo.transition(
+                    workspace, to=WorkspaceStatus.failed, reason_code="CLEANUP_FAILED"
+                )
+            await operations.finish(
+                operation,
+                status=OperationStatus.failed,
+                error_code="CLEANUP_FAILED",
+                error_message=", ".join(failures),
+                result={"status": workspace.status},
+            )
+            message = "workspace cleanup failed"
+        else:
+            if WorkspaceStateMachine.can_transition(
+                WorkspaceStatus(workspace.status), WorkspaceStatus.destroyed
+            ):
+                await repo.transition(
+                    workspace, to=WorkspaceStatus.destroyed, reason_code="DESTROYED"
+                )
+            await operations.finish(
+                operation,
+                status=OperationStatus.succeeded,
+                result={"status": workspace.status},
+            )
+            message = "workspace destroyed"
+
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id=operation.id,
+            status=WorkspaceStatus(workspace.status),
+            message=message,
+        )
+
+    async def _require_workspace(
+        self,
+        repo: WorkspaceRepository,
+        workspace_id: str,
+    ) -> Workspace:
+        workspace = await repo.get(workspace_id)
+        if workspace is None:
+            raise WorkspaceNotFoundError(workspace_id)
+        return workspace
+
+
+async def stop_project_containers(compose_project_name: str | None) -> None:
+    if not compose_project_name:
+        return
+    proc = await asyncio.create_subprocess_exec(
+        "docker",
+        "ps",
+        "-q",
+        "--filter",
+        f"label=com.docker.compose.project={compose_project_name}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, _stderr = await proc.communicate()
+    ids = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line]
+    if not ids:
+        return
+    stop = await asyncio.create_subprocess_exec(
+        "docker",
+        "stop",
+        *ids,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    await stop.communicate()
+
+
+def default_cleaner() -> WorkspaceCleaner:
+    settings = get_settings()
+    work_dir = Path(settings.work_dir)
+    template = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
+    return WorkspaceCleaner(
+        git=GitManager(work_dir / "git"),
+        compose=ComposeManager(work_dir=work_dir / "compose", template_path=template),
+    )
+
+
+def _is_active(status_value: WorkspaceStatus) -> bool:
+    return status_value in {
+        WorkspaceStatus.requested,
+        WorkspaceStatus.provisioning,
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.pushing,
+        WorkspaceStatus.monitoring_pr,
+    }

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -60,6 +60,26 @@ class ActiveWorkspaceDestroyError(WorkspaceControlError):
         )
 
 
+class WorkspaceStackStopError(WorkspaceControlError):
+    def __init__(
+        self,
+        *,
+        operation: str,
+        returncode: int,
+        stdout: str,
+        stderr: str,
+    ) -> None:
+        self.operation = operation
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+        detail = (stderr or stdout).strip() or "<no output>"
+        super().__init__(
+            error_code="STACK_STOP_FAILED",
+            message=f"docker {operation} failed (exit={returncode}): {detail}",
+        )
+
+
 class WorkspaceControlService:
     """Business logic for sensitive workspace lifecycle controls."""
 
@@ -278,27 +298,66 @@ class WorkspaceControlService:
 async def stop_project_containers(compose_project_name: str | None) -> None:
     if not compose_project_name:
         return
-    proc = await asyncio.create_subprocess_exec(
-        "docker",
+    proc = await _docker_process(
         "ps",
         "-q",
         "--filter",
         f"label=com.docker.compose.project={compose_project_name}",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        operation="ps",
     )
-    stdout, _stderr = await proc.communicate()
-    ids = [line.strip() for line in stdout.decode("utf-8", errors="replace").splitlines() if line]
+    stdout, _stderr = await _communicate(proc, operation="ps")
+    ids = [line.strip() for line in stdout.splitlines() if line.strip()]
     if not ids:
         return
-    stop = await asyncio.create_subprocess_exec(
-        "docker",
+    stop = await _docker_process(
         "stop",
         *ids,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
+        operation="stop",
     )
-    await stop.communicate()
+    await _communicate(stop, operation="stop")
+
+
+async def _docker_process(*args: str, operation: str) -> asyncio.subprocess.Process:
+    try:
+        return await asyncio.create_subprocess_exec(
+            "docker",
+            *args,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+    except FileNotFoundError as exc:
+        raise WorkspaceStackStopError(
+            operation=operation,
+            returncode=127,
+            stdout="",
+            stderr=f"docker executable is not available: {exc}",
+        ) from exc
+    except OSError as exc:
+        raise WorkspaceStackStopError(
+            operation=operation,
+            returncode=1,
+            stdout="",
+            stderr=f"{type(exc).__name__}: {exc}",
+        ) from exc
+
+
+async def _communicate(
+    proc: asyncio.subprocess.Process,
+    *,
+    operation: str,
+) -> tuple[str, str]:
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    stdout = stdout_bytes.decode("utf-8", errors="replace")
+    stderr = stderr_bytes.decode("utf-8", errors="replace")
+    assert proc.returncode is not None
+    if proc.returncode != 0:
+        raise WorkspaceStackStopError(
+            operation=operation,
+            returncode=proc.returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    return stdout, stderr
 
 
 def default_cleaner() -> WorkspaceCleaner:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.api.schemas import (
     OperationResponse,
     RuntimeServiceResponse,
+    WorkspaceControlResponse,
     WorkspaceCreateRequest,
     WorkspaceCreateV2Request,
     WorkspaceEventResponse,
@@ -30,6 +31,13 @@ from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
 from awf.runtime.inspection import RuntimeInspector, RuntimeSnapshot
 from awf.runtime.logs import read_log_chunk
+from awf.service.controls import (
+    CleanerFactory,
+    ProjectStopper,
+    WorkspaceControlService,
+    default_cleaner,
+    stop_project_containers,
+)
 
 
 class RuntimeInspection(Protocol):
@@ -45,10 +53,14 @@ class WorkspaceService:
         *,
         log_root: Path | str | None = None,
         runtime_inspector: RuntimeInspection | None = None,
+        project_stopper: ProjectStopper | None = None,
+        cleaner_factory: CleanerFactory | None = None,
     ) -> None:
         self._factory = session_factory
         self._log_root = Path(log_root).resolve() if log_root is not None else None
         self._runtime_inspector = runtime_inspector or RuntimeInspector()
+        self._project_stopper = project_stopper or stop_project_containers
+        self._cleaner_factory = cleaner_factory or default_cleaner
 
     async def create(self, req: WorkspaceCreateRequest) -> WorkspaceResponse:
         async with self._factory() as s:
@@ -83,6 +95,54 @@ class WorkspaceService:
         async with self._factory() as s:
             rows = await WorkspaceRepository(s).list(limit=limit)
             return [WorkspaceResponse.model_validate(r) for r in rows]
+
+    async def cancel_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None = None,
+        stop_stack: bool = True,
+    ) -> WorkspaceControlResponse:
+        async with self._factory() as s:
+            result = await self._controls(s).cancel_workspace(
+                workspace_id,
+                reason=reason,
+                stop_stack=stop_stack,
+            )
+            await s.commit()
+            return result
+
+    async def stop_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None = None,
+    ) -> WorkspaceControlResponse:
+        async with self._factory() as s:
+            result = await self._controls(s).stop_workspace(
+                workspace_id,
+                reason=reason,
+            )
+            await s.commit()
+            return result
+
+    async def destroy_workspace(
+        self,
+        workspace_id: str,
+        *,
+        force: bool = False,
+        remove_volumes: bool = True,
+        remove_worktree: bool = True,
+    ) -> WorkspaceControlResponse:
+        async with self._factory() as s:
+            result = await self._controls(s).destroy_workspace(
+                workspace_id,
+                force=force,
+                remove_volumes=remove_volumes,
+                remove_worktree=remove_worktree,
+            )
+            await s.commit()
+            return result
 
     async def get_runtime(self, workspace_id: str) -> WorkspaceRuntimeResponse | None:
         async with self._factory() as s:
@@ -227,6 +287,13 @@ class WorkspaceService:
             "eof": eof,
             "text": data,
         }
+
+    def _controls(self, session: AsyncSession) -> WorkspaceControlService:
+        return WorkspaceControlService(
+            session,
+            project_stopper=self._project_stopper,
+            cleaner_factory=self._cleaner_factory,
+        )
 
 
 async def create_workspace_v2_row(

--- a/tests/unit/api/test_observability_api.py
+++ b/tests/unit/api/test_observability_api.py
@@ -485,6 +485,8 @@ class TestOperationsAndControls:
                 *,
                 workspace_id: str,
                 repo_url: str,
+                remove_volumes: bool,
+                remove_worktree: bool,
                 compose_project_name: str | None = None,
                 compose_file_path: Path | None = None,
                 worktree_host_path: Path | None = None,
@@ -496,6 +498,8 @@ class TestOperationsAndControls:
                         "compose_project_name": compose_project_name,
                         "compose_file_path": compose_file_path,
                         "worktree_host_path": worktree_host_path,
+                        "remove_volumes": remove_volumes,
+                        "remove_worktree": remove_worktree,
                     }
                 )
                 return []
@@ -505,7 +509,7 @@ class TestOperationsAndControls:
 
         response = await client.delete(
             f"/v1/workspaces/{workspace_id}",
-            params={"force": True},
+            params={"force": True, "remove_volumes": False, "remove_worktree": False},
             headers=headers,
         )
 
@@ -518,6 +522,8 @@ class TestOperationsAndControls:
                 "compose_project_name": None,
                 "compose_file_path": None,
                 "worktree_host_path": None,
+                "remove_volumes": False,
+                "remove_worktree": False,
             }
         ]
 

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -328,6 +328,64 @@ class TestWorkspaceControls:
             "message": "workspace destroyed",
         }
 
+    @pytest.mark.unit
+    async def test_cancel_workspace_records_operation_through_real_service(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        created = await _call(mcp, "awf_create_workspace", _CREATE_ARGS)
+        workspace_id = str(created["id"])  # type: ignore[index]
+
+        payload = await _call(
+            mcp,
+            "awf_cancel_workspace",
+            {
+                "workspace_id": workspace_id,
+                "reason": "no longer needed",
+                "stop_stack": False,
+            },
+        )
+        operations = await _call(
+            mcp,
+            "awf_list_workspace_operations",
+            {"workspace_id": workspace_id},
+        )
+
+        assert payload["workspace_id"] == workspace_id  # type: ignore[index]
+        assert payload["status"] == "cancelled"  # type: ignore[index]
+        assert payload["message"] == "workspace cancellation requested"  # type: ignore[index]
+        assert isinstance(operations, list)
+        assert operations[0]["type"] == "cancel"
+        assert operations[0]["status"] == "succeeded"
+        assert operations[0]["payload"] == {
+            "reason": "no longer needed",
+            "stop_stack": False,
+        }
+        assert operations[0]["result"] == {"status": "cancelled"}
+
+    @pytest.mark.unit
+    async def test_destroy_workspace_requires_force_for_active_workspace(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        from mcp.types import CallToolResult
+
+        created = await _call(mcp, "awf_create_workspace", _CREATE_ARGS)
+        workspace_id = str(created["id"])  # type: ignore[index]
+
+        result = await mcp.call_tool(
+            "awf_destroy_workspace",
+            {"workspace_id": workspace_id},
+        )
+
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert result.structuredContent == {
+            "error_code": "WORKSPACE_ACTIVE",
+            "message": "Active workspaces require force=true before destroy.",
+            "detail": None,
+        }
+
 
 class TestCreateWorkspaceV2:
     @pytest.mark.unit

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from mcp.types import CallToolResult
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.schemas import WorkspaceControlResponse
@@ -61,7 +62,10 @@ async def _call(mcp, name, args) -> object:  # type: ignore[no-untyped-def]
     primitive / None / list returns. This helper normalises to the underlying
     value so tests can assert against it directly.
     """
-    _, payload = await mcp.call_tool(name, args)
+    result = await mcp.call_tool(name, args)
+    if isinstance(result, CallToolResult):
+        return result.structuredContent
+    _, payload = result
     if isinstance(payload, dict) and list(payload.keys()) == ["result"]:
         return payload["result"]
     return payload
@@ -194,9 +198,7 @@ class _RecordingControlService:
         *,
         reason: str | None,
     ) -> WorkspaceControlResponse:
-        self.calls.append(
-            ("stop", {"workspace_id": workspace_id, "reason": reason})
-        )
+        self.calls.append(("stop", {"workspace_id": workspace_id, "reason": reason}))
         return WorkspaceControlResponse(
             workspace_id=workspace_id,
             operation_id="op_stop",

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from awf.api.schemas import WorkspaceControlResponse
 from awf.db.base import Base
 from awf.db.enums import OperationStatus, OperationType
 from awf.db.repositories import OperationRepository, WorkspaceRepository
@@ -85,6 +86,44 @@ class TestToolRegistration:
             "awf_list_workspace_logs",
             "awf_read_workspace_log",
         } <= names
+        assert {
+            "awf_cancel_workspace",
+            "awf_stop_workspace",
+            "awf_destroy_workspace",
+        } <= names
+
+    @pytest.mark.unit
+    async def test_control_tools_are_described_as_operator_controls(
+        self,
+        mcp,
+    ) -> None:  # type: ignore[no-untyped-def]
+        tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+        for name in (
+            "awf_cancel_workspace",
+            "awf_stop_workspace",
+            "awf_destroy_workspace",
+        ):
+            description = (tools[name].description or "").lower()
+            assert "operator control" in description
+            assert "not shell access" in description
+
+    @pytest.mark.unit
+    async def test_control_tool_argument_contracts(self, mcp) -> None:  # type: ignore[no-untyped-def]
+        tools = {tool.name: tool for tool in await mcp.list_tools()}
+
+        cancel_props = tools["awf_cancel_workspace"].inputSchema["properties"]
+        assert cancel_props["reason"]["default"] is None
+        assert cancel_props["stop_stack"]["default"] is True
+
+        stop_props = tools["awf_stop_workspace"].inputSchema["properties"]
+        assert stop_props["reason"]["default"] is None
+        assert "stop_stack" not in stop_props
+
+        destroy_props = tools["awf_destroy_workspace"].inputSchema["properties"]
+        assert destroy_props["force"]["default"] is False
+        assert destroy_props["remove_volumes"]["default"] is True
+        assert destroy_props["remove_worktree"]["default"] is True
 
     @pytest.mark.unit
     async def test_create_workspace_v2_owned_paths_declares_item_constraints(self, mcp) -> None:  # type: ignore[no-untyped-def]
@@ -119,6 +158,175 @@ class TestCreateWorkspace:
 
         with pytest.raises((McpError, Exception)):
             await _call(mcp, "awf_create_workspace", bad)
+
+
+class _RecordingControlService:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    async def cancel_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None,
+        stop_stack: bool,
+    ) -> WorkspaceControlResponse:
+        self.calls.append(
+            (
+                "cancel",
+                {
+                    "workspace_id": workspace_id,
+                    "reason": reason,
+                    "stop_stack": stop_stack,
+                },
+            )
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id="op_cancel",
+            status="cancelled",
+            message="workspace cancellation requested",
+        )
+
+    async def stop_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None,
+    ) -> WorkspaceControlResponse:
+        self.calls.append(
+            ("stop", {"workspace_id": workspace_id, "reason": reason})
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id="op_stop",
+            status="cancelled",
+            message="workspace stack stopped",
+        )
+
+    async def destroy_workspace(
+        self,
+        workspace_id: str,
+        *,
+        force: bool,
+        remove_volumes: bool,
+        remove_worktree: bool,
+    ) -> WorkspaceControlResponse:
+        self.calls.append(
+            (
+                "destroy",
+                {
+                    "workspace_id": workspace_id,
+                    "force": force,
+                    "remove_volumes": remove_volumes,
+                    "remove_worktree": remove_worktree,
+                },
+            )
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id="op_destroy",
+            status="destroyed",
+            message="workspace destroyed",
+        )
+
+
+class TestWorkspaceControls:
+    @pytest.mark.unit
+    async def test_cancel_workspace_calls_service_and_returns_structured_response(
+        self,
+    ) -> None:
+        service = _RecordingControlService()
+        mcp = build_mcp_server(service=service)  # type: ignore[arg-type]
+
+        payload = await _call(
+            mcp,
+            "awf_cancel_workspace",
+            {
+                "workspace_id": "ws_control",
+                "reason": "stale task",
+                "stop_stack": False,
+            },
+        )
+
+        assert service.calls == [
+            (
+                "cancel",
+                {
+                    "workspace_id": "ws_control",
+                    "reason": "stale task",
+                    "stop_stack": False,
+                },
+            )
+        ]
+        assert payload == {
+            "workspace_id": "ws_control",
+            "operation_id": "op_cancel",
+            "status": "cancelled",
+            "message": "workspace cancellation requested",
+        }
+
+    @pytest.mark.unit
+    async def test_stop_workspace_calls_service_and_returns_structured_response(
+        self,
+    ) -> None:
+        service = _RecordingControlService()
+        mcp = build_mcp_server(service=service)  # type: ignore[arg-type]
+
+        payload = await _call(
+            mcp,
+            "awf_stop_workspace",
+            {
+                "workspace_id": "ws_control",
+                "reason": "free local resources",
+            },
+        )
+
+        assert service.calls == [
+            ("stop", {"workspace_id": "ws_control", "reason": "free local resources"})
+        ]
+        assert payload == {
+            "workspace_id": "ws_control",
+            "operation_id": "op_stop",
+            "status": "cancelled",
+            "message": "workspace stack stopped",
+        }
+
+    @pytest.mark.unit
+    async def test_destroy_workspace_calls_service_and_returns_structured_response(
+        self,
+    ) -> None:
+        service = _RecordingControlService()
+        mcp = build_mcp_server(service=service)  # type: ignore[arg-type]
+
+        payload = await _call(
+            mcp,
+            "awf_destroy_workspace",
+            {
+                "workspace_id": "ws_control",
+                "force": True,
+                "remove_volumes": False,
+                "remove_worktree": False,
+            },
+        )
+
+        assert service.calls == [
+            (
+                "destroy",
+                {
+                    "workspace_id": "ws_control",
+                    "force": True,
+                    "remove_volumes": False,
+                    "remove_worktree": False,
+                },
+            )
+        ]
+        assert payload == {
+            "workspace_id": "ws_control",
+            "operation_id": "op_destroy",
+            "status": "destroyed",
+            "message": "workspace destroyed",
+        }
 
 
 class TestCreateWorkspaceV2:

--- a/tests/unit/node/test_cleanup.py
+++ b/tests/unit/node/test_cleanup.py
@@ -63,6 +63,62 @@ class TestCleanup:
         git.remove_worktree.assert_awaited_once()
 
     @pytest.mark.unit
+    async def test_remove_volumes_false_preserves_compose_volumes(
+        self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
+    ) -> None:
+        git, compose, wc = cleaner
+
+        failures = await wc.cleanup(
+            workspace_id="ws_keep_volumes",
+            repo_url="git@x:y.git",
+            remove_volumes=False,
+        )
+
+        assert failures == []
+        compose.down.assert_awaited_once()
+        assert compose.down.await_args.kwargs["remove_volumes"] is False
+        git.remove_worktree.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_remove_volumes_false_applies_to_stored_compose_file(
+        self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
+    ) -> None:
+        git, compose, wc = cleaner
+        compose_file = Path("/var/lib/awf/compose/ws_keep_volumes/compose.yml")
+
+        failures = await wc.cleanup(
+            workspace_id="ws_keep_volumes",
+            repo_url="git@x:y.git",
+            compose_file_path=compose_file,
+            remove_volumes=False,
+        )
+
+        assert failures == []
+        compose.down_project.assert_awaited_once_with(
+            project_name="awf_ws_keep_volumes",
+            compose_file=compose_file,
+            workspace_id="ws_keep_volumes",
+            remove_volumes=False,
+        )
+        git.remove_worktree.assert_awaited_once()
+
+    @pytest.mark.unit
+    async def test_remove_worktree_false_skips_worktree_removal(
+        self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
+    ) -> None:
+        git, compose, wc = cleaner
+
+        failures = await wc.cleanup(
+            workspace_id="ws_keep_worktree",
+            repo_url="git@x:y.git",
+            remove_worktree=False,
+        )
+
+        assert failures == []
+        compose.down.assert_awaited_once()
+        git.remove_worktree.assert_not_awaited()
+
+    @pytest.mark.unit
     async def test_compose_failure_does_not_block_worktree_removal(
         self, cleaner: tuple[AsyncMock, AsyncMock, WorkspaceCleaner]
     ) -> None:

--- a/tests/unit/service/test_controls.py
+++ b/tests/unit/service/test_controls.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from awf.service.controls import WorkspaceStackStopError, stop_project_containers
+
+
+def _mock_proc(returncode: int = 0, stdout: bytes = b"", stderr: bytes = b"") -> AsyncMock:
+    proc = AsyncMock()
+    proc.returncode = returncode
+    proc.communicate.return_value = (stdout, stderr)
+    return proc
+
+
+@pytest.mark.unit
+async def test_stop_project_containers_is_noop_without_project_name() -> None:
+    with patch("awf.service.controls.asyncio.create_subprocess_exec") as mock_exec:
+        await stop_project_containers(None)
+
+    mock_exec.assert_not_called()
+
+
+@pytest.mark.unit
+async def test_stop_project_containers_returns_when_no_containers_match() -> None:
+    with patch(
+        "awf.service.controls.asyncio.create_subprocess_exec",
+        return_value=_mock_proc(),
+    ) as mock_exec:
+        await stop_project_containers("awf_ws_empty")
+
+    assert mock_exec.call_count == 1
+
+
+@pytest.mark.unit
+async def test_stop_project_containers_stops_matching_container_ids() -> None:
+    with patch(
+        "awf.service.controls.asyncio.create_subprocess_exec",
+        side_effect=[
+            _mock_proc(stdout=b"abc123\n def456 \n"),
+            _mock_proc(stdout=b"abc123\ndef456\n"),
+        ],
+    ) as mock_exec:
+        await stop_project_containers("awf_ws_running")
+
+    assert mock_exec.call_count == 2
+    assert mock_exec.call_args_list[1].args[:4] == ("docker", "stop", "abc123", "def456")
+
+
+@pytest.mark.unit
+async def test_stop_project_containers_raises_when_ps_fails() -> None:
+    with (
+        patch(
+            "awf.service.controls.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(returncode=1, stderr=b"daemon unavailable"),
+        ),
+        pytest.raises(WorkspaceStackStopError) as exc_info,
+    ):
+        await stop_project_containers("awf_ws_fail")
+
+    assert exc_info.value.error_code == "STACK_STOP_FAILED"
+    assert exc_info.value.operation == "ps"
+    assert exc_info.value.returncode == 1
+    assert "daemon unavailable" in exc_info.value.message
+
+
+@pytest.mark.unit
+async def test_stop_project_containers_raises_when_stop_fails() -> None:
+    with (
+        patch(
+            "awf.service.controls.asyncio.create_subprocess_exec",
+            side_effect=[
+                _mock_proc(stdout=b"abc123\n"),
+                _mock_proc(returncode=17, stderr=b"permission denied"),
+            ],
+        ),
+        pytest.raises(WorkspaceStackStopError) as exc_info,
+    ):
+        await stop_project_containers("awf_ws_fail")
+
+    assert exc_info.value.error_code == "STACK_STOP_FAILED"
+    assert exc_info.value.operation == "stop"
+    assert exc_info.value.returncode == 17
+    assert "permission denied" in exc_info.value.message


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_bf50cc49d62c4b96872df857` (agent: `codex`).


### Task
Context: AWF is moving toward an always-on local service that Codex/Claude/Gemini can drive through API and MCP. MCP already has create/get/list/runtime/log read tools, but it cannot stop/cancel/destroy workspaces, so an agent cannot safely operate the service end to end.

Implement MCP workspace control tools with strict TDD. Write failing tests first and commit them before implementation.

Required behavior:
1. Add MCP tools: awf_cancel_workspace, awf_stop_workspace, and awf_destroy_workspace. They should mirror the REST control API semantics and return structured operation/workspace status payloads.
2. Avoid duplicating business logic between REST and MCP. If needed, move the core control behavior into a service layer that both API routes and MCP tools call. Keep the public REST API unchanged.
3. cancel accepts reason and stop_stack. stop accepts reason. destroy accepts force, remove_volumes, and remove_worktree. Active workspaces must require force for destroy, same as REST.
4. Add tests showing MCP control tools call the service correctly, return structured responses, and preserve existing MCP create/list/log tools. If you refactor REST controls, keep existing API tests green.
5. Update MCP instructions/docstrings so agents know these are operator control tools, not shell access.

Do not touch GC or monitor-recovery files owned by the other tasks unless a tiny import path adjustment is unavoidable. Do not manually push or merge. AWF owns PR creation, monitoring, comment handling, base sync, and merge.

---
Validation: 3 profile command(s) passed inside the workspace container.
