### PR TITLE
fix(service): harden monitor recovery and agent GitHub auth

### DIFF
--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Stage 2: GitHub CLI ───────────────────────────────────────────────────
+ARG GH_VERSION=2.91.0
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
@@ -77,7 +78,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
       > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
-    && apt-get install -y --no-install-recommends gh \
+    && apt-get install -y --no-install-recommends "gh=${GH_VERSION}" \
     && rm -rf /var/lib/apt/lists/* \
     && gh --version
 

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -69,7 +69,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Stage 2: Node.js (for coding CLIs which are all npm packages) ──────────
+# ── Stage 2: GitHub CLI ───────────────────────────────────────────────────
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/* \
+    && gh --version
+
+# ── Stage 3: Node.js (for coding CLIs which are all npm packages) ──────────
 ARG NODE_VERSION
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -77,7 +89,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && node --version \
     && npm --version
 
-# ── Stage 3: coding CLIs ──────────────────────────────────────────────────
+# ── Stage 4: coding CLIs ──────────────────────────────────────────────────
 #
 # Each CLI is pinned to a version. Bump via PR so we can verify the output
 # format hasn't drifted in the adapters.
@@ -94,7 +106,7 @@ RUN npm install -g --no-fund --no-audit \
     && claude --version || true \
     && gemini --version || true
 
-# ── Stage 4: Python tooling the agent may need inside the container ────────
+# ── Stage 5: Python tooling the agent may need inside the container ────────
 RUN python -m pip install --upgrade pip \
     && python -m pip install --no-cache-dir \
         "alembic>=1.13" \
@@ -102,7 +114,7 @@ RUN python -m pip install --upgrade pip \
         "psycopg[binary]>=3.1" \
         "uv>=0.5"
 
-# ── Stage 5: non-root user + workspace mount point ─────────────────────────
+# ── Stage 6: non-root user + workspace mount point ─────────────────────────
 RUN useradd --create-home --shell /bin/bash agent \
     && mkdir -p /workspace \
     && chown -R agent:agent /workspace

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -371,6 +371,11 @@ def _agent_environment_with_host_auth(
         if name not in existing and source_env.get(name):
             merged.append((name, f"${{{name}}}"))
             existing.add(name)
+    if source_env.get("AWF_GITHUB_TOKEN"):
+        for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+            if name not in existing:
+                merged.append((name, "${AWF_GITHUB_TOKEN}"))
+                existing.add(name)
     return tuple(merged)
 
 

--- a/scripts/run_awf.py
+++ b/scripts/run_awf.py
@@ -60,7 +60,11 @@ from awf.node.compose_manager import (
     WorkspaceComposeSpec,
 )
 from awf.node.git_manager import GitManager
-from awf.profiles.compose import profile_agent_environment, profile_services
+from awf.profiles.compose import (
+    agent_environment_with_github_token,
+    profile_agent_environment,
+    profile_services,
+)
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.registry import aira_profile
 from awf.profiles.resolver import resolve_workspace_profile
@@ -371,12 +375,7 @@ def _agent_environment_with_host_auth(
         if name not in existing and source_env.get(name):
             merged.append((name, f"${{{name}}}"))
             existing.add(name)
-    if source_env.get("AWF_GITHUB_TOKEN"):
-        for name in ("GH_TOKEN", "GITHUB_TOKEN"):
-            if name not in existing:
-                merged.append((name, "${AWF_GITHUB_TOKEN}"))
-                existing.add(name)
-    return tuple(merged)
+    return agent_environment_with_github_token(tuple(merged), host_env=source_env)
 
 
 def _profile_agent_environment(profile: WorkspaceProfile) -> tuple[tuple[str, str], ...]:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -44,7 +44,7 @@ from awf.control.validation_fix_cycle import (
 from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
-from awf.node.compose_manager import ComposeManager
+from awf.node.compose_manager import ComposeManager, ComposeOperationError
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
 from awf.runtime.logs import LogStore
@@ -724,6 +724,10 @@ class WorkspaceExecutor:
                 return
             persisted.pr_url = pr.url
             persisted.pr_number = _extract_pr_number(pr.url)
+            if persisted.task_kind == "feature_branch_pr" and not persisted.remote_push_branch:
+                persisted.remote_push_branch = (
+                    pr.branch or persisted.branch_name or f"awf/{workspace_id}"
+                )
             # Resolve which monitor (if any) to hand off to. Pre-constructed
             # ``pr_monitor`` wins (tests); otherwise the factory builds one
             # from the per-task adapter now that we have it.
@@ -789,6 +793,13 @@ class WorkspaceExecutor:
             )
             return
 
+        if not ws.remote_push_branch and ws.task_kind == "feature_branch_pr" and ws.branch_name:
+            await self._recover_feature_branch_remote_push_branch(
+                workspace_id=workspace_id,
+                remote_push_branch=ws.branch_name,
+            )
+            ws.remote_push_branch = ws.branch_name
+
         missing = _missing_monitor_recovery_metadata(ws)
         if missing:
             await self._mark_failed(
@@ -796,8 +807,7 @@ class WorkspaceExecutor:
                 from_status=WorkspaceStatus.monitoring_pr,
                 failure_reason=FailureReason.infrastructure_failure,
                 message=(
-                    "monitor recovery: missing required persisted metadata: "
-                    + ", ".join(missing)
+                    "monitor recovery: missing required persisted metadata: " + ", ".join(missing)
                 )[:2000],
                 reason_code="MONITOR_RECOVERY_METADATA_MISSING",
             )
@@ -807,6 +817,29 @@ class WorkspaceExecutor:
         compose_file_path = ws.compose_file_path
         assert compose_project is not None
         assert compose_file_path is not None
+
+        try:
+            await self._compose.ensure_project_up(
+                project_name=compose_project,
+                compose_file=Path(compose_file_path),
+                workspace_id=workspace_id,
+                wait=True,
+            )
+        except ComposeOperationError as exc:
+            _log.error(
+                "executor.resume_compose_up_failed",
+                workspace_id=workspace_id,
+                reason_code=exc.reason_code,
+                stderr=exc.stderr[:1000],
+            )
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.monitoring_pr,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=f"monitor recovery: compose stack failed to start: {exc}"[:2000],
+                reason_code="MONITOR_RECOVERY_COMPOSE_FAILED",
+            )
+            return
 
         monitor: _MonitorRunnerProto | None = self._pr_monitor
         try:
@@ -867,6 +900,33 @@ class WorkspaceExecutor:
     async def _load_workspace(self, workspace_id: str) -> Workspace | None:
         async with self._session_factory() as session:
             return await WorkspaceRepository(session).get(workspace_id)
+
+    async def _recover_feature_branch_remote_push_branch(
+        self,
+        *,
+        workspace_id: str,
+        remote_push_branch: str,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            if ws is None or ws.status != WorkspaceStatus.monitoring_pr.value:
+                return
+            if ws.remote_push_branch:
+                return
+            if ws.task_kind != "feature_branch_pr" or not ws.branch_name:
+                return
+            ws.remote_push_branch = remote_push_branch
+            await repo.add_event(
+                ws,
+                event_type="workspace.remote_push_branch_recovered",
+                reason_code="REMOTE_PUSH_BRANCH_RECOVERED",
+                payload={
+                    "remote_push_branch": remote_push_branch,
+                    "source": "branch_name",
+                },
+            )
+            await session.commit()
 
     def _defaults_for(self, agent: AgentRuntime) -> AgentDefaults | None:
         defaults = defaults_with_model_overrides(
@@ -953,7 +1013,9 @@ def _missing_monitor_recovery_metadata(ws: Workspace) -> list[str]:
     if not ws.pr_url:
         missing.append("pr_url")
     if not ws.remote_push_branch:
-        missing.append("remote_push_branch")
+        missing.append(
+            f"remote_push_branch (task_kind={ws.task_kind}, branch_name={ws.branch_name!r})"
+        )
     if not ws.compose_project_name:
         missing.append("compose_project_name")
     if not ws.compose_file_path:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -794,11 +794,12 @@ class WorkspaceExecutor:
             return
 
         if not ws.remote_push_branch and ws.task_kind == "feature_branch_pr" and ws.branch_name:
-            await self._recover_feature_branch_remote_push_branch(
+            recovered_remote_push_branch = await self._recover_feature_branch_remote_push_branch(
                 workspace_id=workspace_id,
                 remote_push_branch=ws.branch_name,
             )
-            ws.remote_push_branch = ws.branch_name
+            if recovered_remote_push_branch:
+                ws.remote_push_branch = recovered_remote_push_branch
 
         missing = _missing_monitor_recovery_metadata(ws)
         if missing:
@@ -906,16 +907,16 @@ class WorkspaceExecutor:
         *,
         workspace_id: str,
         remote_push_branch: str,
-    ) -> None:
+    ) -> str | None:
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
             ws = await repo.get(workspace_id)
             if ws is None or ws.status != WorkspaceStatus.monitoring_pr.value:
-                return
+                return None
             if ws.remote_push_branch:
-                return
+                return ws.remote_push_branch
             if ws.task_kind != "feature_branch_pr" or not ws.branch_name:
-                return
+                return None
             ws.remote_push_branch = remote_push_branch
             await repo.add_event(
                 ws,
@@ -927,6 +928,7 @@ class WorkspaceExecutor:
                 },
             )
             await session.commit()
+            return remote_push_branch
 
     def _defaults_for(self, agent: AgentRuntime) -> AgentDefaults | None:
         defaults = defaults_with_model_overrides(

--- a/src/awf/node/compose_manager.py
+++ b/src/awf/node/compose_manager.py
@@ -267,6 +267,33 @@ class ComposeManager:
         await self._compose(spec.project_name(), paths.compose_file, args, operation="up")
         return paths
 
+    async def ensure_project_up(
+        self,
+        *,
+        project_name: str,
+        compose_file: Path,
+        workspace_id: str,
+        wait: bool = True,
+    ) -> None:
+        """Start an already-rendered compose project without re-rendering.
+
+        Used by PR-monitor resume: the workspace row already records the
+        compose project and compose.yml path that were active before the
+        service restart. Re-rendering from a profile at resume time risks
+        drifting from the stack the monitor originally owned.
+        """
+        args = ["up", "-d"]
+        if wait:
+            args.append("--wait")
+        _log.info(
+            "compose.ensure_project_up",
+            workspace_id=workspace_id,
+            project_name=project_name,
+            compose_file=str(compose_file),
+            wait=wait,
+        )
+        await self._compose(project_name, compose_file, args, operation="up")
+
     async def down(self, spec: WorkspaceComposeSpec, *, remove_volumes: bool = True) -> None:
         """Stop + remove the stack. Idempotent — absent projects are not errors."""
         paths = self._paths_for(spec)

--- a/src/awf/node/stack_launcher.py
+++ b/src/awf/node/stack_launcher.py
@@ -15,7 +15,11 @@ from awf.node.compose_manager import (
     WorkspaceComposeSpec,
 )
 from awf.node.git_manager import WorktreeLayout
-from awf.profiles.compose import profile_agent_environment, profile_services
+from awf.profiles.compose import (
+    agent_environment_with_github_token,
+    profile_agent_environment,
+    profile_services,
+)
 from awf.profiles.models import WorkspaceProfile
 
 
@@ -70,7 +74,9 @@ class ComposeStackLauncher:
             workspace_id=request.workspace_id,
             worktree_host_path=layout.worktree_path,
             agent_runtime_image=self._agent_runtime_image,
-            agent_environment=profile_agent_environment(profile),
+            agent_environment=agent_environment_with_github_token(
+                profile_agent_environment(profile)
+            ),
             docker_mode=profile.docker.mode.value,
             services=profile_services(profile),
             auth_mounts=tuple(auth_mounts),

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+from collections.abc import Mapping
+
 from awf.node.compose_manager import ComposeService
 from awf.profiles.models import WorkspaceProfile
 
@@ -28,3 +31,22 @@ def profile_services(profile: WorkspaceProfile) -> tuple[ComposeService, ...]:
 
 def profile_agent_environment(profile: WorkspaceProfile) -> tuple[tuple[str, str], ...]:
     return tuple(profile.runtime.environment.items())
+
+
+def agent_environment_with_github_token(
+    base_environment: tuple[tuple[str, str], ...],
+    *,
+    host_env: Mapping[str, str] | None = None,
+) -> tuple[tuple[str, str], ...]:
+    """Expose AWF's GitHub token to agent containers via Compose placeholders."""
+    source_env = os.environ if host_env is None else host_env
+    if not source_env.get("AWF_GITHUB_TOKEN"):
+        return base_environment
+
+    merged: list[tuple[str, str]] = list(base_environment)
+    existing = {key for key, _ in merged}
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        if name not in existing:
+            merged.append((name, "${AWF_GITHUB_TOKEN}"))
+            existing.add(name)
+    return tuple(merged)

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -538,6 +538,7 @@ class TestMonitorHandoff:
             assert ws.status == _WS.completed.value
             assert ws.pr_url == "https://github.com/dimileeh/aira-web/pull/7777"
             assert ws.pr_number == 7777
+            assert ws.remote_push_branch == f"awf/{ws_id}"
             assert ws.pr_merge_sha == "stub_merge_sha"
             transitions = [(e.old_state, e.new_state) for e in ws.events]
             assert ("pushing", "monitoring_pr") in transitions

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -1058,6 +1058,68 @@ class TestPrMonitorResume:
             }
 
     @pytest.mark.unit
+    async def test_resume_pr_monitor_does_not_use_stale_recovery_when_status_changed(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        class _UnexpectedCompose:
+            async def ensure_project_up(
+                self,
+                *,
+                project_name: str,
+                compose_file: Path,
+                workspace_id: str,
+                wait: bool = True,
+            ) -> None:
+                del project_name, compose_file, workspace_id, wait
+                raise AssertionError("compose must not restart after recovery skips")
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            branch_name="awf/concurrent-feature",
+            remote_push_branch=None,
+        )
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=lambda *_args: object(),
+            compose=_UnexpectedCompose(),
+        )
+        original_load_workspace = executor._load_workspace
+
+        async def _load_then_complete(workspace_id: str) -> Any:
+            ws = await original_load_workspace(workspace_id)
+            async with factory() as s:
+                repo = WorkspaceRepository(s)
+                fresh = await repo.get(workspace_id)
+                assert fresh is not None
+                await repo.transition(
+                    fresh,
+                    to=WorkspaceStatus.completed,
+                    reason_code="CONCURRENT_COMPLETED",
+                )
+                await s.commit()
+            return ws
+
+        executor._load_workspace = _load_then_complete  # type: ignore[method-assign]
+
+        await executor.resume_pr_monitor(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.remote_push_branch is None
+            assert not [
+                event
+                for event in ws.events
+                if event.event_type == "workspace.remote_push_branch_recovered"
+            ]
+
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "field",
         [

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -62,8 +62,9 @@ def _make_executor(
     tmp_path: Path,
     *,
     pr_monitor_factory: Any = None,
+    compose: Any = None,
 ) -> WorkspaceExecutor:
-    compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+    compose = compose or _NoopResumeCompose()
     validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
     pr = PullRequestCreator(fake)
     return WorkspaceExecutor(
@@ -83,6 +84,18 @@ def _make_executor(
         ),
         pr_monitor_factory=pr_monitor_factory,
     )
+
+
+class _NoopResumeCompose:
+    async def ensure_project_up(
+        self,
+        *,
+        project_name: str,
+        compose_file: Path,
+        workspace_id: str,
+        wait: bool = True,
+    ) -> None:
+        del project_name, compose_file, workspace_id, wait
 
 
 async def _seed_ready(
@@ -118,6 +131,8 @@ async def _seed_ready(
 async def _seed_monitoring_pr(
     factory: async_sessionmaker[AsyncSession],
     *,
+    branch_name: str | None = "awf/x",
+    task_kind: str = "feature_branch_pr",
     pr_number: int | None = 42,
     pr_url: str | None = "https://github.com/x/y/pull/42",
     remote_push_branch: str | None = "awf/x",
@@ -141,8 +156,9 @@ async def _seed_monitoring_pr(
             auto_merge=auto_merge,
             initial_review_grace_period_seconds=initial_review_grace_period_seconds,
         )
+        ws.task_kind = task_kind
         await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
-        ws.branch_name = "awf/x"
+        ws.branch_name = branch_name
         ws.remote_push_branch = remote_push_branch
         ws.base_commit = "a" * 40
         ws.compose_project_name = compose_project_name
@@ -941,12 +957,112 @@ class TestPrMonitorResume:
         ]
 
     @pytest.mark.unit
+    async def test_resume_pr_monitor_restarts_persisted_compose_stack_before_monitor(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        compose_file = tmp_path / "persisted-compose" / "compose.yml"
+        compose_file_path = compose_file
+        call_order: list[str] = []
+
+        class _RecordingCompose:
+            async def ensure_project_up(
+                self,
+                *,
+                project_name: str,
+                compose_file: Path,
+                workspace_id: str,
+                wait: bool = True,
+            ) -> None:
+                call_order.append("compose")
+                assert project_name == "persisted_project"
+                assert compose_file == compose_file_path
+                assert workspace_id == ws_id
+                assert wait is True
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                call_order.append("monitor")
+                assert call_order == ["compose", "monitor"]
+                assert workspace_id == ws_id
+                assert compose_project == "persisted_project"
+                assert compose_file == compose_file_path
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            compose_project_name="persisted_project",
+            compose_file_path=str(compose_file),
+        )
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=lambda *_args: _Monitor(),
+            compose=_RecordingCompose(),
+        )
+
+        await executor.resume_pr_monitor(ws_id)
+
+        assert call_order == ["compose", "monitor"]
+
+    @pytest.mark.unit
+    async def test_resume_pr_monitor_recovers_feature_branch_remote_push_branch(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        monitor_calls: list[str] = []
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                del compose_project, compose_file
+                monitor_calls.append(workspace_id)
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            branch_name="awf/legacy-feature",
+            remote_push_branch=None,
+        )
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=lambda *_args: _Monitor(),
+        )
+
+        await executor.resume_pr_monitor(ws_id)
+
+        assert monitor_calls == [ws_id]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.remote_push_branch == "awf/legacy-feature"
+            recovery_events = [
+                event
+                for event in ws.events
+                if event.event_type == "workspace.remote_push_branch_recovered"
+            ]
+            assert len(recovery_events) == 1
+            assert recovery_events[0].reason_code == "REMOTE_PUSH_BRANCH_RECOVERED"
+            assert recovery_events[0].payload == {
+                "remote_push_branch": "awf/legacy-feature",
+                "source": "branch_name",
+            }
+
+    @pytest.mark.unit
     @pytest.mark.parametrize(
         "field",
         [
             "pr_number",
             "pr_url",
-            "remote_push_branch",
             "compose_project_name",
             "compose_file_path",
         ],
@@ -976,3 +1092,35 @@ class TestPrMonitorResume:
             assert field in (ws.failure_message or "")
             assert "monitor recovery" in (ws.failure_message or "")
             assert ws.events[-1].reason_code == "MONITOR_RECOVERY_METADATA_MISSING"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("task_kind", ["monitor_release_pr", "sync_release_pr", "sync_feature_pr"])
+    async def test_sync_and_release_resume_fail_when_remote_push_branch_is_unknown(
+        self,
+        task_kind: str,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_kind=task_kind,
+            branch_name="release-sync/local-only",
+            remote_push_branch=None,
+        )
+
+        def _monitor_factory(*_args: Any) -> object:
+            raise AssertionError("monitor factory must not run without a safe remote branch")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.resume_pr_monitor(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert "remote_push_branch" in (ws.failure_message or "")
+            assert task_kind in (ws.failure_message or "")
+            assert ws.remote_push_branch is None

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -1094,7 +1094,9 @@ class TestPrMonitorResume:
             assert ws.events[-1].reason_code == "MONITOR_RECOVERY_METADATA_MISSING"
 
     @pytest.mark.unit
-    @pytest.mark.parametrize("task_kind", ["monitor_release_pr", "sync_release_pr", "sync_feature_pr"])
+    @pytest.mark.parametrize(
+        "task_kind", ["monitor_release_pr", "sync_release_pr", "sync_feature_pr"]
+    )
     async def test_sync_and_release_resume_fail_when_remote_push_branch_is_unknown(
         self,
         task_kind: str,

--- a/tests/unit/node/test_compose_manager_subprocess.py
+++ b/tests/unit/node/test_compose_manager_subprocess.py
@@ -110,6 +110,38 @@ class TestUp:
         assert paths.compose_file.name == "compose.yml"
 
 
+class TestEnsureProjectUp:
+    @pytest.mark.unit
+    async def test_uses_persisted_project_and_file_without_rendering(
+        self, manager: ComposeManager, tmp_path: Path
+    ) -> None:
+        compose_file = tmp_path / "persisted-compose.yml"
+        with patch(
+            "awf.node.compose_manager.asyncio.create_subprocess_exec",
+            return_value=_mock_proc(),
+        ) as mock_exec:
+            await manager.ensure_project_up(
+                project_name="awf_persisted_ws",
+                compose_file=compose_file,
+                workspace_id="ws_persisted",
+                wait=True,
+            )
+
+        cmd = mock_exec.call_args[0]
+        assert cmd == (
+            "docker",
+            "compose",
+            "--project-name",
+            "awf_persisted_ws",
+            "--file",
+            str(compose_file),
+            "up",
+            "-d",
+            "--wait",
+        )
+        assert not (tmp_path / "work" / "compose" / "ws_persisted").exists()
+
+
 class TestDown:
     @pytest.mark.unit
     async def test_down_is_noop_when_project_never_rendered(

--- a/tests/unit/node/test_stack_launcher.py
+++ b/tests/unit/node/test_stack_launcher.py
@@ -105,6 +105,65 @@ async def test_compose_stack_launcher_builds_profile_driven_spec() -> None:
 
 
 @pytest.mark.unit
+async def test_compose_stack_launcher_passes_github_token_placeholders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWF_GITHUB_TOKEN", "ghp_raw_secret")
+    compose = _RecordingCompose()
+    launcher = ComposeStackLauncher(
+        compose=compose,  # type: ignore[arg-type]
+        agent_runtime_image="custom-agent-runtime:dev",
+    )
+    layout = WorktreeLayout(
+        mirror_path=Path("/host/awf/git/mirrors/repo.git"),
+        worktree_path=Path("/host/awf/git/worktrees/ws_launcher"),
+        branch_name="awf/ws_launcher",
+    )
+
+    await launcher.launch(
+        WorkspaceStackLaunchRequest(
+            workspace_id="ws_launcher",
+            layout=layout,
+            profile=WorkspaceProfile(name="generic"),
+        )
+    )
+
+    env = dict(compose.specs[0].agent_environment)
+    assert env["GH_TOKEN"] == "${AWF_GITHUB_TOKEN}"
+    assert env["GITHUB_TOKEN"] == "${AWF_GITHUB_TOKEN}"
+    assert "ghp_raw_secret" not in repr(compose.specs[0].agent_environment)
+
+
+@pytest.mark.unit
+async def test_compose_stack_launcher_omits_github_token_placeholders_when_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AWF_GITHUB_TOKEN", raising=False)
+    compose = _RecordingCompose()
+    launcher = ComposeStackLauncher(
+        compose=compose,  # type: ignore[arg-type]
+        agent_runtime_image="custom-agent-runtime:dev",
+    )
+    layout = WorktreeLayout(
+        mirror_path=Path("/host/awf/git/mirrors/repo.git"),
+        worktree_path=Path("/host/awf/git/worktrees/ws_launcher"),
+        branch_name="awf/ws_launcher",
+    )
+
+    await launcher.launch(
+        WorkspaceStackLaunchRequest(
+            workspace_id="ws_launcher",
+            layout=layout,
+            profile=WorkspaceProfile(name="generic"),
+        )
+    )
+
+    env = dict(compose.specs[0].agent_environment)
+    assert "GH_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+
+
+@pytest.mark.unit
 async def test_compose_stack_launcher_appends_service_auth_mounts() -> None:
     compose = _RecordingCompose()
     auth_mount_resolver = _RecordingAuthMountResolver()

--- a/tests/unit/scripts/test_run_awf_handlers.py
+++ b/tests/unit/scripts/test_run_awf_handlers.py
@@ -1261,13 +1261,18 @@ class TestAgentEnvironmentWithHostAuth:
             host_env={
                 "ANTHROPIC_API_KEY": "secret-anthropic",
                 "GEMINI_API_KEY": "secret-gemini",
+                "AWF_GITHUB_TOKEN": "ghp_raw_secret",
             },
         )
 
         assert ("PYTHONUNBUFFERED", "1") in env
         assert ("ANTHROPIC_API_KEY", "${ANTHROPIC_API_KEY}") in env
         assert ("GEMINI_API_KEY", "${GEMINI_API_KEY}") in env
+        assert ("GH_TOKEN", "${AWF_GITHUB_TOKEN}") in env
+        assert ("GITHUB_TOKEN", "${AWF_GITHUB_TOKEN}") in env
         assert ("ANTHROPIC_API_KEY", "secret-anthropic") not in env
+        assert ("GH_TOKEN", "ghp_raw_secret") not in env
+        assert ("GITHUB_TOKEN", "ghp_raw_secret") not in env
 
     @pytest.mark.unit
     def test_profile_env_wins_over_host_passthrough(self) -> None:

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.unit
+def test_agent_runtime_installs_github_cli_from_official_apt_repository() -> None:
+    dockerfile = Path("docker/agent-runtime.Dockerfile").read_text(encoding="utf-8")
+
+    assert "cli.github.com/packages" in dockerfile
+    assert "githubcli-archive-keyring.gpg" in dockerfile
+    assert "apt-get install -y --no-install-recommends gh" in dockerfile
+    assert "gh --version" in dockerfile


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_4f7c070e46014314a41f30c7` (agent: `codex`).


### Task
Context: during the latest AWF dogfood run, Docker Desktop restarted while PR monitors were active. We manually repaired three things that AWF must handle itself: service-created feature PR rows did not persist remote_push_branch, monitor resume did not bring the workspace compose stack back up before AddressComments, and agent containers lacked gh/GH_TOKEN so comment-fix agents could not use GitHub safely.

Implement the durable fix with strict TDD. Write failing tests first and commit them before implementation.

Required behavior:
1. In the service WorkspaceExecutor feature_branch_pr path, persist remote_push_branch before entering monitoring_pr. For normal feature_branch_pr workspaces this must be the PR head branch / workspace branch, not empty.
2. In resume_pr_monitor, legacy feature_branch_pr rows with missing remote_push_branch may recover by using branch_name when branch_name is present. Persist that recovered value and emit a workspace event. Sync/release monitor rows must still fail clearly if the remote branch cannot be known.
3. Before a resumed PR monitor runs, ensure the existing workspace compose stack is up and healthy using the persisted compose project/file. Add a ComposeManager helper if needed; do not re-render the stack from profile during resume.
4. Permanently install GitHub CLI in docker/agent-runtime.Dockerfile.
5. Propagate AWF_GITHUB_TOKEN to agent containers as GH_TOKEN and GITHUB_TOKEN without writing the raw token into tracked files. Prefer a Compose interpolation placeholder such as ${AWF_GITHUB_TOKEN} only when the worker environment has the token.
6. Add focused unit tests for all of the above.

Do not manually push or merge. AWF owns PR creation, monitoring, comment handling, base sync, and merge. Keep changes narrow and production-oriented.

---
Validation: 3 profile command(s) passed inside the workspace container.
