### PR TITLE
feat(service): add terminal workspace garbage collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,33 @@ uv run --python 3.12 --extra dev awf service logs --follow --service api --servi
 the `api` and `worker` services. Repeat `--service` to select `api`, `worker`,
 `migrate`, or `postgres`.
 
+Plan terminal workspace filesystem garbage collection:
+
+```bash
+uv run --python 3.12 --extra dev awf service gc
+uv run --python 3.12 --extra dev awf service gc --format pretty
+uv run --python 3.12 --extra dev awf service gc --min-age-hours 336 --limit 20
+```
+
+`awf service gc` defaults to a dry-run JSON plan. It only considers terminal
+workspaces in `completed`, `failed`, `cancelled`, or `destroyed`, and it never
+selects active workspaces such as `requested`, `provisioning`, `ready`,
+`running`, `validating`, `pushing`, or `monitoring_pr`. Each candidate reports
+the worktree, compose, and auth paths plus estimated bytes; missing paths are
+reported as zero bytes.
+
+Execute the same filesystem-only cleanup with:
+
+```bash
+uv run --python 3.12 --extra dev awf service gc --execute
+```
+
+Execution deletes only `<work_dir>/git/worktrees/<workspace>`,
+`<work_dir>/compose/<workspace>` or the stored compose-file parent, and
+`<work_dir>/auth/<workspace>`. It does not delete control-plane database rows,
+workspace events, or log streams; durable logs remain available for audit and
+postmortem inspection.
+
 Create a workspace:
 
 ```bash

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -18,12 +18,14 @@ import os
 import sys
 import urllib.parse
 from enum import StrEnum
+from pathlib import Path
 from typing import Any
 
 import httpx
 import typer
 
-from awf.db.enums import OperationStatus, OperationType
+from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.service.gc import DEFAULT_MIN_AGE_HOURS
 from awf.service.logs import DEFAULT_LOG_TAIL, ServiceLogName
 
 app = typer.Typer(
@@ -210,6 +212,70 @@ def service_logs(
         typer.echo(result.stdout, nl=False)
     if result.stderr:
         typer.echo(result.stderr, err=True, nl=False)
+
+
+@service_app.command("gc")
+def service_gc(
+    execute: bool = typer.Option(
+        False,
+        "--execute",
+        help="Delete selected worktree, compose, and auth directories. Defaults to dry-run.",
+    ),
+    min_age_hours: int = typer.Option(
+        DEFAULT_MIN_AGE_HOURS,
+        "--min-age-hours",
+        min=0,
+        help="Only consider terminal workspaces whose last update is at least this old.",
+    ),
+    limit: int | None = typer.Option(
+        None,
+        "--limit",
+        min=1,
+        help="Maximum number of candidates to plan, oldest first.",
+    ),
+    status: list[WorkspaceStatus] = typer.Option(
+        [],
+        "--status",
+        help=(
+            "Repeatable terminal status filter. Active statuses are always protected "
+            "even when requested."
+        ),
+    ),
+    exclude_status: list[WorkspaceStatus] = typer.Option(
+        [],
+        "--exclude-status",
+        help="Repeatable status filter to remove from the eligible terminal set.",
+    ),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Plan or execute filesystem GC for terminal service workspaces."""
+    from awf.db.session import make_engine, make_session_factory
+    from awf.service.config import resolve_service_settings
+    from awf.service.gc import run_terminal_workspace_gc
+
+    settings = resolve_service_settings()
+    engine = make_engine(settings.database_url)
+    session_factory = make_session_factory(engine)
+
+    async def _run() -> object:
+        try:
+            result = await run_terminal_workspace_gc(
+                session_factory,
+                work_dir=Path(settings.work_dir).expanduser().resolve(),
+                min_age_hours=min_age_hours,
+                limit=limit,
+                include_statuses=status or None,
+                exclude_statuses=exclude_status or None,
+                execute=execute,
+            )
+            return result.to_dict()
+        finally:
+            await engine.dispose()
+
+    payload = asyncio.run(_run())
+    _emit(payload, fmt)
+    if isinstance(payload, dict) and payload.get("delete_errors"):
+        raise typer.Exit(code=1)
 
 
 @workspace_app.command("create")

--- a/src/awf/service/gc.py
+++ b/src/awf/service/gc.py
@@ -223,13 +223,16 @@ async def plan_terminal_workspace_gc(
     )
     eligible_statuses -= excluded_statuses
     eligible_statuses -= set(PROTECTED_WORKSPACE_GC_STATUSES)
+    plan_include_statuses = (
+        requested_statuses if requested_statuses is not None else eligible_statuses
+    )
 
     if not eligible_statuses:
         return WorkspaceGCPlan(
             work_dir=normalized_work_dir,
             min_age_hours=min_age_hours,
             cutoff_at=cutoff_at,
-            include_statuses=(),
+            include_statuses=tuple(sorted(plan_include_statuses)),
             exclude_statuses=tuple(sorted(excluded_statuses)),
             candidates=[],
         )
@@ -257,7 +260,7 @@ async def plan_terminal_workspace_gc(
         work_dir=normalized_work_dir,
         min_age_hours=min_age_hours,
         cutoff_at=cutoff_at,
-        include_statuses=tuple(sorted(eligible_statuses)),
+        include_statuses=tuple(sorted(plan_include_statuses)),
         exclude_statuses=tuple(sorted(excluded_statuses)),
         candidates=candidates,
     )

--- a/src/awf/service/gc.py
+++ b/src/awf/service/gc.py
@@ -1,0 +1,419 @@
+"""Filesystem garbage collection for terminal service workspaces.
+
+This module only relieves disk pressure from per-workspace runtime directories.
+It deliberately does not delete control-plane rows, workspace events, or durable
+log streams.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Workspace
+
+DEFAULT_MIN_AGE_HOURS = 168
+
+TERMINAL_WORKSPACE_GC_STATUSES = frozenset(
+    {
+        WorkspaceStatus.completed.value,
+        WorkspaceStatus.failed.value,
+        WorkspaceStatus.cancelled.value,
+        WorkspaceStatus.destroyed.value,
+    }
+)
+
+PROTECTED_WORKSPACE_GC_STATUSES = frozenset(
+    {
+        WorkspaceStatus.requested.value,
+        WorkspaceStatus.provisioning.value,
+        WorkspaceStatus.ready.value,
+        WorkspaceStatus.running.value,
+        WorkspaceStatus.validating.value,
+        WorkspaceStatus.pushing.value,
+        WorkspaceStatus.monitoring_pr.value,
+        WorkspaceStatus.destroying.value,
+    }
+)
+
+
+@dataclass(frozen=True)
+class WorkspaceGCPath:
+    """One filesystem target considered for workspace GC."""
+
+    kind: str
+    path: Path
+    exists: bool
+    estimated_bytes: int
+
+    def to_dict(self, *, deleted: bool = False, error: str | None = None) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "path": str(self.path),
+            "exists": self.exists,
+            "estimated_bytes": self.estimated_bytes,
+            "deleted": deleted,
+        }
+        if error is not None:
+            payload["error"] = error
+        return payload
+
+
+@dataclass(frozen=True)
+class WorkspaceGCCandidate:
+    """A terminal workspace whose pressure directories are eligible for GC."""
+
+    workspace_id: str
+    status: str
+    updated_at: datetime
+    age_hours: int
+    worktree: WorkspaceGCPath
+    compose: WorkspaceGCPath
+    auth: WorkspaceGCPath
+
+    @property
+    def total_estimated_bytes(self) -> int:
+        return (
+            self.worktree.estimated_bytes + self.compose.estimated_bytes + self.auth.estimated_bytes
+        )
+
+    def paths(self) -> Iterator[WorkspaceGCPath]:
+        yield self.worktree
+        yield self.compose
+        yield self.auth
+
+    def to_dict(
+        self,
+        *,
+        deleted_paths: set[Path] | None = None,
+        delete_errors: dict[tuple[str, Path], str] | None = None,
+    ) -> dict[str, object]:
+        deleted_paths = deleted_paths or set()
+        delete_errors = delete_errors or {}
+        paths = {
+            item.kind: item.to_dict(
+                deleted=item.path in deleted_paths,
+                error=delete_errors.get((item.kind, item.path)),
+            )
+            for item in self.paths()
+        }
+        return {
+            "workspace_id": self.workspace_id,
+            "status": self.status,
+            "updated_at": self.updated_at.isoformat(),
+            "age_hours": self.age_hours,
+            "estimated_bytes": {
+                "worktree": self.worktree.estimated_bytes,
+                "compose": self.compose.estimated_bytes,
+                "auth": self.auth.estimated_bytes,
+                "total": self.total_estimated_bytes,
+            },
+            "paths": paths,
+        }
+
+
+@dataclass(frozen=True)
+class WorkspaceGCPlan:
+    """Inspectable GC plan before deletion."""
+
+    work_dir: Path
+    min_age_hours: float
+    cutoff_at: datetime
+    include_statuses: tuple[str, ...]
+    exclude_statuses: tuple[str, ...]
+    candidates: list[WorkspaceGCCandidate]
+
+    @property
+    def total_estimated_bytes(self) -> int:
+        return sum(candidate.total_estimated_bytes for candidate in self.candidates)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "work_dir": str(self.work_dir),
+            "min_age_hours": self.min_age_hours,
+            "cutoff_at": self.cutoff_at.isoformat(),
+            "include_statuses": list(self.include_statuses),
+            "exclude_statuses": list(self.exclude_statuses),
+            "candidate_count": len(self.candidates),
+            "total_estimated_bytes": self.total_estimated_bytes,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+        }
+
+
+@dataclass(frozen=True)
+class WorkspaceGCDeleteError:
+    """One deletion failure captured without aborting the rest of the GC run."""
+
+    workspace_id: str
+    kind: str
+    path: Path
+    error: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "workspace_id": self.workspace_id,
+            "kind": self.kind,
+            "path": str(self.path),
+            "error": self.error,
+        }
+
+
+@dataclass(frozen=True)
+class WorkspaceGCResult:
+    """GC plan plus optional execution outcome."""
+
+    plan: WorkspaceGCPlan
+    dry_run: bool
+    deleted_paths: list[Path]
+    delete_errors: list[WorkspaceGCDeleteError]
+
+    def to_dict(self) -> dict[str, object]:
+        deleted_paths = set(self.deleted_paths)
+        delete_errors = {(error.kind, error.path): error.error for error in self.delete_errors}
+        payload = self.plan.to_dict()
+        payload.update(
+            {
+                "dry_run": self.dry_run,
+                "deleted_paths": [str(path) for path in self.deleted_paths],
+                "deleted_path_count": len(self.deleted_paths),
+                "delete_errors": [error.to_dict() for error in self.delete_errors],
+            }
+        )
+        payload["candidates"] = [
+            candidate.to_dict(
+                deleted_paths=deleted_paths,
+                delete_errors=delete_errors,
+            )
+            for candidate in self.plan.candidates
+        ]
+        return payload
+
+
+async def plan_terminal_workspace_gc(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    work_dir: Path | str,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    limit: int | None = None,
+    include_statuses: Iterable[WorkspaceStatus | str] | None = None,
+    exclude_statuses: Iterable[WorkspaceStatus | str] | None = None,
+    now: datetime | None = None,
+) -> WorkspaceGCPlan:
+    """Build a terminal-workspace filesystem cleanup plan.
+
+    Active and destroying workspaces are never eligible, even if explicitly
+    requested through ``include_statuses``.
+    """
+
+    current_time = _to_utc(now or datetime.now(UTC))
+    normalized_work_dir = Path(work_dir).expanduser()
+    cutoff_at = current_time - timedelta(hours=min_age_hours)
+    requested_statuses = _normalize_statuses(include_statuses)
+    excluded_statuses = _normalize_statuses(exclude_statuses) or set()
+    eligible_statuses = (
+        set(TERMINAL_WORKSPACE_GC_STATUSES)
+        if requested_statuses is None
+        else requested_statuses & set(TERMINAL_WORKSPACE_GC_STATUSES)
+    )
+    eligible_statuses -= excluded_statuses
+    eligible_statuses -= set(PROTECTED_WORKSPACE_GC_STATUSES)
+
+    if not eligible_statuses:
+        return WorkspaceGCPlan(
+            work_dir=normalized_work_dir,
+            min_age_hours=min_age_hours,
+            cutoff_at=cutoff_at,
+            include_statuses=(),
+            exclude_statuses=tuple(sorted(excluded_statuses)),
+            candidates=[],
+        )
+
+    async with session_factory() as session:
+        stmt = (
+            select(Workspace)
+            .where(Workspace.status.in_(sorted(eligible_statuses)))
+            .where(Workspace.updated_at <= cutoff_at)
+            .order_by(Workspace.updated_at.asc(), Workspace.id.asc())
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        rows = list((await session.execute(stmt)).scalars())
+
+    candidates = [
+        _candidate_for_workspace(
+            workspace,
+            work_dir=normalized_work_dir,
+            now=current_time,
+        )
+        for workspace in rows
+    ]
+    return WorkspaceGCPlan(
+        work_dir=normalized_work_dir,
+        min_age_hours=min_age_hours,
+        cutoff_at=cutoff_at,
+        include_statuses=tuple(sorted(eligible_statuses)),
+        exclude_statuses=tuple(sorted(excluded_statuses)),
+        candidates=candidates,
+    )
+
+
+async def run_terminal_workspace_gc(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    work_dir: Path | str,
+    min_age_hours: float = DEFAULT_MIN_AGE_HOURS,
+    limit: int | None = None,
+    include_statuses: Iterable[WorkspaceStatus | str] | None = None,
+    exclude_statuses: Iterable[WorkspaceStatus | str] | None = None,
+    execute: bool = False,
+    now: datetime | None = None,
+) -> WorkspaceGCResult:
+    """Plan terminal workspace GC and optionally delete selected directories."""
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=work_dir,
+        min_age_hours=min_age_hours,
+        limit=limit,
+        include_statuses=include_statuses,
+        exclude_statuses=exclude_statuses,
+        now=now,
+    )
+    if not execute:
+        return WorkspaceGCResult(
+            plan=plan,
+            dry_run=True,
+            deleted_paths=[],
+            delete_errors=[],
+        )
+
+    deleted_paths: list[Path] = []
+    delete_errors: list[WorkspaceGCDeleteError] = []
+    for candidate in plan.candidates:
+        for target in candidate.paths():
+            deleted, error = _delete_gc_path(target, work_dir=plan.work_dir)
+            if deleted:
+                deleted_paths.append(target.path)
+            if error is not None:
+                delete_errors.append(
+                    WorkspaceGCDeleteError(
+                        workspace_id=candidate.workspace_id,
+                        kind=target.kind,
+                        path=target.path,
+                        error=error,
+                    )
+                )
+
+    return WorkspaceGCResult(
+        plan=plan,
+        dry_run=False,
+        deleted_paths=deleted_paths,
+        delete_errors=delete_errors,
+    )
+
+
+def _candidate_for_workspace(
+    workspace: Workspace,
+    *,
+    work_dir: Path,
+    now: datetime,
+) -> WorkspaceGCCandidate:
+    updated_at = _to_utc(workspace.updated_at)
+    age_hours = max(0, int((now - updated_at).total_seconds() // 3600))
+    worktree_path = work_dir / "git" / "worktrees" / workspace.id
+    compose_path = (
+        Path(workspace.compose_file_path).expanduser().parent
+        if workspace.compose_file_path
+        else work_dir / "compose" / workspace.id
+    )
+    auth_path = work_dir / "auth" / workspace.id
+    return WorkspaceGCCandidate(
+        workspace_id=workspace.id,
+        status=workspace.status,
+        updated_at=updated_at,
+        age_hours=age_hours,
+        worktree=_gc_path("worktree", worktree_path),
+        compose=_gc_path("compose", compose_path),
+        auth=_gc_path("auth", auth_path),
+    )
+
+
+def _gc_path(kind: str, path: Path) -> WorkspaceGCPath:
+    return WorkspaceGCPath(
+        kind=kind,
+        path=path,
+        exists=path.exists(),
+        estimated_bytes=_estimate_bytes(path),
+    )
+
+
+def _estimate_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    if path.is_file():
+        try:
+            return path.stat().st_size
+        except OSError:
+            return 0
+    total = 0
+    for child in path.rglob("*"):
+        try:
+            if child.is_file():
+                total += child.stat().st_size
+        except OSError:
+            continue
+    return total
+
+
+def _delete_gc_path(target: WorkspaceGCPath, *, work_dir: Path) -> tuple[bool, str | None]:
+    if not target.path.exists():
+        return False, None
+    if not _is_safe_gc_path(target, work_dir=work_dir):
+        return False, "path is outside the expected service GC roots"
+    if target.path.is_symlink():
+        return False, "refusing to delete symlink"
+    if not target.path.is_dir():
+        return False, "refusing to delete non-directory path"
+    try:
+        shutil.rmtree(target.path)
+    except OSError as exc:
+        return False, str(exc)
+    return True, None
+
+
+def _is_safe_gc_path(target: WorkspaceGCPath, *, work_dir: Path) -> bool:
+    roots = {
+        "worktree": work_dir / "git" / "worktrees",
+        "compose": work_dir / "compose",
+        "auth": work_dir / "auth",
+    }
+    root = roots.get(target.kind)
+    if root is None:
+        return False
+    try:
+        target.path.resolve(strict=False).relative_to(root.resolve(strict=False))
+    except ValueError:
+        return False
+    return True
+
+
+def _normalize_statuses(
+    statuses: Iterable[WorkspaceStatus | str] | None,
+) -> set[str] | None:
+    if statuses is None:
+        return None
+    return {
+        status.value if isinstance(status, WorkspaceStatus) else str(status) for status in statuses
+    }
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -6,6 +6,7 @@ import asyncio
 import json
 import subprocess
 import threading
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,45 @@ _runner = CliRunner()
 
 def _combined_output(result: Any) -> str:
     return f"{result.stdout}{getattr(result, 'stderr', '')}"
+
+
+def _write_gc_file(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _create_gc_cli_workspace(
+    *,
+    db_url: str,
+    status: str,
+    updated_at: datetime,
+) -> str:
+    async def _setup() -> str:
+        from awf.db.base import Base
+        from awf.db.repositories import WorkspaceRepository
+        from awf.db.session import make_engine, make_session_factory
+
+        engine = make_engine(db_url)
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/repo.git",
+                branch_base="development",
+                task_title="gc cli",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+            )
+            workspace.status = status
+            workspace.updated_at = updated_at
+            await session.commit()
+            workspace_id = workspace.id
+        await engine.dispose()
+        return workspace_id
+
+    return asyncio.run(_setup())
 
 
 @pytest.mark.unit
@@ -198,6 +238,92 @@ def test_readme_documents_service_logs_command() -> None:
     assert "--tail" in readme
     assert "--service worker" in readme
     assert "--follow" in readme
+
+
+@pytest.mark.unit
+def test_readme_documents_service_gc_command() -> None:
+    readme = Path("README.md").read_text()
+
+    assert "awf service gc" in readme
+    assert "--execute" in readme
+    assert "--min-age-hours" in readme
+    assert "dry-run" in readme.lower()
+    assert "control-plane database" in readme
+    assert "log streams" in readme
+
+
+@pytest.mark.unit
+def test_service_gc_cli_defaults_to_json_dry_run(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}"
+    work_dir = tmp_path / "service"
+    workspace_id = _create_gc_cli_workspace(
+        db_url=db_url,
+        status="failed",
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    _write_gc_file(worktree / "repo.txt", "repo")
+    monkeypatch.setenv("AWF_DATABASE_URL", db_url)
+    monkeypatch.setenv("AWF_WORK_DIR", str(work_dir))
+
+    result = _runner.invoke(app, ["service", "gc", "--min-age-hours", "1"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["dry_run"] is True
+    assert payload["candidate_count"] == 1
+    assert payload["deleted_paths"] == []
+    assert payload["candidates"][0]["workspace_id"] == workspace_id
+    assert payload["candidates"][0]["status"] == "failed"
+    assert payload["candidates"][0]["paths"]["worktree"]["path"] == str(worktree)
+    assert worktree.exists()
+
+
+@pytest.mark.unit
+def test_service_gc_cli_execute_deletes_and_supports_pretty_output(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}"
+    work_dir = tmp_path / "service"
+    workspace_id = _create_gc_cli_workspace(
+        db_url=db_url,
+        status="destroyed",
+        updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    compose = work_dir / "compose" / workspace_id
+    auth = work_dir / "auth" / workspace_id
+    _write_gc_file(worktree / "repo.txt", "repo")
+    _write_gc_file(compose / "compose.yml", "compose")
+    _write_gc_file(auth / "codex" / "auth.json", "auth")
+    monkeypatch.setenv("AWF_DATABASE_URL", db_url)
+    monkeypatch.setenv("AWF_WORK_DIR", str(work_dir))
+
+    result = _runner.invoke(
+        app,
+        [
+            "service",
+            "gc",
+            "--execute",
+            "--min-age-hours",
+            "1",
+            "--format",
+            "pretty",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "dry_run: False" in result.stdout
+    assert "candidate_count: 1" in result.stdout
+    assert workspace_id in result.stdout
+    assert "deleted_paths" in result.stdout
+    assert not worktree.exists()
+    assert not compose.exists()
+    assert not auth.exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_gc.py
+++ b/tests/unit/service/test_gc.py
@@ -1,0 +1,298 @@
+"""Terminal workspace filesystem GC tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Workspace
+from awf.db.repositories import (
+    WorkspaceLogStreamRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_session_factory
+from awf.service.gc import plan_terminal_workspace_gc, run_terminal_workspace_gc
+
+
+@pytest.fixture
+async def session_factory(
+    engine: AsyncEngine,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield make_session_factory(engine)
+
+
+async def _workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    status: WorkspaceStatus,
+    updated_at: datetime,
+    title: str = "gc candidate",
+    compose_file_path: str | None = None,
+) -> str:
+    async with session_factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/repo.git",
+            branch_base="development",
+            task_title=title,
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = status.value
+        workspace.updated_at = updated_at
+        workspace.compose_file_path = compose_file_path
+        await session.commit()
+        return workspace.id
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.unit
+async def test_plan_reports_terminal_candidates_paths_and_estimated_bytes(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "service"
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=200),
+        compose_file_path=str(work_dir / "compose" / "stored-compose-id" / "compose.yml"),
+    )
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    compose = work_dir / "compose" / "stored-compose-id"
+    auth = work_dir / "auth" / workspace_id
+    _write(worktree / "repo.txt", "1234567")
+    _write(compose / "compose.yml", "12345")
+    _write(auth / "codex" / "auth.json", "123456789")
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=work_dir,
+        min_age_hours=24,
+        now=now,
+    )
+
+    assert plan.total_estimated_bytes == 21
+    assert [candidate.workspace_id for candidate in plan.candidates] == [workspace_id]
+    candidate = plan.candidates[0]
+    assert candidate.status == WorkspaceStatus.failed.value
+    assert candidate.age_hours == 200
+    assert candidate.worktree.path == worktree
+    assert candidate.worktree.exists is True
+    assert candidate.worktree.estimated_bytes == 7
+    assert candidate.compose.path == compose
+    assert candidate.compose.exists is True
+    assert candidate.compose.estimated_bytes == 5
+    assert candidate.auth.path == auth
+    assert candidate.auth.exists is True
+    assert candidate.auth.estimated_bytes == 9
+    assert candidate.total_estimated_bytes == 21
+
+
+@pytest.mark.unit
+async def test_plan_excludes_active_and_destroying_workspaces(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    ineligible_statuses = [
+        WorkspaceStatus.requested,
+        WorkspaceStatus.provisioning,
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.pushing,
+        WorkspaceStatus.monitoring_pr,
+        WorkspaceStatus.destroying,
+    ]
+    for status in ineligible_statuses:
+        await _workspace(
+            session_factory,
+            status=status,
+            updated_at=now - timedelta(days=30),
+            title=f"{status.value} workspace",
+        )
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=tmp_path / "service",
+        min_age_hours=1,
+        now=now,
+    )
+
+    assert plan.candidates == []
+
+
+@pytest.mark.unit
+async def test_plan_applies_min_age_filter_and_limit_oldest_first(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    oldest = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.completed,
+        updated_at=now - timedelta(hours=300),
+        title="oldest",
+    )
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=100),
+        title="middle",
+    )
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.cancelled,
+        updated_at=now - timedelta(hours=2),
+        title="fresh",
+    )
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=tmp_path / "service",
+        min_age_hours=24,
+        limit=1,
+        now=now,
+    )
+
+    assert [candidate.workspace_id for candidate in plan.candidates] == [oldest]
+
+    older_than_120h = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=tmp_path / "service",
+        min_age_hours=120,
+        now=now,
+    )
+    assert [candidate.workspace_id for candidate in older_than_120h.candidates] == [oldest]
+
+
+@pytest.mark.unit
+async def test_plan_tolerates_missing_workspace_paths(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "service"
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.destroyed,
+        updated_at=now - timedelta(hours=48),
+    )
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=work_dir,
+        min_age_hours=24,
+        now=now,
+    )
+
+    candidate = plan.candidates[0]
+    assert candidate.workspace_id == workspace_id
+    assert candidate.total_estimated_bytes == 0
+    assert candidate.worktree.path == work_dir / "git" / "worktrees" / workspace_id
+    assert candidate.compose.path == work_dir / "compose" / workspace_id
+    assert candidate.auth.path == work_dir / "auth" / workspace_id
+    assert candidate.worktree.exists is False
+    assert candidate.compose.exists is False
+    assert candidate.auth.exists is False
+
+
+@pytest.mark.unit
+async def test_run_defaults_to_dry_run_and_keeps_candidate_directories(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "service"
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=48),
+    )
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    compose = work_dir / "compose" / workspace_id
+    auth = work_dir / "auth" / workspace_id
+    _write(worktree / "repo.txt", "repo")
+    _write(compose / "compose.yml", "compose")
+    _write(auth / "codex" / "auth.json", "auth")
+
+    result = await run_terminal_workspace_gc(
+        session_factory,
+        work_dir=work_dir,
+        min_age_hours=24,
+        now=now,
+    )
+
+    assert result.dry_run is True
+    assert result.deleted_paths == []
+    assert worktree.exists()
+    assert compose.exists()
+    assert auth.exists()
+
+
+@pytest.mark.unit
+async def test_execute_deletes_only_workspace_pressure_dirs_and_preserves_db_and_logs(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    work_dir = tmp_path / "service"
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.cancelled,
+        updated_at=now - timedelta(hours=48),
+    )
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    compose = work_dir / "compose" / workspace_id
+    auth = work_dir / "auth" / workspace_id
+    log_file = work_dir / "logs" / workspace_id / "agent.log"
+    _write(worktree / "repo.txt", "repo")
+    _write(compose / "compose.yml", "compose")
+    _write(auth / "codex" / "auth.json", "auth")
+    _write(log_file, "agent log")
+    async with session_factory() as session:
+        await WorkspaceLogStreamRepository(session).create_or_get(
+            workspace_id=workspace_id,
+            stream_id="agent/stdout",
+            source="agent",
+            name="stdout",
+            kind="stdout",
+            path=str(log_file),
+        )
+        await session.commit()
+
+    result = await run_terminal_workspace_gc(
+        session_factory,
+        work_dir=work_dir,
+        min_age_hours=24,
+        execute=True,
+        now=now,
+    )
+
+    assert result.dry_run is False
+    assert set(result.deleted_paths) == {worktree, compose, auth}
+    assert not worktree.exists()
+    assert not compose.exists()
+    assert not auth.exists()
+    assert log_file.exists()
+
+    async with session_factory() as session:
+        workspace = await session.get(Workspace, workspace_id)
+        assert workspace is not None
+        assert workspace.status == WorkspaceStatus.cancelled.value
+        assert len(workspace.events) == 1
+        streams = await WorkspaceLogStreamRepository(session).list_for_workspace(workspace_id)
+        assert [stream.path for stream in streams] == [str(log_file)]
+        assert (await session.execute(select(Workspace.id))).scalars().all() == [workspace_id]

--- a/tests/unit/service/test_gc.py
+++ b/tests/unit/service/test_gc.py
@@ -135,6 +135,26 @@ async def test_plan_excludes_active_and_destroying_workspaces(
 
 
 @pytest.mark.unit
+async def test_plan_reports_requested_statuses_when_no_statuses_are_eligible(
+    session_factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 4, 26, 12, tzinfo=UTC)
+
+    plan = await plan_terminal_workspace_gc(
+        session_factory,
+        work_dir=tmp_path / "service",
+        include_statuses=[WorkspaceStatus.running],
+        exclude_statuses=[WorkspaceStatus.completed],
+        now=now,
+    )
+
+    assert plan.candidates == []
+    assert plan.to_dict()["include_statuses"] == [WorkspaceStatus.running.value]
+    assert plan.to_dict()["exclude_statuses"] == [WorkspaceStatus.completed.value]
+
+
+@pytest.mark.unit
 async def test_plan_applies_min_age_filter_and_limit_oldest_first(
     session_factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_6cfb707483244028aac3ff79` (agent: `codex`).


### Task
Context: the local AWF service nearly filled the host disk because old terminal workspace worktrees and compose/auth directories accumulated under ~/.awf/service. Operators need a safe, inspectable cleanup path that preserves the control-plane DB and logs.

Implement terminal workspace garbage collection with strict TDD. Write failing tests first and commit them before implementation.

Required behavior:
1. Add a service GC module that plans cleanup for terminal workspaces only: completed, failed, cancelled, destroyed. Never select requested/provisioning/ready/running/validating/pushing/monitoring_pr.
2. Eligibility should support min age in hours, defaulting conservatively. It should report candidate workspace id, status, paths, and estimated bytes for worktree, compose dir, and auth dir. Missing paths are ok.
3. Add `awf service gc` with JSON default and `--format pretty`. It must default to dry-run. Use `--execute` to delete selected worktree/compose/auth directories. Include `--min-age-hours`, `--limit`, and sensible status include/exclude options if useful.
4. GC must not delete DB rows or log streams. This is filesystem pressure relief only.
5. Update README with the command and safety model.
6. Add focused tests for planning, active-workspace exclusion, age filtering, missing paths, dry-run, execute deletion, and CLI output.

Do not touch monitor recovery/auth files owned by the other task. Do not manually push or merge. AWF owns PR creation, monitoring, comment handling, base sync, and merge.

---
Validation: 3 profile command(s) passed inside the workspace container.
