### PR TITLE
feat(runtime): add Postgres advisory merge coordinator

### DIFF
--- a/src/awf/runtime/merge_coordinator.py
+++ b/src/awf/runtime/merge_coordinator.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import weakref
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, cast
 
-from sqlalchemy import text
+import asyncpg  # type: ignore[import-untyped]
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 
@@ -30,6 +30,17 @@ class MergeCoordinator(Protocol):
         base_branch: str,
     ) -> AbstractAsyncContextManager[None]:
         """Return an async context manager for one repo/base merge lane."""
+
+
+class _AdvisoryConnection(Protocol):
+    async def fetchval(self, query: str, *args: object) -> object: ...
+
+    async def execute(self, query: str, *args: object) -> object: ...
+
+    async def close(self) -> None: ...
+
+
+_AdvisoryConnect = Callable[[str], Awaitable[_AdvisoryConnection]]
 
 
 @dataclass(frozen=True)
@@ -106,10 +117,25 @@ def postgres_advisory_lock_key(*, repo_url: str, base_branch: str) -> int:
 
 
 class PostgresAdvisoryMergeCoordinator:
-    """A coordinator backed by Postgres session-level advisory locks."""
+    """A coordinator backed by Postgres session-level advisory locks.
 
-    def __init__(self, engine: AsyncEngine) -> None:
-        self._engine = engine
+    Session-level advisory locks must stay tied to an open Postgres session for
+    the whole merge body. Use a dedicated asyncpg connection, not the
+    SQLAlchemy application pool, and make contenders poll with try-lock calls so
+    failed attempts return their connection immediately.
+    """
+
+    def __init__(
+        self,
+        engine: AsyncEngine,
+        *,
+        poll_interval_seconds: float = 0.5,
+        connect: _AdvisoryConnect | None = None,
+    ) -> None:
+        self._dsn = _asyncpg_dsn_from_engine(engine)
+        self._poll_interval_seconds = poll_interval_seconds
+        self._connect = connect or _connect_asyncpg
+        self._local = InProcessMergeCoordinator()
 
     @asynccontextmanager
     async def serialized_merge(
@@ -119,18 +145,43 @@ class PostgresAdvisoryMergeCoordinator:
         base_branch: str,
     ) -> AsyncIterator[None]:
         lock_key = postgres_advisory_lock_key(repo_url=repo_url, base_branch=base_branch)
-        async with self._engine.connect() as connection:
-            await connection.execute(
-                text("SELECT pg_advisory_lock(:lock_key)"),
-                {"lock_key": lock_key},
-            )
+        async with self._local.serialized_merge(repo_url=repo_url, base_branch=base_branch):
+            connection = await self._acquire_lock_connection(lock_key)
             try:
                 yield
             finally:
-                await connection.execute(
-                    text("SELECT pg_advisory_unlock(:lock_key)"),
-                    {"lock_key": lock_key},
+                try:
+                    await connection.execute("SELECT pg_advisory_unlock($1)", lock_key)
+                finally:
+                    await connection.close()
+
+    async def _acquire_lock_connection(self, lock_key: int) -> _AdvisoryConnection:
+        while True:
+            connection = await self._connect(self._dsn)
+            try:
+                acquired = bool(
+                    await connection.fetchval("SELECT pg_try_advisory_lock($1)", lock_key)
                 )
+            except BaseException:
+                await connection.close()
+                raise
+
+            if acquired:
+                return connection
+
+            await connection.close()
+            await asyncio.sleep(self._poll_interval_seconds)
+
+
+async def _connect_asyncpg(dsn: str) -> _AdvisoryConnection:
+    return cast(_AdvisoryConnection, await asyncpg.connect(dsn=dsn))
+
+
+def _asyncpg_dsn_from_engine(engine: AsyncEngine) -> str:
+    url = engine.url
+    if "+" in url.drivername:
+        url = url.set(drivername=url.drivername.split("+", 1)[0])
+    return url.render_as_string(hide_password=False)
 
 
 DEFAULT_MERGE_COORDINATOR = InProcessMergeCoordinator()

--- a/src/awf/runtime/merge_coordinator.py
+++ b/src/awf/runtime/merge_coordinator.py
@@ -1,24 +1,23 @@
 """Merge-attempt coordination for PR monitors.
 
-The current implementation is intentionally process-local: it serializes
-auto-merge attempts by ``repo_url + base_branch`` for monitors running in
-the same worker process. That is enough to prevent the local service
-worker from firing simultaneous final rechecks and merge attempts at the
-same repository branch.
-
-Next hardening step: replace this abstraction with a Postgres advisory
-lock so independently spawned monitor processes and multiple workers can
-share the same coordination key.
+The in-process coordinator is kept for tests, SQLite, and compatibility
+paths. Service deployments backed by Postgres can use advisory locks so
+independently spawned monitor processes and multiple workers share the
+same coordination key.
 """
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import weakref
 from collections.abc import AsyncIterator
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from typing import Protocol
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 
 class MergeCoordinator(Protocol):
@@ -96,6 +95,42 @@ class InProcessMergeCoordinator:
         entry.ref_count -= 1
         if entry.ref_count == 0 and not entry.lock.locked() and loop_locks.get(key) is entry:
             del loop_locks[key]
+
+
+def postgres_advisory_lock_key(*, repo_url: str, base_branch: str) -> int:
+    """Return a stable signed 64-bit Postgres advisory lock key."""
+
+    key = MergeCoordinationKey.from_values(repo_url=repo_url, base_branch=base_branch)
+    payload = f"{key.repo_url}\0{key.base_branch}".encode()
+    return int.from_bytes(hashlib.sha256(payload).digest()[:8], "big", signed=True)
+
+
+class PostgresAdvisoryMergeCoordinator:
+    """A coordinator backed by Postgres session-level advisory locks."""
+
+    def __init__(self, engine: AsyncEngine) -> None:
+        self._engine = engine
+
+    @asynccontextmanager
+    async def serialized_merge(
+        self,
+        *,
+        repo_url: str,
+        base_branch: str,
+    ) -> AsyncIterator[None]:
+        lock_key = postgres_advisory_lock_key(repo_url=repo_url, base_branch=base_branch)
+        async with self._engine.connect() as connection:
+            await connection.execute(
+                text("SELECT pg_advisory_lock(:lock_key)"),
+                {"lock_key": lock_key},
+            )
+            try:
+                yield
+            finally:
+                await connection.execute(
+                    text("SELECT pg_advisory_unlock(:lock_key)"),
+                    {"lock_key": lock_key},
+                )
 
 
 DEFAULT_MERGE_COORDINATOR = InProcessMergeCoordinator()

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -17,6 +17,7 @@ import awf.adapters.registry  # noqa: F401 - populate adapter registry for servi
 from awf.adapters.base import AgentAdapter
 from awf.common.commands import AsyncioSubprocessRunner
 from awf.common.github_client import GitHubClient
+from awf.common.logging import get_logger
 from awf.control.executor import ExecutorConfig, WorkspaceExecutor
 from awf.control.worker import ControlWorker, WorkerConfig
 from awf.db.models import Workspace
@@ -37,6 +38,8 @@ from awf.runtime.pr_creator import PullRequestCreator
 from awf.runtime.release_pr_monitor import build_feature_pr_monitor, build_release_pr_monitor
 from awf.runtime.validation import ValidationRunner
 from awf.service.config import ServiceSettings
+
+_log = get_logger(__name__)
 
 
 @dataclass(frozen=True)
@@ -157,9 +160,22 @@ def _merge_coordinator_for_database_url(
 def _is_postgres_database_url(database_url: str) -> bool:
     try:
         backend = make_url(database_url).get_backend_name()
-    except ArgumentError:
+    except ArgumentError as exc:
+        _log.warning(
+            "worker.database_url_parse_failed",
+            error=str(exc),
+            merge_coordinator="in_process",
+        )
         return False
-    return backend in {"postgres", "postgresql"}
+    if backend in {"postgres", "postgresql"}:
+        return True
+    if backend.startswith("postgres"):
+        _log.warning(
+            "worker.postgres_merge_coordinator_not_selected",
+            backend=backend,
+            merge_coordinator="in_process",
+        )
+    return False
 
 
 def _service_git_environment(host_home: Path, *, github_token: str | None = None) -> dict[str, str]:

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 import awf.adapters.registry  # noqa: F401 - populate adapter registry for service execution
@@ -26,7 +28,11 @@ from awf.node.provisioner import Provisioner, ProvisionerConfig
 from awf.node.stack_launcher import ComposeStackLauncher
 from awf.profiles.models import WorkspaceProfile
 from awf.runtime.logs import LogStore
-from awf.runtime.merge_coordinator import InProcessMergeCoordinator
+from awf.runtime.merge_coordinator import (
+    InProcessMergeCoordinator,
+    MergeCoordinator,
+    PostgresAdvisoryMergeCoordinator,
+)
 from awf.runtime.pr_creator import PullRequestCreator
 from awf.runtime.release_pr_monitor import build_feature_pr_monitor, build_release_pr_monitor
 from awf.runtime.validation import ValidationRunner
@@ -53,7 +59,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     compose = ComposeManager(work_dir=work_dir, template_path=template)
     runner = AsyncioSubprocessRunner()
     log_store = LogStore(root=work_dir / "logs", session_factory=session_factory)
-    merge_coordinator = InProcessMergeCoordinator()
+    merge_coordinator = _merge_coordinator_for_database_url(settings.database_url, engine=engine)
     validation = ValidationRunner(
         runner=runner,
         artifacts_dir=work_dir / "artifacts",
@@ -136,6 +142,24 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         ),
     )
     return WorkerRuntime(engine=engine, worker=worker)
+
+
+def _merge_coordinator_for_database_url(
+    database_url: str,
+    *,
+    engine: AsyncEngine,
+) -> MergeCoordinator:
+    if _is_postgres_database_url(database_url):
+        return PostgresAdvisoryMergeCoordinator(engine)
+    return InProcessMergeCoordinator()
+
+
+def _is_postgres_database_url(database_url: str) -> bool:
+    try:
+        backend = make_url(database_url).get_backend_name()
+    except ArgumentError:
+        return False
+    return backend in {"postgres", "postgresql"}
 
 
 def _service_git_environment(host_home: Path, *, github_token: str | None = None) -> dict[str, str]:

--- a/tests/unit/runtime/test_merge_coordinator.py
+++ b/tests/unit/runtime/test_merge_coordinator.py
@@ -12,6 +12,7 @@ import asyncio
 
 import pytest
 
+from awf.runtime import merge_coordinator as merge_coordinator_mod
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
 
 REPO_URL = "git@github.com:dimileeh/aira-web.git"
@@ -177,3 +178,110 @@ class TestInProcessMergeCoordinator:
 
         asyncio.run(contend_once())
         asyncio.run(contend_once())
+
+
+class TestPostgresAdvisoryMergeCoordinator:
+    @pytest.mark.unit
+    def test_advisory_lock_key_is_deterministic_and_normalized(self) -> None:
+        key = merge_coordinator_mod.postgres_advisory_lock_key(
+            repo_url=REPO_URL,
+            base_branch="development",
+        )
+
+        assert key == -4806809152263605362
+        assert key == merge_coordinator_mod.postgres_advisory_lock_key(
+            repo_url=f" {REPO_URL} ",
+            base_branch=" development ",
+        )
+        assert key != merge_coordinator_mod.postgres_advisory_lock_key(
+            repo_url=REPO_URL,
+            base_branch="main",
+        )
+        assert -(2**63) <= key <= 2**63 - 1
+
+    @pytest.mark.unit
+    async def test_context_manager_acquires_before_body_and_releases_after_body(self) -> None:
+        calls: list[object] = []
+        coordinator = merge_coordinator_mod.PostgresAdvisoryMergeCoordinator(
+            _FakeAdvisoryEngine(calls)
+        )
+
+        async with coordinator.serialized_merge(
+            repo_url=REPO_URL,
+            base_branch="development",
+        ):
+            calls.append("body")
+
+        expected_key = -4806809152263605362
+        assert calls == [
+            "connect-enter",
+            ("lock", {"lock_key": expected_key}),
+            "body",
+            ("unlock", {"lock_key": expected_key}),
+            "connect-exit",
+        ]
+
+    @pytest.mark.unit
+    async def test_context_manager_releases_lock_when_body_raises(self) -> None:
+        calls: list[object] = []
+        coordinator = merge_coordinator_mod.PostgresAdvisoryMergeCoordinator(
+            _FakeAdvisoryEngine(calls)
+        )
+
+        with pytest.raises(RuntimeError, match="merge failed"):
+            async with coordinator.serialized_merge(
+                repo_url=REPO_URL,
+                base_branch="development",
+            ):
+                calls.append("body")
+                raise RuntimeError("merge failed")
+
+        expected_key = -4806809152263605362
+        assert calls == [
+            "connect-enter",
+            ("lock", {"lock_key": expected_key}),
+            "body",
+            ("unlock", {"lock_key": expected_key}),
+            "connect-exit",
+        ]
+
+
+class _FakeAdvisoryEngine:
+    def __init__(self, calls: list[object]) -> None:
+        self._calls = calls
+
+    def connect(self) -> "_FakeAdvisoryConnectionContext":
+        return _FakeAdvisoryConnectionContext(self._calls)
+
+
+class _FakeAdvisoryConnectionContext:
+    def __init__(self, calls: list[object]) -> None:
+        self._calls = calls
+        self._connection = _FakeAdvisoryConnection(calls)
+
+    async def __aenter__(self) -> "_FakeAdvisoryConnection":
+        self._calls.append("connect-enter")
+        return self._connection
+
+    async def __aexit__(
+        self,
+        exc_type: object,
+        exc: object,
+        traceback: object,
+    ) -> None:
+        self._calls.append("connect-exit")
+
+
+class _FakeAdvisoryConnection:
+    def __init__(self, calls: list[object]) -> None:
+        self._calls = calls
+
+    async def execute(self, statement: object, parameters: object) -> None:
+        sql = str(statement)
+        if "pg_advisory_unlock" in sql:
+            self._calls.append(("unlock", parameters))
+            return
+        if "pg_advisory_lock" in sql:
+            self._calls.append(("lock", parameters))
+            return
+        raise AssertionError(f"unexpected SQL: {sql}")

--- a/tests/unit/runtime/test_merge_coordinator.py
+++ b/tests/unit/runtime/test_merge_coordinator.py
@@ -250,7 +250,7 @@ class _FakeAdvisoryEngine:
     def __init__(self, calls: list[object]) -> None:
         self._calls = calls
 
-    def connect(self) -> "_FakeAdvisoryConnectionContext":
+    def connect(self) -> _FakeAdvisoryConnectionContext:
         return _FakeAdvisoryConnectionContext(self._calls)
 
 
@@ -259,7 +259,7 @@ class _FakeAdvisoryConnectionContext:
         self._calls = calls
         self._connection = _FakeAdvisoryConnection(calls)
 
-    async def __aenter__(self) -> "_FakeAdvisoryConnection":
+    async def __aenter__(self) -> _FakeAdvisoryConnection:
         self._calls.append("connect-enter")
         return self._connection
 

--- a/tests/unit/runtime/test_merge_coordinator.py
+++ b/tests/unit/runtime/test_merge_coordinator.py
@@ -1,16 +1,19 @@
-"""Unit tests for the in-process merge coordinator.
+"""Unit tests for merge coordinators.
 
-The coordinator is deliberately tiny today: it serializes merge attempts
-inside one worker process by ``repo_url + base_branch``. The tests keep
-that contract explicit so a future Postgres advisory-lock implementation
-can replace it without changing monitor-runner behavior.
+The in-process coordinator serializes merge attempts inside one worker process
+by ``repo_url + base_branch``. The Postgres coordinator uses the same keying
+contract to serialize independently spawned service workers.
 """
 
 from __future__ import annotations
 
 import asyncio
+from types import SimpleNamespace
+from typing import cast
 
 import pytest
+from sqlalchemy.engine import make_url
+from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.runtime import merge_coordinator as merge_coordinator_mod
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
@@ -203,7 +206,8 @@ class TestPostgresAdvisoryMergeCoordinator:
     async def test_context_manager_acquires_before_body_and_releases_after_body(self) -> None:
         calls: list[object] = []
         coordinator = merge_coordinator_mod.PostgresAdvisoryMergeCoordinator(
-            _FakeAdvisoryEngine(calls)
+            _fake_engine(),
+            connect=_FakeAdvisoryConnector(calls).connect,
         )
 
         async with coordinator.serialized_merge(
@@ -214,18 +218,19 @@ class TestPostgresAdvisoryMergeCoordinator:
 
         expected_key = -4806809152263605362
         assert calls == [
-            "connect-enter",
-            ("lock", {"lock_key": expected_key}),
+            ("connect", "postgresql://awf:secret@db:5432/awf"),
+            ("try-lock", expected_key),
             "body",
-            ("unlock", {"lock_key": expected_key}),
-            "connect-exit",
+            ("unlock", expected_key),
+            "close",
         ]
 
     @pytest.mark.unit
     async def test_context_manager_releases_lock_when_body_raises(self) -> None:
         calls: list[object] = []
         coordinator = merge_coordinator_mod.PostgresAdvisoryMergeCoordinator(
-            _FakeAdvisoryEngine(calls)
+            _fake_engine(),
+            connect=_FakeAdvisoryConnector(calls).connect,
         )
 
         with pytest.raises(RuntimeError, match="merge failed"):
@@ -238,50 +243,78 @@ class TestPostgresAdvisoryMergeCoordinator:
 
         expected_key = -4806809152263605362
         assert calls == [
-            "connect-enter",
-            ("lock", {"lock_key": expected_key}),
+            ("connect", "postgresql://awf:secret@db:5432/awf"),
+            ("try-lock", expected_key),
             "body",
-            ("unlock", {"lock_key": expected_key}),
-            "connect-exit",
+            ("unlock", expected_key),
+            "close",
+        ]
+
+    @pytest.mark.unit
+    async def test_contenders_close_connections_between_try_lock_polls(self) -> None:
+        calls: list[object] = []
+        coordinator = merge_coordinator_mod.PostgresAdvisoryMergeCoordinator(
+            _fake_engine(),
+            poll_interval_seconds=0,
+            connect=_FakeAdvisoryConnector(calls, try_lock_results=[False, True]).connect,
+        )
+
+        async with coordinator.serialized_merge(
+            repo_url=REPO_URL,
+            base_branch="development",
+        ):
+            calls.append("body")
+
+        expected_key = -4806809152263605362
+        assert calls == [
+            ("connect", "postgresql://awf:secret@db:5432/awf"),
+            ("try-lock", expected_key),
+            "close",
+            ("connect", "postgresql://awf:secret@db:5432/awf"),
+            ("try-lock", expected_key),
+            "body",
+            ("unlock", expected_key),
+            "close",
         ]
 
 
-class _FakeAdvisoryEngine:
-    def __init__(self, calls: list[object]) -> None:
-        self._calls = calls
+def _fake_engine() -> AsyncEngine:
+    return cast(
+        AsyncEngine,
+        SimpleNamespace(url=make_url("postgresql+asyncpg://awf:secret@db:5432/awf")),
+    )
 
-    def connect(self) -> _FakeAdvisoryConnectionContext:
-        return _FakeAdvisoryConnectionContext(self._calls)
 
-
-class _FakeAdvisoryConnectionContext:
-    def __init__(self, calls: list[object]) -> None:
-        self._calls = calls
-        self._connection = _FakeAdvisoryConnection(calls)
-
-    async def __aenter__(self) -> _FakeAdvisoryConnection:
-        self._calls.append("connect-enter")
-        return self._connection
-
-    async def __aexit__(
+class _FakeAdvisoryConnector:
+    def __init__(
         self,
-        exc_type: object,
-        exc: object,
-        traceback: object,
+        calls: list[object],
+        *,
+        try_lock_results: list[bool] | None = None,
     ) -> None:
-        self._calls.append("connect-exit")
+        self._calls = calls
+        self._try_lock_results = try_lock_results or [True]
+
+    async def connect(self, dsn: str) -> _FakeAdvisoryConnection:
+        self._calls.append(("connect", dsn))
+        return _FakeAdvisoryConnection(self._calls, self._try_lock_results)
 
 
 class _FakeAdvisoryConnection:
-    def __init__(self, calls: list[object]) -> None:
+    def __init__(self, calls: list[object], try_lock_results: list[bool]) -> None:
         self._calls = calls
+        self._try_lock_results = try_lock_results
 
-    async def execute(self, statement: object, parameters: object) -> None:
-        sql = str(statement)
-        if "pg_advisory_unlock" in sql:
-            self._calls.append(("unlock", parameters))
-            return
-        if "pg_advisory_lock" in sql:
-            self._calls.append(("lock", parameters))
-            return
-        raise AssertionError(f"unexpected SQL: {sql}")
+    async def fetchval(self, query: str, *args: object) -> bool:
+        if query != "SELECT pg_try_advisory_lock($1)":
+            raise AssertionError(f"unexpected query: {query}")
+        self._calls.append(("try-lock", args[0]))
+        return self._try_lock_results.pop(0)
+
+    async def execute(self, query: str, *args: object) -> None:
+        if query != "SELECT pg_advisory_unlock($1)":
+            raise AssertionError(f"unexpected query: {query}")
+        self._calls.append(("unlock", args[0]))
+
+    async def close(self) -> None:
+        self._calls.append("close")

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -9,16 +9,22 @@ from typing import Any
 import pytest
 
 from awf.profiles.models import ProfileMonitor, WorkspaceProfile
+from awf.runtime.merge_coordinator import InProcessMergeCoordinator
 from awf.service import worker as worker_mod
 from awf.service.config import ServiceSettings
 
 
-def _settings(tmp_path: Path, *, github_token: str | None = None) -> ServiceSettings:
+def _settings(
+    tmp_path: Path,
+    *,
+    database_url: str | None = None,
+    github_token: str | None = None,
+) -> ServiceSettings:
     return ServiceSettings(
         service_name="awf",
         env="local",
         api_base_url="http://localhost:8000",
-        database_url=f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}",
+        database_url=database_url or f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}",
         docker_host="unix:///var/run/docker.sock",
         agent_runtime_image="custom-agent-runtime:dev",
         work_dir=str((tmp_path / "awf-work").resolve()),
@@ -220,6 +226,10 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["feature_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["feature_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
     assert "merge_coordinator" in created["feature_monitor_kwargs"]
+    assert isinstance(
+        created["feature_monitor_kwargs"]["merge_coordinator"],
+        InProcessMergeCoordinator,
+    )
 
     manual_monitor = created["executor_monitor_factory"](
         object(),
@@ -234,6 +244,79 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert (
         created["release_monitor_kwargs"]["merge_coordinator"]
         is created["feature_monitor_kwargs"]["merge_coordinator"]
+    )
+
+
+@pytest.mark.unit
+def test_build_worker_runtime_uses_postgres_advisory_merge_coordinator_for_postgres(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created: dict[str, Any] = {}
+
+    class _Engine:
+        pass
+
+    class _AnyInit:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    class _WorkspaceExecutor:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            created["pr_monitor_factory"] = kwargs["pr_monitor_factory"]
+
+    class _ControlWorker:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            pass
+
+    class _PostgresCoordinator:
+        def __init__(self, engine: object) -> None:
+            created["coordinator_engine"] = engine
+
+    engine = _Engine()
+    session_factory = object()
+
+    monkeypatch.setattr(worker_mod, "make_engine", lambda _url: engine)
+    monkeypatch.setattr(worker_mod, "make_session_factory", lambda _engine: session_factory)
+    monkeypatch.setattr(worker_mod, "AsyncioSubprocessRunner", _AnyInit)
+    monkeypatch.setattr(worker_mod, "LogStore", _AnyInit)
+    monkeypatch.setattr(worker_mod, "ValidationRunner", _AnyInit)
+    monkeypatch.setattr(worker_mod, "PullRequestCreator", _AnyInit)
+    monkeypatch.setattr(worker_mod, "GitHubClient", _AnyInit)
+    monkeypatch.setattr(worker_mod, "GitManager", _AnyInit)
+    monkeypatch.setattr(worker_mod, "ComposeManager", _AnyInit)
+    monkeypatch.setattr(worker_mod, "ServiceAuthMountResolver", _AnyInit)
+    monkeypatch.setattr(worker_mod, "ComposeStackLauncher", _AnyInit)
+    monkeypatch.setattr(worker_mod, "Provisioner", _AnyInit)
+    monkeypatch.setattr(worker_mod, "WorkspaceExecutor", _WorkspaceExecutor)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+    monkeypatch.setattr(worker_mod, "PostgresAdvisoryMergeCoordinator", _PostgresCoordinator)
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+    monkeypatch.setattr(worker_mod, "_apply_service_git_environment", lambda _env: None)
+
+    def _build_feature_monitor(**kwargs: object) -> object:
+        created["feature_monitor_kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(worker_mod, "build_feature_pr_monitor", _build_feature_monitor)
+    monkeypatch.setattr(worker_mod, "build_release_pr_monitor", lambda **_kwargs: object())
+
+    settings = _settings(
+        tmp_path,
+        database_url="postgresql+asyncpg://awf:pw@localhost:5432/awf",
+    )
+
+    worker_mod.build_worker_runtime(settings)
+    created["pr_monitor_factory"](
+        object(),
+        WorkspaceProfile(name="default"),
+        SimpleNamespace(auto_merge=True, initial_review_grace_period_seconds=None),
+    )
+
+    assert created["coordinator_engine"] is engine
+    assert isinstance(
+        created["feature_monitor_kwargs"]["merge_coordinator"],
+        _PostgresCoordinator,
     )
 
 

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import structlog
 
 from awf.profiles.models import ProfileMonitor, WorkspaceProfile
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
@@ -317,6 +318,33 @@ def test_build_worker_runtime_uses_postgres_advisory_merge_coordinator_for_postg
     assert isinstance(
         created["feature_monitor_kwargs"]["merge_coordinator"],
         _PostgresCoordinator,
+    )
+
+
+@pytest.mark.unit
+def test_is_postgres_database_url_warns_on_parse_failure() -> None:
+    with structlog.testing.capture_logs() as captured:
+        assert worker_mod._is_postgres_database_url("not a url") is False
+
+    assert any(
+        event.get("event") == "worker.database_url_parse_failed"
+        and event.get("log_level") == "warning"
+        and event.get("merge_coordinator") == "in_process"
+        for event in captured
+    )
+
+
+@pytest.mark.unit
+def test_is_postgres_database_url_warns_on_postgres_backend_typo() -> None:
+    with structlog.testing.capture_logs() as captured:
+        assert worker_mod._is_postgres_database_url("postgresq://awf:secret@localhost/awf") is False
+
+    assert any(
+        event.get("event") == "worker.postgres_merge_coordinator_not_selected"
+        and event.get("log_level") == "warning"
+        and event.get("backend") == "postgresq"
+        and event.get("merge_coordinator") == "in_process"
+        for event in captured
     )
 
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_cd89a07c8b6f46f687d91628` (agent: `codex`).

**External task ID**: awf-wave2-postgres-merge-lock-20260426T045914Z

### Task
Implement the next merge-queue hardening slice from the AWF PRD: replace process-local-only auto-merge coordination with a Postgres advisory lock option for service mode.

Problem to solve:
- PR #42 added an in-process merge coordinator, which worked for one worker process.
- The PRD requires a durable always-on control plane and later multiple workers/nodes. In-process locks are not enough when two worker processes monitor PRs against the same repo/base branch.

Required behavior:
- Keep `InProcessMergeCoordinator` for tests/SQLite/compatibility.
- Add a `PostgresAdvisoryMergeCoordinator` that serializes by deterministic repo_url + base_branch key using Postgres advisory locks.
- Wire service-worker construction to use the Postgres coordinator when the configured database URL is Postgres, falling back to in-process otherwise.
- The coordinator must release locks reliably on normal exit and exception.
- The public monitor runner contract should not change.

TDD requirements:
- Add tests for deterministic lock key generation, context-manager acquire/release order, exception release, fallback selection for SQLite, and worker wiring.
- Reproduce the missing Postgres coordinator path first, commit failing tests, then implement.

Validation commands:
- uv run ruff check src/awf/runtime src/awf/service tests/unit/runtime tests/unit/service/test_worker.py
- uv run mypy src/awf/runtime src/awf/service
- uv run pytest tests/unit/runtime/test_merge_coordinator.py tests/unit/runtime/test_merge_coordinator_runner.py tests/unit/service/test_worker.py -q

Strict TDD and AWF contract:
- Write focused failing tests first and commit the red tests, including the failure summary in the commit body.
- Implement until the narrow tests pass, then run the full validation commands listed below.
- Commit locally with conventional commits.
- Do not push, switch branches, rebase, or open/merge PRs. AWF owns branch lifecycle, push, PR creation, comment handling, checks, branch updates, and auto-merge.
- Keep the change tightly scoped to the owned paths and adjust to concurrent PRs by syncing through AWF, not by manual GitHub operations.

---
Validation: 6 profile command(s) passed inside the workspace container.
