### PR TITLE
feat(policy): reject conflicting active owned paths

### DIFF
--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -33,7 +33,7 @@ from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.profiles.resolver import ProfileResolutionError
-from awf.service.workspaces import create_workspace_v2_row
+from awf.service.workspaces import WorkspaceOwnedPathConflictError, create_workspace_v2_row
 
 router = APIRouter(prefix="/v1/workspaces", tags=["workspaces"])
 router_v2 = APIRouter(prefix="/v2/workspaces", tags=["workspaces-v2"])
@@ -118,6 +118,15 @@ async def create_workspace_v2(
             session,
             payload,
             idempotency_key=idempotency_key,
+        )
+    except WorkspaceOwnedPathConflictError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=ErrorResponse(
+                error_code=exc.error_code,
+                message=exc.message,
+                detail=exc.detail,
+            ).model_dump(),
         )
     except ProfileResolutionError as exc:
         return JSONResponse(

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -328,4 +328,4 @@ class ErrorResponse(BaseModel):
 
     error_code: str
     message: str
-    detail: dict[str, str] | None = None
+    detail: dict[str, Any] | None = None

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -10,11 +10,12 @@ SQLAlchemy calls everywhere. Rules:
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Final
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.ids import new_event_id, new_log_stream_id, new_operation_id, new_workspace_id
@@ -124,6 +125,30 @@ class WorkspaceRepository:
     async def get_by_idempotency_key(self, key: str) -> Workspace | None:
         stmt = select(Workspace).where(Workspace.idempotency_key == key)
         return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def acquire_owned_path_conflict_lock(
+        self,
+        *,
+        repo_url: str,
+        branch_base: str,
+        owned_paths: list[str],
+    ) -> None:
+        """Serialize owned-path admission for one repo/base transaction on Postgres."""
+        if not any(_normalize_owned_path(path) != "" for path in owned_paths):
+            return
+
+        bind = self._session.get_bind()
+        if bind.dialect.name != "postgresql":
+            return
+
+        lock_key = _owned_path_conflict_advisory_lock_key(
+            repo_url=repo_url,
+            branch_base=branch_base,
+        )
+        await self._session.execute(
+            text("SELECT pg_advisory_xact_lock(:lock_key)"),
+            {"lock_key": lock_key},
+        )
 
     async def find_active_owned_path_conflicts(
         self,
@@ -253,6 +278,16 @@ def _owned_paths_overlap(left: str, right: str) -> bool:
     if left_prefix is not None and right_prefix is not None:
         return _wildcard_prefixes_overlap(left_prefix, right_prefix)
     return False
+
+
+def _owned_path_conflict_advisory_lock_key(*, repo_url: str, branch_base: str) -> int:
+    digest = hashlib.sha256(
+        f"awf:owned-path-conflicts\x00{repo_url}\x00{branch_base}".encode()
+    ).digest()
+    unsigned = int.from_bytes(digest[:8], byteorder="big", signed=False)
+    if unsigned >= 1 << 63:
+        return unsigned - (1 << 64)
+    return unsigned
 
 
 def _normalize_owned_path(path: str) -> str:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -10,8 +10,9 @@ SQLAlchemy calls everywhere. Rules:
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Final
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -20,6 +21,23 @@ from awf.common.ids import new_event_id, new_log_stream_id, new_operation_id, ne
 from awf.control.state_machine import WorkspaceStateMachine
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import Operation, Workspace, WorkspaceEvent, WorkspaceLogStream
+
+ACTIVE_OWNED_PATH_CONFLICT_STATUSES: Final[tuple[str, ...]] = (
+    WorkspaceStatus.requested.value,
+    WorkspaceStatus.provisioning.value,
+    WorkspaceStatus.ready.value,
+    WorkspaceStatus.running.value,
+    WorkspaceStatus.validating.value,
+    WorkspaceStatus.pushing.value,
+    WorkspaceStatus.monitoring_pr.value,
+)
+
+
+@dataclass(frozen=True)
+class OwnedPathConflict:
+    workspace_id: str
+    existing_path: str
+    requested_path: str
 
 
 class WorkspaceRepository:
@@ -107,6 +125,45 @@ class WorkspaceRepository:
         stmt = select(Workspace).where(Workspace.idempotency_key == key)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
+    async def find_active_owned_path_conflicts(
+        self,
+        *,
+        repo_url: str,
+        branch_base: str,
+        owned_paths: list[str],
+    ) -> list[OwnedPathConflict]:
+        requested_paths = [
+            path for path in owned_paths if _normalize_owned_path(path) != ""
+        ]
+        if not requested_paths:
+            return []
+
+        stmt = (
+            select(Workspace)
+            .where(
+                Workspace.repo_url == repo_url,
+                Workspace.branch_base == branch_base,
+                Workspace.status.in_(ACTIVE_OWNED_PATH_CONFLICT_STATUSES),
+            )
+            .order_by(Workspace.created_at.asc(), Workspace.id.asc())
+        )
+        rows = list((await self._session.execute(stmt)).scalars())
+        conflicts: list[OwnedPathConflict] = []
+        for workspace in rows:
+            for existing_path in workspace.owned_paths:
+                if _normalize_owned_path(existing_path) == "":
+                    continue
+                for requested_path in requested_paths:
+                    if _owned_paths_overlap(existing_path, requested_path):
+                        conflicts.append(
+                            OwnedPathConflict(
+                                workspace_id=workspace.id,
+                                existing_path=existing_path,
+                                requested_path=requested_path,
+                            )
+                        )
+        return conflicts
+
     async def list(
         self,
         *,
@@ -177,6 +234,69 @@ class WorkspaceRepository:
         workspace.events.append(event)
         await self._session.flush()
         return event
+
+
+def _owned_paths_overlap(left: str, right: str) -> bool:
+    left_path = _normalize_owned_path(left)
+    right_path = _normalize_owned_path(right)
+    if left_path == "" or right_path == "":
+        return False
+    if _literal_paths_overlap(left_path, right_path):
+        return True
+
+    left_prefix = _wildcard_prefix(left_path)
+    right_prefix = _wildcard_prefix(right_path)
+    if left_prefix is not None and _wildcard_prefix_overlaps(left_prefix, right_path):
+        return True
+    if right_prefix is not None and _wildcard_prefix_overlaps(right_prefix, left_path):
+        return True
+    if left_prefix is not None and right_prefix is not None:
+        return _wildcard_prefixes_overlap(left_prefix, right_prefix)
+    return False
+
+
+def _normalize_owned_path(path: str) -> str:
+    normalized = path.strip().replace("\\", "/")
+    while "//" in normalized:
+        normalized = normalized.replace("//", "/")
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    normalized = normalized.lstrip("/")
+    normalized = normalized.rstrip("/")
+    return "" if normalized == "." else normalized
+
+
+def _literal_paths_overlap(left: str, right: str) -> bool:
+    return left == right or _is_descendant(left, right) or _is_descendant(right, left)
+
+
+def _is_descendant(parent: str, child: str) -> bool:
+    return child.startswith(f"{parent.rstrip('/')}/")
+
+
+def _wildcard_prefix(path: str) -> str | None:
+    wildcard_indexes = [
+        index for index in (path.find("*"), path.find("?"), path.find("[")) if index >= 0
+    ]
+    if not wildcard_indexes:
+        return None
+    return path[: min(wildcard_indexes)]
+
+
+def _wildcard_prefix_overlaps(prefix: str, path: str) -> bool:
+    if prefix == "":
+        return True
+    if path.startswith(prefix):
+        return True
+    return _literal_paths_overlap(prefix.rstrip("/"), path.rstrip("/"))
+
+
+def _wildcard_prefixes_overlap(left: str, right: str) -> bool:
+    if left == "" or right == "":
+        return True
+    if left.startswith(right) or right.startswith(left):
+        return True
+    return _literal_paths_overlap(left.rstrip("/"), right.rstrip("/"))
 
 
 class WorkspaceEventRepository:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -291,14 +291,16 @@ def _owned_path_conflict_advisory_lock_key(*, repo_url: str, branch_base: str) -
 
 
 def _normalize_owned_path(path: str) -> str:
-    normalized = path.strip().replace("\\", "/")
-    while "//" in normalized:
-        normalized = normalized.replace("//", "/")
-    while normalized.startswith("./"):
-        normalized = normalized[2:]
-    normalized = normalized.lstrip("/")
-    normalized = normalized.rstrip("/")
-    return "" if normalized == "." else normalized
+    segments: list[str] = []
+    for segment in path.strip().replace("\\", "/").split("/"):
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    return "/".join(segments)
 
 
 def _literal_paths_overlap(left: str, right: str) -> bool:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -360,11 +360,11 @@ async def create_workspace_v2_row(
 
 
 def owned_path_conflict_detail(conflicts: list[OwnedPathConflict]) -> dict[str, Any]:
-    workspace_ids: list[str] = []
+    workspace_ids: dict[str, None] = {}
     conflict_items: list[dict[str, str]] = []
     for conflict in conflicts:
         if conflict.workspace_id not in workspace_ids:
-            workspace_ids.append(conflict.workspace_id)
+            workspace_ids[conflict.workspace_id] = None
         conflict_items.append(
             {
                 "workspace_id": conflict.workspace_id,
@@ -373,7 +373,7 @@ def owned_path_conflict_detail(conflicts: list[OwnedPathConflict]) -> dict[str, 
             }
         )
     return {
-        "workspace_ids": workspace_ids,
+        "workspace_ids": list(workspace_ids),
         "conflicts": conflict_items,
     }
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -317,6 +317,11 @@ async def create_workspace_v2_row(
 ) -> Workspace:
     """Persist one v2 workspace request without committing the session."""
     repo = WorkspaceRepository(session)
+    await repo.acquire_owned_path_conflict_lock(
+        repo_url=payload.repo.url,
+        branch_base=payload.repo.base_branch,
+        owned_paths=payload.task.owned_paths,
+    )
     conflicts = await repo.find_active_owned_path_conflicts(
         repo_url=payload.repo.url,
         branch_base=payload.repo.base_branch,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -23,6 +23,7 @@ from awf.db.enums import OperationStatus, OperationType
 from awf.db.models import Workspace
 from awf.db.repositories import (
     OperationRepository,
+    OwnedPathConflict,
     WorkspaceEventRepository,
     WorkspaceLogStreamRepository,
     WorkspaceRepository,
@@ -42,6 +43,18 @@ from awf.service.controls import (
 
 class RuntimeInspection(Protocol):
     async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot: ...
+
+
+OWNED_PATH_CONFLICT_CODE = "WORKSPACE_OWNED_PATH_CONFLICT"
+OWNED_PATH_CONFLICT_MESSAGE = "Requested owned paths overlap an active workspace."
+
+
+class WorkspaceOwnedPathConflictError(Exception):
+    def __init__(self, conflicts: list[OwnedPathConflict]) -> None:
+        self.error_code = OWNED_PATH_CONFLICT_CODE
+        self.message = OWNED_PATH_CONFLICT_MESSAGE
+        self.detail = owned_path_conflict_detail(conflicts)
+        super().__init__(self.message)
 
 
 class WorkspaceService:
@@ -303,8 +316,17 @@ async def create_workspace_v2_row(
     idempotency_key: str | None = None,
 ) -> Workspace:
     """Persist one v2 workspace request without committing the session."""
+    repo = WorkspaceRepository(session)
+    conflicts = await repo.find_active_owned_path_conflicts(
+        repo_url=payload.repo.url,
+        branch_base=payload.repo.base_branch,
+        owned_paths=payload.task.owned_paths,
+    )
+    if conflicts:
+        raise WorkspaceOwnedPathConflictError(conflicts)
+
     requested_profile, resolved_profile = v2_profile_snapshots(payload)
-    ws = await WorkspaceRepository(session).create(
+    ws = await repo.create(
         repo_url=payload.repo.url,
         branch_base=payload.repo.base_branch,
         task_title=payload.task.title,
@@ -330,6 +352,25 @@ async def create_workspace_v2_row(
     ws.task_kind = payload.task.kind
     await session.flush()
     return ws
+
+
+def owned_path_conflict_detail(conflicts: list[OwnedPathConflict]) -> dict[str, Any]:
+    workspace_ids: list[str] = []
+    conflict_items: list[dict[str, str]] = []
+    for conflict in conflicts:
+        if conflict.workspace_id not in workspace_ids:
+            workspace_ids.append(conflict.workspace_id)
+        conflict_items.append(
+            {
+                "workspace_id": conflict.workspace_id,
+                "existing_path": conflict.existing_path,
+                "requested_path": conflict.requested_path,
+            }
+        )
+    return {
+        "workspace_ids": workspace_ids,
+        "conflicts": conflict_items,
+    }
 
 
 def v2_profile_snapshots(

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -42,9 +42,53 @@ _V2_MINIMAL_BODY = {
 }
 
 
+def _v2_body(
+    *,
+    repo_url: str = "git@github.com:example/app.git",
+    base_branch: str = "development",
+    title: str = "Owned path policy test",
+    owned_paths: list[str] | None = None,
+) -> dict[str, object]:
+    task = {
+        **_V2_MINIMAL_BODY["task"],
+        "title": title,
+    }
+    if owned_paths is not None:
+        task["owned_paths"] = owned_paths
+    return {
+        **_V2_MINIMAL_BODY,
+        "repo": {
+            "url": repo_url,
+            "base_branch": base_branch,
+        },
+        "task": task,
+    }
+
+
 async def _create_workspace(client: AsyncClient, **overrides: object) -> str:
     body = {**_MINIMAL_BODY, **overrides}
     response = await client.post("/v1/workspaces", json=body)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _create_v2_workspace(
+    client: AsyncClient,
+    *,
+    repo_url: str = "git@github.com:example/app.git",
+    base_branch: str = "development",
+    title: str = "Owned path policy test",
+    owned_paths: list[str] | None = None,
+) -> str:
+    response = await client.post(
+        "/v2/workspaces",
+        json=_v2_body(
+            repo_url=repo_url,
+            base_branch=base_branch,
+            title=title,
+            owned_paths=owned_paths,
+        ),
+    )
     assert response.status_code == 202
     return str(response.json()["workspace_id"])
 
@@ -61,6 +105,20 @@ async def _transition_workspace(
         assert ws is not None
         for target in targets:
             await repo.transition(ws, to=target, reason_code="TEST")
+        await session.commit()
+
+
+async def _set_workspace_status(
+    engine: AsyncEngine,
+    workspace_id: str,
+    status: WorkspaceStatus,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        ws.status = status.value
         await session.commit()
 
 
@@ -278,6 +336,150 @@ class TestCreateWorkspaceV2PolicyMetadata:
         assert first.status_code == 202
         assert replay.status_code == 409
         assert replay.json()["error_code"] == "IDEMPOTENCY_CONFLICT"
+
+
+class TestCreateWorkspaceV2OwnedPathPolicy:
+    @pytest.mark.unit
+    async def test_no_requested_owned_paths_do_not_block(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        await _create_v2_workspace(
+            client,
+            title="existing",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        response = await client.post(
+            "/v2/workspaces",
+            json=_v2_body(title="new without owned paths", owned_paths=[]),
+        )
+
+        assert response.status_code == 202
+
+    @pytest.mark.unit
+    async def test_non_overlapping_owned_paths_are_allowed(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        await _create_v2_workspace(
+            client,
+            title="existing",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        response = await client.post(
+            "/v2/workspaces",
+            json=_v2_body(title="docs", owned_paths=["docs/**"]),
+        )
+
+        assert response.status_code == 202
+
+    @pytest.mark.unit
+    async def test_same_paths_on_different_repo_or_base_branch_are_allowed(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        await _create_v2_workspace(
+            client,
+            repo_url="git@github.com:example/other.git",
+            base_branch="development",
+            title="other repo",
+            owned_paths=["src/awf/api/**"],
+        )
+        await _create_v2_workspace(
+            client,
+            repo_url="git@github.com:example/app.git",
+            base_branch="main",
+            title="other base",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        response = await client.post(
+            "/v2/workspaces",
+            json=_v2_body(owned_paths=["src/awf/api/routes/workspaces.py"]),
+        )
+
+        assert response.status_code == 202
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "existing_status",
+        [
+            WorkspaceStatus.completed,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+            WorkspaceStatus.destroying,
+            WorkspaceStatus.destroyed,
+        ],
+    )
+    async def test_terminal_and_teardown_statuses_do_not_block(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+        existing_status: WorkspaceStatus,
+    ) -> None:
+        existing_id = await _create_v2_workspace(
+            client,
+            title=f"existing {existing_status.value}",
+            owned_paths=["src/awf/api/**"],
+        )
+        await _set_workspace_status(engine, existing_id, existing_status)
+
+        response = await client.post(
+            "/v2/workspaces",
+            json=_v2_body(
+                title=f"new after {existing_status.value}",
+                owned_paths=["src/awf/api/routes/workspaces.py"],
+            ),
+        )
+
+        assert response.status_code == 202
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("existing_path", "requested_path"),
+        [
+            (
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api/routes/workspaces.py",
+            ),
+            ("src/awf/api", "src/awf/api/routes/workspaces.py"),
+            ("src/awf/api/**", "src/awf/api/routes/workspaces.py"),
+        ],
+    )
+    async def test_active_exact_ancestor_and_wildcard_conflicts_return_409(
+        self,
+        client: AsyncClient,
+        existing_path: str,
+        requested_path: str,
+    ) -> None:
+        existing_id = await _create_v2_workspace(
+            client,
+            title=f"existing {existing_path}",
+            owned_paths=[existing_path],
+        )
+
+        response = await client.post(
+            "/v2/workspaces",
+            json=_v2_body(
+                title=f"new {requested_path}",
+                owned_paths=[requested_path],
+            ),
+        )
+
+        assert response.status_code == 409
+        body = response.json()
+        assert body["error_code"] == "WORKSPACE_OWNED_PATH_CONFLICT"
+        assert body["message"] == "Requested owned paths overlap an active workspace."
+        assert body["detail"]["workspace_ids"] == [existing_id]
+        assert body["detail"]["conflicts"] == [
+            {
+                "workspace_id": existing_id,
+                "existing_path": existing_path,
+                "requested_path": requested_path,
+            }
+        ]
 
 
 class TestIdempotency:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -620,6 +620,16 @@ class TestOwnedPathConflictLookup:
                 "src/awf/api/routes/workspaces.py",
                 "src/awf/api/*.py",
             ),
+            (
+                WorkspaceStatus.running,
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api/../api/routes/workspaces.py",
+            ),
+            (
+                WorkspaceStatus.validating,
+                "src/awf/api/**",
+                "src/awf/service/../api/routes/workspaces.py",
+            ),
         ],
     )
     async def test_active_exact_ancestor_and_wildcard_paths_conflict(

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -64,6 +64,32 @@ async def _create_policy_workspace(
     return workspace
 
 
+class _FakeDialect:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class _FakeBind:
+    def __init__(self, dialect_name: str) -> None:
+        self.dialect = _FakeDialect(dialect_name)
+
+
+class _RecordingSession:
+    def __init__(self, dialect_name: str) -> None:
+        self._bind = _FakeBind(dialect_name)
+        self.executed: list[tuple[str, dict[str, object]]] = []
+
+    def get_bind(self) -> _FakeBind:
+        return self._bind
+
+    async def execute(
+        self,
+        statement: object,
+        parameters: dict[str, object] | None = None,
+    ) -> None:
+        self.executed.append((str(statement), dict(parameters or {})))
+
+
 class TestCreate:
     @pytest.mark.unit
     async def test_create_returns_workspace_in_requested_state(self, session: AsyncSession) -> None:
@@ -426,6 +452,45 @@ class TestListWorkspaces:
 
 
 class TestOwnedPathConflictLookup:
+    @pytest.mark.unit
+    async def test_postgres_conflict_lookup_lock_uses_transaction_advisory_lock(self) -> None:
+        session = _RecordingSession("postgresql")
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        await repo.acquire_owned_path_conflict_lock(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        assert len(session.executed) == 1
+        sql, parameters = session.executed[0]
+        assert "pg_advisory_xact_lock" in sql
+        assert isinstance(parameters["lock_key"], int)
+
+    @pytest.mark.unit
+    async def test_conflict_lookup_lock_is_noop_without_postgres_or_owned_paths(self) -> None:
+        sqlite_session = _RecordingSession("sqlite")
+        sqlite_repo = WorkspaceRepository(sqlite_session)  # type: ignore[arg-type]
+
+        await sqlite_repo.acquire_owned_path_conflict_lock(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        postgres_session = _RecordingSession("postgresql")
+        postgres_repo = WorkspaceRepository(postgres_session)  # type: ignore[arg-type]
+
+        await postgres_repo.acquire_owned_path_conflict_lock(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=[" ", "./"],
+        )
+
+        assert sqlite_session.executed == []
+        assert postgres_session.executed == []
+
     @pytest.mark.unit
     async def test_empty_requested_owned_paths_do_not_conflict(
         self, session: AsyncSession

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -41,6 +41,29 @@ async def session() -> AsyncIterator[AsyncSession]:
     await engine.dispose()
 
 
+async def _create_policy_workspace(
+    session: AsyncSession,
+    repo: WorkspaceRepository,
+    *,
+    repo_url: str = "git@github.com:example/app.git",
+    branch_base: str = "development",
+    owned_paths: list[str] | None = None,
+    status: WorkspaceStatus = WorkspaceStatus.requested,
+) -> Workspace:
+    workspace = await repo.create(
+        repo_url=repo_url,
+        branch_base=branch_base,
+        task_title="policy test",
+        task_prompt="do policy-sensitive work",
+        agent=AgentRuntime.codex.value,
+        test_commands=[],
+        owned_paths=list(owned_paths or []),
+    )
+    workspace.status = status.value
+    await session.flush()
+    return workspace
+
+
 class TestCreate:
     @pytest.mark.unit
     async def test_create_returns_workspace_in_requested_state(self, session: AsyncSession) -> None:
@@ -400,6 +423,165 @@ class TestListWorkspaces:
         listed = await repo.list(limit=3)
 
         assert [row.id for row in listed] == sorted((row.id for row in rows), reverse=True)
+
+
+class TestOwnedPathConflictLookup:
+    @pytest.mark.unit
+    async def test_empty_requested_owned_paths_do_not_conflict(
+        self, session: AsyncSession
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        await _create_policy_workspace(session, repo, owned_paths=["src/awf/api/**"])
+
+        conflicts = await repo.find_active_owned_path_conflicts(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=[],
+        )
+
+        assert conflicts == []
+
+    @pytest.mark.unit
+    async def test_non_overlapping_owned_paths_do_not_conflict(
+        self, session: AsyncSession
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        await _create_policy_workspace(session, repo, owned_paths=["src/awf/api/**"])
+
+        conflicts = await repo.find_active_owned_path_conflicts(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=["docs/**"],
+        )
+
+        assert conflicts == []
+
+    @pytest.mark.unit
+    async def test_same_paths_on_different_repo_or_base_branch_do_not_conflict(
+        self, session: AsyncSession
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        await _create_policy_workspace(
+            session,
+            repo,
+            repo_url="git@github.com:example/other.git",
+            branch_base="development",
+            owned_paths=["src/awf/api/**"],
+        )
+        await _create_policy_workspace(
+            session,
+            repo,
+            repo_url="git@github.com:example/app.git",
+            branch_base="main",
+            owned_paths=["src/awf/api/**"],
+        )
+
+        conflicts = await repo.find_active_owned_path_conflicts(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=["src/awf/api/routes/workspaces.py"],
+        )
+
+        assert conflicts == []
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "status",
+        [
+            WorkspaceStatus.completed,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+            WorkspaceStatus.destroying,
+            WorkspaceStatus.destroyed,
+        ],
+    )
+    async def test_terminal_and_teardown_statuses_do_not_conflict(
+        self,
+        session: AsyncSession,
+        status: WorkspaceStatus,
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        await _create_policy_workspace(
+            session,
+            repo,
+            owned_paths=["src/awf/api/**"],
+            status=status,
+        )
+
+        conflicts = await repo.find_active_owned_path_conflicts(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=["src/awf/api/routes/workspaces.py"],
+        )
+
+        assert conflicts == []
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("status", "existing_path", "requested_path"),
+        [
+            (
+                WorkspaceStatus.requested,
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api/routes/workspaces.py",
+            ),
+            (
+                WorkspaceStatus.provisioning,
+                "src/awf/api",
+                "src/awf/api/routes/workspaces.py",
+            ),
+            (
+                WorkspaceStatus.ready,
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api",
+            ),
+            (
+                WorkspaceStatus.running,
+                "src/awf/api/**",
+                "src/awf/api/routes/workspaces.py",
+            ),
+            (
+                WorkspaceStatus.validating,
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api/**",
+            ),
+            (
+                WorkspaceStatus.pushing,
+                "src/awf/api/*.py",
+                "src/awf/api/routes/workspaces.py",
+            ),
+            (
+                WorkspaceStatus.monitoring_pr,
+                "src/awf/api/routes/workspaces.py",
+                "src/awf/api/*.py",
+            ),
+        ],
+    )
+    async def test_active_exact_ancestor_and_wildcard_paths_conflict(
+        self,
+        session: AsyncSession,
+        status: WorkspaceStatus,
+        existing_path: str,
+        requested_path: str,
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        existing = await _create_policy_workspace(
+            session,
+            repo,
+            owned_paths=[existing_path],
+            status=status,
+        )
+
+        conflicts = await repo.find_active_owned_path_conflicts(
+            repo_url="git@github.com:example/app.git",
+            branch_base="development",
+            owned_paths=[requested_path],
+        )
+
+        assert len(conflicts) == 1
+        assert conflicts[0].workspace_id == existing.id
+        assert conflicts[0].existing_path == existing_path
+        assert conflicts[0].requested_path == requested_path
 
 
 class TestTransition:

--- a/tests/unit/service/test_workspace_owned_path_policy.py
+++ b/tests/unit/service/test_workspace_owned_path_policy.py
@@ -49,6 +49,55 @@ def _request(
 
 
 @pytest.mark.unit
+async def test_create_v2_acquires_conflict_lock_before_lookup(
+    factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    order: list[str] = []
+    original_lock = WorkspaceRepository.acquire_owned_path_conflict_lock
+    original_lookup = WorkspaceRepository.find_active_owned_path_conflicts
+
+    async def lock_spy(
+        self: WorkspaceRepository,
+        *,
+        repo_url: str,
+        branch_base: str,
+        owned_paths: list[str],
+    ) -> None:
+        order.append("lock")
+        await original_lock(
+            self,
+            repo_url=repo_url,
+            branch_base=branch_base,
+            owned_paths=owned_paths,
+        )
+
+    async def lookup_spy(
+        self: WorkspaceRepository,
+        *,
+        repo_url: str,
+        branch_base: str,
+        owned_paths: list[str],
+    ):
+        order.append("lookup")
+        return await original_lookup(
+            self,
+            repo_url=repo_url,
+            branch_base=branch_base,
+            owned_paths=owned_paths,
+        )
+
+    monkeypatch.setattr(WorkspaceRepository, "acquire_owned_path_conflict_lock", lock_spy)
+    monkeypatch.setattr(WorkspaceRepository, "find_active_owned_path_conflicts", lookup_spy)
+
+    service = WorkspaceService(factory)
+
+    await service.create_v2(_request(title="new", owned_paths=["src/awf/api/**"]))
+
+    assert order[:2] == ["lock", "lookup"]
+
+
+@pytest.mark.unit
 async def test_create_v2_allows_empty_requested_owned_paths(
     factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspace_owned_path_policy.py
+++ b/tests/unit/service/test_workspace_owned_path_policy.py
@@ -12,7 +12,7 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-from awf.service.workspaces import WorkspaceService
+from awf.service.workspaces import WorkspaceOwnedPathConflictError, WorkspaceService
 
 
 @pytest.fixture
@@ -101,16 +101,14 @@ async def test_create_v2_rejects_conflicts_with_useful_detail(
         _request(title="existing", owned_paths=["src/awf/service/**"])
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(WorkspaceOwnedPathConflictError) as exc_info:
         await service.create_v2(
             _request(title="new", owned_paths=["src/awf/service/workspaces.py"])
         )
 
-    assert getattr(exc_info.value, "error_code") == "WORKSPACE_OWNED_PATH_CONFLICT"
-    assert getattr(exc_info.value, "message") == (
-        "Requested owned paths overlap an active workspace."
-    )
-    assert getattr(exc_info.value, "detail") == {
+    assert exc_info.value.error_code == "WORKSPACE_OWNED_PATH_CONFLICT"
+    assert exc_info.value.message == "Requested owned paths overlap an active workspace."
+    assert exc_info.value.detail == {
         "workspace_ids": [existing.id],
         "conflicts": [
             {

--- a/tests/unit/service/test_workspace_owned_path_policy.py
+++ b/tests/unit/service/test_workspace_owned_path_policy.py
@@ -1,0 +1,122 @@
+"""Workspace owned-path conflict policy tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import WorkspaceCreateV2Request
+from awf.db.base import Base
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.service.workspaces import WorkspaceService
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+def _request(
+    *,
+    repo_url: str = "git@github.com:example/service.git",
+    base_branch: str = "development",
+    title: str = "Owned path policy",
+    owned_paths: list[str] | None = None,
+) -> WorkspaceCreateV2Request:
+    return WorkspaceCreateV2Request(
+        repo={"url": repo_url, "base_branch": base_branch},
+        task={
+            "title": title,
+            "prompt": "Do policy-sensitive work.",
+            "agent": "codex",
+            "kind": "feature_branch_pr",
+            "owned_paths": list(owned_paths or []),
+        },
+        workspace={"profile_ref": "auto", "profile": None},
+        validation={"commands": ["pytest -q"], "requested_tier": 1},
+        resources={},
+    )
+
+
+@pytest.mark.unit
+async def test_create_v2_allows_empty_requested_owned_paths(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    await service.create_v2(_request(title="existing", owned_paths=["src/awf/api/**"]))
+
+    created = await service.create_v2(_request(title="new", owned_paths=[]))
+
+    assert created.owned_paths == []
+
+
+@pytest.mark.unit
+async def test_create_v2_allows_non_overlapping_owned_paths(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    await service.create_v2(_request(title="existing", owned_paths=["src/awf/api/**"]))
+
+    created = await service.create_v2(_request(title="new", owned_paths=["docs/**"]))
+
+    assert created.owned_paths == ["docs/**"]
+
+
+@pytest.mark.unit
+async def test_create_v2_ignores_terminal_and_teardown_conflicts(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    existing = await service.create_v2(_request(title="existing", owned_paths=["src/awf/api/**"]))
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(existing.id)
+        assert workspace is not None
+        workspace.status = WorkspaceStatus.completed.value
+        await session.commit()
+
+    created = await service.create_v2(
+        _request(title="new", owned_paths=["src/awf/api/routes/workspaces.py"])
+    )
+
+    assert created.owned_paths == ["src/awf/api/routes/workspaces.py"]
+
+
+@pytest.mark.unit
+async def test_create_v2_rejects_conflicts_with_useful_detail(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    existing = await service.create_v2(
+        _request(title="existing", owned_paths=["src/awf/service/**"])
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        await service.create_v2(
+            _request(title="new", owned_paths=["src/awf/service/workspaces.py"])
+        )
+
+    assert getattr(exc_info.value, "error_code") == "WORKSPACE_OWNED_PATH_CONFLICT"
+    assert getattr(exc_info.value, "message") == (
+        "Requested owned paths overlap an active workspace."
+    )
+    assert getattr(exc_info.value, "detail") == {
+        "workspace_ids": [existing.id],
+        "conflicts": [
+            {
+                "workspace_id": existing.id,
+                "existing_path": "src/awf/service/**",
+                "requested_path": "src/awf/service/workspaces.py",
+            }
+        ],
+    }


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_222ed1e8c4f348979a1e667c` (agent: `codex`).

**External task ID**: awf-wave2-owned-path-policy-20260426T045914Z

### Task
Implement the first overlap-policy slice from the AWF PRD: reject new v2 workspaces whose declared owned paths conflict with an already-active workspace for the same repo/base branch.

Problem to solve:
- AWF now persists task_class and owned_paths, but it does not use them to prevent duplicate or conflicting concurrent work.
- The PRD requires deterministic overlap detection before broader scheduling.

Required behavior:
- On `POST /v2/workspaces`, when `task.owned_paths` is non-empty, detect active workspaces with the same `repo.url` and `repo.base_branch` whose owned paths overlap.
- Active statuses should include requested, provisioning, ready, running, validating, pushing, and monitoring_pr. Terminal/destroying/destroyed/completed/failed/cancelled rows must not block.
- Return HTTP 409 with a structured error code such as `WORKSPACE_OWNED_PATH_CONFLICT`, including conflicting workspace ids and paths in the response detail where the existing error schema allows.
- Keep legacy v1 create unchanged for this slice.
- Implement conservative path overlap: exact match, ancestor/descendant directory overlap, and simple wildcard-prefix overlap are enough. Avoid a large glob engine unless the repo already has one.

TDD requirements:
- Add API/service/repository tests for no owned paths, non-overlapping paths allowed, different repo/base allowed, terminal conflicts ignored, active exact/ancestor/wildcard conflicts rejected with useful detail.
- Reproduce missing conflict rejection first, commit failing tests, then implement.

Validation commands:
- uv run ruff check src/awf/api src/awf/service src/awf/db tests/unit/api tests/unit/service tests/unit/db
- uv run mypy src/awf/api src/awf/service src/awf/db
- uv run pytest tests/unit/api tests/unit/service tests/unit/db -q

Strict TDD and AWF contract:
- Write focused failing tests first and commit the red tests, including the failure summary in the commit body.
- Implement until the narrow tests pass, then run the full validation commands listed below.
- Commit locally with conventional commits.
- Do not push, switch branches, rebase, or open/merge PRs. AWF owns branch lifecycle, push, PR creation, comment handling, checks, branch updates, and auto-merge.
- Keep the change tightly scoped to the owned paths and adjust to concurrent PRs by syncing through AWF, not by manual GitHub operations.

---
Validation: 6 profile command(s) passed inside the workspace container.
