### PR TITLE
fix(control): make cancel and destroy race-safe

### DIFF
--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -730,12 +730,6 @@ class WorkspaceExecutor:
             action="start_push",
         ):
             return
-        if not await self._recheck_status(
-            workspace_id,
-            expected=WorkspaceStatus.pushing,
-            action="push_pr",
-        ):
-            return
 
         pr_title = ws.task_title
         pr_body = _build_pr_body(ws)

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -150,6 +150,12 @@ class WorkspaceExecutor:
         ws = await self._claim_ready(workspace_id)
         if ws is None:
             return
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.running,
+            action="execute",
+        ):
+            return
 
         compose_file = (
             Path(ws.compose_file_path)
@@ -193,6 +199,12 @@ class WorkspaceExecutor:
                     )[:2000],
                 )
                 return
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.running,
+                action="agent_run",
+            ):
+                return
             await adapter.run(
                 compose_project=compose_project,
                 compose_file=compose_file,
@@ -235,6 +247,13 @@ class WorkspaceExecutor:
             return
 
         # ── Step 1b: capture the agent's work as a commit on the feature branch ──
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.running,
+            action="post_agent_commit",
+        ):
+            return
+
         # Coding CLIs make file edits reliably but are inconsistent about git:
         # some commit, some leave changes unstaged, some commit partial subsets
         # and leave the rest dirty. AWF normalizes: after the agent exits, we
@@ -540,7 +559,14 @@ class WorkspaceExecutor:
             return
 
         # ── Step 2: validation (tests + optional Alembic), with fix-cycle ──
-        await self._transition(workspace_id, to=WorkspaceStatus.validating, reason="AGENT_RUN_OK")
+        if not await self._transition_if_current(
+            workspace_id,
+            from_status=WorkspaceStatus.running,
+            to=WorkspaceStatus.validating,
+            reason="AGENT_RUN_OK",
+            action="start_validation",
+        ):
+            return
 
         max_fix_passes = self._config.max_validation_fix_passes
         profile = _profile_for_workspace(ws, worktree_path=worktree_path)
@@ -553,6 +579,12 @@ class WorkspaceExecutor:
         for pass_number in range(max_fix_passes + 1):
             # pass_number == 0 is the initial run (already-committed agent
             # work). 1..N are fix attempts driven by the retry prompt.
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.validating,
+                action="validate",
+            ):
+                return
             val_result = await self._validation.run_profile_phases(
                 workspace_id=workspace_id,
                 compose_project=compose_project,
@@ -615,6 +647,12 @@ class WorkspaceExecutor:
                 max_fix_passes=max_fix_passes,
                 failed_command=first_fail.command,
             )
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.validating,
+                action="validation_fix_agent_run",
+            ):
+                return
             try:
                 await adapter.run(
                     compose_project=compose_project,
@@ -636,12 +674,17 @@ class WorkspaceExecutor:
                     reason_code=exc.reason_code,
                 )
 
-            # Commit whatever the fix pass produced. Simpler than the
-            # initial post-agent commit block — orphan-history recovery
-            # isn't possible here (HEAD already descends from base after
-            # the initial run succeeded); zero-change fix passes are
-            # allowed (agent may think no change was needed, which next
-            # validation will confirm or refute).
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.validating,
+                action="validation_fix_commit",
+            ):
+                return
+
+            # Commit whatever the fix pass produced. Simpler than the initial
+            # post-agent commit block — orphan-history recovery isn't possible
+            # here (HEAD already descends from base after the initial run
+            # succeeded); zero-change fix passes are allowed.
             fix_add = await _git_in_worktree(["add", "-A"])
             if not fix_add.ok:
                 _log.warning(
@@ -679,7 +722,20 @@ class WorkspaceExecutor:
             # Loop back to re-validate.
 
         # ── Step 3: push + open PR ──────────────────────────────────────────
-        await self._transition(workspace_id, to=WorkspaceStatus.pushing, reason="VALIDATION_OK")
+        if not await self._transition_if_current(
+            workspace_id,
+            from_status=WorkspaceStatus.validating,
+            to=WorkspaceStatus.pushing,
+            reason="VALIDATION_OK",
+            action="start_push",
+        ):
+            return
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.pushing,
+            action="push_pr",
+        ):
+            return
 
         pr_title = ws.task_title
         pr_body = _build_pr_body(ws)
@@ -722,6 +778,16 @@ class WorkspaceExecutor:
             persisted = await repo.get(workspace_id)
             if persisted is None:  # pragma: no cover - destroyed mid-flight
                 return
+            if persisted.status != WorkspaceStatus.pushing.value:
+                await self._record_stale_action_skip(
+                    repo,
+                    persisted,
+                    action="persist_pr",
+                    expected=WorkspaceStatus.pushing,
+                    reason_code="EXECUTOR_STALE_STATUS",
+                )
+                await session.commit()
+                return
             persisted.pr_url = pr.url
             persisted.pr_number = _extract_pr_number(pr.url)
             if persisted.task_kind == "feature_branch_pr" and not persisted.remote_push_branch:
@@ -761,6 +827,12 @@ class WorkspaceExecutor:
                 workspace_id=workspace_id,
                 pr_url=pr.url,
             )
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.monitoring_pr,
+                action="run_pr_monitor",
+            ):
+                return
             await monitor.run(
                 workspace_id=workspace_id,
                 compose_project=compose_project,
@@ -792,6 +864,12 @@ class WorkspaceExecutor:
                 status=ws.status,
             )
             return
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.monitoring_pr,
+            action="resume_pr_monitor",
+        ):
+            return
 
         if not ws.remote_push_branch and ws.task_kind == "feature_branch_pr" and ws.branch_name:
             recovered_remote_push_branch = await self._recover_feature_branch_remote_push_branch(
@@ -818,6 +896,13 @@ class WorkspaceExecutor:
         compose_file_path = ws.compose_file_path
         assert compose_project is not None
         assert compose_file_path is not None
+
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.monitoring_pr,
+            action="resume_compose",
+        ):
+            return
 
         try:
             await self._compose.ensure_project_up(
@@ -890,6 +975,12 @@ class WorkspaceExecutor:
             pr_url=ws.pr_url,
             pr_number=ws.pr_number,
         )
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.monitoring_pr,
+            action="resume_monitor_run",
+        ):
+            return
         await monitor.run(
             workspace_id=workspace_id,
             compose_project=compose_project,
@@ -956,14 +1047,90 @@ class WorkspaceExecutor:
             # Return a detached snapshot (session closes).
             return ws
 
-    async def _transition(self, workspace_id: str, *, to: WorkspaceStatus, reason: str) -> None:
+    async def _recheck_status(
+        self,
+        workspace_id: str,
+        *,
+        expected: WorkspaceStatus,
+        action: str,
+        reason_code: str = "EXECUTOR_STALE_STATUS",
+    ) -> bool:
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
             ws = await repo.get(workspace_id)
             if ws is None:  # pragma: no cover - destroyed mid-flight
-                return
+                _log.warning(
+                    "executor.skip_unknown",
+                    workspace_id=workspace_id,
+                    action=action,
+                )
+                return False
+            if ws.status == expected.value:
+                return True
+            await self._record_stale_action_skip(
+                repo,
+                ws,
+                action=action,
+                expected=expected,
+                reason_code=reason_code,
+            )
+            await session.commit()
+            return False
+
+    async def _transition_if_current(
+        self,
+        workspace_id: str,
+        *,
+        from_status: WorkspaceStatus,
+        to: WorkspaceStatus,
+        reason: str,
+        action: str,
+    ) -> bool:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            if ws is None:  # pragma: no cover - destroyed mid-flight
+                return False
+            if ws.status != from_status.value:
+                await self._record_stale_action_skip(
+                    repo,
+                    ws,
+                    action=action,
+                    expected=from_status,
+                    reason_code="EXECUTOR_STALE_STATUS",
+                )
+                await session.commit()
+                return False
             await repo.transition(ws, to=to, reason_code=reason)
             await session.commit()
+            return True
+
+    async def _record_stale_action_skip(
+        self,
+        repo: WorkspaceRepository,
+        ws: Workspace,
+        *,
+        action: str,
+        expected: WorkspaceStatus,
+        reason_code: str,
+    ) -> None:
+        _log.info(
+            "executor.skip_stale_status",
+            workspace_id=ws.id,
+            action=action,
+            expected_status=expected.value,
+            status=ws.status,
+        )
+        await repo.add_event(
+            ws,
+            event_type="workspace.stale_action_skipped",
+            reason_code=reason_code,
+            payload={
+                "action": action,
+                "expected_status": expected.value,
+                "actual_status": ws.status,
+            },
+        )
 
     async def _mark_failed(
         self,
@@ -981,6 +1148,14 @@ class WorkspaceExecutor:
                 return
             if ws.status != from_status.value:
                 # Already moved (e.g. cancelled) — respect it.
+                await self._record_stale_action_skip(
+                    repo,
+                    ws,
+                    action="mark_failed",
+                    expected=from_status,
+                    reason_code="EXECUTOR_MARK_FAILED_SKIPPED",
+                )
+                await session.commit()
                 return
             ws.failure_reason = failure_reason.value
             ws.failure_message = message

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -73,6 +73,11 @@ class ControlWorker:
         dispatched_ids: set[str] = set()
 
         requested_ids = await self._list_requested()
+        requested_ids = await self._filter_current_status(
+            requested_ids,
+            expected=WorkspaceStatus.requested,
+            action="provision",
+        )
         if requested_ids:
             await asyncio.gather(
                 *(self._safely_provision(ws_id) for ws_id in requested_ids),
@@ -88,6 +93,11 @@ class ControlWorker:
                     limit=execution_slots,
                     exclude_ids=active_execution_ids,
                 )
+                monitoring_ids = await self._filter_current_status(
+                    monitoring_ids,
+                    expected=WorkspaceStatus.monitoring_pr,
+                    action="resume_pr_monitor",
+                )
                 dispatched_ids.update(
                     self._dispatch_monitor_resumes(monitoring_ids, limit=execution_slots)
                 )
@@ -97,6 +107,11 @@ class ControlWorker:
                 ready_ids = await self._list_ready(
                     limit=execution_slots,
                     exclude_ids=set(self._execution_tasks),
+                )
+                ready_ids = await self._filter_current_status(
+                    ready_ids,
+                    expected=WorkspaceStatus.ready,
+                    action="execute",
                 )
                 dispatched_ids.update(
                     self._dispatch_ready_executions(ready_ids, limit=execution_slots)
@@ -181,6 +196,37 @@ class ControlWorker:
             stmt = stmt.order_by(Workspace.created_at).limit(limit)
             result = await session.execute(stmt)
             return [row[0] for row in result.all()]
+
+    async def _filter_current_status(
+        self,
+        workspace_ids: list[str],
+        *,
+        expected: WorkspaceStatus,
+        action: str,
+    ) -> list[str]:
+        if not workspace_ids:
+            return []
+
+        async with self._session_factory() as session:
+            stmt = select(Workspace.id, Workspace.status).where(Workspace.id.in_(workspace_ids))
+            result = await session.execute(stmt)
+            statuses: dict[str, str] = {row[0]: row[1] for row in result.all()}
+
+        current_ids: list[str] = []
+        for workspace_id in workspace_ids:
+            actual = statuses.get(workspace_id)
+            if actual == expected.value:
+                current_ids.append(workspace_id)
+                continue
+
+            _log.info(
+                "worker.skip_stale_dispatch",
+                workspace_id=workspace_id,
+                action=action,
+                expected_status=expected.value,
+                status=actual,
+            )
+        return current_ids
 
     def _available_execution_slots(self) -> int:
         return max(0, self._config.max_concurrent_executions - len(self._execution_tasks))

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -76,6 +76,14 @@ class Provisioner:
             if ws is None:
                 return  # Workspace disappeared or wasn't requested; nothing to do.
 
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.provisioning,
+            action="provision",
+            reason_code="PROVISIONER_STALE_STATUS",
+        ):
+            return
+
         # 2. Do the git work outside a DB transaction (it's slow).
         branch_name = f"{self._config.branch_prefix}/{workspace_id}"
         try:
@@ -85,6 +93,13 @@ class Provisioner:
                 base_branch=ws.branch_base,
                 new_branch=branch_name,
             )
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.provisioning,
+                action="provision",
+                reason_code="PROVISIONER_STALE_STATUS",
+            ):
+                return
             base_commit = await self._git.head_sha(workspace_id=workspace_id)
             profile_resolution = None
             if ws.resolved_profile is None:
@@ -99,6 +114,13 @@ class Provisioner:
                 profile = WorkspaceProfile.model_validate(ws.resolved_profile)
             stack_paths: ComposeProjectPaths | None = None
             if self._stack_launcher is not None:
+                if not await self._recheck_status(
+                    workspace_id,
+                    expected=WorkspaceStatus.provisioning,
+                    action="provision",
+                    reason_code="PROVISIONER_STALE_STATUS",
+                ):
+                    return
                 stack_paths = await self._stack_launcher.launch(
                     WorkspaceStackLaunchRequest(
                         workspace_id=workspace_id,
@@ -166,6 +188,16 @@ class Provisioner:
             repo = WorkspaceRepository(session)
             persisted = await repo.get(workspace_id)
             if persisted is None:  # pragma: no cover - defensive; workspace removed mid-provision
+                return
+            if persisted.status != WorkspaceStatus.provisioning.value:
+                await self._record_stale_action_skip(
+                    repo,
+                    persisted,
+                    action="provision",
+                    expected=WorkspaceStatus.provisioning,
+                    reason_code="PROVISIONER_STALE_STATUS",
+                )
+                await session.commit()
                 return
 
             persisted.node_id = self._config.node_id
@@ -241,6 +273,14 @@ class Provisioner:
                     return
                 if ws.status != from_status.value:
                     # Already moved elsewhere (e.g. cancelled). Respect that.
+                    await self._record_stale_action_skip(
+                        repo,
+                        ws,
+                        action="mark_failed",
+                        expected=from_status,
+                        reason_code="PROVISIONER_MARK_FAILED_SKIPPED",
+                    )
+                    await session.commit()
                     return
                 ws.failure_reason = failure_reason.value
                 ws.failure_message = message
@@ -252,3 +292,60 @@ class Provisioner:
                 await session.commit()
         except Exception:  # pragma: no cover - defensive
             _log.exception("provisioner.mark_failed_failed", workspace_id=workspace_id)
+
+    async def _recheck_status(
+        self,
+        workspace_id: str,
+        *,
+        expected: WorkspaceStatus,
+        action: str,
+        reason_code: str,
+    ) -> bool:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            if ws is None:  # pragma: no cover - race with hard deletion
+                _log.warning(
+                    "provisioner.skip_unknown",
+                    workspace_id=workspace_id,
+                    action=action,
+                )
+                return False
+            if ws.status == expected.value:
+                return True
+            await self._record_stale_action_skip(
+                repo,
+                ws,
+                action=action,
+                expected=expected,
+                reason_code=reason_code,
+            )
+            await session.commit()
+            return False
+
+    async def _record_stale_action_skip(
+        self,
+        repo: WorkspaceRepository,
+        ws: Workspace,
+        *,
+        action: str,
+        expected: WorkspaceStatus,
+        reason_code: str,
+    ) -> None:
+        _log.info(
+            "provisioner.skip_stale_status",
+            workspace_id=ws.id,
+            action=action,
+            expected_status=expected.value,
+            status=ws.status,
+        )
+        await repo.add_event(
+            ws,
+            event_type="workspace.stale_action_skipped",
+            reason_code=reason_code,
+            payload={
+                "action": action,
+                "expected_status": expected.value,
+                "actual_status": ws.status,
+            },
+        )

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -63,9 +63,10 @@ def _make_executor(
     *,
     pr_monitor_factory: Any = None,
     compose: Any = None,
+    validation: Any = None,
 ) -> WorkspaceExecutor:
     compose = compose or _NoopResumeCompose()
-    validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+    validation = validation or ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
     pr = PullRequestCreator(fake)
     return WorkspaceExecutor(
         session_factory=factory,
@@ -96,6 +97,38 @@ class _NoopResumeCompose:
         wait: bool = True,
     ) -> None:
         del project_name, compose_file, workspace_id, wait
+
+
+class _RecordingValidation:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def run_profile_phases(
+        self,
+        *,
+        phase_names: tuple[str, ...],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        self.calls.append(phase_names)
+        return SimpleNamespace(all_passed=True, first_failure=None)
+
+
+async def _move_to_operator_control_status(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    final_status: WorkspaceStatus,
+) -> None:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        await repo.transition(ws, to=WorkspaceStatus.cancelled, reason_code="TEST_OPERATOR")
+        if final_status == WorkspaceStatus.destroyed:
+            await repo.transition(ws, to=WorkspaceStatus.destroying, reason_code="TEST_OPERATOR")
+            await repo.transition(ws, to=WorkspaceStatus.destroyed, reason_code="TEST_OPERATOR")
+        else:
+            assert final_status == WorkspaceStatus.cancelled
+        await s.commit()
 
 
 async def _seed_ready(
@@ -290,6 +323,108 @@ class TestUnexpectedErrorDuringAgentRun:
             assert ws is not None
             assert ws.status == WorkspaceStatus.failed.value
             assert "unexpected error" in (ws.failure_message or "")
+
+
+class TestOperatorControlRaces:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
+    )
+    async def test_execute_rechecks_after_claim_before_setup(
+        self,
+        final_status: WorkspaceStatus,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_ready(factory)
+        validation = _RecordingValidation()
+        executor = _make_executor(fake, factory, tmp_path, validation=validation)
+        original_claim_ready = executor._claim_ready
+
+        async def _claim_then_operator_control(workspace_id: str) -> Any:
+            ws = await original_claim_ready(workspace_id)
+            assert ws is not None
+            async with factory() as s:
+                repo = WorkspaceRepository(s)
+                fresh = await repo.get(workspace_id)
+                assert fresh is not None
+                assert fresh.status == WorkspaceStatus.running.value
+            await _move_to_operator_control_status(factory, workspace_id, final_status)
+            return ws
+
+        executor._claim_ready = _claim_then_operator_control  # type: ignore[method-assign]
+
+        await executor.execute(ws_id)
+
+        assert validation.calls == []
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == final_status.value
+            assert ws.failure_reason is None
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
+    )
+    async def test_resume_pr_monitor_rechecks_after_load_before_compose(
+        self,
+        final_status: WorkspaceStatus,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        compose_calls: list[str] = []
+        monitor_calls: list[str] = []
+
+        class _RecordingCompose:
+            async def ensure_project_up(
+                self,
+                *,
+                project_name: str,
+                compose_file: Path,
+                workspace_id: str,
+                wait: bool = True,
+            ) -> None:
+                del project_name, compose_file, wait
+                compose_calls.append(workspace_id)
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                del compose_project, compose_file
+                monitor_calls.append(workspace_id)
+
+        ws_id = await _seed_monitoring_pr(factory)
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=lambda *_args: _Monitor(),
+            compose=_RecordingCompose(),
+        )
+        original_load_workspace = executor._load_workspace
+
+        async def _load_then_operator_control(workspace_id: str) -> Any:
+            ws = await original_load_workspace(workspace_id)
+            assert ws is not None
+            await _move_to_operator_control_status(factory, workspace_id, final_status)
+            return ws
+
+        executor._load_workspace = _load_then_operator_control  # type: ignore[method-assign]
+
+        await executor.resume_pr_monitor(ws_id)
+
+        assert compose_calls == []
+        assert monitor_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == final_status.value
+            assert ws.failure_reason is None
 
 
 class TestAgentWatchdogConfig:

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -142,6 +142,24 @@ async def _create_monitoring_pr(
         return ws.id
 
 
+async def _move_to_operator_control_status(
+    session_factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    final_status: WorkspaceStatus,
+) -> None:
+    async with session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        await repo.transition(ws, to=WorkspaceStatus.cancelled, reason_code="TEST_OPERATOR")
+        if final_status == WorkspaceStatus.destroyed:
+            await repo.transition(ws, to=WorkspaceStatus.destroying, reason_code="TEST_OPERATOR")
+            await repo.transition(ws, to=WorkspaceStatus.destroyed, reason_code="TEST_OPERATOR")
+        else:
+            assert final_status == WorkspaceStatus.cancelled
+        await s.commit()
+
+
 class _TransitioningProvisioner:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
@@ -479,6 +497,42 @@ class TestRunOnceExecution:
             assert ws.failure_reason is None
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
+    )
+    async def test_stale_ready_list_entry_is_rechecked_before_dispatch(
+        self,
+        final_status: WorkspaceStatus,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        ready_id = await _create_ready(session_factory, origin_repo, "stale-ready")
+        await _move_to_operator_control_status(session_factory, ready_id, final_status)
+
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_provisions=3),
+        )
+
+        async def _stale_ready_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            del limit, exclude_ids
+            return [ready_id]
+
+        worker._list_ready = _stale_ready_list  # type: ignore[method-assign]
+
+        assert await worker.run_once() == 0
+        await worker.wait_for_execution_tasks()
+
+        assert executor.calls == []
+
+    @pytest.mark.unit
     async def test_bad_ready_execution_does_not_abort_other_ready_workspaces(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -586,6 +640,44 @@ class TestRunOnceMonitorRecovery:
         assert await worker.run_once() == 1
         await worker.wait_for_execution_tasks()
         assert executor.calls == [ready_id]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
+    )
+    async def test_stale_monitoring_list_entry_is_rechecked_before_dispatch(
+        self,
+        final_status: WorkspaceStatus,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "stale-monitor"
+        )
+        await _move_to_operator_control_status(session_factory, monitor_id, final_status)
+
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=3),
+        )
+
+        async def _stale_monitor_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            del limit, exclude_ids
+            return [monitor_id]
+
+        worker._list_monitoring_pr = _stale_monitor_list  # type: ignore[method-assign]
+
+        assert await worker.run_once() == 0
+        await worker.wait_for_execution_tasks()
+
+        assert executor.resume_calls == []
 
     @pytest.mark.unit
     async def test_monitor_resume_does_not_duplicate_active_task(

--- a/tests/unit/node/test_provisioner.py
+++ b/tests/unit/node/test_provisioner.py
@@ -19,7 +19,7 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.node.compose_manager import ComposeOperationError, ComposeProjectPaths
-from awf.node.git_manager import GitManager, GitOperationError
+from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 
 
@@ -68,6 +68,20 @@ def provisioner(
         git=git_manager,
         config=ProvisionerConfig(node_id="test-node-01"),
     )
+
+
+async def _force_destroy_provisioning_workspace(
+    session_factory: async_sessionmaker[AsyncSession], workspace_id: str
+) -> None:
+    async with session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.provisioning.value
+        await repo.transition(ws, to=WorkspaceStatus.cancelled, reason_code="TEST_DESTROY")
+        await repo.transition(ws, to=WorkspaceStatus.destroying, reason_code="TEST_DESTROY")
+        await repo.transition(ws, to=WorkspaceStatus.destroyed, reason_code="TEST_DESTROY")
+        await s.commit()
 
 
 class TestSuccess:
@@ -307,6 +321,147 @@ class TestFailureHandling:
             assert reloaded.failure_message is not None
             assert "unexpected provisioning failure" in reloaded.failure_message
             assert "workspace.base.yml.j2" in reloaded.failure_message
+
+
+class TestOperatorControlRaces:
+    @pytest.mark.unit
+    async def test_destroy_after_claim_skips_git_and_ready_transition(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+        origin_repo: Path,
+    ) -> None:
+        class _RecordingGit:
+            def __init__(self) -> None:
+                self.add_worktree_calls: list[str] = []
+                self.head_calls: list[str] = []
+
+            async def add_worktree(
+                self,
+                *,
+                workspace_id: str,
+                repo_url: str,
+                base_branch: str,
+                new_branch: str,
+            ) -> WorktreeLayout:
+                del repo_url, base_branch
+                self.add_worktree_calls.append(workspace_id)
+                return WorktreeLayout(
+                    mirror_path=tmp_path / "mirror.git",
+                    worktree_path=tmp_path / "worktrees" / workspace_id,
+                    branch_name=new_branch,
+                )
+
+            async def head_sha(self, *, workspace_id: str) -> str:
+                self.head_calls.append(workspace_id)
+                return "c" * 40
+
+        class _DestroyAfterClaimProvisioner(Provisioner):
+            async def _load_and_claim(
+                self, session: AsyncSession, workspace_id: str
+            ) -> Any:
+                ws = await super()._load_and_claim(session, workspace_id)
+                assert ws is not None
+                await _force_destroy_provisioning_workspace(session_factory, workspace_id)
+                return ws
+
+        fake_git = _RecordingGit()
+        provisioner = _DestroyAfterClaimProvisioner(
+            session_factory=session_factory,
+            git=fake_git,  # type: ignore[arg-type]
+            config=ProvisionerConfig(node_id="test-node-01"),
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).create(
+                repo_url=str(origin_repo),
+                branch_base="development",
+                task_title="t",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+            )
+            await s.commit()
+            ws_id = ws.id
+
+        await provisioner.provision(ws_id)
+
+        assert fake_git.add_worktree_calls == []
+        assert fake_git.head_calls == []
+        async with session_factory() as s:
+            reloaded = await WorkspaceRepository(s).get(ws_id)
+            assert reloaded is not None
+            assert reloaded.status == WorkspaceStatus.destroyed.value
+            skip_events = [
+                event
+                for event in reloaded.events
+                if event.event_type == "workspace.stale_action_skipped"
+            ]
+            assert skip_events
+            assert skip_events[-1].reason_code == "PROVISIONER_STALE_STATUS"
+            assert skip_events[-1].payload == {
+                "action": "provision",
+                "expected_status": WorkspaceStatus.provisioning.value,
+                "actual_status": WorkspaceStatus.destroyed.value,
+            }
+
+    @pytest.mark.unit
+    async def test_stack_failure_after_destroy_does_not_mark_workspace_failed(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        git_manager: GitManager,
+        origin_repo: Path,
+    ) -> None:
+        class _DestroyingFailingStackLauncher:
+            async def launch(self, request: Any) -> object:
+                await _force_destroy_provisioning_workspace(
+                    session_factory, request.workspace_id
+                )
+                raise ComposeOperationError(
+                    operation="up",
+                    returncode=17,
+                    stdout="",
+                    stderr="workspace was already destroyed",
+                )
+
+        provisioner = Provisioner(
+            session_factory=session_factory,
+            git=git_manager,
+            stack_launcher=_DestroyingFailingStackLauncher(),
+            config=ProvisionerConfig(node_id="test-node-01"),
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).create(
+                repo_url=str(origin_repo),
+                branch_base="development",
+                task_title="t",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+            )
+            await s.commit()
+            ws_id = ws.id
+
+        with pytest.raises(ComposeOperationError):
+            await provisioner.provision(ws_id)
+
+        async with session_factory() as s:
+            reloaded = await WorkspaceRepository(s).get(ws_id)
+            assert reloaded is not None
+            assert reloaded.status == WorkspaceStatus.destroyed.value
+            assert reloaded.failure_reason is None
+            assert reloaded.failure_message is None
+            skip_events = [
+                event
+                for event in reloaded.events
+                if event.event_type == "workspace.stale_action_skipped"
+            ]
+            assert skip_events
+            assert skip_events[-1].reason_code == "PROVISIONER_MARK_FAILED_SKIPPED"
+            assert skip_events[-1].payload == {
+                "action": "mark_failed",
+                "expected_status": WorkspaceStatus.provisioning.value,
+                "actual_status": WorkspaceStatus.destroyed.value,
+            }
 
 
 class TestIdempotency:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_15e1302194b645ea8111bd9e` (agent: `codex`).

**External task ID**: awf-wave2-race-safe-controls-20260426T045914Z

### Task
Implement the next reliability slice from the AWF PRD: make operator cancel/destroy race-safe when the worker has already listed or claimed a workspace.

Problem to solve:
- We observed a real local bug where a throwaway workspace was force-destroyed, but a worker/provision path had already raced and later moved the same workspace to failed after attempting setup.
- A destroyed or cancelled workspace must not be resurrected, provisioned, executed, validated, pushed, or marked failed by stale worker/executor state.

Required behavior:
- Worker/provisioner/executor paths must re-check persisted workspace status at each handoff before doing destructive or forward-moving work.
- Force destroy of active/requested/provisioning/ready/running/monitoring workspaces must win over stale worker tasks.
- Best-effort failure handlers must not overwrite cancelled/destroying/destroyed terminal-control states.
- Add structured log/event coverage where useful so operators can see a skipped stale action.
- Keep API semantics unchanged: active destroy still requires force=true, repeated cancel/destroy remains idempotent.

TDD requirements:
- Add focused unit tests for the race: requested workspace destroyed while worker/provisioner is in flight; provisioning failure after destroy does not mark failed; ready execution skipped after cancellation/destroy; monitoring resume skipped after cancellation/destroy.
- Reproduce the failure first, commit the failing tests, then implement.

Validation commands:
- uv run ruff check src/awf/control src/awf/node src/awf/service tests/unit/control tests/unit/node tests/unit/service
- uv run mypy src/awf/control src/awf/node src/awf/service
- uv run pytest tests/unit/control tests/unit/node tests/unit/service -q

Strict TDD and AWF contract:
- Write focused failing tests first and commit the red tests, including the failure summary in the commit body.
- Implement until the narrow tests pass, then run the full validation commands listed below.
- Commit locally with conventional commits.
- Do not push, switch branches, rebase, or open/merge PRs. AWF owns branch lifecycle, push, PR creation, comment handling, checks, branch updates, and auto-merge.
- Keep the change tightly scoped to the owned paths and adjust to concurrent PRs by syncing through AWF, not by manual GitHub operations.

---
Validation: 6 profile command(s) passed inside the workspace container.
