### PR TITLE
fix(watchdog): skip respawning monitors stuck in NotifyHuman terminal state

### DIFF
--- a/src/awf/cli/watchdog.py
+++ b/src/awf/cli/watchdog.py
@@ -87,7 +87,12 @@ def _default_gh_lister(repo: str, *, limit: int = 200) -> str:
 
     ``limit`` maps directly to ``gh pr list --limit``. The watchdog
     binds this via ``functools.partial`` from ``WatchdogConfig.gh_pr_limit``
-    so operators can raise it if a repo ever exceeds the default."""
+    so operators can raise it if a repo ever exceeds the default.
+
+    ``headRefOid`` is requested so the NotifyHuman-aware respawn-skip
+    can compare the PR's current head SHA against the SHA recorded in
+    the latest defer-signal artifact — without it, a NotifyHuman PR
+    that received new commits would never re-engage."""
     result = subprocess.run(
         [
             "gh",
@@ -100,7 +105,7 @@ def _default_gh_lister(repo: str, *, limit: int = 200) -> str:
             "--head",
             "awf/",
             "--json",
-            "number,headRefName,baseRefName",
+            "number,headRefName,headRefOid,baseRefName",
             "--limit",
             str(limit),
         ],
@@ -180,6 +185,80 @@ def _extract_owner_name(repo: str) -> tuple[str, str]:
     return owner, name
 
 
+def _latest_defer_signal_for_pr(
+    artifacts_root: Path, *, owner: str, repo: str, pr_number: int
+) -> dict | None:
+    """Scan ``artifacts_root`` for the most-recent ``*.defer-signal.json``
+    whose payload matches this owner/repo/pr_number triple. Returns the
+    parsed JSON or None if no match is found. Corrupt files are skipped
+    silently — the watchdog's default behaviour (respawn) covers the
+    fall-through case correctly.
+
+    Multiple workspaces can drive the same PR over its lifetime
+    (a workspace exits, the operator re-attaches, etc.); we use file
+    mtime to pick the freshest artifact so a stale NotifyHuman cannot
+    silence a more recent Abort."""
+    if not artifacts_root.is_dir():
+        return None
+    expected_slug = f"{owner}/{repo}"
+    candidates: list[tuple[float, dict]] = []
+    for path in artifacts_root.glob("*.defer-signal.json"):
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("pr_number") != pr_number:
+            continue
+        if payload.get("repo") != expected_slug:
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        candidates.append((mtime, payload))
+    if not candidates:
+        return None
+    candidates.sort(key=lambda c: c[0], reverse=True)
+    return candidates[0][1]
+
+
+def _should_skip_respawn(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    current_head_sha: str,
+    artifacts_root: Path,
+) -> bool:
+    """Return True iff the previous monitor for this PR exited via
+    ``NotifyHuman`` AND the PR's head_sha hasn't moved since.
+
+    Crash recovery is the watchdog's primary purpose, so the default for
+    every uncertain case is False (respawn). We only skip when there is
+    POSITIVE evidence the previous run reached a terminal that explicitly
+    handed control back to a human and there's nothing new to look at."""
+    signal = _latest_defer_signal_for_pr(
+        artifacts_root, owner=owner, repo=repo, pr_number=pr_number
+    )
+    if signal is None:
+        return False  # crash recovery — never silence
+    if signal.get("terminal_action") != "NotifyHuman":
+        return False  # Merge / Abort / ShortCircuitCompleted → respawn
+    artifact_sha = str(signal.get("head_sha") or "")
+    if not artifact_sha or artifact_sha != current_head_sha:
+        return False  # new commits arrived → re-engage
+    _log.info(
+        "watchdog.skipped_notify_human_terminal",
+        repo=f"{owner}/{repo}",
+        pr_number=pr_number,
+        head_sha=current_head_sha[:10],
+        reason="awaiting human merge or new commits",
+    )
+    return True
+
+
 def _pr_already_monitored(*, repo: str, pr_number: int, ps_output: str) -> bool:
     """True iff ``ps_output`` contains a process line that references
     the deterministic spec filename for this repo+PR.
@@ -242,6 +321,7 @@ def run_one_scan(
             _log.warning("watchdog.gh_output_wrong_shape", repo=repo, raw=repr(prs)[:200])
             continue
 
+        owner, name = _extract_owner_name(repo)
         for pr in prs:
             pr_number = pr.get("number") if isinstance(pr, dict) else None
             if not isinstance(pr_number, int):
@@ -250,6 +330,16 @@ def run_one_scan(
 
             if _pr_already_monitored(repo=repo, pr_number=pr_number, ps_output=ps_output):
                 _log.info("watchdog.pr_already_monitored", repo=repo, pr=pr_number)
+                continue
+
+            head_sha = pr.get("headRefOid") if isinstance(pr, dict) else None
+            if _should_skip_respawn(
+                owner=owner,
+                repo=name,
+                pr_number=pr_number,
+                current_head_sha=str(head_sha or ""),
+                artifacts_root=config.work_dir / "artifacts",
+            ):
                 continue
 
             _log.info("watchdog.respawning_monitor", repo=repo, pr=pr_number)

--- a/src/awf/cli/watchdog.py
+++ b/src/awf/cli/watchdog.py
@@ -206,10 +206,16 @@ def _latest_defer_signal_for_pr(
     artifacts_root: Path, *, owner: str, repo: str, pr_number: int
 ) -> dict[str, object] | None:
     """Scan ``artifacts_root`` for the most-recent ``*.defer-signal.json``
-    whose payload matches this owner/repo/pr_number triple. Returns the
-    parsed JSON or None if no match is found. Corrupt files are skipped
-    silently — the watchdog's default behaviour (respawn) covers the
-    fall-through case correctly.
+    whose payload matches this owner/repo/pr_number triple.
+
+    Returns the parsed JSON, or None when no match is found, OR when any
+    unreadable artifact has a newer mtime than the latest matching one.
+    The PR number lives inside the JSON (not in the filename), so a
+    corrupt sibling's PR is unknowable — it might well be a fresher
+    state for THIS PR. Falling back to an older NotifyHuman in that
+    "latest state uncertain" case would silence the very respawn the
+    watchdog exists to perform; returning None instead lets
+    ``_should_skip_respawn`` default to crash recovery.
 
     Multiple workspaces can drive the same PR over its lifetime
     (a workspace exits, the operator re-attaches, etc.); we use file
@@ -218,27 +224,34 @@ def _latest_defer_signal_for_pr(
     if not artifacts_root.is_dir():
         return None
     expected_slug = f"{owner}/{repo}"
-    candidates: list[tuple[float, dict[str, object]]] = []
+    latest_match: tuple[float, dict[str, object]] | None = None
+    latest_unreadable_mtime: float | None = None
     for path in artifacts_root.glob("*.defer-signal.json"):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
         try:
             payload = json.loads(path.read_text())
         except (OSError, json.JSONDecodeError):
+            if latest_unreadable_mtime is None or mtime > latest_unreadable_mtime:
+                latest_unreadable_mtime = mtime
             continue
         if not isinstance(payload, dict):
+            if latest_unreadable_mtime is None or mtime > latest_unreadable_mtime:
+                latest_unreadable_mtime = mtime
             continue
         if payload.get("pr_number") != pr_number:
             continue
         if payload.get("repo") != expected_slug:
             continue
-        try:
-            mtime = path.stat().st_mtime
-        except OSError:
-            continue
-        candidates.append((mtime, payload))
-    if not candidates:
+        if latest_match is None or mtime > latest_match[0]:
+            latest_match = (mtime, payload)
+    if latest_match is None:
         return None
-    candidates.sort(key=lambda c: c[0], reverse=True)
-    return candidates[0][1]
+    if latest_unreadable_mtime is not None and latest_unreadable_mtime > latest_match[0]:
+        return None
+    return latest_match[1]
 
 
 def _should_skip_respawn(

--- a/src/awf/cli/watchdog.py
+++ b/src/awf/cli/watchdog.py
@@ -15,6 +15,23 @@ scripts". The attach script is itself idempotent (see the file-lock in
 ``scripts/attach_feature_pr_monitor.py``) so repeated invocations from
 concurrent watchdog instances can never double-spawn.
 
+NotifyHuman-aware skip
+----------------------
+
+Crash recovery is the watchdog's primary purpose, but a previous
+monitor may have exited intentionally — typically a release PR with
+``auto_merge=False`` whose only unresolved feedback is a deferred bot
+comment. In that case the runner writes a defer-signal artifact (see
+``pr_monitor_runner._write_defer_signal``) with ``terminal_action ==
+"NotifyHuman"`` and the PR's head_sha. Before respawning, the watchdog
+consults the latest such artifact for the PR: when the recorded
+terminal is ``NotifyHuman`` AND the head_sha hasn't moved, it skips
+the respawn (logging ``watchdog.skipped_notify_human_terminal``). New
+commits, any other terminal action, a missing artifact, or a corrupt
+artifact all fall through to respawn — the strict default is "respawn
+unless we have positive evidence the previous run handed control back
+to a human".
+
 Entry point: ``awf-watchdog start --work-dir <dir> --poll-seconds
 300``. See ``main()`` for the full invocation.
 """
@@ -442,7 +459,15 @@ def start(
         help="Max PRs fetched per repo via 'gh pr list --limit'. Raise if any repo has >200 open awf/ PRs.",
     ),
 ) -> None:
-    """Run the watchdog loop (blocks forever until SIGTERM/SIGINT)."""
+    """Run the watchdog loop (blocks forever until SIGTERM/SIGINT).
+
+    Per scan, each open ``awf/`` PR is respawned UNLESS either (a) a
+    matching ``run_awf.py`` process is already attached to its spec
+    file, or (b) the latest defer-signal artifact under
+    ``<work_dir>/artifacts/`` records ``terminal_action == "NotifyHuman"``
+    with the PR's current head_sha — in which case the watchdog stays
+    out of the way until a new commit (or a manual re-attach) arrives.
+    """
     config = WatchdogConfig(
         work_dir=work_dir,
         repos=list(repo) if repo else list(_DEFAULT_REPOS),

--- a/src/awf/cli/watchdog.py
+++ b/src/awf/cli/watchdog.py
@@ -204,7 +204,7 @@ def _extract_owner_name(repo: str) -> tuple[str, str]:
 
 def _latest_defer_signal_for_pr(
     artifacts_root: Path, *, owner: str, repo: str, pr_number: int
-) -> dict | None:
+) -> dict[str, object] | None:
     """Scan ``artifacts_root`` for the most-recent ``*.defer-signal.json``
     whose payload matches this owner/repo/pr_number triple. Returns the
     parsed JSON or None if no match is found. Corrupt files are skipped
@@ -218,7 +218,7 @@ def _latest_defer_signal_for_pr(
     if not artifacts_root.is_dir():
         return None
     expected_slug = f"{owner}/{repo}"
-    candidates: list[tuple[float, dict]] = []
+    candidates: list[tuple[float, dict[str, object]]] = []
     for path in artifacts_root.glob("*.defer-signal.json"):
         try:
             payload = json.loads(path.read_text())

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -300,6 +300,7 @@ class PullRequestMonitorRunner:
                 merged=True,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -317,6 +318,7 @@ class PullRequestMonitorRunner:
                 merged=False,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_failed(
                 workspace_id,
@@ -393,6 +395,7 @@ class PullRequestMonitorRunner:
                     merged=False,
                     status=status,
                     state=state,
+                    repo=repo,
                 )
                 await self._terminate_completed(
                     workspace_id,
@@ -408,6 +411,7 @@ class PullRequestMonitorRunner:
                 merged=True,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -430,6 +434,7 @@ class PullRequestMonitorRunner:
                 merged=False,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -824,6 +829,7 @@ class PullRequestMonitorRunner:
         merged: bool,
         status: PRStatus,
         state: MonitorState,
+        repo: RepoRef,
     ) -> None:
         """Persist a machine-readable drop of the workspace's terminal
         state for an orchestrator to consume.
@@ -834,6 +840,11 @@ class PullRequestMonitorRunner:
         presence as the authoritative "monitor is done" signal without
         also having to handle a missing-file case.
 
+        ``repo`` (owner/name) and ``head_sha`` are recorded so the
+        stranded-PR watchdog can disambiguate cross-repo PR-number
+        collisions and detect new commits since the terminal — both
+        needed for the NotifyHuman-aware respawn-skip.
+
         Called with a best-effort contract: a failure to write MUST NOT
         stop the state-machine transition (the DB write has priority).
         """
@@ -842,8 +853,10 @@ class PullRequestMonitorRunner:
             bot_items, human_items = _collect_defer_items(status, state)
             payload = {
                 "workspace_id": workspace_id,
+                "repo": repo.slug(),
                 "pr_number": pr_number,
                 "terminal_action": terminal_action,
+                "head_sha": status.head_sha,
                 "merged": merged,
                 "deferred_bot_items": bot_items,
                 "deferred_human_items": human_items,

--- a/tests/unit/cli/test_watchdog.py
+++ b/tests/unit/cli/test_watchdog.py
@@ -27,13 +27,19 @@ from pathlib import Path
 from awf.cli.watchdog import WatchdogConfig, run_one_scan
 
 
-def _canned_gh_output(*, repo: str, prs: list[tuple[int, str]]) -> str:
-    """Shape mirrors ``gh pr list --json number,headRefName,baseRefName``."""
+def _canned_gh_output(
+    *,
+    repo: str,
+    prs: list[tuple[int, str]],
+    head_oid: str = "abc1234567890def",
+) -> str:
+    """Shape mirrors ``gh pr list --json number,headRefName,baseRefName,headRefOid``."""
     return json.dumps(
         [
             {
                 "number": pr[0],
                 "headRefName": pr[1],
+                "headRefOid": head_oid,
                 "baseRefName": "development",
                 "repository": {"nameWithOwner": repo},
             }
@@ -268,3 +274,112 @@ class TestWatchdogConfig:
             "dimileeh/aira-web",
             "dimileeh/aira-agent-workspace-fabric",
         ]
+
+
+class TestWatchdogSkipNotifyHuman:
+    """Integration: ``run_one_scan`` must consult the defer-signal
+    artifact and skip respawn when the previous monitor exited via
+    ``NotifyHuman`` and no new commits have arrived. Without this, the
+    watchdog re-spawns the same monitor every poll for a release PR
+    that's intentionally awaiting human merge."""
+
+    def test_main_loop_skips_notify_human_pr_with_same_sha(
+        self, tmp_path: Path
+    ) -> None:
+        head = "deadbeefcafe1234"
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                    head_oid=head,
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        # Drop a NotifyHuman artifact for PR 355 with matching head_sha.
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text(
+            json.dumps(
+                {
+                    "workspace_id": "ws_abc",
+                    "repo": "dimileeh/aira-agent",
+                    "pr_number": 355,
+                    "terminal_action": "NotifyHuman",
+                    "head_sha": head,
+                    "merged": False,
+                    "deferred_bot_items": [],
+                    "deferred_human_items": [],
+                }
+            )
+        )
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        # The whole point: no respawn for an intentionally-deferred PR.
+        assert spawn.calls == []
+
+    def test_main_loop_respawns_notify_human_pr_when_sha_advanced(
+        self, tmp_path: Path
+    ) -> None:
+        """Same artifact, but the PR has new commits → must re-engage."""
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                    head_oid="newsha2222222222",
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text(
+            json.dumps(
+                {
+                    "workspace_id": "ws_abc",
+                    "repo": "dimileeh/aira-agent",
+                    "pr_number": 355,
+                    "terminal_action": "NotifyHuman",
+                    "head_sha": "oldsha0000000000",
+                    "merged": False,
+                    "deferred_bot_items": [],
+                    "deferred_human_items": [],
+                }
+            )
+        )
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        assert len(spawn.calls) == 1
+        assert spawn.calls[0]["pr_number"] == 355
+
+    def test_main_loop_respawns_when_no_artifact_exists(
+        self, tmp_path: Path
+    ) -> None:
+        """Crash recovery — if no artifact was ever written for this PR,
+        respawn (the watchdog's primary purpose)."""
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        assert len(spawn.calls) == 1

--- a/tests/unit/cli/test_watchdog.py
+++ b/tests/unit/cli/test_watchdog.py
@@ -283,9 +283,7 @@ class TestWatchdogSkipNotifyHuman:
     watchdog re-spawns the same monitor every poll for a release PR
     that's intentionally awaiting human merge."""
 
-    def test_main_loop_skips_notify_human_pr_with_same_sha(
-        self, tmp_path: Path
-    ) -> None:
+    def test_main_loop_skips_notify_human_pr_with_same_sha(self, tmp_path: Path) -> None:
         head = "deadbeefcafe1234"
         gh = _FakeGhLister(
             per_repo={
@@ -323,9 +321,7 @@ class TestWatchdogSkipNotifyHuman:
         # The whole point: no respawn for an intentionally-deferred PR.
         assert spawn.calls == []
 
-    def test_main_loop_respawns_notify_human_pr_when_sha_advanced(
-        self, tmp_path: Path
-    ) -> None:
+    def test_main_loop_respawns_notify_human_pr_when_sha_advanced(self, tmp_path: Path) -> None:
         """Same artifact, but the PR has new commits → must re-engage."""
         gh = _FakeGhLister(
             per_repo={
@@ -362,9 +358,7 @@ class TestWatchdogSkipNotifyHuman:
         assert len(spawn.calls) == 1
         assert spawn.calls[0]["pr_number"] == 355
 
-    def test_main_loop_respawns_when_no_artifact_exists(
-        self, tmp_path: Path
-    ) -> None:
+    def test_main_loop_respawns_when_no_artifact_exists(self, tmp_path: Path) -> None:
         """Crash recovery — if no artifact was ever written for this PR,
         respawn (the watchdog's primary purpose)."""
         gh = _FakeGhLister(

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -343,3 +343,71 @@ class TestShouldSkipRespawn:
             )
             is True
         )
+
+    def test_newer_corrupt_artifact_poisons_older_notify_human(self, tmp_path: Path) -> None:
+        """A corrupt artifact's PR number is unknowable (the number lives
+        inside the JSON, not in the filename), so it might well be the
+        newest state for THIS PR. Defaulting to an older NotifyHuman in
+        that "latest state uncertain" case silences a respawn the watchdog
+        is supposed to perform — see PR #48 thread PRRT_kwDOSJAM6s59owC_.
+
+        Expected: the older valid NotifyHuman is poisoned by the newer
+        corrupt sibling → fall through to respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        artifacts_root.mkdir(parents=True, exist_ok=True)
+        corrupt = artifacts_root / "ws_new.defer-signal.json"
+        corrupt.write_text("{not valid json")
+        os.utime(corrupt, (now, now))
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_older_corrupt_artifact_does_not_poison_newer_notify_human(
+        self, tmp_path: Path
+    ) -> None:
+        """The poisoning rule is asymmetric: only an unreadable artifact
+        NEWER than the latest matching one creates "latest state uncertain".
+        An older corrupt sibling is just noise and must not block a valid
+        recent NotifyHuman from skipping the respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        artifacts_root.mkdir(parents=True, exist_ok=True)
+        corrupt = artifacts_root / "ws_old.defer-signal.json"
+        corrupt.write_text("{not valid json")
+        os.utime(corrupt, (now - 3600, now - 3600))
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is True
+        )

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -1,0 +1,342 @@
+"""Tests for the NotifyHuman-aware respawn-skip in the stranded-PR watchdog.
+
+PR #12 added the watchdog: every poll interval, it lists open ``awf/`` PRs
+and respawns ``attach_feature_pr_monitor.py`` for any PR with no live
+``run_awf.py`` process. That fix is correct for crash recovery, but it
+respawned on EVERY missing-process scan — even when the previous monitor
+exited intentionally with ``NotifyHuman`` (release PR with ``auto_merge=False``,
+or a deferred-bot-comment-only situation). The agent kept being woken up
+to address the same comments and re-defer them, in an infinite cycle.
+
+The fix consults the defer-signal artifact (PR #9): when the LATEST
+artifact for this PR shows ``terminal_action == "NotifyHuman"`` AND the
+PR's current head_sha matches the artifact's recorded head_sha, skip the
+respawn. New commits or any other terminal action falls through to
+respawn — preserving crash recovery as the primary purpose of the
+watchdog.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from pathlib import Path
+
+from awf.cli.watchdog import _should_skip_respawn
+
+
+def _write_artifact(
+    artifacts_root: Path,
+    *,
+    workspace_id: str,
+    repo: str,
+    pr_number: int,
+    terminal_action: str,
+    head_sha: str = "abc1234567890def",
+    mtime: float | None = None,
+) -> Path:
+    """Helper: drop a defer-signal JSON exactly like the runner does."""
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+    path = artifacts_root / f"{workspace_id}.defer-signal.json"
+    payload = {
+        "workspace_id": workspace_id,
+        "repo": repo,
+        "pr_number": pr_number,
+        "terminal_action": terminal_action,
+        "head_sha": head_sha,
+        "merged": terminal_action == "Merge",
+        "deferred_bot_items": [],
+        "deferred_human_items": [],
+    }
+    path.write_text(json.dumps(payload))
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestShouldSkipRespawn:
+    def test_no_artifact_means_respawn(self, tmp_path: Path) -> None:
+        """Empty artifacts dir → respawn (covers crash recovery — the
+        primary purpose of the watchdog)."""
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_missing_artifacts_dir_means_respawn(self, tmp_path: Path) -> None:
+        """Even the artifacts directory may not exist yet (fresh host)."""
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=tmp_path / "does-not-exist",
+            )
+            is False
+        )
+
+    def test_notify_human_terminal_with_same_sha_skips(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """The whole point of the fix: PR has a NotifyHuman artifact AND
+        the head_sha hasn't moved → don't respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        head = "deadbeefcafe1234"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha=head,
+        )
+        with caplog.at_level(logging.INFO):
+            result = _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha=head,
+                artifacts_root=artifacts_root,
+            )
+        assert result is True
+        # Operator should be able to grep for this exact event.
+        assert any(
+            "watchdog.skipped_notify_human_terminal" in rec.getMessage()
+            or "watchdog.skipped_notify_human_terminal" in str(rec.__dict__)
+            for rec in caplog.records
+        ), "expected watchdog.skipped_notify_human_terminal log line"
+
+    def test_notify_human_terminal_with_different_sha_respawns(
+        self, tmp_path: Path
+    ) -> None:
+        """New commits arrived since the NotifyHuman → re-engage."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="oldsha0000000000",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="newsha1111111111",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_merge_terminal_does_not_skip(self, tmp_path: Path) -> None:
+        """A previously-merged PR being re-opened (or stale artifact for
+        a different PR life cycle) should NOT silence the watchdog."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Merge",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_abort_terminal_does_not_skip(self, tmp_path: Path) -> None:
+        """Abort = upstream invariant violation / closed PR. The watchdog
+        should still respawn because the PR is somehow open AND in an AWF
+        state — the operator wants visibility."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_short_circuit_does_not_skip(self, tmp_path: Path) -> None:
+        """ShortCircuitCompleted = PR was merged externally. If it's still
+        open, the artifact is stale and respawn is correct."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="ShortCircuitCompleted",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_corrupted_artifact_treated_as_missing(self, tmp_path: Path) -> None:
+        """A truncated / non-JSON artifact must not crash the watchdog —
+        fall through to respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text("{not valid json")
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_artifact_for_different_pr_is_ignored(self, tmp_path: Path) -> None:
+        """A NotifyHuman artifact for PR 999 must NOT silence the watchdog
+        when scanning PR 355 (cross-PR contamination guard)."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_other",
+            repo="dimileeh/aira-agent",
+            pr_number=999,
+            terminal_action="NotifyHuman",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_artifact_for_different_repo_is_ignored(self, tmp_path: Path) -> None:
+        """PR number 100 in repo A and repo B can collide. The repo field
+        is what disambiguates."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_other",
+            repo="dimileeh/aira-web",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",  # different repo, same PR number
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_picks_latest_artifact_when_multiple(self, tmp_path: Path) -> None:
+        """Two workspaces have driven PR 355 over its lifetime. The most
+        recent artifact wins — older NotifyHuman should not silence a
+        newer Abort, for example."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        # Older: NotifyHuman (would skip if it won)
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        # Newer: Abort (should NOT skip)
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_picks_latest_artifact_when_multiple_notify_human(
+        self, tmp_path: Path
+    ) -> None:
+        """Symmetric counter-test: newest IS NotifyHuman → skip wins."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is True
+        )

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -19,7 +19,6 @@ watchdog.
 from __future__ import annotations
 
 import json
-import logging
 import os
 import time
 from pathlib import Path
@@ -86,9 +85,7 @@ class TestShouldSkipRespawn:
             is False
         )
 
-    def test_notify_human_terminal_with_same_sha_skips(
-        self, tmp_path: Path, caplog
-    ) -> None:
+    def test_notify_human_terminal_with_same_sha_skips(self, tmp_path: Path, capsys) -> None:
         """The whole point of the fix: PR has a NotifyHuman artifact AND
         the head_sha hasn't moved → don't respawn."""
         artifacts_root = tmp_path / "artifacts"
@@ -101,25 +98,21 @@ class TestShouldSkipRespawn:
             terminal_action="NotifyHuman",
             head_sha=head,
         )
-        with caplog.at_level(logging.INFO):
-            result = _should_skip_respawn(
-                owner="dimileeh",
-                repo="aira-agent",
-                pr_number=355,
-                current_head_sha=head,
-                artifacts_root=artifacts_root,
-            )
+        result = _should_skip_respawn(
+            owner="dimileeh",
+            repo="aira-agent",
+            pr_number=355,
+            current_head_sha=head,
+            artifacts_root=artifacts_root,
+        )
         assert result is True
-        # Operator should be able to grep for this exact event.
-        assert any(
-            "watchdog.skipped_notify_human_terminal" in rec.getMessage()
-            or "watchdog.skipped_notify_human_terminal" in str(rec.__dict__)
-            for rec in caplog.records
-        ), "expected watchdog.skipped_notify_human_terminal log line"
+        # Operator should be able to grep stdout for this exact event.
+        captured = capsys.readouterr()
+        assert "watchdog.skipped_notify_human_terminal" in (captured.out + captured.err), (
+            "expected watchdog.skipped_notify_human_terminal log line"
+        )
 
-    def test_notify_human_terminal_with_different_sha_respawns(
-        self, tmp_path: Path
-    ) -> None:
+    def test_notify_human_terminal_with_different_sha_respawns(self, tmp_path: Path) -> None:
         """New commits arrived since the NotifyHuman → re-engage."""
         artifacts_root = tmp_path / "artifacts"
         _write_artifact(
@@ -306,9 +299,7 @@ class TestShouldSkipRespawn:
             is False
         )
 
-    def test_picks_latest_artifact_when_multiple_notify_human(
-        self, tmp_path: Path
-    ) -> None:
+    def test_picks_latest_artifact_when_multiple_notify_human(self, tmp_path: Path) -> None:
         """Symmetric counter-test: newest IS NotifyHuman → skip wins."""
         artifacts_root = tmp_path / "artifacts"
         now = time.time()

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -120,8 +120,7 @@ class TestShouldSkipRespawn:
         assert result is True
         # Operator should be able to grep logs for this exact event.
         assert any(
-            entry.get("event") == "watchdog.skipped_notify_human_terminal"
-            for entry in cap_logs
+            entry.get("event") == "watchdog.skipped_notify_human_terminal" for entry in cap_logs
         ), f"expected watchdog.skipped_notify_human_terminal log line, got {cap_logs!r}"
 
     def test_notify_human_terminal_with_different_sha_respawns(self, tmp_path: Path) -> None:

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -23,6 +23,8 @@ import os
 import time
 from pathlib import Path
 
+from structlog.testing import capture_logs
+
 from awf.cli.watchdog import _should_skip_respawn
 
 
@@ -85,9 +87,18 @@ class TestShouldSkipRespawn:
             is False
         )
 
-    def test_notify_human_terminal_with_same_sha_skips(self, tmp_path: Path, capsys) -> None:
+    def test_notify_human_terminal_with_same_sha_skips(self, tmp_path: Path) -> None:
         """The whole point of the fix: PR has a NotifyHuman artifact AND
-        the head_sha hasn't moved → don't respawn."""
+        the head_sha hasn't moved → don't respawn.
+
+        We use ``structlog.testing.capture_logs`` instead of ``capsys`` /
+        ``caplog`` because the project's structlog config can route events
+        either via the default ``PrintLogger`` (no ``configure_logging``
+        call yet) or via ``structlog.stdlib.LoggerFactory`` (after one of
+        the logging tests has run earlier in the suite, binding a stdout
+        handler to the original ``sys.stdout``). Neither capsys nor caplog
+        catches both cases. ``capture_logs`` intercepts events at the
+        bound-logger boundary, so it works regardless of factory."""
         artifacts_root = tmp_path / "artifacts"
         head = "deadbeefcafe1234"
         _write_artifact(
@@ -98,19 +109,20 @@ class TestShouldSkipRespawn:
             terminal_action="NotifyHuman",
             head_sha=head,
         )
-        result = _should_skip_respawn(
-            owner="dimileeh",
-            repo="aira-agent",
-            pr_number=355,
-            current_head_sha=head,
-            artifacts_root=artifacts_root,
-        )
+        with capture_logs() as cap_logs:
+            result = _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha=head,
+                artifacts_root=artifacts_root,
+            )
         assert result is True
-        # Operator should be able to grep stdout for this exact event.
-        captured = capsys.readouterr()
-        assert "watchdog.skipped_notify_human_terminal" in (captured.out + captured.err), (
-            "expected watchdog.skipped_notify_human_terminal log line"
-        )
+        # Operator should be able to grep logs for this exact event.
+        assert any(
+            entry.get("event") == "watchdog.skipped_notify_human_terminal"
+            for entry in cap_logs
+        ), f"expected watchdog.skipped_notify_human_terminal log line, got {cap_logs!r}"
 
     def test_notify_human_terminal_with_different_sha_respawns(self, tmp_path: Path) -> None:
         """New commits arrived since the NotifyHuman → re-engage."""

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -119,6 +119,12 @@ class TestDeferSignalArtifact:
         data = _artifact_for(artifacts_root, ws_id)
         assert data["workspace_id"] == ws_id
         assert data["pr_number"] == 42
+        # ``repo`` (owner/name) is required for the watchdog to disambiguate
+        # PR-number collisions across repos.
+        assert data["repo"] == "dimileeh/aira-web"
+        # ``head_sha`` lets the watchdog detect new commits since the
+        # terminal — without it, NotifyHuman + new push would never re-engage.
+        assert data["head_sha"]
         assert data["terminal_action"] == "Merge"
         assert data["merged"] is True
         assert len(data["deferred_bot_items"]) == 1
@@ -238,6 +244,8 @@ class TestDeferSignalArtifact:
         )
         data = _artifact_for(artifacts_root, ws_id)
         assert data["terminal_action"] == "NotifyHuman"
+        assert data["repo"] == "dimileeh/aira-web"
+        assert data["head_sha"]
         assert data["merged"] is False
         assert data["deferred_bot_items"] == []
         assert len(data["deferred_human_items"]) == 1

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -124,7 +124,9 @@ class TestDeferSignalArtifact:
         assert data["repo"] == "dimileeh/aira-web"
         # ``head_sha`` lets the watchdog detect new commits since the
         # terminal — without it, NotifyHuman + new push would never re-engage.
-        assert data["head_sha"]
+        # Pin the exact SHA so a regression that writes the wrong commit
+        # (e.g. base SHA, empty string) is caught.
+        assert data["head_sha"] == "abc1234567890def"
         assert data["terminal_action"] == "Merge"
         assert data["merged"] is True
         assert len(data["deferred_bot_items"]) == 1
@@ -245,7 +247,7 @@ class TestDeferSignalArtifact:
         data = _artifact_for(artifacts_root, ws_id)
         assert data["terminal_action"] == "NotifyHuman"
         assert data["repo"] == "dimileeh/aira-web"
-        assert data["head_sha"]
+        assert data["head_sha"] == "abc1234567890def"
         assert data["merged"] is False
         assert data["deferred_bot_items"] == []
         assert len(data["deferred_human_items"]) == 1


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_70799318cf564b14a1d32677` (agent: `claude_code`).


### Task
## Context — watchdog respawn loop on release PRs

The stranded-PR watchdog (added in PR #12) periodically scans open `awf/` PRs and respawns `attach_feature_pr_monitor` for any PR without an active `run_awf.py` process. This was the right idea for crashed monitors, but it has a bug:

When a monitor terminates LEGITIMATELY with `NotifyHuman` (e.g., a release PR with `auto_merge=False` whose only unresolved feedback is a deferred bot comment), the watchdog's next 5-min poll sees "no monitor for open AWF PR" and respawns it. The fresh monitor has empty `threads_addressed_ids` → re-addresses the same comments → defers → NotifyHuman → exits → watchdog respawns. Infinite cycle, wasted LLM cycles.

Observable on aira-agent PR #355 (release PR, dev→main): two CodeRabbit comments on test code. Agent correctly deferred (release PR has no diff to fix). Monitor exited with NotifyHuman. Watchdog respawned every 5 min, each respawn burned ~3-4 minutes of agent.run cycles addressing the SAME comments and reaching the SAME defer verdict.

## The fix

The defer-signal artifact (from PR #9, written at terminal transitions to `<work_dir>/artifacts/<workspace_id>.defer-signal.json`) already records the terminal action. The watchdog needs to consult it before respawning.

Policy:

- For each open AWF PR with no active monitor process, find the LATEST defer-signal artifact for any workspace that monitored this PR (look for `pr_number` field in the artifacts).
- If found AND `terminal_action == "NotifyHuman"` AND the PR's current `head_sha` matches the artifact's recorded head_sha → skip respawn. Log `watchdog.skipped_notify_human_terminal pr=N reason="awaiting human merge or new commits"`.
- If no artifact found, OR terminal was something else (Abort due to crash, ShortCircuit), OR the head_sha has changed (new commits arrived) → respawn as today.

This honors the NotifyHuman terminal: the human (or new pushes) are the only events that should prompt re-engagement.

## Environment

AWF workspace, aira-agent-workspace-fabric at `/workspace`, fresh feature branch off `main`. Python 3.12 + uv. First setup: `uv pip install -e ".[dev]" --quiet`.

## Strict TDD workflow

Tests FIRST. Commit order:

1. Red-commit: failing tests for (a) skip on NotifyHuman + same SHA, (b) respawn on NotifyHuman + new SHA, (c) respawn when no artifact exists, (d) respawn on Abort / ShortCircuit terminals.
2. Green-commit: implement the artifact-consultation logic in the watchdog.
3. Docs-commit: update the watchdog's CLI help / module docstring to describe the NotifyHuman-skip behavior.

Paste the failing-test output into the red-commit body.

## Scope — `src/awf/cli/watchdog.py` (or wherever PR #12 placed the watchdog)

Find the function that decides whether to respawn for a given PR. Add a helper:

```python
from pathlib import Path
import json
import structlog

_log = structlog.get_logger()

def _latest_defer_signal_for_pr(
    artifacts_root: Path, *, owner: str, repo: str, pr_number: int
) -> dict | None:
    """Scan ``artifacts_root`` for the most-recent ``*.defer-signal.json`` whose
    payload's ``pr_number`` matches. Returns parsed JSON or None."""
    if not artifacts_root.is_dir():
        return None
    candidates = []
    for path in artifacts_root.glob("*.defer-signal.json"):
        try:
            payload = json.loads(path.read_text())
        except (OSError, json.JSONDecodeError):
            continue
        if payload.get("pr_number") == pr_number and payload.get("repo") == f"{owner}/{repo}":
            candidates.append((path.stat().st_mtime, payload))
    if not candidates:
        return None
    candidates.sort(reverse=True)
    return candidates[0][1]


def _should_skip_respawn(
    pr: PROpenInfo,  # whatever the watchdog uses
    artifacts_root: Path,
) -> bool:
    signal = _latest_defer_signal_for_pr(
        artifacts_root, owner=pr.owner, repo=pr.repo, pr_number=pr.number
    )
    if signal is None:
        return False  # no terminal artifact → respawn (covers crash recovery)
    terminal = signal.get("terminal_action")
    if terminal != "NotifyHuman":
        return False  # respawn for crashes / aborts
    artifact_sha = (signal.get("head_sha") or "")[:10]
    current_sha = (pr.head_sha or "")[:10]
    if artifact_sha and artifact_sha == current_sha:
        _log.info(
            "watchdog.skipped_notify_human_terminal",
            pr_number=pr.number,
            head_sha=current_sha,
            reason="awaiting human merge or new commits",
        )
        return True
    return False  # head SHA changed → new commits arrived → respawn worthwhile
```

The defer-signal artifact (per PR #9's spec) needs a `repo` field for this lookup. **Verify it has one.** Read PR #9's actual implementation; if `repo` was not added, also add it to the artifact-write site as part of THIS PR (small additive change). If pr_number alone is enough to disambiguate (because workspaces are owner/repo-scoped via the spec), skip the repo check.

Wire `_should_skip_respawn` into the watchdog's main loop — when about to call `attach_feature_pr_monitor`, check first and skip if true.

## Tests (required — write first)

### `tests/unit/cli/test_watchdog_skip_notify_human.py` (new)

1. `test_no_artifact_means_respawn`: artifacts dir empty → `_should_skip_respawn` returns False.
2. `test_notify_human_terminal_with_same_sha_skips`: write artifact with `terminal_action="NotifyHuman"` and matching head_sha → returns True. Assert log line `watchdog.skipped_notify_human_terminal` fires.
3. `test_notify_human_terminal_with_different_sha_respawns`: artifact head_sha differs from current → returns False (new commits arrived).
4. `test_merge_terminal_does_not_skip`: artifact `terminal_action="Merge"` → returns False. (Edge case: PR was merged in a previous run, then reopened? Defensive.)
5. `test_abort_terminal_does_not_skip`: `terminal_action="Abort"` → returns False (legit crash recovery).
6. `test_short_circuit_does_not_skip`: `terminal_action="ShortCircuitCompleted"` → returns False.
7. `test_corrupted_artifact_treated_as_missing`: file exists but is not valid JSON → returns False (fall through to respawn, don't crash).
8. `test_picks_latest_artifact_when_multiple`: write 2 artifacts for same PR with different mtimes → uses the most recent.

### Update existing watchdog tests

Find `tests/unit/cli/test_watchdog.py` (PR #12's tests). Add an integration test that wires `_should_skip_respawn` into the main loop:

- `test_watchdog_main_loop_skips_notify_human_pr`: mock `gh pr list` to return one PR. Mock no active process. Write a NotifyHuman defer-signal for that PR. Assert `attach_feature_pr_monitor` is NOT called.

## Verification checklist

- `ruff check .` clean.
- `ruff format --check .` clean.
- `pytest tests/unit/cli/test_watchdog_skip_notify_human.py tests/unit/cli/test_watchdog.py -v --timeout 60` green.
- `pytest tests/unit/cli/ tests/unit/runtime/ -v --timeout 60` — no regressions.

## Do NOT

- Do NOT remove the watchdog's respawn-on-crash behavior — that's the PRIMARY purpose; this fix only narrows when respawn fires.
- Do NOT add a database table for tracking — the JSON artifacts are the source of truth.
- Do NOT change `attach_feature_pr_monitor.py`'s file-lock idempotency — it's correct, separate concern.
- Do NOT change the monitor's terminal-action logic (PR #9). The fix is at the watchdog layer.
- Do NOT broaden the artifact schema beyond adding `repo` (if missing).
- Do NOT auto-resolve the bot threads on github.com from the watchdog — that's a different feature and would need rate-limit care.

---
Validation: 4 test command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watchdog now intelligently skips rescheduling when a human notification has been sent for a pull request with an unchanged commit, reducing unnecessary executions.
  * Defer-signal artifacts now track repository identity and commit information for improved handling of cross-repository scenarios.

* **Tests**
  * Added comprehensive test coverage for new NotifyHuman-aware respawn skipping logic and defer-signal artifact validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->