### PR TITLE
feat(runtime): install Docker CLI in agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -823,6 +823,9 @@ uv run --python 3.12 --extra dev mypy
 ### Build the Agent Runtime Image
 
 AWF workspaces use `awf-agent-runtime:latest` unless configured otherwise.
+The image includes the Docker CLI and Docker Compose plugin so DinD profiles
+can run project Compose diagnostics inside the workspace sidecar. Rebuild this
+image whenever the runtime Dockerfile or those Docker tooling packages change.
 
 ```bash
 docker build -t awf-agent-runtime:latest -f docker/agent-runtime.Dockerfile .

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -69,7 +69,23 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Stage 2: GitHub CLI ───────────────────────────────────────────────────
+# ── Stage 2: Docker CLI + Compose plugin ──────────────────────────────────
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg \
+      -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && . /etc/os-release \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" \
+      > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        docker-ce-cli \
+        docker-compose-plugin \
+    && rm -rf /var/lib/apt/lists/* \
+    && docker --version \
+    && docker compose version
+
+# ── Stage 3: GitHub CLI ───────────────────────────────────────────────────
 ARG GH_VERSION=2.91.0
 RUN mkdir -p -m 755 /etc/apt/keyrings \
     && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
@@ -82,7 +98,7 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && rm -rf /var/lib/apt/lists/* \
     && gh --version
 
-# ── Stage 3: Node.js (for coding CLIs which are all npm packages) ──────────
+# ── Stage 4: Node.js (for coding CLIs which are all npm packages) ──────────
 ARG NODE_VERSION
 RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
@@ -90,7 +106,7 @@ RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
     && node --version \
     && npm --version
 
-# ── Stage 4: coding CLIs ──────────────────────────────────────────────────
+# ── Stage 5: coding CLIs ──────────────────────────────────────────────────
 #
 # Each CLI is pinned to a version. Bump via PR so we can verify the output
 # format hasn't drifted in the adapters.
@@ -107,7 +123,7 @@ RUN npm install -g --no-fund --no-audit \
     && claude --version || true \
     && gemini --version || true
 
-# ── Stage 5: Python tooling the agent may need inside the container ────────
+# ── Stage 6: Python tooling the agent may need inside the container ────────
 RUN python -m pip install --upgrade pip \
     && python -m pip install --no-cache-dir \
         "alembic>=1.13" \
@@ -115,7 +131,7 @@ RUN python -m pip install --upgrade pip \
         "psycopg[binary]>=3.1" \
         "uv>=0.5"
 
-# ── Stage 6: non-root user + workspace mount point ─────────────────────────
+# ── Stage 7: non-root user + workspace mount point ─────────────────────────
 RUN useradd --create-home --shell /bin/bash agent \
     && mkdir -p /workspace \
     && chown -R agent:agent /workspace

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -70,6 +70,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Stage 2: Docker CLI + Compose plugin ──────────────────────────────────
+ARG DOCKER_CE_CLI_VERSION=5:29.4.1-1~debian.12~bookworm
+ARG DOCKER_COMPOSE_PLUGIN_VERSION=5.1.3-1~debian.12~bookworm
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg \
       -o /etc/apt/keyrings/docker.asc \
@@ -79,8 +81,8 @@ RUN install -m 0755 -d /etc/apt/keyrings \
       > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        docker-ce-cli \
-        docker-compose-plugin \
+        "docker-ce-cli=${DOCKER_CE_CLI_VERSION}" \
+        "docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}" \
     && rm -rf /var/lib/apt/lists/* \
     && docker --version \
     && docker compose version

--- a/docker/control-plane.Dockerfile
+++ b/docker/control-plane.Dockerfile
@@ -4,6 +4,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV UV_LINK_MODE=copy
 ENV PATH="/app/.venv/bin:${PATH}"
 
+ARG DOCKER_CE_CLI_VERSION=5:29.4.1-1~debian.12~bookworm
+ARG DOCKER_COMPOSE_PLUGIN_VERSION=5.1.3-1~debian.12~bookworm
+
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -21,8 +24,8 @@ RUN apt-get update \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-        docker-ce-cli \
-        docker-compose-plugin \
+        "docker-ce-cli=${DOCKER_CE_CLI_VERSION}" \
+        "docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}" \
         gh \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/integration/test_local_service_compose.py
+++ b/tests/integration/test_local_service_compose.py
@@ -28,8 +28,10 @@ def test_local_service_compose_declares_control_plane_stack() -> None:
         }
 
     dockerfile = dockerfile_path.read_text()
-    assert "docker-ce-cli" in dockerfile
-    assert "docker-compose-plugin" in dockerfile
+    assert "ARG DOCKER_CE_CLI_VERSION=" in dockerfile
+    assert '"docker-ce-cli=${DOCKER_CE_CLI_VERSION}"' in dockerfile
+    assert "ARG DOCKER_COMPOSE_PLUGIN_VERSION=" in dockerfile
+    assert '"docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}"' in dockerfile
     assert "githubcli-archive-keyring.gpg" in dockerfile
     assert "gh" in dockerfile
     assert "COPY src ./src" in dockerfile

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -692,10 +692,6 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
         async def wait_for_execution_tasks(self) -> None:
             created["wait_for_execution_tasks"] = True
 
-    class _PostgresCoordinator:
-        def __init__(self, engine: object) -> None:
-            created["merge_coordinator_engine"] = engine
-
     engine = _Engine()
     session_factory = object()
 
@@ -717,7 +713,6 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     monkeypatch.setattr(worker_mod, "ComposeManager", _ComposeManager, raising=False)
     monkeypatch.setattr(worker_mod, "ComposeStackLauncher", _ComposeStackLauncher, raising=False)
     monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)
-    monkeypatch.setattr(worker_mod, "PostgresAdvisoryMergeCoordinator", _PostgresCoordinator)
     monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
 
     host_work_dir = (tmp_path / "awf-work").resolve()
@@ -725,7 +720,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
         service_name="awf",
         env="local",
         api_base_url="http://localhost:8000",
-        database_url="postgresql+asyncpg://awf:pw@localhost:5433/awf",
+        database_url=f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}",
         docker_host="unix:///var/run/docker.sock",
         agent_runtime_image="custom-agent-runtime:dev",
         work_dir=str(host_work_dir),
@@ -742,7 +737,6 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
 
     assert created["db_url"] == settings.database_url
     assert created["session_engine"] is engine
-    assert created["merge_coordinator_engine"] is engine
     assert created["git_work_dir"] == host_work_dir / "git"
     assert created["git_env"]["HOME"] == str((tmp_path / "host-home").resolve())
     assert created["compose_work_dir"] == host_work_dir

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -692,6 +692,10 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
         async def wait_for_execution_tasks(self) -> None:
             created["wait_for_execution_tasks"] = True
 
+    class _PostgresCoordinator:
+        def __init__(self, engine: object) -> None:
+            created["merge_coordinator_engine"] = engine
+
     engine = _Engine()
     session_factory = object()
 
@@ -713,6 +717,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     monkeypatch.setattr(worker_mod, "ComposeManager", _ComposeManager, raising=False)
     monkeypatch.setattr(worker_mod, "ComposeStackLauncher", _ComposeStackLauncher, raising=False)
     monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)
+    monkeypatch.setattr(worker_mod, "PostgresAdvisoryMergeCoordinator", _PostgresCoordinator)
     monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
 
     host_work_dir = (tmp_path / "awf-work").resolve()
@@ -737,6 +742,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
 
     assert created["db_url"] == settings.database_url
     assert created["session_engine"] is engine
+    assert created["merge_coordinator_engine"] is engine
     assert created["git_work_dir"] == host_work_dir / "git"
     assert created["git_env"]["HOME"] == str((tmp_path / "host-home").resolve())
     assert created["compose_work_dir"] == host_work_dir

--- a/tests/unit/node/test_compose_manager.py
+++ b/tests/unit/node/test_compose_manager.py
@@ -13,6 +13,7 @@ import pytest
 import yaml
 
 from awf.node.compose_manager import ComposeManager, WorkspaceComposeSpec
+from awf.profiles.registry import docker_compose_profile
 
 _TEMPLATE = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
 
@@ -264,14 +265,20 @@ class TestRender:
 
     @pytest.mark.unit
     def test_dind_profile_adds_docker_daemon(self, manager: ComposeManager, tmp_path: Path) -> None:
+        profile = docker_compose_profile()
         spec = _spec(
             tmp_path,
-            docker_mode="dind",
-            agent_environment=(("DOCKER_HOST", "tcp://docker:2375"),),
+            docker_mode=profile.docker.mode.value,
+            agent_environment=tuple(profile.runtime.environment.items()),
         )
         parsed = yaml.safe_load(manager.render(spec).compose_file.read_text())
         assert parsed["services"]["docker"]["image"] == "docker:27-dind"
         assert parsed["services"]["docker"]["privileged"] is True
+        assert parsed["services"]["docker"]["environment"]["DOCKER_TLS_CERTDIR"] == ""
+        assert parsed["services"]["docker"]["healthcheck"]["test"] == [
+            "CMD-SHELL",
+            "docker info >/dev/null 2>&1",
+        ]
         assert parsed["services"]["agent"]["environment"]["DOCKER_HOST"] == "tcp://docker:2375"
         assert parsed["services"]["agent"]["depends_on"] == {
             "docker": {"condition": "service_healthy"}

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -5,11 +5,46 @@ from pathlib import Path
 import pytest
 
 
+def _agent_runtime_dockerfile() -> str:
+    return Path("docker/agent-runtime.Dockerfile").read_text(encoding="utf-8")
+
+
 @pytest.mark.unit
 def test_agent_runtime_installs_github_cli_from_official_apt_repository() -> None:
-    dockerfile = Path("docker/agent-runtime.Dockerfile").read_text(encoding="utf-8")
+    dockerfile = _agent_runtime_dockerfile()
 
     assert "cli.github.com/packages" in dockerfile
     assert "githubcli-archive-keyring.gpg" in dockerfile
-    assert "apt-get install -y --no-install-recommends gh" in dockerfile
+    assert "gh=${GH_VERSION}" in dockerfile
     assert "gh --version" in dockerfile
+
+
+@pytest.mark.unit
+def test_agent_runtime_installs_docker_cli_from_official_apt_repository() -> None:
+    dockerfile = _agent_runtime_dockerfile()
+
+    assert "download.docker.com/linux/debian" in dockerfile
+    assert "docker.asc" in dockerfile
+    assert "docker-ce-cli" in dockerfile
+    assert "docker --version" in dockerfile
+
+
+@pytest.mark.unit
+def test_agent_runtime_installs_docker_compose_plugin() -> None:
+    dockerfile = _agent_runtime_dockerfile()
+
+    assert "docker-compose-plugin" in dockerfile
+    assert "docker compose version" in dockerfile
+
+
+@pytest.mark.unit
+def test_readme_notes_agent_runtime_rebuild_for_docker_tooling_changes() -> None:
+    readme = Path("README.md").read_text(encoding="utf-8")
+    start = readme.index("### Build the Agent Runtime Image")
+    end = readme.index("### Configure Environment")
+    section = readme[start:end]
+
+    assert "Docker CLI" in section
+    assert "Docker Compose plugin" in section
+    assert "rebuild" in section.lower()
+    assert "docker build -t awf-agent-runtime:latest" in section

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -25,7 +25,8 @@ def test_agent_runtime_installs_docker_cli_from_official_apt_repository() -> Non
 
     assert "download.docker.com/linux/debian" in dockerfile
     assert "docker.asc" in dockerfile
-    assert "docker-ce-cli" in dockerfile
+    assert "ARG DOCKER_CE_CLI_VERSION=" in dockerfile
+    assert '"docker-ce-cli=${DOCKER_CE_CLI_VERSION}"' in dockerfile
     assert "docker --version" in dockerfile
 
 
@@ -33,7 +34,8 @@ def test_agent_runtime_installs_docker_cli_from_official_apt_repository() -> Non
 def test_agent_runtime_installs_docker_compose_plugin() -> None:
     dockerfile = _agent_runtime_dockerfile()
 
-    assert "docker-compose-plugin" in dockerfile
+    assert "ARG DOCKER_COMPOSE_PLUGIN_VERSION=" in dockerfile
+    assert '"docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}"' in dockerfile
     assert "docker compose version" in dockerfile
 
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_612be0ca6913408ca9d96a1f` (agent: `codex`).

**External task ID**: awf-wave3-agent-docker-cli-20260426T055128Z

### Task
Implement the next Dockerized-project support slice: make the agent runtime capable of using AWF's DinD sidecar.

Problem:
- AWF can render a `docker` DinD service for docker-compose profiles and inject `DOCKER_HOST=tcp://docker:2375`.
- The agent runtime image currently does not install the Docker CLI / Compose plugin, so agents cannot actually run `docker compose` diagnostics/tests inside DinD-based workspaces.

Required behavior:
- Update `docker/agent-runtime.Dockerfile` to install Docker CLI and Docker Compose plugin in the agent runtime image, following the committed control-plane Dockerfile pattern where reasonable.
- Keep the image non-root at runtime; only build-time installation should use root.
- Add/update unit tests that inspect the Dockerfile and profile/rendered compose behavior: Docker CLI package present, compose plugin package present, dind profile renders docker sidecar, dind profile exposes DOCKER_HOST, and README mentions rebuilding the agent runtime when this changes.
- Do not attempt a live Docker integration in this slice.

TDD requirements:
- Add failing Dockerfile/profile tests first, commit them, then implement.

Validation commands:
- uv run ruff check tests/unit/test_agent_runtime_dockerfile.py tests/unit/profiles/test_profiles.py tests/unit/node/test_compose_manager.py
- uv run mypy src/awf/profiles src/awf/node
- uv run pytest tests/unit/test_agent_runtime_dockerfile.py tests/unit/profiles/test_profiles.py tests/unit/node/test_compose_manager.py -q

Strict TDD and AWF contract:
- Write focused failing tests first and commit the red tests, including the failure summary in the commit body.
- Implement until green, then run the validation commands listed below.
- Commit locally with conventional commits.
- Do not push, switch branches, rebase, open PRs, merge PRs, or resolve GitHub threads manually outside the task contract. AWF owns those lifecycle steps.
- Keep the change tightly scoped to the owned paths.

---
Validation: 6 profile command(s) passed inside the workspace container.
