### PR TITLE
feat(tasks): add task and attempt lineage skeleton

### DIFF
--- a/migrations/versions/9b1c2d3e4f5a_task_attempt_lifecycle.py
+++ b/migrations/versions/9b1c2d3e4f5a_task_attempt_lifecycle.py
@@ -1,0 +1,91 @@
+"""Add first-class tasks and task attempts.
+
+Revision ID: 9b1c2d3e4f5a
+Revises: a7b8c9d0e1f2
+Create Date: 2026-04-26 00:00:00.000000+00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "9b1c2d3e4f5a"
+down_revision: str | Sequence[str] | None = "a7b8c9d0e1f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "tasks",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("external_id", sa.String(length=128), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=128), nullable=True),
+        sa.Column("repo_url", sa.String(length=512), nullable=False),
+        sa.Column("base_branch", sa.String(length=256), nullable=False),
+        sa.Column("title", sa.String(length=512), nullable=False),
+        sa.Column("prompt", sa.String(length=16384), nullable=False),
+        sa.Column("task_class", sa.String(length=32), nullable=True),
+        sa.Column(
+            "owned_paths",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("external_id", name="uq_tasks_external_id"),
+        sa.UniqueConstraint("idempotency_key", name="uq_tasks_idempotency_key"),
+    )
+    op.create_index("ix_tasks_created_at", "tasks", ["created_at"], unique=False)
+    op.create_index("ix_tasks_repo_base", "tasks", ["repo_url", "base_branch"], unique=False)
+
+    op.create_table(
+        "task_attempts",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_number", sa.Integer(), nullable=False),
+        sa.Column("agent", sa.String(length=32), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("repo_url", sa.String(length=512), nullable=False),
+        sa.Column("base_branch", sa.String(length=256), nullable=False),
+        sa.Column("title", sa.String(length=512), nullable=False),
+        sa.Column("task_class", sa.String(length=32), nullable=True),
+        sa.Column(
+            "owned_paths",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("workspace_id", name="uq_task_attempts_workspace_id"),
+        sa.UniqueConstraint(
+            "task_id",
+            "attempt_number",
+            name="uq_task_attempts_task_number",
+        ),
+    )
+    op.create_index("ix_task_attempts_created_at", "task_attempts", ["created_at"])
+    op.create_index("ix_task_attempts_status", "task_attempts", ["status"])
+    op.create_index("ix_task_attempts_task", "task_attempts", ["task_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_task_attempts_task", table_name="task_attempts")
+    op.drop_index("ix_task_attempts_status", table_name="task_attempts")
+    op.drop_index("ix_task_attempts_created_at", table_name="task_attempts")
+    op.drop_table("task_attempts")
+
+    op.drop_index("ix_tasks_repo_base", table_name="tasks")
+    op.drop_index("ix_tasks_created_at", table_name="tasks")
+    op.drop_table("tasks")

--- a/src/awf/api/routes/tasks.py
+++ b/src/awf/api/routes/tasks.py
@@ -10,7 +10,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awf.api.deps import get_db_session
 from awf.api.schemas import TaskListResponse, TaskResponse
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.models import TaskAttempt, Workspace
+from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
 
 router = APIRouter(prefix="/v1/tasks", tags=["tasks"])
 
@@ -23,29 +24,62 @@ async def list_tasks(
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
     session: AsyncSession = Depends(get_db_session),
 ) -> TaskListResponse:
-    rows = await WorkspaceRepository(session).list(
+    attempt_rows = await TaskAttemptRepository(session).list_latest(
         status=workspace_status,
         agent=agent,
         repo_url=repo_url,
         limit=limit,
     )
+    legacy_rows = await WorkspaceRepository(session).list_without_task_attempts(
+        status=workspace_status,
+        agent=agent,
+        repo_url=repo_url,
+        limit=limit,
+    )
+    items = [_task_from_attempt(row) for row in attempt_rows]
+    items.extend(_task_from_workspace(row) for row in legacy_rows)
+    items.sort(key=lambda item: (item.created_at, item.workspace_id), reverse=True)
     return TaskListResponse(
-        items=[
-            TaskResponse(
-                task_id=row.task_external_id or row.id,
-                workspace_id=row.id,
-                title=row.task_title,
-                repo_url=row.repo_url,
-                base_branch=row.branch_base,
-                task_class=row.task_class,
-                owned_paths=list(row.owned_paths),
-                agent=AgentRuntime(row.agent),
-                status=WorkspaceStatus(row.status),
-                pr_url=row.pr_url,
-                failure_reason=row.failure_reason,
-                created_at=row.created_at,
-                updated_at=row.updated_at,
-            )
-            for row in rows
-        ]
+        items=items[:limit],
+    )
+
+
+def _task_from_attempt(attempt: TaskAttempt) -> TaskResponse:
+    workspace = attempt.workspace
+    return TaskResponse(
+        task_id=attempt.task.external_id or attempt.task.id,
+        attempt_id=attempt.id,
+        attempt_number=attempt.attempt_number,
+        workspace_id=attempt.workspace_id,
+        title=attempt.title,
+        repo_url=attempt.repo_url,
+        base_branch=attempt.base_branch,
+        task_class=attempt.task_class,
+        owned_paths=list(attempt.owned_paths),
+        agent=AgentRuntime(attempt.agent),
+        status=WorkspaceStatus(workspace.status),
+        pr_url=workspace.pr_url,
+        failure_reason=workspace.failure_reason,
+        created_at=attempt.created_at,
+        updated_at=workspace.updated_at,
+    )
+
+
+def _task_from_workspace(row: Workspace) -> TaskResponse:
+    return TaskResponse(
+        task_id=row.task_external_id or row.id,
+        attempt_id=None,
+        attempt_number=None,
+        workspace_id=row.id,
+        title=row.task_title,
+        repo_url=row.repo_url,
+        base_branch=row.branch_base,
+        task_class=row.task_class,
+        owned_paths=list(row.owned_paths),
+        agent=AgentRuntime(row.agent),
+        status=WorkspaceStatus(row.status),
+        pr_url=row.pr_url,
+        failure_reason=row.failure_reason,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
     )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -187,6 +187,8 @@ class TaskResponse(BaseModel):
     """Workspace-backed task row for operator consoles."""
 
     task_id: str
+    attempt_id: str | None = None
+    attempt_number: int | None = None
     workspace_id: str
     title: str
     repo_url: str

--- a/src/awf/common/ids.py
+++ b/src/awf/common/ids.py
@@ -14,6 +14,14 @@ def new_workspace_id() -> str:
     return f"ws_{uuid4().hex[:24]}"
 
 
+def new_task_id() -> str:
+    return f"task_{uuid4().hex[:24]}"
+
+
+def new_task_attempt_id() -> str:
+    return f"att_{uuid4().hex[:24]}"
+
+
 def new_operation_id() -> str:
     return f"op_{uuid4().hex[:24]}"
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -211,6 +211,92 @@ class Workspace(Base):
         lazy="selectin",
         order_by="WorkspaceLogStream.opened_at",
     )
+    task_attempt: Mapped[TaskAttempt | None] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        uselist=False,
+    )
+
+
+class Task(Base):
+    """First-class logical task, separate from any workspace execution attempt."""
+
+    __tablename__ = "tasks"
+    __table_args__ = (
+        UniqueConstraint("external_id", name="uq_tasks_external_id"),
+        UniqueConstraint("idempotency_key", name="uq_tasks_idempotency_key"),
+        Index("ix_tasks_created_at", "created_at"),
+        Index("ix_tasks_repo_base", "repo_url", "base_branch"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    external_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    repo_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    base_branch: Mapped[str] = mapped_column(String(256), nullable=False)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+    prompt: Mapped[str] = mapped_column(String(16384), nullable=False)
+    task_class: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    owned_paths: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default=text("'[]'")
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, onupdate=_now, nullable=False
+    )
+
+    attempts: Mapped[list[TaskAttempt]] = relationship(
+        back_populates="task",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="TaskAttempt.attempt_number",
+    )
+
+
+class TaskAttempt(Base):
+    """One execution lineage node for a task, currently backed by one workspace."""
+
+    __tablename__ = "task_attempts"
+    __table_args__ = (
+        UniqueConstraint("workspace_id", name="uq_task_attempts_workspace_id"),
+        UniqueConstraint("task_id", "attempt_number", name="uq_task_attempts_task_number"),
+        Index("ix_task_attempts_task", "task_id"),
+        Index("ix_task_attempts_status", "status"),
+        Index("ix_task_attempts_created_at", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    task_id: Mapped[str] = mapped_column(String(36), ForeignKey("tasks.id"), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+    attempt_number: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    agent: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    repo_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    base_branch: Mapped[str] = mapped_column(String(256), nullable=False)
+    title: Mapped[str] = mapped_column(String(512), nullable=False)
+    task_class: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    owned_paths: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=list, server_default=text("'[]'")
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, onupdate=_now, nullable=False
+    )
+
+    task: Mapped[Task] = relationship(back_populates="attempts")
+    workspace: Mapped[Workspace] = relationship(back_populates="task_attempt")
 
 
 class Operation(Base):

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -10,18 +10,34 @@ SQLAlchemy calls everywhere. Rules:
 
 from __future__ import annotations
 
+import builtins
 import hashlib
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Final
 
-from sqlalchemy import select, text
+from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
-from awf.common.ids import new_event_id, new_log_stream_id, new_operation_id, new_workspace_id
+from awf.common.ids import (
+    new_event_id,
+    new_log_stream_id,
+    new_operation_id,
+    new_task_attempt_id,
+    new_task_id,
+    new_workspace_id,
+)
 from awf.control.state_machine import WorkspaceStateMachine
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
-from awf.db.models import Operation, Workspace, WorkspaceEvent, WorkspaceLogStream
+from awf.db.models import (
+    Operation,
+    Task,
+    TaskAttempt,
+    Workspace,
+    WorkspaceEvent,
+    WorkspaceLogStream,
+)
 
 ACTIVE_OWNED_PATH_CONFLICT_STATUSES: Final[tuple[str, ...]] = (
     WorkspaceStatus.requested.value,
@@ -39,6 +55,157 @@ class OwnedPathConflict:
     workspace_id: str
     existing_path: str
     requested_path: str
+
+
+class TaskRepository:
+    """CRUD helpers for first-class task rows."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_or_get(
+        self,
+        *,
+        repo_url: str,
+        base_branch: str,
+        title: str,
+        prompt: str,
+        external_id: str | None,
+        idempotency_key: str | None,
+        task_class: str | None,
+        owned_paths: list[str],
+    ) -> Task:
+        existing = await self._find_reusable(
+            external_id=external_id,
+            idempotency_key=idempotency_key,
+        )
+        if existing is not None:
+            if existing.external_id is None and external_id is not None:
+                existing.external_id = external_id
+            if existing.idempotency_key is None and idempotency_key is not None:
+                existing.idempotency_key = idempotency_key
+            await self._session.flush()
+            return existing
+
+        task = Task(
+            id=new_task_id(),
+            external_id=external_id,
+            idempotency_key=idempotency_key,
+            repo_url=repo_url,
+            base_branch=base_branch,
+            title=title,
+            prompt=prompt,
+            task_class=task_class,
+            owned_paths=list(owned_paths),
+        )
+        self._session.add(task)
+        await self._session.flush()
+        return task
+
+    async def get(self, task_id: str) -> Task | None:
+        return await self._session.get(Task, task_id)
+
+    async def _find_reusable(
+        self,
+        *,
+        external_id: str | None,
+        idempotency_key: str | None,
+    ) -> Task | None:
+        if external_id is not None:
+            stmt = select(Task).where(Task.external_id == external_id)
+            existing = (await self._session.execute(stmt)).scalar_one_or_none()
+            if existing is not None:
+                return existing
+
+        if idempotency_key is not None:
+            stmt = select(Task).where(Task.idempotency_key == idempotency_key)
+            return (await self._session.execute(stmt)).scalar_one_or_none()
+
+        return None
+
+
+class TaskAttemptRepository:
+    """CRUD helpers for task-attempt rows."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create_for_workspace(
+        self,
+        *,
+        task: Task,
+        workspace: Workspace,
+    ) -> TaskAttempt:
+        max_attempt_number = (
+            await self._session.execute(
+                select(func.max(TaskAttempt.attempt_number)).where(
+                    TaskAttempt.task_id == task.id
+                )
+            )
+        ).scalar_one()
+        attempt_number = (max_attempt_number or 0) + 1
+        attempt = TaskAttempt(
+            id=new_task_attempt_id(),
+            task_id=task.id,
+            workspace_id=workspace.id,
+            attempt_number=attempt_number,
+            agent=workspace.agent,
+            status=workspace.status,
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            task_class=workspace.task_class,
+            owned_paths=list(workspace.owned_paths),
+        )
+        self._session.add(attempt)
+        await self._session.flush()
+        return attempt
+
+    async def get_by_workspace_id(self, workspace_id: str) -> TaskAttempt | None:
+        stmt = select(TaskAttempt).where(TaskAttempt.workspace_id == workspace_id)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_latest(
+        self,
+        *,
+        status: WorkspaceStatus | str | None = None,
+        agent: AgentRuntime | str | None = None,
+        repo_url: str | None = None,
+        limit: int = 50,
+    ) -> list[TaskAttempt]:
+        latest_attempt_numbers = (
+            select(
+                TaskAttempt.task_id.label("task_id"),
+                func.max(TaskAttempt.attempt_number).label("attempt_number"),
+            )
+            .group_by(TaskAttempt.task_id)
+            .subquery()
+        )
+        stmt = (
+            select(TaskAttempt)
+            .join(
+                latest_attempt_numbers,
+                and_(
+                    TaskAttempt.task_id == latest_attempt_numbers.c.task_id,
+                    TaskAttempt.attempt_number
+                    == latest_attempt_numbers.c.attempt_number,
+                ),
+            )
+            .join(Workspace, TaskAttempt.workspace_id == Workspace.id)
+            .options(
+                selectinload(TaskAttempt.task),
+                selectinload(TaskAttempt.workspace),
+            )
+        )
+        if status is not None:
+            stmt = stmt.where(Workspace.status == status)
+        if agent is not None:
+            stmt = stmt.where(TaskAttempt.agent == agent)
+        if repo_url is not None:
+            stmt = stmt.where(TaskAttempt.repo_url == repo_url)
+
+        stmt = stmt.order_by(TaskAttempt.created_at.desc(), TaskAttempt.id.desc()).limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
 
 
 class WorkspaceRepository:
@@ -196,8 +363,30 @@ class WorkspaceRepository:
         agent: AgentRuntime | str | None = None,
         repo_url: str | None = None,
         limit: int = 50,
-    ) -> list[Workspace]:
+    ) -> builtins.list[Workspace]:
         stmt = select(Workspace)
+        if status is not None:
+            stmt = stmt.where(Workspace.status == status)
+        if agent is not None:
+            stmt = stmt.where(Workspace.agent == agent)
+        if repo_url is not None:
+            stmt = stmt.where(Workspace.repo_url == repo_url)
+        stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def list_without_task_attempts(
+        self,
+        *,
+        status: WorkspaceStatus | str | None = None,
+        agent: AgentRuntime | str | None = None,
+        repo_url: str | None = None,
+        limit: int = 50,
+    ) -> builtins.list[Workspace]:
+        stmt = (
+            select(Workspace)
+            .outerjoin(TaskAttempt, TaskAttempt.workspace_id == Workspace.id)
+            .where(TaskAttempt.id.is_(None))
+        )
         if status is not None:
             stmt = stmt.where(Workspace.status == status)
         if agent is not None:
@@ -225,6 +414,9 @@ class WorkspaceRepository:
         old_state = workspace.status
         workspace.status = to.value
         workspace.version += 1
+        attempt = await TaskAttemptRepository(self._session).get_by_workspace_id(workspace.id)
+        if attempt is not None:
+            attempt.status = to.value
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
             workspace.monitor_started_at = datetime.now(UTC)
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -19,6 +19,7 @@ from typing import Any, Final
 from sqlalchemy import and_, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
+from sqlalchemy.sql import Select
 
 from awf.common.ids import (
     new_event_id,
@@ -136,6 +137,7 @@ class TaskAttemptRepository:
         task: Task,
         workspace: Workspace,
     ) -> TaskAttempt:
+        await self._lock_attempt_number_sequence(task.id)
         max_attempt_number = (
             await self._session.execute(
                 select(func.max(TaskAttempt.attempt_number)).where(
@@ -160,6 +162,17 @@ class TaskAttemptRepository:
         self._session.add(attempt)
         await self._session.flush()
         return attempt
+
+    async def _lock_attempt_number_sequence(self, task_id: str) -> None:
+        bind = self._session.get_bind()
+        if bind.dialect.name != "postgresql":
+            return
+
+        await self._session.execute(self._attempt_number_sequence_lock_stmt(task_id))
+
+    @staticmethod
+    def _attempt_number_sequence_lock_stmt(task_id: str) -> Select[tuple[str]]:
+        return select(Task.id).where(Task.id == task_id).with_for_update()
 
     async def get_by_workspace_id(self, workspace_id: str) -> TaskAttempt | None:
         stmt = select(TaskAttempt).where(TaskAttempt.workspace_id == workspace_id)

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -24,6 +24,8 @@ from awf.db.models import Workspace
 from awf.db.repositories import (
     OperationRepository,
     OwnedPathConflict,
+    TaskAttemptRepository,
+    TaskRepository,
     WorkspaceEventRepository,
     WorkspaceLogStreamRepository,
     WorkspaceRepository,
@@ -355,6 +357,19 @@ async def create_workspace_v2_row(
         idempotency_key=idempotency_key,
     )
     ws.task_kind = payload.task.kind
+    task = await TaskRepository(session).create_or_get(
+        repo_url=payload.repo.url,
+        base_branch=payload.repo.base_branch,
+        title=payload.task.title,
+        prompt=payload.task.prompt,
+        external_id=payload.task.external_id,
+        idempotency_key=idempotency_key,
+        task_class=(
+            payload.task.task_class.value if payload.task.task_class is not None else None
+        ),
+        owned_paths=payload.task.owned_paths,
+    )
+    await TaskAttemptRepository(session).create_for_workspace(task=task, workspace=ws)
     await session.flush()
     return ws
 

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -11,7 +11,6 @@ from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 
-
 _V1_BODY = {
     "repo_url": "git@github.com:example/console.git",
     "branch_base": "main",

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -1,0 +1,204 @@
+"""Task listing API tests for first-class task attempts."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+_V1_BODY = {
+    "repo_url": "git@github.com:example/console.git",
+    "branch_base": "main",
+    "task_title": "Legacy console row",
+    "task_prompt": "Expose useful workspace observability.",
+    "task_external_id": "LEGACY-1",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+def _v2_body(
+    *,
+    external_id: str | None = "TICKET-123",
+    title: str = "Add task attempts",
+    owned_paths: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "repo": {
+            "url": "git@github.com:example/console.git",
+            "base_branch": "main",
+        },
+        "task": {
+            "title": title,
+            "prompt": "Persist first-class task attempts.",
+            "kind": "feature_branch_pr",
+            "agent": "codex",
+            "external_id": external_id,
+            "task_class": "test_task",
+            "owned_paths": [] if owned_paths is None else owned_paths,
+        },
+        "workspace": {"profile_ref": "auto", "profile": None},
+        "validation": {"commands": ["pytest -q"], "requested_tier": 1},
+        "resources": {},
+    }
+
+
+async def _create_v1_workspace(client: AsyncClient) -> str:
+    response = await client.post("/v1/workspaces", json=_V1_BODY)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _create_v2_workspace(
+    client: AsyncClient,
+    *,
+    external_id: str | None = "TICKET-123",
+    title: str = "Add task attempts",
+    headers: dict[str, str] | None = None,
+) -> str:
+    response = await client.post(
+        "/v2/workspaces",
+        json=_v2_body(external_id=external_id, title=title),
+        headers=headers,
+    )
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+class TestTaskList:
+    @pytest.mark.unit
+    async def test_lists_new_task_attempt_rows_and_legacy_workspace_rows(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        legacy_workspace_id = await _create_v1_workspace(client)
+        new_workspace_id = await _create_v2_workspace(
+            client,
+            external_id="TICKET-NEW",
+            title="First-class task",
+        )
+
+        response = await client.get("/v1/tasks")
+
+        assert response.status_code == 200
+        items_by_workspace = {
+            item["workspace_id"]: item for item in response.json()["items"]
+        }
+        legacy = items_by_workspace[legacy_workspace_id]
+        new = items_by_workspace[new_workspace_id]
+
+        assert legacy["task_id"] == "LEGACY-1"
+        assert legacy["attempt_id"] is None
+        assert legacy["attempt_number"] is None
+
+        assert new["task_id"] == "TICKET-NEW"
+        assert new["attempt_id"].startswith("att_")
+        assert new["attempt_number"] == 1
+        assert new["title"] == "First-class task"
+        assert new["repo_url"] == "git@github.com:example/console.git"
+        assert new["base_branch"] == "main"
+        assert new["task_class"] == "test_task"
+        assert new["status"] == WorkspaceStatus.requested.value
+
+    @pytest.mark.unit
+    async def test_idempotent_v2_replay_does_not_duplicate_attempts(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        from awf.db.models import Task, TaskAttempt
+
+        headers = {"Idempotency-Key": "task-attempt-idem"}
+
+        first_id = await _create_v2_workspace(
+            client,
+            external_id="TICKET-IDEM",
+            title="Idempotent task",
+            headers=headers,
+        )
+        second_id = await _create_v2_workspace(
+            client,
+            external_id="TICKET-IDEM",
+            title="Idempotent task",
+            headers=headers,
+        )
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            tasks = list((await session.execute(select(Task))).scalars())
+            attempts = list((await session.execute(select(TaskAttempt))).scalars())
+
+        assert second_id == first_id
+        assert len(tasks) == 1
+        assert len(attempts) == 1
+        assert attempts[0].attempt_number == 1
+        assert attempts[0].workspace_id == first_id
+
+    @pytest.mark.unit
+    async def test_lists_latest_attempt_for_task(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        from awf.db.repositories import TaskAttemptRepository, TaskRepository
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            task = await TaskRepository(session).create_or_get(
+                repo_url="git@github.com:example/console.git",
+                base_branch="main",
+                title="Manual retry",
+                prompt="Retry this task.",
+                external_id="TICKET-LATEST",
+                idempotency_key=None,
+                task_class="test_task",
+                owned_paths=[],
+            )
+            first_workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/console.git",
+                branch_base="main",
+                task_title="First attempt",
+                task_prompt="Retry this task.",
+                task_external_id="TICKET-LATEST",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            second_workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/console.git",
+                branch_base="main",
+                task_title="Second attempt",
+                task_prompt="Retry this task.",
+                task_external_id="TICKET-LATEST",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            attempt_repo = TaskAttemptRepository(session)
+            await attempt_repo.create_for_workspace(task=task, workspace=first_workspace)
+            second_attempt = await attempt_repo.create_for_workspace(
+                task=task,
+                workspace=second_workspace,
+            )
+            second_workspace.status = WorkspaceStatus.ready.value
+            second_attempt.status = WorkspaceStatus.ready.value
+            await session.commit()
+
+        response = await client.get("/v1/tasks")
+
+        assert response.status_code == 200
+        items = [
+            item
+            for item in response.json()["items"]
+            if item["task_id"] == "TICKET-LATEST"
+        ]
+        assert len(items) == 1
+        assert items[0]["attempt_id"] == second_attempt.id
+        assert items[0]["attempt_number"] == 2
+        assert items[0]["workspace_id"] == second_workspace.id
+        assert items[0]["title"] == "Second attempt"
+        assert items[0]["status"] == WorkspaceStatus.ready.value

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import httpx
 import pytest
+from sqlalchemy.engine import make_url
 from typer.testing import CliRunner
 
 from awf.cli.main import app
@@ -632,6 +633,9 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     created: dict[str, Any] = {}
 
     class _Engine:
+        def __init__(self) -> None:
+            self.url = make_url("sqlite+aiosqlite:///:memory:")
+
         async def dispose(self) -> None:
             created["disposed"] = True
 
@@ -697,6 +701,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
 
     def _make_engine(url: str) -> _Engine:
         created["db_url"] = url
+        engine.url = make_url(url)
         return engine
 
     def _make_session_factory(eng: _Engine) -> object:

--- a/tests/unit/db/test_task_attempts.py
+++ b/tests/unit/db/test_task_attempts.py
@@ -1,0 +1,167 @@
+"""Task and task-attempt persistence tests."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = make_session_factory(engine)
+    async with factory() as s:
+        yield s
+
+    await engine.dispose()
+
+
+async def _workspace(
+    session: AsyncSession,
+    *,
+    title: str,
+    repo_url: str = "git@github.com:example/app.git",
+    branch_base: str = "development",
+) -> object:
+    workspace = await WorkspaceRepository(session).create(
+        repo_url=repo_url,
+        branch_base=branch_base,
+        task_title=title,
+        task_prompt="Do the work.",
+        agent=AgentRuntime.codex.value,
+        test_commands=[],
+    )
+    await session.flush()
+    return workspace
+
+
+class TestTaskAttemptRepository:
+    @pytest.mark.unit
+    async def test_create_or_get_task_reuses_external_id(self, session: AsyncSession) -> None:
+        from awf.db.repositories import TaskRepository
+
+        repo = TaskRepository(session)
+
+        first = await repo.create_or_get(
+            repo_url="git@github.com:example/app.git",
+            base_branch="development",
+            title="First title",
+            prompt="First prompt",
+            external_id="TICKET-123",
+            idempotency_key=None,
+            task_class="refactor_task",
+            owned_paths=["src/awf/**"],
+        )
+        second = await repo.create_or_get(
+            repo_url="git@github.com:example/app.git",
+            base_branch="development",
+            title="Updated title should not duplicate",
+            prompt="Updated prompt",
+            external_id="TICKET-123",
+            idempotency_key=None,
+            task_class="refactor_task",
+            owned_paths=["src/awf/**"],
+        )
+
+        assert second.id == first.id
+        assert second.external_id == "TICKET-123"
+        assert second.repo_url == "git@github.com:example/app.git"
+        assert second.base_branch == "development"
+
+    @pytest.mark.unit
+    async def test_attempt_numbers_increment_for_same_task(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        from awf.db.repositories import TaskAttemptRepository, TaskRepository
+
+        task = await TaskRepository(session).create_or_get(
+            repo_url="git@github.com:example/app.git",
+            base_branch="development",
+            title="Retryable task",
+            prompt="Do the work.",
+            external_id="TICKET-RETRY",
+            idempotency_key=None,
+            task_class=None,
+            owned_paths=[],
+        )
+        first_workspace = await _workspace(session, title="first attempt")
+        second_workspace = await _workspace(session, title="second attempt")
+
+        repo = TaskAttemptRepository(session)
+        first_attempt = await repo.create_for_workspace(task=task, workspace=first_workspace)
+        second_attempt = await repo.create_for_workspace(task=task, workspace=second_workspace)
+
+        assert first_attempt.attempt_number == 1
+        assert first_attempt.workspace_id == first_workspace.id
+        assert first_attempt.status == WorkspaceStatus.requested.value
+        assert second_attempt.attempt_number == 2
+        assert second_attempt.workspace_id == second_workspace.id
+        assert second_attempt.agent == AgentRuntime.codex.value
+
+
+class TestTaskAttemptMigration:
+    @pytest.mark.unit
+    def test_task_attempt_migration_creates_tables(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        repo_root = Path(__file__).resolve().parents[3]
+        db_path = tmp_path / "awf.db"
+        env = {
+            **os.environ,
+            "AWF_DATABASE_URL": f"sqlite+aiosqlite:///{db_path}",
+        }
+
+        monkeypatch.chdir(repo_root)
+        subprocess.run(
+            [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"],
+            cwd=repo_root,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        with sqlite3.connect(db_path) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                ).fetchall()
+            }
+            task_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(tasks)").fetchall()
+            }
+            attempt_columns = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(task_attempts)").fetchall()
+            }
+
+        assert "tasks" in tables
+        assert "task_attempts" in tables
+        assert {"id", "external_id", "repo_url", "base_branch", "title"} <= task_columns
+        assert {
+            "id",
+            "task_id",
+            "workspace_id",
+            "attempt_number",
+            "agent",
+            "status",
+        } <= attempt_columns

--- a/tests/unit/db/test_task_attempts.py
+++ b/tests/unit/db/test_task_attempts.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.db.base import Base
@@ -51,6 +52,16 @@ async def _workspace(
 
 
 class TestTaskAttemptRepository:
+    @pytest.mark.unit
+    def test_attempt_number_sequence_lock_uses_postgres_for_update(self) -> None:
+        from awf.db.repositories import TaskAttemptRepository
+
+        stmt = TaskAttemptRepository._attempt_number_sequence_lock_stmt("task-123")
+        compiled = str(stmt.compile(dialect=postgresql.dialect()))
+
+        assert "FROM tasks" in compiled
+        assert "FOR UPDATE" in compiled
+
     @pytest.mark.unit
     async def test_create_or_get_task_reuses_external_id(self, session: AsyncSession) -> None:
         from awf.db.repositories import TaskRepository

--- a/tests/unit/service/test_task_attempts.py
+++ b/tests/unit/service/test_task_attempts.py
@@ -1,0 +1,111 @@
+"""Service-level task-attempt persistence tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import WorkspaceCreateV2Request
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.session import make_engine, make_session_factory
+from awf.service.workspaces import WorkspaceService
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+def _request(
+    *,
+    external_id: str | None = "TICKET-123",
+    title: str = "Add task attempts",
+    repo_url: str = "git@github.com:example/app.git",
+    base_branch: str = "development",
+    owned_paths: list[str] | None = None,
+) -> WorkspaceCreateV2Request:
+    return WorkspaceCreateV2Request(
+        repo={"url": repo_url, "base_branch": base_branch},
+        task={
+            "title": title,
+            "prompt": "Persist first-class task attempts.",
+            "agent": "codex",
+            "kind": "feature_branch_pr",
+            "external_id": external_id,
+            "task_class": "refactor_task",
+            "owned_paths": ["src/awf/service/**"] if owned_paths is None else owned_paths,
+        },
+        workspace={"profile_ref": "auto", "profile": None},
+        validation={"commands": ["uv run pytest -q"], "requested_tier": 1},
+        resources={},
+    )
+
+
+@pytest.mark.unit
+async def test_create_v2_creates_task_and_attempt(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.db.models import Task, TaskAttempt
+
+    service = WorkspaceService(factory)
+
+    created = await service.create_v2(_request())
+
+    async with factory() as session:
+        tasks = list((await session.execute(select(Task))).scalars())
+        attempts = list((await session.execute(select(TaskAttempt))).scalars())
+
+    assert len(tasks) == 1
+    assert tasks[0].external_id == "TICKET-123"
+    assert tasks[0].repo_url == "git@github.com:example/app.git"
+    assert tasks[0].base_branch == "development"
+    assert tasks[0].title == "Add task attempts"
+    assert tasks[0].task_class == "refactor_task"
+    assert tasks[0].owned_paths == ["src/awf/service/**"]
+
+    assert len(attempts) == 1
+    assert attempts[0].task_id == tasks[0].id
+    assert attempts[0].workspace_id == created.id
+    assert attempts[0].attempt_number == 1
+    assert attempts[0].agent == AgentRuntime.codex.value
+    assert attempts[0].status == WorkspaceStatus.requested.value
+    assert attempts[0].repo_url == "git@github.com:example/app.git"
+    assert attempts[0].base_branch == "development"
+    assert attempts[0].title == "Add task attempts"
+
+
+@pytest.mark.unit
+async def test_create_v2_reuses_task_and_increments_attempt_for_same_external_id(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.db.models import Task, TaskAttempt
+
+    service = WorkspaceService(factory)
+
+    first = await service.create_v2(_request(title="first dispatch", owned_paths=[]))
+    second = await service.create_v2(_request(title="manual redispatch", owned_paths=[]))
+
+    async with factory() as session:
+        tasks = list((await session.execute(select(Task))).scalars())
+        attempts = list(
+            (
+                await session.execute(
+                    select(TaskAttempt).order_by(TaskAttempt.attempt_number.asc())
+                )
+            ).scalars()
+        )
+
+    assert len(tasks) == 1
+    assert [attempt.attempt_number for attempt in attempts] == [1, 2]
+    assert [attempt.workspace_id for attempt in attempts] == [first.id, second.id]
+    assert {attempt.task_id for attempt in attempts} == {tasks[0].id}


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_691fca79d75c4e6793f8d2ef` (agent: `codex`).

**External task ID**: awf-wave3-task-attempt-lineage-20260426T055128Z

### Task
Implement the next PRD lifecycle-model slice: introduce first-class task and task-attempt persistence while preserving the current workspace-backed execution model.

Problem:
- The PRD says task, task attempt, workspace, and operation should be distinct lifecycle objects.
- Current AWF treats a workspace as the task. That is good enough for execution, but bad for retry lineage, redispatch, supersession, and future scheduling.

Required behavior for this slice:
- Add `tasks` and `task_attempts` DB models plus Alembic migration.
- On v2 workspace creation, create or reuse a task row keyed by request external_id/idempotency where available, then create one task_attempt row linked to the workspace.
- Attempt should store workspace_id, attempt_number, agent, status/current workspace status snapshot, created_at/updated_at, and enough repo/base/title metadata to support `/v1/tasks` without losing compatibility.
- Keep existing workspace fields and API responses backward compatible.
- Update `/v1/tasks` to expose task_id and current/latest attempt from the new tables when present, falling back to workspace-backed rows for historical data.
- Do not rewrite scheduling or retries in this slice.

TDD requirements:
- Add failing DB/service/API tests first: v2 create creates task + attempt, repeated idempotent create does not duplicate attempts, task listing works for new rows and legacy workspace-only rows, attempt numbers increment for a manually-created second attempt fixture.

Validation commands:
- uv run ruff check src/awf/db src/awf/api/routes/tasks.py src/awf/api/schemas.py src/awf/service/workspaces.py migrations tests/unit/db tests/unit/api/test_tasks.py tests/unit/service/test_task_attempts.py
- uv run mypy src/awf/db src/awf/api/routes/tasks.py src/awf/api/schemas.py src/awf/service/workspaces.py
- uv run pytest tests/unit/db/test_task_attempts.py tests/unit/api/test_tasks.py tests/unit/service/test_task_attempts.py -q

Strict TDD and AWF contract:
- Write focused failing tests first and commit the red tests, including the failure summary in the commit body.
- Implement until green, then run the validation commands listed below.
- Commit locally with conventional commits.
- Do not push, switch branches, rebase, open PRs, merge PRs, or resolve GitHub threads manually outside the task contract. AWF owns those lifecycle steps.
- Keep the change tightly scoped to the owned paths.

---
Validation: 6 profile command(s) passed inside the workspace container.
