### PR TITLE
feat(worker): claim workspace batches with Postgres skip-locked semantics

### DIFF
--- a/migrations/versions/0a1b2c3d4e5f_monitor_recovery_claims.py
+++ b/migrations/versions/0a1b2c3d4e5f_monitor_recovery_claims.py
@@ -1,0 +1,32 @@
+"""Add monitor recovery claim lease columns.
+
+Revision ID: 0a1b2c3d4e5f
+Revises: 9b1c2d3e4f5a
+Create Date: 2026-04-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0a1b2c3d4e5f"
+down_revision: str | Sequence[str] | None = "9b1c2d3e4f5a"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.add_column(sa.Column("monitor_claimed_by", sa.String(length=128), nullable=True))
+        batch.add_column(
+            sa.Column("monitor_claim_expires_at", sa.DateTime(timezone=True), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.drop_column("monitor_claim_expires_at")
+        batch.drop_column("monitor_claimed_by")

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1023,9 +1023,10 @@ class WorkspaceExecutor:
         return defaults.get(agent)
 
     async def _claim_ready(self, workspace_id: str) -> Workspace | None:
+        """Atomically transition a ready workspace to running before execution."""
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
-            ws = await repo.get(workspace_id)
+            ws = await repo.get_for_update(workspace_id)
             if ws is None:
                 _log.warning("executor.skip_unknown", workspace_id=workspace_id)
                 return None

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1026,21 +1026,26 @@ class WorkspaceExecutor:
         """Atomically transition a ready workspace to running before execution."""
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
-            ws = await repo.get_for_update(workspace_id)
-            if ws is None:
+            ws = await repo.transition_if_current(
+                workspace_id,
+                from_status=WorkspaceStatus.ready,
+                to=WorkspaceStatus.running,
+                reason_code="EXECUTOR_CLAIMED",
+            )
+            if ws is not None:
+                await session.commit()
+                return ws
+
+            current = await repo.get(workspace_id)
+            if current is None:
                 _log.warning("executor.skip_unknown", workspace_id=workspace_id)
                 return None
-            if ws.status != WorkspaceStatus.ready.value:
-                _log.info(
-                    "executor.skip_not_ready",
-                    workspace_id=workspace_id,
-                    status=ws.status,
-                )
-                return None
-            await repo.transition(ws, to=WorkspaceStatus.running, reason_code="EXECUTOR_CLAIMED")
-            await session.commit()
-            # Return a detached snapshot (session closes).
-            return ws
+            _log.info(
+                "executor.skip_not_ready",
+                workspace_id=workspace_id,
+                status=current.status,
+            )
+            return None
 
     async def _recheck_status(
         self,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1,8 +1,9 @@
 """Async control-plane worker.
 
 Polls the DB for workspaces needing action and dispatches them to the
-Provisioner. Uses a single-process poll loop for the MVP; multi-node
-``SELECT FOR UPDATE SKIP LOCKED`` scheduling is deferred to Phase 1.5.
+Provisioner. Postgres-backed deployments claim schedulable rows with
+``SELECT FOR UPDATE SKIP LOCKED``; SQLite keeps the portable select path used
+by local tests.
 
 Split into two methods:
 
@@ -24,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.common.logging import get_logger
 from awf.db.enums import WorkspaceStatus
 from awf.db.models import Workspace
+from awf.db.repositories import WorkspaceRepository
 from awf.node.provisioner import Provisioner
 
 _log = get_logger(__name__)
@@ -190,12 +192,11 @@ class ControlWorker:
             return []
 
         async with self._session_factory() as session:
-            stmt = select(Workspace.id).where(Workspace.status == status.value)
-            if exclude_ids:
-                stmt = stmt.where(~Workspace.id.in_(exclude_ids))
-            stmt = stmt.order_by(Workspace.created_at).limit(limit)
-            result = await session.execute(stmt)
-            return [row[0] for row in result.all()]
+            return await WorkspaceRepository(session).claim_schedulable_ids(
+                status=status,
+                limit=limit,
+                exclude_ids=exclude_ids,
+            )
 
     async def _filter_current_status(
         self,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1,9 +1,9 @@
 """Async control-plane worker.
 
 Polls the DB for workspaces needing action and dispatches them to the
-Provisioner. Postgres-backed deployments claim schedulable rows with
-``SELECT FOR UPDATE SKIP LOCKED``; SQLite keeps the portable select path used
-by local tests.
+Provisioner. Postgres-backed deployments list schedulable candidate rows with
+``SELECT FOR UPDATE SKIP LOCKED``; provisioning and ready-execution handlers
+then claim selected rows by locking and transitioning them in one transaction.
 
 Split into two methods:
 
@@ -66,7 +66,7 @@ class ControlWorker:
         self._stopped.set()
 
     async def run_once(self) -> int:
-        """Claim + dispatch requested provisioning and workspace runtime tasks.
+        """List + dispatch requested provisioning and workspace runtime tasks.
 
         Returns the number of workspaces dispatched. A zero return is a signal
         for ``run_forever`` to sleep; non-zero means we may be throughput-bound
@@ -192,7 +192,7 @@ class ControlWorker:
             return []
 
         async with self._session_factory() as session:
-            return await WorkspaceRepository(session).claim_schedulable_ids(
+            return await WorkspaceRepository(session).list_schedulable_ids(
                 status=status,
                 limit=limit,
                 exclude_ids=exclude_ids,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -3,7 +3,9 @@
 Polls the DB for workspaces needing action and dispatches them to the
 Provisioner. Postgres-backed deployments list schedulable candidate rows with
 ``SELECT FOR UPDATE SKIP LOCKED``; provisioning and ready-execution handlers
-then claim selected rows by locking and transitioning them in one transaction.
+then claim selected rows with conditional status transitions. PR monitor
+recovery uses a short DB-backed lease so multiple workers do not resume the
+same monitor concurrently.
 
 Split into two methods:
 
@@ -15,7 +17,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import uuid
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from typing import Protocol
 
@@ -36,6 +40,7 @@ class WorkerConfig:
     poll_interval_seconds: float = 1.0
     max_concurrent_provisions: int = 3
     max_concurrent_executions: int = 3
+    monitor_claim_lease_seconds: float = 300.0
 
 
 class WorkspaceExecutorProtocol(Protocol):
@@ -60,6 +65,7 @@ class ControlWorker:
         self._config = config
         self._stopped = asyncio.Event()
         self._execution_tasks: dict[str, asyncio.Task[None]] = {}
+        self._worker_id = f"control-worker-{uuid.uuid4().hex}"
 
     def request_stop(self) -> None:
         """Signal ``run_forever`` to exit after the current batch."""
@@ -100,6 +106,10 @@ class ControlWorker:
                     expected=WorkspaceStatus.monitoring_pr,
                     action="resume_pr_monitor",
                 )
+                monitoring_ids = await self._claim_monitoring_pr_ids(
+                    monitoring_ids,
+                    limit=execution_slots,
+                )
                 dispatched_ids.update(
                     self._dispatch_monitor_resumes(monitoring_ids, limit=execution_slots)
                 )
@@ -124,7 +134,11 @@ class ControlWorker:
     async def wait_for_execution_tasks(self) -> None:
         """Wait for ready execution or monitor-resume tasks started by this worker."""
         while self._execution_tasks:
-            await asyncio.gather(*tuple(self._execution_tasks.values()))
+            tasks = tuple(self._execution_tasks.values())
+            await asyncio.gather(*tasks)
+            for workspace_id, task in list(self._execution_tasks.items()):
+                if task.done():
+                    self._execution_tasks.pop(workspace_id, None)
 
     async def run_forever(self) -> None:
         while not self._stopped.is_set():
@@ -258,7 +272,7 @@ class ControlWorker:
                 continue
 
             task = asyncio.create_task(
-                self._safely_resume_pr_monitor(workspace_id),
+                self._safely_resume_claimed_pr_monitor(workspace_id),
                 name=f"awf-monitor-{workspace_id}",
             )
             self._execution_tasks[workspace_id] = task
@@ -298,3 +312,89 @@ class ControlWorker:
             # dispatch still must not take the service worker down if a single
             # workspace hits an unexpected runtime error.
             _log.exception("worker.pr_monitor_resume_failed", workspace_id=workspace_id)
+
+    async def _claim_monitoring_pr_ids(self, workspace_ids: list[str], *, limit: int) -> list[str]:
+        claimed: list[str] = []
+        for workspace_id in workspace_ids:
+            if len(claimed) >= limit:
+                break
+            if workspace_id in self._execution_tasks:
+                continue
+            if await self._claim_monitoring_pr(workspace_id):
+                claimed.append(workspace_id)
+        return claimed
+
+    async def _claim_monitoring_pr(self, workspace_id: str) -> bool:
+        now = datetime.now(UTC)
+        lease_expires_at = now + timedelta(seconds=self._config.monitor_claim_lease_seconds)
+        async with self._session_factory() as session:
+            claimed = await WorkspaceRepository(session).claim_monitoring_pr(
+                workspace_id,
+                owner_id=self._worker_id,
+                lease_expires_at=lease_expires_at,
+                now=now,
+            )
+            await session.commit()
+            return claimed
+
+    async def _safely_resume_claimed_pr_monitor(self, workspace_id: str) -> None:
+        heartbeat = asyncio.create_task(
+            self._refresh_monitoring_pr_claim_loop(workspace_id),
+            name=f"awf-monitor-claim-{workspace_id}",
+        )
+        try:
+            await self._safely_resume_pr_monitor(workspace_id)
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+            await self._release_monitoring_pr_claim(workspace_id)
+
+    async def _refresh_monitoring_pr_claim_loop(self, workspace_id: str) -> None:
+        interval = max(1.0, min(60.0, self._config.monitor_claim_lease_seconds / 3))
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                refreshed = await self._refresh_monitoring_pr_claim(workspace_id)
+            except Exception:
+                _log.exception(
+                    "worker.monitor_claim_refresh_failed",
+                    workspace_id=workspace_id,
+                    worker_id=self._worker_id,
+                )
+                return
+            if not refreshed:
+                _log.warning(
+                    "worker.monitor_claim_lost",
+                    workspace_id=workspace_id,
+                    worker_id=self._worker_id,
+                )
+                return
+
+    async def _refresh_monitoring_pr_claim(self, workspace_id: str) -> bool:
+        lease_expires_at = datetime.now(UTC) + timedelta(
+            seconds=self._config.monitor_claim_lease_seconds
+        )
+        async with self._session_factory() as session:
+            refreshed = await WorkspaceRepository(session).refresh_monitoring_pr_claim(
+                workspace_id,
+                owner_id=self._worker_id,
+                lease_expires_at=lease_expires_at,
+            )
+            await session.commit()
+            return refreshed
+
+    async def _release_monitoring_pr_claim(self, workspace_id: str) -> None:
+        try:
+            async with self._session_factory() as session:
+                await WorkspaceRepository(session).release_monitoring_pr_claim(
+                    workspace_id,
+                    owner_id=self._worker_id,
+                )
+                await session.commit()
+        except Exception:
+            _log.exception(
+                "worker.monitor_claim_release_failed",
+                workspace_id=workspace_id,
+                worker_id=self._worker_id,
+            )

--- a/src/awf/db/dialect.py
+++ b/src/awf/db/dialect.py
@@ -1,0 +1,7 @@
+"""Database dialect metadata shared by session and repository code."""
+
+from __future__ import annotations
+
+from typing import Final
+
+SESSION_DIALECT_NAME_KEY: Final = "awf.dialect_name"

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -178,6 +178,14 @@ class Workspace(Base):
     )
     """Wall-clock start of the monitor phase, for wall-clock-cap arithmetic."""
 
+    monitor_claimed_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    """Ephemeral service-worker owner currently resuming the PR monitor."""
+
+    monitor_claim_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    """Lease expiry for ``monitor_claimed_by`` so crashed workers do not wedge recovery."""
+
     # Idempotency
     idempotency_key: Mapped[str | None] = mapped_column(String(128), nullable=True)
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -409,6 +409,33 @@ class WorkspaceRepository:
         stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
+    async def claim_schedulable_ids(
+        self,
+        *,
+        status: WorkspaceStatus,
+        limit: int,
+        exclude_ids: set[str] | None = None,
+    ) -> builtins.list[str]:
+        """Claim schedulable workspace IDs for one worker poll.
+
+        Postgres uses row-level locks with ``SKIP LOCKED`` so concurrent worker
+        processes skip rows another transaction has already selected. SQLite
+        does not support that locking mode, so tests and local DBs use the same
+        deterministic select without lock hints.
+        """
+        if limit <= 0:
+            return []
+
+        bind = self._session.get_bind()
+        stmt = _schedulable_workspace_ids_stmt(
+            status=status,
+            limit=limit,
+            exclude_ids=exclude_ids,
+            skip_locked=bind.dialect.name == "postgresql",
+        )
+        result = await self._session.execute(stmt)
+        return list(result.scalars().all())
+
     async def transition(
         self,
         workspace: Workspace,
@@ -464,6 +491,22 @@ class WorkspaceRepository:
         workspace.events.append(event)
         await self._session.flush()
         return event
+
+
+def _schedulable_workspace_ids_stmt(
+    *,
+    status: WorkspaceStatus,
+    limit: int,
+    exclude_ids: set[str] | None = None,
+    skip_locked: bool,
+) -> Select[tuple[str]]:
+    stmt = select(Workspace.id).where(Workspace.status == status.value)
+    if exclude_ids:
+        stmt = stmt.where(~Workspace.id.in_(sorted(exclude_ids)))
+    stmt = stmt.order_by(Workspace.created_at.asc(), Workspace.id.asc()).limit(limit)
+    if skip_locked:
+        stmt = stmt.with_for_update(skip_locked=True, of=Workspace)
+    return stmt
 
 
 def _owned_paths_overlap(left: str, right: str) -> bool:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -298,6 +298,14 @@ class WorkspaceRepository:
     async def get(self, workspace_id: str) -> Workspace | None:
         return await self._session.get(Workspace, workspace_id)
 
+    async def get_for_update(self, workspace_id: str) -> Workspace | None:
+        """Load one workspace with a row lock when the database supports it."""
+        stmt = select(Workspace).where(Workspace.id == workspace_id)
+        bind = self._session.get_bind()
+        if bind.dialect.name == "postgresql":
+            stmt = stmt.with_for_update(of=Workspace)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
     async def exists(self, workspace_id: str) -> bool:
         stmt = select(Workspace.id).where(Workspace.id == workspace_id).limit(1)
         return (await self._session.execute(stmt)).scalar_one_or_none() is not None
@@ -409,19 +417,20 @@ class WorkspaceRepository:
         stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
-    async def claim_schedulable_ids(
+    async def list_schedulable_ids(
         self,
         *,
         status: WorkspaceStatus,
         limit: int,
         exclude_ids: set[str] | None = None,
     ) -> builtins.list[str]:
-        """Claim schedulable workspace IDs for one worker poll.
+        """Return candidate workspace IDs for one worker poll.
 
-        Postgres uses row-level locks with ``SKIP LOCKED`` so concurrent worker
-        processes skip rows another transaction has already selected. SQLite
-        does not support that locking mode, so tests and local DBs use the same
-        deterministic select without lock hints.
+        Postgres uses row-level locks with ``SKIP LOCKED`` to reduce duplicate
+        candidates while poll transactions overlap. For provisioning and ready
+        execution, the durable claim happens when the dispatcher reloads each
+        row with ``get_for_update()`` and performs the state transition in that
+        same transaction.
         """
         if limit <= 0:
             return []

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -30,6 +30,7 @@ from awf.common.ids import (
     new_workspace_id,
 )
 from awf.control.state_machine import WorkspaceStateMachine
+from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import (
     Operation,
@@ -56,6 +57,25 @@ class OwnedPathConflict:
     workspace_id: str
     existing_path: str
     requested_path: str
+
+
+def _resolve_session_dialect_name(
+    session: AsyncSession,
+    dialect_name: str | None,
+) -> str | None:
+    if dialect_name is not None:
+        return dialect_name
+
+    info_value = session.info.get(SESSION_DIALECT_NAME_KEY)
+    if isinstance(info_value, str):
+        return info_value
+
+    bind = getattr(session, "bind", None)
+    if bind is None:
+        return None
+    dialect = getattr(bind, "dialect", None)
+    name = getattr(dialect, "name", None)
+    return name if isinstance(name, str) else None
 
 
 class TaskRepository:
@@ -128,8 +148,9 @@ class TaskRepository:
 class TaskAttemptRepository:
     """CRUD helpers for task-attempt rows."""
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: AsyncSession, *, dialect_name: str | None = None) -> None:
         self._session = session
+        self._dialect_name = _resolve_session_dialect_name(session, dialect_name)
 
     async def create_for_workspace(
         self,
@@ -164,8 +185,7 @@ class TaskAttemptRepository:
         return attempt
 
     async def _lock_attempt_number_sequence(self, task_id: str) -> None:
-        bind = self._session.get_bind()
-        if bind.dialect.name != "postgresql":
+        if self._dialect_name != "postgresql":
             return
 
         await self._session.execute(self._attempt_number_sequence_lock_stmt(task_id))
@@ -228,8 +248,9 @@ class WorkspaceRepository:
     of work. Do not reuse across request boundaries.
     """
 
-    def __init__(self, session: AsyncSession) -> None:
+    def __init__(self, session: AsyncSession, *, dialect_name: str | None = None) -> None:
         self._session = session
+        self._dialect_name = _resolve_session_dialect_name(session, dialect_name)
 
     async def create(
         self,
@@ -301,8 +322,7 @@ class WorkspaceRepository:
     async def get_for_update(self, workspace_id: str) -> Workspace | None:
         """Load one workspace with a row lock when the database supports it."""
         stmt = select(Workspace).where(Workspace.id == workspace_id)
-        bind = self._session.get_bind()
-        if bind.dialect.name == "postgresql":
+        if self._dialect_name == "postgresql":
             stmt = stmt.with_for_update(of=Workspace)
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
@@ -325,8 +345,7 @@ class WorkspaceRepository:
         if not any(_normalize_owned_path(path) != "" for path in owned_paths):
             return
 
-        bind = self._session.get_bind()
-        if bind.dialect.name != "postgresql":
+        if self._dialect_name != "postgresql":
             return
 
         lock_key = _owned_path_conflict_advisory_lock_key(
@@ -435,12 +454,11 @@ class WorkspaceRepository:
         if limit <= 0:
             return []
 
-        bind = self._session.get_bind()
         stmt = _schedulable_workspace_ids_stmt(
             status=status,
             limit=limit,
             exclude_ids=exclude_ids,
-            skip_locked=bind.dialect.name == "postgresql",
+            skip_locked=self._dialect_name == "postgresql",
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
@@ -463,7 +481,10 @@ class WorkspaceRepository:
         old_state = workspace.status
         workspace.status = to.value
         workspace.version += 1
-        attempt = await TaskAttemptRepository(self._session).get_by_workspace_id(workspace.id)
+        attempt = await TaskAttemptRepository(
+            self._session,
+            dialect_name=self._dialect_name,
+        ).get_by_workspace_id(workspace.id)
         if attempt is not None:
             attempt.status = to.value
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Final
 
-from sqlalchemy import and_, func, select, text
+from sqlalchemy import and_, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
@@ -447,9 +447,9 @@ class WorkspaceRepository:
 
         Postgres uses row-level locks with ``SKIP LOCKED`` to reduce duplicate
         candidates while poll transactions overlap. For provisioning and ready
-        execution, the durable claim happens when the dispatcher reloads each
-        row with ``get_for_update()`` and performs the state transition in that
-        same transaction.
+        execution, the durable claim happens through ``transition_if_current()``.
+        For monitor recovery, active claim leases are filtered out before
+        limiting so claimed rows do not block later unclaimed rows.
         """
         if limit <= 0:
             return []
@@ -459,6 +459,7 @@ class WorkspaceRepository:
             limit=limit,
             exclude_ids=exclude_ids,
             skip_locked=self._dialect_name == "postgresql",
+            claim_cutoff=datetime.now(UTC) if status == WorkspaceStatus.monitoring_pr else None,
         )
         result = await self._session.execute(stmt)
         return list(result.scalars().all())
@@ -501,6 +502,134 @@ class WorkspaceRepository:
         )
         return workspace
 
+    async def transition_if_current(
+        self,
+        workspace_id: str,
+        *,
+        from_status: WorkspaceStatus,
+        to: WorkspaceStatus,
+        reason_code: str,
+    ) -> Workspace | None:
+        """Atomically transition a row only if it is still in ``from_status``."""
+        WorkspaceStateMachine.assert_transition(from_status, to)
+
+        now = datetime.now(UTC)
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.status == from_status.value,
+            )
+            .values(
+                status=to.value,
+                version=Workspace.version + 1,
+                updated_at=now,
+            )
+            .returning(Workspace.id)
+        )
+        if result.scalar_one_or_none() is None:
+            return None
+
+        workspace = await self.get(workspace_id)
+        if workspace is None:  # pragma: no cover - row was just updated in this txn
+            return None
+
+        attempt = await TaskAttemptRepository(
+            self._session,
+            dialect_name=self._dialect_name,
+        ).get_by_workspace_id(workspace.id)
+        if attempt is not None:
+            attempt.status = to.value
+        if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
+            workspace.monitor_started_at = now
+
+        workspace.events.append(
+            WorkspaceEvent(
+                id=new_event_id(),
+                event_type="workspace.state_changed",
+                old_state=from_status.value,
+                new_state=to.value,
+                reason_code=reason_code,
+            )
+        )
+        await self._session.flush()
+        return workspace
+
+    async def claim_monitoring_pr(
+        self,
+        workspace_id: str,
+        *,
+        owner_id: str,
+        lease_expires_at: datetime,
+        now: datetime | None = None,
+    ) -> bool:
+        """Claim a monitor-recovery workspace unless another lease is active."""
+        cutoff = now or datetime.now(UTC)
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.status == WorkspaceStatus.monitoring_pr.value,
+                or_(
+                    Workspace.monitor_claim_expires_at.is_(None),
+                    Workspace.monitor_claim_expires_at <= cutoff,
+                    Workspace.monitor_claimed_by == owner_id,
+                ),
+            )
+            .values(
+                monitor_claimed_by=owner_id,
+                monitor_claim_expires_at=lease_expires_at,
+                updated_at=Workspace.updated_at,
+            )
+            .returning(Workspace.id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def refresh_monitoring_pr_claim(
+        self,
+        workspace_id: str,
+        *,
+        owner_id: str,
+        lease_expires_at: datetime,
+    ) -> bool:
+        """Extend this worker's active monitor-recovery lease."""
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.status == WorkspaceStatus.monitoring_pr.value,
+                Workspace.monitor_claimed_by == owner_id,
+            )
+            .values(
+                monitor_claim_expires_at=lease_expires_at,
+                updated_at=Workspace.updated_at,
+            )
+            .returning(Workspace.id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def release_monitoring_pr_claim(
+        self,
+        workspace_id: str,
+        *,
+        owner_id: str,
+    ) -> bool:
+        """Release this worker's monitor-recovery lease, if it still owns it."""
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.monitor_claimed_by == owner_id,
+            )
+            .values(
+                monitor_claimed_by=None,
+                monitor_claim_expires_at=None,
+                updated_at=Workspace.updated_at,
+            )
+            .returning(Workspace.id)
+        )
+        return result.scalar_one_or_none() is not None
+
     async def add_event(
         self,
         workspace: Workspace,
@@ -529,8 +658,16 @@ def _schedulable_workspace_ids_stmt(
     limit: int,
     exclude_ids: set[str] | None = None,
     skip_locked: bool,
+    claim_cutoff: datetime | None = None,
 ) -> Select[tuple[str]]:
     stmt = select(Workspace.id).where(Workspace.status == status.value)
+    if status == WorkspaceStatus.monitoring_pr and claim_cutoff is not None:
+        stmt = stmt.where(
+            or_(
+                Workspace.monitor_claim_expires_at.is_(None),
+                Workspace.monitor_claim_expires_at <= claim_cutoff,
+            )
+        )
     if exclude_ids:
         stmt = stmt.where(~Workspace.id.in_(sorted(exclude_ids)))
     stmt = stmt.order_by(Workspace.created_at.asc(), Workspace.id.asc()).limit(limit)

--- a/src/awf/db/session.py
+++ b/src/awf/db/session.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.runtime.events import ensure_workspace_event_broadcasting
 
 
@@ -36,7 +37,12 @@ def make_session_factory(engine: AsyncEngine) -> async_sessionmaker[AsyncSession
     important for API handlers that return ORM objects after a write.
     """
     ensure_workspace_event_broadcasting()
-    return async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    return async_sessionmaker(
+        engine,
+        expire_on_commit=False,
+        class_=AsyncSession,
+        info={SESSION_DIALECT_NAME_KEY: engine.dialect.name},
+    )
 
 
 @asynccontextmanager

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -232,10 +232,12 @@ class Provisioner:
 
         Returns None (rather than raising) if the workspace isn't in ``requested`` —
         another worker may have already claimed it. This makes the provisioner safe
-        to call at-least-once from the poll loop.
+        to call at-least-once from the poll loop. Postgres callers lock the row
+        before checking status so concurrent workers cannot both commit the
+        ``requested`` -> ``provisioning`` claim.
         """
         repo = WorkspaceRepository(session)
-        ws = await repo.get(workspace_id)
+        ws = await repo.get_for_update(workspace_id)
         if ws is None:
             _log.warning("provisioner.skip_unknown", workspace_id=workspace_id)
             return None

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -232,26 +232,31 @@ class Provisioner:
 
         Returns None (rather than raising) if the workspace isn't in ``requested`` —
         another worker may have already claimed it. This makes the provisioner safe
-        to call at-least-once from the poll loop. Postgres callers lock the row
-        before checking status so concurrent workers cannot both commit the
-        ``requested`` -> ``provisioning`` claim.
+        to call at-least-once from the poll loop. The claim is a conditional
+        ``requested`` -> ``provisioning`` transition, so concurrent workers cannot
+        both commit it.
         """
         repo = WorkspaceRepository(session)
-        ws = await repo.get_for_update(workspace_id)
-        if ws is None:
+        ws = await repo.transition_if_current(
+            workspace_id,
+            from_status=WorkspaceStatus.requested,
+            to=WorkspaceStatus.provisioning,
+            reason_code="WORKER_CLAIMED",
+        )
+        if ws is not None:
+            await session.commit()
+            return ws
+
+        current = await repo.get(workspace_id)
+        if current is None:
             _log.warning("provisioner.skip_unknown", workspace_id=workspace_id)
             return None
-        if ws.status != WorkspaceStatus.requested.value:
-            _log.info(
-                "provisioner.skip_not_requested",
-                workspace_id=workspace_id,
-                status=ws.status,
-            )
-            return None
-
-        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="WORKER_CLAIMED")
-        await session.commit()
-        return ws
+        _log.info(
+            "provisioner.skip_not_requested",
+            workspace_id=workspace_id,
+            status=current.status,
+        )
+        return None
 
     async def _mark_failed(
         self,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -422,6 +422,50 @@ class TestRunOnceExecution:
             worker._execution_tasks.pop("busy", None)
 
     @pytest.mark.unit
+    async def test_schedulable_statuses_are_claimed_through_repository(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        claims: list[tuple[WorkspaceStatus, int, set[str]]] = []
+
+        async def _claim_schedulable_ids(
+            self: WorkspaceRepository,
+            *,
+            status: WorkspaceStatus,
+            limit: int,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            del self
+            claims.append((status, limit, set(exclude_ids or set())))
+            return []
+
+        monkeypatch.setattr(
+            WorkspaceRepository,
+            "claim_schedulable_ids",
+            _claim_schedulable_ids,
+            raising=False,
+        )
+
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=2,
+                max_concurrent_executions=4,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        assert claims == [
+            (WorkspaceStatus.requested, 2, set()),
+            (WorkspaceStatus.monitoring_pr, 4, set()),
+            (WorkspaceStatus.ready, 4, set()),
+        ]
+
+    @pytest.mark.unit
     async def test_monitor_query_excludes_active_ids_before_limiting(
         self,
         worker: ControlWorker,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -606,6 +606,136 @@ class TestRunOnceExecution:
         await worker.wait_for_execution_tasks()
         assert set(executor.calls) == {first_id, second_id}
 
+    @pytest.mark.unit
+    async def test_concurrent_workers_do_not_claim_same_requested_workspace(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        requested_id = await _create_requested(session_factory, origin_repo, "race-requested")
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls: list[str] = []
+
+        class _ClaimingProvisioner:
+            async def provision(self, workspace_id: str) -> None:
+                async with session_factory() as s:
+                    repo = WorkspaceRepository(s)
+                    ws = await repo.transition_if_current(
+                        workspace_id,
+                        from_status=WorkspaceStatus.requested,
+                        to=WorkspaceStatus.provisioning,
+                        reason_code="TEST_CLAIM",
+                    )
+                    if ws is None:
+                        return
+                    await s.commit()
+
+                calls.append(workspace_id)
+                started.set()
+                await release.wait()
+
+                async with session_factory() as s:
+                    repo = WorkspaceRepository(s)
+                    ws = await repo.get(workspace_id)
+                    assert ws is not None
+                    if ws.status != WorkspaceStatus.provisioning.value:
+                        return
+                    ws.branch_name = f"awf/{workspace_id}"
+                    ws.base_commit = "c" * 40
+                    ws.compose_project_name = f"awf_{workspace_id}"
+                    ws.compose_file_path = f"/tmp/awf/{workspace_id}/compose.yml"
+                    await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="TEST_READY")
+                    await s.commit()
+
+        provisioner = _ClaimingProvisioner()
+        worker_a = ControlWorker(
+            session_factory=session_factory,
+            provisioner=provisioner,  # type: ignore[arg-type]
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_provisions=1),
+        )
+        worker_b = ControlWorker(
+            session_factory=session_factory,
+            provisioner=provisioner,  # type: ignore[arg-type]
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_provisions=1),
+        )
+
+        runs = [
+            asyncio.create_task(worker_a.run_once()),
+            asyncio.create_task(worker_b.run_once()),
+        ]
+        await asyncio.wait_for(started.wait(), timeout=0.2)
+        release.set()
+        await asyncio.wait_for(asyncio.gather(*runs), timeout=0.5)
+
+        assert calls == [requested_id]
+
+    @pytest.mark.unit
+    async def test_concurrent_workers_do_not_claim_same_ready_workspace(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        ready_id = await _create_ready(session_factory, origin_repo, "race-ready")
+        started = asyncio.Event()
+        release = asyncio.Event()
+        calls: list[str] = []
+
+        class _ClaimingExecutor:
+            async def execute(self, workspace_id: str) -> None:
+                async with session_factory() as s:
+                    repo = WorkspaceRepository(s)
+                    ws = await repo.transition_if_current(
+                        workspace_id,
+                        from_status=WorkspaceStatus.ready,
+                        to=WorkspaceStatus.running,
+                        reason_code="TEST_EXECUTOR_CLAIMED",
+                    )
+                    if ws is None:
+                        return
+                    await s.commit()
+
+                calls.append(workspace_id)
+                started.set()
+                await release.wait()
+
+            async def resume_pr_monitor(self, workspace_id: str) -> None:
+                raise AssertionError(f"unexpected monitor resume for {workspace_id}")
+
+        executor = _ClaimingExecutor()
+        worker_a = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker_b = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=1,
+            ),
+        )
+
+        await asyncio.gather(worker_a.run_once(), worker_b.run_once())
+        await asyncio.wait_for(started.wait(), timeout=0.2)
+        release.set()
+        await asyncio.wait_for(
+            asyncio.gather(
+                worker_a.wait_for_execution_tasks(), worker_b.wait_for_execution_tasks()
+            ),
+            timeout=0.5,
+        )
+
+        assert calls == [ready_id]
+
 
 class TestRunOnceMonitorRecovery:
     @pytest.mark.unit
@@ -761,3 +891,66 @@ class TestRunOnceMonitorRecovery:
 
         release_monitor.set()
         await asyncio.wait_for(worker.wait_for_execution_tasks(), timeout=0.2)
+
+    @pytest.mark.unit
+    async def test_concurrent_workers_do_not_claim_same_monitoring_pr_workspace(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "race-monitor")
+        monitor_started = asyncio.Event()
+        release_monitor = asyncio.Event()
+
+        class _BlockingExecutor(_RecordingExecutor):
+            async def resume_pr_monitor(self, workspace_id: str) -> None:
+                self.resume_calls.append(workspace_id)
+                monitor_started.set()
+                await release_monitor.wait()
+
+        executor = _BlockingExecutor()
+        worker_a = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker_b = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=1,
+                max_concurrent_executions=1,
+            ),
+        )
+
+        dispatched = await asyncio.gather(worker_a.run_once(), worker_b.run_once())
+        await asyncio.wait_for(monitor_started.wait(), timeout=0.2)
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(monitor_id)
+            assert ws is not None
+            assert ws.monitor_claimed_by is not None
+            assert ws.monitor_claim_expires_at is not None
+
+        release_monitor.set()
+        await asyncio.wait_for(
+            asyncio.gather(
+                worker_a.wait_for_execution_tasks(), worker_b.wait_for_execution_tasks()
+            ),
+            timeout=0.5,
+        )
+
+        assert sorted(dispatched) == [0, 1]
+        assert executor.resume_calls == [monitor_id]
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(monitor_id)
+            assert ws is not None
+            assert ws.monitor_claimed_by is None
+            assert ws.monitor_claim_expires_at is None

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -2,7 +2,7 @@
 
 We use the real Provisioner against real git + SQLite to validate the full
 pipeline, rather than mocking the provisioner. The worker's contract is
-primarily about claiming work off the DB in the right order and bounding
+primarily about listing work off the DB in the right order and bounding
 concurrency, so end-to-end is the most useful test.
 """
 
@@ -422,14 +422,14 @@ class TestRunOnceExecution:
             worker._execution_tasks.pop("busy", None)
 
     @pytest.mark.unit
-    async def test_schedulable_statuses_are_claimed_through_repository(
+    async def test_schedulable_statuses_are_listed_through_repository(
         self,
         monkeypatch: pytest.MonkeyPatch,
         session_factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        claims: list[tuple[WorkspaceStatus, int, set[str]]] = []
+        queries: list[tuple[WorkspaceStatus, int, set[str]]] = []
 
-        async def _claim_schedulable_ids(
+        async def _list_schedulable_ids(
             self: WorkspaceRepository,
             *,
             status: WorkspaceStatus,
@@ -437,13 +437,13 @@ class TestRunOnceExecution:
             exclude_ids: set[str] | None = None,
         ) -> list[str]:
             del self
-            claims.append((status, limit, set(exclude_ids or set())))
+            queries.append((status, limit, set(exclude_ids or set())))
             return []
 
         monkeypatch.setattr(
             WorkspaceRepository,
-            "claim_schedulable_ids",
-            _claim_schedulable_ids,
+            "list_schedulable_ids",
+            _list_schedulable_ids,
             raising=False,
         )
 
@@ -459,7 +459,7 @@ class TestRunOnceExecution:
         )
 
         assert await worker.run_once() == 0
-        assert claims == [
+        assert queries == [
             (WorkspaceStatus.requested, 2, set()),
             (WorkspaceStatus.monitoring_pr, 4, set()),
             (WorkspaceStatus.ready, 4, set()),

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.control.state_machine import InvalidWorkspaceTransitionError
@@ -88,6 +89,36 @@ class _RecordingSession:
         parameters: dict[str, object] | None = None,
     ) -> None:
         self.executed.append((str(statement), dict(parameters or {})))
+
+
+class _FakeScalarResult:
+    def __init__(self, values: list[str]) -> None:
+        self._values = values
+
+    def scalars(self) -> _FakeScalarResult:
+        return self
+
+    def all(self) -> list[str]:
+        return self._values
+
+
+class _RecordingClaimSession:
+    def __init__(self, dialect_name: str, values: list[str] | None = None) -> None:
+        self._bind = _FakeBind(dialect_name)
+        self.values = list(values or [])
+        self.executed: list[object] = []
+
+    def get_bind(self) -> _FakeBind:
+        return self._bind
+
+    async def execute(
+        self,
+        statement: object,
+        parameters: dict[str, object] | None = None,
+    ) -> _FakeScalarResult:
+        del parameters
+        self.executed.append(statement)
+        return _FakeScalarResult(self.values)
 
 
 class TestCreate:
@@ -452,6 +483,62 @@ class TestListWorkspaces:
 
 
 class TestOwnedPathConflictLookup:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "status",
+        [
+            WorkspaceStatus.requested,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.monitoring_pr,
+        ],
+    )
+    async def test_postgres_scheduler_claims_skip_locked_rows(
+        self,
+        status: WorkspaceStatus,
+    ) -> None:
+        session = _RecordingClaimSession("postgresql", values=["ws_claimed"])
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        claimed = await repo.claim_schedulable_ids(
+            status=status,
+            limit=1,
+            exclude_ids={"ws_active"},
+        )
+
+        assert claimed == ["ws_claimed"]
+        assert len(session.executed) == 1
+        sql = str(
+            session.executed[0].compile(  # type: ignore[attr-defined]
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "FOR UPDATE" in sql
+        assert "SKIP LOCKED" in sql
+        assert f"workspaces.status = '{status.value}'" in sql
+        assert "workspaces.id NOT IN ('ws_active')" in sql
+
+    @pytest.mark.unit
+    async def test_sqlite_scheduler_claims_use_portable_select(self) -> None:
+        session = _RecordingClaimSession("sqlite", values=["ws_claimed"])
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        claimed = await repo.claim_schedulable_ids(
+            status=WorkspaceStatus.requested,
+            limit=1,
+        )
+
+        assert claimed == ["ws_claimed"]
+        assert len(session.executed) == 1
+        sql = str(
+            session.executed[0].compile(  # type: ignore[attr-defined]
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "FOR UPDATE" not in sql
+        assert "SKIP LOCKED" not in sql
+
     @pytest.mark.unit
     async def test_postgres_conflict_lookup_lock_uses_transaction_advisory_lock(self) -> None:
         session = _RecordingSession("postgresql")

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -101,8 +101,11 @@ class _FakeScalarResult:
     def all(self) -> list[str]:
         return self._values
 
+    def scalar_one_or_none(self) -> str | None:
+        return self._values[0] if self._values else None
 
-class _RecordingClaimSession:
+
+class _RecordingSchedulerSession:
     def __init__(self, dialect_name: str, values: list[str] | None = None) -> None:
         self._bind = _FakeBind(dialect_name)
         self.values = list(values or [])
@@ -492,20 +495,20 @@ class TestOwnedPathConflictLookup:
             WorkspaceStatus.monitoring_pr,
         ],
     )
-    async def test_postgres_scheduler_claims_skip_locked_rows(
+    async def test_postgres_scheduler_lists_skip_locked_rows(
         self,
         status: WorkspaceStatus,
     ) -> None:
-        session = _RecordingClaimSession("postgresql", values=["ws_claimed"])
+        session = _RecordingSchedulerSession("postgresql", values=["ws_claimed"])
         repo = WorkspaceRepository(session)  # type: ignore[arg-type]
 
-        claimed = await repo.claim_schedulable_ids(
+        listed = await repo.list_schedulable_ids(
             status=status,
             limit=1,
             exclude_ids={"ws_active"},
         )
 
-        assert claimed == ["ws_claimed"]
+        assert listed == ["ws_claimed"]
         assert len(session.executed) == 1
         sql = str(
             session.executed[0].compile(  # type: ignore[attr-defined]
@@ -519,16 +522,16 @@ class TestOwnedPathConflictLookup:
         assert "workspaces.id NOT IN ('ws_active')" in sql
 
     @pytest.mark.unit
-    async def test_sqlite_scheduler_claims_use_portable_select(self) -> None:
-        session = _RecordingClaimSession("sqlite", values=["ws_claimed"])
+    async def test_sqlite_scheduler_lists_use_portable_select(self) -> None:
+        session = _RecordingSchedulerSession("sqlite", values=["ws_claimed"])
         repo = WorkspaceRepository(session)  # type: ignore[arg-type]
 
-        claimed = await repo.claim_schedulable_ids(
+        listed = await repo.list_schedulable_ids(
             status=WorkspaceStatus.requested,
             limit=1,
         )
 
-        assert claimed == ["ws_claimed"]
+        assert listed == ["ws_claimed"]
         assert len(session.executed) == 1
         sql = str(
             session.executed[0].compile(  # type: ignore[attr-defined]
@@ -538,6 +541,41 @@ class TestOwnedPathConflictLookup:
         )
         assert "FOR UPDATE" not in sql
         assert "SKIP LOCKED" not in sql
+
+    @pytest.mark.unit
+    async def test_postgres_get_for_update_locks_workspace_row(self) -> None:
+        session = _RecordingSchedulerSession("postgresql", values=["ws_locked"])
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        locked = await repo.get_for_update("ws_locked")
+
+        assert locked == "ws_locked"
+        assert len(session.executed) == 1
+        sql = str(
+            session.executed[0].compile(  # type: ignore[attr-defined]
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "FOR UPDATE" in sql
+        assert "workspaces.id = 'ws_locked'" in sql
+
+    @pytest.mark.unit
+    async def test_sqlite_get_for_update_uses_portable_select(self) -> None:
+        session = _RecordingSchedulerSession("sqlite", values=["ws_locked"])
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        locked = await repo.get_for_update("ws_locked")
+
+        assert locked == "ws_locked"
+        assert len(session.executed) == 1
+        sql = str(
+            session.executed[0].compile(  # type: ignore[attr-defined]
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "FOR UPDATE" not in sql
 
     @pytest.mark.unit
     async def test_postgres_conflict_lookup_lock_uses_transaction_advisory_lock(self) -> None:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -22,6 +22,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.control.state_machine import InvalidWorkspaceTransitionError
 from awf.db.base import Base
+from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace, WorkspaceEvent
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
@@ -65,23 +66,10 @@ async def _create_policy_workspace(
     return workspace
 
 
-class _FakeDialect:
-    def __init__(self, name: str) -> None:
-        self.name = name
-
-
-class _FakeBind:
-    def __init__(self, dialect_name: str) -> None:
-        self.dialect = _FakeDialect(dialect_name)
-
-
 class _RecordingSession:
     def __init__(self, dialect_name: str) -> None:
-        self._bind = _FakeBind(dialect_name)
+        del dialect_name
         self.executed: list[tuple[str, dict[str, object]]] = []
-
-    def get_bind(self) -> _FakeBind:
-        return self._bind
 
     async def execute(
         self,
@@ -107,12 +95,10 @@ class _FakeScalarResult:
 
 class _RecordingSchedulerSession:
     def __init__(self, dialect_name: str, values: list[str] | None = None) -> None:
-        self._bind = _FakeBind(dialect_name)
+        del dialect_name
+        self.info: dict[str, object] = {}
         self.values = list(values or [])
         self.executed: list[object] = []
-
-    def get_bind(self) -> _FakeBind:
-        return self._bind
 
     async def execute(
         self,
@@ -500,7 +486,7 @@ class TestOwnedPathConflictLookup:
         status: WorkspaceStatus,
     ) -> None:
         session = _RecordingSchedulerSession("postgresql", values=["ws_claimed"])
-        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+        repo = WorkspaceRepository(session, dialect_name="postgresql")  # type: ignore[arg-type]
 
         listed = await repo.list_schedulable_ids(
             status=status,
@@ -524,7 +510,7 @@ class TestOwnedPathConflictLookup:
     @pytest.mark.unit
     async def test_sqlite_scheduler_lists_use_portable_select(self) -> None:
         session = _RecordingSchedulerSession("sqlite", values=["ws_claimed"])
-        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+        repo = WorkspaceRepository(session, dialect_name="sqlite")  # type: ignore[arg-type]
 
         listed = await repo.list_schedulable_ids(
             status=WorkspaceStatus.requested,
@@ -545,7 +531,7 @@ class TestOwnedPathConflictLookup:
     @pytest.mark.unit
     async def test_postgres_get_for_update_locks_workspace_row(self) -> None:
         session = _RecordingSchedulerSession("postgresql", values=["ws_locked"])
-        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+        repo = WorkspaceRepository(session, dialect_name="postgresql")  # type: ignore[arg-type]
 
         locked = await repo.get_for_update("ws_locked")
 
@@ -563,7 +549,7 @@ class TestOwnedPathConflictLookup:
     @pytest.mark.unit
     async def test_sqlite_get_for_update_uses_portable_select(self) -> None:
         session = _RecordingSchedulerSession("sqlite", values=["ws_locked"])
-        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+        repo = WorkspaceRepository(session, dialect_name="sqlite")  # type: ignore[arg-type]
 
         locked = await repo.get_for_update("ws_locked")
 
@@ -578,9 +564,29 @@ class TestOwnedPathConflictLookup:
         assert "FOR UPDATE" not in sql
 
     @pytest.mark.unit
+    async def test_session_info_dialect_drives_scheduler_locking(self) -> None:
+        session = _RecordingSchedulerSession("postgresql", values=["ws_claimed"])
+        session.info[SESSION_DIALECT_NAME_KEY] = "postgresql"
+        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+
+        listed = await repo.list_schedulable_ids(
+            status=WorkspaceStatus.requested,
+            limit=1,
+        )
+
+        assert listed == ["ws_claimed"]
+        sql = str(
+            session.executed[0].compile(  # type: ignore[attr-defined]
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+        assert "SKIP LOCKED" in sql
+
+    @pytest.mark.unit
     async def test_postgres_conflict_lookup_lock_uses_transaction_advisory_lock(self) -> None:
         session = _RecordingSession("postgresql")
-        repo = WorkspaceRepository(session)  # type: ignore[arg-type]
+        repo = WorkspaceRepository(session, dialect_name="postgresql")  # type: ignore[arg-type]
 
         await repo.acquire_owned_path_conflict_lock(
             repo_url="git@github.com:example/app.git",
@@ -596,7 +602,7 @@ class TestOwnedPathConflictLookup:
     @pytest.mark.unit
     async def test_conflict_lookup_lock_is_noop_without_postgres_or_owned_paths(self) -> None:
         sqlite_session = _RecordingSession("sqlite")
-        sqlite_repo = WorkspaceRepository(sqlite_session)  # type: ignore[arg-type]
+        sqlite_repo = WorkspaceRepository(sqlite_session, dialect_name="sqlite")  # type: ignore[arg-type]
 
         await sqlite_repo.acquire_owned_path_conflict_lock(
             repo_url="git@github.com:example/app.git",
@@ -605,7 +611,10 @@ class TestOwnedPathConflictLookup:
         )
 
         postgres_session = _RecordingSession("postgresql")
-        postgres_repo = WorkspaceRepository(postgres_session)  # type: ignore[arg-type]
+        postgres_repo = WorkspaceRepository(
+            postgres_session,
+            dialect_name="postgresql",
+        )  # type: ignore[arg-type]
 
         await postgres_repo.acquire_owned_path_conflict_lock(
             repo_url="git@github.com:example/app.git",


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_54ad710e09e24f3c81878ba8` (agent: `codex`).


### Task
Implement the PRD-backed durable worker scheduling slice. Goal: ControlWorker must claim requested/ready/monitoring_pr work in a way that is safe for multiple worker processes against Postgres, using SELECT ... FOR UPDATE SKIP LOCKED or an equivalent SQLAlchemy pattern, while preserving SQLite/test compatibility. Strict TDD: first add focused failing tests proving two workers cannot claim the same requested/ready/monitoring_pr workspace and that SQLite still follows the compatibility path. Then implement. Keep the change narrowly scoped to worker/repository scheduling helpers. Do not push or change branches; AWF owns branch lifecycle. Commit locally with conventional commit messages. Validation commands must pass: uv run ruff check src/awf/control src/awf/db tests/unit/control tests/unit/db; uv run mypy src/awf/control src/awf/db; uv run pytest tests/unit/control tests/unit/db -q.

---
Validation: 6 profile command(s) passed inside the workspace container.
