### PR TITLE
feat(locks): expose active owned-path reservations

### DIFF
--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -25,6 +25,7 @@ from awf.api.routes import (
     controls,
     events,
     health,
+    locks,
     logs,
     metrics,
     operations,
@@ -109,6 +110,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     app.include_router(workspaces.router_v2)
     app.include_router(events.router)
     app.include_router(tasks.router)
+    app.include_router(locks.router)
     app.include_router(runtime.router)
     app.include_router(artifacts.router)
     app.include_router(logs.router)

--- a/src/awf/api/routes/locks.py
+++ b/src/awf/api/routes/locks.py
@@ -1,0 +1,37 @@
+"""Lock reservation visibility endpoints."""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.deps import get_db_session_factory
+from awf.api.schemas import WorkspaceLockListResponse, WorkspaceLockResponse
+from awf.db.enums import TaskClass, WorkspaceStatus
+from awf.service.locks import list_workspace_locks
+
+router = APIRouter(prefix="/v1/locks", tags=["locks"])
+
+
+@router.get("", response_model=WorkspaceLockListResponse)
+async def list_locks(
+    repo_url: Annotated[str | None, Query(min_length=1, max_length=512)] = None,
+    task_class: Annotated[TaskClass | None, Query()] = None,
+    workspace_status: Annotated[WorkspaceStatus | None, Query(alias="status")] = None,
+    limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
+) -> WorkspaceLockListResponse:
+    rows = await list_workspace_locks(
+        session_factory,
+        repo_url=repo_url,
+        task_class=task_class,
+        status=workspace_status,
+        limit=limit,
+    )
+    return WorkspaceLockListResponse(
+        items=[WorkspaceLockResponse.model_validate(row) for row in rows],
+        next_cursor=None,
+        has_more=False,
+    )

--- a/src/awf/api/routes/locks.py
+++ b/src/awf/api/routes/locks.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import status as fastapi_status
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.deps import get_db_session_factory
 from awf.api.schemas import WorkspaceLockListResponse, WorkspaceLockResponse
 from awf.db.enums import TaskClass, WorkspaceStatus
-from awf.service.locks import list_workspace_locks
+from awf.service.locks import InvalidWorkspaceLockCursorError, list_workspace_lock_page
 
 router = APIRouter(prefix="/v1/locks", tags=["locks"])
 
@@ -21,17 +22,25 @@ async def list_locks(
     task_class: Annotated[TaskClass | None, Query()] = None,
     workspace_status: Annotated[WorkspaceStatus | None, Query(alias="status")] = None,
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
+    cursor: Annotated[str | None, Query(max_length=256)] = None,
     session_factory: async_sessionmaker[AsyncSession] = Depends(get_db_session_factory),
 ) -> WorkspaceLockListResponse:
-    rows = await list_workspace_locks(
-        session_factory,
-        repo_url=repo_url,
-        task_class=task_class,
-        status=workspace_status,
-        limit=limit,
-    )
+    try:
+        page = await list_workspace_lock_page(
+            session_factory,
+            repo_url=repo_url,
+            task_class=task_class,
+            status=workspace_status,
+            limit=limit,
+            cursor=cursor,
+        )
+    except InvalidWorkspaceLockCursorError as exc:
+        raise HTTPException(
+            status_code=fastapi_status.HTTP_400_BAD_REQUEST,
+            detail={"error_code": "INVALID_CURSOR", "message": "Invalid lock list cursor."},
+        ) from exc
     return WorkspaceLockListResponse(
-        items=[WorkspaceLockResponse.model_validate(row) for row in rows],
-        next_cursor=None,
-        has_more=False,
+        items=[WorkspaceLockResponse.model_validate(row) for row in page.items],
+        next_cursor=page.next_cursor,
+        has_more=page.has_more,
     )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -236,6 +236,28 @@ class WorkspaceOverviewListResponse(BaseModel):
     has_more: bool = False
 
 
+class WorkspaceLockResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    workspace_id: str
+    title: str
+    agent: AgentRuntime
+    status: WorkspaceStatus
+    repo_url: str
+    branch_base: str
+    task_class: TaskClass | None
+    owned_paths: list[str]
+    pr_url: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class WorkspaceLockListResponse(BaseModel):
+    items: list[WorkspaceLockResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
 class RuntimeServiceResponse(BaseModel):
     name: str
     container_id: str | None = None

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -24,7 +24,7 @@ from typing import Any
 import httpx
 import typer
 
-from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.enums import OperationStatus, OperationType, TaskClass, WorkspaceStatus
 from awf.service.gc import DEFAULT_MIN_AGE_HOURS
 from awf.service.logs import DEFAULT_LOG_TAIL, ServiceLogName
 
@@ -38,9 +38,11 @@ app = typer.Typer(
 workspace_app = typer.Typer(help="Workspace lifecycle (create/inspect/destroy).")
 profile_app = typer.Typer(help="Workspace profile inspection.")
 service_app = typer.Typer(help="Local service operations.")
+locks_app = typer.Typer(help="Lock reservation visibility.")
 app.add_typer(workspace_app, name="workspace")
 app.add_typer(profile_app, name="profile")
 app.add_typer(service_app, name="service")
+app.add_typer(locks_app, name="locks")
 
 
 class OutputFormat(StrEnum):
@@ -102,7 +104,12 @@ def _call(method: str, path: str, *, base_url: str, **kwargs: Any) -> httpx.Resp
         raise typer.Exit(code=2) from exc
 
 
-def _handle_response(response: httpx.Response, fmt: OutputFormat) -> None:
+def _handle_response(
+    response: httpx.Response,
+    fmt: OutputFormat,
+    *,
+    pretty_items: bool = False,
+) -> None:
     if response.status_code >= 400:
         try:
             typer.echo(json.dumps(response.json(), indent=2), err=True)
@@ -111,7 +118,16 @@ def _handle_response(response: httpx.Response, fmt: OutputFormat) -> None:
         raise typer.Exit(code=1)
     if response.status_code == 204 or not response.content:
         return
-    _emit(response.json(), fmt)
+    payload = response.json()
+    if (
+        pretty_items
+        and fmt == OutputFormat.pretty
+        and isinstance(payload, dict)
+        and isinstance(payload.get("items"), list)
+    ):
+        _emit(payload["items"], fmt)
+        return
+    _emit(payload, fmt)
 
 
 # ── Commands ─────────────────────────────────────────────────────────────
@@ -359,6 +375,34 @@ def workspace_list(
         params={"limit": limit},
     )
     _handle_response(response, fmt)
+
+
+@locks_app.command("list")
+def locks_list(
+    repo_url: str | None = typer.Option(None, "--repo-url"),
+    task_class: TaskClass | None = typer.Option(None, "--task-class"),
+    status: WorkspaceStatus | None = typer.Option(None, "--status"),
+    limit: int = typer.Option(50, "--limit", min=1, max=500),
+    api_token: str | None = _api_token_option(),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """List workspace lock reservations."""
+    params: dict[str, Any] = {"limit": limit}
+    if repo_url is not None:
+        params["repo_url"] = repo_url
+    if task_class is not None:
+        params["task_class"] = task_class.value
+    if status is not None:
+        params["status"] = status.value
+    response = _call(
+        "GET",
+        "/v1/locks",
+        base_url=_base_url(base_url),
+        params=params,
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt, pretty_items=True)
 
 
 @workspace_app.command("events")

--- a/src/awf/service/locks.py
+++ b/src/awf/service/locks.py
@@ -148,7 +148,7 @@ async def list_workspace_lock_page_for_session(
         )
     stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit + 1)
 
-    rows = list((await session.execute(stmt)).scalars())
+    rows = (await session.execute(stmt)).scalars().all()
     page_rows = rows[:limit]
     has_more = len(rows) > limit
     return WorkspaceLockPage(

--- a/src/awf/service/locks.py
+++ b/src/awf/service/locks.py
@@ -25,7 +25,7 @@ class WorkspaceLock:
     repo_url: str
     branch_base: str
     task_class: str | None
-    owned_paths: list[str]
+    owned_paths: tuple[str, ...]
     pr_url: str | None
     created_at: datetime
     updated_at: datetime
@@ -167,7 +167,7 @@ def _workspace_lock(workspace: Workspace) -> WorkspaceLock:
         repo_url=workspace.repo_url,
         branch_base=workspace.branch_base,
         task_class=workspace.task_class,
-        owned_paths=list(workspace.owned_paths),
+        owned_paths=tuple(workspace.owned_paths),
         pr_url=workspace.pr_url,
         created_at=workspace.created_at,
         updated_at=workspace.updated_at,

--- a/src/awf/service/locks.py
+++ b/src/awf/service/locks.py
@@ -1,0 +1,105 @@
+"""Read-only lock reservation queries for operator visibility."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.enums import TaskClass, WorkspaceStatus
+from awf.db.models import Workspace
+from awf.db.repositories import ACTIVE_OWNED_PATH_CONFLICT_STATUSES
+
+
+@dataclass(frozen=True)
+class WorkspaceLock:
+    workspace_id: str
+    title: str
+    agent: str
+    status: str
+    repo_url: str
+    branch_base: str
+    task_class: str | None
+    owned_paths: list[str]
+    pr_url: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+async def list_workspace_locks(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    repo_url: str | None = None,
+    task_class: TaskClass | str | None = None,
+    status: WorkspaceStatus | str | None = None,
+    limit: int = 50,
+) -> list[WorkspaceLock]:
+    """List workspace lock reservations, newest first.
+
+    With no explicit status, the listing mirrors the owned-path admission policy
+    and shows only workspaces that still block new overlapping reservations.
+    """
+    async with session_factory() as session:
+        return await list_workspace_locks_for_session(
+            session,
+            repo_url=repo_url,
+            task_class=task_class,
+            status=status,
+            limit=limit,
+        )
+
+
+async def list_workspace_locks_for_session(
+    session: AsyncSession,
+    *,
+    repo_url: str | None = None,
+    task_class: TaskClass | str | None = None,
+    status: WorkspaceStatus | str | None = None,
+    limit: int = 50,
+) -> list[WorkspaceLock]:
+    status_value = _status_value(status)
+    task_class_value = _task_class_value(task_class)
+
+    stmt = select(Workspace)
+    if status_value is None:
+        stmt = stmt.where(Workspace.status.in_(ACTIVE_OWNED_PATH_CONFLICT_STATUSES))
+    else:
+        stmt = stmt.where(Workspace.status == status_value)
+    if repo_url is not None:
+        stmt = stmt.where(Workspace.repo_url == repo_url)
+    if task_class_value is not None:
+        stmt = stmt.where(Workspace.task_class == task_class_value)
+    stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
+
+    rows = list((await session.execute(stmt)).scalars())
+    return [_workspace_lock(row) for row in rows]
+
+
+def _workspace_lock(workspace: Workspace) -> WorkspaceLock:
+    return WorkspaceLock(
+        workspace_id=workspace.id,
+        title=workspace.task_title,
+        agent=workspace.agent,
+        status=workspace.status,
+        repo_url=workspace.repo_url,
+        branch_base=workspace.branch_base,
+        task_class=workspace.task_class,
+        owned_paths=list(workspace.owned_paths),
+        pr_url=workspace.pr_url,
+        created_at=workspace.created_at,
+        updated_at=workspace.updated_at,
+    )
+
+
+def _status_value(status: WorkspaceStatus | str | None) -> str | None:
+    if status is None:
+        return None
+    return status.value if isinstance(status, WorkspaceStatus) else status
+
+
+def _task_class_value(task_class: TaskClass | str | None) -> str | None:
+    if task_class is None:
+        return None
+    return task_class.value if isinstance(task_class, TaskClass) else task_class

--- a/src/awf/service/locks.py
+++ b/src/awf/service/locks.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import base64
+import binascii
+import json
 from dataclasses import dataclass
 from datetime import datetime
 
-from sqlalchemy import select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.db.enums import TaskClass, WorkspaceStatus
@@ -28,6 +31,23 @@ class WorkspaceLock:
     updated_at: datetime
 
 
+@dataclass(frozen=True)
+class WorkspaceLockPage:
+    items: list[WorkspaceLock]
+    next_cursor: str | None
+    has_more: bool
+
+
+@dataclass(frozen=True)
+class _DecodedCursor:
+    created_at: datetime
+    workspace_id: str
+
+
+class InvalidWorkspaceLockCursorError(ValueError):
+    """Raised when a workspace lock pagination cursor cannot be decoded."""
+
+
 async def list_workspace_locks(
     session_factory: async_sessionmaker[AsyncSession],
     *,
@@ -35,19 +55,42 @@ async def list_workspace_locks(
     task_class: TaskClass | str | None = None,
     status: WorkspaceStatus | str | None = None,
     limit: int = 50,
+    cursor: str | None = None,
 ) -> list[WorkspaceLock]:
     """List workspace lock reservations, newest first.
 
     With no explicit status, the listing mirrors the owned-path admission policy
     and shows only workspaces that still block new overlapping reservations.
     """
+    page = await list_workspace_lock_page(
+        session_factory,
+        repo_url=repo_url,
+        task_class=task_class,
+        status=status,
+        limit=limit,
+        cursor=cursor,
+    )
+    return page.items
+
+
+async def list_workspace_lock_page(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    repo_url: str | None = None,
+    task_class: TaskClass | str | None = None,
+    status: WorkspaceStatus | str | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> WorkspaceLockPage:
+    """List one page of workspace lock reservations, newest first."""
     async with session_factory() as session:
-        return await list_workspace_locks_for_session(
+        return await list_workspace_lock_page_for_session(
             session,
             repo_url=repo_url,
             task_class=task_class,
             status=status,
             limit=limit,
+            cursor=cursor,
         )
 
 
@@ -58,9 +101,31 @@ async def list_workspace_locks_for_session(
     task_class: TaskClass | str | None = None,
     status: WorkspaceStatus | str | None = None,
     limit: int = 50,
+    cursor: str | None = None,
 ) -> list[WorkspaceLock]:
+    page = await list_workspace_lock_page_for_session(
+        session,
+        repo_url=repo_url,
+        task_class=task_class,
+        status=status,
+        limit=limit,
+        cursor=cursor,
+    )
+    return page.items
+
+
+async def list_workspace_lock_page_for_session(
+    session: AsyncSession,
+    *,
+    repo_url: str | None = None,
+    task_class: TaskClass | str | None = None,
+    status: WorkspaceStatus | str | None = None,
+    limit: int = 50,
+    cursor: str | None = None,
+) -> WorkspaceLockPage:
     status_value = _status_value(status)
     task_class_value = _task_class_value(task_class)
+    decoded_cursor = _decode_cursor(cursor)
 
     stmt = select(Workspace)
     if status_value is None:
@@ -71,10 +136,26 @@ async def list_workspace_locks_for_session(
         stmt = stmt.where(Workspace.repo_url == repo_url)
     if task_class_value is not None:
         stmt = stmt.where(Workspace.task_class == task_class_value)
-    stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit)
+    if decoded_cursor is not None:
+        stmt = stmt.where(
+            or_(
+                Workspace.created_at < decoded_cursor.created_at,
+                and_(
+                    Workspace.created_at == decoded_cursor.created_at,
+                    Workspace.id < decoded_cursor.workspace_id,
+                ),
+            )
+        )
+    stmt = stmt.order_by(Workspace.created_at.desc(), Workspace.id.desc()).limit(limit + 1)
 
     rows = list((await session.execute(stmt)).scalars())
-    return [_workspace_lock(row) for row in rows]
+    page_rows = rows[:limit]
+    has_more = len(rows) > limit
+    return WorkspaceLockPage(
+        items=[_workspace_lock(row) for row in page_rows],
+        next_cursor=_encode_cursor(page_rows[-1]) if has_more and page_rows else None,
+        has_more=has_more,
+    )
 
 
 def _workspace_lock(workspace: Workspace) -> WorkspaceLock:
@@ -103,3 +184,34 @@ def _task_class_value(task_class: TaskClass | str | None) -> str | None:
     if task_class is None:
         return None
     return task_class.value if isinstance(task_class, TaskClass) else task_class
+
+
+def _encode_cursor(workspace: Workspace) -> str:
+    payload = {
+        "created_at": workspace.created_at.isoformat(),
+        "workspace_id": workspace.id,
+    }
+    encoded = base64.urlsafe_b64encode(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    return encoded.decode("ascii")
+
+
+def _decode_cursor(cursor: str | None) -> _DecodedCursor | None:
+    if cursor is None:
+        return None
+    try:
+        decoded = base64.urlsafe_b64decode(cursor.encode("ascii"))
+        payload = json.loads(decoded.decode("utf-8"))
+        created_at = datetime.fromisoformat(payload["created_at"])
+        workspace_id = payload["workspace_id"]
+    except (
+        binascii.Error,
+        KeyError,
+        TypeError,
+        UnicodeDecodeError,
+        ValueError,
+        json.JSONDecodeError,
+    ) as exc:
+        raise InvalidWorkspaceLockCursorError("Invalid workspace lock cursor") from exc
+    if not isinstance(workspace_id, str) or workspace_id == "":
+        raise InvalidWorkspaceLockCursorError("Invalid workspace lock cursor")
+    return _DecodedCursor(created_at=created_at, workspace_id=workspace_id)

--- a/tests/unit/api/test_locks.py
+++ b/tests/unit/api/test_locks.py
@@ -160,3 +160,49 @@ async def test_get_locks_applies_repo_task_class_status_and_limit_filters(
 
     assert response.status_code == 200
     assert [item["workspace_id"] for item in response.json()["items"]] == [matching_id]
+
+
+@pytest.mark.unit
+async def test_get_locks_reports_has_more_and_accepts_next_cursor(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    first_id = await _create_lock_workspace(
+        client,
+        title="First reservation",
+        owned_paths=["src/first/**"],
+    )
+    second_id = await _create_lock_workspace(
+        client,
+        title="Second reservation",
+        owned_paths=["src/second/**"],
+    )
+    await _set_workspace_status(engine, first_id, WorkspaceStatus.ready)
+    await _set_workspace_status(engine, second_id, WorkspaceStatus.ready)
+
+    first_response = await client.get(
+        "/v1/locks",
+        params={"status": "ready", "limit": 1},
+    )
+
+    assert first_response.status_code == 200
+    first_body = first_response.json()
+    assert len(first_body["items"]) == 1
+    assert first_body["has_more"] is True
+    assert first_body["next_cursor"] is not None
+
+    second_response = await client.get(
+        "/v1/locks",
+        params={"status": "ready", "limit": 1, "cursor": first_body["next_cursor"]},
+    )
+
+    assert second_response.status_code == 200
+    second_body = second_response.json()
+    assert len(second_body["items"]) == 1
+    assert second_body["has_more"] is False
+    assert second_body["next_cursor"] is None
+    returned_ids = {
+        first_body["items"][0]["workspace_id"],
+        second_body["items"][0]["workspace_id"],
+    }
+    assert returned_ids == {first_id, second_id}

--- a/tests/unit/api/test_locks.py
+++ b/tests/unit/api/test_locks.py
@@ -1,0 +1,162 @@
+"""Lock reservation API tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+def _v2_body(
+    *,
+    repo_url: str = "git@github.com:example/app.git",
+    base_branch: str = "main",
+    title: str = "Expose locks",
+    task_class: str = "refactor_task",
+    owned_paths: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "repo": {"url": repo_url, "base_branch": base_branch},
+        "task": {
+            "title": title,
+            "prompt": "Expose lock reservations.",
+            "agent": "codex",
+            "kind": "feature_branch_pr",
+            "task_class": task_class,
+            "owned_paths": list(owned_paths or []),
+        },
+        "workspace": {"profile_ref": "auto", "profile": None},
+        "validation": {"commands": ["pytest -q"], "requested_tier": 1},
+        "resources": {},
+    }
+
+
+async def _create_lock_workspace(
+    client: AsyncClient,
+    *,
+    repo_url: str = "git@github.com:example/app.git",
+    title: str = "Expose locks",
+    task_class: str = "refactor_task",
+    owned_paths: list[str] | None = None,
+) -> str:
+    response = await client.post(
+        "/v2/workspaces",
+        json=_v2_body(
+            repo_url=repo_url,
+            title=title,
+            task_class=task_class,
+            owned_paths=owned_paths,
+        ),
+    )
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _set_workspace_status(
+    engine: AsyncEngine,
+    workspace_id: str,
+    status: WorkspaceStatus,
+    *,
+    pr_url: str | None = None,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        workspace.status = status.value
+        workspace.pr_url = pr_url
+        await session.commit()
+
+
+@pytest.mark.unit
+async def test_get_locks_lists_active_reservations_and_excludes_terminal_by_default(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    active_id = await _create_lock_workspace(
+        client,
+        title="API lock visibility",
+        task_class="refactor_task",
+        owned_paths=["src/awf/api/**", "tests/unit/api/**"],
+    )
+    terminal_id = await _create_lock_workspace(
+        client,
+        title="Completed reservation",
+        task_class="docs_task",
+        owned_paths=["docs/**"],
+    )
+    await _set_workspace_status(
+        engine,
+        active_id,
+        WorkspaceStatus.running,
+        pr_url="https://github.com/example/app/pull/12",
+    )
+    await _set_workspace_status(engine, terminal_id, WorkspaceStatus.completed)
+
+    response = await client.get("/v1/locks")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["next_cursor"] is None
+    assert body["has_more"] is False
+    assert [item["workspace_id"] for item in body["items"]] == [active_id]
+    item = body["items"][0]
+    assert item["title"] == "API lock visibility"
+    assert item["agent"] == "codex"
+    assert item["status"] == "running"
+    assert item["repo_url"] == "git@github.com:example/app.git"
+    assert item["branch_base"] == "main"
+    assert item["task_class"] == "refactor_task"
+    assert item["owned_paths"] == ["src/awf/api/**", "tests/unit/api/**"]
+    assert item["pr_url"] == "https://github.com/example/app/pull/12"
+    assert "created_at" in item
+    assert "updated_at" in item
+
+
+@pytest.mark.unit
+async def test_get_locks_applies_repo_task_class_status_and_limit_filters(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    matching_id = await _create_lock_workspace(
+        client,
+        repo_url="git@github.com:example/app.git",
+        title="Matching reservation",
+        task_class="test_task",
+        owned_paths=["tests/unit/**"],
+    )
+    wrong_repo_id = await _create_lock_workspace(
+        client,
+        repo_url="git@github.com:example/docs.git",
+        title="Wrong repo",
+        task_class="test_task",
+        owned_paths=["docs/**"],
+    )
+    wrong_class_id = await _create_lock_workspace(
+        client,
+        repo_url="git@github.com:example/app.git",
+        title="Wrong class",
+        task_class="docs_task",
+        owned_paths=["README.md"],
+    )
+    await _set_workspace_status(engine, matching_id, WorkspaceStatus.ready)
+    await _set_workspace_status(engine, wrong_repo_id, WorkspaceStatus.ready)
+    await _set_workspace_status(engine, wrong_class_id, WorkspaceStatus.ready)
+
+    response = await client.get(
+        "/v1/locks",
+        params={
+            "repo_url": "git@github.com:example/app.git",
+            "task_class": "test_task",
+            "status": "ready",
+            "limit": 1,
+        },
+    )
+
+    assert response.status_code == 200
+    assert [item["workspace_id"] for item in response.json()["items"]] == [matching_id]

--- a/tests/unit/cli/test_locks.py
+++ b/tests/unit/cli/test_locks.py
@@ -1,0 +1,104 @@
+"""Lock reservation CLI tests."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from typer.testing import CliRunner
+
+from awf.cli.main import app
+
+_runner = CliRunner()
+
+
+def _mock_response(*, status_code: int = 200, payload: object = None) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = status_code
+    response.content = b"ok" if payload is not None else b""
+    response.text = json.dumps(payload) if payload is not None else ""
+    response.json.return_value = payload
+    return response
+
+
+class TestLocksList:
+    @pytest.mark.unit
+    def test_fetches_locks_with_filters_and_json_default(self) -> None:
+        payload = {
+            "items": [
+                {
+                    "workspace_id": "ws_lock",
+                    "title": "Lock visibility",
+                    "agent": "codex",
+                    "status": "running",
+                    "repo_url": "git@github.com:example/app.git",
+                    "branch_base": "main",
+                    "task_class": "test_task",
+                    "owned_paths": ["tests/unit/**"],
+                    "pr_url": None,
+                    "created_at": "2026-04-26T12:00:00Z",
+                    "updated_at": "2026-04-26T12:05:00Z",
+                }
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+        response = _mock_response(payload=payload)
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "locks",
+                    "list",
+                    "--repo-url",
+                    "git@github.com:example/app.git",
+                    "--task-class",
+                    "test_task",
+                    "--status",
+                    "running",
+                    "--limit",
+                    "25",
+                    "--base-url",
+                    "http://awf.local",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert json.loads(result.stdout) == payload
+        assert mock.call_args[0] == ("GET", "http://awf.local/v1/locks")
+        assert mock.call_args.kwargs["params"] == {
+            "limit": 25,
+            "repo_url": "git@github.com:example/app.git",
+            "task_class": "test_task",
+            "status": "running",
+        }
+
+    @pytest.mark.unit
+    def test_pretty_format_prints_one_lock_per_block(self) -> None:
+        payload = {
+            "items": [
+                {
+                    "workspace_id": "ws_1",
+                    "title": "First lock",
+                    "status": "ready",
+                },
+                {
+                    "workspace_id": "ws_2",
+                    "title": "Second lock",
+                    "status": "monitoring_pr",
+                },
+            ],
+            "next_cursor": None,
+            "has_more": False,
+        }
+        response = _mock_response(payload=payload)
+        with patch("awf.cli.main.httpx.request", return_value=response):
+            result = _runner.invoke(app, ["locks", "list", "--format", "pretty"])
+
+        assert result.exit_code == 0
+        assert "--- #1 ---" in result.stdout
+        assert "--- #2 ---" in result.stdout
+        assert "workspace_id: ws_1" in result.stdout
+        assert "workspace_id: ws_2" in result.stdout

--- a/tests/unit/service/test_locks.py
+++ b/tests/unit/service/test_locks.py
@@ -1,0 +1,158 @@
+"""Read-only lock reservation service tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+@pytest.fixture
+async def session_factory(
+    engine: AsyncEngine,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield make_session_factory(engine)
+
+
+async def _workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    title: str,
+    repo_url: str = "git@github.com:example/app.git",
+    branch_base: str = "main",
+    task_class: str | None = "refactor_task",
+    owned_paths: list[str] | None = None,
+    status: WorkspaceStatus = WorkspaceStatus.requested,
+    created_at: datetime,
+) -> str:
+    async with session_factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url=repo_url,
+            branch_base=branch_base,
+            task_title=title,
+            task_prompt="Expose lock reservations to operators.",
+            task_class=task_class,
+            owned_paths=list(owned_paths or []),
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = status.value
+        workspace.pr_url = f"https://github.com/example/app/pull/{title[-1]}"
+        workspace.created_at = created_at
+        workspace.updated_at = created_at + timedelta(minutes=5)
+        await session.commit()
+        return workspace.id
+
+
+@pytest.mark.unit
+async def test_list_workspace_locks_defaults_to_active_non_terminal_workspaces(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.locks import list_workspace_locks
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    older_active_id = await _workspace(
+        session_factory,
+        title="Active 1",
+        owned_paths=["src/awf/api/**"],
+        status=WorkspaceStatus.requested,
+        created_at=now,
+    )
+    newer_active_id = await _workspace(
+        session_factory,
+        title="Active 2",
+        owned_paths=["src/awf/service/**"],
+        status=WorkspaceStatus.monitoring_pr,
+        created_at=now + timedelta(minutes=1),
+    )
+    completed_id = await _workspace(
+        session_factory,
+        title="Done 3",
+        owned_paths=["docs/**"],
+        status=WorkspaceStatus.completed,
+        created_at=now + timedelta(minutes=2),
+    )
+    destroying_id = await _workspace(
+        session_factory,
+        title="Cleanup 4",
+        owned_paths=["tests/**"],
+        status=WorkspaceStatus.destroying,
+        created_at=now + timedelta(minutes=3),
+    )
+
+    locks = await list_workspace_locks(session_factory)
+
+    assert [lock.workspace_id for lock in locks] == [newer_active_id, older_active_id]
+    assert completed_id not in {lock.workspace_id for lock in locks}
+    assert destroying_id not in {lock.workspace_id for lock in locks}
+    assert locks[0].title == "Active 2"
+    assert locks[0].agent == "codex"
+    assert locks[0].status == WorkspaceStatus.monitoring_pr.value
+    assert locks[0].repo_url == "git@github.com:example/app.git"
+    assert locks[0].branch_base == "main"
+    assert locks[0].task_class == "refactor_task"
+    assert locks[0].owned_paths == ["src/awf/service/**"]
+    assert locks[0].pr_url == "https://github.com/example/app/pull/2"
+    assert locks[0].created_at == (now + timedelta(minutes=1)).replace(tzinfo=None)
+    assert locks[0].updated_at == (now + timedelta(minutes=6)).replace(tzinfo=None)
+
+
+@pytest.mark.unit
+async def test_list_workspace_locks_applies_repo_task_class_status_and_limit_filters(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.locks import list_workspace_locks
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    matching_id = await _workspace(
+        session_factory,
+        title="Match 1",
+        repo_url="git@github.com:example/app.git",
+        task_class="test_task",
+        owned_paths=["tests/unit/**"],
+        status=WorkspaceStatus.ready,
+        created_at=now,
+    )
+    await _workspace(
+        session_factory,
+        title="Wrong repo 2",
+        repo_url="git@github.com:example/docs.git",
+        task_class="test_task",
+        owned_paths=["tests/unit/**"],
+        status=WorkspaceStatus.ready,
+        created_at=now + timedelta(minutes=1),
+    )
+    await _workspace(
+        session_factory,
+        title="Wrong class 3",
+        repo_url="git@github.com:example/app.git",
+        task_class="docs_task",
+        owned_paths=["docs/**"],
+        status=WorkspaceStatus.ready,
+        created_at=now + timedelta(minutes=2),
+    )
+    await _workspace(
+        session_factory,
+        title="Wrong status 4",
+        repo_url="git@github.com:example/app.git",
+        task_class="test_task",
+        owned_paths=["src/**"],
+        status=WorkspaceStatus.running,
+        created_at=now + timedelta(minutes=3),
+    )
+
+    locks = await list_workspace_locks(
+        session_factory,
+        repo_url="git@github.com:example/app.git",
+        task_class="test_task",
+        status=WorkspaceStatus.ready,
+        limit=1,
+    )
+
+    assert [lock.workspace_id for lock in locks] == [matching_id]

--- a/tests/unit/service/test_locks.py
+++ b/tests/unit/service/test_locks.py
@@ -97,7 +97,8 @@ async def test_list_workspace_locks_defaults_to_active_non_terminal_workspaces(
     assert locks[0].repo_url == "git@github.com:example/app.git"
     assert locks[0].branch_base == "main"
     assert locks[0].task_class == "refactor_task"
-    assert locks[0].owned_paths == ["src/awf/service/**"]
+    assert locks[0].owned_paths == ("src/awf/service/**",)
+    assert isinstance(hash(locks[0]), int)
     assert locks[0].pr_url == "https://github.com/example/app/pull/2"
     assert locks[0].created_at == (now + timedelta(minutes=1)).replace(tzinfo=None)
     assert locks[0].updated_at == (now + timedelta(minutes=6)).replace(tzinfo=None)

--- a/tests/unit/service/test_locks.py
+++ b/tests/unit/service/test_locks.py
@@ -156,3 +156,51 @@ async def test_list_workspace_locks_applies_repo_task_class_status_and_limit_fil
     )
 
     assert [lock.workspace_id for lock in locks] == [matching_id]
+
+
+@pytest.mark.unit
+async def test_list_workspace_lock_page_reports_more_rows_and_uses_next_cursor(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.locks import list_workspace_lock_page
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    oldest_id = await _workspace(
+        session_factory,
+        title="Old 1",
+        status=WorkspaceStatus.ready,
+        created_at=now,
+    )
+    middle_id = await _workspace(
+        session_factory,
+        title="Middle 2",
+        status=WorkspaceStatus.ready,
+        created_at=now + timedelta(minutes=1),
+    )
+    newest_id = await _workspace(
+        session_factory,
+        title="Newest 3",
+        status=WorkspaceStatus.ready,
+        created_at=now + timedelta(minutes=2),
+    )
+
+    first_page = await list_workspace_lock_page(
+        session_factory,
+        status=WorkspaceStatus.ready,
+        limit=2,
+    )
+
+    assert [lock.workspace_id for lock in first_page.items] == [newest_id, middle_id]
+    assert first_page.has_more is True
+    assert first_page.next_cursor is not None
+
+    second_page = await list_workspace_lock_page(
+        session_factory,
+        status=WorkspaceStatus.ready,
+        limit=2,
+        cursor=first_page.next_cursor,
+    )
+
+    assert [lock.workspace_id for lock in second_page.items] == [oldest_id]
+    assert second_page.has_more is False
+    assert second_page.next_cursor is None


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_677ac5840807426aae0f6136` (agent: `codex`).


### Task
Implement the PRD operator visibility slice for locks. Add a read-only locks/reservations listing so operators can see which active workspaces currently reserve task_class + owned_paths and what they would block. Preferred public surface: GET /v1/locks with optional filters for repo_url/task_class/status and CLI command awf locks list with JSON default plus --format pretty. Include workspace id, title, agent, status, repo_url, branch_base, task_class, owned_paths, PR URL, created_at, updated_at. Only active non-terminal workspaces should appear by default. Strict TDD: write API/service/CLI tests first, then implement. Do not push or change branches; AWF owns branch lifecycle. Commit locally with conventional commit messages. Validation commands must pass: uv run ruff check src/awf/api src/awf/service src/awf/cli tests/unit/api tests/unit/service tests/unit/cli; uv run mypy src/awf/api src/awf/service src/awf/cli; uv run pytest tests/unit/api tests/unit/service tests/unit/cli -q.

---
Validation: 6 profile command(s) passed inside the workspace container.
