### PR TITLE
fix(worker): recover stale active executions after service or Docker restart

### DIFF
--- a/migrations/versions/1b2c3d4e5f6a_active_execution_claims.py
+++ b/migrations/versions/1b2c3d4e5f6a_active_execution_claims.py
@@ -1,0 +1,32 @@
+"""Add active execution claim lease columns.
+
+Revision ID: 1b2c3d4e5f6a
+Revises: 0a1b2c3d4e5f
+Create Date: 2026-04-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "1b2c3d4e5f6a"
+down_revision: str | Sequence[str] | None = "0a1b2c3d4e5f"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.add_column(sa.Column("execution_claimed_by", sa.String(length=128), nullable=True))
+        batch.add_column(
+            sa.Column("execution_claim_expires_at", sa.DateTime(timezone=True), nullable=True)
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("workspaces") as batch:
+        batch.drop_column("execution_claim_expires_at")
+        batch.drop_column("execution_claimed_by")

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -19,6 +19,7 @@ import inspect
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -140,14 +141,24 @@ class WorkspaceExecutor:
         self._pr_monitor_factory = pr_monitor_factory
         self._log_store = log_store
 
-    async def execute(self, workspace_id: str) -> None:
+    async def execute(
+        self,
+        workspace_id: str,
+        *,
+        execution_owner_id: str | None = None,
+        execution_lease_expires_at: datetime | None = None,
+    ) -> None:
         """Drive a ``ready`` workspace to ``completed`` (or ``failed``).
 
         The function is idempotent in the sense that it refuses to run on a
         workspace that is not currently in ``ready`` — useful when a poll
         loop races with a manual invocation.
         """
-        ws = await self._claim_ready(workspace_id)
+        ws = await self._claim_ready(
+            workspace_id,
+            execution_owner_id=execution_owner_id,
+            execution_lease_expires_at=execution_lease_expires_at,
+        )
         if ws is None:
             return
         if not await self._recheck_status(
@@ -1022,7 +1033,13 @@ class WorkspaceExecutor:
         )
         return defaults.get(agent)
 
-    async def _claim_ready(self, workspace_id: str) -> Workspace | None:
+    async def _claim_ready(
+        self,
+        workspace_id: str,
+        *,
+        execution_owner_id: str | None = None,
+        execution_lease_expires_at: datetime | None = None,
+    ) -> Workspace | None:
         """Atomically transition a ready workspace to running before execution."""
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
@@ -1033,6 +1050,8 @@ class WorkspaceExecutor:
                 reason_code="EXECUTOR_CLAIMED",
             )
             if ws is not None:
+                ws.execution_claimed_by = execution_owner_id
+                ws.execution_claim_expires_at = execution_lease_expires_at
                 await session.commit()
                 return ws
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -21,18 +21,27 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from functools import partial
-from typing import Protocol
+from typing import Any, Protocol
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.logging import get_logger
-from awf.db.enums import WorkspaceStatus
-from awf.db.models import Workspace
+from awf.db.enums import FailureReason, WorkspaceStatus
+from awf.db.models import Workspace, WorkspaceEvent
 from awf.db.repositories import WorkspaceRepository
 from awf.node.provisioner import Provisioner
+from awf.runtime.inspection import RuntimeInspector, RuntimeSnapshot
 
 _log = get_logger(__name__)
+
+_ACTIVE_EXECUTION_STATUSES: tuple[WorkspaceStatus, ...] = (
+    WorkspaceStatus.running,
+    WorkspaceStatus.validating,
+    WorkspaceStatus.pushing,
+)
+_STALE_ACTIVE_EXECUTION_REASON_CODE = "STALE_ACTIVE_EXECUTION"
+_STALE_ACTIVE_EXECUTION_EVENT_TYPE = "workspace.stale_active_execution_detected"
 
 
 @dataclass(frozen=True)
@@ -43,9 +52,20 @@ class WorkerConfig:
     monitor_claim_lease_seconds: float = 300.0
 
 
+@dataclass(frozen=True)
+class _ActiveExecutionCandidate:
+    workspace_id: str
+    status: WorkspaceStatus
+    compose_project_name: str | None
+
+
 class WorkspaceExecutorProtocol(Protocol):
     async def execute(self, workspace_id: str) -> None: ...
     async def resume_pr_monitor(self, workspace_id: str) -> None: ...
+
+
+class RuntimeInspectorProtocol(Protocol):
+    async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot: ...
 
 
 class ControlWorker:
@@ -57,11 +77,13 @@ class ControlWorker:
         session_factory: async_sessionmaker[AsyncSession],
         provisioner: Provisioner,
         executor: WorkspaceExecutorProtocol | None = None,
+        runtime_inspector: RuntimeInspectorProtocol | None = None,
         config: WorkerConfig,
     ) -> None:
         self._session_factory = session_factory
         self._provisioner = provisioner
         self._executor = executor
+        self._runtime_inspector = runtime_inspector or RuntimeInspector()
         self._config = config
         self._stopped = asyncio.Event()
         self._execution_tasks: dict[str, asyncio.Task[None]] = {}
@@ -79,6 +101,9 @@ class ControlWorker:
         and should immediately loop again.
         """
         dispatched_ids: set[str] = set()
+
+        if self._executor is not None:
+            await self._recover_stale_active_executions()
 
         requested_ids = await self._list_requested()
         requested_ids = await self._filter_current_status(
@@ -243,6 +268,145 @@ class ControlWorker:
             )
         return current_ids
 
+    async def _recover_stale_active_executions(self) -> None:
+        candidates = await self._list_stale_active_execution_candidates(
+            exclude_ids=set(self._execution_tasks)
+        )
+        for candidate in candidates:
+            await self._recover_stale_active_execution(candidate)
+
+    async def _list_stale_active_execution_candidates(
+        self,
+        *,
+        exclude_ids: set[str],
+    ) -> list[_ActiveExecutionCandidate]:
+        active_status_values = [status.value for status in _ACTIVE_EXECUTION_STATUSES]
+        stmt = (
+            select(Workspace.id, Workspace.status, Workspace.compose_project_name)
+            .where(Workspace.status.in_(active_status_values))
+            .order_by(Workspace.created_at.asc(), Workspace.id.asc())
+        )
+        if exclude_ids:
+            stmt = stmt.where(~Workspace.id.in_(sorted(exclude_ids)))
+
+        async with self._session_factory() as session:
+            result = await session.execute(stmt)
+            rows = result.all()
+
+        return [
+            _ActiveExecutionCandidate(
+                workspace_id=row[0],
+                status=WorkspaceStatus(row[1]),
+                compose_project_name=row[2],
+            )
+            for row in rows
+        ]
+
+    async def _recover_stale_active_execution(
+        self,
+        candidate: _ActiveExecutionCandidate,
+    ) -> None:
+        try:
+            snapshot = await self._runtime_inspector.inspect(candidate.compose_project_name)
+        except Exception as exc:  # pragma: no cover - defensive around Docker tooling
+            _log.exception(
+                "worker.stale_active_execution_inspect_failed",
+                workspace_id=candidate.workspace_id,
+                status=candidate.status.value,
+                compose_project_name=candidate.compose_project_name,
+            )
+            snapshot = RuntimeSnapshot(
+                stack_state="unavailable",
+                reason=f"runtime inspection failed: {exc}",
+            )
+
+        if candidate.compose_project_name and snapshot.stack_state == "running":
+            await self._record_stale_active_execution_detected(candidate, snapshot)
+            return
+
+        await self._fail_stale_active_execution(candidate, snapshot)
+
+    async def _record_stale_active_execution_detected(
+        self,
+        candidate: _ActiveExecutionCandidate,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
+        payload = {
+            "compose_project_name": candidate.compose_project_name,
+            "workspace_status": candidate.status.value,
+            "runtime": _runtime_snapshot_payload(snapshot),
+        }
+
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            if ws is None or ws.status != candidate.status.value:
+                return
+            if await self._has_stale_active_execution_event(session, candidate.workspace_id):
+                return
+
+            await repo.add_event(
+                ws,
+                event_type=_STALE_ACTIVE_EXECUTION_EVENT_TYPE,
+                reason_code=_STALE_ACTIVE_EXECUTION_REASON_CODE,
+                payload=payload,
+            )
+            await session.commit()
+
+        _log.warning(
+            _STALE_ACTIVE_EXECUTION_EVENT_TYPE,
+            workspace_id=candidate.workspace_id,
+            status=candidate.status.value,
+            compose_project_name=candidate.compose_project_name,
+            runtime=payload["runtime"],
+        )
+
+    async def _has_stale_active_execution_event(
+        self,
+        session: AsyncSession,
+        workspace_id: str,
+    ) -> bool:
+        stmt = (
+            select(WorkspaceEvent.id)
+            .where(
+                WorkspaceEvent.workspace_id == workspace_id,
+                WorkspaceEvent.event_type == _STALE_ACTIVE_EXECUTION_EVENT_TYPE,
+                WorkspaceEvent.reason_code == _STALE_ACTIVE_EXECUTION_REASON_CODE,
+            )
+            .limit(1)
+        )
+        return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+    async def _fail_stale_active_execution(
+        self,
+        candidate: _ActiveExecutionCandidate,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
+        message = _stale_active_execution_failure_message(candidate, snapshot)
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.transition_if_current(
+                candidate.workspace_id,
+                from_status=candidate.status,
+                to=WorkspaceStatus.failed,
+                reason_code=_STALE_ACTIVE_EXECUTION_REASON_CODE,
+            )
+            if ws is None:
+                return
+            ws.failure_reason = FailureReason.infrastructure_failure.value
+            ws.failure_message = message[:2048]
+            await session.commit()
+
+        _log.error(
+            "worker.stale_active_execution_failed",
+            workspace_id=candidate.workspace_id,
+            status=candidate.status.value,
+            compose_project_name=candidate.compose_project_name,
+            runtime_state=snapshot.stack_state,
+            runtime_reason=snapshot.reason,
+            reason_code=_STALE_ACTIVE_EXECUTION_REASON_CODE,
+        )
+
     def _available_execution_slots(self) -> int:
         return max(0, self._config.max_concurrent_executions - len(self._execution_tasks))
 
@@ -398,3 +562,44 @@ class ControlWorker:
                 workspace_id=workspace_id,
                 worker_id=self._worker_id,
             )
+
+
+def _runtime_snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
+    return {
+        "stack_state": snapshot.stack_state,
+        "reason": snapshot.reason,
+        "services": [
+            {
+                "name": service.name,
+                "container_id": service.container_id,
+                "image": service.image,
+                "state": service.state,
+                "status": service.status,
+                "health": service.health,
+                "ports": list(service.ports),
+                "started_at": service.started_at,
+            }
+            for service in snapshot.services
+        ],
+    }
+
+
+def _stale_active_execution_failure_message(
+    candidate: _ActiveExecutionCandidate,
+    snapshot: RuntimeSnapshot,
+) -> str:
+    if not candidate.compose_project_name:
+        runtime_detail = "no compose project is persisted for the workspace"
+    else:
+        runtime_detail = f"compose runtime state is {snapshot.stack_state}"
+        if snapshot.reason:
+            runtime_detail = f"{runtime_detail}: {snapshot.reason.strip()}"
+
+    return (
+        "active execution was lost after a service or Docker restart. "
+        f"The workspace is still marked {candidate.status.value!r}, but this worker has "
+        f"no in-process execution task and {runtime_detail}. "
+        "AWF marked the workspace failed without cleanup; logs, the worktree, and any "
+        "surviving files were preserved for inspection. Inspect the workspace, then "
+        "cancel and redispatch the task when ready."
+    )

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -50,6 +50,7 @@ class WorkerConfig:
     max_concurrent_provisions: int = 3
     max_concurrent_executions: int = 3
     monitor_claim_lease_seconds: float = 300.0
+    node_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -284,6 +285,7 @@ class ControlWorker:
         stmt = (
             select(Workspace.id, Workspace.status, Workspace.compose_project_name)
             .where(Workspace.status.in_(active_status_values))
+            .where(Workspace.node_id == self._config.node_id)
             .order_by(Workspace.created_at.asc(), Workspace.id.asc())
         )
         if exclude_ids:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -3,9 +3,9 @@
 Polls the DB for workspaces needing action and dispatches them to the
 Provisioner. Postgres-backed deployments list schedulable candidate rows with
 ``SELECT FOR UPDATE SKIP LOCKED``; provisioning and ready-execution handlers
-then claim selected rows with conditional status transitions. PR monitor
-recovery uses a short DB-backed lease so multiple workers do not resume the
-same monitor concurrently.
+then claim selected rows with conditional status transitions. Active execution
+and PR monitor recovery use short DB-backed leases so multiple workers do not
+resume the same runtime task concurrently.
 
 Split into two methods:
 
@@ -24,7 +24,7 @@ from functools import partial
 from time import monotonic
 from typing import Any, Protocol
 
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.logging import get_logger
@@ -51,6 +51,7 @@ class WorkerConfig:
     max_concurrent_provisions: int = 3
     max_concurrent_executions: int = 3
     monitor_claim_lease_seconds: float = 300.0
+    execution_claim_lease_seconds: float = 300.0
     stale_active_execution_scan_interval_seconds: float = 300.0
     node_id: str | None = None
 
@@ -63,7 +64,14 @@ class _ActiveExecutionCandidate:
 
 
 class WorkspaceExecutorProtocol(Protocol):
-    async def execute(self, workspace_id: str) -> None: ...
+    async def execute(
+        self,
+        workspace_id: str,
+        *,
+        execution_owner_id: str | None = None,
+        execution_lease_expires_at: datetime | None = None,
+    ) -> None: ...
+
     async def resume_pr_monitor(self, workspace_id: str) -> None: ...
 
 
@@ -294,10 +302,12 @@ class ControlWorker:
         exclude_ids: set[str],
     ) -> list[_ActiveExecutionCandidate]:
         active_status_values = [status.value for status in _ACTIVE_EXECUTION_STATUSES]
+        claim_cutoff = datetime.now(UTC)
         stmt = (
             select(Workspace.id, Workspace.status, Workspace.compose_project_name)
             .where(Workspace.status.in_(active_status_values))
             .where(Workspace.node_id == self._config.node_id)
+            .where(_stale_execution_claim_filter(claim_cutoff))
             .order_by(Workspace.created_at.asc(), Workspace.id.asc())
         )
         if exclude_ids:
@@ -356,6 +366,8 @@ class ControlWorker:
             ws = await repo.get(candidate.workspace_id)
             if ws is None or ws.status != candidate.status.value:
                 return
+            if not _execution_claim_is_stale(ws, datetime.now(UTC)):
+                return
             if await self._has_stale_active_execution_event(session, candidate.workspace_id):
                 return
 
@@ -404,9 +416,12 @@ class ControlWorker:
                 from_status=candidate.status,
                 to=WorkspaceStatus.failed,
                 reason_code=_STALE_ACTIVE_EXECUTION_REASON_CODE,
+                extra_conditions=(_stale_execution_claim_filter(datetime.now(UTC)),),
             )
             if ws is None:
                 return
+            ws.execution_claimed_by = None
+            ws.execution_claim_expires_at = None
             ws.failure_reason = FailureReason.infrastructure_failure.value
             ws.failure_message = message[:2048]
             await session.commit()
@@ -433,7 +448,7 @@ class ControlWorker:
                 continue
 
             task = asyncio.create_task(
-                self._safely_execute(workspace_id),
+                self._safely_execute_claimed(workspace_id),
                 name=f"awf-execute-{workspace_id}",
             )
             self._execution_tasks[workspace_id] = task
@@ -473,12 +488,29 @@ class ControlWorker:
         if self._executor is None:
             return
         try:
-            await self._executor.execute(workspace_id)
+            await self._executor.execute(
+                workspace_id,
+                execution_owner_id=self._worker_id,
+                execution_lease_expires_at=self._execution_claim_expires_at(),
+            )
         except Exception:
             # WorkspaceExecutor.execute() owns state transitions, including
             # skip-if-no-longer-ready semantics. The worker must keep polling
             # even if one execution path crashes before it can mark a failure.
             _log.exception("worker.execute_failed", workspace_id=workspace_id)
+
+    async def _safely_execute_claimed(self, workspace_id: str) -> None:
+        heartbeat = asyncio.create_task(
+            self._refresh_execution_claim_loop(workspace_id),
+            name=f"awf-execution-claim-{workspace_id}",
+        )
+        try:
+            await self._safely_execute(workspace_id)
+        finally:
+            heartbeat.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat
+            await self._release_execution_claim(workspace_id)
 
     async def _safely_resume_pr_monitor(self, workspace_id: str) -> None:
         if self._executor is None:
@@ -549,6 +581,27 @@ class ControlWorker:
                 )
                 return
 
+    async def _refresh_execution_claim_loop(self, workspace_id: str) -> None:
+        interval = max(1.0, min(60.0, self._config.execution_claim_lease_seconds / 3))
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                refreshed = await self._refresh_execution_claim(workspace_id)
+            except Exception:
+                _log.exception(
+                    "worker.execution_claim_refresh_failed",
+                    workspace_id=workspace_id,
+                    worker_id=self._worker_id,
+                )
+                return
+            if not refreshed:
+                _log.warning(
+                    "worker.execution_claim_lost",
+                    workspace_id=workspace_id,
+                    worker_id=self._worker_id,
+                )
+                return
+
     async def _refresh_monitoring_pr_claim(self, workspace_id: str) -> bool:
         lease_expires_at = datetime.now(UTC) + timedelta(
             seconds=self._config.monitor_claim_lease_seconds
@@ -561,6 +614,34 @@ class ControlWorker:
             )
             await session.commit()
             return refreshed
+
+    def _execution_claim_expires_at(self) -> datetime:
+        return datetime.now(UTC) + timedelta(seconds=self._config.execution_claim_lease_seconds)
+
+    async def _refresh_execution_claim(self, workspace_id: str) -> bool:
+        async with self._session_factory() as session:
+            refreshed = await WorkspaceRepository(session).refresh_execution_claim(
+                workspace_id,
+                owner_id=self._worker_id,
+                lease_expires_at=self._execution_claim_expires_at(),
+            )
+            await session.commit()
+            return refreshed
+
+    async def _release_execution_claim(self, workspace_id: str) -> None:
+        try:
+            async with self._session_factory() as session:
+                await WorkspaceRepository(session).release_execution_claim(
+                    workspace_id,
+                    owner_id=self._worker_id,
+                )
+                await session.commit()
+        except Exception:
+            _log.exception(
+                "worker.execution_claim_release_failed",
+                workspace_id=workspace_id,
+                worker_id=self._worker_id,
+            )
 
     async def _release_monitoring_pr_claim(self, workspace_id: str) -> None:
         try:
@@ -576,6 +657,24 @@ class ControlWorker:
                 workspace_id=workspace_id,
                 worker_id=self._worker_id,
             )
+
+
+def _stale_execution_claim_filter(claim_cutoff: datetime) -> Any:
+    return or_(
+        Workspace.execution_claimed_by.is_(None),
+        Workspace.execution_claim_expires_at.is_(None),
+        Workspace.execution_claim_expires_at <= claim_cutoff,
+    )
+
+
+def _execution_claim_is_stale(workspace: Workspace, claim_cutoff: datetime) -> bool:
+    if workspace.execution_claimed_by is None or workspace.execution_claim_expires_at is None:
+        return True
+
+    expires_at = workspace.execution_claim_expires_at
+    if expires_at.tzinfo is None and claim_cutoff.tzinfo is not None:
+        claim_cutoff = claim_cutoff.replace(tzinfo=None)
+    return expires_at <= claim_cutoff
 
 
 def _runtime_snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -21,6 +21,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from functools import partial
+from time import monotonic
 from typing import Any, Protocol
 
 from sqlalchemy import select
@@ -50,6 +51,7 @@ class WorkerConfig:
     max_concurrent_provisions: int = 3
     max_concurrent_executions: int = 3
     monitor_claim_lease_seconds: float = 300.0
+    stale_active_execution_scan_interval_seconds: float = 300.0
     node_id: str | None = None
 
 
@@ -89,6 +91,7 @@ class ControlWorker:
         self._stopped = asyncio.Event()
         self._execution_tasks: dict[str, asyncio.Task[None]] = {}
         self._worker_id = f"control-worker-{uuid.uuid4().hex}"
+        self._next_stale_active_execution_scan_at = 0.0
 
     def request_stop(self) -> None:
         """Signal ``run_forever`` to exit after the current batch."""
@@ -104,7 +107,7 @@ class ControlWorker:
         dispatched_ids: set[str] = set()
 
         if self._executor is not None:
-            await self._recover_stale_active_executions()
+            await self._maybe_recover_stale_active_executions()
 
         requested_ids = await self._list_requested()
         requested_ids = await self._filter_current_status(
@@ -268,6 +271,15 @@ class ControlWorker:
                 status=actual,
             )
         return current_ids
+
+    async def _maybe_recover_stale_active_executions(self) -> None:
+        now = monotonic()
+        if now < self._next_stale_active_execution_scan_at:
+            return
+
+        await self._recover_stale_active_executions()
+        interval = max(0.0, self._config.stale_active_execution_scan_interval_seconds)
+        self._next_stale_active_execution_scan_at = monotonic() + interval
 
     async def _recover_stale_active_executions(self) -> None:
         candidates = await self._list_stale_active_execution_candidates(

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -136,6 +136,13 @@ class Workspace(Base):
     node_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
     compose_project_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
     compose_file_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    execution_claimed_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    """Ephemeral service-worker owner currently driving active execution."""
+
+    execution_claim_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    """Lease expiry for ``execution_claimed_by`` so crashed workers can be recovered."""
 
     # Terminal-state metadata
     pr_url: Mapped[str | None] = mapped_column(String(512), nullable=True)

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -20,6 +20,7 @@ from sqlalchemy import and_, func, or_, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from sqlalchemy.sql import Select
+from sqlalchemy.sql.elements import ColumnElement
 
 from awf.common.ids import (
     new_event_id,
@@ -509,6 +510,7 @@ class WorkspaceRepository:
         from_status: WorkspaceStatus,
         to: WorkspaceStatus,
         reason_code: str,
+        extra_conditions: tuple[ColumnElement[bool], ...] = (),
     ) -> Workspace | None:
         """Atomically transition a row only if it is still in ``from_status``."""
         WorkspaceStateMachine.assert_transition(from_status, to)
@@ -519,6 +521,7 @@ class WorkspaceRepository:
             .where(
                 Workspace.id == workspace_id,
                 Workspace.status == from_status.value,
+                *extra_conditions,
             )
             .values(
                 status=to.value,
@@ -602,6 +605,50 @@ class WorkspaceRepository:
             )
             .values(
                 monitor_claim_expires_at=lease_expires_at,
+                updated_at=Workspace.updated_at,
+            )
+            .returning(Workspace.id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def refresh_execution_claim(
+        self,
+        workspace_id: str,
+        *,
+        owner_id: str,
+        lease_expires_at: datetime,
+    ) -> bool:
+        """Extend this worker's active-execution lease."""
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.execution_claimed_by == owner_id,
+            )
+            .values(
+                execution_claim_expires_at=lease_expires_at,
+                updated_at=Workspace.updated_at,
+            )
+            .returning(Workspace.id)
+        )
+        return result.scalar_one_or_none() is not None
+
+    async def release_execution_claim(
+        self,
+        workspace_id: str,
+        *,
+        owner_id: str,
+    ) -> bool:
+        """Release this worker's active-execution lease, if it still owns it."""
+        result = await self._session.execute(
+            update(Workspace)
+            .where(
+                Workspace.id == workspace_id,
+                Workspace.execution_claimed_by == owner_id,
+            )
+            .values(
+                execution_claimed_by=None,
+                execution_claim_expires_at=None,
                 updated_at=Workspace.updated_at,
             )
             .returning(Workspace.id)

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -79,12 +79,13 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         agent_runtime_image=settings.agent_runtime_image,
         auth_mount_resolver=auth_mount_resolver,
     )
+    node_id = settings.node_id or socket.gethostname()
     provisioner = Provisioner(
         session_factory=session_factory,
         git=git,
         stack_launcher=stack_launcher,
         config=ProvisionerConfig(
-            node_id=settings.node_id or socket.gethostname(),
+            node_id=node_id,
             branch_prefix=settings.branch_prefix,
         ),
     )
@@ -142,6 +143,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             poll_interval_seconds=settings.worker_poll_interval_seconds,
             max_concurrent_provisions=settings.worker_max_concurrent_provisions,
             max_concurrent_executions=settings.worker_max_concurrent_executions,
+            node_id=node_id,
         ),
     )
     return WorkerRuntime(engine=engine, worker=worker)

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -759,6 +759,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     assert created["worker_config"].poll_interval_seconds == 0.25
     assert created["worker_config"].max_concurrent_provisions == 2
     assert created["worker_config"].max_concurrent_executions == 4
+    assert created["worker_config"].node_id == "node-1"
     assert created["run_once"] is True
     assert created["wait_for_execution_tasks"] is True
     assert created["disposed"] is True

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -8,6 +8,7 @@ since each call is distinguishable by its argv.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -122,6 +123,29 @@ async def _seed_ready_workspace(
 
 
 class TestHappyPath:
+    @pytest.mark.unit
+    async def test_claim_ready_persists_execution_claim(
+        self,
+        executor: WorkspaceExecutor,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+        lease_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+
+        ws = await executor._claim_ready(
+            ws_id,
+            execution_owner_id="worker-a",
+            execution_lease_expires_at=lease_expires_at,
+        )
+
+        assert ws is not None
+        async with factory() as s:
+            persisted = await WorkspaceRepository(s).get(ws_id)
+            assert persisted is not None
+            assert persisted.status == WorkspaceStatus.running.value
+            assert persisted.execution_claimed_by == "worker-a"
+            assert persisted.execution_claim_expires_at == lease_expires_at.replace(tzinfo=None)
+
     @pytest.mark.unit
     async def test_drives_ready_to_completed_and_records_pr_url(
         self,

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -342,8 +342,8 @@ class TestOperatorControlRaces:
         executor = _make_executor(fake, factory, tmp_path, validation=validation)
         original_claim_ready = executor._claim_ready
 
-        async def _claim_then_operator_control(workspace_id: str) -> Any:
-            ws = await original_claim_ready(workspace_id)
+        async def _claim_then_operator_control(workspace_id: str, **kwargs: Any) -> Any:
+            ws = await original_claim_ready(workspace_id, **kwargs)
             assert ws is not None
             async with factory() as s:
                 repo = WorkspaceRepository(s)

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -1186,7 +1186,11 @@ class TestRunOnceStaleActiveExecutionRecovery:
             provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
             executor=_RecordingExecutor(),
             runtime_inspector=inspector,
-            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
         )
 
         assert await worker.run_once() == 0
@@ -1224,6 +1228,62 @@ class TestRunOnceStaleActiveExecutionRecovery:
                 },
             }
         assert inspector.calls == ["awf_pushing_running", "awf_pushing_running"]
+
+    @pytest.mark.unit
+    async def test_stale_active_execution_scan_is_throttled_between_intervals(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        current_time = 1_000.0
+        monkeypatch.setattr("awf.control.worker.monotonic", lambda: current_time)
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "throttled-running",
+            WorkspaceStatus.pushing,
+            compose_project_name="awf_throttled_running",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_throttled_running": RuntimeSnapshot(
+                    stack_state="running",
+                    services=[
+                        RuntimeService(
+                            name="agent",
+                            container_id="abc123",
+                            image="awf-agent:latest",
+                            state="running",
+                        )
+                    ],
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+                stale_active_execution_scan_interval_seconds=60.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        assert await worker.run_once() == 0
+        assert inspector.calls == ["awf_throttled_running"]
+
+        current_time = 1_060.0
+
+        assert await worker.run_once() == 0
+        assert inspector.calls == ["awf_throttled_running", "awf_throttled_running"]
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.pushing.value
 
     @pytest.mark.unit
     async def test_current_in_memory_execution_task_is_not_touched(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -150,6 +150,7 @@ async def _create_active_execution(
     status: WorkspaceStatus,
     *,
     compose_project_name: str | None = None,
+    node_id: str | None = None,
     persist_compose_project: bool = True,
 ) -> str:
     assert status in {
@@ -171,6 +172,7 @@ async def _create_active_execution(
         ws.branch_name = f"awf/{ws.id}"
         ws.remote_push_branch = ws.branch_name
         ws.base_commit = "a" * 40
+        ws.node_id = node_id
         if persist_compose_project:
             ws.compose_project_name = (
                 compose_project_name
@@ -1270,6 +1272,60 @@ class TestRunOnceStaleActiveExecutionRecovery:
             release.set()
             await asyncio.wait_for(task, timeout=0.2)
             worker._execution_tasks.pop(workspace_id, None)
+
+    @pytest.mark.unit
+    async def test_stale_active_execution_scan_is_limited_to_worker_node(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        local_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "local-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_local_running",
+            node_id="node-a",
+        )
+        remote_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "remote-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_remote_running",
+            node_id="node-b",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_local_running": RuntimeSnapshot(
+                    stack_state="unavailable",
+                    reason="docker unavailable",
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            local_ws = await WorkspaceRepository(s).get(local_id)
+            remote_ws = await WorkspaceRepository(s).get(remote_id)
+            assert local_ws is not None
+            assert remote_ws is not None
+            assert local_ws.status == WorkspaceStatus.failed.value
+            assert remote_ws.status == WorkspaceStatus.running.value
+            assert remote_ws.failure_reason is None
+        assert inspector.calls == ["awf_local_running"]
 
     @pytest.mark.unit
     async def test_monitoring_pr_is_not_touched_by_stale_active_execution_scan(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
@@ -279,7 +280,7 @@ class _RecordingExecutor:
         self.calls: list[str] = []
         self.resume_calls: list[str] = []
 
-    async def execute(self, workspace_id: str) -> None:
+    async def execute(self, workspace_id: str, **_kwargs: object) -> None:
         self.calls.append(workspace_id)
 
     async def resume_pr_monitor(self, workspace_id: str) -> None:
@@ -414,7 +415,7 @@ class TestRunOnceExecution:
             def __init__(self) -> None:
                 self.calls: list[str] = []
 
-            async def execute(self, workspace_id: str) -> None:
+            async def execute(self, workspace_id: str, **_kwargs: object) -> None:
                 self.calls.append(workspace_id)
                 started.set()
                 await release.wait()
@@ -620,7 +621,7 @@ class TestRunOnceExecution:
         ready_id = await _create_ready(session_factory, origin_repo, "race")
 
         class _CancellingExecutor:
-            async def execute(self, workspace_id: str) -> None:
+            async def execute(self, workspace_id: str, **_kwargs: object) -> None:
                 async with session_factory() as s:
                     repo = WorkspaceRepository(s)
                     ws = await repo.get(workspace_id)
@@ -693,7 +694,7 @@ class TestRunOnceExecution:
             def __init__(self) -> None:
                 self.calls: list[str] = []
 
-            async def execute(self, workspace_id: str) -> None:
+            async def execute(self, workspace_id: str, **_kwargs: object) -> None:
                 self.calls.append(workspace_id)
                 if workspace_id == first_id:
                     raise RuntimeError("boom")
@@ -786,7 +787,7 @@ class TestRunOnceExecution:
         calls: list[str] = []
 
         class _ClaimingExecutor:
-            async def execute(self, workspace_id: str) -> None:
+            async def execute(self, workspace_id: str, **_kwargs: object) -> None:
                 async with session_factory() as s:
                     repo = WorkspaceRepository(s)
                     ws = await repo.transition_if_current(
@@ -1332,6 +1333,158 @@ class TestRunOnceStaleActiveExecutionRecovery:
             release.set()
             await asyncio.wait_for(task, timeout=0.2)
             worker._execution_tasks.pop(workspace_id, None)
+
+    @pytest.mark.unit
+    async def test_stale_active_execution_scan_skips_unexpired_execution_claim(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "claimed-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_claimed_running",
+            node_id="node-a",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "other-worker"
+            ws.execution_claim_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector({})
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.running.value
+            assert ws.failure_reason is None
+        assert inspector.calls == []
+
+    @pytest.mark.unit
+    async def test_stale_active_execution_scan_recovers_expired_execution_claim(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "expired-claim-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_expired_claim_running",
+            node_id="node-a",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "dead-worker"
+            ws.execution_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_expired_claim_running": RuntimeSnapshot(
+                    stack_state="unavailable",
+                    reason="docker unavailable",
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+        assert inspector.calls == ["awf_expired_claim_running"]
+
+    @pytest.mark.unit
+    async def test_stale_active_execution_failure_rechecks_refreshed_claim(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "refreshed-claim-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_refreshed_claim_running",
+            node_id="node-a",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "worker-a"
+            ws.execution_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await s.commit()
+
+        class _RefreshingInspector:
+            def __init__(self) -> None:
+                self.calls: list[str | None] = []
+
+            async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
+                self.calls.append(compose_project_name)
+                async with session_factory() as s:
+                    ws = await WorkspaceRepository(s).get(workspace_id)
+                    assert ws is not None
+                    ws.execution_claim_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+                    await s.commit()
+                return RuntimeSnapshot(
+                    stack_state="unavailable",
+                    reason="docker unavailable",
+                )
+
+        inspector = _RefreshingInspector()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.running.value
+            assert ws.failure_reason is None
+        assert inspector.calls == ["awf_refreshed_claim_running"]
 
     @pytest.mark.unit
     async def test_stale_active_execution_scan_is_limited_to_worker_node(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -19,10 +19,11 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.control.worker import ControlWorker, WorkerConfig
 from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.node.git_manager import GitManager
 from awf.node.provisioner import Provisioner, ProvisionerConfig
+from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
 
 
 def _git(args: list[str], cwd: Path) -> None:
@@ -142,6 +143,97 @@ async def _create_monitoring_pr(
         return ws.id
 
 
+async def _create_active_execution(
+    session_factory: async_sessionmaker[AsyncSession],
+    origin: Path,
+    title: str,
+    status: WorkspaceStatus,
+    *,
+    compose_project_name: str | None = None,
+    persist_compose_project: bool = True,
+) -> str:
+    assert status in {
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.pushing,
+    }
+    async with session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url=str(origin),
+            branch_base="development",
+            task_title=title,
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.remote_push_branch = ws.branch_name
+        ws.base_commit = "a" * 40
+        if persist_compose_project:
+            ws.compose_project_name = (
+                compose_project_name
+                if compose_project_name is not None
+                else f"awf_{ws.id}"
+            )
+        else:
+            ws.compose_project_name = None
+        ws.compose_file_path = f"/tmp/awf/{ws.id}/compose.yml"
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="SEED")
+        if status in {WorkspaceStatus.validating, WorkspaceStatus.pushing}:
+            await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="SEED")
+        if status == WorkspaceStatus.pushing:
+            await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="SEED")
+        await s.commit()
+        return ws.id
+
+
+async def _create_terminal_execution(
+    session_factory: async_sessionmaker[AsyncSession],
+    origin: Path,
+    title: str,
+    status: WorkspaceStatus,
+) -> str:
+    async with session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url=str(origin),
+            branch_base="development",
+            task_title=title,
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.remote_push_branch = ws.branch_name
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.compose_file_path = f"/tmp/awf/{ws.id}/compose.yml"
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="SEED")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="SEED")
+        if status == WorkspaceStatus.failed:
+            ws.failure_reason = "infrastructure_failure"
+            ws.failure_message = "seed failure"
+            await repo.transition(ws, to=WorkspaceStatus.failed, reason_code="SEED")
+        elif status == WorkspaceStatus.cancelled:
+            await repo.transition(ws, to=WorkspaceStatus.cancelled, reason_code="SEED")
+        else:
+            await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="SEED")
+            await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="SEED")
+            if status == WorkspaceStatus.completed:
+                await repo.transition(ws, to=WorkspaceStatus.completed, reason_code="SEED")
+            else:
+                assert status == WorkspaceStatus.destroyed
+                await repo.transition(ws, to=WorkspaceStatus.cancelled, reason_code="SEED")
+                await repo.transition(ws, to=WorkspaceStatus.destroying, reason_code="SEED")
+                await repo.transition(ws, to=WorkspaceStatus.destroyed, reason_code="SEED")
+        await s.commit()
+        return ws.id
+
+
 async def _move_to_operator_control_status(
     session_factory: async_sessionmaker[AsyncSession],
     workspace_id: str,
@@ -190,6 +282,16 @@ class _RecordingExecutor:
 
     async def resume_pr_monitor(self, workspace_id: str) -> None:
         self.resume_calls.append(workspace_id)
+
+
+class _RecordingRuntimeInspector:
+    def __init__(self, snapshots: dict[str | None, RuntimeSnapshot]) -> None:
+        self._snapshots = snapshots
+        self.calls: list[str | None] = []
+
+    async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
+        self.calls.append(compose_project_name)
+        return self._snapshots[compose_project_name]
 
 
 class TestRunOnce:
@@ -954,3 +1056,287 @@ class TestRunOnceMonitorRecovery:
             assert ws is not None
             assert ws.monitor_claimed_by is None
             assert ws.monitor_claim_expires_at is None
+
+
+class TestRunOnceStaleActiveExecutionRecovery:
+    @pytest.mark.unit
+    async def test_stale_running_with_missing_compose_project_fails(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "stale-running",
+            WorkspaceStatus.running,
+            persist_compose_project=False,
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                None: RuntimeSnapshot(
+                    stack_state="unknown",
+                    reason="workspace has no compose project",
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert ws.failure_message is not None
+            assert "active execution was lost after a service or Docker restart" in (
+                ws.failure_message
+            )
+            assert "preserved" in ws.failure_message
+            events = await WorkspaceEventRepository(s).list(workspace_id=workspace_id)
+            assert any(
+                event.event_type == "workspace.state_changed"
+                and event.reason_code == "STALE_ACTIVE_EXECUTION"
+                for event in events
+            )
+        assert inspector.calls == [None]
+
+    @pytest.mark.unit
+    async def test_stale_validating_with_unavailable_docker_fails(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "stale-validating",
+            WorkspaceStatus.validating,
+            compose_project_name="awf_validating_unavailable",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_validating_unavailable": RuntimeSnapshot(
+                    stack_state="unavailable",
+                    reason="Cannot connect to the Docker daemon",
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert ws.failure_message is not None
+            assert "Cannot connect to the Docker daemon" in ws.failure_message
+            events = await WorkspaceEventRepository(s).list(workspace_id=workspace_id)
+            assert any(event.reason_code == "STALE_ACTIVE_EXECUTION" for event in events)
+
+    @pytest.mark.unit
+    async def test_stale_pushing_with_running_stack_is_preserved_and_evented(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "stale-pushing",
+            WorkspaceStatus.pushing,
+            compose_project_name="awf_pushing_running",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_pushing_running": RuntimeSnapshot(
+                    stack_state="running",
+                    services=[
+                        RuntimeService(
+                            name="agent",
+                            container_id="abc123",
+                            image="awf-agent:latest",
+                            state="running",
+                            status="Up 2 minutes",
+                            health="healthy",
+                        )
+                    ],
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+        )
+
+        assert await worker.run_once() == 0
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.pushing.value
+            assert ws.failure_reason is None
+            events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+            assert len(events) == 1
+            assert events[0].reason_code == "STALE_ACTIVE_EXECUTION"
+            assert events[0].payload == {
+                "compose_project_name": "awf_pushing_running",
+                "workspace_status": "pushing",
+                "runtime": {
+                    "stack_state": "running",
+                    "reason": None,
+                    "services": [
+                        {
+                            "name": "agent",
+                            "container_id": "abc123",
+                            "image": "awf-agent:latest",
+                            "state": "running",
+                            "status": "Up 2 minutes",
+                            "health": "healthy",
+                            "ports": [],
+                            "started_at": None,
+                        }
+                    ],
+                },
+            }
+        assert inspector.calls == ["awf_pushing_running", "awf_pushing_running"]
+
+    @pytest.mark.unit
+    async def test_current_in_memory_execution_task_is_not_touched(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "owned-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_owned_running",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_owned_running": RuntimeSnapshot(
+                    stack_state="unavailable",
+                    reason="docker unavailable",
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+        )
+        release = asyncio.Event()
+
+        async def _busy() -> None:
+            await release.wait()
+
+        task = asyncio.create_task(_busy())
+        worker._execution_tasks[workspace_id] = task
+        try:
+            assert await worker.run_once() == 0
+            async with session_factory() as s:
+                ws = await WorkspaceRepository(s).get(workspace_id)
+                assert ws is not None
+                assert ws.status == WorkspaceStatus.running.value
+                assert ws.failure_reason is None
+            assert inspector.calls == []
+        finally:
+            release.set()
+            await asyncio.wait_for(task, timeout=0.2)
+            worker._execution_tasks.pop(workspace_id, None)
+
+    @pytest.mark.unit
+    async def test_monitoring_pr_is_not_touched_by_stale_active_execution_scan(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_monitoring_pr(
+            session_factory,
+            origin_repo,
+            "monitoring-pr",
+        )
+        inspector = _RecordingRuntimeInspector({})
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.failure_reason is None
+        assert inspector.calls == []
+        assert executor.resume_calls == []
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "status",
+        [
+            WorkspaceStatus.completed,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+            WorkspaceStatus.destroyed,
+        ],
+    )
+    async def test_terminal_rows_are_ignored(
+        self,
+        status: WorkspaceStatus,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_terminal_execution(
+            session_factory,
+            origin_repo,
+            f"terminal-{status.value}",
+            status,
+        )
+        inspector = _RecordingRuntimeInspector({})
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == status.value
+        assert inspector.calls == []

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -203,6 +203,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["worker_config"].poll_interval_seconds == 0.25
     assert created["worker_config"].max_concurrent_provisions == 2
     assert created["worker_config"].max_concurrent_executions == 4
+    assert created["worker_config"].node_id == "node-1"
 
     default_monitor = created["executor_monitor_factory"](
         object(),


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_aa351e54c9b348aa83e105f5` (agent: `codex`).


### Task
## Context
During dogfooding, Docker Desktop/service interruption left a workspace in `running` with no live workspace containers and no in-process worker task. The operator had to cancel and redispatch manually. AWF needs a first-class recovery guard so active execution states cannot remain stuck after worker/service/Docker restart.

## Goal
Implement a focused recovery slice for stale active execution rows in `running`, `validating`, and `pushing`. This is not PR monitor recovery; `monitoring_pr` already has a resume path.

## Required behavior
- On worker `run_once`/startup scan, detect active execution workspaces in `running`, `validating`, or `pushing` that are not owned by the current worker's in-memory `_execution_tasks`.
- Inspect the persisted compose project/runtime before taking action. If the workspace has no compose project, or Docker reports the compose stack/container is absent or unavailable, mark the workspace `failed` with `failure_reason="infrastructure_failure"`, reason code `STALE_ACTIVE_EXECUTION`, and an actionable failure message explaining that the active execution was lost after service/Docker restart.
- Preserve logs, worktree, and any surviving files. Do not run cleanup from this recovery path.
- If the compose stack is still running, do not fail it in this slice; emit a structured event/log such as `workspace.stale_active_execution_detected` with payload showing the observed runtime state so a later slice can do process-level adoption/kill.
- Never touch terminal workspaces, `requested`, `provisioning`, `ready`, or `monitoring_pr`.
- Keep behavior idempotent: repeated scans should not emit noisy duplicate terminal transitions.

## TDD
Write failing tests first. Cover: stale running with missing compose fails; stale validating with unavailable Docker fails; stale pushing with running stack is preserved and evented; current in-memory execution task is not touched; monitoring_pr is not touched; terminal rows are ignored.

## Validation
Run:
- `uv run --python 3.12 --extra dev ruff check src/awf/control src/awf/db tests/unit/control tests/unit/db`
- `uv run --python 3.12 --extra dev mypy src/awf/control src/awf/db`
- `uv run --python 3.12 --extra dev pytest tests/unit/control tests/unit/db -q`

Commit locally with conventional commits. Do not push; AWF owns push, PR creation, review handling, base sync, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
