### PR TITLE
feat(service): report disk pressure and guard workspace admission

### DIFF
--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -10,10 +10,11 @@ returns 409 ``IDEMPOTENCY_CONFLICT`` per docs/PLAN_MVP.md § Error code taxonomy
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -29,14 +30,17 @@ from awf.api.schemas import (
     WorkspaceOverviewResponse,
     WorkspaceResponse,
 )
+from awf.common.config import Settings, get_settings
 from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.profiles.resolver import ProfileResolutionError
+from awf.service.disk import DiskCheck, check_disk_space
 from awf.service.workspaces import WorkspaceOwnedPathConflictError, create_workspace_v2_row
 
 router = APIRouter(prefix="/v1/workspaces", tags=["workspaces"])
 router_v2 = APIRouter(prefix="/v2/workspaces", tags=["workspaces-v2"])
+DiskCheckProvider = Callable[[Settings], DiskCheck]
 
 
 @router.post(
@@ -88,10 +92,14 @@ async def create_workspace(
     "",
     response_model=WorkspaceAcceptedResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    responses={409: {"model": ErrorResponse}},
+    responses={
+        409: {"model": ErrorResponse},
+        503: {"model": ErrorResponse},
+    },
 )
 async def create_workspace_v2(
     payload: WorkspaceCreateV2Request,
+    request: Request,
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkspaceAcceptedResponse | JSONResponse:
@@ -112,6 +120,10 @@ async def create_workspace_v2(
                     ).model_dump(),
                 )
             return _accepted(existing.id, existing.status, existing.version, existing.created_at)
+
+    disk_check = _workspace_admission_disk_check(request)
+    if not disk_check.ok:
+        return _insufficient_disk_response(disk_check)
 
     try:
         ws = await create_workspace_v2_row(
@@ -138,6 +150,31 @@ async def create_workspace_v2(
         )
 
     return _accepted(ws.id, ws.status, ws.version, ws.created_at)
+
+
+def _workspace_admission_disk_check(request: Request) -> DiskCheck:
+    settings = get_settings()
+    provider = cast(
+        DiskCheckProvider | None,
+        getattr(request.app.state, "workspace_admission_disk_check", None),
+    )
+    if provider is not None:
+        return provider(settings)
+    return check_disk_space(
+        settings.work_dir,
+        min_free_bytes=settings.min_free_disk_bytes,
+    )
+
+
+def _insufficient_disk_response(disk_check: DiskCheck) -> JSONResponse:
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content=ErrorResponse(
+            error_code="INSUFFICIENT_DISK",
+            message="Insufficient free disk to create a new workspace.",
+            detail={"disk": disk_check.to_dict()},
+        ).model_dump(),
+    )
 
 
 @router.get("/overview", response_model=WorkspaceOverviewListResponse)

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -102,6 +102,7 @@ async def create_workspace_v2(
     payload: WorkspaceCreateV2Request,
     request: Request,
     idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    settings: Settings = Depends(get_settings),
     session: AsyncSession = Depends(get_db_session),
 ) -> WorkspaceAcceptedResponse | JSONResponse:
     repo = WorkspaceRepository(session)
@@ -122,7 +123,7 @@ async def create_workspace_v2(
                 )
             return _accepted(existing.id, existing.status, existing.version, existing.created_at)
 
-    disk_check = await _workspace_admission_disk_check(request)
+    disk_check = await _workspace_admission_disk_check(request, settings)
     if not disk_check.ok:
         return _insufficient_disk_response(disk_check)
 
@@ -153,8 +154,7 @@ async def create_workspace_v2(
     return _accepted(ws.id, ws.status, ws.version, ws.created_at)
 
 
-async def _workspace_admission_disk_check(request: Request) -> DiskCheck:
-    settings = get_settings()
+async def _workspace_admission_disk_check(request: Request, settings: Settings) -> DiskCheck:
     provider = cast(
         DiskCheckProvider | None,
         getattr(request.app.state, "workspace_admission_disk_check", None),

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -10,6 +10,7 @@ returns 409 ``IDEMPOTENCY_CONFLICT`` per docs/PLAN_MVP.md § Error code taxonomy
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from datetime import datetime
 from typing import Annotated, cast
@@ -121,7 +122,7 @@ async def create_workspace_v2(
                 )
             return _accepted(existing.id, existing.status, existing.version, existing.created_at)
 
-    disk_check = _workspace_admission_disk_check(request)
+    disk_check = await _workspace_admission_disk_check(request)
     if not disk_check.ok:
         return _insufficient_disk_response(disk_check)
 
@@ -152,15 +153,16 @@ async def create_workspace_v2(
     return _accepted(ws.id, ws.status, ws.version, ws.created_at)
 
 
-def _workspace_admission_disk_check(request: Request) -> DiskCheck:
+async def _workspace_admission_disk_check(request: Request) -> DiskCheck:
     settings = get_settings()
     provider = cast(
         DiskCheckProvider | None,
         getattr(request.app.state, "workspace_admission_disk_check", None),
     )
     if provider is not None:
-        return provider(settings)
-    return check_disk_space(
+        return await asyncio.to_thread(provider, settings)
+    return await asyncio.to_thread(
+        check_disk_space,
         settings.work_dir,
         min_free_bytes=settings.min_free_disk_bytes,
     )

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -90,9 +90,14 @@ def _emit(payload: object, fmt: OutputFormat) -> None:
     typer.echo(str(payload))
 
 
-def _emit_pretty_dict(d: dict[str, Any]) -> None:
+def _emit_pretty_dict(d: dict[str, Any], *, prefix: str = "") -> None:
     for key in sorted(d.keys()):
-        typer.echo(f"  {key}: {d[key]}")
+        pretty_key = f"{prefix}.{key}" if prefix else key
+        value = d[key]
+        if isinstance(value, dict):
+            _emit_pretty_dict(value, prefix=pretty_key)
+            continue
+        typer.echo(f"  {pretty_key}: {value}")
 
 
 def _call(method: str, path: str, *, base_url: str, **kwargs: Any) -> httpx.Response:

--- a/src/awf/common/config.py
+++ b/src/awf/common/config.py
@@ -18,6 +18,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 RuntimeEnv = Literal["local", "ci", "staging", "prod"]
+DEFAULT_MIN_FREE_DISK_BYTES = 10 * 1024 * 1024 * 1024
 
 
 class Settings(BaseSettings):
@@ -73,6 +74,14 @@ class Settings(BaseSettings):
     work_dir: str = Field(
         default=".awf",
         description="Local AWF state root. Log streams live under <work_dir>/logs.",
+    )
+    min_free_disk_bytes: int = Field(
+        default=DEFAULT_MIN_FREE_DISK_BYTES,
+        ge=0,
+        description=(
+            "Minimum free bytes required on the AWF work directory filesystem before "
+            "admitting new local workspaces."
+        ),
     )
     host_home: str = Field(
         default="~",

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 
 from sqlalchemy.engine import make_url
 
-from awf.common.config import Settings
+from awf.common.config import DEFAULT_MIN_FREE_DISK_BYTES, Settings
 
 DEFAULT_LOCAL_SERVICE_DATABASE_URL = "postgresql+asyncpg://awf:awf_dev@localhost:5433/awf"
 
@@ -34,6 +34,7 @@ class ServiceSettings:
     host_home: str = "~"
     node_id: str | None = None
     branch_prefix: str = "awf"
+    min_free_disk_bytes: int = DEFAULT_MIN_FREE_DISK_BYTES
 
 
 def resolve_service_settings(
@@ -69,6 +70,7 @@ def resolve_service_settings(
         docker_host=settings.docker_host,
         agent_runtime_image=settings.agent_runtime_image,
         work_dir=settings.work_dir,
+        min_free_disk_bytes=settings.min_free_disk_bytes,
         host_home=settings.host_home or "~",
         api_token=_empty_to_none(settings.api_token),
         github_token=_empty_to_none(settings.github_token),

--- a/src/awf/service/disk.py
+++ b/src/awf/service/disk.py
@@ -1,0 +1,142 @@
+"""Disk pressure checks for local AWF workspace admission."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+
+class DiskUsageStats(Protocol):
+    @property
+    def total(self) -> int: ...
+
+    @property
+    def used(self) -> int: ...
+
+    @property
+    def free(self) -> int: ...
+
+
+class DiskUsage(Protocol):
+    def __call__(self, path: Path) -> DiskUsageStats: ...
+
+
+@dataclass(frozen=True, kw_only=True)
+class DiskCheck:
+    path: str
+    checked_path: str
+    total_bytes: int
+    used_bytes: int
+    free_bytes: int
+    percent_free: float
+    threshold_bytes: int
+    ok: bool
+    status: str
+    reason: str
+    detail: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "path": self.path,
+            "checked_path": self.checked_path,
+            "total_bytes": self.total_bytes,
+            "used_bytes": self.used_bytes,
+            "free_bytes": self.free_bytes,
+            "percent_free": self.percent_free,
+            "threshold_bytes": self.threshold_bytes,
+            "ok": self.ok,
+            "status": self.status,
+            "reason": self.reason,
+        }
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+def check_disk_space(
+    work_dir: str | Path,
+    *,
+    min_free_bytes: int,
+    disk_usage: DiskUsage | None = None,
+) -> DiskCheck:
+    """Return a structured disk-pressure check for the AWF work directory.
+
+    ``shutil.disk_usage`` requires an existing path. The configured work
+    directory may not exist on a fresh node, so the check walks up to the nearest
+    existing parent while still reporting the configured target path.
+    """
+
+    target_path = Path(work_dir).expanduser().resolve(strict=False)
+    checked_path = _nearest_existing_path(target_path)
+    usage_fn = disk_usage or _shutil_disk_usage
+    try:
+        usage = usage_fn(checked_path)
+    except Exception as exc:
+        return DiskCheck(
+            path=str(target_path),
+            checked_path=str(checked_path),
+            total_bytes=0,
+            used_bytes=0,
+            free_bytes=0,
+            percent_free=0.0,
+            threshold_bytes=min_free_bytes,
+            ok=False,
+            status="fail",
+            reason="DISK_USAGE_UNAVAILABLE",
+            detail=(
+                "Could not inspect free disk for the AWF work directory; "
+                f"verify the path is accessible: {type(exc).__name__}: {exc}"
+            ),
+        )
+
+    total = int(usage.total)
+    used = int(usage.used)
+    free = int(usage.free)
+    percent_free = round((free / total) * 100, 2) if total > 0 else 0.0
+    if free >= min_free_bytes:
+        return DiskCheck(
+            path=str(target_path),
+            checked_path=str(checked_path),
+            total_bytes=total,
+            used_bytes=used,
+            free_bytes=free,
+            percent_free=percent_free,
+            threshold_bytes=min_free_bytes,
+            ok=True,
+            status="ok",
+            reason="SUFFICIENT_DISK",
+        )
+
+    return DiskCheck(
+        path=str(target_path),
+        checked_path=str(checked_path),
+        total_bytes=total,
+        used_bytes=used,
+        free_bytes=free,
+        percent_free=percent_free,
+        threshold_bytes=min_free_bytes,
+        ok=False,
+        status="fail",
+        reason="INSUFFICIENT_DISK",
+        detail=(
+            "Free disk is below AWF_MIN_FREE_DISK_BYTES for the AWF work directory; "
+            "free disk before creating new workspaces or intentionally lower the "
+            f"threshold. free_bytes={free} threshold_bytes={min_free_bytes}"
+        ),
+    )
+
+
+def _nearest_existing_path(path: Path) -> Path:
+    current = path
+    while not current.exists():
+        parent = current.parent
+        if parent == current:
+            return current
+        current = parent
+    return current
+
+
+def _shutil_disk_usage(path: Path) -> DiskUsageStats:
+    return shutil.disk_usage(path)

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -14,6 +14,7 @@ from sqlalchemy import text
 
 from awf.db.session import make_engine
 from awf.service.config import ServiceSettings
+from awf.service.disk import DiskUsage, check_disk_space
 
 _CHECK_TIMEOUT_SECONDS = 5.0
 
@@ -60,6 +61,7 @@ async def collect_service_status(
     db_probe: DbProbe | None = None,
     run_subprocess: SubprocessRun | None = None,
     socket_exists: SocketExists | None = None,
+    disk_usage: DiskUsage | None = None,
 ) -> dict[str, object]:
     """Collect service dependency status without requiring Docker in tests."""
 
@@ -68,17 +70,24 @@ async def collect_service_status(
     resolved_run = run_subprocess or _run_subprocess
     resolved_socket_exists = socket_exists or Path.exists
 
-    api_check, db_check, docker_check, image_check = await asyncio.gather(
+    api_check, db_check, docker_check, image_check, disk_check = await asyncio.gather(
         _check_api(settings, resolved_api_get),
         resolved_db_probe(settings.database_url),
         asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
         asyncio.to_thread(_check_agent_runtime_image, settings, resolved_run),
+        asyncio.to_thread(
+            check_disk_space,
+            settings.work_dir,
+            min_free_bytes=settings.min_free_disk_bytes,
+            disk_usage=disk_usage,
+        ),
     )
     checks = {
         "api": api_check,
         "db": db_check,
         "docker": docker_check,
         "agent_runtime_image": image_check,
+        "disk": disk_check.to_dict(),
     }
     overall_ok = all(bool(check["ok"]) for check in checks.values())
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,8 +15,27 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.api.app import configure_database, create_app
+from awf.common.config import Settings
 from awf.db.base import Base
 from awf.db.session import make_engine, make_session_factory
+from awf.service.disk import DiskCheck
+
+
+def _ok_workspace_admission_disk_check(settings: Settings) -> DiskCheck:
+    threshold = settings.min_free_disk_bytes
+    free = threshold + 1
+    return DiskCheck(
+        path=settings.work_dir,
+        checked_path=settings.work_dir,
+        total_bytes=free,
+        used_bytes=0,
+        free_bytes=free,
+        percent_free=100.0,
+        threshold_bytes=threshold,
+        ok=True,
+        status="ok",
+        reason="SUFFICIENT_DISK",
+    )
 
 
 @pytest.fixture
@@ -40,6 +59,7 @@ async def client(engine: AsyncEngine) -> AsyncIterator[AsyncClient]:
     """
     app = create_app(use_lifespan=False)
     configure_database(app, make_session_factory(engine))
+    app.state.workspace_admission_disk_check = _ok_workspace_admission_disk_check
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
         yield c

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -15,6 +15,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.api.app import configure_database, create_app
+from awf.common.config import Settings, get_settings
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
@@ -258,6 +259,35 @@ class TestCreateWorkspaceV2DiskPressure:
         assert response.status_code == 202
         assert len(listed.json()) == 1
         assert listed.json()[0]["id"] == response.json()["workspace_id"]
+
+    @pytest.mark.unit
+    async def test_disk_admission_uses_dependency_overridden_settings(
+        self,
+        disk_app_and_client: tuple[Any, AsyncClient],
+    ) -> None:
+        app, client = disk_app_and_client
+        settings = Settings(
+            _env_file=None,
+            work_dir="/tmp/awf-test-workspaces",
+            min_free_disk_bytes=123,
+        )
+        seen: dict[str, Settings] = {}
+
+        def admission_check(provider_settings: Settings) -> DiskCheck:
+            seen["settings"] = provider_settings
+            return _disk_check(
+                free_bytes=124,
+                threshold_bytes=provider_settings.min_free_disk_bytes,
+                ok=True,
+            )
+
+        app.dependency_overrides[get_settings] = lambda: settings
+        app.state.workspace_admission_disk_check = admission_check
+
+        response = await client.post("/v2/workspaces", json=_V2_MINIMAL_BODY)
+
+        assert response.status_code == 202
+        assert seen["settings"] is settings
 
 
 class TestCreateWorkspaceV2MonitorPolicy:

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -7,13 +7,18 @@ true integration + E2E tests live under tests/integration/ and tests/e2e/.
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from typing import Any
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
+from awf.api.app import configure_database, create_app
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.disk import DiskCheck
 
 _MINIMAL_BODY = {
     "repo_url": "git@github.com:dimileeh/aira-agent.git",
@@ -93,6 +98,35 @@ async def _create_v2_workspace(
     return str(response.json()["workspace_id"])
 
 
+def _disk_check(
+    *,
+    free_bytes: int,
+    threshold_bytes: int,
+    ok: bool,
+) -> DiskCheck:
+    return DiskCheck(
+        path="/workspace/.awf",
+        checked_path="/workspace",
+        total_bytes=1000,
+        used_bytes=1000 - free_bytes,
+        free_bytes=free_bytes,
+        percent_free=free_bytes / 10,
+        threshold_bytes=threshold_bytes,
+        ok=ok,
+        status="ok" if ok else "fail",
+        reason="SUFFICIENT_DISK" if ok else "INSUFFICIENT_DISK",
+        detail=None if ok else "Free disk is below AWF_MIN_FREE_DISK_BYTES.",
+    )
+
+
+@pytest.fixture
+async def disk_app_and_client(engine: AsyncEngine) -> AsyncIterator[tuple[Any, AsyncClient]]:
+    app = create_app(use_lifespan=False)
+    configure_database(app, make_session_factory(engine))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield app, c
+
+
 async def _transition_workspace(
     engine: AsyncEngine,
     workspace_id: str,
@@ -153,6 +187,77 @@ class TestCreateWorkspace:
         bad = {**_MINIMAL_BODY, "hax0r_field": "value"}
         response = await client.post("/v1/workspaces", json=bad)
         assert response.status_code == 422
+
+
+class TestCreateWorkspaceV2DiskPressure:
+    @pytest.mark.unit
+    async def test_rejects_low_disk_without_creating_row(
+        self,
+        disk_app_and_client: tuple[Any, AsyncClient],
+    ) -> None:
+        app, client = disk_app_and_client
+        app.state.workspace_admission_disk_check = lambda _settings: _disk_check(
+            free_bytes=300,
+            threshold_bytes=400,
+            ok=False,
+        )
+
+        response = await client.post("/v2/workspaces", json=_V2_MINIMAL_BODY)
+        listed = await client.get("/v1/workspaces")
+
+        assert response.status_code == 503
+        body = response.json()
+        assert body["error_code"] == "INSUFFICIENT_DISK"
+        assert body["detail"]["disk"]["free_bytes"] == 300
+        assert body["detail"]["disk"]["threshold_bytes"] == 400
+        assert listed.status_code == 200
+        assert listed.json() == []
+
+    @pytest.mark.unit
+    async def test_idempotent_replay_returns_existing_row_under_low_disk(
+        self,
+        disk_app_and_client: tuple[Any, AsyncClient],
+    ) -> None:
+        app, client = disk_app_and_client
+        headers = {"Idempotency-Key": "disk-pressure-replay"}
+        app.state.workspace_admission_disk_check = lambda _settings: _disk_check(
+            free_bytes=700,
+            threshold_bytes=400,
+            ok=True,
+        )
+        first = await client.post("/v2/workspaces", json=_V2_MINIMAL_BODY, headers=headers)
+
+        app.state.workspace_admission_disk_check = lambda _settings: _disk_check(
+            free_bytes=300,
+            threshold_bytes=400,
+            ok=False,
+        )
+        replay = await client.post("/v2/workspaces", json=_V2_MINIMAL_BODY, headers=headers)
+        listed = await client.get("/v1/workspaces")
+
+        assert first.status_code == 202
+        assert replay.status_code == 202
+        assert replay.json()["workspace_id"] == first.json()["workspace_id"]
+        assert len(listed.json()) == 1
+
+    @pytest.mark.unit
+    async def test_create_succeeds_when_disk_is_above_threshold(
+        self,
+        disk_app_and_client: tuple[Any, AsyncClient],
+    ) -> None:
+        app, client = disk_app_and_client
+        app.state.workspace_admission_disk_check = lambda _settings: _disk_check(
+            free_bytes=700,
+            threshold_bytes=400,
+            ok=True,
+        )
+
+        response = await client.post("/v2/workspaces", json=_V2_MINIMAL_BODY)
+        listed = await client.get("/v1/workspaces")
+
+        assert response.status_code == 202
+        assert len(listed.json()) == 1
+        assert listed.json()[0]["id"] == response.json()["workspace_id"]
 
 
 class TestCreateWorkspaceV2MonitorPolicy:

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -25,6 +25,16 @@ def _combined_output(result: Any) -> str:
     return f"{result.stdout}{getattr(result, 'stderr', '')}"
 
 
+class _FakeDiskUsage:
+    total = 20 * 1024 * 1024 * 1024
+    used = 1 * 1024 * 1024 * 1024
+    free = 19 * 1024 * 1024 * 1024
+
+
+def _ok_disk_usage(_path: Path) -> _FakeDiskUsage:
+    return _FakeDiskUsage()
+
+
 def _write_gc_file(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
@@ -469,6 +479,7 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
             db_probe=_db_probe,
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: True,
+            disk_usage=_ok_disk_usage,
         )
     )
 
@@ -562,6 +573,7 @@ def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> N
             db_probe=_db_probe,
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: True,
+            disk_usage=_ok_disk_usage,
         )
     )
 
@@ -612,6 +624,7 @@ def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> N
             db_probe=_db_probe,
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: False,
+            disk_usage=_ok_disk_usage,
         )
     )
 
@@ -620,6 +633,41 @@ def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> N
     assert status["checks"]["db"]["reason"] == "DB_CONNECTION_FAILED"
     assert status["checks"]["docker"]["reason"] == "DOCKER_SOCKET_UNREACHABLE"
     assert status["checks"]["agent_runtime_image"]["reason"] == "AGENT_RUNTIME_IMAGE_MISSING"
+
+
+@pytest.mark.unit
+def test_service_status_pretty_output_includes_disk_check(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from awf.service import config as config_mod
+    from awf.service import status as status_mod
+
+    settings = object()
+    monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
+
+    async def _collect(received: object) -> dict[str, object]:
+        assert received is settings
+        return {
+            "service": "awf",
+            "status": "ok",
+            "checks": {
+                "disk": {
+                    "ok": True,
+                    "status": "ok",
+                    "reason": "SUFFICIENT_DISK",
+                    "free_bytes": 300,
+                    "threshold_bytes": 200,
+                }
+            },
+        }
+
+    monkeypatch.setattr(status_mod, "collect_service_status", _collect)
+
+    result = _runner.invoke(app, ["service", "status", "--format", "pretty"])
+
+    assert result.exit_code == 0, result.output
+    assert "checks.disk.free_bytes: 300" in result.stdout
+    assert "checks.disk.threshold_bytes: 200" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_config.py
+++ b/tests/unit/service/test_config.py
@@ -6,7 +6,7 @@ import json
 
 import pytest
 
-from awf.common.config import Settings
+from awf.common.config import DEFAULT_MIN_FREE_DISK_BYTES, Settings
 from awf.service.config import resolve_service_settings, service_config_payload
 
 
@@ -36,3 +36,22 @@ def test_agent_watchdog_settings_flow_from_settings_to_service_settings() -> Non
 
     assert settings.agent_wall_timeout_seconds == 1234
     assert settings.agent_idle_timeout_seconds == 56
+
+
+@pytest.mark.unit
+def test_min_free_disk_threshold_defaults_to_conservative_10_gib_payload() -> None:
+    settings = resolve_service_settings(Settings(_env_file=None), environ={})
+    payload = service_config_payload(settings)
+
+    assert DEFAULT_MIN_FREE_DISK_BYTES == 10 * 1024 * 1024 * 1024
+    assert settings.min_free_disk_bytes == DEFAULT_MIN_FREE_DISK_BYTES
+    assert payload["min_free_disk_bytes"] == DEFAULT_MIN_FREE_DISK_BYTES
+
+
+@pytest.mark.unit
+def test_min_free_disk_threshold_flows_from_settings_to_service_settings() -> None:
+    base = Settings(_env_file=None, min_free_disk_bytes=123456)
+
+    settings = resolve_service_settings(base, environ={"AWF_MIN_FREE_DISK_BYTES": "123456"})
+
+    assert settings.min_free_disk_bytes == 123456

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -1,0 +1,109 @@
+"""Service status disk-pressure checks."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from awf.service.config import ServiceSettings
+from awf.service.status import collect_service_status
+
+
+def _settings(tmp_path: Path, *, min_free_disk_bytes: int) -> ServiceSettings:
+    return ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="sqlite+aiosqlite:///:memory:",
+        docker_host=f"unix://{tmp_path / 'docker.sock'}",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "work"),
+        api_token=None,
+        github_token=None,
+        worker_poll_interval_seconds=0.1,
+        worker_max_concurrent_provisions=1,
+        min_free_disk_bytes=min_free_disk_bytes,
+    )
+
+
+class _Response:
+    status_code = 200
+
+    def json(self) -> dict[str, str]:
+        return {"status": "ok"}
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _DiskUsage:
+    def __init__(self, *, total: int, used: int, free: int) -> None:
+        self.total = total
+        self.used = used
+        self.free = free
+
+
+async def _api_get(_url: str, *, timeout: float) -> _Response:
+    return _Response()
+
+
+async def _db_probe(_database_url: str) -> dict[str, Any]:
+    return {"ok": True, "status": "ok"}
+
+
+def _run_subprocess(args: list[str], **_kwargs: object) -> Any:
+    if args[:2] == ["docker", "info"]:
+        return type("Completed", (), {"returncode": 0, "stdout": "27.0.3\n", "stderr": ""})()
+    if args[:3] == ["docker", "image", "inspect"]:
+        return type("Completed", (), {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""})()
+    raise AssertionError(f"unexpected subprocess call: {args}")
+
+
+@pytest.mark.unit
+def test_service_status_includes_ok_disk_check_from_mocked_usage(tmp_path: Path) -> None:
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path, min_free_disk_bytes=200),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+        )
+    )
+
+    assert status["status"] == "ok"
+    disk = status["checks"]["disk"]
+    assert disk["ok"] is True
+    assert disk["status"] == "ok"
+    assert disk["reason"] == "SUFFICIENT_DISK"
+    assert disk["total_bytes"] == 1000
+    assert disk["used_bytes"] == 700
+    assert disk["free_bytes"] == 300
+    assert disk["percent_free"] == 30.0
+    assert disk["threshold_bytes"] == 200
+
+
+@pytest.mark.unit
+def test_service_status_fails_when_disk_is_below_threshold(tmp_path: Path) -> None:
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path, min_free_disk_bytes=400),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+        )
+    )
+
+    assert status["status"] == "fail"
+    disk = status["checks"]["disk"]
+    assert disk["ok"] is False
+    assert disk["status"] == "fail"
+    assert disk["reason"] == "INSUFFICIENT_DISK"
+    assert disk["threshold_bytes"] == 400
+    assert "AWF_MIN_FREE_DISK_BYTES" in str(disk["detail"])


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_4c601350f5e746fdaded2287` (agent: `codex`).


### Task
## Context
Dogfooding nearly filled the local disk and caused Docker/runtime failures. AWF must make disk pressure visible and stop admitting new work before the node becomes unsafe.

## Goal
Add a small, configurable disk-pressure check used by service status and v2 workspace admission.

## Required behavior
- Add a disk check for the configured AWF work directory and Docker availability/status surface. Include total/free/used bytes, percentage free, threshold bytes, `ok`, and actionable `reason` fields.
- Add config/env support for a local threshold, e.g. `AWF_MIN_FREE_DISK_BYTES`, with a conservative default around 10 GiB. Tests should not depend on the real host disk.
- `awf service status` should include the disk check in JSON and pretty output.
- `POST /v2/workspaces` should reject new non-idempotent workspace creation when free disk is below threshold, returning a structured API error such as `INSUFFICIENT_DISK` without creating a row. Idempotent replay of an already-created workspace should still return the existing row.
- Keep SQLite/test mode usable; disk checks must be mockable and deterministic in tests.
- Do not delete files or run Docker prune from this feature. This is visibility/admission only.

## TDD
Write failing tests first. Cover status ok/low disk, pretty output includes disk, v2 create rejects below threshold, idempotent replay still works, and create succeeds when above threshold.

## Validation
Run:
- `uv run --python 3.12 --extra dev ruff check src/awf/service src/awf/api src/awf/cli tests/unit/service tests/unit/api tests/unit/cli`
- `uv run --python 3.12 --extra dev mypy src/awf/service src/awf/api src/awf/cli`
- `uv run --python 3.12 --extra dev pytest tests/unit/service tests/unit/api tests/unit/cli -q`

Commit locally with conventional commits. Do not push; AWF owns push, PR creation, review handling, base sync, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
