### PR TITLE
feat(monitor): expose stale pending check observability

### DIFF
--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import json
 import re
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
 from awf.common.commands import AsyncCommandRunner
@@ -33,6 +34,7 @@ from awf.common.logging import get_logger
 from awf.runtime.pr_monitor import (
     CheckFailure,
     CheckState,
+    CheckTiming,
     MergeableState,
     MergeStateStatus,
     PRStatus,
@@ -73,7 +75,27 @@ query($owner: String!, $repo: String!, $number: Int!) {
       commits(last: 1) {
         nodes {
           commit {
-            statusCheckRollup { state }
+            statusCheckRollup {
+              state
+              contexts(first: 100) {
+                nodes {
+                  __typename
+                  ... on CheckRun {
+                    name
+                    status
+                    conclusion
+                    startedAt
+                    completedAt
+                    detailsUrl
+                  }
+                  ... on StatusContext {
+                    context
+                    state
+                    targetUrl
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -184,6 +206,7 @@ class GitHubClient:
         rollup = _dig(pr, "commits", "nodes", 0, "commit", "statusCheckRollup")
         check_state_str = (rollup or {}).get("state") or "PENDING"
         check_state = _parse_check_state(check_state_str)
+        checks = _parse_check_contexts(rollup)
 
         # ── Mergeable ──────────────────────────────────────────────────
         mergeable = _parse_mergeable(pr.get("mergeable"))
@@ -276,6 +299,7 @@ class GitHubClient:
             base_behind_count=base_behind_count,
             merge_state_status=merge_state_status,
             ci_failures=(),  # populated by fetch_failing_check_logs if needed
+            checks=checks,
             closed=bool(pr.get("closed")),
             merged=bool(pr.get("merged")),
         )
@@ -501,6 +525,63 @@ def _parse_check_state(value: str) -> CheckState:
     if upper == "PENDING" or upper == "EXPECTED":
         return CheckState.PENDING
     return CheckState.NEUTRAL
+
+
+def _parse_check_contexts(rollup: Any) -> tuple[CheckTiming, ...]:
+    checks: list[CheckTiming] = []
+    for node in _dig(rollup, "contexts", "nodes") or []:
+        if not isinstance(node, dict):
+            continue
+        typename = node.get("__typename")
+        if typename == "StatusContext":
+            name = _clean_optional_str(node.get("context"))
+            if name is None:
+                continue
+            checks.append(
+                CheckTiming(
+                    name=name,
+                    status=_clean_optional_str(node.get("state")),
+                    details_url=_clean_optional_str(node.get("targetUrl")),
+                )
+            )
+            continue
+
+        name = _clean_optional_str(node.get("name") or node.get("context"))
+        if name is None:
+            continue
+        checks.append(
+            CheckTiming(
+                name=name,
+                status=_clean_optional_str(node.get("status") or node.get("state")),
+                conclusion=_clean_optional_str(node.get("conclusion")),
+                started_at=_parse_github_datetime(node.get("startedAt")),
+                completed_at=_parse_github_datetime(node.get("completedAt")),
+                details_url=_clean_optional_str(node.get("detailsUrl") or node.get("targetUrl")),
+            )
+        )
+    return tuple(checks)
+
+
+def _clean_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _parse_github_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = f"{raw[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed.astimezone(UTC)
 
 
 def _parse_mergeable(value: Any) -> MergeableState:

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -94,6 +94,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
                     targetUrl
                   }
                 }
+                pageInfo { hasNextPage }
               }
             }
           }
@@ -207,6 +208,13 @@ class GitHubClient:
         check_state_str = (rollup or {}).get("state") or "PENDING"
         check_state = _parse_check_state(check_state_str)
         checks = _parse_check_contexts(rollup)
+        if _dig(rollup, "contexts", "pageInfo", "hasNextPage") is True:
+            _log.warning(
+                "github.check_contexts_truncated",
+                repo=repo.slug(),
+                pr_number=pr_number,
+                fetched_contexts_limit=100,
+            )
 
         # ── Mergeable ──────────────────────────────────────────────────
         mergeable = _parse_mergeable(pr.get("mergeable"))

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -59,6 +59,13 @@ class OwnedPathConflict:
     requested_path: str
 
 
+@dataclass(frozen=True)
+class WorkspaceEventCreate:
+    event_type: str
+    reason_code: str | None = None
+    payload: dict[str, Any] | None = None
+
+
 def _resolve_session_dialect_name(
     session: AsyncSession,
     dialect_name: str | None,
@@ -638,18 +645,39 @@ class WorkspaceRepository:
         reason_code: str | None = None,
         payload: dict[str, Any] | None = None,
     ) -> WorkspaceEvent:
-        event = WorkspaceEvent(
-            id=new_event_id(),
-            workspace_id=workspace.id,
-            event_type=event_type,
-            old_state=workspace.status,
-            new_state=workspace.status,
-            reason_code=reason_code,
-            payload=payload,
+        events = await self.add_events(
+            workspace,
+            events=[
+                WorkspaceEventCreate(
+                    event_type=event_type,
+                    reason_code=reason_code,
+                    payload=payload,
+                )
+            ],
         )
-        workspace.events.append(event)
+        return events[0]
+
+    async def add_events(
+        self,
+        workspace: Workspace,
+        *,
+        events: builtins.list[WorkspaceEventCreate],
+    ) -> builtins.list[WorkspaceEvent]:
+        created = [
+            WorkspaceEvent(
+                id=new_event_id(),
+                workspace_id=workspace.id,
+                event_type=event.event_type,
+                old_state=workspace.status,
+                new_state=workspace.status,
+                reason_code=event.reason_code,
+                payload=event.payload,
+            )
+            for event in events
+        ]
+        workspace.events.extend(created)
         await self._session.flush()
-        return event
+        return created
 
 
 def _schedulable_workspace_ids_stmt(

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import time
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
@@ -125,6 +126,18 @@ class CheckFailure:
 
 
 @dataclass(frozen=True)
+class CheckTiming:
+    """Timing and link metadata for an individual GitHub check/status context."""
+
+    name: str
+    status: str | None = None
+    conclusion: str | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    details_url: str | None = None
+
+
+@dataclass(frozen=True)
 class PRStatus:
     """Snapshot of a single PR's state as seen by the runner.
 
@@ -148,6 +161,7 @@ class PRStatus:
     shipped PR #335 / #336 as "ready to merge" when they were BEHIND)."""
 
     ci_failures: tuple[CheckFailure, ...] = ()
+    checks: tuple[CheckTiming, ...] = ()
     closed: bool = False
     merged: bool = False
 
@@ -200,6 +214,11 @@ class MonitorConfig:
     """Final quiet-period wait before an auto-merge. Review apps often
     post comments shortly after checks first turn green; merging on the
     first green snapshot can race those reviewers."""
+
+    stale_pending_check_warning_seconds: float = 900.0
+    """Warn operators when an individual pending/in-progress check has
+    exceeded this age. This is observability only; pending checks still
+    block merge through the ordinary WaitForCI path."""
 
 
 # ── Actions — the vocabulary decide() returns to the runner ────────────────

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1635,7 +1635,10 @@ def _is_pending_check(check: CheckTiming) -> bool:
         return False
     if conclusion in _TERMINAL_CHECK_CONCLUSIONS:
         return False
-    return False
+    # Preserve stale-check observability for future GitHub/provider states:
+    # unknown populated values are non-terminal until an explicit terminal
+    # status or conclusion says otherwise.
+    return bool(status or conclusion)
 
 
 def _normalized_check_value(value: str | None) -> str:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -56,6 +56,7 @@ from awf.runtime.pr_monitor import (
     AbortReason,
     AddressComments,
     CheckFailure,
+    CheckTiming,
     Merge,
     MergeStateStatus,
     MonitorAction,
@@ -163,6 +164,71 @@ class PullRequestMonitorRunner:
             await sink.write(json.dumps(payload, default=str, sort_keys=True) + "\n")
         except Exception as exc:
             _log.warning("monitor.log_write_failed", error=str(exc)[:400])
+
+    async def _record_stale_pending_check_warnings(
+        self,
+        *,
+        workspace_id: str,
+        status: PRStatus,
+        state: MonitorState,
+        monitor_log: WorkspaceLogSink | None,
+    ) -> bool:
+        emitted = False
+        warnings = _stale_pending_check_warnings(
+            status,
+            now=datetime.now(UTC),
+            threshold_seconds=self._config.stale_pending_check_warning_seconds,
+        )
+        for warning in warnings:
+            key = _stale_pending_check_warning_key(
+                workspace_id=workspace_id,
+                head_sha=status.head_sha,
+                check_name=warning.check_name,
+                threshold_seconds=warning.threshold_seconds,
+                threshold_window=warning.threshold_window,
+            )
+            if state.threads_addressed_ids.get(key) == "emitted":
+                continue
+            state.mark_addressed(key, "emitted")
+            payload = warning.payload()
+            _log.warning("workspace.pending_check_stale", workspace_id=workspace_id, **payload)
+            await self._write_monitor_log(
+                monitor_log,
+                {
+                    "event": "workspace.pending_check_stale",
+                    "workspace_id": workspace_id,
+                    **payload,
+                },
+            )
+            await self._append_workspace_event(
+                workspace_id=workspace_id,
+                event_type="workspace.pending_check_stale",
+                reason_code="PENDING_CHECK_STALE",
+                payload=payload,
+            )
+            emitted = True
+        return emitted
+
+    async def _append_workspace_event(
+        self,
+        *,
+        workspace_id: str,
+        event_type: str,
+        reason_code: str | None,
+        payload: dict[str, object],
+    ) -> None:
+        async with self._deps.session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            if ws is None:
+                return
+            await repo.add_event(
+                ws,
+                event_type=event_type,
+                reason_code=reason_code,
+                payload=payload,
+            )
+            await s.commit()
 
     # ── Entry point ────────────────────────────────────────────────────────
 
@@ -418,6 +484,14 @@ class PullRequestMonitorRunner:
             return True
 
         if isinstance(action, WaitForCI):
+            emitted_stale_warning = await self._record_stale_pending_check_warnings(
+                workspace_id=workspace_id,
+                status=status,
+                state=state,
+                monitor_log=monitor_log,
+            )
+            if emitted_stale_warning:
+                await self._persist_state(workspace_id, state)
             await self._deps.sleep(self._config.poll_interval_seconds)
             return False
 
@@ -1467,6 +1541,125 @@ def _with_ci_failures(status: PRStatus, failures: tuple[CheckFailure, ...]) -> P
     from dataclasses import replace
 
     return replace(status, ci_failures=failures)
+
+
+_PENDING_CHECK_STATUSES = frozenset(
+    {
+        "EXPECTED",
+        "IN_PROGRESS",
+        "PENDING",
+        "QUEUED",
+        "REQUESTED",
+        "WAITING",
+    }
+)
+_TERMINAL_CHECK_STATUSES = frozenset({"COMPLETED", "ERROR", "FAILURE", "SUCCESS"})
+_TERMINAL_CHECK_CONCLUSIONS = frozenset(
+    {
+        "ACTION_REQUIRED",
+        "CANCELLED",
+        "FAILURE",
+        "NEUTRAL",
+        "SKIPPED",
+        "STALE",
+        "SUCCESS",
+        "TIMED_OUT",
+    }
+)
+
+
+@dataclass(frozen=True)
+class _StalePendingCheckWarning:
+    check_name: str
+    age_seconds: int
+    head_sha: str
+    pr_number: int
+    threshold_seconds: float
+    threshold_window: int
+    check_status: str | None
+    check_conclusion: str | None
+    details_url: str | None
+
+    def payload(self) -> dict[str, object]:
+        return {
+            "check_name": self.check_name,
+            "age_seconds": self.age_seconds,
+            "head_sha": self.head_sha,
+            "pr_number": self.pr_number,
+            "threshold_seconds": self.threshold_seconds,
+            "threshold_window": self.threshold_window,
+            "check_status": self.check_status,
+            "check_conclusion": self.check_conclusion,
+            "details_url": self.details_url,
+        }
+
+
+def _stale_pending_check_warnings(
+    status: PRStatus,
+    *,
+    now: datetime,
+    threshold_seconds: float,
+) -> tuple[_StalePendingCheckWarning, ...]:
+    if threshold_seconds <= 0:
+        return ()
+    now_utc = _as_utc(now)
+    warnings: list[_StalePendingCheckWarning] = []
+    for check in status.checks:
+        if not _is_pending_check(check) or check.started_at is None:
+            continue
+        age_float = (now_utc - _as_utc(check.started_at)).total_seconds()
+        if age_float <= threshold_seconds:
+            continue
+        warnings.append(
+            _StalePendingCheckWarning(
+                check_name=check.name,
+                age_seconds=max(0, int(age_float)),
+                head_sha=status.head_sha,
+                pr_number=status.number,
+                threshold_seconds=threshold_seconds,
+                threshold_window=max(1, int(age_float // threshold_seconds)),
+                check_status=check.status,
+                check_conclusion=check.conclusion,
+                details_url=check.details_url,
+            )
+        )
+    return tuple(warnings)
+
+
+def _is_pending_check(check: CheckTiming) -> bool:
+    status = _normalized_check_value(check.status)
+    conclusion = _normalized_check_value(check.conclusion)
+    if status in _PENDING_CHECK_STATUSES:
+        return True
+    if status in _TERMINAL_CHECK_STATUSES:
+        return False
+    if conclusion in _TERMINAL_CHECK_CONCLUSIONS:
+        return False
+    return False
+
+
+def _normalized_check_value(value: str | None) -> str:
+    return (value or "").strip().upper()
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _stale_pending_check_warning_key(
+    *,
+    workspace_id: str,
+    head_sha: str,
+    check_name: str,
+    threshold_seconds: float,
+    threshold_window: int,
+) -> str:
+    return (
+        "__awf_pending_check_stale__:"
+        f"{workspace_id}:{head_sha}:{check_name}:{threshold_seconds:g}:{threshold_window}"
+    )
 
 
 def _notify_human_reason(status: PRStatus, state: MonitorState) -> str | None:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -41,7 +41,7 @@ from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.common.logging import get_logger
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import WorkspaceEventCreate, WorkspaceRepository
 from awf.runtime.logs import LogStore, WorkspaceLogSink
 from awf.runtime.merge_coordinator import DEFAULT_MERGE_COORDINATOR, MergeCoordinator
 from awf.runtime.monitor_prompts import (
@@ -179,6 +179,7 @@ class PullRequestMonitorRunner:
             now=datetime.now(UTC),
             threshold_seconds=self._config.stale_pending_check_warning_seconds,
         )
+        events: list[WorkspaceEventCreate] = []
         for warning in warnings:
             key = _stale_pending_check_warning_key(
                 workspace_id=workspace_id,
@@ -200,34 +201,30 @@ class PullRequestMonitorRunner:
                     **payload,
                 },
             )
-            await self._append_workspace_event(
-                workspace_id=workspace_id,
-                event_type="workspace.pending_check_stale",
-                reason_code="PENDING_CHECK_STALE",
-                payload=payload,
+            events.append(
+                WorkspaceEventCreate(
+                    event_type="workspace.pending_check_stale",
+                    reason_code="PENDING_CHECK_STALE",
+                    payload=payload,
+                )
             )
             emitted = True
+        if events:
+            await self._append_workspace_events(workspace_id=workspace_id, events=events)
         return emitted
 
-    async def _append_workspace_event(
+    async def _append_workspace_events(
         self,
         *,
         workspace_id: str,
-        event_type: str,
-        reason_code: str | None,
-        payload: dict[str, object],
+        events: list[WorkspaceEventCreate],
     ) -> None:
         async with self._deps.session_factory() as s:
             repo = WorkspaceRepository(s)
             ws = await repo.get(workspace_id)
             if ws is None:
                 return
-            await repo.add_event(
-                ws,
-                event_type=event_type,
-                reason_code=reason_code,
-                payload=payload,
-            )
+            await repo.add_events(ws, events=events)
             await s.commit()
 
     # ── Entry point ────────────────────────────────────────────────────────

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1659,9 +1659,9 @@ def _stale_pending_check_warning_key(
     threshold_seconds: float,
     threshold_window: int,
 ) -> str:
-    return (
-        "__awf_pending_check_stale__:"
-        f"{workspace_id}:{head_sha}:{check_name}:{threshold_seconds:g}:{threshold_window}"
+    return "__awf_pending_check_stale__:" + json.dumps(
+        [workspace_id, head_sha, check_name, f"{threshold_seconds:g}", threshold_window],
+        separators=(",", ":"),
     )
 
 

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -53,11 +53,13 @@ class TestRepoRef:
 
 def _sample_pr_payload(
     *,
+    head_sha: str = "abc123",
     closed: bool = False,
     merged: bool = False,
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
+    check_contexts: list[dict] | None = None,
     threads: list[dict] | None = None,
     reviews: list[dict] | None = None,
     comments: list[dict] | None = None,
@@ -69,7 +71,7 @@ def _sample_pr_payload(
                 "repository": {
                     "pullRequest": {
                         "number": 42,
-                        "headRefOid": "abc123",
+                        "headRefOid": head_sha,
                         "mergeable": mergeable,
                         "mergeStateStatus": merge_state_status,
                         "isDraft": False,
@@ -77,7 +79,16 @@ def _sample_pr_payload(
                         "merged": merged,
                         "baseRef": {"name": "development", "target": {"oid": "base0"}},
                         "commits": {
-                            "nodes": [{"commit": {"statusCheckRollup": {"state": check_state}}}]
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "state": check_state,
+                                            "contexts": {"nodes": check_contexts or []},
+                                        }
+                                    }
+                                }
+                            ]
                         },
                         "reviewThreads": {"nodes": threads or []},
                         "reviews": {"nodes": reviews or []},
@@ -143,6 +154,52 @@ class TestFetchPrStatus:
         assert c.comment_id == "9001"
         assert c.body_excerpt == "Summary with suggestions"
         assert c.blocks_merge is False
+
+    @pytest.mark.unit
+    async def test_parses_check_timing_metadata_from_rollup_contexts(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=_sample_pr_payload(
+                check_state="PENDING",
+                check_contexts=[
+                    {
+                        "__typename": "CheckRun",
+                        "name": "Greptile",
+                        "status": "IN_PROGRESS",
+                        "conclusion": None,
+                        "startedAt": "2026-04-26T12:00:00Z",
+                        "completedAt": None,
+                        "detailsUrl": "https://checks.example/greptile",
+                    },
+                    {
+                        "__typename": "StatusContext",
+                        "context": "ci/build",
+                        "state": "PENDING",
+                        "targetUrl": "https://checks.example/build",
+                    },
+                ],
+            ),
+        )
+        client = GitHubClient(fake)
+        status = await client.fetch_pr_status(
+            repo=RepoRef(owner="o", name="r"), pr_number=1, base_behind_count=0
+        )
+
+        assert len(status.checks) == 2
+        check_run = status.checks[0]
+        assert check_run.name == "Greptile"
+        assert check_run.status == "IN_PROGRESS"
+        assert check_run.conclusion is None
+        assert check_run.started_at is not None
+        assert check_run.started_at.isoformat() == "2026-04-26T12:00:00+00:00"
+        assert check_run.completed_at is None
+        assert check_run.details_url == "https://checks.example/greptile"
+
+        status_context = status.checks[1]
+        assert status_context.name == "ci/build"
+        assert status_context.status == "PENDING"
+        assert status_context.details_url == "https://checks.example/build"
 
     @pytest.mark.unit
     async def test_ignores_non_actionable_review_disabled_issue_comment(self) -> None:

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 
 import pytest
+import structlog
 
 from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import (
@@ -60,6 +61,7 @@ def _sample_pr_payload(
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
     check_contexts: list[dict] | None = None,
+    check_contexts_has_next_page: bool = False,
     threads: list[dict] | None = None,
     reviews: list[dict] | None = None,
     comments: list[dict] | None = None,
@@ -84,7 +86,12 @@ def _sample_pr_payload(
                                     "commit": {
                                         "statusCheckRollup": {
                                             "state": check_state,
-                                            "contexts": {"nodes": check_contexts or []},
+                                            "contexts": {
+                                                "nodes": check_contexts or [],
+                                                "pageInfo": {
+                                                    "hasNextPage": check_contexts_has_next_page
+                                                },
+                                            },
                                         }
                                     }
                                 }
@@ -200,6 +207,28 @@ class TestFetchPrStatus:
         assert status_context.name == "ci/build"
         assert status_context.status == "PENDING"
         assert status_context.details_url == "https://checks.example/build"
+
+    @pytest.mark.unit
+    async def test_warns_when_check_contexts_are_truncated(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=_sample_pr_payload(check_contexts_has_next_page=True),
+        )
+        client = GitHubClient(fake)
+
+        with structlog.testing.capture_logs() as captured:
+            await client.fetch_pr_status(
+                repo=RepoRef(owner="o", name="r"), pr_number=1, base_behind_count=0
+            )
+
+        assert {
+            "event": "github.check_contexts_truncated",
+            "repo": "o/r",
+            "pr_number": 1,
+            "fetched_contexts_limit": 100,
+            "log_level": "warning",
+        } in captured
 
     @pytest.mark.unit
     async def test_ignores_non_actionable_review_disabled_issue_comment(self) -> None:
@@ -585,6 +614,7 @@ class TestFetchPrStatus:
         assert args[0:3] == ["gh", "api", "graphql"]
         # Query passed via -f query=…, numeric number passed via -F
         assert any(a.startswith("query=") and "pullRequest" in a for a in args)
+        assert any(a.startswith("query=") and "pageInfo { hasNextPage }" in a for a in args)
         assert "number=123" in args and "-F" in args
         assert "owner=dimileeh" in args and "repo=aira-web" in args
 

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -89,11 +89,13 @@ class RecordedSleep:
 
 def pr_payload(
     *,
+    head_sha: str = "abc1234567890def",
     closed: bool = False,
     merged: bool = False,
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
+    check_contexts: list[dict] | None = None,
     threads: list[dict] | None = None,
     reviews: list[dict] | None = None,
     comments: list[dict] | None = None,
@@ -104,7 +106,7 @@ def pr_payload(
                 "repository": {
                     "pullRequest": {
                         "number": 42,
-                        "headRefOid": "abc1234567890def",
+                        "headRefOid": head_sha,
                         "mergeable": mergeable,
                         "mergeStateStatus": merge_state_status,
                         "isDraft": False,
@@ -112,7 +114,16 @@ def pr_payload(
                         "merged": merged,
                         "baseRef": {"name": "development", "target": {"oid": "base0"}},
                         "commits": {
-                            "nodes": [{"commit": {"statusCheckRollup": {"state": check_state}}}]
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "state": check_state,
+                                            "contexts": {"nodes": check_contexts or []},
+                                        }
+                                    }
+                                }
+                            ]
                         },
                         "reviewThreads": {"nodes": threads or []},
                         "reviews": {"nodes": reviews or []},
@@ -211,6 +222,8 @@ def make_runner(
     auto_merge: bool = True,
     pre_merge_settle_seconds: float = 0,
     initial_review_grace_period_seconds: float = 0,
+    stale_pending_check_warning_seconds: float = 900,
+    max_outer_iterations: int = 20,
     artifacts_root: Path | None = None,
     log_store: LogStore | None = None,
     merge_coordinator: object | None = None,
@@ -226,8 +239,12 @@ def make_runner(
             settle_interval_seconds=30,
             initial_review_grace_period_seconds=initial_review_grace_period_seconds,
             pre_merge_settle_seconds=pre_merge_settle_seconds,
+            stale_pending_check_warning_seconds=stale_pending_check_warning_seconds,
         ),
-        "runner_config": MonitorRunnerConfig(max_outer_iterations=20, max_fix_cycle_passes=3),
+        "runner_config": MonitorRunnerConfig(
+            max_outer_iterations=max_outer_iterations,
+            max_fix_cycle_passes=3,
+        ),
         "sleep": sleep_fn,
         "worktrees_root": worktrees_root,
         "log_store": log_store,

--- a/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
@@ -16,7 +16,7 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.runtime.pr_monitor import CheckTiming
-from awf.runtime.pr_monitor_runner import _is_pending_check
+from awf.runtime.pr_monitor_runner import _is_pending_check, _stale_pending_check_warning_key
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
@@ -92,6 +92,25 @@ class TestStalePendingCheckWarnings:
         check = CheckTiming(name="Future CI", status="AWAITING_RUN", conclusion="SUCCESS")
 
         assert not _is_pending_check(check)
+
+    @pytest.mark.unit
+    def test_warning_key_encodes_colons_in_check_name(self) -> None:
+        key_with_colon_check = _stale_pending_check_warning_key(
+            workspace_id="ws_1",
+            head_sha="sha1",
+            check_name="a:b",
+            threshold_seconds=60.0,
+            threshold_window=1,
+        )
+        boundary_shifted_key = _stale_pending_check_warning_key(
+            workspace_id="ws_1",
+            head_sha="sha1:a",
+            check_name="b",
+            threshold_seconds=60.0,
+            threshold_window=1,
+        )
+
+        assert key_with_colon_check != boundary_shifted_key
 
     @pytest.mark.unit
     async def test_no_event_before_threshold(

--- a/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
@@ -15,7 +15,13 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-from awf.runtime.pr_monitor import CheckTiming
+from awf.runtime.pr_monitor import (
+    CheckState,
+    CheckTiming,
+    MergeableState,
+    MonitorState,
+    PRStatus,
+)
 from awf.runtime.pr_monitor_runner import _is_pending_check, _stale_pending_check_warning_key
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
@@ -78,6 +84,16 @@ async def _pending_check_events(
             workspace_id=workspace_id,
             event_type="workspace.pending_check_stale",
         )
+
+
+class CountingSessionFactory:
+    def __init__(self, wrapped: async_sessionmaker[AsyncSession]) -> None:
+        self._wrapped = wrapped
+        self.calls = 0
+
+    def __call__(self) -> AsyncSession:
+        self.calls += 1
+        return self._wrapped()
 
 
 class TestStalePendingCheckWarnings:
@@ -211,6 +227,65 @@ class TestStalePendingCheckWarnings:
         assert payload["pr_number"] == 42
         assert payload["head_sha"] == "abc1234567890def"
         assert payload["age_seconds"] >= 60
+
+    @pytest.mark.unit
+    async def test_multiple_stale_pending_checks_use_one_event_session(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        counted_factory = CountingSessionFactory(factory)
+        started = datetime.now(UTC) - timedelta(seconds=75)
+        runner = make_runner(
+            factory=counted_factory,  # type: ignore[arg-type]
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+        status = PRStatus(
+            number=42,
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.MERGEABLE,
+            check_state=CheckState.PENDING,
+            unresolved_inline_threads=(),
+            unresolved_review_comments=(),
+            base_behind_count=0,
+            checks=(
+                CheckTiming(
+                    name="Greptile",
+                    status="IN_PROGRESS",
+                    started_at=started,
+                    details_url="https://checks.example/greptile",
+                ),
+                CheckTiming(
+                    name="Unit Tests",
+                    status="QUEUED",
+                    started_at=started,
+                    details_url="https://checks.example/unit",
+                ),
+            ),
+        )
+
+        emitted = await runner._record_stale_pending_check_warnings(
+            workspace_id=ws_id,
+            status=status,
+            state=MonitorState(),
+            monitor_log=None,
+        )
+
+        assert emitted is True
+        assert counted_factory.calls == 1
+        events = await _pending_check_events(factory, ws_id)
+        assert {e.payload["check_name"] for e in events if e.payload is not None} == {
+            "Greptile",
+            "Unit Tests",
+        }
 
     @pytest.mark.unit
     async def test_duplicate_polls_do_not_spam_same_threshold_window(

--- a/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
@@ -1,0 +1,360 @@
+"""Stale pending-check observability for the PR monitor runner."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.base import Base
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+def _pending_check(
+    *,
+    name: str = "Greptile",
+    started_at: datetime | None,
+    details_url: str = "https://checks.example/greptile",
+) -> dict:
+    return {
+        "__typename": "CheckRun",
+        "name": name,
+        "status": "IN_PROGRESS",
+        "conclusion": None,
+        "startedAt": started_at.isoformat() if started_at is not None else None,
+        "completedAt": None,
+        "detailsUrl": details_url,
+    }
+
+
+async def _pending_check_events(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> list:
+    async with factory() as s:
+        return await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.pending_check_stale",
+        )
+
+
+class TestStalePendingCheckWarnings:
+    @pytest.mark.unit
+    async def test_no_event_before_threshold(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        started = datetime.now(UTC) - timedelta(seconds=30)
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(
+            returncode=0,
+            stdout=pr_payload(
+                check_state="PENDING",
+                check_contexts=[_pending_check(started_at=started)],
+            ),
+        )
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        cmd.queue_result(returncode=0)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        assert not [r for r in captured if r.get("event") == "workspace.pending_check_stale"]
+        assert await _pending_check_events(factory, ws_id) == []
+        assert sleep_fn.calls == [60]
+
+    @pytest.mark.unit
+    async def test_event_after_threshold(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        started = datetime.now(UTC) - timedelta(seconds=75)
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(
+            returncode=0,
+            stdout=pr_payload(
+                check_state="PENDING",
+                check_contexts=[_pending_check(started_at=started)],
+            ),
+        )
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        cmd.queue_result(returncode=0)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        log_entries = [r for r in captured if r.get("event") == "workspace.pending_check_stale"]
+        assert len(log_entries) == 1
+        assert log_entries[0]["check_name"] == "Greptile"
+        assert log_entries[0]["pr_number"] == 42
+        assert log_entries[0]["head_sha"] == "abc1234567890def"
+        assert log_entries[0]["age_seconds"] >= 60
+
+        events = await _pending_check_events(factory, ws_id)
+        assert len(events) == 1
+        payload = events[0].payload
+        assert payload is not None
+        assert payload["check_name"] == "Greptile"
+        assert payload["pr_number"] == 42
+        assert payload["head_sha"] == "abc1234567890def"
+        assert payload["age_seconds"] >= 60
+
+    @pytest.mark.unit
+    async def test_duplicate_polls_do_not_spam_same_threshold_window(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        started = datetime.now(UTC) - timedelta(seconds=75)
+        for _ in range(2):
+            cmd.queue_result(returncode=0)
+            cmd.queue_result(returncode=0, stdout="0\n")
+            cmd.queue_result(
+                returncode=0,
+                stdout=pr_payload(
+                    check_state="PENDING",
+                    check_contexts=[_pending_check(started_at=started)],
+                ),
+            )
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        cmd.queue_result(returncode=0)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        assert len([r for r in captured if r.get("event") == "workspace.pending_check_stale"]) == 1
+        assert len(await _pending_check_events(factory, ws_id)) == 1
+        assert sleep_fn.calls == [60, 60]
+
+    @pytest.mark.unit
+    async def test_new_head_can_emit_again(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        started = datetime.now(UTC) - timedelta(seconds=75)
+        for head_sha in ("abc1234567890def", "def4567890abcdef"):
+            cmd.queue_result(returncode=0)
+            cmd.queue_result(returncode=0, stdout="0\n")
+            cmd.queue_result(
+                returncode=0,
+                stdout=pr_payload(
+                    head_sha=head_sha,
+                    check_state="PENDING",
+                    check_contexts=[_pending_check(started_at=started)],
+                ),
+            )
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        cmd.queue_result(returncode=0)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+
+        events = await _pending_check_events(factory, ws_id)
+        assert [e.payload["head_sha"] for e in events if e.payload is not None] == [
+            "def4567890abcdef",
+            "abc1234567890def",
+        ]
+
+    @pytest.mark.unit
+    async def test_missing_started_at_is_ignored_without_crashing(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(
+            returncode=0,
+            stdout=pr_payload(
+                check_state="PENDING",
+                check_contexts=[_pending_check(started_at=None)],
+            ),
+        )
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+        cmd.queue_result(returncode=0)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+        )
+
+        await runner.run(
+            workspace_id=ws_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+
+        assert await _pending_check_events(factory, ws_id) == []
+        assert sleep_fn.calls == [60]
+
+    @pytest.mark.unit
+    async def test_stale_pending_check_still_waits_for_ci(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        started = datetime.now(UTC) - timedelta(seconds=75)
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(
+            returncode=0,
+            stdout=pr_payload(
+                check_state="PENDING",
+                check_contexts=[_pending_check(started_at=started)],
+            ),
+        )
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            stale_pending_check_warning_seconds=60,
+            max_outer_iterations=1,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        actions = [r["action"] for r in captured if r.get("event") == "monitor.action"]
+        assert actions == ["WaitForCI"]
+        assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_message is not None
+            assert "max_outer_iterations" in ws.failure_message

--- a/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_stale_pending_checks.py
@@ -15,6 +15,8 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
+from awf.runtime.pr_monitor import CheckTiming
+from awf.runtime.pr_monitor_runner import _is_pending_check
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
@@ -79,6 +81,18 @@ async def _pending_check_events(
 
 
 class TestStalePendingCheckWarnings:
+    @pytest.mark.unit
+    def test_unknown_nonterminal_status_is_pending(self) -> None:
+        check = CheckTiming(name="Future CI", status="AWAITING_RUN", conclusion=None)
+
+        assert _is_pending_check(check)
+
+    @pytest.mark.unit
+    def test_terminal_conclusion_overrides_unknown_status(self) -> None:
+        check = CheckTiming(name="Future CI", status="AWAITING_RUN", conclusion="SUCCESS")
+
+        assert not _is_pending_check(check)
+
     @pytest.mark.unit
     async def test_no_event_before_threshold(
         self,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_d5737ff551444509a79a6da9` (agent: `codex`).


### Task
## Context
PR 52 waited a long time on an external Greptile check. Waiting was correct, but operators need visibility into long-pending external checks instead of guessing whether AWF is idle or stuck.

## Goal
Add monitor observability for pending checks that exceed a configurable age. This slice must not bypass checks or auto-merge around them.

## Required behavior
- Carry check timing metadata from the GitHub status/check fetch path when available: name/context, status, conclusion, started_at, completed_at, details URL if already available in the client model.
- Add monitor config for `stale_pending_check_warning_seconds` with a default around 900 seconds.
- While monitor action is `WaitForCI`, if any pending/in-progress check has exceeded the threshold, emit a structured log and workspace event such as `workspace.pending_check_stale` with check name, age seconds, head sha, and PR number.
- Avoid duplicate event spam: emit once per workspace/head/check name/threshold window.
- Keep merge behavior unchanged: stale pending checks still block merge unless existing policy says otherwise.
- Add small helper functions if needed so the decision logic stays readable.

## TDD
Write failing tests first. Cover: no event before threshold; event after threshold; duplicate polls do not spam; new head can emit again; missing started_at is handled without crashing; merge behavior remains WaitForCI while pending.

## Validation
Run:
- `uv run --python 3.12 --extra dev ruff check src/awf/runtime src/awf/common tests/unit/runtime tests/unit/common`
- `uv run --python 3.12 --extra dev mypy src/awf/runtime src/awf/common`
- `uv run --python 3.12 --extra dev pytest tests/unit/runtime tests/unit/common -q`

Commit locally with conventional commits. Do not push; AWF owns push, PR creation, review handling, base sync, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
