### PR TITLE
feat(profiles): detect more project types

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,10 @@ Built-in profile directions include:
 | `python` | Detects `pyproject.toml` or `requirements.txt`; installs dev deps and runs `pytest -q`. |
 | `node` | Detects `package.json`; chooses npm, pnpm, yarn, or bun from lockfiles. |
 | `nextjs` | Node profile plus Next.js lint/test defaults when `next` is present. |
+| `go` | Detects `go.mod`; downloads modules and runs `go test ./...`. |
+| `rust` | Detects `Cargo.toml`; fetches crates and runs `cargo test --all-targets`. |
+| `java` | Detects `pom.xml`, `build.gradle`, or `gradlew`; uses Maven or Gradle test defaults. |
+| `cpp` | Detects `CMakeLists.txt`; configures with CMake, builds, then runs CTest. |
 | `docker-compose` | Enables per-workspace DinD and runs project Compose inside it. |
 | `aira` | Compatibility profile for Aira's Postgres/pgvector/Alembic expectations. |
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Built-in profile directions include:
 | `nextjs` | Node profile plus Next.js lint/test defaults when `next` is present. |
 | `go` | Detects `go.mod`; downloads modules and runs `go test ./...`. |
 | `rust` | Detects `Cargo.toml`; fetches crates and runs `cargo test --all-targets`. |
-| `java` | Detects `pom.xml`, `build.gradle`, or `gradlew`; uses Maven or Gradle test defaults. |
+| `java` | Detects `mvnw`, `pom.xml`, `build.gradle`, or `gradlew`; uses Maven or Gradle test defaults. |
 | `cpp` | Detects `CMakeLists.txt`; configures with CMake, builds, then runs CTest. |
 | `docker-compose` | Enables per-workspace DinD and runs project Compose inside it. |
 | `aira` | Compatibility profile for Aira's Postgres/pgvector/Alembic expectations. |

--- a/src/awf/profiles/registry.py
+++ b/src/awf/profiles/registry.py
@@ -113,7 +113,11 @@ def nextjs_profile(
 
 
 def java_profile(*, build_tool: str = "maven", source: str = "builtin:java") -> WorkspaceProfile:
-    if build_tool == "gradle-wrapper":
+    if build_tool == "maven-wrapper":
+        setup = "./mvnw -B -DskipTests dependency:go-offline"
+        validate = "./mvnw -B test"
+        description = "Generic Java project profile using the Maven wrapper."
+    elif build_tool == "gradle-wrapper":
         setup = "./gradlew --no-daemon dependencies"
         validate = "./gradlew --no-daemon test"
         description = "Generic Java project profile using the Gradle wrapper."
@@ -213,9 +217,7 @@ BUILTIN_PROFILES: dict[str, WorkspaceProfile] = {
 }
 
 
-def get_builtin_profile(
-    name: str, *, worktree_path: Path | None = None
-) -> WorkspaceProfile | None:
+def get_builtin_profile(name: str, *, worktree_path: Path | None = None) -> WorkspaceProfile | None:
     if name == "java" and worktree_path is not None:
         java_build_tool = _detect_java_build_tool(worktree_path)
         if java_build_tool is not None:
@@ -275,6 +277,8 @@ def _detect_package_manager(worktree_path: Path) -> str:
 
 
 def _detect_java_build_tool(worktree_path: Path) -> str | None:
+    if (worktree_path / "mvnw").is_file():
+        return "maven-wrapper"
     if (worktree_path / "pom.xml").is_file():
         return "maven"
     if (worktree_path / "gradlew").is_file():

--- a/src/awf/profiles/registry.py
+++ b/src/awf/profiles/registry.py
@@ -38,6 +38,32 @@ def python_profile(*, source: str = "builtin:python") -> WorkspaceProfile:
     )
 
 
+def go_profile(*, source: str = "builtin:go") -> WorkspaceProfile:
+    return WorkspaceProfile(
+        name="go",
+        source=source,
+        confidence="medium",
+        description="Generic Go project profile using modules.",
+        phases={
+            "setup": ["go mod download"],
+            "validate": ["go test ./..."],
+        },
+    )
+
+
+def rust_profile(*, source: str = "builtin:rust") -> WorkspaceProfile:
+    return WorkspaceProfile(
+        name="rust",
+        source=source,
+        confidence="medium",
+        description="Generic Rust project profile using Cargo.",
+        phases={
+            "setup": ["cargo fetch"],
+            "validate": ["cargo test --all-targets"],
+        },
+    )
+
+
 def node_profile(*, package_manager: str = "npm", source: str = "builtin:node") -> WorkspaceProfile:
     install = {
         "pnpm": "pnpm install --frozen-lockfile",
@@ -83,6 +109,44 @@ def nextjs_profile(
                 }
             ),
         }
+    )
+
+
+def java_profile(*, build_tool: str = "maven", source: str = "builtin:java") -> WorkspaceProfile:
+    if build_tool == "gradle-wrapper":
+        setup = "./gradlew --no-daemon dependencies"
+        validate = "./gradlew --no-daemon test"
+        description = "Generic Java project profile using the Gradle wrapper."
+    elif build_tool == "gradle":
+        setup = "gradle --no-daemon dependencies"
+        validate = "gradle --no-daemon test"
+        description = "Generic Java project profile using Gradle."
+    else:
+        setup = "mvn -B -DskipTests dependency:go-offline"
+        validate = "mvn -B test"
+        description = "Generic Java project profile using Maven."
+    return WorkspaceProfile(
+        name="java",
+        source=source,
+        confidence="medium",
+        description=description,
+        phases={
+            "setup": [setup],
+            "validate": [validate],
+        },
+    )
+
+
+def cpp_profile(*, source: str = "builtin:cpp") -> WorkspaceProfile:
+    return WorkspaceProfile(
+        name="cpp",
+        source=source,
+        confidence="medium",
+        description="Generic C++ project profile using CMake.",
+        phases={
+            "setup": ["cmake -S . -B build"],
+            "validate": ["cmake --build build", "ctest --test-dir build --output-on-failure"],
+        },
     )
 
 
@@ -140,6 +204,10 @@ BUILTIN_PROFILES: dict[str, WorkspaceProfile] = {
     "python": python_profile(),
     "node": node_profile(),
     "nextjs": nextjs_profile(),
+    "go": go_profile(),
+    "rust": rust_profile(),
+    "java": java_profile(),
+    "cpp": cpp_profile(),
     "docker-compose": docker_compose_profile(),
     "aira": aira_profile(),
 }
@@ -166,6 +234,15 @@ def detect_profile(worktree_path: Path) -> WorkspaceProfile | None:
         worktree_path / "requirements.txt"
     ).is_file():
         return python_profile(source="detector:python")
+    if (worktree_path / "go.mod").is_file():
+        return go_profile(source="detector:go")
+    if (worktree_path / "Cargo.toml").is_file():
+        return rust_profile(source="detector:rust")
+    java_build_tool = _detect_java_build_tool(worktree_path)
+    if java_build_tool is not None:
+        return java_profile(build_tool=java_build_tool, source="detector:java")
+    if (worktree_path / "CMakeLists.txt").is_file():
+        return cpp_profile(source="detector:cpp")
     return None
 
 
@@ -189,6 +266,16 @@ def _detect_package_manager(worktree_path: Path) -> str:
     if (worktree_path / "bun.lockb").is_file() or (worktree_path / "bun.lock").is_file():
         return "bun"
     return "npm"
+
+
+def _detect_java_build_tool(worktree_path: Path) -> str | None:
+    if (worktree_path / "pom.xml").is_file():
+        return "maven"
+    if (worktree_path / "gradlew").is_file():
+        return "gradle-wrapper"
+    if (worktree_path / "build.gradle").is_file():
+        return "gradle"
+    return None
 
 
 def _looks_like_nextjs(package_json: Path) -> bool:

--- a/src/awf/profiles/registry.py
+++ b/src/awf/profiles/registry.py
@@ -213,7 +213,13 @@ BUILTIN_PROFILES: dict[str, WorkspaceProfile] = {
 }
 
 
-def get_builtin_profile(name: str) -> WorkspaceProfile | None:
+def get_builtin_profile(
+    name: str, *, worktree_path: Path | None = None
+) -> WorkspaceProfile | None:
+    if name == "java" and worktree_path is not None:
+        java_build_tool = _detect_java_build_tool(worktree_path)
+        if java_build_tool is not None:
+            return java_profile(build_tool=java_build_tool)
     profile = BUILTIN_PROFILES.get(name)
     return profile.model_copy(deep=True) if profile is not None else None
 

--- a/src/awf/profiles/registry.py
+++ b/src/awf/profiles/registry.py
@@ -279,10 +279,10 @@ def _detect_package_manager(worktree_path: Path) -> str:
 def _detect_java_build_tool(worktree_path: Path) -> str | None:
     if (worktree_path / "mvnw").is_file():
         return "maven-wrapper"
-    if (worktree_path / "pom.xml").is_file():
-        return "maven"
     if (worktree_path / "gradlew").is_file():
         return "gradle-wrapper"
+    if (worktree_path / "pom.xml").is_file():
+        return "maven"
     if (worktree_path / "build.gradle").is_file():
         return "gradle"
     return None

--- a/src/awf/profiles/resolver.py
+++ b/src/awf/profiles/resolver.py
@@ -53,7 +53,7 @@ class ProfileResolver:
 
         if profile is None and profile_ref and profile_ref != "auto":
             considered.append(f"registry:{profile_ref}")
-            profile = get_builtin_profile(profile_ref)
+            profile = get_builtin_profile(profile_ref, worktree_path=worktree_path)
             if profile is None:
                 raise ProfileResolutionError(f"unknown workspace profile_ref: {profile_ref}")
             reason = f"central registry profile {profile_ref}"

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -108,6 +108,41 @@ def test_language_profiles_can_be_selected_from_registry(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("marker", "contents", "setup_command", "validate_command"),
+    [
+        (
+            "build.gradle",
+            "plugins { id 'java' }\n",
+            "gradle --no-daemon dependencies",
+            "gradle --no-daemon test",
+        ),
+        (
+            "gradlew",
+            "#!/bin/sh\n",
+            "./gradlew --no-daemon dependencies",
+            "./gradlew --no-daemon test",
+        ),
+    ],
+)
+def test_explicit_java_registry_profile_uses_detected_build_tool(
+    tmp_path: Path,
+    marker: str,
+    contents: str,
+    setup_command: str,
+    validate_command: str,
+) -> None:
+    (tmp_path / marker).write_text(contents, encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="java")
+
+    assert result.reason == "central registry profile java"
+    assert result.profile.name == "java"
+    assert result.profile.source == "builtin:java"
+    assert result.profile.phases.setup[0].command == setup_command
+    assert [c.command for c in result.profile.phases.validate_commands] == [validate_command]
+
+
+@pytest.mark.unit
 def test_auto_detection_prefers_docker_compose(tmp_path: Path) -> None:
     (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -112,6 +112,12 @@ def test_language_profiles_can_be_selected_from_registry(
     ("marker", "contents", "setup_command", "validate_command"),
     [
         (
+            "mvnw",
+            "#!/bin/sh\n",
+            "./mvnw -B -DskipTests dependency:go-offline",
+            "./mvnw -B test",
+        ),
+        (
             "build.gradle",
             "plugins { id 'java' }\n",
             "gradle --no-daemon dependencies",
@@ -178,7 +184,7 @@ def test_auto_detection_keeps_nextjs_ahead_of_language_profiles(tmp_path: Path) 
         json.dumps({"dependencies": {"next": "latest"}}),
         encoding="utf-8",
     )
-    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "app"\n', encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "nextjs"
 
@@ -196,7 +202,7 @@ def test_auto_detection_keeps_node_ahead_of_language_profiles(tmp_path: Path) ->
 
 @pytest.mark.unit
 def test_auto_detection_keeps_python_ahead_of_language_profiles(tmp_path: Path) -> None:
-    (tmp_path / "pyproject.toml").write_text("[project]\nname = \"app\"\n", encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "app"\n', encoding="utf-8")
     (tmp_path / "CMakeLists.txt").write_text("project(app)\n", encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "python"
@@ -205,10 +211,10 @@ def test_auto_detection_keeps_python_ahead_of_language_profiles(tmp_path: Path) 
 @pytest.mark.unit
 def test_auto_detection_keeps_aira_ahead_of_language_profiles(tmp_path: Path) -> None:
     (tmp_path / "pyproject.toml").write_text(
-        "[project]\nname = \"aira-agent\"\n",
+        '[project]\nname = "aira-agent"\n',
         encoding="utf-8",
     )
-    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "app"\n', encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "aira"
 
@@ -225,7 +231,7 @@ def test_auto_detection_detects_go(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 def test_auto_detection_detects_rust(tmp_path: Path) -> None:
-    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    (tmp_path / "Cargo.toml").write_text('[package]\nname = "app"\n', encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "rust"
     assert result.profile.source == "detector:rust"
@@ -239,6 +245,12 @@ def test_auto_detection_detects_rust(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("marker", "contents", "setup_command", "validate_command"),
     [
+        (
+            "mvnw",
+            "#!/bin/sh\n",
+            "./mvnw -B -DskipTests dependency:go-offline",
+            "./mvnw -B test",
+        ),
         (
             "pom.xml",
             "<project></project>\n",
@@ -272,6 +284,17 @@ def test_auto_detection_detects_java(
     assert result.profile.source == "detector:java"
     assert result.profile.phases.setup[0].command == setup_command
     assert [c.command for c in result.profile.phases.validate_commands] == [validate_command]
+
+
+@pytest.mark.unit
+def test_auto_detection_prefers_maven_wrapper_over_plain_maven(tmp_path: Path) -> None:
+    (tmp_path / "mvnw").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tmp_path / "pom.xml").write_text("<project></project>\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "java"
+    assert result.profile.source == "detector:java"
+    assert result.profile.phases.setup[0].command == "./mvnw -B -DskipTests dependency:go-offline"
+    assert [c.command for c in result.profile.phases.validate_commands] == ["./mvnw -B test"]
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -298,6 +298,19 @@ def test_auto_detection_prefers_maven_wrapper_over_plain_maven(tmp_path: Path) -
 
 
 @pytest.mark.unit
+def test_auto_detection_prefers_gradle_wrapper_over_plain_maven(tmp_path: Path) -> None:
+    (tmp_path / "gradlew").write_text("#!/bin/sh\n", encoding="utf-8")
+    (tmp_path / "pom.xml").write_text("<project></project>\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "java"
+    assert result.profile.source == "detector:java"
+    assert result.profile.phases.setup[0].command == "./gradlew --no-daemon dependencies"
+    assert [c.command for c in result.profile.phases.validate_commands] == [
+        "./gradlew --no-daemon test"
+    ]
+
+
+@pytest.mark.unit
 def test_auto_detection_detects_cpp(tmp_path: Path) -> None:
     (tmp_path / "CMakeLists.txt").write_text("project(app)\n", encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -80,11 +80,49 @@ def test_repo_profile_beats_registry(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("profile_ref", "setup_command", "validate_commands"),
+    [
+        ("go", "go mod download", ["go test ./..."]),
+        ("rust", "cargo fetch", ["cargo test --all-targets"]),
+        (
+            "java",
+            "mvn -B -DskipTests dependency:go-offline",
+            ["mvn -B test"],
+        ),
+        (
+            "cpp",
+            "cmake -S . -B build",
+            ["cmake --build build", "ctest --test-dir build --output-on-failure"],
+        ),
+    ],
+)
+def test_language_profiles_can_be_selected_from_registry(
+    profile_ref: str, setup_command: str, validate_commands: list[str]
+) -> None:
+    result = ProfileResolver().resolve(worktree_path=None, profile_ref=profile_ref)
+    assert result.profile.name == profile_ref
+    assert result.profile.confidence == "medium"
+    assert result.profile.phases.setup[0].command == setup_command
+    assert [c.command for c in result.profile.phases.validate_commands] == validate_commands
+
+
+@pytest.mark.unit
 def test_auto_detection_prefers_docker_compose(tmp_path: Path) -> None:
     (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "docker-compose"
     assert result.profile.docker.mode == DockerMode.dind
+
+
+@pytest.mark.unit
+def test_auto_detection_keeps_docker_compose_ahead_of_language_profiles(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
+    (tmp_path / "go.mod").write_text("module example.com/app\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "docker-compose"
 
 
 @pytest.mark.unit
@@ -97,6 +135,121 @@ def test_auto_detection_detects_nextjs(tmp_path: Path) -> None:
     result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
     assert result.profile.name == "nextjs"
     assert result.profile.phases.setup[0].command == "pnpm install --frozen-lockfile"
+
+
+@pytest.mark.unit
+def test_auto_detection_keeps_nextjs_ahead_of_language_profiles(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"dependencies": {"next": "latest"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "nextjs"
+
+
+@pytest.mark.unit
+def test_auto_detection_keeps_node_ahead_of_language_profiles(tmp_path: Path) -> None:
+    (tmp_path / "package.json").write_text(
+        json.dumps({"scripts": {"test": "vitest"}}),
+        encoding="utf-8",
+    )
+    (tmp_path / "go.mod").write_text("module example.com/app\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "node"
+
+
+@pytest.mark.unit
+def test_auto_detection_keeps_python_ahead_of_language_profiles(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = \"app\"\n", encoding="utf-8")
+    (tmp_path / "CMakeLists.txt").write_text("project(app)\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "python"
+
+
+@pytest.mark.unit
+def test_auto_detection_keeps_aira_ahead_of_language_profiles(tmp_path: Path) -> None:
+    (tmp_path / "pyproject.toml").write_text(
+        "[project]\nname = \"aira-agent\"\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "aira"
+
+
+@pytest.mark.unit
+def test_auto_detection_detects_go(tmp_path: Path) -> None:
+    (tmp_path / "go.mod").write_text("module example.com/app\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "go"
+    assert result.profile.source == "detector:go"
+    assert result.profile.phases.setup[0].command == "go mod download"
+    assert [c.command for c in result.profile.phases.validate_commands] == ["go test ./..."]
+
+
+@pytest.mark.unit
+def test_auto_detection_detects_rust(tmp_path: Path) -> None:
+    (tmp_path / "Cargo.toml").write_text("[package]\nname = \"app\"\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "rust"
+    assert result.profile.source == "detector:rust"
+    assert result.profile.phases.setup[0].command == "cargo fetch"
+    assert [c.command for c in result.profile.phases.validate_commands] == [
+        "cargo test --all-targets"
+    ]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("marker", "contents", "setup_command", "validate_command"),
+    [
+        (
+            "pom.xml",
+            "<project></project>\n",
+            "mvn -B -DskipTests dependency:go-offline",
+            "mvn -B test",
+        ),
+        (
+            "build.gradle",
+            "plugins { id 'java' }\n",
+            "gradle --no-daemon dependencies",
+            "gradle --no-daemon test",
+        ),
+        (
+            "gradlew",
+            "#!/bin/sh\n",
+            "./gradlew --no-daemon dependencies",
+            "./gradlew --no-daemon test",
+        ),
+    ],
+)
+def test_auto_detection_detects_java(
+    tmp_path: Path,
+    marker: str,
+    contents: str,
+    setup_command: str,
+    validate_command: str,
+) -> None:
+    (tmp_path / marker).write_text(contents, encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "java"
+    assert result.profile.source == "detector:java"
+    assert result.profile.phases.setup[0].command == setup_command
+    assert [c.command for c in result.profile.phases.validate_commands] == [validate_command]
+
+
+@pytest.mark.unit
+def test_auto_detection_detects_cpp(tmp_path: Path) -> None:
+    (tmp_path / "CMakeLists.txt").write_text("project(app)\n", encoding="utf-8")
+    result = ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="auto")
+    assert result.profile.name == "cpp"
+    assert result.profile.source == "detector:cpp"
+    assert result.profile.phases.setup[0].command == "cmake -S . -B build"
+    assert [c.command for c in result.profile.phases.validate_commands] == [
+        "cmake --build build",
+        "ctest --test-dir build --output-on-failure",
+    ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_52ee2edaae384269a62b79cd` (agent: `codex`).


### Task
Implement the next universal-profile slice. Use strict TDD: add failing profile resolver tests first, then implement built-in profiles/detectors for Go, Rust, Java, and C++ projects. Expected detection: go.mod -> go profile; Cargo.toml -> rust profile; pom.xml or build.gradle/gradlew -> java profile; CMakeLists.txt -> cpp profile. Keep commands conservative, profile-driven, and explicit enough for operators to override through .awf/workspace.yml. Do not disturb existing Aira, Docker Compose, Python, Node, or Next.js precedence. Do not switch branches or push; AWF owns branch lifecycle, PR creation, monitoring, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
