### PR TITLE
feat(api): add workspace retry operation

### DIFF
--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -30,6 +30,7 @@ from awf.api.schemas import (
     WorkspaceOverviewListResponse,
     WorkspaceOverviewResponse,
     WorkspaceResponse,
+    WorkspaceRetryResponse,
 )
 from awf.common.config import Settings, get_settings
 from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus
@@ -37,7 +38,15 @@ from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from awf.profiles.resolver import ProfileResolutionError
 from awf.service.disk import DiskCheck, check_disk_space
-from awf.service.workspaces import WorkspaceOwnedPathConflictError, create_workspace_v2_row
+from awf.service.workspaces import (
+    WorkspaceOwnedPathConflictError,
+    WorkspaceRetryError,
+    WorkspaceRetryNotAllowedError,
+    WorkspaceRetryNotFoundError,
+    create_workspace_v2_row,
+    retry_workspace_row,
+    workspace_retry_response,
+)
 
 router = APIRouter(prefix="/v1/workspaces", tags=["workspaces"])
 router_v2 = APIRouter(prefix="/v2/workspaces", tags=["workspaces-v2"])
@@ -179,6 +188,23 @@ def _insufficient_disk_response(disk_check: DiskCheck) -> JSONResponse:
     )
 
 
+def _retry_error_response(exc: WorkspaceRetryError) -> JSONResponse:
+    if isinstance(exc, WorkspaceRetryNotFoundError):
+        status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, WorkspaceRetryNotAllowedError):
+        status_code = status.HTTP_409_CONFLICT
+    else:  # pragma: no cover - future retry error subclasses
+        status_code = status.HTTP_409_CONFLICT
+    return JSONResponse(
+        status_code=status_code,
+        content=ErrorResponse(
+            error_code=exc.error_code,
+            message=exc.message,
+            detail=exc.detail,
+        ).model_dump(),
+    )
+
+
 @router.get("/overview", response_model=WorkspaceOverviewListResponse)
 async def list_workspace_overview(
     workspace_status: Annotated[WorkspaceStatus | None, Query(alias="status")] = None,
@@ -257,6 +283,36 @@ async def list_workspace_events(
     return WorkspaceEventListResponse(
         items=[WorkspaceEventResponse.model_validate(row) for row in rows]
     )
+
+
+@router.post(
+    "/{workspace_id}/retry",
+    response_model=WorkspaceRetryResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    responses={
+        404: {"model": ErrorResponse},
+        409: {"model": ErrorResponse},
+    },
+)
+async def retry_workspace(
+    workspace_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceRetryResponse | JSONResponse:
+    try:
+        result = await retry_workspace_row(session, workspace_id)
+    except WorkspaceOwnedPathConflictError as exc:
+        return JSONResponse(
+            status_code=status.HTTP_409_CONFLICT,
+            content=ErrorResponse(
+                error_code=exc.error_code,
+                message=exc.message,
+                detail=exc.detail,
+            ).model_dump(),
+        )
+    except WorkspaceRetryError as exc:
+        return _retry_error_response(exc)
+
+    return workspace_retry_response(result)
 
 
 @router.get("/{workspace_id}", response_model=WorkspaceResponse)

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -160,6 +160,18 @@ class WorkspaceAcceptedResponse(BaseModel):
     accepted_at: datetime
 
 
+class WorkspaceRetryResponse(BaseModel):
+    """202 Accepted payload for retrying a terminal workspace."""
+
+    source_workspace_id: str
+    new_workspace_id: str
+    operation_id: str
+    status: WorkspaceStatus
+    attempt_number: int
+    status_url: str
+    events_url: str
+
+
 class WorkspaceEventResponse(BaseModel):
     """Representation of an immutable workspace event."""
 

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -366,6 +366,23 @@ def workspace_show(
     _handle_response(response, fmt)
 
 
+@workspace_app.command("retry")
+def workspace_retry(
+    workspace_id: str = typer.Argument(...),
+    api_token: str | None = _api_token_option(),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Retry a failed or cancelled workspace as a fresh attempt."""
+    response = _call(
+        "POST",
+        f"/v1/workspaces/{workspace_id}/retry",
+        base_url=_base_url(base_url),
+        headers=_api_token_headers(api_token),
+    )
+    _handle_response(response, fmt)
+
+
 @workspace_app.command("list")
 def workspace_list(
     limit: int = typer.Option(50, "--limit"),

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -61,6 +61,7 @@ class OperationType(StrEnum):
     start = "start"
     validate = "validate"
     push = "push"
+    retry = "retry"
     cancel = "cancel"
     stop = "stop"
     destroy = "destroy"

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -280,6 +280,8 @@ class WorkspaceRepository:
         requested_profile: dict[str, Any] | None = None,
         resolved_profile: dict[str, Any] | None = None,
         idempotency_key: str | None = None,
+        task_kind: str = "feature_branch_pr",
+        remote_push_branch: str | None = None,
     ) -> Workspace:
         """Create a new workspace in ``requested`` status and emit a creation event.
 
@@ -291,10 +293,12 @@ class WorkspaceRepository:
             version=1,
             repo_url=repo_url,
             branch_base=branch_base,
+            remote_push_branch=remote_push_branch,
             task_title=task_title,
             task_prompt=task_prompt,
             task_external_id=task_external_id,
             task_class=task_class,
+            task_kind=task_kind,
             owned_paths=list(owned_paths or []),
             auto_merge=auto_merge,
             initial_review_grace_period_seconds=initial_review_grace_period_seconds,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -539,13 +539,14 @@ async def _retry_task_for_source(session: AsyncSession, source: Workspace) -> Ta
         if task is not None:
             return task
 
+    fallback_idempotency_key = f"retry-source-workspace:{source.id}"
     return await TaskRepository(session).create_or_get(
         repo_url=source.repo_url,
         base_branch=source.branch_base,
         title=source.task_title,
         prompt=source.task_prompt,
         external_id=source.task_external_id,
-        idempotency_key=None,
+        idempotency_key=fallback_idempotency_key,
         task_class=source.task_class,
         owned_paths=list(source.owned_paths),
     )

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -471,6 +471,7 @@ async def retry_workspace_row(
         idempotency_key=None,
     )
     retried.task_kind = source.task_kind
+    retried.remote_push_branch = source.remote_push_branch
 
     task = await _retry_task_for_source(session, source)
     attempt = await TaskAttemptRepository(session).create_for_workspace(

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -69,29 +69,40 @@ class WorkspaceOwnedPathConflictError(Exception):
 class WorkspaceRetryError(Exception):
     error_code = "WORKSPACE_RETRY_ERROR"
     message = "Workspace retry failed."
-    detail: dict[str, Any] | None = None
+    detail: dict[str, Any] | None
+
+    def __init__(
+        self,
+        message: str | None = None,
+        *,
+        detail: dict[str, Any] | None = None,
+    ) -> None:
+        if message is not None:
+            self.message = message
+        self.detail = detail
+        super().__init__(self.message)
 
 
 class WorkspaceRetryNotFoundError(WorkspaceRetryError):
     error_code = "WORKSPACE_NOT_FOUND"
 
     def __init__(self, workspace_id: str) -> None:
-        self.message = f"No workspace with id {workspace_id}"
-        super().__init__(self.message)
+        super().__init__(f"No workspace with id {workspace_id}")
 
 
 class WorkspaceRetryNotAllowedError(WorkspaceRetryError):
     error_code = "WORKSPACE_NOT_RETRYABLE"
 
     def __init__(self, workspace: Workspace) -> None:
-        self.message = "Only failed or cancelled workspaces can be retried."
-        self.detail = {
-            "status": workspace.status,
-            "retryable_statuses": [
-                status.value for status in RETRYABLE_WORKSPACE_STATUSES
-            ],
-        }
-        super().__init__(self.message)
+        super().__init__(
+            "Only failed or cancelled workspaces can be retried.",
+            detail={
+                "status": workspace.status,
+                "retryable_statuses": [
+                    status.value for status in RETRYABLE_WORKSPACE_STATUSES
+                ],
+            },
+        )
 
 
 @dataclass(frozen=True)

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -404,8 +404,8 @@ async def create_workspace_v2_row(
         test_commands=payload.validation.commands,
         requires_database=False,
         idempotency_key=idempotency_key,
+        task_kind=payload.task.kind,
     )
-    ws.task_kind = payload.task.kind
     task = await TaskRepository(session).create_or_get(
         repo_url=payload.repo.url,
         base_branch=payload.repo.base_branch,
@@ -469,9 +469,9 @@ async def retry_workspace_row(
         test_commands=list(source.test_commands),
         requires_database=source.requires_database,
         idempotency_key=None,
+        task_kind=source.task_kind,
+        remote_push_branch=source.remote_push_branch,
     )
-    retried.task_kind = source.task_kind
-    retried.remote_push_branch = source.remote_push_branch
 
     task = await _retry_task_for_source(session, source)
     attempt = await TaskAttemptRepository(session).create_for_workspace(

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import builtins
+from copy import deepcopy
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -17,10 +19,11 @@ from awf.api.schemas import (
     WorkspaceEventResponse,
     WorkspaceLogStreamResponse,
     WorkspaceResponse,
+    WorkspaceRetryResponse,
     WorkspaceRuntimeResponse,
 )
-from awf.db.enums import OperationStatus, OperationType
-from awf.db.models import Workspace
+from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.models import Operation, Task, Workspace
 from awf.db.repositories import (
     OperationRepository,
     OwnedPathConflict,
@@ -49,6 +52,10 @@ class RuntimeInspection(Protocol):
 
 OWNED_PATH_CONFLICT_CODE = "WORKSPACE_OWNED_PATH_CONFLICT"
 OWNED_PATH_CONFLICT_MESSAGE = "Requested owned paths overlap an active workspace."
+RETRYABLE_WORKSPACE_STATUSES = (
+    WorkspaceStatus.failed,
+    WorkspaceStatus.cancelled,
+)
 
 
 class WorkspaceOwnedPathConflictError(Exception):
@@ -57,6 +64,42 @@ class WorkspaceOwnedPathConflictError(Exception):
         self.message = OWNED_PATH_CONFLICT_MESSAGE
         self.detail = owned_path_conflict_detail(conflicts)
         super().__init__(self.message)
+
+
+class WorkspaceRetryError(Exception):
+    error_code = "WORKSPACE_RETRY_ERROR"
+    message = "Workspace retry failed."
+    detail: dict[str, Any] | None = None
+
+
+class WorkspaceRetryNotFoundError(WorkspaceRetryError):
+    error_code = "WORKSPACE_NOT_FOUND"
+
+    def __init__(self, workspace_id: str) -> None:
+        self.message = f"No workspace with id {workspace_id}"
+        super().__init__(self.message)
+
+
+class WorkspaceRetryNotAllowedError(WorkspaceRetryError):
+    error_code = "WORKSPACE_NOT_RETRYABLE"
+
+    def __init__(self, workspace: Workspace) -> None:
+        self.message = "Only failed or cancelled workspaces can be retried."
+        self.detail = {
+            "status": workspace.status,
+            "retryable_statuses": [
+                status.value for status in RETRYABLE_WORKSPACE_STATUSES
+            ],
+        }
+        super().__init__(self.message)
+
+
+@dataclass(frozen=True)
+class WorkspaceRetryResult:
+    source_workspace_id: str
+    new_workspace: Workspace
+    operation: Operation
+    attempt_number: int
 
 
 class WorkspaceService:
@@ -100,6 +143,12 @@ class WorkspaceService:
             ws = await create_workspace_v2_row(s, req)
             await s.commit()
             return WorkspaceResponse.model_validate(ws)
+
+    async def retry_workspace(self, workspace_id: str) -> WorkspaceRetryResponse:
+        async with self._factory() as s:
+            result = await retry_workspace_row(s, workspace_id)
+            await s.commit()
+            return workspace_retry_response(result)
 
     async def get(self, workspace_id: str) -> WorkspaceResponse | None:
         async with self._factory() as s:
@@ -372,6 +421,135 @@ async def create_workspace_v2_row(
     await TaskAttemptRepository(session).create_for_workspace(task=task, workspace=ws)
     await session.flush()
     return ws
+
+
+async def retry_workspace_row(
+    session: AsyncSession,
+    workspace_id: str,
+) -> WorkspaceRetryResult:
+    """Create a fresh requested workspace cloned from a failed/cancelled attempt."""
+    repo = WorkspaceRepository(session)
+    source = await repo.get_for_update(workspace_id)
+    if source is None:
+        raise WorkspaceRetryNotFoundError(workspace_id)
+
+    if WorkspaceStatus(source.status) not in RETRYABLE_WORKSPACE_STATUSES:
+        raise WorkspaceRetryNotAllowedError(source)
+
+    await repo.acquire_owned_path_conflict_lock(
+        repo_url=source.repo_url,
+        branch_base=source.branch_base,
+        owned_paths=list(source.owned_paths),
+    )
+    conflicts = await repo.find_active_owned_path_conflicts(
+        repo_url=source.repo_url,
+        branch_base=source.branch_base,
+        owned_paths=list(source.owned_paths),
+    )
+    if conflicts:
+        raise WorkspaceOwnedPathConflictError(conflicts)
+
+    retried = await repo.create(
+        repo_url=source.repo_url,
+        branch_base=source.branch_base,
+        task_title=source.task_title,
+        task_prompt=source.task_prompt,
+        task_external_id=source.task_external_id,
+        task_class=source.task_class,
+        owned_paths=list(source.owned_paths),
+        auto_merge=source.auto_merge,
+        initial_review_grace_period_seconds=(
+            source.initial_review_grace_period_seconds
+        ),
+        agent=source.agent,
+        env_profile=source.env_profile,
+        profile_ref=source.profile_ref,
+        requested_profile=deepcopy(source.requested_profile),
+        resolved_profile=deepcopy(source.resolved_profile),
+        test_commands=list(source.test_commands),
+        requires_database=source.requires_database,
+        idempotency_key=None,
+    )
+    retried.task_kind = source.task_kind
+
+    task = await _retry_task_for_source(session, source)
+    attempt = await TaskAttemptRepository(session).create_for_workspace(
+        task=task,
+        workspace=retried,
+    )
+
+    operation_repo = OperationRepository(session)
+    operation = await operation_repo.create(
+        workspace_id=source.id,
+        operation_type=OperationType.retry,
+        status=OperationStatus.running,
+        payload={"source_workspace_id": source.id},
+    )
+    event_payload = {
+        "source_workspace_id": source.id,
+        "new_workspace_id": retried.id,
+        "attempt_number": attempt.attempt_number,
+    }
+    await repo.add_event(
+        source,
+        event_type="workspace.retry_requested",
+        reason_code="RETRY_REQUESTED",
+        payload=event_payload,
+    )
+    await repo.add_event(
+        retried,
+        event_type="workspace.retry_created",
+        reason_code="RETRY_CREATED",
+        payload=event_payload,
+    )
+    await operation_repo.finish(
+        operation,
+        status=OperationStatus.succeeded,
+        result={
+            "new_workspace_id": retried.id,
+            "attempt_number": attempt.attempt_number,
+            "status": retried.status,
+        },
+    )
+    await session.flush()
+    return WorkspaceRetryResult(
+        source_workspace_id=source.id,
+        new_workspace=retried,
+        operation=operation,
+        attempt_number=attempt.attempt_number,
+    )
+
+
+async def _retry_task_for_source(session: AsyncSession, source: Workspace) -> Task:
+    attempt = await TaskAttemptRepository(session).get_by_workspace_id(source.id)
+    if attempt is not None:
+        task = await TaskRepository(session).get(attempt.task_id)
+        if task is not None:
+            return task
+
+    return await TaskRepository(session).create_or_get(
+        repo_url=source.repo_url,
+        base_branch=source.branch_base,
+        title=source.task_title,
+        prompt=source.task_prompt,
+        external_id=source.task_external_id,
+        idempotency_key=None,
+        task_class=source.task_class,
+        owned_paths=list(source.owned_paths),
+    )
+
+
+def workspace_retry_response(result: WorkspaceRetryResult) -> WorkspaceRetryResponse:
+    new_workspace_id = result.new_workspace.id
+    return WorkspaceRetryResponse(
+        source_workspace_id=result.source_workspace_id,
+        new_workspace_id=new_workspace_id,
+        operation_id=result.operation.id,
+        status=WorkspaceStatus(result.new_workspace.status),
+        attempt_number=result.attempt_number,
+        status_url=f"/v1/workspaces/{new_workspace_id}",
+        events_url=f"/v1/workspaces/{new_workspace_id}/events",
+    )
 
 
 def owned_path_conflict_detail(conflicts: list[OwnedPathConflict]) -> dict[str, Any]:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -481,7 +481,7 @@ async def retry_workspace_row(
 
     operation_repo = OperationRepository(session)
     operation = await operation_repo.create(
-        workspace_id=source.id,
+        workspace_id=retried.id,
         operation_type=OperationType.retry,
         status=OperationStatus.running,
         payload={"source_workspace_id": source.id},

--- a/tests/unit/api/test_workspace_retry.py
+++ b/tests/unit/api/test_workspace_retry.py
@@ -10,7 +10,6 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 
-
 _V2_RETRY_BODY = {
     "repo": {
         "url": "git@github.com:example/retry-api.git",
@@ -46,6 +45,31 @@ async def _create_failed_workspace(client: AsyncClient, engine: AsyncEngine) -> 
         workspace.failure_reason = "validation_failure"
         workspace.failure_message = "pytest failed"
         await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        await session.commit()
+    return workspace_id
+
+
+async def _create_cancelled_workspace(client: AsyncClient, engine: AsyncEngine) -> str:
+    created = await client.post(
+        "/v2/workspaces",
+        json={
+            **_V2_RETRY_BODY,
+            "task": {
+                **_V2_RETRY_BODY["task"],
+                "external_id": "TICKET-API-RETRY-CANCELLED",
+                "owned_paths": ["src/awf/api/retry-cancelled.py"],
+            },
+        },
+    )
+    assert created.status_code == 202
+    workspace_id = str(created.json()["workspace_id"])
+
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.cancelled, reason_code="TEST_CANCEL")
         await session.commit()
     return workspace_id
 
@@ -87,6 +111,21 @@ async def test_retry_endpoint_creates_new_requested_workspace(
 
 
 @pytest.mark.unit
+async def test_retry_endpoint_accepts_cancelled_workspace(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    original_id = await _create_cancelled_workspace(client, engine)
+
+    response = await client.post(f"/v1/workspaces/{original_id}/retry")
+
+    assert response.status_code == 202
+    assert response.json()["source_workspace_id"] == original_id
+    assert response.json()["status"] == "requested"
+    assert response.json()["attempt_number"] == 2
+
+
+@pytest.mark.unit
 async def test_retry_endpoint_rejects_missing_workspace(client: AsyncClient) -> None:
     response = await client.post("/v1/workspaces/ws_missing_retry/retry")
 
@@ -107,4 +146,3 @@ async def test_retry_endpoint_rejects_non_terminal_workspace(client: AsyncClient
     assert body["error_code"] == "WORKSPACE_NOT_RETRYABLE"
     assert body["detail"]["status"] == "requested"
     assert body["detail"]["retryable_statuses"] == ["failed", "cancelled"]
-

--- a/tests/unit/api/test_workspace_retry.py
+++ b/tests/unit/api/test_workspace_retry.py
@@ -1,0 +1,110 @@
+"""Retry/requeue API contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+_V2_RETRY_BODY = {
+    "repo": {
+        "url": "git@github.com:example/retry-api.git",
+        "base_branch": "development",
+    },
+    "task": {
+        "title": "Retry API task",
+        "prompt": "Retry this failed workspace.",
+        "kind": "feature_branch_pr",
+        "agent": "codex",
+        "external_id": "TICKET-API-RETRY",
+        "task_class": "test_task",
+        "owned_paths": ["src/awf/api/retry.py"],
+        "auto_merge": False,
+    },
+    "workspace": {"profile_ref": "python", "profile": None},
+    "validation": {"commands": ["pytest tests/unit/api -q"], "requested_tier": 2},
+    "resources": {},
+}
+
+
+async def _create_failed_workspace(client: AsyncClient, engine: AsyncEngine) -> str:
+    created = await client.post("/v2/workspaces", json=_V2_RETRY_BODY)
+    assert created.status_code == 202
+    workspace_id = str(created.json()["workspace_id"])
+
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        workspace.failure_reason = "validation_failure"
+        workspace.failure_message = "pytest failed"
+        await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        await session.commit()
+    return workspace_id
+
+
+@pytest.mark.unit
+async def test_retry_endpoint_creates_new_requested_workspace(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    original_id = await _create_failed_workspace(client, engine)
+
+    response = await client.post(f"/v1/workspaces/{original_id}/retry")
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["source_workspace_id"] == original_id
+    assert body["new_workspace_id"].startswith("ws_")
+    assert body["new_workspace_id"] != original_id
+    assert body["status"] == "requested"
+    assert body["attempt_number"] == 2
+    assert body["status_url"] == f"/v1/workspaces/{body['new_workspace_id']}"
+    assert body["events_url"] == f"/v1/workspaces/{body['new_workspace_id']}/events"
+
+    retried = await client.get(f"/v1/workspaces/{body['new_workspace_id']}")
+    assert retried.status_code == 200
+    retried_body = retried.json()
+    assert retried_body["repo_url"] == _V2_RETRY_BODY["repo"]["url"]
+    assert retried_body["branch_base"] == _V2_RETRY_BODY["repo"]["base_branch"]
+    assert retried_body["task_title"] == _V2_RETRY_BODY["task"]["title"]
+    assert retried_body["task_prompt"] == _V2_RETRY_BODY["task"]["prompt"]
+    assert retried_body["task_external_id"] == _V2_RETRY_BODY["task"]["external_id"]
+    assert retried_body["task_class"] == _V2_RETRY_BODY["task"]["task_class"]
+    assert retried_body["owned_paths"] == _V2_RETRY_BODY["task"]["owned_paths"]
+    assert retried_body["auto_merge"] is False
+    assert retried_body["profile_ref"] == "python"
+    assert retried_body["test_commands"] == _V2_RETRY_BODY["validation"]["commands"]
+    assert retried_body["failure_reason"] is None
+    assert retried_body["failure_message"] is None
+
+
+@pytest.mark.unit
+async def test_retry_endpoint_rejects_missing_workspace(client: AsyncClient) -> None:
+    response = await client.post("/v1/workspaces/ws_missing_retry/retry")
+
+    assert response.status_code == 404
+    assert response.json()["error_code"] == "WORKSPACE_NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_retry_endpoint_rejects_non_terminal_workspace(client: AsyncClient) -> None:
+    created = await client.post("/v2/workspaces", json=_V2_RETRY_BODY)
+    assert created.status_code == 202
+    workspace_id = str(created.json()["workspace_id"])
+
+    response = await client.post(f"/v1/workspaces/{workspace_id}/retry")
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error_code"] == "WORKSPACE_NOT_RETRYABLE"
+    assert body["detail"]["status"] == "requested"
+    assert body["detail"]["retryable_statuses"] == ["failed", "cancelled"]
+

--- a/tests/unit/api/test_workspace_retry.py
+++ b/tests/unit/api/test_workspace_retry.py
@@ -88,10 +88,19 @@ async def test_retry_endpoint_creates_new_requested_workspace(
     assert body["source_workspace_id"] == original_id
     assert body["new_workspace_id"].startswith("ws_")
     assert body["new_workspace_id"] != original_id
+    assert body["operation_id"].startswith("op_")
     assert body["status"] == "requested"
     assert body["attempt_number"] == 2
     assert body["status_url"] == f"/v1/workspaces/{body['new_workspace_id']}"
     assert body["events_url"] == f"/v1/workspaces/{body['new_workspace_id']}/events"
+
+    operations = await client.get(
+        f"/v1/workspaces/{body['new_workspace_id']}/operations?type=retry"
+    )
+    assert operations.status_code == 200
+    assert [item["id"] for item in operations.json()["items"]] == [
+        body["operation_id"]
+    ]
 
     retried = await client.get(f"/v1/workspaces/{body['new_workspace_id']}")
     assert retried.status_code == 200

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -197,6 +197,30 @@ class TestWorkspaceShow:
         assert id_pos < status_pos
 
 
+class TestWorkspaceRetry:
+    @pytest.mark.unit
+    def test_posts_retry_request_and_prints_new_workspace(self) -> None:
+        response = _mock_response(
+            status_code=202,
+            payload={
+                "source_workspace_id": "ws_old",
+                "new_workspace_id": "ws_new",
+                "operation_id": "op_retry",
+                "status": "requested",
+                "attempt_number": 2,
+            },
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(app, ["workspace", "retry", "ws_old"])
+
+        assert result.exit_code == 0
+        assert "ws_new" in result.stdout
+        assert mock.call_args[0] == (
+            "POST",
+            "http://localhost:8000/v1/workspaces/ws_old/retry",
+        )
+
+
 class TestWorkspaceList:
     @pytest.mark.unit
     def test_passes_limit_as_query_param(self) -> None:

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -178,6 +178,57 @@ async def test_retry_failed_workspace_clones_v2_metadata_and_increments_attempt(
 
 
 @pytest.mark.unit
+async def test_retry_legacy_workspace_without_attempt_reuses_fallback_task(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        source = await repo.create(
+            repo_url="git@github.com:example/retryable.git",
+            branch_base="development",
+            task_title="Retry legacy validation",
+            task_prompt="Fix a legacy workspace without task attempts.",
+            task_external_id=None,
+            task_class="test_task",
+            owned_paths=[],
+            auto_merge=False,
+            initial_review_grace_period_seconds=30,
+            agent=AgentRuntime.codex.value,
+            profile_ref="python",
+            requested_profile={"source": "legacy-test-profile"},
+            resolved_profile={"source": "legacy-test-profile"},
+            test_commands=["uv run pytest tests/unit -q"],
+        )
+        await repo.transition(source, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        await repo.transition(source, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        await session.commit()
+        source_id = source.id
+
+    service = WorkspaceService(factory)
+    first_retry = await service.retry_workspace(source_id)
+    second_retry = await service.retry_workspace(source_id)
+
+    async with factory() as session:
+        tasks = list((await session.execute(select(Task))).scalars())
+        attempts = list(
+            (
+                await session.execute(
+                    select(TaskAttempt).order_by(TaskAttempt.attempt_number.asc())
+                )
+            ).scalars()
+        )
+
+    assert len(tasks) == 1
+    assert tasks[0].idempotency_key == f"retry-source-workspace:{source_id}"
+    assert [attempt.workspace_id for attempt in attempts] == [
+        first_retry.new_workspace_id,
+        second_retry.new_workspace_id,
+    ]
+    assert [attempt.attempt_number for attempt in attempts] == [1, 2]
+    assert {attempt.task_id for attempt in attempts} == {tasks[0].id}
+
+
+@pytest.mark.unit
 async def test_retry_preserves_remote_push_branch_for_sync_workspace(
     factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -14,7 +14,7 @@ from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Operation, Task, TaskAttempt, WorkspaceEvent
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
-from awf.service.workspaces import WorkspaceService
+from awf.service.workspaces import WorkspaceRetryNotFoundError, WorkspaceService
 
 
 @pytest.fixture
@@ -46,6 +46,14 @@ def _request(*, task_kind: str = "feature_branch_pr") -> WorkspaceCreateV2Reques
         validation={"commands": ["uv run pytest tests/unit -q"], "requested_tier": 2},
         resources={},
     )
+
+
+@pytest.mark.unit
+def test_retry_not_found_error_has_instance_detail() -> None:
+    error = WorkspaceRetryNotFoundError("ws_missing")
+
+    assert error.detail is None
+    assert error.__dict__["detail"] is None
 
 
 async def _mark_failed(

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.schemas import WorkspaceCreateV2Request
@@ -197,3 +197,42 @@ async def test_retry_preserves_remote_push_branch_for_sync_workspace(
     assert retried.task_kind == "sync_release_pr"
     assert retried.branch_name is None
     assert retried.remote_push_branch == "development"
+
+
+@pytest.mark.unit
+async def test_retry_persists_task_kind_without_post_insert_update() -> None:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = make_session_factory(engine)
+    service = WorkspaceService(factory)
+    first = await service.create_v2(_request(task_kind="sync_release_pr"))
+    await _mark_failed(factory, first.id)
+
+    statements: list[str] = []
+
+    def record_sql(
+        conn: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        del conn, cursor, parameters, context, executemany
+        statements.append(" ".join(statement.lower().split()))
+
+    event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+    try:
+        await service.retry_workspace(first.id)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+        await engine.dispose()
+
+    task_kind_updates = [
+        statement
+        for statement in statements
+        if statement.startswith("update workspaces") and "task_kind" in statement
+    ]
+    assert task_kind_updates == []

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -1,0 +1,165 @@
+"""Service-level retry/requeue tests for terminal workspaces."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import WorkspaceCreateV2Request
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.models import Operation, Task, TaskAttempt, WorkspaceEvent
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.service.workspaces import WorkspaceService
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+def _request() -> WorkspaceCreateV2Request:
+    return WorkspaceCreateV2Request(
+        repo={"url": "git@github.com:example/retryable.git", "base_branch": "development"},
+        task={
+            "title": "Retry flaky validation",
+            "prompt": "Fix the intermittent validation failure.",
+            "agent": "codex",
+            "kind": "feature_branch_pr",
+            "external_id": "TICKET-RETRY",
+            "task_class": "test_task",
+            "owned_paths": ["src/awf/retry/**"],
+            "auto_merge": False,
+            "initial_review_grace_period_seconds": 30,
+        },
+        workspace={"profile_ref": "python", "profile": None},
+        validation={"commands": ["uv run pytest tests/unit -q"], "requested_tier": 2},
+        resources={},
+    )
+
+
+async def _mark_failed(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> dict[str, object]:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        workspace.failure_reason = "validation_failure"
+        workspace.failure_message = "pytest failed"
+        workspace.branch_name = "codex/old-attempt"
+        workspace.pr_url = "https://github.com/example/retryable/pull/10"
+        workspace.compose_project_name = "awf_old_attempt"
+        assert workspace.resolved_profile is not None
+        frozen_profile = {
+            **workspace.resolved_profile,
+            "source": "frozen:test-profile",
+        }
+        workspace.resolved_profile = frozen_profile
+        await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        await session.commit()
+        return frozen_profile
+
+
+@pytest.mark.unit
+async def test_retry_failed_workspace_clones_v2_metadata_and_increments_attempt(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    first = await service.create_v2(_request())
+    frozen_profile = await _mark_failed(factory, first.id)
+
+    retry = await service.retry_workspace(first.id)
+
+    async with factory() as session:
+        original = await WorkspaceRepository(session).get(first.id)
+        retried = await WorkspaceRepository(session).get(retry.new_workspace_id)
+        tasks = list((await session.execute(select(Task))).scalars())
+        attempts = list(
+            (
+                await session.execute(
+                    select(TaskAttempt).order_by(TaskAttempt.attempt_number.asc())
+                )
+            ).scalars()
+        )
+        operations = list(
+            (
+                await session.execute(
+                    select(Operation).where(Operation.workspace_id == first.id)
+                )
+            ).scalars()
+        )
+        retry_events = list(
+            (
+                await session.execute(
+                    select(WorkspaceEvent).where(
+                        WorkspaceEvent.event_type.in_(
+                            ["workspace.retry_requested", "workspace.retry_created"]
+                        )
+                    )
+                )
+            ).scalars()
+        )
+
+    assert original is not None
+    assert retried is not None
+    assert retry.source_workspace_id == first.id
+    assert retry.new_workspace_id != first.id
+    assert retry.status == WorkspaceStatus.requested
+    assert retry.attempt_number == 2
+
+    assert retried.status == WorkspaceStatus.requested.value
+    assert retried.repo_url == original.repo_url
+    assert retried.branch_base == original.branch_base
+    assert retried.task_title == original.task_title
+    assert retried.task_prompt == original.task_prompt
+    assert retried.task_external_id == original.task_external_id
+    assert retried.task_class == original.task_class
+    assert retried.owned_paths == original.owned_paths
+    assert retried.auto_merge is False
+    assert retried.initial_review_grace_period_seconds == 30
+    assert retried.agent == AgentRuntime.codex.value
+    assert retried.profile_ref == "python"
+    assert retried.resolved_profile == frozen_profile
+    assert retried.test_commands == ["uv run pytest tests/unit -q"]
+    assert retried.failure_reason is None
+    assert retried.failure_message is None
+    assert retried.pr_url is None
+    assert retried.compose_project_name is None
+
+    assert len(tasks) == 1
+    assert [attempt.workspace_id for attempt in attempts] == [first.id, retried.id]
+    assert [attempt.attempt_number for attempt in attempts] == [1, 2]
+    assert {attempt.task_id for attempt in attempts} == {tasks[0].id}
+
+    assert len(operations) == 1
+    assert operations[0].type == "retry"
+    assert operations[0].status == "succeeded"
+    assert operations[0].payload == {"source_workspace_id": first.id}
+    assert operations[0].result == {
+        "new_workspace_id": retried.id,
+        "attempt_number": 2,
+        "status": "requested",
+    }
+
+    assert {
+        (event.workspace_id, event.event_type, event.payload["source_workspace_id"])
+        for event in retry_events
+        if event.payload is not None
+    } == {
+        (first.id, "workspace.retry_requested", first.id),
+        (retried.id, "workspace.retry_created", first.id),
+    }
+

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -28,14 +28,14 @@ async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
         await engine.dispose()
 
 
-def _request() -> WorkspaceCreateV2Request:
+def _request(*, task_kind: str = "feature_branch_pr") -> WorkspaceCreateV2Request:
     return WorkspaceCreateV2Request(
         repo={"url": "git@github.com:example/retryable.git", "base_branch": "development"},
         task={
             "title": "Retry flaky validation",
             "prompt": "Fix the intermittent validation failure.",
             "agent": "codex",
-            "kind": "feature_branch_pr",
+            "kind": task_kind,
             "external_id": "TICKET-RETRY",
             "task_class": "test_task",
             "owned_paths": ["src/awf/retry/**"],
@@ -51,6 +51,9 @@ def _request() -> WorkspaceCreateV2Request:
 async def _mark_failed(
     factory: async_sessionmaker[AsyncSession],
     workspace_id: str,
+    *,
+    branch_name: str = "codex/old-attempt",
+    remote_push_branch: str | None = None,
 ) -> dict[str, object]:
     async with factory() as session:
         repo = WorkspaceRepository(session)
@@ -59,7 +62,8 @@ async def _mark_failed(
         await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
         workspace.failure_reason = "validation_failure"
         workspace.failure_message = "pytest failed"
-        workspace.branch_name = "codex/old-attempt"
+        workspace.branch_name = branch_name
+        workspace.remote_push_branch = remote_push_branch
         workspace.pr_url = "https://github.com/example/retryable/pull/10"
         workspace.compose_project_name = "awf_old_attempt"
         assert workspace.resolved_profile is not None
@@ -163,3 +167,33 @@ async def test_retry_failed_workspace_clones_v2_metadata_and_increments_attempt(
         (retried.id, "workspace.retry_created", first.id),
     }
 
+
+@pytest.mark.unit
+async def test_retry_preserves_remote_push_branch_for_sync_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+    first = await service.create_v2(_request(task_kind="sync_release_pr"))
+    await _mark_failed(
+        factory,
+        first.id,
+        branch_name="release-sync/ws_old",
+        remote_push_branch="development",
+    )
+
+    retry = await service.retry_workspace(first.id)
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        original = await repo.get(first.id)
+        retried = await repo.get(retry.new_workspace_id)
+
+    assert original is not None
+    assert retried is not None
+    assert original.task_kind == "sync_release_pr"
+    assert original.branch_name == "release-sync/ws_old"
+    assert original.remote_push_branch == "development"
+
+    assert retried.task_kind == "sync_release_pr"
+    assert retried.branch_name is None
+    assert retried.remote_push_branch == "development"

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -101,7 +101,7 @@ async def test_retry_failed_workspace_clones_v2_metadata_and_increments_attempt(
         operations = list(
             (
                 await session.execute(
-                    select(Operation).where(Operation.workspace_id == first.id)
+                    select(Operation).where(Operation.workspace_id == retried.id)
                 )
             ).scalars()
         )
@@ -149,6 +149,7 @@ async def test_retry_failed_workspace_clones_v2_metadata_and_increments_attempt(
     assert {attempt.task_id for attempt in attempts} == {tasks[0].id}
 
     assert len(operations) == 1
+    assert operations[0].workspace_id == retried.id
     assert operations[0].type == "retry"
     assert operations[0].status == "succeeded"
     assert operations[0].payload == {"source_workspace_id": first.id}


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8134afd07e2d48619029b979` (agent: `codex`).


### Task
Implement the PRD retry/requeue slice for AWF. Use strict TDD: write failing unit tests first, commit the red test if practical, then implement until green. Add POST /v1/workspaces/{workspace_id}/retry for terminal failed/cancelled workspaces. It should create a fresh v2 workspace request cloned from the original task/repo/profile/validation metadata, keep task lineage so TaskAttempt attempt_number increments, record an operation/event linking old and new workspace ids, return a structured response with the new workspace id, and reject missing/non-terminal workspaces with stable error codes. Add a small CLI command `awf workspace retry <workspace_id>` if it fits the existing CLI style. Do not switch branches or push; AWF owns branch lifecycle, PR creation, monitoring, and merge. Keep the write scope tight to retry API/service/db tests.

---
Validation: 6 profile command(s) passed inside the workspace container.
