### PR TITLE
feat(metrics): expose resource saturation summary

### DIFF
--- a/src/awf/api/routes/metrics.py
+++ b/src/awf/api/routes/metrics.py
@@ -2,22 +2,28 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Callable
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, cast
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.deps import get_db_session
+from awf.common.config import Settings, get_settings
+from awf.service.disk import DiskCheck, check_disk_space
 from awf.service.metrics import (
     DEFAULT_SUMMARY_WINDOW_HOURS,
     MAX_SUMMARY_WINDOW_HOURS,
     MIN_SUMMARY_WINDOW_HOURS,
+    summarize_resource_saturation_for_session,
     summarize_workspace_reliability_for_session,
 )
 
 router = APIRouter(prefix="/v1/metrics", tags=["metrics"])
+DiskCheckProvider = Callable[[Settings], DiskCheck]
 
 
 class WorkspaceReliabilitySummaryResponse(BaseModel):
@@ -44,6 +50,119 @@ class WorkspaceReliabilitySummaryResponse(BaseModel):
     cleanup_failure_count: int
 
 
+class WorkspaceSaturationCountsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    by_status: dict[str, int]
+    active_total: int
+    requested: int
+    provisioning: int
+    ready: int
+    running: int
+    validating: int
+    pushing: int
+    monitoring_pr: int
+    destroying: int
+    completed: int
+    failed: int
+    cancelled: int
+    destroyed: int
+
+
+class WorkerConcurrencySettingsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    max_concurrent_provisions: int
+    max_concurrent_executions: int
+
+
+class WorkspaceResourceDefaultsResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+
+
+class ReservedResourcesResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    active_workspace_count: int
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+
+
+class ConcurrencyLaneResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    limit: int
+    in_use: int
+    queued: int
+    available: int
+
+
+class ResourceConcurrencyResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    provision: ConcurrencyLaneResponse
+    execution: ConcurrencyLaneResponse
+
+
+class DiskCheckResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    path: str
+    checked_path: str
+    total_bytes: int
+    used_bytes: int
+    free_bytes: int
+    percent_free: float
+    threshold_bytes: int
+    ok: bool
+    status: str
+    reason: str
+    detail: str | None = None
+
+
+class AdmissionSummaryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    ok: bool
+    status: str
+    reason: str
+    detail: str | None = None
+
+
+class ResourceSaturationSummaryResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    generated_at: datetime
+    workspace_counts: WorkspaceSaturationCountsResponse = Field(
+        description="Current workspace counts by status plus active non-terminal totals.",
+    )
+    worker: WorkerConcurrencySettingsResponse = Field(
+        description="Configured local worker concurrency limits.",
+    )
+    resource_defaults: WorkspaceResourceDefaultsResponse = Field(
+        description="Configured per-workspace steady and peak resource defaults.",
+    )
+    reserved_resources: ReservedResourcesResponse = Field(
+        description="Resource reservations implied by active workspace count and defaults.",
+    )
+    concurrency: ResourceConcurrencyResponse = Field(
+        description="Provisioning and execution worker lane saturation.",
+    )
+    disk: DiskCheckResponse = Field(
+        description="Disk pressure check for the AWF work directory.",
+    )
+    admission: AdmissionSummaryResponse = Field(
+        description="Actionable summary explaining whether new workspace admission is blocked.",
+    )
+
+
 @router.get(
     "/workspaces/summary",
     response_model=WorkspaceReliabilitySummaryResponse,
@@ -63,3 +182,35 @@ async def get_workspace_reliability_summary(
         since_hours=since_hours,
     )
     return WorkspaceReliabilitySummaryResponse.model_validate(summary)
+
+
+@router.get(
+    "/resources/saturation",
+    response_model=ResourceSaturationSummaryResponse,
+)
+async def get_resource_saturation_summary(
+    request: Request,
+    settings: Settings = Depends(get_settings),
+    session: AsyncSession = Depends(get_db_session),
+) -> ResourceSaturationSummaryResponse:
+    disk_check = await _resource_saturation_disk_check(request, settings)
+    summary = await summarize_resource_saturation_for_session(
+        session,
+        settings=settings,
+        disk_check=disk_check,
+    )
+    return ResourceSaturationSummaryResponse.model_validate(summary)
+
+
+async def _resource_saturation_disk_check(request: Request, settings: Settings) -> DiskCheck:
+    provider = cast(
+        DiskCheckProvider | None,
+        getattr(request.app.state, "workspace_admission_disk_check", None),
+    )
+    if provider is not None:
+        return await asyncio.to_thread(provider, settings)
+    return await asyncio.to_thread(
+        check_disk_space,
+        settings.work_dir,
+        min_free_bytes=settings.min_free_disk_bytes,
+    )

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
@@ -243,11 +244,14 @@ async def summarize_resource_saturation_for_session(
         resource_defaults=resource_defaults,
     )
     concurrency = _resource_concurrency(status_counts, worker=worker)
-    resolved_disk_check = disk_check or check_disk_space(
-        settings.work_dir,
-        min_free_bytes=settings.min_free_disk_bytes,
-        disk_usage=disk_usage,
-    )
+    resolved_disk_check = disk_check
+    if resolved_disk_check is None:
+        resolved_disk_check = await asyncio.to_thread(
+            check_disk_space,
+            settings.work_dir,
+            min_free_bytes=settings.min_free_disk_bytes,
+            disk_usage=disk_usage,
+        )
     admission = _resource_admission_summary(
         disk_check=resolved_disk_check,
         concurrency=concurrency,

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -42,6 +42,9 @@ EXECUTION_QUEUE_STATUSES = frozenset({WorkspaceStatus.ready.value})
 ADMISSION_OK_REASON = "ADMISSION_OK"
 WORKER_PROVISION_CONCURRENCY_SATURATED_REASON = "WORKER_PROVISION_CONCURRENCY_SATURATED"
 WORKER_EXECUTION_CONCURRENCY_SATURATED_REASON = "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+WORKER_PROVISION_AND_EXECUTION_CONCURRENCY_SATURATED_REASON = (
+    "WORKER_PROVISION_AND_EXECUTION_CONCURRENCY_SATURATED"
+)
 
 
 @dataclass(frozen=True)
@@ -404,7 +407,22 @@ def _resource_admission_summary(
             ),
         )
 
-    if concurrency.execution.available <= 0:
+    provision_saturated = concurrency.provision.available <= 0
+    execution_saturated = concurrency.execution.available <= 0
+
+    if provision_saturated and execution_saturated:
+        return AdmissionSummary(
+            ok=True,
+            status="saturated",
+            reason=WORKER_PROVISION_AND_EXECUTION_CONCURRENCY_SATURATED_REASON,
+            detail=(
+                "Provisioning and execution workers are at their configured concurrency limits; "
+                "new workspaces can be accepted but may wait for both provisioning and "
+                "execution capacity."
+            ),
+        )
+
+    if execution_saturated:
         return AdmissionSummary(
             ok=True,
             status="saturated",
@@ -415,7 +433,7 @@ def _resource_admission_summary(
             ),
         )
 
-    if concurrency.provision.available <= 0:
+    if provision_saturated:
         return AdmissionSummary(
             ok=True,
             status="saturated",

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -8,8 +8,10 @@ from datetime import UTC, datetime, timedelta
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from awf.common.config import Settings
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
+from awf.service.disk import DiskCheck, DiskUsage, check_disk_space
 
 DEFAULT_SUMMARY_WINDOW_HOURS = 24
 MIN_SUMMARY_WINDOW_HOURS = 1
@@ -23,6 +25,22 @@ TERMINAL_WORKSPACE_STATUSES = frozenset(
         WorkspaceStatus.destroyed.value,
     }
 )
+
+PROVISION_IN_USE_STATUSES = frozenset({WorkspaceStatus.provisioning.value})
+PROVISION_QUEUE_STATUSES = frozenset({WorkspaceStatus.requested.value})
+EXECUTION_IN_USE_STATUSES = frozenset(
+    {
+        WorkspaceStatus.running.value,
+        WorkspaceStatus.validating.value,
+        WorkspaceStatus.pushing.value,
+        WorkspaceStatus.monitoring_pr.value,
+    }
+)
+EXECUTION_QUEUE_STATUSES = frozenset({WorkspaceStatus.ready.value})
+
+ADMISSION_OK_REASON = "ADMISSION_OK"
+WORKER_PROVISION_CONCURRENCY_SATURATED_REASON = "WORKER_PROVISION_CONCURRENCY_SATURATED"
+WORKER_EXECUTION_CONCURRENCY_SATURATED_REASON = "WORKER_EXECUTION_CONCURRENCY_SATURATED"
 
 
 @dataclass(frozen=True)
@@ -39,6 +57,81 @@ class WorkspaceReliabilitySummary:
     cancelled_count: int
     destroyed_count: int
     cleanup_failure_count: int
+
+
+@dataclass(frozen=True)
+class WorkspaceSaturationCounts:
+    by_status: dict[str, int]
+    active_total: int
+    requested: int
+    provisioning: int
+    ready: int
+    running: int
+    validating: int
+    pushing: int
+    monitoring_pr: int
+    destroying: int
+    completed: int
+    failed: int
+    cancelled: int
+    destroyed: int
+
+
+@dataclass(frozen=True)
+class WorkerConcurrencySettings:
+    max_concurrent_provisions: int
+    max_concurrent_executions: int
+
+
+@dataclass(frozen=True)
+class WorkspaceResourceDefaults:
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+
+
+@dataclass(frozen=True)
+class ReservedResources:
+    active_workspace_count: int
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+
+
+@dataclass(frozen=True)
+class ConcurrencyLane:
+    limit: int
+    in_use: int
+    queued: int
+    available: int
+
+
+@dataclass(frozen=True)
+class ResourceConcurrency:
+    provision: ConcurrencyLane
+    execution: ConcurrencyLane
+
+
+@dataclass(frozen=True)
+class AdmissionSummary:
+    ok: bool
+    status: str
+    reason: str
+    detail: str | None = None
+
+
+@dataclass(frozen=True)
+class ResourceSaturationSummary:
+    generated_at: datetime
+    workspace_counts: WorkspaceSaturationCounts
+    worker: WorkerConcurrencySettings
+    resource_defaults: WorkspaceResourceDefaults
+    reserved_resources: ReservedResources
+    concurrency: ResourceConcurrency
+    disk: DiskCheck
+    admission: AdmissionSummary
 
 
 async def summarize_workspace_reliability(
@@ -102,6 +195,76 @@ async def summarize_workspace_reliability_for_session(
     )
 
 
+async def summarize_resource_saturation(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    settings: Settings,
+    disk_check: DiskCheck | None = None,
+    disk_usage: DiskUsage | None = None,
+    now: datetime | None = None,
+) -> ResourceSaturationSummary:
+    """Summarize local resource saturation using deterministic backend inputs."""
+
+    async with session_factory() as session:
+        return await summarize_resource_saturation_for_session(
+            session,
+            settings=settings,
+            disk_check=disk_check,
+            disk_usage=disk_usage,
+            now=now,
+        )
+
+
+async def summarize_resource_saturation_for_session(
+    session: AsyncSession,
+    *,
+    settings: Settings,
+    disk_check: DiskCheck | None = None,
+    disk_usage: DiskUsage | None = None,
+    now: datetime | None = None,
+) -> ResourceSaturationSummary:
+    """Build the resource saturation payload for local console capacity views."""
+
+    generated_at = _to_utc(now or datetime.now(UTC))
+    status_counts = await _count_current_by_status(session)
+    workspace_counts = _workspace_saturation_counts(status_counts)
+    worker = WorkerConcurrencySettings(
+        max_concurrent_provisions=settings.worker_max_concurrent_provisions,
+        max_concurrent_executions=settings.worker_max_concurrent_executions,
+    )
+    resource_defaults = WorkspaceResourceDefaults(
+        steady_cpu=settings.workspace_steady_cpu,
+        steady_memory_gb=settings.workspace_steady_memory_gb,
+        peak_cpu=settings.workspace_peak_cpu,
+        peak_memory_gb=settings.workspace_peak_memory_gb,
+    )
+    reserved_resources = _reserved_resources(
+        workspace_counts.active_total,
+        resource_defaults=resource_defaults,
+    )
+    concurrency = _resource_concurrency(status_counts, worker=worker)
+    resolved_disk_check = disk_check or check_disk_space(
+        settings.work_dir,
+        min_free_bytes=settings.min_free_disk_bytes,
+        disk_usage=disk_usage,
+    )
+    admission = _resource_admission_summary(
+        disk_check=resolved_disk_check,
+        concurrency=concurrency,
+    )
+
+    return ResourceSaturationSummary(
+        generated_at=generated_at,
+        workspace_counts=workspace_counts,
+        worker=worker,
+        resource_defaults=resource_defaults,
+        reserved_resources=reserved_resources,
+        concurrency=concurrency,
+        disk=resolved_disk_check,
+        admission=admission,
+    )
+
+
 async def _count_by_status(
     session: AsyncSession,
     *,
@@ -113,6 +276,15 @@ async def _count_by_status(
         .where(Workspace.updated_at >= window_start)
         .group_by(Workspace.status)
     )
+    rows = await session.execute(stmt)
+    for status, count in rows.all():
+        counts[str(status)] = int(count)
+    return counts
+
+
+async def _count_current_by_status(session: AsyncSession) -> dict[str, int]:
+    counts = {status.value: 0 for status in WorkspaceStatus}
+    stmt = select(Workspace.status, func.count()).group_by(Workspace.status)
     rows = await session.execute(stmt)
     for status, count in rows.all():
         counts[str(status)] = int(count)
@@ -146,6 +318,115 @@ async def _count_active_workspaces(session: AsyncSession) -> int:
 async def _count_workspaces_with_status(session: AsyncSession, status: WorkspaceStatus) -> int:
     stmt = select(func.count()).select_from(Workspace).where(Workspace.status == status.value)
     return int(await session.scalar(stmt) or 0)
+
+
+def _workspace_saturation_counts(status_counts: dict[str, int]) -> WorkspaceSaturationCounts:
+    active_total = sum(
+        count
+        for status, count in status_counts.items()
+        if status not in TERMINAL_WORKSPACE_STATUSES
+    )
+    return WorkspaceSaturationCounts(
+        by_status=status_counts,
+        active_total=active_total,
+        requested=status_counts[WorkspaceStatus.requested.value],
+        provisioning=status_counts[WorkspaceStatus.provisioning.value],
+        ready=status_counts[WorkspaceStatus.ready.value],
+        running=status_counts[WorkspaceStatus.running.value],
+        validating=status_counts[WorkspaceStatus.validating.value],
+        pushing=status_counts[WorkspaceStatus.pushing.value],
+        monitoring_pr=status_counts[WorkspaceStatus.monitoring_pr.value],
+        destroying=status_counts[WorkspaceStatus.destroying.value],
+        completed=status_counts[WorkspaceStatus.completed.value],
+        failed=status_counts[WorkspaceStatus.failed.value],
+        cancelled=status_counts[WorkspaceStatus.cancelled.value],
+        destroyed=status_counts[WorkspaceStatus.destroyed.value],
+    )
+
+
+def _reserved_resources(
+    active_workspace_count: int,
+    *,
+    resource_defaults: WorkspaceResourceDefaults,
+) -> ReservedResources:
+    return ReservedResources(
+        active_workspace_count=active_workspace_count,
+        steady_cpu=active_workspace_count * resource_defaults.steady_cpu,
+        steady_memory_gb=active_workspace_count * resource_defaults.steady_memory_gb,
+        peak_cpu=active_workspace_count * resource_defaults.peak_cpu,
+        peak_memory_gb=active_workspace_count * resource_defaults.peak_memory_gb,
+    )
+
+
+def _resource_concurrency(
+    status_counts: dict[str, int],
+    *,
+    worker: WorkerConcurrencySettings,
+) -> ResourceConcurrency:
+    provision_in_use = _sum_status_counts(status_counts, PROVISION_IN_USE_STATUSES)
+    provision_queued = _sum_status_counts(status_counts, PROVISION_QUEUE_STATUSES)
+    execution_in_use = _sum_status_counts(status_counts, EXECUTION_IN_USE_STATUSES)
+    execution_queued = _sum_status_counts(status_counts, EXECUTION_QUEUE_STATUSES)
+    return ResourceConcurrency(
+        provision=ConcurrencyLane(
+            limit=worker.max_concurrent_provisions,
+            in_use=provision_in_use,
+            queued=provision_queued,
+            available=max(0, worker.max_concurrent_provisions - provision_in_use),
+        ),
+        execution=ConcurrencyLane(
+            limit=worker.max_concurrent_executions,
+            in_use=execution_in_use,
+            queued=execution_queued,
+            available=max(0, worker.max_concurrent_executions - execution_in_use),
+        ),
+    )
+
+
+def _resource_admission_summary(
+    *,
+    disk_check: DiskCheck,
+    concurrency: ResourceConcurrency,
+) -> AdmissionSummary:
+    if not disk_check.ok:
+        return AdmissionSummary(
+            ok=False,
+            status="blocked",
+            reason=disk_check.reason,
+            detail=disk_check.detail
+            or (
+                "Free disk is below the configured workspace admission threshold. "
+                f"free_bytes={disk_check.free_bytes} threshold_bytes={disk_check.threshold_bytes}"
+            ),
+        )
+
+    if concurrency.execution.available <= 0:
+        return AdmissionSummary(
+            ok=True,
+            status="saturated",
+            reason=WORKER_EXECUTION_CONCURRENCY_SATURATED_REASON,
+            detail=(
+                "Execution workers are at AWF_WORKER_MAX_CONCURRENT_EXECUTIONS; "
+                "new workspaces can be accepted but may wait for execution capacity."
+            ),
+        )
+
+    if concurrency.provision.available <= 0:
+        return AdmissionSummary(
+            ok=True,
+            status="saturated",
+            reason=WORKER_PROVISION_CONCURRENCY_SATURATED_REASON,
+            detail=(
+                "Provisioning workers are at AWF_WORKER_MAX_CONCURRENT_PROVISIONS; "
+                "new workspaces can be accepted but may wait for provisioning capacity."
+            ),
+        )
+
+    return AdmissionSummary(ok=True, status="ok", reason=ADMISSION_OK_REASON)
+
+
+def _sum_status_counts(status_counts: dict[str, int], statuses: frozenset[str]) -> int:
+    return sum(status_counts[status] for status in statuses)
 
 
 def _validate_since_hours(since_hours: int) -> None:

--- a/tests/unit/api/test_metrics.py
+++ b/tests/unit/api/test_metrics.py
@@ -2,16 +2,20 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from awf.common.config import get_settings
+from awf.api.app import configure_database, create_app
+from awf.common.config import Settings, get_settings
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.disk import DiskCheck
 
 
 async def _workspace(
@@ -39,6 +43,40 @@ async def _workspace(
 
 def _zero_status_counts() -> dict[str, int]:
     return {status.value: 0 for status in WorkspaceStatus}
+
+
+def _disk_check(
+    settings: Settings,
+    *,
+    ok: bool = True,
+    free_bytes: int | None = None,
+    reason: str = "SUFFICIENT_DISK",
+) -> DiskCheck:
+    threshold = settings.min_free_disk_bytes
+    free = threshold + 1 if free_bytes is None else free_bytes
+    return DiskCheck(
+        path=settings.work_dir,
+        checked_path=settings.work_dir,
+        total_bytes=max(free + 1, threshold + 1),
+        used_bytes=1,
+        free_bytes=free,
+        percent_free=99.0,
+        threshold_bytes=threshold,
+        ok=ok,
+        status="ok" if ok else "fail",
+        reason=reason,
+        detail=None if ok else "Free disk is below the configured admission threshold.",
+    )
+
+
+@pytest.fixture
+async def metrics_app_and_client(
+    engine: AsyncEngine,
+) -> AsyncIterator[tuple[Any, AsyncClient]]:
+    app = create_app(use_lifespan=False)
+    configure_database(app, make_session_factory(engine))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield app, c
 
 
 @pytest.mark.unit
@@ -184,3 +222,102 @@ async def test_workspace_summary_is_token_free_when_api_token_is_configured(
         get_settings.cache_clear()
 
     assert response.status_code == 200
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_reports_local_capacity_inputs(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+    engine: AsyncEngine,
+) -> None:
+    app, client = metrics_app_and_client
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-metrics-work",
+        min_free_disk_bytes=700,
+        worker_max_concurrent_provisions=5,
+        worker_max_concurrent_executions=2,
+        workspace_steady_cpu=2.0,
+        workspace_steady_memory_gb=7.5,
+        workspace_peak_cpu=4.0,
+        workspace_peak_memory_gb=12.0,
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
+        provider_settings,
+        ok=True,
+    )
+    now = datetime.now(UTC)
+    for status in (
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.completed,
+    ):
+        await _workspace(engine, status=status, updated_at=now - timedelta(minutes=5))
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace_counts"]["active_total"] == 3
+    assert body["workspace_counts"]["ready"] == 1
+    assert body["workspace_counts"]["running"] == 1
+    assert body["workspace_counts"]["validating"] == 1
+    assert body["workspace_counts"]["by_status"][WorkspaceStatus.completed.value] == 1
+    assert body["worker"] == {
+        "max_concurrent_provisions": 5,
+        "max_concurrent_executions": 2,
+    }
+    assert body["resource_defaults"] == {
+        "steady_cpu": 2.0,
+        "steady_memory_gb": 7.5,
+        "peak_cpu": 4.0,
+        "peak_memory_gb": 12.0,
+    }
+    assert body["reserved_resources"] == {
+        "active_workspace_count": 3,
+        "steady_cpu": 6.0,
+        "steady_memory_gb": 22.5,
+        "peak_cpu": 12.0,
+        "peak_memory_gb": 36.0,
+    }
+    assert body["concurrency"]["execution"] == {
+        "limit": 2,
+        "in_use": 2,
+        "queued": 1,
+        "available": 0,
+    }
+    assert body["disk"]["reason"] == "SUFFICIENT_DISK"
+    assert body["admission"]["ok"] is True
+    assert body["admission"]["status"] == "saturated"
+    assert body["admission"]["reason"] == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_explains_disk_admission_denial(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = metrics_app_and_client
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-metrics-work",
+        min_free_disk_bytes=700,
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
+        provider_settings,
+        ok=False,
+        free_bytes=100,
+        reason="INSUFFICIENT_DISK",
+    )
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["disk"]["ok"] is False
+    assert body["disk"]["reason"] == "INSUFFICIENT_DISK"
+    assert body["admission"]["ok"] is False
+    assert body["admission"]["status"] == "blocked"
+    assert body["admission"]["reason"] == "INSUFFICIENT_DISK"
+    assert "free disk" in body["admission"]["detail"].lower()

--- a/tests/unit/api/test_metrics.py
+++ b/tests/unit/api/test_metrics.py
@@ -2,20 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from awf.api.app import configure_database, create_app
-from awf.common.config import Settings, get_settings
+from awf.common.config import get_settings
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
-from awf.service.disk import DiskCheck
 
 
 async def _workspace(
@@ -43,40 +39,6 @@ async def _workspace(
 
 def _zero_status_counts() -> dict[str, int]:
     return {status.value: 0 for status in WorkspaceStatus}
-
-
-def _disk_check(
-    settings: Settings,
-    *,
-    ok: bool = True,
-    free_bytes: int | None = None,
-    reason: str = "SUFFICIENT_DISK",
-) -> DiskCheck:
-    threshold = settings.min_free_disk_bytes
-    free = threshold + 1 if free_bytes is None else free_bytes
-    return DiskCheck(
-        path=settings.work_dir,
-        checked_path=settings.work_dir,
-        total_bytes=max(free + 1, threshold + 1),
-        used_bytes=1,
-        free_bytes=free,
-        percent_free=99.0,
-        threshold_bytes=threshold,
-        ok=ok,
-        status="ok" if ok else "fail",
-        reason=reason,
-        detail=None if ok else "Free disk is below the configured admission threshold.",
-    )
-
-
-@pytest.fixture
-async def metrics_app_and_client(
-    engine: AsyncEngine,
-) -> AsyncIterator[tuple[Any, AsyncClient]]:
-    app = create_app(use_lifespan=False)
-    configure_database(app, make_session_factory(engine))
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-        yield app, c
 
 
 @pytest.mark.unit
@@ -222,102 +184,3 @@ async def test_workspace_summary_is_token_free_when_api_token_is_configured(
         get_settings.cache_clear()
 
     assert response.status_code == 200
-
-
-@pytest.mark.unit
-async def test_resource_saturation_endpoint_reports_local_capacity_inputs(
-    metrics_app_and_client: tuple[Any, AsyncClient],
-    engine: AsyncEngine,
-) -> None:
-    app, client = metrics_app_and_client
-    settings = Settings(
-        _env_file=None,
-        work_dir="/tmp/awf-metrics-work",
-        min_free_disk_bytes=700,
-        worker_max_concurrent_provisions=5,
-        worker_max_concurrent_executions=2,
-        workspace_steady_cpu=2.0,
-        workspace_steady_memory_gb=7.5,
-        workspace_peak_cpu=4.0,
-        workspace_peak_memory_gb=12.0,
-    )
-    app.dependency_overrides[get_settings] = lambda: settings
-    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
-        provider_settings,
-        ok=True,
-    )
-    now = datetime.now(UTC)
-    for status in (
-        WorkspaceStatus.ready,
-        WorkspaceStatus.running,
-        WorkspaceStatus.validating,
-        WorkspaceStatus.completed,
-    ):
-        await _workspace(engine, status=status, updated_at=now - timedelta(minutes=5))
-
-    response = await client.get("/v1/metrics/resources/saturation")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert body["workspace_counts"]["active_total"] == 3
-    assert body["workspace_counts"]["ready"] == 1
-    assert body["workspace_counts"]["running"] == 1
-    assert body["workspace_counts"]["validating"] == 1
-    assert body["workspace_counts"]["by_status"][WorkspaceStatus.completed.value] == 1
-    assert body["worker"] == {
-        "max_concurrent_provisions": 5,
-        "max_concurrent_executions": 2,
-    }
-    assert body["resource_defaults"] == {
-        "steady_cpu": 2.0,
-        "steady_memory_gb": 7.5,
-        "peak_cpu": 4.0,
-        "peak_memory_gb": 12.0,
-    }
-    assert body["reserved_resources"] == {
-        "active_workspace_count": 3,
-        "steady_cpu": 6.0,
-        "steady_memory_gb": 22.5,
-        "peak_cpu": 12.0,
-        "peak_memory_gb": 36.0,
-    }
-    assert body["concurrency"]["execution"] == {
-        "limit": 2,
-        "in_use": 2,
-        "queued": 1,
-        "available": 0,
-    }
-    assert body["disk"]["reason"] == "SUFFICIENT_DISK"
-    assert body["admission"]["ok"] is True
-    assert body["admission"]["status"] == "saturated"
-    assert body["admission"]["reason"] == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
-
-
-@pytest.mark.unit
-async def test_resource_saturation_endpoint_explains_disk_admission_denial(
-    metrics_app_and_client: tuple[Any, AsyncClient],
-) -> None:
-    app, client = metrics_app_and_client
-    settings = Settings(
-        _env_file=None,
-        work_dir="/tmp/awf-metrics-work",
-        min_free_disk_bytes=700,
-    )
-    app.dependency_overrides[get_settings] = lambda: settings
-    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
-        provider_settings,
-        ok=False,
-        free_bytes=100,
-        reason="INSUFFICIENT_DISK",
-    )
-
-    response = await client.get("/v1/metrics/resources/saturation")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert body["disk"]["ok"] is False
-    assert body["disk"]["reason"] == "INSUFFICIENT_DISK"
-    assert body["admission"]["ok"] is False
-    assert body["admission"]["status"] == "blocked"
-    assert body["admission"]["reason"] == "INSUFFICIENT_DISK"
-    assert "free disk" in body["admission"]["detail"].lower()

--- a/tests/unit/api/test_metrics_capacity.py
+++ b/tests/unit/api/test_metrics_capacity.py
@@ -1,5 +1,172 @@
-"""Resource saturation metrics API tests.
+"""Resource saturation metrics API tests."""
 
-The capacity endpoint coverage lives in ``test_metrics.py`` alongside the
-workspace summary metrics tests; this module is kept for the validation target.
-"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.api.app import configure_database, create_app
+from awf.common.config import Settings, get_settings
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.service.disk import DiskCheck
+
+
+async def _workspace(
+    engine: AsyncEngine,
+    *,
+    status: WorkspaceStatus,
+    updated_at: datetime,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/metrics-api.git",
+            branch_base="main",
+            task_title=f"{status.value} workspace",
+            task_prompt="Collect workspace reliability metrics.",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = status.value
+        workspace.updated_at = updated_at
+        await session.commit()
+
+
+def _disk_check(
+    settings: Settings,
+    *,
+    ok: bool = True,
+    free_bytes: int | None = None,
+    reason: str = "SUFFICIENT_DISK",
+) -> DiskCheck:
+    threshold = settings.min_free_disk_bytes
+    free = threshold + 1 if free_bytes is None else free_bytes
+    return DiskCheck(
+        path=settings.work_dir,
+        checked_path=settings.work_dir,
+        total_bytes=max(free + 1, threshold + 1),
+        used_bytes=1,
+        free_bytes=free,
+        percent_free=99.0,
+        threshold_bytes=threshold,
+        ok=ok,
+        status="ok" if ok else "fail",
+        reason=reason,
+        detail=None if ok else "Free disk is below the configured admission threshold.",
+    )
+
+
+@pytest.fixture
+async def metrics_app_and_client(
+    engine: AsyncEngine,
+) -> AsyncIterator[tuple[Any, AsyncClient]]:
+    app = create_app(use_lifespan=False)
+    configure_database(app, make_session_factory(engine))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+        yield app, c
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_reports_local_capacity_inputs(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+    engine: AsyncEngine,
+) -> None:
+    app, client = metrics_app_and_client
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-metrics-work",
+        min_free_disk_bytes=700,
+        worker_max_concurrent_provisions=5,
+        worker_max_concurrent_executions=2,
+        workspace_steady_cpu=2.0,
+        workspace_steady_memory_gb=7.5,
+        workspace_peak_cpu=4.0,
+        workspace_peak_memory_gb=12.0,
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
+        provider_settings,
+        ok=True,
+    )
+    now = datetime.now(UTC)
+    for status in (
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.completed,
+    ):
+        await _workspace(engine, status=status, updated_at=now - timedelta(minutes=5))
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace_counts"]["active_total"] == 3
+    assert body["workspace_counts"]["ready"] == 1
+    assert body["workspace_counts"]["running"] == 1
+    assert body["workspace_counts"]["validating"] == 1
+    assert body["workspace_counts"]["by_status"][WorkspaceStatus.completed.value] == 1
+    assert body["worker"] == {
+        "max_concurrent_provisions": 5,
+        "max_concurrent_executions": 2,
+    }
+    assert body["resource_defaults"] == {
+        "steady_cpu": 2.0,
+        "steady_memory_gb": 7.5,
+        "peak_cpu": 4.0,
+        "peak_memory_gb": 12.0,
+    }
+    assert body["reserved_resources"] == {
+        "active_workspace_count": 3,
+        "steady_cpu": 6.0,
+        "steady_memory_gb": 22.5,
+        "peak_cpu": 12.0,
+        "peak_memory_gb": 36.0,
+    }
+    assert body["concurrency"]["execution"] == {
+        "limit": 2,
+        "in_use": 2,
+        "queued": 1,
+        "available": 0,
+    }
+    assert body["disk"]["reason"] == "SUFFICIENT_DISK"
+    assert body["admission"]["ok"] is True
+    assert body["admission"]["status"] == "saturated"
+    assert body["admission"]["reason"] == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_explains_disk_admission_denial(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = metrics_app_and_client
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-metrics-work",
+        min_free_disk_bytes=700,
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
+        provider_settings,
+        ok=False,
+        free_bytes=100,
+        reason="INSUFFICIENT_DISK",
+    )
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["disk"]["ok"] is False
+    assert body["disk"]["reason"] == "INSUFFICIENT_DISK"
+    assert body["admission"]["ok"] is False
+    assert body["admission"]["status"] == "blocked"
+    assert body["admission"]["reason"] == "INSUFFICIENT_DISK"
+    assert "free disk" in body["admission"]["detail"].lower()

--- a/tests/unit/api/test_metrics_capacity.py
+++ b/tests/unit/api/test_metrics_capacity.py
@@ -1,0 +1,5 @@
+"""Resource saturation metrics API tests.
+
+The capacity endpoint coverage lives in ``test_metrics.py`` alongside the
+workspace summary metrics tests; this module is kept for the validation target.
+"""

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -8,9 +8,11 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
+from awf.common.config import Settings
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.disk import DiskCheck
 
 
 @pytest.fixture
@@ -44,6 +46,28 @@ async def _workspace(
 
 def _zero_status_counts() -> dict[str, int]:
     return {status.value: 0 for status in WorkspaceStatus}
+
+
+def _disk_check(
+    *,
+    ok: bool = True,
+    free_bytes: int = 900,
+    threshold_bytes: int = 400,
+    reason: str = "SUFFICIENT_DISK",
+) -> DiskCheck:
+    return DiskCheck(
+        path="/tmp/awf-work",
+        checked_path="/tmp",
+        total_bytes=1000,
+        used_bytes=1000 - free_bytes,
+        free_bytes=free_bytes,
+        percent_free=round(free_bytes / 1000 * 100, 2),
+        threshold_bytes=threshold_bytes,
+        ok=ok,
+        status="ok" if ok else "fail",
+        reason=reason,
+        detail=None if ok else "Free disk is below the configured admission threshold.",
+    )
 
 
 @pytest.mark.unit
@@ -188,3 +212,109 @@ async def test_current_counts_include_workspaces_outside_updated_at_window(
     assert summary.status_counts == _zero_status_counts()
     assert summary.active_count == 2
     assert summary.destroying_count == 1
+
+
+@pytest.mark.unit
+async def test_resource_saturation_reports_active_counts_and_configured_defaults(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_resource_saturation
+
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        worker_max_concurrent_provisions=2,
+        worker_max_concurrent_executions=4,
+        workspace_steady_cpu=2.5,
+        workspace_steady_memory_gb=8.0,
+        workspace_peak_cpu=5.0,
+        workspace_peak_memory_gb=14.0,
+    )
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    for status in (
+        WorkspaceStatus.requested,
+        WorkspaceStatus.provisioning,
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.pushing,
+        WorkspaceStatus.monitoring_pr,
+        WorkspaceStatus.destroying,
+        WorkspaceStatus.completed,
+    ):
+        await _workspace(session_factory, status=status, updated_at=now)
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_check=_disk_check(),
+        now=now,
+    )
+
+    assert summary.generated_at == now
+    assert summary.workspace_counts.active_total == 8
+    assert summary.workspace_counts.requested == 1
+    assert summary.workspace_counts.provisioning == 1
+    assert summary.workspace_counts.ready == 1
+    assert summary.workspace_counts.running == 1
+    assert summary.workspace_counts.validating == 1
+    assert summary.workspace_counts.pushing == 1
+    assert summary.workspace_counts.monitoring_pr == 1
+    assert summary.workspace_counts.destroying == 1
+    assert summary.workspace_counts.by_status[WorkspaceStatus.completed.value] == 1
+    assert summary.worker.max_concurrent_provisions == 2
+    assert summary.worker.max_concurrent_executions == 4
+    assert summary.resource_defaults.steady_cpu == 2.5
+    assert summary.resource_defaults.steady_memory_gb == 8.0
+    assert summary.resource_defaults.peak_cpu == 5.0
+    assert summary.resource_defaults.peak_memory_gb == 14.0
+    assert summary.reserved_resources.active_workspace_count == 8
+    assert summary.reserved_resources.steady_cpu == 20.0
+    assert summary.reserved_resources.steady_memory_gb == 64.0
+    assert summary.reserved_resources.peak_cpu == 40.0
+    assert summary.reserved_resources.peak_memory_gb == 112.0
+    assert summary.concurrency.provision.in_use == 1
+    assert summary.concurrency.provision.queued == 1
+    assert summary.concurrency.provision.available == 1
+    assert summary.concurrency.execution.in_use == 4
+    assert summary.concurrency.execution.queued == 1
+    assert summary.concurrency.execution.available == 0
+    assert summary.disk.reason == "SUFFICIENT_DISK"
+    assert summary.admission.ok is True
+    assert summary.admission.status == "saturated"
+    assert summary.admission.reason == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+
+
+@pytest.mark.unit
+async def test_resource_saturation_admission_blocks_on_disk_pressure(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_resource_saturation
+
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        worker_max_concurrent_provisions=3,
+        worker_max_concurrent_executions=3,
+    )
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_check=_disk_check(
+            ok=False,
+            free_bytes=100,
+            threshold_bytes=400,
+            reason="INSUFFICIENT_DISK",
+        ),
+        now=now,
+    )
+
+    assert summary.workspace_counts.active_total == 0
+    assert summary.disk.ok is False
+    assert summary.disk.reason == "INSUFFICIENT_DISK"
+    assert summary.admission.ok is False
+    assert summary.admission.status == "blocked"
+    assert summary.admission.reason == "INSUFFICIENT_DISK"
+    assert summary.admission.detail is not None

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -318,3 +319,52 @@ async def test_resource_saturation_admission_blocks_on_disk_pressure(
     assert summary.admission.status == "blocked"
     assert summary.admission.reason == "INSUFFICIENT_DISK"
     assert summary.admission.detail is not None
+
+
+@pytest.mark.unit
+async def test_resource_saturation_runs_fallback_disk_check_in_thread(
+    session_factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import awf.service.metrics as metrics_mod
+    from awf.service.metrics import summarize_resource_saturation
+
+    class _Usage:
+        total = 1000
+        used = 100
+        free = 900
+
+    def fake_disk_usage(_path: object) -> _Usage:
+        return _Usage()
+
+    to_thread_calls: list[tuple[Callable[..., Any], tuple[Any, ...], dict[str, Any]]] = []
+
+    async def fake_to_thread(
+        func: Callable[..., Any],
+        /,
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        to_thread_calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(metrics_mod.asyncio, "to_thread", fake_to_thread)
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        min_free_disk_bytes=400,
+    )
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_usage=fake_disk_usage,
+    )
+
+    assert summary.disk.reason == "SUFFICIENT_DISK"
+    assert len(to_thread_calls) == 1
+    func, args, kwargs = to_thread_calls[0]
+    assert func is metrics_mod.check_disk_space
+    assert args == (settings.work_dir,)
+    assert kwargs["min_free_bytes"] == settings.min_free_disk_bytes
+    assert kwargs["disk_usage"] is fake_disk_usage

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -287,6 +287,38 @@ async def test_resource_saturation_reports_active_counts_and_configured_defaults
 
 
 @pytest.mark.unit
+async def test_resource_saturation_admission_reports_both_saturated_concurrency_lanes(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_resource_saturation
+
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        worker_max_concurrent_provisions=1,
+        worker_max_concurrent_executions=1,
+    )
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    await _workspace(session_factory, status=WorkspaceStatus.provisioning, updated_at=now)
+    await _workspace(session_factory, status=WorkspaceStatus.running, updated_at=now)
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_check=_disk_check(),
+        now=now,
+    )
+
+    assert summary.concurrency.provision.available == 0
+    assert summary.concurrency.execution.available == 0
+    assert summary.admission.ok is True
+    assert summary.admission.status == "saturated"
+    assert summary.admission.reason == "WORKER_PROVISION_AND_EXECUTION_CONCURRENCY_SATURATED"
+    assert summary.admission.detail is not None
+    assert "Provisioning and execution workers" in summary.admission.detail
+
+
+@pytest.mark.unit
 async def test_resource_saturation_admission_blocks_on_disk_pressure(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e7daa158e14649b099b23ec7` (agent: `codex`).


### Task
Implement a PRD-backed resource saturation metrics slice for the local AWF service. Use strict TDD: write failing unit tests first, then implement. Add a read-only API endpoint under /v1/metrics that reports active workspace counts, configured worker concurrency/resource defaults, disk pressure using the existing disk check, and an actionable admission summary such as ok/status/reason. Keep it backend-local and deterministic; do not call Docker unless there is an existing injected/testable helper. This should feed the future console resource saturation dashboard and explain why new workspaces may be denied. Do not switch branches or push; AWF owns branch lifecycle, PR creation, monitoring, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
