### PR TITLE
feat(console): show merge queue overview

### DIFF
--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -39,6 +39,7 @@ import type {
   ApiEnvelope,
   AwfStreamFrame,
   ListEnvelope,
+  MergeQueueItem,
   Operation,
   ConcurrencyLane,
   ResourceSaturationSummary,
@@ -119,6 +120,9 @@ export function ConsoleDashboard() {
   const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
   const [resourceSaturation, setResourceSaturation] = useState<ResourceSaturationSummary | null>(null);
   const [resourceError, setResourceError] = useState<string | null>(null);
+  const [mergeQueue, setMergeQueue] = useState<MergeQueueItem[]>([]);
+  const [mergeQueueLoaded, setMergeQueueLoaded] = useState(false);
+  const [mergeQueueError, setMergeQueueError] = useState<string | null>(null);
   const [retryState, setRetryState] = useState<RetryActionState>({ status: "idle" });
   const [apiState, setApiState] = useState<"checking" | "ok" | "error">("checking");
   const [streamState, setStreamState] = useState<"idle" | "connecting" | "live" | "error">("idle");
@@ -168,6 +172,17 @@ export function ConsoleDashboard() {
     }
     setResourceError(null);
     setResourceSaturation(result.data);
+  }, []);
+
+  const loadMergeQueue = useCallback(async () => {
+    const result = await apiGet<ListEnvelope<MergeQueueItem>>("/api/awf/merge-queue?limit=20");
+    setMergeQueueLoaded(true);
+    if (!result.ok) {
+      setMergeQueueError(result.message);
+      return;
+    }
+    setMergeQueueError(null);
+    setMergeQueue(result.data.items);
   }, []);
 
   const loadWorkspace = useCallback(async (workspaceId: string) => {
@@ -225,8 +240,8 @@ export function ConsoleDashboard() {
       newWorkspaceId: result.data.new_workspace_id,
       operationId: result.data.operation_id,
     });
-    await Promise.all([loadOverview(), loadResourceSaturation()]);
-  }, [loadOverview, loadResourceSaturation, selectedId]);
+    await Promise.all([loadOverview(), loadResourceSaturation(), loadMergeQueue()]);
+  }, [loadMergeQueue, loadOverview, loadResourceSaturation, selectedId]);
 
   const loadLogTail = useCallback(
     async (workspaceId: string, stream: WorkspaceLogStream) => {
@@ -300,6 +315,12 @@ export function ConsoleDashboard() {
     const interval = window.setInterval(() => void loadResourceSaturation(), pollMs);
     return () => window.clearInterval(interval);
   }, [loadResourceSaturation]);
+
+  useEffect(() => {
+    void loadMergeQueue();
+    const interval = window.setInterval(() => void loadMergeQueue(), pollMs);
+    return () => window.clearInterval(interval);
+  }, [loadMergeQueue]);
 
   useEffect(() => {
     setDetail(emptyDetail);
@@ -501,6 +522,7 @@ export function ConsoleDashboard() {
           startTransition(() => {
             void loadOverview();
             void loadResourceSaturation();
+            void loadMergeQueue();
           })
         }
         isPending={isPending}
@@ -541,8 +563,13 @@ export function ConsoleDashboard() {
 
         <section className="min-w-0">
           {error ? <ErrorBanner message={error} /> : null}
-          <div className="p-4 pb-0">
+          <div className="grid gap-4 p-4 pb-0 2xl:grid-cols-[minmax(0,1fr)_minmax(460px,0.85fr)]">
             <ResourceCapacityPanel saturation={resourceSaturation} error={resourceError} />
+            <MergeQueuePanel
+              items={mergeQueue}
+              loaded={mergeQueueLoaded}
+              error={mergeQueueError}
+            />
           </div>
           {selectedId && selectedOverview ? (
             <div className="grid gap-4 p-4 xl:grid-cols-[minmax(0,1.1fr)_minmax(420px,0.9fr)]">
@@ -1064,6 +1091,126 @@ function ResourceCapacityPanel({
       )}
     </Panel>
   );
+}
+
+function MergeQueuePanel({
+  items,
+  loaded,
+  error,
+}: {
+  items: MergeQueueItem[];
+  loaded: boolean;
+  error: string | null;
+}) {
+  const hasSnapshot = items.length > 0;
+
+  return (
+    <Panel
+      title="Merge Queue"
+      icon={<GitPullRequest size={16} aria-hidden />}
+      action={
+        <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] text-slate-600">
+          {loaded ? `${items.length} candidate${items.length === 1 ? "" : "s"}` : "loading"}
+        </span>
+      }
+    >
+      {!loaded && !hasSnapshot ? (
+        <MutedLine>Merge queue snapshot loading.</MutedLine>
+      ) : !hasSnapshot ? (
+        <MutedLine>
+          {error ? `Unable to load merge queue: ${error}` : "No PR-backed merge candidates are queued."}
+        </MutedLine>
+      ) : (
+        <div className="grid gap-2">
+          {error ? (
+            <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+              Showing last merge queue snapshot. Refresh failed: {error}
+            </div>
+          ) : null}
+          <div className="grid max-h-[460px] gap-2 overflow-auto pr-1">
+            {items.map((item, index) => (
+              <MergeQueueRow key={item.workspace_id} item={item} position={index + 1} />
+            ))}
+          </div>
+        </div>
+      )}
+    </Panel>
+  );
+}
+
+function MergeQueueRow({ item, position }: { item: MergeQueueItem; position: number }) {
+  return (
+    <article className="grid gap-2 border-b border-slate-100 pb-2 text-xs last:border-b-0 last:pb-0">
+      <div className="flex min-w-0 items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="mono shrink-0 rounded-md border border-slate-200 bg-slate-50 px-1.5 py-0.5 text-[10px] text-slate-500">
+              #{position}
+            </span>
+            <h3 className="truncate text-sm font-semibold text-slate-950">{item.title}</h3>
+          </div>
+          <div className="mono mt-1 truncate text-[11px] text-slate-500">{item.workspace_id}</div>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Badge value={item.status} />
+          <SmallExternalAnchor href={item.pr_url} label="PR" />
+        </div>
+      </div>
+      <div className="grid gap-1 sm:grid-cols-2">
+        <QueueDatum label="Mode" value={item.auto_merge ? "auto-merge" : "manual"} />
+        <QueueDatum label="Task class" value={item.task_class ?? "unclassified"} />
+        <QueueDatum label="Last event" value={lastEventReason(item.last_event)} mono />
+        <QueueDatum label="Blocker" value={item.merge_blocker_reason} mono tone={mergeBlockerTone(item.merge_blocker_reason)} />
+      </div>
+      <div className="grid gap-1 text-[11px] text-slate-500 sm:grid-cols-2">
+        <span className="truncate">
+          base <span className="mono text-slate-700">{item.base_branch}</span>
+        </span>
+        <span className="truncate">updated {formatDateTime(item.updated_at)}</span>
+      </div>
+    </article>
+  );
+}
+
+function QueueDatum({
+  label,
+  value,
+  mono = false,
+  tone,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  tone?: ReturnType<typeof statusTone>;
+}) {
+  return (
+    <div className={`min-w-0 rounded-md border px-2 py-1.5 ${tone ? toneClass(tone) : "border-slate-200 bg-slate-50"}`}>
+      <div className="text-[10px] font-medium text-slate-500">{label}</div>
+      <div className={`${mono ? "mono" : ""} truncate text-[11px] text-slate-900`}>{value}</div>
+    </div>
+  );
+}
+
+function lastEventReason(event: WorkspaceEvent | null): string {
+  if (!event) {
+    return "none";
+  }
+  return event.reason_code ?? event.event_type;
+}
+
+function mergeBlockerTone(reason: MergeQueueItem["merge_blocker_reason"]): ReturnType<typeof statusTone> {
+  switch (reason) {
+    case "ready_to_merge_or_waiting_for_github":
+    case "completed":
+      return "good";
+    case "manual_merge_required":
+    case "waiting_for_monitor":
+      return "warn";
+    case "failed_or_cancelled":
+      return "bad";
+    default:
+      return "info";
+  }
 }
 
 function StatusCountStrip({ counts }: { counts: ResourceSaturationSummary["workspace_counts"] }) {

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -60,6 +60,7 @@ const mergeQueueLimit = 20;
 
 type WorkspaceSortKey = "created_at" | "updated_at";
 type SortDirection = "asc" | "desc";
+type MergeQueueStatus = "loading" | "success" | "error";
 
 type DetailState = {
   workspace: Workspace | null;
@@ -123,7 +124,7 @@ export function ConsoleDashboard() {
   const [resourceError, setResourceError] = useState<string | null>(null);
   const [mergeQueue, setMergeQueue] = useState<MergeQueueItem[]>([]);
   const [mergeQueueHasMore, setMergeQueueHasMore] = useState(false);
-  const [mergeQueueLoaded, setMergeQueueLoaded] = useState(false);
+  const [mergeQueueStatus, setMergeQueueStatus] = useState<MergeQueueStatus>("loading");
   const [mergeQueueError, setMergeQueueError] = useState<string | null>(null);
   const [retryState, setRetryState] = useState<RetryActionState>({ status: "idle" });
   const [apiState, setApiState] = useState<"checking" | "ok" | "error">("checking");
@@ -178,14 +179,15 @@ export function ConsoleDashboard() {
 
   const loadMergeQueue = useCallback(async () => {
     const result = await apiGet<ListEnvelope<MergeQueueItem>>(`/api/awf/merge-queue?limit=${mergeQueueLimit}`);
-    setMergeQueueLoaded(true);
     if (!result.ok) {
       setMergeQueueError(result.message);
+      setMergeQueueStatus("error");
       return;
     }
     setMergeQueueError(null);
     setMergeQueue(result.data.items);
     setMergeQueueHasMore(result.data.has_more);
+    setMergeQueueStatus("success");
   }, []);
 
   const loadWorkspace = useCallback(async (workspaceId: string) => {
@@ -571,7 +573,7 @@ export function ConsoleDashboard() {
             <MergeQueuePanel
               items={mergeQueue}
               hasMore={mergeQueueHasMore}
-              loaded={mergeQueueLoaded}
+              status={mergeQueueStatus}
               error={mergeQueueError}
             />
           </div>
@@ -1100,15 +1102,23 @@ function ResourceCapacityPanel({
 function MergeQueuePanel({
   items,
   hasMore,
-  loaded,
+  status,
   error,
 }: {
   items: MergeQueueItem[];
   hasMore: boolean;
-  loaded: boolean;
+  status: MergeQueueStatus;
   error: string | null;
 }) {
   const hasSnapshot = items.length > 0;
+  const isLoading = status === "loading";
+  const isError = status === "error";
+  const summary =
+    isLoading && !hasSnapshot
+      ? "loading"
+      : isError && !hasSnapshot
+        ? "error"
+        : `${items.length}${hasMore ? "+" : ""} candidate${items.length === 1 ? "" : "s"}`;
 
   return (
     <Panel
@@ -1116,16 +1126,16 @@ function MergeQueuePanel({
       icon={<GitPullRequest size={16} aria-hidden />}
       action={
         <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] text-slate-600">
-          {loaded ? `${items.length}${hasMore ? "+" : ""} candidate${items.length === 1 ? "" : "s"}` : "loading"}
+          {summary}
         </span>
       }
     >
-      {!loaded && !hasSnapshot ? (
+      {isLoading && !hasSnapshot ? (
         <MutedLine>Merge queue snapshot loading.</MutedLine>
+      ) : isError && !hasSnapshot ? (
+        <MutedLine>Unable to load merge queue: {error}</MutedLine>
       ) : !hasSnapshot ? (
-        <MutedLine>
-          {error ? `Unable to load merge queue: ${error}` : "No PR-backed merge candidates are queued."}
-        </MutedLine>
+        <MutedLine>No PR-backed merge candidates are queued.</MutedLine>
       ) : (
         <div className="grid gap-2">
           {error ? (

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -56,6 +56,7 @@ import type {
 
 const pollMs = Number(process.env.NEXT_PUBLIC_AWF_CONSOLE_POLL_MS || "5000");
 const maxLogChars = 180_000;
+const mergeQueueLimit = 20;
 
 type WorkspaceSortKey = "created_at" | "updated_at";
 type SortDirection = "asc" | "desc";
@@ -121,6 +122,7 @@ export function ConsoleDashboard() {
   const [resourceSaturation, setResourceSaturation] = useState<ResourceSaturationSummary | null>(null);
   const [resourceError, setResourceError] = useState<string | null>(null);
   const [mergeQueue, setMergeQueue] = useState<MergeQueueItem[]>([]);
+  const [mergeQueueHasMore, setMergeQueueHasMore] = useState(false);
   const [mergeQueueLoaded, setMergeQueueLoaded] = useState(false);
   const [mergeQueueError, setMergeQueueError] = useState<string | null>(null);
   const [retryState, setRetryState] = useState<RetryActionState>({ status: "idle" });
@@ -175,7 +177,7 @@ export function ConsoleDashboard() {
   }, []);
 
   const loadMergeQueue = useCallback(async () => {
-    const result = await apiGet<ListEnvelope<MergeQueueItem>>("/api/awf/merge-queue?limit=20");
+    const result = await apiGet<ListEnvelope<MergeQueueItem>>(`/api/awf/merge-queue?limit=${mergeQueueLimit}`);
     setMergeQueueLoaded(true);
     if (!result.ok) {
       setMergeQueueError(result.message);
@@ -183,6 +185,7 @@ export function ConsoleDashboard() {
     }
     setMergeQueueError(null);
     setMergeQueue(result.data.items);
+    setMergeQueueHasMore(result.data.has_more);
   }, []);
 
   const loadWorkspace = useCallback(async (workspaceId: string) => {
@@ -567,6 +570,7 @@ export function ConsoleDashboard() {
             <ResourceCapacityPanel saturation={resourceSaturation} error={resourceError} />
             <MergeQueuePanel
               items={mergeQueue}
+              hasMore={mergeQueueHasMore}
               loaded={mergeQueueLoaded}
               error={mergeQueueError}
             />
@@ -1095,10 +1099,12 @@ function ResourceCapacityPanel({
 
 function MergeQueuePanel({
   items,
+  hasMore,
   loaded,
   error,
 }: {
   items: MergeQueueItem[];
+  hasMore: boolean;
   loaded: boolean;
   error: string | null;
 }) {
@@ -1110,7 +1116,7 @@ function MergeQueuePanel({
       icon={<GitPullRequest size={16} aria-hidden />}
       action={
         <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] text-slate-600">
-          {loaded ? `${items.length} candidate${items.length === 1 ? "" : "s"}` : "loading"}
+          {loaded ? `${items.length}${hasMore ? "+" : ""} candidate${items.length === 1 ? "" : "s"}` : "loading"}
         </span>
       }
     >
@@ -1125,6 +1131,11 @@ function MergeQueuePanel({
           {error ? (
             <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
               Showing last merge queue snapshot. Refresh failed: {error}
+            </div>
+          ) : null}
+          {hasMore ? (
+            <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600">
+              Showing first {items.length} merge candidates. More are queued.
             </div>
           ) : null}
           <div className="grid max-h-[460px] gap-2 overflow-auto pr-1">

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -1219,6 +1219,8 @@ function mergeBlockerTone(reason: MergeQueueItem["merge_blocker_reason"]): Retur
       return "warn";
     case "failed_or_cancelled":
       return "bad";
+    case "workspace_not_terminal":
+      return "info";
     default:
       return "info";
   }

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -48,6 +48,31 @@ export interface WorkspaceOverview {
   updated_at: string;
 }
 
+export type MergeBlockerReason =
+  | "ready_to_merge_or_waiting_for_github"
+  | "manual_merge_required"
+  | "waiting_for_monitor"
+  | "workspace_not_terminal"
+  | "completed"
+  | "failed_or_cancelled";
+
+export interface MergeQueueItem {
+  workspace_id: string;
+  title: string;
+  repo_url: string;
+  base_branch: string;
+  branch_name: string | null;
+  pr_url: string;
+  status: WorkspaceStatus;
+  auto_merge: boolean;
+  task_class: string | null;
+  owned_paths: string[];
+  created_at: string;
+  updated_at: string;
+  last_event: WorkspaceEvent | null;
+  merge_blocker_reason: MergeBlockerReason;
+}
+
 export interface Workspace {
   id: string;
   status: WorkspaceStatus;


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_74fef5b1bf5a4389aae4a67a` (agent: `codex`).

**External task ID**: AWF-ROADMAP-CONSOLE-MERGE-QUEUE

### Task
Add a merge queue overview panel to the AWF console.

Context:
- `/v1/merge-queue` now exists and exposes workspace-backed merge candidate information.
- PRD section 12 requires the operator console to explain queue state and merge blockers.
- Browser must still go through the Next.js BFF; never expose AWF_API_TOKEN.

Strict TDD workflow:
1. Run lint/typecheck before changes and capture the current state in the first commit body if useful.
2. Implement the UI slice.
3. Run the validation commands below.
4. Commit with conventional commits. Do not push; AWF owns push, PR creation, monitoring, comments, base sync, and merge.

Required behavior:
- Fetch merge queue data through the existing token-safe BFF path, or add a small BFF route if needed.
- Add a compact Merge Queue panel near the Resource/Capacity panel.
- Show PR link, workspace title/id, status, auto-merge/manual mode, task class, last event reason, and `merge_blocker_reason`.
- Sort newest/most recently updated first as returned by the API.
- Show useful empty/error states without crashing.
- Keep the UI dense and operational. Do not break existing workspace list, retry action, capacity panel, or fullscreen logs.

Validation commands:
- npm --prefix apps/console ci
- npm --prefix apps/console run lint
- npm --prefix apps/console run typecheck
- npm --prefix apps/console run build

---
Validation: 7 profile command(s) passed inside the workspace container.
