### PR TITLE
feat(api): expose validation provenance

### DIFF
--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -32,6 +32,7 @@ from awf.api.routes import (
     operations,
     runtime,
     tasks,
+    validation,
     workspaces,
     ws,
 )
@@ -115,6 +116,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     app.include_router(runtime.router)
     app.include_router(artifacts.router)
     app.include_router(logs.router)
+    app.include_router(validation.router)
     app.include_router(merge_queue.router)
     app.include_router(metrics.router)
     app.include_router(operations.router)

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -1,0 +1,305 @@
+"""Validation provenance endpoints."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.api.deps import get_db_session
+from awf.api.schemas import (
+    ValidationProvenanceItemResponse,
+    ValidationProvenanceListResponse,
+    ValidationProvenanceStatus,
+)
+from awf.db.enums import FailureReason, WorkspaceStatus
+from awf.db.models import Workspace, WorkspaceLogStream
+from awf.db.repositories import WorkspaceLogStreamRepository, WorkspaceRepository
+from awf.profiles.models import WorkspaceProfile
+
+router = APIRouter(prefix="/v1/workspaces/{workspace_id}/validation", tags=["validation"])
+
+_LABEL_RE = re.compile(r"^(?P<index>\d+)_(?P<phase>[A-Za-z][A-Za-z0-9_-]*)$")
+_LEGACY_LABEL_RE = re.compile(r"^cmd_(?P<index>\d+)$")
+_TRAILING_NUMBER_RE = re.compile(r"(?P<index>\d+)$")
+
+_PHASE_ORDER = {
+    "setup": 0,
+    "pre_agent": 1,
+    "healthcheck": 2,
+    "post_agent": 3,
+    "validate": 4,
+    "cleanup": 5,
+    "unknown": 99,
+}
+_SUCCESS_WORKSPACE_STATUSES = {
+    WorkspaceStatus.pushing.value,
+    WorkspaceStatus.monitoring_pr.value,
+    WorkspaceStatus.completed.value,
+}
+_VALIDATION_FAILURE_REASONS = {
+    FailureReason.validation_failure.value,
+    FailureReason.phase_timeout.value,
+    FailureReason.health_check_failure.value,
+    FailureReason.service_startup_failure.value,
+}
+
+
+@router.get("", response_model=ValidationProvenanceListResponse)
+async def list_validation_provenance(
+    workspace_id: str,
+    session: AsyncSession = Depends(get_db_session),
+) -> ValidationProvenanceListResponse:
+    workspace = await WorkspaceRepository(session).get(workspace_id)
+    if workspace is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
+        )
+
+    streams = await WorkspaceLogStreamRepository(session).list_validation_for_workspace(
+        workspace_id
+    )
+    return ValidationProvenanceListResponse(
+        items=_build_validation_items(workspace, streams)
+    )
+
+
+@dataclass
+class _StreamPair:
+    base_stream_id: str
+    stdout: WorkspaceLogStream | None = None
+    stderr: WorkspaceLogStream | None = None
+
+    def add(self, fd: str, stream: WorkspaceLogStream) -> None:
+        if fd == "stdout":
+            self.stdout = stream
+        elif fd == "stderr":
+            self.stderr = stream
+
+    def streams(self) -> list[WorkspaceLogStream]:
+        return [stream for stream in (self.stdout, self.stderr) if stream is not None]
+
+
+@dataclass(frozen=True)
+class _CommandRecord:
+    pair: _StreamPair
+    phase: str
+    command_index: int
+    command: str | None
+
+    @property
+    def sort_key(self) -> tuple[int, int, str, str]:
+        return (
+            _PHASE_ORDER.get(self.phase, _PHASE_ORDER["unknown"]),
+            self.command_index,
+            self.phase,
+            self.pair.base_stream_id,
+        )
+
+
+def _build_validation_items(
+    workspace: Workspace,
+    streams: list[WorkspaceLogStream],
+) -> list[ValidationProvenanceItemResponse]:
+    command_lookup = _command_lookup(workspace)
+    records = [
+        _command_record(pair, command_lookup)
+        for pair in _group_streams(streams).values()
+    ]
+    records.sort(key=lambda record: record.sort_key)
+    failed_record = _failed_record(workspace, records)
+    return [
+        ValidationProvenanceItemResponse(
+            workspace_id=workspace.id,
+            phase=record.phase,
+            command_index=record.command_index,
+            command=record.command,
+            stream_ids={
+                "stdout": record.pair.stdout.stream_id if record.pair.stdout else None,
+                "stderr": record.pair.stderr.stream_id if record.pair.stderr else None,
+            },
+            stdout_byte_count=record.pair.stdout.byte_count if record.pair.stdout else 0,
+            stdout_line_count=record.pair.stdout.line_count if record.pair.stdout else 0,
+            stderr_byte_count=record.pair.stderr.byte_count if record.pair.stderr else 0,
+            stderr_line_count=record.pair.stderr.line_count if record.pair.stderr else 0,
+            opened_at=_opened_at(record.pair),
+            closed_at=_closed_at(record.pair),
+            status=_record_status(workspace, record, failed_record),
+            base_commit=workspace.base_commit,
+            branch_name=workspace.branch_name,
+        )
+        for record in records
+    ]
+
+
+def _group_streams(streams: list[WorkspaceLogStream]) -> dict[str, _StreamPair]:
+    grouped: dict[str, _StreamPair] = {}
+    for stream in streams:
+        fd = _stream_fd(stream)
+        if fd is None:
+            continue
+        base_stream_id = _base_stream_id(stream.stream_id)
+        pair = grouped.setdefault(base_stream_id, _StreamPair(base_stream_id=base_stream_id))
+        pair.add(fd, stream)
+    return grouped
+
+
+def _stream_fd(stream: WorkspaceLogStream) -> str | None:
+    if stream.kind in {"stdout", "stderr"}:
+        return stream.kind
+    if stream.stream_id.endswith(".stdout"):
+        return "stdout"
+    if stream.stream_id.endswith(".stderr"):
+        return "stderr"
+    return None
+
+
+def _base_stream_id(stream_id: str) -> str:
+    for suffix in (".stdout", ".stderr"):
+        if stream_id.endswith(suffix):
+            return stream_id[: -len(suffix)]
+    return stream_id
+
+
+def _command_record(
+    pair: _StreamPair,
+    command_lookup: dict[tuple[str, int], str],
+) -> _CommandRecord:
+    phase, command_index = _phase_and_index(pair)
+    return _CommandRecord(
+        pair=pair,
+        phase=phase,
+        command_index=command_index,
+        command=command_lookup.get((phase, command_index)),
+    )
+
+
+def _phase_and_index(pair: _StreamPair) -> tuple[str, int]:
+    label = _label(pair.base_stream_id)
+    if match := _LABEL_RE.match(label):
+        return _normalize_phase(match.group("phase")), int(match.group("index"))
+    if match := _LEGACY_LABEL_RE.match(label):
+        return _phase_from_stream_name(pair) or "validate", int(match.group("index"))
+    if match := _TRAILING_NUMBER_RE.search(label):
+        return _phase_from_stream_name(pair) or "unknown", int(match.group("index"))
+    return _phase_from_stream_name(pair) or "unknown", 0
+
+
+def _label(base_stream_id: str) -> str:
+    for prefix in ("validation.", "setup."):
+        if base_stream_id.startswith(prefix):
+            return base_stream_id[len(prefix) :]
+    return base_stream_id.rsplit(".", maxsplit=1)[-1]
+
+
+def _phase_from_stream_name(pair: _StreamPair) -> str | None:
+    for stream in pair.streams():
+        first = stream.name.split(maxsplit=1)[0].strip()
+        phase = _normalize_phase(first)
+        if phase in _PHASE_ORDER and phase != "unknown":
+            return phase
+    return None
+
+
+def _normalize_phase(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _command_lookup(workspace: Workspace) -> dict[tuple[str, int], str]:
+    lookup: dict[tuple[str, int], str] = {}
+    profile = _resolved_profile(workspace)
+    if profile is not None:
+        for index, (phase, command) in enumerate(
+            profile.phases.commands_for(("setup", "pre_agent")),
+            start=1,
+        ):
+            lookup.setdefault((_normalize_phase(phase), index), command.command)
+
+        index = 1
+        for healthcheck in profile.validation.healthchecks:
+            lookup.setdefault(("healthcheck", index), healthcheck.command)
+            index += 1
+        for phase, command in profile.phases.commands_for(("post_agent", "validate")):
+            lookup.setdefault((_normalize_phase(phase), index), command.command)
+            index += 1
+
+        for index, (phase, command) in enumerate(
+            profile.phases.commands_for(("cleanup",)),
+            start=1,
+        ):
+            lookup.setdefault((_normalize_phase(phase), index), command.command)
+
+    for index, test_command in enumerate(workspace.test_commands, start=1):
+        lookup.setdefault(("validate", index), test_command)
+
+    return lookup
+
+
+def _resolved_profile(workspace: Workspace) -> WorkspaceProfile | None:
+    if not isinstance(workspace.resolved_profile, dict):
+        return None
+    try:
+        return WorkspaceProfile.model_validate(workspace.resolved_profile)
+    except ValueError:
+        return None
+
+
+def _opened_at(pair: _StreamPair) -> datetime:
+    return _ensure_utc(min(stream.opened_at for stream in pair.streams()))
+
+
+def _closed_at(pair: _StreamPair) -> datetime | None:
+    streams = pair.streams()
+    closed = [stream.closed_at for stream in streams]
+    if any(value is None for value in closed):
+        return None
+    latest = max(value for value in closed if value is not None)
+    return _ensure_utc(latest)
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _record_status(
+    workspace: Workspace,
+    record: _CommandRecord,
+    failed_record: _CommandRecord | None,
+) -> ValidationProvenanceStatus:
+    if _closed_at(record.pair) is None:
+        return "running"
+    if workspace.status in _SUCCESS_WORKSPACE_STATUSES:
+        return "succeeded"
+    if workspace.status == WorkspaceStatus.failed.value and failed_record is not None:
+        if record is failed_record:
+            return "failed"
+        if record.sort_key < failed_record.sort_key:
+            return "succeeded"
+    return "unknown"
+
+
+def _failed_record(
+    workspace: Workspace,
+    records: list[_CommandRecord],
+) -> _CommandRecord | None:
+    if (
+        workspace.status != WorkspaceStatus.failed.value
+        or workspace.failure_reason not in _VALIDATION_FAILURE_REASONS
+    ):
+        return None
+    message = (workspace.failure_message or "").lower()
+    if not message:
+        return None
+
+    for record in records:
+        if record.command is not None and record.command.lower() in message:
+            return record
+
+    matches = [record for record in records if record.phase in message]
+    return matches[0] if len(matches) == 1 else None

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -302,4 +302,4 @@ def _failed_record(
             return record
 
     matches = [record for record in records if record.phase in message]
-    return matches[0] if len(matches) == 1 else None
+    return matches[-1] if matches else None

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -271,6 +271,8 @@ def _record_status(
     failed_record: _CommandRecord | None,
 ) -> ValidationProvenanceStatus:
     if _closed_at(record.pair) is None:
+        if workspace.status == WorkspaceStatus.failed.value:
+            return "failed"
         return "running"
     if workspace.status in _SUCCESS_WORKSPACE_STATUSES:
         return "succeeded"

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -63,9 +63,7 @@ async def list_validation_provenance(
     streams = await WorkspaceLogStreamRepository(session).list_validation_for_workspace(
         workspace_id
     )
-    return ValidationProvenanceListResponse(
-        items=_build_validation_items(workspace, streams)
-    )
+    return ValidationProvenanceListResponse(items=_build_validation_items(workspace, streams))
 
 
 @dataclass
@@ -106,10 +104,7 @@ def _build_validation_items(
     streams: list[WorkspaceLogStream],
 ) -> list[ValidationProvenanceItemResponse]:
     command_lookup = _command_lookup(workspace)
-    records = [
-        _command_record(pair, command_lookup)
-        for pair in _group_streams(streams).values()
-    ]
+    records = [_command_record(pair, command_lookup) for pair in _group_streams(streams).values()]
     records.sort(key=lambda record: record.sort_key)
     failed_record = _failed_record(workspace, records)
     return [
@@ -213,25 +208,28 @@ def _command_lookup(workspace: Workspace) -> dict[tuple[str, int], str]:
     lookup: dict[tuple[str, int], str] = {}
     profile = _resolved_profile(workspace)
     if profile is not None:
-        for index, (phase, command) in enumerate(
-            profile.phases.commands_for(("setup", "pre_agent")),
-            start=1,
+        for phase_name in (
+            "setup",
+            "pre_agent",
+            "healthcheck",
+            "post_agent",
+            "validate",
+            "cleanup",
         ):
-            lookup.setdefault((_normalize_phase(phase), index), command.command)
+            phase_key = _normalize_phase(phase_name)
+            if phase_name == "healthcheck":
+                for index, healthcheck in enumerate(
+                    profile.validation.healthchecks,
+                    start=1,
+                ):
+                    lookup.setdefault((phase_key, index), healthcheck.command)
+                continue
 
-        index = 1
-        for healthcheck in profile.validation.healthchecks:
-            lookup.setdefault(("healthcheck", index), healthcheck.command)
-            index += 1
-        for phase, command in profile.phases.commands_for(("post_agent", "validate")):
-            lookup.setdefault((_normalize_phase(phase), index), command.command)
-            index += 1
-
-        for index, (phase, command) in enumerate(
-            profile.phases.commands_for(("cleanup",)),
-            start=1,
-        ):
-            lookup.setdefault((_normalize_phase(phase), index), command.command)
+            for index, (_, command) in enumerate(
+                profile.phases.commands_for((phase_name,)),
+                start=1,
+            ):
+                lookup.setdefault((phase_key, index), command.command)
 
     for index, test_command in enumerate(workspace.test_commands, start=1):
         lookup.setdefault(("validate", index), test_command)

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -350,6 +350,32 @@ class WorkspaceLogReadResponse(BaseModel):
     data: str
 
 
+ValidationProvenanceStatus = Literal["running", "succeeded", "failed", "unknown"]
+
+
+class ValidationProvenanceItemResponse(BaseModel):
+    workspace_id: str
+    phase: str
+    command_index: int
+    command: str | None
+    stream_ids: dict[str, str | None]
+    stdout_byte_count: int
+    stdout_line_count: int
+    stderr_byte_count: int
+    stderr_line_count: int
+    opened_at: datetime
+    closed_at: datetime | None
+    status: ValidationProvenanceStatus
+    base_commit: str | None
+    branch_name: str | None
+
+
+class ValidationProvenanceListResponse(BaseModel):
+    items: list[ValidationProvenanceItemResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
 class OperationResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -1039,6 +1039,21 @@ class WorkspaceLogStreamRepository:
         )
         return list((await self._session.execute(stmt)).scalars())
 
+    async def list_validation_for_workspace(self, workspace_id: str) -> list[WorkspaceLogStream]:
+        stmt = (
+            select(WorkspaceLogStream)
+            .where(
+                WorkspaceLogStream.workspace_id == workspace_id,
+                or_(
+                    WorkspaceLogStream.source.in_(("validation", "setup")),
+                    WorkspaceLogStream.stream_id.like("validation.%"),
+                    WorkspaceLogStream.stream_id.like("setup.%"),
+                ),
+            )
+            .order_by(WorkspaceLogStream.opened_at, WorkspaceLogStream.stream_id)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
     async def append_metadata(
         self,
         *,

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -159,8 +159,13 @@ class ValidationRunner:
 
         results: list[ValidationCommandResult] = []
         ordered = [*healthchecks, *commands]
+        phase_indices: dict[str, int] = {}
         for index, (phase, command) in enumerate(ordered, start=1):
-            label = f"cmd_{index:02d}" if legacy_command_labels else f"{index:02d}_{phase}"
+            if legacy_command_labels:
+                label = f"cmd_{index:02d}"
+            else:
+                phase_indices[phase] = phase_indices.get(phase, 0) + 1
+                label = f"{phase_indices[phase]:02d}_{phase}"
             result = await self._exec(
                 compose_project=compose_project,
                 compose_file=compose_file,

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -1,0 +1,247 @@
+"""Validation provenance API contract tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceLogStreamRepository, WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+_V2_PROFILE_BODY = {
+    "repo": {
+        "url": "git@github.com:example/provenance.git",
+        "base_branch": "main",
+    },
+    "task": {
+        "title": "Expose validation provenance",
+        "prompt": "Add validation provenance API.",
+        "kind": "feature_branch_pr",
+        "agent": "codex",
+    },
+    "workspace": {
+        "profile_ref": "auto",
+        "profile": {
+            "name": "api-provenance-test",
+            "phases": {
+                "setup": ["uv sync"],
+                "validate": ["pytest -q"],
+            },
+        },
+    },
+    "validation": {"commands": ["ruff check"], "requested_tier": 1},
+    "resources": {},
+}
+
+
+_V1_BODY = {
+    "repo_url": "git@github.com:example/provenance.git",
+    "branch_base": "main",
+    "task_title": "Expose validation provenance",
+    "task_prompt": "Add validation provenance API.",
+    "agent": "codex",
+    "test_commands": ["pytest -q"],
+}
+
+
+async def _create_v2_profile_workspace(client: AsyncClient) -> str:
+    response = await client.post("/v2/workspaces", json=_V2_PROFILE_BODY)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _create_v1_workspace(client: AsyncClient) -> str:
+    response = await client.post("/v1/workspaces", json=_V1_BODY)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _create_stream_pair(
+    engine: AsyncEngine,
+    *,
+    workspace_id: str,
+    base_stream_id: str,
+    phase: str,
+    stdout_bytes: int,
+    stdout_lines: int,
+    stderr_bytes: int,
+    stderr_lines: int,
+    closed: bool = True,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceLogStreamRepository(session)
+        stdout = await repo.create_or_get(
+            workspace_id=workspace_id,
+            stream_id=f"{base_stream_id}.stdout",
+            source="validation",
+            name=f"{phase} {base_stream_id.removeprefix('validation.')} stdout",
+            kind="stdout",
+            path=f"/tmp/{base_stream_id}.stdout.log",
+        )
+        stderr = await repo.create_or_get(
+            workspace_id=workspace_id,
+            stream_id=f"{base_stream_id}.stderr",
+            source="validation",
+            name=f"{phase} {base_stream_id.removeprefix('validation.')} stderr",
+            kind="stderr",
+            path=f"/tmp/{base_stream_id}.stderr.log",
+        )
+        opened_at = datetime(2026, 4, 26, 12, 0, tzinfo=UTC) + timedelta(
+            minutes=len(base_stream_id)
+        )
+        stdout.opened_at = opened_at
+        stderr.opened_at = opened_at
+        await repo.append_metadata(
+            workspace_id=workspace_id,
+            stream_id=f"{base_stream_id}.stdout",
+            byte_delta=stdout_bytes,
+            line_delta=stdout_lines,
+        )
+        await repo.append_metadata(
+            workspace_id=workspace_id,
+            stream_id=f"{base_stream_id}.stderr",
+            byte_delta=stderr_bytes,
+            line_delta=stderr_lines,
+        )
+        if closed:
+            await repo.close(workspace_id=workspace_id, stream_id=f"{base_stream_id}.stdout")
+            await repo.close(workspace_id=workspace_id, stream_id=f"{base_stream_id}.stderr")
+        await session.commit()
+
+
+async def _mark_workspace_completed(engine: AsyncEngine, workspace_id: str) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.status = WorkspaceStatus.completed.value
+        workspace.branch_name = "codex/validation-provenance"
+        workspace.base_commit = "abc123def456"
+        await session.commit()
+
+
+@pytest.mark.unit
+async def test_validation_provenance_groups_streams_and_resolves_profile_commands(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v2_profile_workspace(client)
+    await _mark_workspace_completed(engine, workspace_id)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.01_setup",
+        phase="setup",
+        stdout_bytes=120,
+        stdout_lines=4,
+        stderr_bytes=0,
+        stderr_lines=0,
+    )
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.01_validate",
+        phase="validate",
+        stdout_bytes=2048,
+        stdout_lines=32,
+        stderr_bytes=18,
+        stderr_lines=1,
+    )
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.02_validate",
+        phase="validate",
+        stdout_bytes=4096,
+        stdout_lines=64,
+        stderr_bytes=0,
+        stderr_lines=0,
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["next_cursor"] is None
+    assert body["has_more"] is False
+    assert [
+        (item["phase"], item["command_index"], item["command"]) for item in body["items"]
+    ] == [
+        ("setup", 1, "uv sync"),
+        ("validate", 1, "pytest -q"),
+        ("validate", 2, "ruff check"),
+    ]
+    first = body["items"][0]
+    assert first["workspace_id"] == workspace_id
+    assert first["stream_ids"] == {
+        "stdout": "validation.01_setup.stdout",
+        "stderr": "validation.01_setup.stderr",
+    }
+    assert first["stdout_byte_count"] == 120
+    assert first["stdout_line_count"] == 4
+    assert first["stderr_byte_count"] == 0
+    assert first["stderr_line_count"] == 0
+    assert first["opened_at"] == "2026-04-26T12:19:00Z"
+    assert first["closed_at"] is not None
+    assert first["status"] == "succeeded"
+    assert first["base_commit"] == "abc123def456"
+    assert first["branch_name"] == "codex/validation-provenance"
+
+
+@pytest.mark.unit
+async def test_validation_provenance_marks_open_streams_running_and_uses_request_commands(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace(client)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_01",
+        phase="validate",
+        stdout_bytes=12,
+        stdout_lines=1,
+        stderr_bytes=7,
+        stderr_lines=1,
+        closed=False,
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["phase"] == "validate"
+    assert item["command_index"] == 1
+    assert item["command"] == "pytest -q"
+    assert item["status"] == "running"
+    assert item["closed_at"] is None
+
+
+@pytest.mark.unit
+async def test_validation_provenance_empty_when_workspace_has_no_validation_logs(
+    client: AsyncClient,
+) -> None:
+    workspace_id = await _create_v1_workspace(client)
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "next_cursor": None, "has_more": False}
+
+
+@pytest.mark.unit
+async def test_validation_provenance_missing_workspace_returns_404(
+    client: AsyncClient,
+) -> None:
+    response = await client.get("/v1/workspaces/ws_missing/validation")
+
+    assert response.status_code == 404
+    assert response.json()["detail"]["error_code"] == "NOT_FOUND"

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -8,10 +8,9 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from awf.db.enums import WorkspaceStatus
+from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.repositories import WorkspaceLogStreamRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
-
 
 _V2_PROFILE_BODY = {
     "repo": {
@@ -57,6 +56,18 @@ async def _create_v2_profile_workspace(client: AsyncClient) -> str:
 
 async def _create_v1_workspace(client: AsyncClient) -> str:
     response = await client.post("/v1/workspaces", json=_V1_BODY)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
+async def _create_v1_workspace_with_commands(
+    client: AsyncClient,
+    commands: list[str],
+) -> str:
+    response = await client.post(
+        "/v1/workspaces",
+        json={**_V1_BODY, "test_commands": commands},
+    )
     assert response.status_code == 202
     return str(response.json()["workspace_id"])
 
@@ -123,6 +134,17 @@ async def _mark_workspace_completed(engine: AsyncEngine, workspace_id: str) -> N
         workspace.status = WorkspaceStatus.completed.value
         workspace.branch_name = "codex/validation-provenance"
         workspace.base_commit = "abc123def456"
+        await session.commit()
+
+
+async def _mark_workspace_validation_failed(engine: AsyncEngine, workspace_id: str) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.status = WorkspaceStatus.failed.value
+        workspace.failure_reason = FailureReason.validation_failure.value
+        workspace.failure_message = "validation failed: ruff check"
         await session.commit()
 
 
@@ -223,6 +245,48 @@ async def test_validation_provenance_marks_open_streams_running_and_uses_request
     assert item["command"] == "pytest -q"
     assert item["status"] == "running"
     assert item["closed_at"] is None
+
+
+@pytest.mark.unit
+async def test_validation_provenance_marks_failed_command_from_workspace_failure(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace_with_commands(
+        client,
+        ["pytest -q", "ruff check"],
+    )
+    await _mark_workspace_validation_failed(engine, workspace_id)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_01",
+        phase="validate",
+        stdout_bytes=20,
+        stdout_lines=1,
+        stderr_bytes=0,
+        stderr_lines=0,
+    )
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_02",
+        phase="validate",
+        stdout_bytes=0,
+        stdout_lines=0,
+        stderr_bytes=15,
+        stderr_lines=1,
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    assert [
+        (item["command"], item["status"]) for item in response.json()["items"]
+    ] == [
+        ("pytest -q", "succeeded"),
+        ("ruff check", "failed"),
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -143,14 +143,18 @@ async def _mark_workspace_completed(engine: AsyncEngine, workspace_id: str) -> N
         await session.commit()
 
 
-async def _mark_workspace_validation_failed(engine: AsyncEngine, workspace_id: str) -> None:
+async def _mark_workspace_validation_failed(
+    engine: AsyncEngine,
+    workspace_id: str,
+    message: str = "validation failed: ruff check",
+) -> None:
     factory = make_session_factory(engine)
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
         assert workspace is not None
         workspace.status = WorkspaceStatus.failed.value
         workspace.failure_reason = FailureReason.validation_failure.value
-        workspace.failure_message = "validation failed: ruff check"
+        workspace.failure_message = message
         await session.commit()
 
 
@@ -354,6 +358,46 @@ async def test_validation_provenance_marks_failed_command_from_workspace_failure
         ["pytest -q", "ruff check"],
     )
     await _mark_workspace_validation_failed(engine, workspace_id)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_01",
+        phase="validate",
+        stdout_bytes=20,
+        stdout_lines=1,
+        stderr_bytes=0,
+        stderr_lines=0,
+    )
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_02",
+        phase="validate",
+        stdout_bytes=0,
+        stdout_lines=0,
+        stderr_bytes=15,
+        stderr_lines=1,
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    assert [(item["command"], item["status"]) for item in response.json()["items"]] == [
+        ("pytest -q", "succeeded"),
+        ("ruff check", "failed"),
+    ]
+
+
+@pytest.mark.unit
+async def test_validation_provenance_phase_failure_uses_last_matching_phase_record(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace_with_commands(
+        client,
+        ["pytest -q", "ruff check"],
+    )
+    await _mark_workspace_validation_failed(engine, workspace_id, message="validate phase failed")
     await _create_stream_pair(
         engine,
         workspace_id=workspace_id,

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -318,6 +318,33 @@ async def test_validation_provenance_marks_open_streams_running_and_uses_request
 
 
 @pytest.mark.unit
+async def test_validation_provenance_marks_open_streams_failed_for_failed_workspace(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace_with_commands(client, ["ruff check"])
+    await _mark_workspace_validation_failed(engine, workspace_id)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_01",
+        phase="validate",
+        stdout_bytes=12,
+        stdout_lines=1,
+        stderr_bytes=7,
+        stderr_lines=1,
+        closed=False,
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["status"] == "failed"
+    assert item["closed_at"] is None
+
+
+@pytest.mark.unit
 async def test_validation_provenance_marks_failed_command_from_workspace_failure(
     client: AsyncClient,
     engine: AsyncEngine,

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -54,6 +54,12 @@ async def _create_v2_profile_workspace(client: AsyncClient) -> str:
     return str(response.json()["workspace_id"])
 
 
+async def _create_v2_workspace_with_body(client: AsyncClient, body: dict) -> str:
+    response = await client.post("/v2/workspaces", json=body)
+    assert response.status_code == 202
+    return str(response.json()["workspace_id"])
+
+
 async def _create_v1_workspace(client: AsyncClient) -> str:
     response = await client.post("/v1/workspaces", json=_V1_BODY)
     assert response.status_code == 202
@@ -192,9 +198,7 @@ async def test_validation_provenance_groups_streams_and_resolves_profile_command
     body = response.json()
     assert body["next_cursor"] is None
     assert body["has_more"] is False
-    assert [
-        (item["phase"], item["command_index"], item["command"]) for item in body["items"]
-    ] == [
+    assert [(item["phase"], item["command_index"], item["command"]) for item in body["items"]] == [
         ("setup", 1, "uv sync"),
         ("validate", 1, "pytest -q"),
         ("validate", 2, "ruff check"),
@@ -214,6 +218,72 @@ async def test_validation_provenance_groups_streams_and_resolves_profile_command
     assert first["status"] == "succeeded"
     assert first["base_commit"] == "abc123def456"
     assert first["branch_name"] == "codex/validation-provenance"
+
+
+@pytest.mark.unit
+async def test_validation_provenance_resolves_profile_commands_by_phase_index(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v2_workspace_with_body(
+        client,
+        {
+            **_V2_PROFILE_BODY,
+            "workspace": {
+                "profile_ref": "auto",
+                "profile": {
+                    "name": "api-provenance-phase-index-test",
+                    "phases": {
+                        "setup": ["uv sync"],
+                        "pre_agent": ["python scripts/preflight.py"],
+                        "post_agent": ["ruff format --check"],
+                        "validate": ["pytest -q"],
+                    },
+                    "validation": {
+                        "healthchecks": [
+                            {
+                                "name": "api",
+                                "command": "curl -fsS http://localhost:8000/health",
+                            }
+                        ]
+                    },
+                },
+            },
+            "validation": {"commands": ["ruff check"], "requested_tier": 1},
+        },
+    )
+    for phase, base_stream_id in (
+        ("setup", "validation.01_setup"),
+        ("pre_agent", "validation.01_pre_agent"),
+        ("healthcheck", "validation.01_healthcheck"),
+        ("post_agent", "validation.01_post_agent"),
+        ("validate", "validation.01_validate"),
+        ("validate", "validation.02_validate"),
+    ):
+        await _create_stream_pair(
+            engine,
+            workspace_id=workspace_id,
+            base_stream_id=base_stream_id,
+            phase=phase,
+            stdout_bytes=1,
+            stdout_lines=1,
+            stderr_bytes=0,
+            stderr_lines=0,
+        )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    assert [
+        (item["phase"], item["command_index"], item["command"]) for item in response.json()["items"]
+    ] == [
+        ("setup", 1, "uv sync"),
+        ("pre_agent", 1, "python scripts/preflight.py"),
+        ("healthcheck", 1, "curl -fsS http://localhost:8000/health"),
+        ("post_agent", 1, "ruff format --check"),
+        ("validate", 1, "pytest -q"),
+        ("validate", 2, "ruff check"),
+    ]
 
 
 @pytest.mark.unit
@@ -281,9 +351,7 @@ async def test_validation_provenance_marks_failed_command_from_workspace_failure
     response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
 
     assert response.status_code == 200
-    assert [
-        (item["command"], item["status"]) for item in response.json()["items"]
-    ] == [
+    assert [(item["command"], item["status"]) for item in response.json()["items"]] == [
         ("pytest -q", "succeeded"),
         ("ruff check", "failed"),
     ]

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from awf.common.commands import FakeCommandRunner
+from awf.profiles.models import WorkspaceProfile
 from awf.runtime.validation import ValidationRunner
 
 _COMPOSE_PROJECT = "awf_ws_val"
@@ -62,6 +63,48 @@ class TestHappyPath:
         assert stderr_path.read_text() == "one-stderr"
         assert stdout_path.parent.name == "ws_a"
         assert stdout_path.name == "cmd_01.stdout"
+
+    @pytest.mark.unit
+    async def test_profile_phase_artifacts_use_per_phase_indices(
+        self, runner: tuple[FakeCommandRunner, ValidationRunner]
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(returncode=0, stdout="health ok")
+        fake.queue_result(returncode=0, stdout="format ok")
+        fake.queue_result(returncode=0, stdout="tests ok")
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "phase-label-test",
+                "phases": {
+                    "post_agent": ["ruff format --check"],
+                    "validate": ["pytest -q"],
+                },
+                "validation": {
+                    "healthchecks": [
+                        {
+                            "name": "api",
+                            "command": "curl -fsS http://localhost:8000/health",
+                        }
+                    ]
+                },
+            }
+        )
+
+        result = await val.run_profile_phases(
+            workspace_id="ws_phase_labels",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase_names=("post_agent", "validate"),
+            run_healthchecks=True,
+        )
+
+        assert result.all_passed
+        assert [command.stdout_path.name for command in result.commands] == [
+            "01_healthcheck.stdout",
+            "01_post_agent.stdout",
+            "01_validate.stdout",
+        ]
 
 
 class TestFailureStopsEarly:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a05c593f58c748f99c1b966e` (agent: `codex`).

**External task ID**: AWF-ROADMAP-VALIDATION-PROVENANCE

### Task
Implement the first validation provenance API slice from the AWF PRD.

Context:
- PRD section 12 requires a validation provenance view: what passed, when, where, against which base commit, and with which command/log evidence.
- AWF already persists log stream metadata and workspace events. This first slice should not add a new migration unless absolutely necessary.

Strict TDD workflow:
1. Write failing API tests first and commit the red failure output in the commit body.
2. Implement until green.
3. Run the validation commands below.
4. Commit with conventional commits. Do not push; AWF owns push, PR creation, monitor comments, base sync, and merge.

Required behavior:
- Add `GET /v1/workspaces/{workspace_id}/validation`.
- Return an envelope `{ items, next_cursor, has_more }`.
- Items should be command/provenance records derived from validation/setup log streams and workspace state/events where available.
- Include: workspace_id, phase, command_index, stream_ids, stdout/stderr byte and line counts, opened_at, closed_at, status (`running`, `succeeded`, `failed`, or `unknown`), base_commit, branch_name, and validation command text when it can be derived from the resolved profile or request validation commands.
- Sort command records by phase/index ascending.
- Missing workspace returns 404.
- Workspaces with no validation logs return an empty list, not an error.
- Wire the route into FastAPI and add focused tests.

Validation commands:
- uv run --python 3.12 --extra dev ruff check src/awf/api src/awf/db tests/unit/api/test_validation_provenance.py
- uv run --python 3.12 --extra dev mypy src/awf/api src/awf/db
- uv run --python 3.12 --extra dev pytest tests/unit/api/test_validation_provenance.py -q

---
Validation: 6 profile command(s) passed inside the workspace container.
