### PR TITLE
feat(status): detect orphan AWF workspace containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,6 +494,16 @@ uv run --python 3.12 --extra dev awf service status
 uv run --python 3.12 --extra dev awf service status --format pretty
 ```
 
+`awf service status` reports an `orphan_workspaces` check alongside the
+existing API / DB / Docker / image / disk checks. It reads
+`docker ps -a --filter label=com.docker.compose.project` to find
+compose stacks named `awf_ws_*` or `awf-ws_*` and compares them with
+the workspaces table; containers belonging to terminal/destroyed
+workspaces or to workspace ids missing from the DB are flagged as
+orphans with the suggested cleanup command. The check returns a
+structured `unavailable`/`unknown` payload (rather than raising) when
+Docker or the database is offline.
+
 Inspect the local service Compose logs without writing Docker commands:
 
 ```bash

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -97,6 +97,10 @@ def _emit_pretty_dict(d: dict[str, Any], *, prefix: str = "") -> None:
         if isinstance(value, dict):
             _emit_pretty_dict(value, prefix=pretty_key)
             continue
+        if isinstance(value, list) and value and all(isinstance(item, dict) for item in value):
+            for i, item in enumerate(value):
+                _emit_pretty_dict(item, prefix=f"{pretty_key}[{i}]")
+            continue
         typer.echo(f"  {pretty_key}: {value}")
 
 

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -3,24 +3,62 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import subprocess
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
 import httpx
 from sqlalchemy import text
 
+from awf.db.enums import WorkspaceStatus
 from awf.db.session import make_engine
 from awf.service.config import ServiceSettings
 from awf.service.disk import DiskUsage, check_disk_space
 
 _CHECK_TIMEOUT_SECONDS = 5.0
+_ORPHAN_EXAMPLE_LIMIT = 5
+_AWF_PROJECT_PREFIXES = ("awf_", "awf-")
+
+_ACTIVE_WORKSPACE_STATUSES = frozenset(
+    {
+        WorkspaceStatus.requested.value,
+        WorkspaceStatus.provisioning.value,
+        WorkspaceStatus.ready.value,
+        WorkspaceStatus.running.value,
+        WorkspaceStatus.validating.value,
+        WorkspaceStatus.pushing.value,
+        WorkspaceStatus.monitoring_pr.value,
+        WorkspaceStatus.destroying.value,
+    }
+)
+_TERMINAL_WORKSPACE_STATUSES = frozenset(
+    {
+        WorkspaceStatus.completed.value,
+        WorkspaceStatus.failed.value,
+        WorkspaceStatus.cancelled.value,
+        WorkspaceStatus.destroyed.value,
+    }
+)
 
 CheckPayload = dict[str, object]
 DbProbe = Callable[[str], Awaitable[CheckPayload]]
 SocketExists = Callable[[Path], bool]
+
+
+@dataclass(frozen=True)
+class WorkspaceIdView:
+    """Snapshot of workspace ids partitioned by lifecycle, used for orphan checks."""
+
+    active_ids: frozenset[str]
+    terminal_ids: frozenset[str]
+    available: bool
+
+
+WorkspaceIdLookup = Callable[[str], Awaitable[WorkspaceIdView]]
 
 
 class HttpResponse(Protocol):
@@ -54,6 +92,13 @@ class SubprocessRun(Protocol):
     ) -> CompletedProcessLike: ...
 
 
+@dataclass(frozen=True)
+class _WorkspaceProject:
+    compose_project: str
+    workspace_id: str
+    containers: list[dict[str, str]]
+
+
 async def collect_service_status(
     settings: ServiceSettings,
     *,
@@ -62,6 +107,7 @@ async def collect_service_status(
     run_subprocess: SubprocessRun | None = None,
     socket_exists: SocketExists | None = None,
     disk_usage: DiskUsage | None = None,
+    workspace_id_lookup: WorkspaceIdLookup | None = None,
 ) -> dict[str, object]:
     """Collect service dependency status without requiring Docker in tests."""
 
@@ -69,6 +115,17 @@ async def collect_service_status(
     resolved_db_probe = db_probe or check_database
     resolved_run = run_subprocess or _run_subprocess
     resolved_socket_exists = socket_exists or Path.exists
+    resolved_workspace_lookup = workspace_id_lookup or _default_workspace_id_lookup
+
+    async def _await_workspace_view() -> WorkspaceIdView:
+        return await resolved_workspace_lookup(settings.database_url)
+
+    ps_task: asyncio.Task[CompletedProcessLike | Exception] = asyncio.create_task(
+        asyncio.to_thread(_run_workspace_ps, settings, resolved_run)
+    )
+    workspace_lookup_task: asyncio.Task[WorkspaceIdView] = asyncio.create_task(
+        _await_workspace_view()
+    )
 
     api_check, db_check, docker_check, image_check, disk_check = await asyncio.gather(
         _check_api(settings, resolved_api_get),
@@ -82,12 +139,16 @@ async def collect_service_status(
             disk_usage=disk_usage,
         ),
     )
+    ps_result = await ps_task
+    workspace_view = await workspace_lookup_task
+    orphan_check = _build_orphan_check(ps_result, workspace_view=workspace_view)
     checks = {
         "api": api_check,
         "db": db_check,
         "docker": docker_check,
         "agent_runtime_image": image_check,
         "disk": disk_check.to_dict(),
+        "orphan_workspaces": orphan_check,
     }
     overall_ok = all(bool(check["ok"]) for check in checks.values())
     return {
@@ -166,6 +227,228 @@ def _check_agent_runtime_image(
         result,
         fail_reason="AGENT_RUNTIME_IMAGE_MISSING",
         detail_prefix=f"{settings.agent_runtime_image}: ",
+    )
+
+
+def _run_workspace_ps(
+    settings: ServiceSettings,
+    run_subprocess: SubprocessRun,
+) -> CompletedProcessLike | Exception:
+    return _run_docker_command(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "label=com.docker.compose.project",
+            "--format",
+            "{{json .}}",
+        ],
+        settings=settings,
+        run_subprocess=run_subprocess,
+    )
+
+
+def _build_orphan_check(
+    result: CompletedProcessLike | Exception,
+    *,
+    workspace_view: WorkspaceIdView,
+) -> CheckPayload:
+    if isinstance(result, FileNotFoundError):
+        return _orphan_unavailable("DOCKER_CLI_NOT_FOUND", "docker binary not found on PATH")
+    if isinstance(result, subprocess.TimeoutExpired):
+        return _orphan_unavailable("DOCKER_UNAVAILABLE", _truncate(str(result)))
+    if isinstance(result, Exception):
+        return _orphan_unavailable(
+            "DOCKER_UNAVAILABLE",
+            _truncate(f"{type(result).__name__}: {result}"),
+        )
+    if result.returncode != 0:
+        detail = _truncate(result.stderr or result.stdout) or "docker ps exited non-zero"
+        return _orphan_unavailable("DOCKER_UNAVAILABLE", detail)
+
+    workspace_projects = _parse_workspace_projects(result.stdout)
+
+    if not workspace_view.available:
+        examples = [
+            {
+                "compose_project": project.compose_project,
+                "workspace_id": project.workspace_id,
+                "containers": project.containers,
+                "classification": "unknown",
+                "reason": "DB_UNAVAILABLE",
+            }
+            for project in workspace_projects[:_ORPHAN_EXAMPLE_LIMIT]
+        ]
+        return {
+            "ok": True,
+            "status": "unknown",
+            "reason": "DB_UNAVAILABLE",
+            "detail": (
+                "Workspace database is unreachable; cannot classify AWF compose projects."
+            ),
+            "container_count": len(workspace_projects),
+            "examples": examples,
+            "action": (
+                "Re-run `awf service status` once the control-plane database is reachable."
+            ),
+        }
+
+    orphans: list[dict[str, object]] = []
+    expected_count = 0
+    for project in workspace_projects:
+        if project.workspace_id in workspace_view.active_ids:
+            expected_count += 1
+            continue
+        if project.workspace_id in workspace_view.terminal_ids:
+            classification = "terminal"
+            reason = "WORKSPACE_TERMINAL"
+        else:
+            classification = "missing"
+            reason = "WORKSPACE_MISSING"
+        orphans.append(
+            {
+                "compose_project": project.compose_project,
+                "workspace_id": project.workspace_id,
+                "containers": project.containers,
+                "classification": classification,
+                "reason": reason,
+            }
+        )
+
+    if not orphans:
+        return {
+            "ok": True,
+            "status": "ok",
+            "reason": "NO_ORPHANS",
+            "active_count": expected_count,
+            "orphan_count": 0,
+            "examples": [],
+        }
+
+    missing_count = sum(1 for orphan in orphans if orphan["classification"] == "missing")
+    terminal_count = len(orphans) - missing_count
+    return {
+        "ok": False,
+        "status": "fail",
+        "reason": "ORPHANS_PRESENT",
+        "active_count": expected_count,
+        "orphan_count": len(orphans),
+        "orphan_missing_count": missing_count,
+        "orphan_terminal_count": terminal_count,
+        "examples": orphans[:_ORPHAN_EXAMPLE_LIMIT],
+        "action": (
+            "Run `docker compose -p <project> down -v --remove-orphans` for each "
+            "orphan project, then `awf service gc --execute` to reclaim filesystem state."
+        ),
+    }
+
+
+def _orphan_unavailable(reason: str, detail: str) -> CheckPayload:
+    return {
+        "ok": True,
+        "status": "unavailable",
+        "reason": reason,
+        "detail": detail,
+        "orphan_count": 0,
+        "examples": [],
+    }
+
+
+def _parse_workspace_projects(stdout: str) -> list[_WorkspaceProject]:
+    grouped: dict[str, list[dict[str, str]]] = {}
+    workspace_ids: dict[str, str] = {}
+    for line in stdout.splitlines():
+        if not line.strip():
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(row, dict):
+            continue
+        labels = _parse_labels(str(row.get("Labels") or ""))
+        project = labels.get("com.docker.compose.project")
+        if not project:
+            continue
+        ws_id = _workspace_id_from_project(project)
+        if ws_id is None:
+            continue
+        grouped.setdefault(project, []).append(
+            {
+                "id": str(row.get("ID") or ""),
+                "name": str(row.get("Names") or ""),
+                "service": labels.get("com.docker.compose.service", ""),
+                "state": str(row.get("State") or ""),
+                "status": str(row.get("Status") or ""),
+            }
+        )
+        workspace_ids[project] = ws_id
+    return [
+        _WorkspaceProject(
+            compose_project=project,
+            workspace_id=workspace_ids[project],
+            containers=containers,
+        )
+        for project, containers in sorted(grouped.items())
+    ]
+
+
+def _parse_labels(labels: str) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for pair in labels.split(","):
+        if "=" not in pair:
+            continue
+        key, _, value = pair.partition("=")
+        key = key.strip()
+        if key:
+            out[key] = value
+    return out
+
+
+def _workspace_id_from_project(project: str) -> str | None:
+    for prefix in _AWF_PROJECT_PREFIXES:
+        if project.startswith(prefix):
+            ws_id = project[len(prefix) :]
+            if ws_id.startswith("ws_"):
+                return ws_id
+    return None
+
+
+async def _default_workspace_id_lookup(database_url: str) -> WorkspaceIdView:
+    """Read live workspace ids from the control-plane DB.
+
+    Failures (missing tables, unreachable host, auth errors) collapse to
+    ``available=False`` so the orphan check can degrade gracefully instead
+    of raising.
+    """
+
+    engine = make_engine(database_url)
+    try:
+        async with engine.connect() as conn:
+            rows = (await conn.execute(text("SELECT id, status FROM workspaces"))).all()
+    except Exception:
+        return WorkspaceIdView(
+            active_ids=frozenset(),
+            terminal_ids=frozenset(),
+            available=False,
+        )
+    finally:
+        await engine.dispose()
+
+    active: set[str] = set()
+    terminal: set[str] = set()
+    for ws_id, status in rows:
+        ws_id_str = str(ws_id)
+        status_str = str(status)
+        if status_str in _ACTIVE_WORKSPACE_STATUSES:
+            active.add(ws_id_str)
+        elif status_str in _TERMINAL_WORKSPACE_STATUSES:
+            terminal.add(ws_id_str)
+    return WorkspaceIdView(
+        active_ids=frozenset(active),
+        terminal_ids=frozenset(terminal),
+        available=True,
     )
 
 

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Literal, Protocol
 
 import httpx
-from sqlalchemy import text
+from sqlalchemy import bindparam, text
 
 from awf.db.enums import WorkspaceStatus
 from awf.db.session import make_engine
@@ -44,6 +44,7 @@ _TERMINAL_WORKSPACE_STATUSES = frozenset(
         WorkspaceStatus.destroyed.value,
     }
 )
+_KNOWN_WORKSPACE_STATUSES = sorted(_ACTIVE_WORKSPACE_STATUSES | _TERMINAL_WORKSPACE_STATUSES)
 
 CheckPayload = dict[str, object]
 DbProbe = Callable[[str], Awaitable[CheckPayload]]
@@ -424,9 +425,14 @@ async def _default_workspace_id_lookup(database_url: str) -> WorkspaceIdView:
     """
 
     engine = make_engine(database_url)
+    stmt = text("SELECT id, status FROM workspaces WHERE status IN :statuses").bindparams(
+        bindparam("statuses", expanding=True)
+    )
     try:
         async with engine.connect() as conn:
-            rows = (await conn.execute(text("SELECT id, status FROM workspaces"))).all()
+            rows = (
+                await conn.execute(stmt, {"statuses": _KNOWN_WORKSPACE_STATUSES})
+            ).all()
     except Exception:
         return WorkspaceIdView(
             active_ids=frozenset(),

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -250,7 +250,12 @@ def _run_workspace_ps(
             "--filter",
             "label=com.docker.compose.project",
             "--format",
-            "{{json .}}",
+            (
+                '{"id":{{json .ID}},"name":{{json .Names}},'
+                '"state":{{json .State}},"status":{{json .Status}},'
+                '"project":{{json (.Label "com.docker.compose.project")}},'
+                '"service":{{json (.Label "com.docker.compose.service")}}}'
+            ),
         ],
         settings=settings,
         run_subprocess=run_subprocess,
@@ -375,8 +380,7 @@ def _parse_workspace_projects(stdout: str) -> list[_WorkspaceProject]:
             continue
         if not isinstance(row, dict):
             continue
-        labels = _parse_labels(str(row.get("Labels") or ""))
-        project = labels.get("com.docker.compose.project")
+        project = str(row.get("project") or "")
         if not project:
             continue
         ws_id = _workspace_id_from_project(project)
@@ -384,11 +388,11 @@ def _parse_workspace_projects(stdout: str) -> list[_WorkspaceProject]:
             continue
         grouped.setdefault(project, []).append(
             {
-                "id": str(row.get("ID") or ""),
-                "name": str(row.get("Names") or ""),
-                "service": labels.get("com.docker.compose.service", ""),
-                "state": str(row.get("State") or ""),
-                "status": str(row.get("Status") or ""),
+                "id": str(row.get("id") or ""),
+                "name": str(row.get("name") or ""),
+                "service": str(row.get("service") or ""),
+                "state": str(row.get("state") or ""),
+                "status": str(row.get("status") or ""),
             }
         )
         workspace_ids[project] = ws_id
@@ -400,18 +404,6 @@ def _parse_workspace_projects(stdout: str) -> list[_WorkspaceProject]:
         )
         for project, containers in sorted(grouped.items())
     ]
-
-
-def _parse_labels(labels: str) -> dict[str, str]:
-    out: dict[str, str] = {}
-    for pair in labels.split(","):
-        if "=" not in pair:
-            continue
-        key, _, value = pair.partition("=")
-        key = key.strip()
-        if key:
-            out[key] = value
-    return out
 
 
 def _workspace_id_from_project(project: str) -> str | None:

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -419,16 +419,18 @@ def _workspace_id_from_project(project: str) -> str | None:
 async def _default_workspace_id_lookup(database_url: str) -> WorkspaceIdView:
     """Read live workspace ids from the control-plane DB.
 
-    Failures (missing tables, unreachable host, auth errors) collapse to
+    Failures (missing tables, unreachable host, auth errors, or even a
+    malformed URL that trips engine construction) collapse to
     ``available=False`` so the orphan check can degrade gracefully instead
     of raising.
     """
 
-    engine = make_engine(database_url)
     stmt = text("SELECT id, status FROM workspaces WHERE status IN :statuses").bindparams(
         bindparam("statuses", expanding=True)
     )
+    engine = None
     try:
+        engine = make_engine(database_url)
         async with engine.connect() as conn:
             rows = (
                 await conn.execute(stmt, {"statuses": _KNOWN_WORKSPACE_STATUSES})
@@ -440,7 +442,8 @@ async def _default_workspace_id_lookup(database_url: str) -> WorkspaceIdView:
             available=False,
         )
     finally:
-        await engine.dispose()
+        if engine is not None:
+            await engine.dispose()
 
     active: set[str] = set()
     terminal: set[str] = set()

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import subprocess
@@ -127,20 +128,27 @@ async def collect_service_status(
         _await_workspace_view()
     )
 
-    api_check, db_check, docker_check, image_check, disk_check = await asyncio.gather(
-        _check_api(settings, resolved_api_get),
-        resolved_db_probe(settings.database_url),
-        asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
-        asyncio.to_thread(_check_agent_runtime_image, settings, resolved_run),
-        asyncio.to_thread(
-            check_disk_space,
-            settings.work_dir,
-            min_free_bytes=settings.min_free_disk_bytes,
-            disk_usage=disk_usage,
-        ),
-    )
-    ps_result = await ps_task
-    workspace_view = await workspace_lookup_task
+    try:
+        api_check, db_check, docker_check, image_check, disk_check = await asyncio.gather(
+            _check_api(settings, resolved_api_get),
+            resolved_db_probe(settings.database_url),
+            asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
+            asyncio.to_thread(_check_agent_runtime_image, settings, resolved_run),
+            asyncio.to_thread(
+                check_disk_space,
+                settings.work_dir,
+                min_free_bytes=settings.min_free_disk_bytes,
+                disk_usage=disk_usage,
+            ),
+        )
+        ps_result = await ps_task
+        workspace_view = await workspace_lookup_task
+    finally:
+        for pending in (ps_task, workspace_lookup_task):
+            if not pending.done():
+                pending.cancel()
+            with contextlib.suppress(BaseException):
+                await pending
     orphan_check = _build_orphan_check(ps_result, workspace_view=workspace_view)
     checks = {
         "api": api_check,

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -496,3 +496,59 @@ class TestConnectionErrors:
 
         assert result.exit_code == 2
         assert "could not reach" in result.stderr
+
+
+class TestServiceStatusOrphanReporting:
+    @pytest.mark.unit
+    def test_pretty_output_surfaces_orphan_summary(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from awf.service import config as config_mod
+        from awf.service import status as status_mod
+
+        settings = object()
+        monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
+
+        async def _collect(received: object) -> dict[str, object]:
+            assert received is settings
+            return {
+                "service": "awf",
+                "status": "fail",
+                "checks": {
+                    "orphan_workspaces": {
+                        "ok": False,
+                        "status": "fail",
+                        "reason": "ORPHANS_PRESENT",
+                        "orphan_count": 2,
+                        "active_count": 1,
+                        "examples": [
+                            {
+                                "workspace_id": "ws_dead",
+                                "compose_project": "awf_ws_dead",
+                                "classification": "terminal",
+                                "reason": "WORKSPACE_TERMINAL",
+                            },
+                            {
+                                "workspace_id": "ws_ghost",
+                                "compose_project": "awf-ws_ghost",
+                                "classification": "missing",
+                                "reason": "WORKSPACE_MISSING",
+                            },
+                        ],
+                        "action": (
+                            "Run docker compose -p <project> down -v --remove-orphans"
+                        ),
+                    }
+                },
+            }
+
+        monkeypatch.setattr(status_mod, "collect_service_status", _collect)
+
+        result = _runner.invoke(app, ["service", "status", "--format", "pretty"])
+
+        assert result.exit_code == 1, result.output
+        assert "checks.orphan_workspaces.orphan_count: 2" in result.stdout
+        assert "checks.orphan_workspaces.active_count: 1" in result.stdout
+        assert "ORPHANS_PRESENT" in result.stdout
+        assert "ws_dead" in result.stdout
+        assert "ws_ghost" in result.stdout

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -456,6 +456,12 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
                 (),
                 {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""},
             )()
+        if args[:3] == ["docker", "ps", "-a"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "", "stderr": ""},
+            )()
         raise AssertionError(f"unexpected subprocess call: {args}")
 
     settings = ServiceSettings(
@@ -549,6 +555,12 @@ def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> N
                 "Completed",
                 (),
                 {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""},
+            )()
+        if args[:3] == ["docker", "ps", "-a"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "", "stderr": ""},
             )()
         raise AssertionError(f"unexpected subprocess call: {args}")
 

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -1,18 +1,19 @@
-"""Service status disk-pressure checks."""
+"""Service status disk-pressure and orphan-container checks."""
 
 from __future__ import annotations
 
 import asyncio
+import json
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from awf.service.config import ServiceSettings
-from awf.service.status import collect_service_status
+from awf.service.status import WorkspaceIdView, collect_service_status
 
 
-def _settings(tmp_path: Path, *, min_free_disk_bytes: int) -> ServiceSettings:
+def _settings(tmp_path: Path, *, min_free_disk_bytes: int = 200) -> ServiceSettings:
     return ServiceSettings(
         service_name="awf",
         env="local",
@@ -54,12 +55,42 @@ async def _db_probe(_database_url: str) -> dict[str, Any]:
     return {"ok": True, "status": "ok"}
 
 
-def _run_subprocess(args: list[str], **_kwargs: object) -> Any:
-    if args[:2] == ["docker", "info"]:
-        return type("Completed", (), {"returncode": 0, "stdout": "27.0.3\n", "stderr": ""})()
-    if args[:3] == ["docker", "image", "inspect"]:
-        return type("Completed", (), {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""})()
-    raise AssertionError(f"unexpected subprocess call: {args}")
+def _docker_ps_payload(*containers: dict[str, str]) -> str:
+    return "".join(json.dumps(container) + "\n" for container in containers)
+
+
+def _make_run_subprocess(
+    *,
+    ps_payload: str = "",
+    ps_returncode: int = 0,
+    ps_stderr: str = "",
+) -> Any:
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        if args[:2] == ["docker", "info"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "27.0.3\n", "stderr": ""})()
+        if args[:3] == ["docker", "image", "inspect"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": 0, "stdout": "sha256:deadbeef\n", "stderr": ""},
+            )()
+        if args[:3] == ["docker", "ps", "-a"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": ps_returncode, "stdout": ps_payload, "stderr": ps_stderr},
+            )()
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    return _run
+
+
+async def _empty_workspace_view(_database_url: str) -> WorkspaceIdView:
+    return WorkspaceIdView(
+        active_ids=frozenset(),
+        terminal_ids=frozenset(),
+        available=True,
+    )
 
 
 @pytest.mark.unit
@@ -69,9 +100,10 @@ def test_service_status_includes_ok_disk_check_from_mocked_usage(tmp_path: Path)
             _settings(tmp_path, min_free_disk_bytes=200),
             api_get=_api_get,
             db_probe=_db_probe,
-            run_subprocess=_run_subprocess,
+            run_subprocess=_make_run_subprocess(),
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
         )
     )
 
@@ -94,9 +126,10 @@ def test_service_status_fails_when_disk_is_below_threshold(tmp_path: Path) -> No
             _settings(tmp_path, min_free_disk_bytes=400),
             api_get=_api_get,
             db_probe=_db_probe,
-            run_subprocess=_run_subprocess,
+            run_subprocess=_make_run_subprocess(),
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
         )
     )
 
@@ -107,3 +140,311 @@ def test_service_status_fails_when_disk_is_below_threshold(tmp_path: Path) -> No
     assert disk["reason"] == "INSUFFICIENT_DISK"
     assert disk["threshold_bytes"] == 400
     assert "AWF_MIN_FREE_DISK_BYTES" in str(disk["detail"])
+
+
+@pytest.mark.unit
+def test_orphan_check_reports_no_orphans_when_no_awf_containers(tmp_path: Path) -> None:
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=""),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+        )
+    )
+
+    assert status["status"] == "ok"
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is True
+    assert orphans["status"] == "ok"
+    assert orphans["reason"] == "NO_ORPHANS"
+    assert orphans["orphan_count"] == 0
+    assert orphans["active_count"] == 0
+    assert orphans["examples"] == []
+
+
+@pytest.mark.unit
+def test_orphan_check_treats_active_workspace_containers_as_expected(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        {
+            "ID": "abc",
+            "Names": "awf_ws_alive-agent-1",
+            "State": "running",
+            "Status": "Up 3 minutes",
+            "Labels": (
+                "com.docker.compose.project=awf_ws_alive,com.docker.compose.service=agent"
+            ),
+        },
+        {
+            "ID": "def",
+            "Names": "awf_ws_alive-postgres-1",
+            "State": "running",
+            "Status": "Up 3 minutes (healthy)",
+            "Labels": (
+                "com.docker.compose.project=awf_ws_alive,com.docker.compose.service=postgres"
+            ),
+        },
+    )
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset({"ws_alive"}),
+            terminal_ids=frozenset(),
+            available=True,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    assert status["status"] == "ok"
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["reason"] == "NO_ORPHANS"
+    assert orphans["active_count"] == 1
+    assert orphans["orphan_count"] == 0
+
+
+@pytest.mark.unit
+def test_orphan_check_flags_terminal_workspace_with_running_container(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        {
+            "ID": "abc",
+            "Names": "awf_ws_dead-agent-1",
+            "State": "running",
+            "Status": "Up 1 day",
+            "Labels": (
+                "com.docker.compose.project=awf_ws_dead,com.docker.compose.service=agent"
+            ),
+        }
+    )
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset(),
+            terminal_ids=frozenset({"ws_dead"}),
+            available=True,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    assert status["status"] == "fail"
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is False
+    assert orphans["status"] == "fail"
+    assert orphans["reason"] == "ORPHANS_PRESENT"
+    assert orphans["orphan_count"] == 1
+    assert orphans["active_count"] == 0
+    examples = orphans["examples"]
+    assert isinstance(examples, list)
+    assert len(examples) == 1
+    example = examples[0]
+    assert example["workspace_id"] == "ws_dead"
+    assert example["compose_project"] == "awf_ws_dead"
+    assert example["classification"] == "terminal"
+    assert example["reason"] == "WORKSPACE_TERMINAL"
+    action = orphans.get("action")
+    assert isinstance(action, str) and action.strip()
+
+
+@pytest.mark.unit
+def test_orphan_check_flags_workspace_missing_from_db(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        {
+            "ID": "ghost",
+            "Names": "awf-ws_ghost-agent-1",
+            "State": "exited",
+            "Status": "Exited (0) 5 minutes ago",
+            "Labels": (
+                "com.docker.compose.project=awf-ws_ghost,com.docker.compose.service=agent"
+            ),
+        }
+    )
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset({"ws_alive"}),
+            terminal_ids=frozenset(),
+            available=True,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is False
+    assert orphans["reason"] == "ORPHANS_PRESENT"
+    examples = orphans["examples"]
+    assert examples[0]["workspace_id"] == "ws_ghost"
+    assert examples[0]["compose_project"] == "awf-ws_ghost"
+    assert examples[0]["classification"] == "missing"
+    assert examples[0]["reason"] == "WORKSPACE_MISSING"
+
+
+@pytest.mark.unit
+def test_orphan_check_skips_non_awf_compose_projects(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        {
+            "ID": "x",
+            "Names": "myapp-db-1",
+            "State": "running",
+            "Status": "Up",
+            "Labels": "com.docker.compose.project=myapp,com.docker.compose.service=db",
+        }
+    )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is True
+    assert orphans["reason"] == "NO_ORPHANS"
+    assert orphans["orphan_count"] == 0
+
+
+@pytest.mark.unit
+def test_orphan_check_marks_unknown_when_db_unavailable(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        {
+            "ID": "abc",
+            "Names": "awf_ws_solo-agent-1",
+            "State": "running",
+            "Status": "Up 2 minutes",
+            "Labels": (
+                "com.docker.compose.project=awf_ws_solo,com.docker.compose.service=agent"
+            ),
+        }
+    )
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset(),
+            terminal_ids=frozenset(),
+            available=False,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is True
+    assert orphans["status"] == "unknown"
+    assert orphans["reason"] == "DB_UNAVAILABLE"
+    assert orphans["container_count"] == 1
+    examples = orphans["examples"]
+    assert isinstance(examples, list)
+    assert examples[0]["workspace_id"] == "ws_solo"
+    assert examples[0]["compose_project"] == "awf_ws_solo"
+    assert examples[0]["classification"] == "unknown"
+
+
+@pytest.mark.unit
+def test_orphan_check_unavailable_when_docker_ps_fails(tmp_path: Path) -> None:
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        if args[:2] == ["docker", "info"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "27\n", "stderr": ""})()
+        if args[:3] == ["docker", "image", "inspect"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "sha\n", "stderr": ""})()
+        if args[:3] == ["docker", "ps", "-a"]:
+            return type(
+                "Completed",
+                (),
+                {"returncode": 1, "stdout": "", "stderr": "Cannot connect to Docker"},
+            )()
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset({"ws_alive"}),
+            terminal_ids=frozenset(),
+            available=True,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is True
+    assert orphans["status"] == "unavailable"
+    assert orphans["reason"] == "DOCKER_UNAVAILABLE"
+    assert "Cannot connect" in str(orphans.get("detail", ""))
+    assert orphans["orphan_count"] == 0
+
+
+@pytest.mark.unit
+def test_orphan_check_handles_missing_docker_binary(tmp_path: Path) -> None:
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        raise FileNotFoundError("docker")
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["ok"] is True
+    assert orphans["status"] == "unavailable"
+    assert orphans["reason"] == "DOCKER_CLI_NOT_FOUND"

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -10,7 +10,11 @@ from typing import Any
 import pytest
 
 from awf.service.config import ServiceSettings
-from awf.service.status import WorkspaceIdView, collect_service_status
+from awf.service.status import (
+    WorkspaceIdView,
+    _default_workspace_id_lookup,
+    collect_service_status,
+)
 
 
 def _settings(tmp_path: Path, *, min_free_disk_bytes: int = 200) -> ServiceSettings:
@@ -533,3 +537,12 @@ def test_orphan_check_handles_missing_docker_binary(tmp_path: Path) -> None:
     assert orphans["ok"] is True
     assert orphans["status"] == "unavailable"
     assert orphans["reason"] == "DOCKER_CLI_NOT_FOUND"
+
+
+@pytest.mark.unit
+def test_default_workspace_id_lookup_returns_unavailable_for_malformed_url() -> None:
+    view = asyncio.run(_default_workspace_id_lookup("not-a-real-database-url"))
+
+    assert view.available is False
+    assert view.active_ids == frozenset()
+    assert view.terminal_ids == frozenset()

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -59,6 +59,25 @@ def _docker_ps_payload(*containers: dict[str, str]) -> str:
     return "".join(json.dumps(container) + "\n" for container in containers)
 
 
+def _container(
+    *,
+    id: str,
+    name: str,
+    state: str,
+    status: str,
+    project: str,
+    service: str,
+) -> dict[str, str]:
+    return {
+        "id": id,
+        "name": name,
+        "state": state,
+        "status": status,
+        "project": project,
+        "service": service,
+    }
+
+
 def _make_run_subprocess(
     *,
     ps_payload: str = "",
@@ -169,24 +188,22 @@ def test_orphan_check_reports_no_orphans_when_no_awf_containers(tmp_path: Path) 
 @pytest.mark.unit
 def test_orphan_check_treats_active_workspace_containers_as_expected(tmp_path: Path) -> None:
     payload = _docker_ps_payload(
-        {
-            "ID": "abc",
-            "Names": "awf_ws_alive-agent-1",
-            "State": "running",
-            "Status": "Up 3 minutes",
-            "Labels": (
-                "com.docker.compose.project=awf_ws_alive,com.docker.compose.service=agent"
-            ),
-        },
-        {
-            "ID": "def",
-            "Names": "awf_ws_alive-postgres-1",
-            "State": "running",
-            "Status": "Up 3 minutes (healthy)",
-            "Labels": (
-                "com.docker.compose.project=awf_ws_alive,com.docker.compose.service=postgres"
-            ),
-        },
+        _container(
+            id="abc",
+            name="awf_ws_alive-agent-1",
+            state="running",
+            status="Up 3 minutes",
+            project="awf_ws_alive",
+            service="agent",
+        ),
+        _container(
+            id="def",
+            name="awf_ws_alive-postgres-1",
+            state="running",
+            status="Up 3 minutes (healthy)",
+            project="awf_ws_alive",
+            service="postgres",
+        ),
     )
 
     async def _ws_lookup(_url: str) -> WorkspaceIdView:
@@ -218,15 +235,14 @@ def test_orphan_check_treats_active_workspace_containers_as_expected(tmp_path: P
 @pytest.mark.unit
 def test_orphan_check_flags_terminal_workspace_with_running_container(tmp_path: Path) -> None:
     payload = _docker_ps_payload(
-        {
-            "ID": "abc",
-            "Names": "awf_ws_dead-agent-1",
-            "State": "running",
-            "Status": "Up 1 day",
-            "Labels": (
-                "com.docker.compose.project=awf_ws_dead,com.docker.compose.service=agent"
-            ),
-        }
+        _container(
+            id="abc",
+            name="awf_ws_dead-agent-1",
+            state="running",
+            status="Up 1 day",
+            project="awf_ws_dead",
+            service="agent",
+        )
     )
 
     async def _ws_lookup(_url: str) -> WorkspaceIdView:
@@ -270,15 +286,14 @@ def test_orphan_check_flags_terminal_workspace_with_running_container(tmp_path: 
 @pytest.mark.unit
 def test_orphan_check_flags_workspace_missing_from_db(tmp_path: Path) -> None:
     payload = _docker_ps_payload(
-        {
-            "ID": "ghost",
-            "Names": "awf-ws_ghost-agent-1",
-            "State": "exited",
-            "Status": "Exited (0) 5 minutes ago",
-            "Labels": (
-                "com.docker.compose.project=awf-ws_ghost,com.docker.compose.service=agent"
-            ),
-        }
+        _container(
+            id="ghost",
+            name="awf-ws_ghost-agent-1",
+            state="exited",
+            status="Exited (0) 5 minutes ago",
+            project="awf-ws_ghost",
+            service="agent",
+        )
     )
 
     async def _ws_lookup(_url: str) -> WorkspaceIdView:
@@ -313,13 +328,14 @@ def test_orphan_check_flags_workspace_missing_from_db(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_orphan_check_skips_non_awf_compose_projects(tmp_path: Path) -> None:
     payload = _docker_ps_payload(
-        {
-            "ID": "x",
-            "Names": "myapp-db-1",
-            "State": "running",
-            "Status": "Up",
-            "Labels": "com.docker.compose.project=myapp,com.docker.compose.service=db",
-        }
+        _container(
+            id="x",
+            name="myapp-db-1",
+            state="running",
+            status="Up",
+            project="myapp",
+            service="db",
+        )
     )
 
     status = asyncio.run(
@@ -343,15 +359,14 @@ def test_orphan_check_skips_non_awf_compose_projects(tmp_path: Path) -> None:
 @pytest.mark.unit
 def test_orphan_check_marks_unknown_when_db_unavailable(tmp_path: Path) -> None:
     payload = _docker_ps_payload(
-        {
-            "ID": "abc",
-            "Names": "awf_ws_solo-agent-1",
-            "State": "running",
-            "Status": "Up 2 minutes",
-            "Labels": (
-                "com.docker.compose.project=awf_ws_solo,com.docker.compose.service=agent"
-            ),
-        }
+        _container(
+            id="abc",
+            name="awf_ws_solo-agent-1",
+            state="running",
+            status="Up 2 minutes",
+            project="awf_ws_solo",
+            service="agent",
+        )
     )
 
     async def _ws_lookup(_url: str) -> WorkspaceIdView:
@@ -425,6 +440,76 @@ def test_orphan_check_unavailable_when_docker_ps_fails(tmp_path: Path) -> None:
     assert orphans["reason"] == "DOCKER_UNAVAILABLE"
     assert "Cannot connect" in str(orphans.get("detail", ""))
     assert orphans["orphan_count"] == 0
+
+
+@pytest.mark.unit
+def test_orphan_check_extracts_labels_via_docker_template(tmp_path: Path) -> None:
+    captured_args: list[list[str]] = []
+
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        captured_args.append(list(args))
+        if args[:2] == ["docker", "info"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "27\n", "stderr": ""})()
+        if args[:3] == ["docker", "image", "inspect"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "sha\n", "stderr": ""})()
+        if args[:3] == ["docker", "ps", "-a"]:
+            return type("Completed", (), {"returncode": 0, "stdout": "", "stderr": ""})()
+        raise AssertionError(f"unexpected subprocess call: {args}")
+
+    asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+        )
+    )
+
+    ps_args = next(args for args in captured_args if args[:3] == ["docker", "ps", "-a"])
+    fmt_index = ps_args.index("--format")
+    fmt = ps_args[fmt_index + 1]
+    assert '.Label "com.docker.compose.project"' in fmt
+    assert '.Label "com.docker.compose.service"' in fmt
+
+
+@pytest.mark.unit
+def test_orphan_check_handles_label_value_with_comma(tmp_path: Path) -> None:
+    payload = _docker_ps_payload(
+        _container(
+            id="abc",
+            name="awf_ws_alive-agent-1",
+            state="running",
+            status="Up 3 minutes, restarting",
+            project="awf_ws_alive",
+            service="agent",
+        )
+    )
+
+    async def _ws_lookup(_url: str) -> WorkspaceIdView:
+        return WorkspaceIdView(
+            active_ids=frozenset({"ws_alive"}),
+            terminal_ids=frozenset(),
+            available=True,
+        )
+
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(ps_payload=payload),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_ws_lookup,
+        )
+    )
+
+    orphans = status["checks"]["orphan_workspaces"]
+    assert orphans["reason"] == "NO_ORPHANS"
+    assert orphans["active_count"] == 1
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8e3a9a49739e4f138cc0299a` (agent: `claude_code`).


### Task
Implement orphan-container detection in awf service status with strict TDD.

Context:
- The PRD requires cleanup visibility and no orphaned workspace containers after destroy/merge.
- Operators need awf service status to identify AWF workspace containers or compose projects that are still running when no active workspace should own them.
- A recent local issue showed stale containers can confuse the console and service health, so this should be actionable but never crash when Docker is unavailable.

Required behavior:
1. Extend the service-status model behind `awf service status` to report orphan AWF workspace containers/stacks.
2. Detect containers by AWF workspace naming/labels, for example workspace compose projects/names matching AWF workspace stacks such as `awf_ws_*` or `awf-ws_*` and Docker Compose labels when available.
3. Compare Docker-visible workspace containers with known workspace rows when the DB is reachable:
   - container for missing workspace row => orphan.
   - container for terminal/destroyed workspace => orphan/leaked runtime.
   - container for active workspace => expected.
4. If DB or Docker is unavailable, return structured unavailable/unknown fields rather than raising.
5. Include count, examples, and reason/action fields in JSON and make the pretty output useful.
6. Add focused mocked subprocess/DB tests first, commit red test failure output in the commit body, then implement.
7. Update README/service-status docs briefly.

Validation commands to run before final commit:
- uv run --python 3.12 --extra dev ruff check src/awf/service/status.py src/awf/cli/main.py tests/unit/service/test_status.py tests/unit/cli/test_cli.py
- uv run --python 3.12 --extra dev mypy src/awf/service src/awf/cli
- uv run --python 3.12 --extra dev pytest tests/unit/service/test_status.py tests/unit/cli/test_cli.py -q

Rules:
- Commit with conventional commits.
- Do not push; AWF owns push, PR creation, monitoring, comment handling, and merge.
- Do not switch branches.
- Keep the working tree clean when done.

---
Validation: 6 profile command(s) passed inside the workspace container.
