### PR TITLE
feat(queue): add canonical attempts and merge candidates

### DIFF
--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -1219,7 +1219,7 @@ function MergeQueuePanel({
           ) : null}
           <div className="grid max-h-[460px] gap-2 overflow-auto pr-1">
             {items.map((item, index) => (
-              <MergeQueueRow key={item.workspace_id} item={item} position={index + 1} />
+              <MergeQueueRow key={item.candidate_id ?? item.workspace_id} item={item} position={index + 1} />
             ))}
           </div>
         </div>
@@ -1246,9 +1246,13 @@ function MergeQueueRow({ item, position }: { item: MergeQueueItem; position: num
           <SmallExternalAnchor href={item.pr_url} label="PR" />
         </div>
       </div>
-      <div className="grid gap-1 sm:grid-cols-2">
+      <div className="grid gap-1 sm:grid-cols-3">
+        <QueueDatum label="Candidate" value={item.candidate_id ? compactId(item.candidate_id, 10) : "legacy"} mono />
+        <QueueDatum label="Attempt" value={item.attempt_id ? compactId(item.attempt_id, 10) : "none"} mono />
+        <QueueDatum label="Canonical" value={item.canonical ? "canonical" : "superseded"} tone={item.canonical ? statusTone("completed") : statusTone("failed")} />
+        <QueueDatum label="Candidate status" value={item.candidate_status ?? "unknown"} mono />
+        <QueueDatum label="Readiness" value={readinessSummary(item)} mono tone={mergeBlockerTone(item.merge_blocker_reason)} />
         <QueueDatum label="Mode" value={item.auto_merge ? "auto-merge" : "manual"} />
-        <QueueDatum label="Task class" value={item.task_class ?? "unclassified"} />
         <QueueDatum label="Last event" value={lastEventReason(item.last_event)} mono />
         <QueueDatum label="Blocker" value={item.merge_blocker_reason} mono tone={mergeBlockerTone(item.merge_blocker_reason)} />
       </div>
@@ -1295,14 +1299,45 @@ function mergeBlockerTone(reason: MergeQueueItem["merge_blocker_reason"]): Retur
       return "good";
     case "manual_merge_required":
     case "waiting_for_monitor":
+    case "stale":
       return "warn";
     case "failed_or_cancelled":
+    case "not_canonical":
       return "bad";
     case "workspace_not_terminal":
       return "info";
     default:
       return "info";
   }
+}
+
+function readinessSummary(item: MergeQueueItem): string {
+  const readiness = item.readiness;
+  if (!readiness) {
+    return "legacy";
+  }
+  if (readiness.ready) {
+    return "ready";
+  }
+  if (readiness.completed) {
+    return "completed";
+  }
+  if (readiness.manual_merge_required) {
+    return "manual";
+  }
+  if (readiness.waiting_for_monitor) {
+    return "waiting";
+  }
+  if (readiness.failed_or_cancelled) {
+    return "failed_or_cancelled";
+  }
+  if (readiness.not_canonical) {
+    return "not_canonical";
+  }
+  if (readiness.stale) {
+    return "stale";
+  }
+  return "blocked";
 }
 
 function StatusCountStrip({ counts }: { counts: ResourceSaturationSummary["workspace_counts"] }) {

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -54,9 +54,28 @@ export type MergeBlockerReason =
   | "waiting_for_monitor"
   | "workspace_not_terminal"
   | "completed"
-  | "failed_or_cancelled";
+  | "failed_or_cancelled"
+  | "not_canonical"
+  | "stale";
+
+export type MergeCandidateStatus = "open" | "merged" | "closed";
+
+export interface MergeCandidateReadiness {
+  ready: boolean;
+  manual_merge_required: boolean;
+  waiting_for_monitor: boolean;
+  failed_or_cancelled: boolean;
+  completed: boolean;
+  not_canonical: boolean;
+  stale: boolean;
+}
 
 export interface MergeQueueItem {
+  candidate_id: string | null;
+  candidate_status: MergeCandidateStatus | null;
+  close_reason: string | null;
+  attempt_id: string | null;
+  task_id: string;
   workspace_id: string;
   title: string;
   repo_url: string;
@@ -71,6 +90,8 @@ export interface MergeQueueItem {
   updated_at: string;
   last_event: WorkspaceEvent | null;
   merge_blocker_reason: MergeBlockerReason;
+  readiness: MergeCandidateReadiness | null;
+  canonical: boolean;
 }
 
 export interface Workspace {
@@ -293,4 +314,3 @@ export interface FailureSummaryResponse {
   taxonomy: FailureTaxonomyCount[];
   latest_examples: FailureExample[];
 }
-

--- a/migrations/versions/c4d5e6f7a8b9_merge_candidates.py
+++ b/migrations/versions/c4d5e6f7a8b9_merge_candidates.py
@@ -1,0 +1,150 @@
+"""Add canonical attempt lineage and merge candidates.
+
+Revision ID: c4d5e6f7a8b9
+Revises: 2c3d4e5f6a1b
+Create Date: 2026-04-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c4d5e6f7a8b9"
+down_revision: str | Sequence[str] | None = "2c3d4e5f6a1b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("task_attempts") as batch:
+        batch.add_column(
+            sa.Column("parent_attempt_id", sa.String(length=36), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("redispatch_from_attempt_id", sa.String(length=36), nullable=True)
+        )
+        batch.add_column(
+            sa.Column("superseded_by_attempt_id", sa.String(length=36), nullable=True)
+        )
+        batch.add_column(
+            sa.Column(
+                "is_canonical_for_merge",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+        batch.create_foreign_key(
+            "fk_task_attempts_parent_attempt_id",
+            "task_attempts",
+            ["parent_attempt_id"],
+            ["id"],
+        )
+        batch.create_foreign_key(
+            "fk_task_attempts_redispatch_from_attempt_id",
+            "task_attempts",
+            ["redispatch_from_attempt_id"],
+            ["id"],
+        )
+        batch.create_foreign_key(
+            "fk_task_attempts_superseded_by_attempt_id",
+            "task_attempts",
+            ["superseded_by_attempt_id"],
+            ["id"],
+        )
+
+    op.create_index(
+        "uq_task_attempts_one_canonical_per_task",
+        "task_attempts",
+        ["task_id"],
+        unique=True,
+        sqlite_where=sa.text("is_canonical_for_merge = 1"),
+        postgresql_where=sa.text("is_canonical_for_merge = true"),
+    )
+
+    op.create_table(
+        "merge_candidates",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("pr_url", sa.String(length=512), nullable=False),
+        sa.Column("pr_number", sa.Integer(), nullable=True),
+        sa.Column("repo_url", sa.String(length=512), nullable=False),
+        sa.Column("base_branch", sa.String(length=256), nullable=False),
+        sa.Column("branch_name", sa.String(length=256), nullable=True),
+        sa.Column("head_sha", sa.String(length=64), nullable=True),
+        sa.Column("base_sha", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("close_reason", sa.String(length=64), nullable=True),
+        sa.Column("ready", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column(
+            "manual_merge_required",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "waiting_for_monitor",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column(
+            "failed_or_cancelled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column("completed", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("not_canonical", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("stale", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("closed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("merged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["attempt_id"], ["task_attempts.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("attempt_id", name="uq_merge_candidates_attempt_id"),
+    )
+    op.create_index("ix_merge_candidates_task", "merge_candidates", ["task_id"])
+    op.create_index("ix_merge_candidates_workspace", "merge_candidates", ["workspace_id"])
+    op.create_index(
+        "ix_merge_candidates_status_updated",
+        "merge_candidates",
+        ["status", "updated_at"],
+    )
+    op.create_index(
+        "ix_merge_candidates_repo_base",
+        "merge_candidates",
+        ["repo_url", "base_branch"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_merge_candidates_repo_base", table_name="merge_candidates")
+    op.drop_index("ix_merge_candidates_status_updated", table_name="merge_candidates")
+    op.drop_index("ix_merge_candidates_workspace", table_name="merge_candidates")
+    op.drop_index("ix_merge_candidates_task", table_name="merge_candidates")
+    op.drop_table("merge_candidates")
+
+    op.drop_index("uq_task_attempts_one_canonical_per_task", table_name="task_attempts")
+    with op.batch_alter_table("task_attempts") as batch:
+        batch.drop_constraint(
+            "fk_task_attempts_superseded_by_attempt_id",
+            type_="foreignkey",
+        )
+        batch.drop_constraint(
+            "fk_task_attempts_redispatch_from_attempt_id",
+            type_="foreignkey",
+        )
+        batch.drop_constraint("fk_task_attempts_parent_attempt_id", type_="foreignkey")
+        batch.drop_column("is_canonical_for_merge")
+        batch.drop_column("superseded_by_attempt_id")
+        batch.drop_column("redispatch_from_attempt_id")
+        batch.drop_column("parent_attempt_id")

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -16,13 +16,14 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awf.api.deps import get_db_session
 from awf.api.schemas import (
     MergeBlockerReason,
+    MergeCandidateReadinessResponse,
     MergeQueueItemResponse,
     MergeQueueListResponse,
     WorkspaceEventResponse,
 )
 from awf.db.enums import WorkspaceStatus
-from awf.db.models import Workspace, WorkspaceEvent
-from awf.db.repositories import WorkspaceRepository
+from awf.db.models import MergeCandidate, Workspace, WorkspaceEvent
+from awf.db.repositories import MergeCandidateRepository, WorkspaceRepository
 
 router = APIRouter(prefix="/v1/merge-queue", tags=["merge-queue"])
 
@@ -56,7 +57,7 @@ async def list_merge_queue(
                 "message": "Invalid merge queue cursor.",
             },
         ) from exc
-    rows = await WorkspaceRepository(session).list_merge_queue(
+    candidate_rows = await MergeCandidateRepository(session).list_queue(
         repo_url=repo_url,
         base_branch=base_branch,
         status=workspace_status,
@@ -64,21 +65,80 @@ async def list_merge_queue(
         before_workspace_id=decoded_cursor.workspace_id if decoded_cursor is not None else None,
         limit=limit + 1,
     )
+    legacy_rows = await WorkspaceRepository(session).list_merge_queue_without_candidates(
+        repo_url=repo_url,
+        base_branch=base_branch,
+        status=workspace_status,
+        before_updated_at=decoded_cursor.updated_at if decoded_cursor is not None else None,
+        before_workspace_id=decoded_cursor.workspace_id if decoded_cursor is not None else None,
+        limit=limit + 1,
+    )
+    queue_rows: list[MergeCandidate | Workspace] = [*candidate_rows, *legacy_rows]
+    rows = sorted(
+        queue_rows,
+        key=lambda row: (_row_workspace(row).updated_at, _row_workspace(row).id),
+        reverse=True,
+    )
     page_rows = rows[:limit]
     has_more = len(rows) > limit
     return MergeQueueListResponse(
-        items=[_item_from_workspace(row) for row in page_rows],
-        next_cursor=_encode_cursor(page_rows[-1]) if has_more and page_rows else None,
+        items=[_item_from_row(row) for row in page_rows],
+        next_cursor=_encode_cursor(_row_workspace(page_rows[-1]))
+        if has_more and page_rows
+        else None,
         has_more=has_more,
     )
 
 
-def _item_from_workspace(workspace: Workspace) -> MergeQueueItemResponse:
+def _item_from_row(row: MergeCandidate | Workspace) -> MergeQueueItemResponse:
+    if isinstance(row, MergeCandidate):
+        return _item_from_candidate(row)
+    return _item_from_legacy_workspace(row)
+
+
+def _item_from_candidate(candidate: MergeCandidate) -> MergeQueueItemResponse:
+    workspace = candidate.workspace
+    latest_event = _latest_event(workspace.events)
+    return MergeQueueItemResponse(
+        candidate_id=candidate.id,
+        candidate_status=candidate.status,
+        close_reason=candidate.close_reason,
+        attempt_id=candidate.attempt_id,
+        task_id=candidate.task_id,
+        workspace_id=workspace.id,
+        title=workspace.task_title,
+        repo_url=workspace.repo_url,
+        base_branch=workspace.branch_base,
+        branch_name=workspace.branch_name,
+        pr_url=candidate.pr_url,
+        status=WorkspaceStatus(workspace.status),
+        auto_merge=workspace.auto_merge,
+        task_class=workspace.task_class,
+        owned_paths=list(workspace.owned_paths),
+        created_at=workspace.created_at,
+        updated_at=workspace.updated_at,
+        last_event=(
+            WorkspaceEventResponse.model_validate(latest_event)
+            if latest_event is not None
+            else None
+        ),
+        merge_blocker_reason=_merge_blocker_reason(candidate),
+        readiness=_readiness_from_candidate(candidate),
+        canonical=candidate.attempt.is_canonical_for_merge,
+    )
+
+
+def _item_from_legacy_workspace(workspace: Workspace) -> MergeQueueItemResponse:
     latest_event = _latest_event(workspace.events)
     pr_url = workspace.pr_url
     if pr_url is None:  # pragma: no cover - filtered at repository boundary
-        raise ValueError("merge queue rows must have a PR URL")
+        raise ValueError("legacy merge queue rows must have a PR URL")
     return MergeQueueItemResponse(
+        candidate_id=None,
+        candidate_status=None,
+        close_reason=None,
+        attempt_id=None,
+        task_id=workspace.task_external_id or workspace.id,
         workspace_id=workspace.id,
         title=workspace.task_title,
         repo_url=workspace.repo_url,
@@ -96,15 +156,47 @@ def _item_from_workspace(workspace: Workspace) -> MergeQueueItemResponse:
             if latest_event is not None
             else None
         ),
-        merge_blocker_reason=_merge_blocker_reason(workspace),
+        merge_blocker_reason=_merge_blocker_reason_from_workspace(workspace),
+        readiness=None,
+        canonical=False,
     )
+
+
+def _row_workspace(row: MergeCandidate | Workspace) -> Workspace:
+    if isinstance(row, MergeCandidate):
+        return row.workspace
+    return row
 
 
 def _latest_event(events: list[WorkspaceEvent]) -> WorkspaceEvent | None:
     return events[-1] if events else None
 
 
-def _merge_blocker_reason(workspace: Workspace) -> MergeBlockerReason:
+def _merge_blocker_reason(candidate: MergeCandidate) -> MergeBlockerReason:
+    if candidate.completed:
+        return "completed"
+    if candidate.failed_or_cancelled:
+        return "failed_or_cancelled"
+    if candidate.not_canonical:
+        return "not_canonical"
+    if candidate.stale:
+        return "stale"
+    if candidate.manual_merge_required:
+        return "manual_merge_required"
+    if candidate.waiting_for_monitor:
+        return "waiting_for_monitor"
+    if candidate.ready:
+        return "ready_to_merge_or_waiting_for_github"
+    workspace = candidate.workspace
+    workspace_status = WorkspaceStatus(workspace.status)
+    if workspace_status == WorkspaceStatus.completed:
+        return "completed"
+    if workspace_status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
+        return "failed_or_cancelled"
+    return "workspace_not_terminal"
+
+
+def _merge_blocker_reason_from_workspace(workspace: Workspace) -> MergeBlockerReason:
     workspace_status = WorkspaceStatus(workspace.status)
     if workspace_status == WorkspaceStatus.monitoring_pr:
         if workspace.auto_merge:
@@ -117,6 +209,18 @@ def _merge_blocker_reason(workspace: Workspace) -> MergeBlockerReason:
     if workspace_status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
         return "failed_or_cancelled"
     return "workspace_not_terminal"
+
+
+def _readiness_from_candidate(candidate: MergeCandidate) -> MergeCandidateReadinessResponse:
+    return MergeCandidateReadinessResponse(
+        ready=candidate.ready,
+        manual_merge_required=candidate.manual_merge_required,
+        waiting_for_monitor=candidate.waiting_for_monitor,
+        failed_or_cancelled=candidate.failed_or_cancelled,
+        completed=candidate.completed,
+        not_canonical=candidate.not_canonical,
+        stale=candidate.stale,
+    )
 
 
 def _encode_cursor(workspace: Workspace) -> str:

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -187,12 +187,6 @@ def _merge_blocker_reason(candidate: MergeCandidate) -> MergeBlockerReason:
         return "waiting_for_monitor"
     if candidate.ready:
         return "ready_to_merge_or_waiting_for_github"
-    workspace = candidate.workspace
-    workspace_status = WorkspaceStatus(workspace.status)
-    if workspace_status == WorkspaceStatus.completed:
-        return "completed"
-    if workspace_status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
-        return "failed_or_cancelled"
     return "workspace_not_terminal"
 
 

--- a/src/awf/api/routes/tasks.py
+++ b/src/awf/api/routes/tasks.py
@@ -43,13 +43,15 @@ async def list_tasks(
         repo_url=repo_url,
         limit=limit,
     )
+    canonical_attempt_ids = await attempt_repo.list_canonical_ids_for_tasks(
+        row.task_id for row in attempt_rows
+    )
     items: list[TaskResponse] = []
     for row in attempt_rows:
-        canonical = await attempt_repo.get_canonical_for_task(row.task_id)
         items.append(
             _task_from_attempt(
                 row,
-                canonical_attempt_id=canonical.id if canonical is not None else None,
+                canonical_attempt_id=canonical_attempt_ids.get(row.task_id),
             )
         )
     items.extend(_task_from_workspace(row) for row in legacy_rows)

--- a/src/awf/api/routes/tasks.py
+++ b/src/awf/api/routes/tasks.py
@@ -4,14 +4,20 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.deps import get_db_session
-from awf.api.schemas import TaskListResponse, TaskResponse
+from awf.api.schemas import (
+    MergeCandidateReadinessResponse,
+    TaskAttemptListResponse,
+    TaskAttemptResponse,
+    TaskListResponse,
+    TaskResponse,
+)
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.models import TaskAttempt, Workspace
-from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
+from awf.db.models import MergeCandidate, TaskAttempt, Workspace
+from awf.db.repositories import TaskAttemptRepository, TaskRepository, WorkspaceRepository
 
 router = APIRouter(prefix="/v1/tasks", tags=["tasks"])
 
@@ -24,7 +30,8 @@ async def list_tasks(
     limit: Annotated[int, Query(ge=1, le=500)] = 50,
     session: AsyncSession = Depends(get_db_session),
 ) -> TaskListResponse:
-    attempt_rows = await TaskAttemptRepository(session).list_latest(
+    attempt_repo = TaskAttemptRepository(session)
+    attempt_rows = await attempt_repo.list_latest(
         status=workspace_status,
         agent=agent,
         repo_url=repo_url,
@@ -36,7 +43,15 @@ async def list_tasks(
         repo_url=repo_url,
         limit=limit,
     )
-    items = [_task_from_attempt(row) for row in attempt_rows]
+    items: list[TaskResponse] = []
+    for row in attempt_rows:
+        canonical = await attempt_repo.get_canonical_for_task(row.task_id)
+        items.append(
+            _task_from_attempt(
+                row,
+                canonical_attempt_id=canonical.id if canonical is not None else None,
+            )
+        )
     items.extend(_task_from_workspace(row) for row in legacy_rows)
     items.sort(key=lambda item: (item.created_at, item.workspace_id), reverse=True)
     return TaskListResponse(
@@ -44,12 +59,46 @@ async def list_tasks(
     )
 
 
-def _task_from_attempt(attempt: TaskAttempt) -> TaskResponse:
+@router.get("/{task_ref}/attempts", response_model=TaskAttemptListResponse)
+async def list_task_attempts(
+    task_ref: str,
+    limit: Annotated[int, Query(ge=1, le=500)] = 100,
+    session: AsyncSession = Depends(get_db_session),
+) -> TaskAttemptListResponse:
+    task = await TaskRepository(session).get_by_ref(task_ref)
+    if task is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error_code": "NOT_FOUND", "message": f"No task with ref {task_ref}"},
+        )
+
+    rows = await TaskAttemptRepository(session).list_for_task(task.id, limit=limit)
+    return TaskAttemptListResponse(
+        task_id=task.id,
+        task_ref=task_ref,
+        items=[_attempt_response(row) for row in rows],
+    )
+
+
+def _task_from_attempt(
+    attempt: TaskAttempt,
+    *,
+    canonical_attempt_id: str | None,
+) -> TaskResponse:
     workspace = attempt.workspace
+    candidate = attempt.merge_candidate
     return TaskResponse(
         task_id=attempt.task.external_id or attempt.task.id,
         attempt_id=attempt.id,
         attempt_number=attempt.attempt_number,
+        parent_attempt_id=attempt.parent_attempt_id,
+        redispatch_from_attempt_id=attempt.redispatch_from_attempt_id,
+        superseded_by_attempt_id=attempt.superseded_by_attempt_id,
+        is_canonical_for_merge=attempt.is_canonical_for_merge,
+        canonical_attempt_id=canonical_attempt_id,
+        candidate_id=candidate.id if candidate is not None else None,
+        candidate_status=candidate.status if candidate is not None else None,
+        readiness=_readiness_from_candidate(candidate),
         workspace_id=attempt.workspace_id,
         title=attempt.title,
         repo_url=attempt.repo_url,
@@ -65,11 +114,43 @@ def _task_from_attempt(attempt: TaskAttempt) -> TaskResponse:
     )
 
 
+def _attempt_response(attempt: TaskAttempt) -> TaskAttemptResponse:
+    workspace = attempt.workspace
+    candidate = attempt.merge_candidate
+    return TaskAttemptResponse(
+        attempt_id=attempt.id,
+        task_id=attempt.task_id,
+        workspace_id=attempt.workspace_id,
+        attempt_number=attempt.attempt_number,
+        parent_attempt_id=attempt.parent_attempt_id,
+        redispatch_from_attempt_id=attempt.redispatch_from_attempt_id,
+        superseded_by_attempt_id=attempt.superseded_by_attempt_id,
+        is_canonical_for_merge=attempt.is_canonical_for_merge,
+        candidate_id=candidate.id if candidate is not None else None,
+        candidate_status=candidate.status if candidate is not None else None,
+        readiness=_readiness_from_candidate(candidate),
+        agent=AgentRuntime(attempt.agent),
+        status=WorkspaceStatus(workspace.status),
+        pr_url=workspace.pr_url,
+        failure_reason=workspace.failure_reason,
+        created_at=attempt.created_at,
+        updated_at=workspace.updated_at,
+    )
+
+
 def _task_from_workspace(row: Workspace) -> TaskResponse:
     return TaskResponse(
         task_id=row.task_external_id or row.id,
         attempt_id=None,
         attempt_number=None,
+        parent_attempt_id=None,
+        redispatch_from_attempt_id=None,
+        superseded_by_attempt_id=None,
+        is_canonical_for_merge=None,
+        canonical_attempt_id=None,
+        candidate_id=None,
+        candidate_status=None,
+        readiness=None,
         workspace_id=row.id,
         title=row.task_title,
         repo_url=row.repo_url,
@@ -82,4 +163,20 @@ def _task_from_workspace(row: Workspace) -> TaskResponse:
         failure_reason=row.failure_reason,
         created_at=row.created_at,
         updated_at=row.updated_at,
+    )
+
+
+def _readiness_from_candidate(
+    candidate: MergeCandidate | None,
+) -> MergeCandidateReadinessResponse | None:
+    if candidate is None:
+        return None
+    return MergeCandidateReadinessResponse(
+        ready=candidate.ready,
+        manual_merge_required=candidate.manual_merge_required,
+        waiting_for_monitor=candidate.waiting_for_monitor,
+        failed_or_cancelled=candidate.failed_or_cancelled,
+        completed=candidate.completed,
+        not_canonical=candidate.not_canonical,
+        stale=candidate.stale,
     )

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -23,7 +23,20 @@ MergeBlockerReason = Literal[
     "workspace_not_terminal",
     "completed",
     "failed_or_cancelled",
+    "not_canonical",
+    "stale",
 ]
+MergeCandidateStatus = Literal["open", "merged", "closed"]
+
+
+class MergeCandidateReadinessResponse(BaseModel):
+    ready: bool
+    manual_merge_required: bool
+    waiting_for_monitor: bool
+    failed_or_cancelled: bool
+    completed: bool
+    not_canonical: bool
+    stale: bool
 
 
 class WorkspaceCreateRequest(BaseModel):
@@ -209,6 +222,14 @@ class TaskResponse(BaseModel):
     task_id: str
     attempt_id: str | None = None
     attempt_number: int | None = None
+    parent_attempt_id: str | None = None
+    redispatch_from_attempt_id: str | None = None
+    superseded_by_attempt_id: str | None = None
+    is_canonical_for_merge: bool | None = None
+    canonical_attempt_id: str | None = None
+    candidate_id: str | None = None
+    candidate_status: MergeCandidateStatus | None = None
+    readiness: MergeCandidateReadinessResponse | None = None
     workspace_id: str
     title: str
     repo_url: str
@@ -225,6 +246,34 @@ class TaskResponse(BaseModel):
 
 class TaskListResponse(BaseModel):
     items: list[TaskResponse]
+    next_cursor: str | None = None
+    has_more: bool = False
+
+
+class TaskAttemptResponse(BaseModel):
+    attempt_id: str
+    task_id: str
+    workspace_id: str
+    attempt_number: int
+    parent_attempt_id: str | None
+    redispatch_from_attempt_id: str | None
+    superseded_by_attempt_id: str | None
+    is_canonical_for_merge: bool
+    candidate_id: str | None = None
+    candidate_status: MergeCandidateStatus | None = None
+    readiness: MergeCandidateReadinessResponse | None = None
+    agent: AgentRuntime
+    status: WorkspaceStatus
+    pr_url: str | None
+    failure_reason: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class TaskAttemptListResponse(BaseModel):
+    task_id: str
+    task_ref: str
+    items: list[TaskAttemptResponse]
     next_cursor: str | None = None
     has_more: bool = False
 
@@ -257,6 +306,11 @@ class WorkspaceOverviewListResponse(BaseModel):
 
 
 class MergeQueueItemResponse(BaseModel):
+    candidate_id: str | None = None
+    candidate_status: MergeCandidateStatus | None = None
+    close_reason: str | None = None
+    attempt_id: str | None = None
+    task_id: str
     workspace_id: str
     title: str
     repo_url: str
@@ -271,6 +325,8 @@ class MergeQueueItemResponse(BaseModel):
     updated_at: datetime
     last_event: WorkspaceEventResponse | None
     merge_blocker_reason: MergeBlockerReason
+    readiness: MergeCandidateReadinessResponse | None = None
+    canonical: bool
 
 
 class MergeQueueListResponse(BaseModel):

--- a/src/awf/common/ids.py
+++ b/src/awf/common/ids.py
@@ -22,6 +22,10 @@ def new_task_attempt_id() -> str:
     return f"att_{uuid4().hex[:24]}"
 
 
+def new_merge_candidate_id() -> str:
+    return f"mc_{uuid4().hex[:24]}"
+
+
 def new_operation_id() -> str:
     return f"op_{uuid4().hex[:24]}"
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -31,6 +31,7 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
+    false,
     text,
     true,
 )
@@ -233,6 +234,12 @@ class Workspace(Base):
         lazy="selectin",
         uselist=False,
     )
+    merge_candidates: Mapped[list[MergeCandidate]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="MergeCandidate.updated_at",
+    )
 
 
 class Task(Base):
@@ -272,6 +279,12 @@ class Task(Base):
         lazy="selectin",
         order_by="TaskAttempt.attempt_number",
     )
+    merge_candidates: Mapped[list[MergeCandidate]] = relationship(
+        back_populates="task",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="MergeCandidate.updated_at",
+    )
 
 
 class TaskAttempt(Base):
@@ -281,6 +294,13 @@ class TaskAttempt(Base):
     __table_args__ = (
         UniqueConstraint("workspace_id", name="uq_task_attempts_workspace_id"),
         UniqueConstraint("task_id", "attempt_number", name="uq_task_attempts_task_number"),
+        Index(
+            "uq_task_attempts_one_canonical_per_task",
+            "task_id",
+            unique=True,
+            sqlite_where=text("is_canonical_for_merge = 1"),
+            postgresql_where=text("is_canonical_for_merge = true"),
+        ),
         Index("ix_task_attempts_task", "task_id"),
         Index("ix_task_attempts_status", "status"),
         Index("ix_task_attempts_created_at", "created_at"),
@@ -292,6 +312,21 @@ class TaskAttempt(Base):
         String(36), ForeignKey("workspaces.id"), nullable=False
     )
     attempt_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    parent_attempt_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=True
+    )
+    redispatch_from_attempt_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=True
+    )
+    superseded_by_attempt_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=True
+    )
+    is_canonical_for_merge: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=false(),
+    )
 
     agent: Mapped[str] = mapped_column(String(32), nullable=False)
     status: Mapped[str] = mapped_column(String(32), nullable=False)
@@ -313,6 +348,70 @@ class TaskAttempt(Base):
 
     task: Mapped[Task] = relationship(back_populates="attempts")
     workspace: Mapped[Workspace] = relationship(back_populates="task_attempt")
+    merge_candidate: Mapped[MergeCandidate | None] = relationship(
+        back_populates="attempt",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        uselist=False,
+    )
+
+
+class MergeCandidate(Base):
+    """Explicit PR-backed merge queue entry for a task attempt."""
+
+    __tablename__ = "merge_candidates"
+    __table_args__ = (
+        UniqueConstraint("attempt_id", name="uq_merge_candidates_attempt_id"),
+        Index("ix_merge_candidates_task", "task_id"),
+        Index("ix_merge_candidates_workspace", "workspace_id"),
+        Index("ix_merge_candidates_status_updated", "status", "updated_at"),
+        Index("ix_merge_candidates_repo_base", "repo_url", "base_branch"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    task_id: Mapped[str] = mapped_column(String(36), ForeignKey("tasks.id"), nullable=False)
+    attempt_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=False
+    )
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+
+    pr_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    pr_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    repo_url: Mapped[str] = mapped_column(String(512), nullable=False)
+    base_branch: Mapped[str] = mapped_column(String(256), nullable=False)
+    branch_name: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    head_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    base_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="open")
+    close_reason: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    ready: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    manual_merge_required: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+    )
+    waiting_for_monitor: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    failed_or_cancelled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    completed: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    not_canonical: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    stale: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, onupdate=_now, nullable=False
+    )
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    merged_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    task: Mapped[Task] = relationship(back_populates="merge_candidates")
+    attempt: Mapped[TaskAttempt] = relationship(back_populates="merge_candidate")
+    workspace: Mapped[Workspace] = relationship(back_populates="merge_candidates")
 
 
 class Operation(Base):

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -540,7 +540,7 @@ class MergeCandidateRepository:
         now = datetime.now(UTC)
         candidate.status = "merged"
         candidate.close_reason = None
-        candidate.closed_at = now
+        candidate.closed_at = None
         candidate.merged_at = now
         _sync_candidate_readiness(
             candidate,

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -25,6 +25,7 @@ from sqlalchemy.sql.elements import ColumnElement
 from awf.common.ids import (
     new_event_id,
     new_log_stream_id,
+    new_merge_candidate_id,
     new_operation_id,
     new_task_attempt_id,
     new_task_id,
@@ -34,6 +35,7 @@ from awf.control.state_machine import WorkspaceStateMachine
 from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import (
+    MergeCandidate,
     Operation,
     Task,
     TaskAttempt,
@@ -134,6 +136,13 @@ class TaskRepository:
     async def get(self, task_id: str) -> Task | None:
         return await self._session.get(Task, task_id)
 
+    async def get_by_ref(self, task_ref: str) -> Task | None:
+        task = await self.get(task_ref)
+        if task is not None:
+            return task
+        stmt = select(Task).where(Task.external_id == task_ref)
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
     async def _find_reusable(
         self,
         *,
@@ -165,6 +174,8 @@ class TaskAttemptRepository:
         *,
         task: Task,
         workspace: Workspace,
+        parent_attempt_id: str | None = None,
+        redispatch_from_attempt_id: str | None = None,
     ) -> TaskAttempt:
         await self._lock_attempt_number_sequence(task.id)
         max_attempt_number = (
@@ -180,6 +191,8 @@ class TaskAttemptRepository:
             task_id=task.id,
             workspace_id=workspace.id,
             attempt_number=attempt_number,
+            parent_attempt_id=parent_attempt_id,
+            redispatch_from_attempt_id=redispatch_from_attempt_id,
             agent=workspace.agent,
             status=workspace.status,
             repo_url=workspace.repo_url,
@@ -205,6 +218,36 @@ class TaskAttemptRepository:
     async def get_by_workspace_id(self, workspace_id: str) -> TaskAttempt | None:
         stmt = select(TaskAttempt).where(TaskAttempt.workspace_id == workspace_id)
         return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def get_canonical_for_task(self, task_id: str) -> TaskAttempt | None:
+        stmt = select(TaskAttempt).where(
+            TaskAttempt.task_id == task_id,
+            TaskAttempt.is_canonical_for_merge.is_(True),
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def mark_canonical_for_merge(self, attempt: TaskAttempt) -> TaskAttempt:
+        current = await self.get_canonical_for_task(attempt.task_id)
+        if current is not None and current.id != attempt.id:
+            current.is_canonical_for_merge = False
+            current.superseded_by_attempt_id = attempt.id
+            await self._session.flush([current])
+        attempt.is_canonical_for_merge = True
+        await self._session.flush()
+        return attempt
+
+    async def list_for_task(self, task_id: str, *, limit: int = 100) -> list[TaskAttempt]:
+        stmt = (
+            select(TaskAttempt)
+            .where(TaskAttempt.task_id == task_id)
+            .options(
+                selectinload(TaskAttempt.workspace),
+                selectinload(TaskAttempt.merge_candidate),
+            )
+            .order_by(TaskAttempt.attempt_number.desc(), TaskAttempt.id.desc())
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars())
 
     async def list_latest(
         self,
@@ -236,6 +279,7 @@ class TaskAttemptRepository:
             .options(
                 selectinload(TaskAttempt.task),
                 selectinload(TaskAttempt.workspace),
+                selectinload(TaskAttempt.merge_candidate),
             )
         )
         if status is not None:
@@ -247,6 +291,250 @@ class TaskAttemptRepository:
 
         stmt = stmt.order_by(TaskAttempt.created_at.desc(), TaskAttempt.id.desc()).limit(limit)
         return list((await self._session.execute(stmt)).scalars())
+
+
+class MergeCandidateRepository:
+    """CRUD helpers for explicit PR-backed merge candidates."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def get_by_attempt_id(self, attempt_id: str) -> MergeCandidate | None:
+        stmt = (
+            select(MergeCandidate)
+            .where(MergeCandidate.attempt_id == attempt_id)
+            .options(
+                selectinload(MergeCandidate.attempt),
+                selectinload(MergeCandidate.workspace),
+                selectinload(MergeCandidate.task),
+            )
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_for_task(
+        self,
+        task_id: str,
+        *,
+        limit: int = 100,
+    ) -> builtins.list[MergeCandidate]:
+        stmt = (
+            select(MergeCandidate)
+            .where(MergeCandidate.task_id == task_id)
+            .options(
+                selectinload(MergeCandidate.attempt),
+                selectinload(MergeCandidate.workspace).selectinload(Workspace.events),
+                selectinload(MergeCandidate.task),
+            )
+            .order_by(
+                MergeCandidate.updated_at.desc(),
+                MergeCandidate.id.desc(),
+            )
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def list_queue(
+        self,
+        *,
+        repo_url: str | None = None,
+        base_branch: str | None = None,
+        status: WorkspaceStatus | str | None = None,
+        before_updated_at: datetime | None = None,
+        before_workspace_id: str | None = None,
+        limit: int = 50,
+    ) -> builtins.list[MergeCandidate]:
+        stmt = (
+            select(MergeCandidate)
+            .join(Workspace, MergeCandidate.workspace_id == Workspace.id)
+            .where(
+                ~Workspace.status.in_(
+                    (
+                        WorkspaceStatus.destroying.value,
+                        WorkspaceStatus.destroyed.value,
+                    )
+                )
+            )
+            .options(
+                selectinload(MergeCandidate.attempt),
+                selectinload(MergeCandidate.workspace).selectinload(Workspace.events),
+                selectinload(MergeCandidate.task),
+            )
+            .order_by(Workspace.updated_at.desc(), Workspace.id.desc())
+        )
+        if repo_url is not None:
+            stmt = stmt.where(MergeCandidate.repo_url == repo_url)
+        if base_branch is not None:
+            stmt = stmt.where(MergeCandidate.base_branch == base_branch)
+        if status is not None:
+            stmt = stmt.where(Workspace.status == status)
+        if before_updated_at is not None and before_workspace_id is not None:
+            stmt = stmt.where(
+                or_(
+                    Workspace.updated_at < before_updated_at,
+                    and_(
+                        Workspace.updated_at == before_updated_at,
+                        Workspace.id < before_workspace_id,
+                    ),
+                )
+            )
+        stmt = stmt.limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def create_or_update_open_for_attempt(
+        self,
+        *,
+        task: Task,
+        attempt: TaskAttempt,
+        workspace: Workspace,
+        head_sha: str | None = None,
+        base_sha: str | None = None,
+    ) -> MergeCandidate:
+        if not workspace.pr_url:
+            raise ValueError("merge candidates require a workspace PR URL")
+
+        candidate = await self.get_by_attempt_id(attempt.id)
+        if candidate is None:
+            candidate = MergeCandidate(
+                id=new_merge_candidate_id(),
+                task_id=task.id,
+                attempt_id=attempt.id,
+                workspace_id=workspace.id,
+                pr_url=workspace.pr_url,
+                pr_number=workspace.pr_number,
+                repo_url=workspace.repo_url,
+                base_branch=workspace.branch_base,
+                branch_name=workspace.branch_name,
+                head_sha=head_sha,
+                base_sha=base_sha,
+                status="open",
+            )
+            self._session.add(candidate)
+        else:
+            candidate.task_id = task.id
+            candidate.workspace_id = workspace.id
+            candidate.pr_url = workspace.pr_url
+            candidate.pr_number = workspace.pr_number
+            candidate.repo_url = workspace.repo_url
+            candidate.base_branch = workspace.branch_base
+            candidate.branch_name = workspace.branch_name
+            if head_sha is not None:
+                candidate.head_sha = head_sha
+            if base_sha is not None:
+                candidate.base_sha = base_sha
+            candidate.status = "open"
+            candidate.close_reason = None
+            candidate.closed_at = None
+            candidate.merged_at = None
+
+        _sync_candidate_readiness(candidate, workspace=workspace, attempt=attempt)
+        await self._session.flush()
+        return candidate
+
+    async def make_attempt_canonical_and_create_candidate(
+        self,
+        *,
+        task: Task,
+        attempt: TaskAttempt,
+        workspace: Workspace,
+        head_sha: str | None = None,
+        base_sha: str | None = None,
+    ) -> MergeCandidate:
+        attempt_repo = TaskAttemptRepository(self._session)
+        previous = await attempt_repo.get_canonical_for_task(attempt.task_id)
+        await attempt_repo.mark_canonical_for_merge(attempt)
+        if previous is not None and previous.id != attempt.id:
+            await self.close_open_for_attempt(
+                previous.id,
+                close_reason="CANONICAL_CHANGED",
+            )
+        return await self.create_or_update_open_for_attempt(
+            task=task,
+            attempt=attempt,
+            workspace=workspace,
+            head_sha=head_sha,
+            base_sha=base_sha,
+        )
+
+    async def close_open_for_attempt(
+        self,
+        attempt_id: str,
+        *,
+        close_reason: str,
+    ) -> MergeCandidate | None:
+        candidate = await self.get_by_attempt_id(attempt_id)
+        if candidate is None or candidate.status != "open":
+            return candidate
+        candidate.status = "closed"
+        candidate.close_reason = close_reason
+        candidate.closed_at = datetime.now(UTC)
+        _sync_candidate_readiness(
+            candidate,
+            workspace=candidate.workspace,
+            attempt=candidate.attempt,
+        )
+        await self._session.flush()
+        return candidate
+
+    async def close_open_for_workspace(
+        self,
+        workspace_id: str,
+        *,
+        close_reason: str,
+    ) -> builtins.list[MergeCandidate]:
+        stmt = (
+            select(MergeCandidate)
+            .where(
+                MergeCandidate.workspace_id == workspace_id,
+                MergeCandidate.status == "open",
+            )
+            .options(
+                selectinload(MergeCandidate.workspace),
+                selectinload(MergeCandidate.attempt),
+            )
+        )
+        candidates = list((await self._session.execute(stmt)).scalars())
+        now = datetime.now(UTC)
+        for candidate in candidates:
+            candidate.status = "closed"
+            candidate.close_reason = close_reason
+            candidate.closed_at = now
+            _sync_candidate_readiness(
+                candidate,
+                workspace=candidate.workspace,
+                attempt=candidate.attempt,
+            )
+        await self._session.flush()
+        return candidates
+
+    async def mark_workspace_merged(self, workspace_id: str) -> MergeCandidate | None:
+        stmt = (
+            select(MergeCandidate)
+            .where(
+                MergeCandidate.workspace_id == workspace_id,
+                MergeCandidate.status == "open",
+            )
+            .options(
+                selectinload(MergeCandidate.workspace),
+                selectinload(MergeCandidate.attempt),
+            )
+            .order_by(MergeCandidate.updated_at.desc(), MergeCandidate.id.desc())
+            .limit(1)
+        )
+        candidate = (await self._session.execute(stmt)).scalar_one_or_none()
+        if candidate is None:
+            return None
+        now = datetime.now(UTC)
+        candidate.status = "merged"
+        candidate.close_reason = None
+        candidate.closed_at = now
+        candidate.merged_at = now
+        _sync_candidate_readiness(
+            candidate,
+            workspace=candidate.workspace,
+            attempt=candidate.attempt,
+        )
+        await self._session.flush()
+        return candidate
 
 
 class WorkspaceRepository:
@@ -491,6 +779,51 @@ class WorkspaceRepository:
         stmt = stmt.limit(limit)
         return list((await self._session.execute(stmt)).scalars())
 
+    async def list_merge_queue_without_candidates(
+        self,
+        *,
+        repo_url: str | None = None,
+        base_branch: str | None = None,
+        status: WorkspaceStatus | str | None = None,
+        before_updated_at: datetime | None = None,
+        before_workspace_id: str | None = None,
+        limit: int = 50,
+    ) -> builtins.list[Workspace]:
+        stmt = (
+            select(Workspace)
+            .outerjoin(MergeCandidate, MergeCandidate.workspace_id == Workspace.id)
+            .where(
+                MergeCandidate.id.is_(None),
+                Workspace.pr_url.is_not(None),
+                Workspace.pr_url != "",
+                ~Workspace.status.in_(
+                    (
+                        WorkspaceStatus.destroying.value,
+                        WorkspaceStatus.destroyed.value,
+                    )
+                ),
+            )
+            .order_by(Workspace.updated_at.desc(), Workspace.id.desc())
+        )
+        if repo_url is not None:
+            stmt = stmt.where(Workspace.repo_url == repo_url)
+        if base_branch is not None:
+            stmt = stmt.where(Workspace.branch_base == base_branch)
+        if status is not None:
+            stmt = stmt.where(Workspace.status == status)
+        if before_updated_at is not None and before_workspace_id is not None:
+            stmt = stmt.where(
+                or_(
+                    Workspace.updated_at < before_updated_at,
+                    and_(
+                        Workspace.updated_at == before_updated_at,
+                        Workspace.id < before_workspace_id,
+                    ),
+                )
+            )
+        stmt = stmt.limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
+
     async def list_schedulable_ids(
         self,
         *,
@@ -545,6 +878,7 @@ class WorkspaceRepository:
             attempt.status = to.value
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
             workspace.monitor_started_at = datetime.now(UTC)
+        await self._sync_merge_candidate_lifecycle(workspace, attempt=attempt, to=to)
 
         workspace.events.append(
             WorkspaceEvent(
@@ -599,6 +933,7 @@ class WorkspaceRepository:
             attempt.status = to.value
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
             workspace.monitor_started_at = now
+        await self._sync_merge_candidate_lifecycle(workspace, attempt=attempt, to=to)
 
         workspace.events.append(
             WorkspaceEvent(
@@ -611,6 +946,37 @@ class WorkspaceRepository:
         )
         await self._session.flush()
         return workspace
+
+    async def _sync_merge_candidate_lifecycle(
+        self,
+        workspace: Workspace,
+        *,
+        attempt: TaskAttempt | None,
+        to: WorkspaceStatus,
+    ) -> None:
+        candidate_repo = MergeCandidateRepository(self._session)
+        if to == WorkspaceStatus.monitoring_pr:
+            if attempt is None or not workspace.pr_url:
+                return
+            task = await TaskRepository(self._session).get(attempt.task_id)
+            if task is None:  # pragma: no cover - FK invariant
+                return
+            await candidate_repo.make_attempt_canonical_and_create_candidate(
+                task=task,
+                attempt=attempt,
+                workspace=workspace,
+            )
+            return
+
+        if to == WorkspaceStatus.completed:
+            await candidate_repo.mark_workspace_merged(workspace.id)
+            return
+
+        if to in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
+            await candidate_repo.close_open_for_workspace(
+                workspace.id,
+                close_reason=_candidate_terminal_close_reason(to),
+            )
 
     async def claim_monitoring_pr(
         self,
@@ -772,6 +1138,59 @@ class WorkspaceRepository:
         workspace.events.extend(created)
         await self._session.flush()
         return created
+
+
+def _candidate_terminal_close_reason(status: WorkspaceStatus) -> str:
+    if status == WorkspaceStatus.failed:
+        return "WORKSPACE_FAILED"
+    if status == WorkspaceStatus.cancelled:
+        return "WORKSPACE_CANCELLED"
+    return f"WORKSPACE_{status.value.upper()}"
+
+
+def _sync_candidate_readiness(
+    candidate: MergeCandidate,
+    *,
+    workspace: Workspace,
+    attempt: TaskAttempt,
+) -> None:
+    workspace_status = WorkspaceStatus(workspace.status)
+    is_open = candidate.status == "open"
+    is_canonical = attempt.is_canonical_for_merge
+    is_completed = candidate.status == "merged" or workspace_status == WorkspaceStatus.completed
+    failed_or_cancelled = workspace_status in {
+        WorkspaceStatus.failed,
+        WorkspaceStatus.cancelled,
+    }
+    not_canonical = not is_canonical
+
+    candidate.completed = is_completed
+    candidate.failed_or_cancelled = failed_or_cancelled
+    candidate.not_canonical = not_canonical
+    candidate.waiting_for_monitor = is_open and workspace_status == WorkspaceStatus.pushing
+    candidate.manual_merge_required = (
+        is_open
+        and workspace_status == WorkspaceStatus.monitoring_pr
+        and not workspace.auto_merge
+        and is_canonical
+        and not candidate.stale
+    )
+    candidate.ready = (
+        is_open
+        and workspace_status == WorkspaceStatus.monitoring_pr
+        and workspace.auto_merge
+        and is_canonical
+        and not candidate.stale
+    )
+    if not is_open:
+        candidate.ready = False
+        candidate.waiting_for_monitor = False
+        candidate.manual_merge_required = False
+    if is_completed:
+        candidate.ready = False
+        candidate.waiting_for_monitor = False
+        candidate.manual_merge_required = False
+        candidate.failed_or_cancelled = False
 
 
 def _schedulable_workspace_ids_stmt(

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -360,6 +360,7 @@ class MergeCandidateRepository:
             select(MergeCandidate)
             .join(Workspace, MergeCandidate.workspace_id == Workspace.id)
             .where(
+                MergeCandidate.status == "open",
                 ~Workspace.status.in_(
                     (
                         WorkspaceStatus.destroying.value,

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import builtins
 import hashlib
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Final
@@ -225,6 +226,18 @@ class TaskAttemptRepository:
             TaskAttempt.is_canonical_for_merge.is_(True),
         )
         return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_canonical_ids_for_tasks(self, task_ids: Iterable[str]) -> dict[str, str]:
+        unique_task_ids = tuple(dict.fromkeys(task_ids))
+        if not unique_task_ids:
+            return {}
+
+        stmt = select(TaskAttempt.task_id, TaskAttempt.id).where(
+            TaskAttempt.task_id.in_(unique_task_ids),
+            TaskAttempt.is_canonical_for_merge.is_(True),
+        )
+        rows = (await self._session.execute(stmt)).tuples().all()
+        return dict(rows)
 
     async def mark_canonical_for_merge(self, attempt: TaskAttempt) -> TaskAttempt:
         current = await self.get_canonical_for_task(attempt.task_id)

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -239,15 +239,15 @@ class TaskAttemptRepository:
         rows = (await self._session.execute(stmt)).tuples().all()
         return dict(rows)
 
-    async def mark_canonical_for_merge(self, attempt: TaskAttempt) -> TaskAttempt:
-        current = await self.get_canonical_for_task(attempt.task_id)
-        if current is not None and current.id != attempt.id:
-            current.is_canonical_for_merge = False
-            current.superseded_by_attempt_id = attempt.id
-            await self._session.flush([current])
+    async def mark_canonical_for_merge(self, attempt: TaskAttempt) -> TaskAttempt | None:
+        previous = await self.get_canonical_for_task(attempt.task_id)
+        if previous is not None and previous.id != attempt.id:
+            previous.is_canonical_for_merge = False
+            previous.superseded_by_attempt_id = attempt.id
+            await self._session.flush([previous])
         attempt.is_canonical_for_merge = True
         await self._session.flush()
-        return attempt
+        return previous
 
     async def list_for_task(self, task_id: str, *, limit: int = 100) -> list[TaskAttempt]:
         stmt = (
@@ -454,8 +454,7 @@ class MergeCandidateRepository:
         base_sha: str | None = None,
     ) -> MergeCandidate:
         attempt_repo = TaskAttemptRepository(self._session)
-        previous = await attempt_repo.get_canonical_for_task(attempt.task_id)
-        await attempt_repo.mark_canonical_for_merge(attempt)
+        previous = await attempt_repo.mark_canonical_for_merge(attempt)
         if previous is not None and previous.id != attempt.id:
             await self.close_open_for_attempt(
                 previous.id,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -23,7 +23,7 @@ from awf.api.schemas import (
     WorkspaceRuntimeResponse,
 )
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
-from awf.db.models import Operation, Task, Workspace
+from awf.db.models import Operation, Task, TaskAttempt, Workspace
 from awf.db.repositories import (
     OperationRepository,
     OwnedPathConflict,
@@ -484,10 +484,14 @@ async def retry_workspace_row(
         remote_push_branch=source.remote_push_branch,
     )
 
-    task = await _retry_task_for_source(session, source)
-    attempt = await TaskAttemptRepository(session).create_for_workspace(
+    attempt_repo = TaskAttemptRepository(session)
+    source_attempt = await attempt_repo.get_by_workspace_id(source.id)
+    task = await _retry_task_for_source(session, source, source_attempt=source_attempt)
+    attempt = await attempt_repo.create_for_workspace(
         task=task,
         workspace=retried,
+        parent_attempt_id=source_attempt.id if source_attempt is not None else None,
+        redispatch_from_attempt_id=source_attempt.id if source_attempt is not None else None,
     )
 
     operation_repo = OperationRepository(session)
@@ -532,10 +536,16 @@ async def retry_workspace_row(
     )
 
 
-async def _retry_task_for_source(session: AsyncSession, source: Workspace) -> Task:
-    attempt = await TaskAttemptRepository(session).get_by_workspace_id(source.id)
-    if attempt is not None:
-        task = await TaskRepository(session).get(attempt.task_id)
+async def _retry_task_for_source(
+    session: AsyncSession,
+    source: Workspace,
+    *,
+    source_attempt: TaskAttempt | None = None,
+) -> Task:
+    if source_attempt is None:
+        source_attempt = await TaskAttemptRepository(session).get_by_workspace_id(source.id)
+    if source_attempt is not None:
+        task = await TaskRepository(session).get(source_attempt.task_id)
         if task is not None:
             return task
 

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -27,6 +27,8 @@ async def _create_queue_workspace(
     owned_paths: list[str] | None = None,
     updated_at: datetime | None = None,
 ) -> str:
+    from awf.db.repositories import MergeCandidateRepository, TaskAttemptRepository, TaskRepository
+
     factory = make_session_factory(engine)
     async with factory() as session:
         repo = WorkspaceRepository(session)
@@ -45,8 +47,42 @@ async def _create_queue_workspace(
         workspace.status = status.value
         workspace.branch_name = branch_name
         workspace.pr_url = pr_url
+        workspace.pr_number = (
+            int(pr_url.rstrip("/").split("/")[-1]) if pr_url is not None else None
+        )
         if updated_at is not None:
             workspace.updated_at = updated_at
+        task = await TaskRepository(session).create_or_get(
+            repo_url=repo_url,
+            base_branch=base_branch,
+            title=title,
+            prompt=f"Implement {title}.",
+            external_id=f"QUEUE-{title}",
+            idempotency_key=None,
+            task_class=task_class,
+            owned_paths=["src/awf/api/**"] if owned_paths is None else owned_paths,
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        if pr_url is not None:
+            attempt.is_canonical_for_merge = True
+            candidate_repo = MergeCandidateRepository(session)
+            await candidate_repo.create_or_update_open_for_attempt(
+                task=task,
+                attempt=attempt,
+                workspace=workspace,
+                head_sha="head123",
+                base_sha="base123",
+            )
+            if status == WorkspaceStatus.completed:
+                await candidate_repo.mark_workspace_merged(workspace.id)
+            elif status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
+                await candidate_repo.close_open_for_workspace(
+                    workspace.id,
+                    close_reason=f"WORKSPACE_{status.value.upper()}",
+                )
         await repo.add_event(
             workspace,
             event_type="merge_queue.test_marker",
@@ -97,6 +133,11 @@ class TestMergeQueueList:
 
         item = body["items"][0]
         assert set(item) == {
+            "candidate_id",
+            "candidate_status",
+            "close_reason",
+            "attempt_id",
+            "task_id",
             "workspace_id",
             "title",
             "repo_url",
@@ -111,7 +152,13 @@ class TestMergeQueueList:
             "updated_at",
             "last_event",
             "merge_blocker_reason",
+            "readiness",
+            "canonical",
         }
+        assert item["candidate_id"].startswith("mc_")
+        assert item["candidate_status"] == "merged"
+        assert item["attempt_id"].startswith("att_")
+        assert item["task_id"].startswith("task_")
         assert item["title"] == "Newer completed PR"
         assert item["repo_url"] == "git@github.com:example/console.git"
         assert item["base_branch"] == "main"
@@ -123,6 +170,8 @@ class TestMergeQueueList:
         assert item["owned_paths"] == ["src/awf/api/**"]
         assert item["last_event"]["event_type"] == "merge_queue.test_marker"
         assert item["merge_blocker_reason"] == "completed"
+        assert item["canonical"] is True
+        assert item["readiness"]["completed"] is True
 
     @pytest.mark.unit
     async def test_filters_by_repo_base_status_and_limit(
@@ -283,3 +332,41 @@ class TestMergeQueueList:
             for item in response.json()["items"]
         }
         assert actual == expected
+
+    @pytest.mark.unit
+    async def test_returns_candidate_backed_readiness_while_preserving_workspace_fields(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_queue_workspace(
+            engine,
+            title="Candidate readiness",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/21",
+            branch_name="awf/candidate-readiness",
+            updated_at=datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
+        )
+
+        response = await client.get("/v1/merge-queue")
+
+        assert response.status_code == 200
+        item = next(
+            item
+            for item in response.json()["items"]
+            if item["workspace_id"] == workspace_id
+        )
+        assert item["workspace_id"] == workspace_id
+        assert item["status"] == WorkspaceStatus.monitoring_pr.value
+        assert item["candidate_status"] == "open"
+        assert item["canonical"] is True
+        assert item["readiness"] == {
+            "ready": True,
+            "manual_merge_required": False,
+            "waiting_for_monitor": False,
+            "failed_or_cancelled": False,
+            "completed": False,
+            "not_canonical": False,
+            "stale": False,
+        }
+        assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -95,7 +95,7 @@ async def _create_queue_workspace(
 
 class TestMergeQueueList:
     @pytest.mark.unit
-    async def test_lists_pr_workspaces_newest_updated_first_with_required_shape(
+    async def test_lists_active_pr_workspaces_newest_updated_first_with_required_shape(
         self,
         client: AsyncClient,
         engine: AsyncEngine,
@@ -129,7 +129,7 @@ class TestMergeQueueList:
         body = response.json()
         assert body["next_cursor"] is None
         assert body["has_more"] is False
-        assert [item["workspace_id"] for item in body["items"]] == [newer_id, older_id]
+        assert [item["workspace_id"] for item in body["items"]] == [older_id]
 
         item = body["items"][0]
         assert set(item) == {
@@ -156,22 +156,31 @@ class TestMergeQueueList:
             "canonical",
         }
         assert item["candidate_id"].startswith("mc_")
-        assert item["candidate_status"] == "merged"
+        assert item["candidate_status"] == "open"
         assert item["attempt_id"].startswith("att_")
         assert item["task_id"].startswith("task_")
-        assert item["title"] == "Newer completed PR"
+        assert item["title"] == "Older monitored PR"
         assert item["repo_url"] == "git@github.com:example/console.git"
         assert item["base_branch"] == "main"
-        assert item["branch_name"] == "codex/completed"
-        assert item["pr_url"] == "https://github.com/example/console/pull/2"
-        assert item["status"] == WorkspaceStatus.completed.value
+        assert item["branch_name"] == "codex/merge-queue"
+        assert item["pr_url"] == "https://github.com/example/console/pull/1"
+        assert item["status"] == WorkspaceStatus.monitoring_pr.value
         assert item["auto_merge"] is True
         assert item["task_class"] == "test_task"
         assert item["owned_paths"] == ["src/awf/api/**"]
         assert item["last_event"]["event_type"] == "merge_queue.test_marker"
-        assert item["merge_blocker_reason"] == "completed"
+        assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
         assert item["canonical"] is True
-        assert item["readiness"]["completed"] is True
+        assert item["readiness"] == {
+            "ready": True,
+            "manual_merge_required": False,
+            "waiting_for_monitor": False,
+            "failed_or_cancelled": False,
+            "completed": False,
+            "not_canonical": False,
+            "stale": False,
+        }
+        assert newer_id not in {row["workspace_id"] for row in body["items"]}
 
     @pytest.mark.unit
     async def test_filters_by_repo_base_status_and_limit(
@@ -293,7 +302,7 @@ class TestMergeQueueList:
         assert response.status_code == 422
 
     @pytest.mark.unit
-    async def test_derives_blocker_reasons_from_workspace_state_only(
+    async def test_derives_blocker_reasons_for_active_candidates(
         self,
         client: AsyncClient,
         engine: AsyncEngine,
@@ -322,7 +331,12 @@ class TestMergeQueueList:
                 pr_url=f"https://github.com/example/console/pull/{index + 10}",
                 updated_at=datetime(2026, 4, 20 + index, 12, 0, tzinfo=UTC),
             )
-            expected[workspace_id] = reason
+            if status not in {
+                WorkspaceStatus.completed,
+                WorkspaceStatus.failed,
+                WorkspaceStatus.cancelled,
+            }:
+                expected[workspace_id] = reason
 
         response = await client.get("/v1/merge-queue", params={"limit": 20})
 

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -201,3 +201,127 @@ class TestTaskList:
         assert items[0]["workspace_id"] == second_workspace.id
         assert items[0]["title"] == "Second attempt"
         assert items[0]["status"] == WorkspaceStatus.ready.value
+
+    @pytest.mark.unit
+    async def test_tasks_exposes_canonical_attempt_and_candidate_fields(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_v2_workspace(
+            client,
+            external_id="TICKET-CANONICAL",
+            title="Canonical task",
+        )
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            repo = WorkspaceRepository(session)
+            workspace = await repo.get(workspace_id)
+            assert workspace is not None
+            for target in (
+                WorkspaceStatus.provisioning,
+                WorkspaceStatus.ready,
+                WorkspaceStatus.running,
+                WorkspaceStatus.validating,
+                WorkspaceStatus.pushing,
+            ):
+                await repo.transition(workspace, to=target, reason_code="TEST")
+            workspace.branch_name = "awf/canonical-task"
+            workspace.remote_push_branch = "awf/canonical-task"
+            workspace.base_commit = "a" * 40
+            workspace.pr_url = "https://github.com/example/console/pull/41"
+            workspace.pr_number = 41
+            await repo.transition(
+                workspace,
+                to=WorkspaceStatus.monitoring_pr,
+                reason_code="PR_OPENED",
+            )
+            await session.commit()
+
+        response = await client.get("/v1/tasks")
+
+        assert response.status_code == 200
+        item = next(
+            item
+            for item in response.json()["items"]
+            if item["task_id"] == "TICKET-CANONICAL"
+        )
+        assert item["is_canonical_for_merge"] is True
+        assert item["canonical_attempt_id"] == item["attempt_id"]
+        assert item["candidate_id"].startswith("mc_")
+        assert item["candidate_status"] == "open"
+        assert item["readiness"] == {
+            "ready": True,
+            "manual_merge_required": False,
+            "waiting_for_monitor": False,
+            "failed_or_cancelled": False,
+            "completed": False,
+            "not_canonical": False,
+            "stale": False,
+        }
+
+    @pytest.mark.unit
+    async def test_task_attempts_endpoint_resolves_external_id_and_lists_lineage_newest_first(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        from awf.db.repositories import TaskAttemptRepository, TaskRepository
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            task = await TaskRepository(session).create_or_get(
+                repo_url="git@github.com:example/console.git",
+                base_branch="main",
+                title="Lineage task",
+                prompt="Retry this task.",
+                external_id="TICKET-LINEAGE",
+                idempotency_key=None,
+                task_class="test_task",
+                owned_paths=[],
+            )
+            workspaces = [
+                await WorkspaceRepository(session).create(
+                    repo_url="git@github.com:example/console.git",
+                    branch_base="main",
+                    task_title=f"Attempt {number}",
+                    task_prompt="Retry this task.",
+                    task_external_id="TICKET-LINEAGE",
+                    agent=AgentRuntime.codex.value,
+                    test_commands=[],
+                )
+                for number in (1, 2, 3)
+            ]
+            attempt_repo = TaskAttemptRepository(session)
+            first = await attempt_repo.create_for_workspace(task=task, workspace=workspaces[0])
+            second = await attempt_repo.create_for_workspace(
+                task=task,
+                workspace=workspaces[1],
+                parent_attempt_id=first.id,
+                redispatch_from_attempt_id=first.id,
+            )
+            third = await attempt_repo.create_for_workspace(
+                task=task,
+                workspace=workspaces[2],
+                parent_attempt_id=second.id,
+                redispatch_from_attempt_id=second.id,
+            )
+            await session.commit()
+
+        response = await client.get("/v1/tasks/TICKET-LINEAGE/attempts")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["task_id"] == task.id
+        assert body["task_ref"] == "TICKET-LINEAGE"
+        assert [item["attempt_id"] for item in body["items"]] == [
+            third.id,
+            second.id,
+            first.id,
+        ]
+        assert [item["attempt_number"] for item in body["items"]] == [3, 2, 1]
+        assert body["items"][0]["parent_attempt_id"] == second.id
+        assert body["items"][0]["redispatch_from_attempt_id"] == second.id
+        assert body["items"][1]["parent_attempt_id"] == first.id
+        assert body["items"][2]["parent_attempt_id"] is None

--- a/tests/unit/api/test_tasks.py
+++ b/tests/unit/api/test_tasks.py
@@ -8,7 +8,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
 
 _V1_BODY = {
@@ -260,6 +260,73 @@ class TestTaskList:
             "not_canonical": False,
             "stale": False,
         }
+
+    @pytest.mark.unit
+    async def test_tasks_batches_canonical_attempt_lookup(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        workspace_ids = [
+            await _create_v2_workspace(
+                client,
+                external_id=f"TICKET-CANONICAL-BATCH-{number}",
+                title=f"Canonical batch task {number}",
+            )
+            for number in range(2)
+        ]
+
+        factory = make_session_factory(engine)
+        async with factory() as session:
+            repo = WorkspaceRepository(session)
+            for number, workspace_id in enumerate(workspace_ids, start=1):
+                workspace = await repo.get(workspace_id)
+                assert workspace is not None
+                for target in (
+                    WorkspaceStatus.provisioning,
+                    WorkspaceStatus.ready,
+                    WorkspaceStatus.running,
+                    WorkspaceStatus.validating,
+                    WorkspaceStatus.pushing,
+                ):
+                    await repo.transition(workspace, to=target, reason_code="TEST")
+                workspace.branch_name = f"awf/canonical-batch-{number}"
+                workspace.remote_push_branch = f"awf/canonical-batch-{number}"
+                workspace.base_commit = "a" * 40
+                workspace.pr_url = f"https://github.com/example/console/pull/{number}"
+                workspace.pr_number = number
+                await repo.transition(
+                    workspace,
+                    to=WorkspaceStatus.monitoring_pr,
+                    reason_code="PR_OPENED",
+                )
+            await session.commit()
+
+        async def fail_get_canonical_for_task(
+            self: TaskAttemptRepository,
+            task_id: str,
+        ) -> object:
+            raise AssertionError(
+                f"list_tasks should batch canonical lookup for task {task_id}"
+            )
+
+        monkeypatch.setattr(
+            TaskAttemptRepository,
+            "get_canonical_for_task",
+            fail_get_canonical_for_task,
+        )
+
+        response = await client.get("/v1/tasks")
+
+        assert response.status_code == 200
+        items = [
+            item
+            for item in response.json()["items"]
+            if item["task_id"].startswith("TICKET-CANONICAL-BATCH-")
+        ]
+        assert len(items) == 2
+        assert all(item["canonical_attempt_id"] == item["attempt_id"] for item in items)
 
     @pytest.mark.unit
     async def test_task_attempts_endpoint_resolves_external_id_and_lists_lineage_newest_first(

--- a/tests/unit/db/test_task_attempts.py
+++ b/tests/unit/db/test_task_attempts.py
@@ -195,6 +195,37 @@ class TestTaskAttemptRepository:
             await session.flush()
 
     @pytest.mark.unit
+    async def test_mark_canonical_for_merge_returns_previous_canonical_attempt(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        from awf.db.repositories import TaskAttemptRepository
+
+        task = await _task(session)
+        first_workspace = await _workspace(session, title="first attempt")
+        second_workspace = await _workspace(session, title="second attempt")
+
+        attempt_repo = TaskAttemptRepository(session)
+        first_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=first_workspace,
+        )
+        second_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=second_workspace,
+        )
+
+        initial_previous = await attempt_repo.mark_canonical_for_merge(first_attempt)
+        superseded_previous = await attempt_repo.mark_canonical_for_merge(second_attempt)
+
+        assert initial_previous is None
+        assert superseded_previous is not None
+        assert superseded_previous.id == first_attempt.id
+        assert first_attempt.is_canonical_for_merge is False
+        assert first_attempt.superseded_by_attempt_id == second_attempt.id
+        assert second_attempt.is_canonical_for_merge is True
+
+    @pytest.mark.unit
     async def test_retry_pr_ready_attempt_supersedes_canonical_and_closes_old_candidate(
         self,
         session: AsyncSession,

--- a/tests/unit/db/test_task_attempts.py
+++ b/tests/unit/db/test_task_attempts.py
@@ -244,6 +244,7 @@ class TestTaskAttemptRepository:
             ).scalars()
         )
         candidates = await MergeCandidateRepository(session).list_for_task(task.id, limit=10)
+        queued_candidates = await MergeCandidateRepository(session).list_queue(limit=10)
 
         assert [attempt.id for attempt in attempts] == [first_attempt.id, second_attempt.id]
         assert attempts[0].is_canonical_for_merge is False
@@ -263,6 +264,7 @@ class TestTaskAttemptRepository:
         assert first_candidate.not_canonical is True
         assert second_candidate.status == "open"
         assert second_candidate.close_reason is None
+        assert [candidate.attempt_id for candidate in queued_candidates] == [second_attempt.id]
 
 
 class TestTaskAttemptMigration:

--- a/tests/unit/db/test_task_attempts.py
+++ b/tests/unit/db/test_task_attempts.py
@@ -10,11 +10,14 @@ from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.db.base import Base
 from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.models import TaskAttempt
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 
@@ -49,6 +52,45 @@ async def _workspace(
     )
     await session.flush()
     return workspace
+
+
+async def _task(session: AsyncSession, *, external_id: str = "TICKET-LINEAGE") -> object:
+    from awf.db.repositories import TaskRepository
+
+    return await TaskRepository(session).create_or_get(
+        repo_url="git@github.com:example/app.git",
+        base_branch="development",
+        title="Merge lineage task",
+        prompt="Do the work.",
+        external_id=external_id,
+        idempotency_key=None,
+        task_class="test_task",
+        owned_paths=["src/awf/**"],
+    )
+
+
+async def _drive_to_monitoring_pr(
+    session: AsyncSession,
+    workspace: object,
+    *,
+    pr_number: int,
+    branch_name: str,
+) -> None:
+    repo = WorkspaceRepository(session)
+    for target in (
+        WorkspaceStatus.provisioning,
+        WorkspaceStatus.ready,
+        WorkspaceStatus.running,
+        WorkspaceStatus.validating,
+        WorkspaceStatus.pushing,
+    ):
+        await repo.transition(workspace, to=target, reason_code="TEST")
+    workspace.branch_name = branch_name
+    workspace.remote_push_branch = branch_name
+    workspace.base_commit = "a" * 40
+    workspace.pr_url = f"https://github.com/example/app/pull/{pr_number}"
+    workspace.pr_number = pr_number
+    await repo.transition(workspace, to=WorkspaceStatus.monitoring_pr, reason_code="PR_OPENED")
 
 
 class TestTaskAttemptRepository:
@@ -124,6 +166,103 @@ class TestTaskAttemptRepository:
         assert second_attempt.attempt_number == 2
         assert second_attempt.workspace_id == second_workspace.id
         assert second_attempt.agent == AgentRuntime.codex.value
+
+    @pytest.mark.unit
+    async def test_database_allows_only_one_canonical_attempt_per_task(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        from awf.db.repositories import TaskAttemptRepository
+
+        task = await _task(session)
+        first_workspace = await _workspace(session, title="first attempt")
+        second_workspace = await _workspace(session, title="second attempt")
+
+        attempt_repo = TaskAttemptRepository(session)
+        first_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=first_workspace,
+        )
+        second_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=second_workspace,
+        )
+
+        first_attempt.is_canonical_for_merge = True
+        second_attempt.is_canonical_for_merge = True
+
+        with pytest.raises(IntegrityError):
+            await session.flush()
+
+    @pytest.mark.unit
+    async def test_retry_pr_ready_attempt_supersedes_canonical_and_closes_old_candidate(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        from awf.db.repositories import MergeCandidateRepository, TaskAttemptRepository
+
+        task = await _task(session, external_id="TICKET-SUPERSEDE")
+        first_workspace = await _workspace(session, title="first attempt")
+        second_workspace = await _workspace(session, title="retry attempt")
+
+        attempt_repo = TaskAttemptRepository(session)
+        first_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=first_workspace,
+        )
+        second_attempt = await attempt_repo.create_for_workspace(
+            task=task,
+            workspace=second_workspace,
+            parent_attempt_id=first_attempt.id,
+            redispatch_from_attempt_id=first_attempt.id,
+        )
+
+        await _drive_to_monitoring_pr(
+            session,
+            first_workspace,
+            pr_number=11,
+            branch_name="awf/first-attempt",
+        )
+        first_candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+            first_attempt.id
+        )
+        assert first_candidate is not None
+        assert first_candidate.status == "open"
+
+        await _drive_to_monitoring_pr(
+            session,
+            second_workspace,
+            pr_number=12,
+            branch_name="awf/retry-attempt",
+        )
+
+        attempts = list(
+            (
+                await session.execute(
+                    select(TaskAttempt).order_by(TaskAttempt.attempt_number.asc())
+                )
+            ).scalars()
+        )
+        candidates = await MergeCandidateRepository(session).list_for_task(task.id, limit=10)
+
+        assert [attempt.id for attempt in attempts] == [first_attempt.id, second_attempt.id]
+        assert attempts[0].is_canonical_for_merge is False
+        assert attempts[0].superseded_by_attempt_id == second_attempt.id
+        assert attempts[1].is_canonical_for_merge is True
+        assert attempts[1].parent_attempt_id == first_attempt.id
+        assert attempts[1].redispatch_from_attempt_id == first_attempt.id
+
+        first_candidate = next(
+            candidate for candidate in candidates if candidate.attempt_id == first_attempt.id
+        )
+        second_candidate = next(
+            candidate for candidate in candidates if candidate.attempt_id == second_attempt.id
+        )
+        assert first_candidate.status == "closed"
+        assert first_candidate.close_reason == "CANONICAL_CHANGED"
+        assert first_candidate.not_canonical is True
+        assert second_candidate.status == "open"
+        assert second_candidate.close_reason is None
 
 
 class TestTaskAttemptMigration:

--- a/tests/unit/runtime/test_merge_candidate_lifecycle.py
+++ b/tests/unit/runtime/test_merge_candidate_lifecycle.py
@@ -141,6 +141,8 @@ async def test_completed_pr_monitor_marks_candidate_merged(
     assert workspace.status == WorkspaceStatus.completed.value
     assert candidate is not None
     assert candidate.status == "merged"
+    assert candidate.closed_at is None
+    assert candidate.merged_at is not None
     assert candidate.completed is True
     assert candidate.ready is False
 

--- a/tests/unit/runtime/test_merge_candidate_lifecycle.py
+++ b/tests/unit/runtime/test_merge_candidate_lifecycle.py
@@ -1,0 +1,197 @@
+"""PR monitor merge-candidate lifecycle wiring tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.runtime.pr_monitor import MonitorState, NotifyHuman
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+)
+from tests.unit.runtime.test_pr_monitor import _status
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+async def _seed_monitoring_candidate_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    auto_merge: bool = True,
+) -> tuple[str, str]:
+    from awf.db.repositories import TaskAttemptRepository, TaskRepository
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            branch_base="development",
+            task_title="candidate monitor test",
+            task_prompt="x",
+            auto_merge=auto_merge,
+            agent=AgentRuntime.claude_code.value,
+            test_commands=["pytest -q"],
+        )
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id="TICKET-MONITOR-CANDIDATE",
+            idempotency_key=None,
+            task_class=None,
+            owned_paths=[],
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+        ):
+            await repo.transition(workspace, to=target, reason_code="TEST")
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = "a" * 40
+        workspace.compose_project_name = f"awf_{workspace.id}"
+        workspace.pr_url = "https://github.com/dimileeh/aira-web/pull/42"
+        workspace.pr_number = 42
+        await repo.transition(workspace, to=WorkspaceStatus.monitoring_pr, reason_code="PR_OPENED")
+        await session.commit()
+        return workspace.id, attempt.id
+
+
+@pytest.mark.unit
+async def test_completed_pr_monitor_marks_candidate_merged(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    from awf.db.repositories import MergeCandidateRepository
+
+    workspace_id, attempt_id = await _seed_monitoring_candidate_workspace(factory)
+    cmd.queue_result(returncode=0)  # git fetch origin <base>
+    cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+    cmd.queue_result(returncode=0, stdout=pr_payload())  # mergeable PR state
+    cmd.queue_result(returncode=0)  # gh pr merge
+    cmd.queue_result(returncode=0, stdout="MERGESHA\n")  # merge SHA lookup
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=0,
+    )
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    async with factory() as session:
+        candidate = await MergeCandidateRepository(session).get_by_attempt_id(attempt_id)
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.completed.value
+    assert candidate is not None
+    assert candidate.status == "merged"
+    assert candidate.completed is True
+    assert candidate.ready is False
+
+
+@pytest.mark.unit
+async def test_manual_merge_candidate_stays_open_until_external_merge_is_observed(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    from awf.db.repositories import MergeCandidateRepository
+
+    workspace_id, attempt_id = await _seed_monitoring_candidate_workspace(
+        factory,
+        auto_merge=False,
+    )
+    cmd.queue_result(returncode=0)  # gh pr comment
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        auto_merge=False,
+    )
+    terminal = await runner._execute(
+        action=NotifyHuman(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef.from_url("git@github.com:dimileeh/aira-web.git"),
+        pr_number=42,
+        status=_status(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    async with factory() as session:
+        candidate = await MergeCandidateRepository(session).get_by_attempt_id(attempt_id)
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+
+    assert terminal is False
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.monitoring_pr.value
+    assert candidate is not None
+    assert candidate.status == "open"
+    assert candidate.manual_merge_required is True
+    assert candidate.completed is False

--- a/tests/unit/service/test_merge_candidates.py
+++ b/tests/unit/service/test_merge_candidates.py
@@ -1,0 +1,145 @@
+"""Service-level merge candidate lifecycle tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_attempted_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    auto_merge: bool = True,
+) -> tuple[str, str]:
+    from awf.db.repositories import TaskAttemptRepository, TaskRepository
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/service.git",
+            branch_base="development",
+            task_title="Candidate lifecycle",
+            task_prompt="Open a PR and monitor it.",
+            task_external_id="TICKET-CANDIDATE",
+            auto_merge=auto_merge,
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+        )
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=workspace.task_external_id,
+            idempotency_key=None,
+            task_class=None,
+            owned_paths=[],
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+        ):
+            await repo.transition(workspace, to=target, reason_code="TEST")
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = "a" * 40
+        workspace.pr_url = "https://github.com/example/service/pull/31"
+        workspace.pr_number = 31
+        await session.commit()
+        return workspace.id, attempt.id
+
+
+@pytest.mark.unit
+async def test_pr_opened_monitoring_transition_creates_open_canonical_candidate(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.db.repositories import MergeCandidateRepository, TaskAttemptRepository
+
+    workspace_id, attempt_id = await _seed_attempted_workspace(factory)
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.monitoring_pr,
+            reason_code="PR_OPENED",
+        )
+        await session.commit()
+
+    async with factory() as session:
+        attempt = await TaskAttemptRepository(session).get_by_workspace_id(workspace_id)
+        candidate = await MergeCandidateRepository(session).get_by_attempt_id(attempt_id)
+
+    assert attempt is not None
+    assert attempt.is_canonical_for_merge is True
+    assert candidate is not None
+    assert candidate.status == "open"
+    assert candidate.workspace_id == workspace_id
+    assert candidate.attempt_id == attempt_id
+    assert candidate.ready is True
+    assert candidate.manual_merge_required is False
+    assert candidate.waiting_for_monitor is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("terminal", "expected_reason"),
+    [
+        (WorkspaceStatus.failed, "WORKSPACE_FAILED"),
+        (WorkspaceStatus.cancelled, "WORKSPACE_CANCELLED"),
+    ],
+)
+async def test_failed_or_cancelled_workspace_closes_open_candidate_with_reason(
+    factory: async_sessionmaker[AsyncSession],
+    terminal: WorkspaceStatus,
+    expected_reason: str,
+) -> None:
+    from awf.db.repositories import MergeCandidateRepository
+
+    workspace_id, attempt_id = await _seed_attempted_workspace(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.monitoring_pr, reason_code="PR_OPENED")
+        if terminal == WorkspaceStatus.failed:
+            workspace.failure_reason = "infrastructure_failure"
+            workspace.failure_message = "monitor failed"
+        await repo.transition(workspace, to=terminal, reason_code="TEST_TERMINAL")
+        await session.commit()
+
+    async with factory() as session:
+        candidate = await MergeCandidateRepository(session).get_by_attempt_id(attempt_id)
+
+    assert candidate is not None
+    assert candidate.status == "closed"
+    assert candidate.close_reason == expected_reason
+    assert candidate.failed_or_cancelled is True
+    assert candidate.ready is False


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_63ab3c770b4a44cf9d97d39d` (agent: `codex`).


### Task
Implement AWF's next PRD-backed merge backbone slice: canonical task attempts and merge candidates.

Context:
- Repo is a Python/FastAPI control plane with Next.js console under apps/console.
- Workspaces remain the primary operator-facing concept.
- Existing code already has Task and TaskAttempt basics, /v1/tasks, /v1/merge-queue, workspace retry, and PR monitor lifecycle.
- Your job is NOT to build full stale detection or full validation-tier provenance yet. Build the backbone those features will attach to.

Strict TDD workflow:
1. Write focused failing tests first for DB/model/repository behavior, API shape, and monitor/service lifecycle wiring.
2. Commit the red tests with the failing output in the commit body.
3. Implement until green.
4. Run all validation commands listed below.
5. Commit with conventional commits. Multiple commits are OK.
6. Do not push. AWF owns push, PR creation, PR monitoring, comment handling, base sync, validation fixes, and merge.
7. Do not switch branches. AWF owns branch lifecycle.

Required implementation:

1. Extend task attempts with merge-lineage fields:
- parent_attempt_id
- redispatch_from_attempt_id
- superseded_by_attempt_id
- is_canonical_for_merge
Keep existing workspace-status mirroring for compatibility.

2. Add merge_candidates as the explicit queue object:
- References task_id, attempt_id, workspace_id, PR URL/number, repo, base branch, branch name, head/base SHA where available.
- Status values: open, merged, closed.
- Readiness/blocker fields at minimum: ready, manual_merge_required, waiting_for_monitor, failed_or_cancelled, completed, not_canonical, stale.
- Close old candidates with close_reason=CANONICAL_CHANGED when a newer attempt becomes canonical.

3. Wire lifecycle behavior:
- When a workspace opens a PR and enters monitoring_pr, make that attempt canonical and create/update its open merge candidate.
- On retry reaching PR stage, supersede the prior canonical attempt.
- When PR monitor completes/merged, mark candidate merged.
- When a workspace fails or is cancelled with an open candidate, close that candidate with an actionable reason.
- Manual-merge mode remains open/monitored until external merge is observed; do not mark it merged early.

4. Update APIs without breaking existing clients:
- /v1/tasks adds canonical/candidate fields.
- /v1/merge-queue becomes candidate-backed but preserves existing fields; add candidate_id, attempt_id, task_id, readiness, canonical flag.
- Add GET /v1/tasks/{task_ref}/attempts, resolving internal task id first, then external id, and listing attempts newest-first.

5. Console:
- Keep the main detail panel centered on Workspace, not Task.
- Update the Merge Queue panel to show candidate/readiness/canonical attempt fields.
- Do not add a noisy task-centric panel to the main workspace detail.

Required tests:
- DB/model tests: one canonical attempt per task; retry/PR-ready attempt supersedes prior canonical; old candidate closes with CANONICAL_CHANGED.
- API tests: /v1/tasks exposes canonical/candidate fields; /v1/tasks/{task_ref}/attempts lists lineage newest-first; /v1/merge-queue returns candidate-backed readiness while preserving the current response fields.
- Runtime/service tests: PR opened creates candidate; completed PR marks candidate merged; failed/cancelled candidate closes with reason; manual-merge workspaces remain open until external merge is observed.

Validation commands to run before final commit:
uv run --python 3.12 --extra dev ruff check src/awf tests/unit
uv run --python 3.12 --extra dev mypy src/awf
uv run --python 3.12 --extra dev pytest tests/unit/api tests/unit/service tests/unit/db tests/unit/runtime -q
npm --prefix apps/console run lint
npm --prefix apps/console run typecheck

Final response from the agent should summarize commits, files changed, and validation results. Make sure the working tree is clean before exiting.

---
Validation: 8 profile command(s) passed inside the workspace container.
