### PR TITLE
feat(stale): add stale detection and reasons

### DIFF
--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -70,6 +70,37 @@ export interface MergeCandidateReadiness {
   stale: boolean;
 }
 
+export type StaleReasonCode =
+  | "STALE_TARGET_ADVANCED"
+  | "STALE_OVERLAP"
+  | "STALE_DEPENDENCY"
+  | "STALE_BUILD_CONFIG"
+  | "STALE_SCHEMA";
+
+export type StaleReasonTrigger =
+  | "target_advanced"
+  | "path_overlap"
+  | "schema_changed"
+  | "dependency_changed"
+  | "build_config_changed";
+
+export type StaleReasonStatus = "active" | "resolved";
+
+export interface StaleReason {
+  id: string;
+  workspace_id: string;
+  candidate_id: string | null;
+  attempt_id: string | null;
+  task_id: string | null;
+  trigger_type: StaleReasonTrigger;
+  trigger_ref: string | null;
+  reason_code: StaleReasonCode;
+  explanation: string;
+  status: StaleReasonStatus;
+  detected_at: string;
+  resolved_at: string | null;
+}
+
 export interface MergeQueueItem {
   candidate_id: string | null;
   candidate_status: MergeCandidateStatus | null;
@@ -92,6 +123,7 @@ export interface MergeQueueItem {
   merge_blocker_reason: MergeBlockerReason;
   readiness: MergeCandidateReadiness | null;
   canonical: boolean;
+  stale_reasons: StaleReason[];
 }
 
 export interface Workspace {

--- a/migrations/versions/d5e6f7a8b9c0_stale_reasons.py
+++ b/migrations/versions/d5e6f7a8b9c0_stale_reasons.py
@@ -1,0 +1,58 @@
+"""Add stale_reasons table for the stale detection engine.
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-04-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: str | Sequence[str] | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stale_reasons",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("candidate_id", sa.String(length=36), nullable=True),
+        sa.Column("attempt_id", sa.String(length=36), nullable=True),
+        sa.Column("task_id", sa.String(length=36), nullable=True),
+        sa.Column("trigger_type", sa.String(length=64), nullable=False),
+        sa.Column("trigger_ref", sa.String(length=512), nullable=True),
+        sa.Column("reason_code", sa.String(length=64), nullable=False),
+        sa.Column("explanation", sa.String(length=2048), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=16),
+            nullable=False,
+            server_default=sa.text("'active'"),
+        ),
+        sa.Column("detected_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("resolved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.ForeignKeyConstraint(["candidate_id"], ["merge_candidates.id"]),
+        sa.ForeignKeyConstraint(["attempt_id"], ["task_attempts.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_stale_reasons_workspace", "stale_reasons", ["workspace_id"])
+    op.create_index("ix_stale_reasons_candidate", "stale_reasons", ["candidate_id"])
+    op.create_index("ix_stale_reasons_status", "stale_reasons", ["status"])
+    op.create_index("ix_stale_reasons_detected_at", "stale_reasons", ["detected_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_stale_reasons_detected_at", table_name="stale_reasons")
+    op.drop_index("ix_stale_reasons_status", table_name="stale_reasons")
+    op.drop_index("ix_stale_reasons_candidate", table_name="stale_reasons")
+    op.drop_index("ix_stale_reasons_workspace", table_name="stale_reasons")
+    op.drop_table("stale_reasons")

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -19,11 +19,16 @@ from awf.api.schemas import (
     MergeCandidateReadinessResponse,
     MergeQueueItemResponse,
     MergeQueueListResponse,
+    StaleReasonResponse,
     WorkspaceEventResponse,
 )
 from awf.db.enums import WorkspaceStatus
-from awf.db.models import MergeCandidate, Workspace, WorkspaceEvent
-from awf.db.repositories import MergeCandidateRepository, WorkspaceRepository
+from awf.db.models import MergeCandidate, StaleReason, Workspace, WorkspaceEvent
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    StaleReasonRepository,
+    WorkspaceRepository,
+)
 
 router = APIRouter(prefix="/v1/merge-queue", tags=["merge-queue"])
 
@@ -81,8 +86,14 @@ async def list_merge_queue(
     )
     page_rows = rows[:limit]
     has_more = len(rows) > limit
+
+    stale_reasons_by_candidate = await _load_active_stale_reasons(session, page_rows)
+
     return MergeQueueListResponse(
-        items=[_item_from_row(row) for row in page_rows],
+        items=[
+            _item_from_row(row, stale_reasons_by_candidate)
+            for row in page_rows
+        ],
         next_cursor=_encode_cursor(_row_workspace(page_rows[-1]))
         if has_more and page_rows
         else None,
@@ -90,13 +101,39 @@ async def list_merge_queue(
     )
 
 
-def _item_from_row(row: MergeCandidate | Workspace) -> MergeQueueItemResponse:
+async def _load_active_stale_reasons(
+    session: AsyncSession,
+    rows: list[MergeCandidate | Workspace],
+) -> dict[str, list[StaleReason]]:
+    candidate_ids = [
+        row.id for row in rows if isinstance(row, MergeCandidate)
+    ]
+    if not candidate_ids:
+        return {}
+    repo = StaleReasonRepository(session)
+    out: dict[str, list[StaleReason]] = {}
+    for candidate_id in candidate_ids:
+        out[candidate_id] = await repo.list_active_for_candidate(candidate_id)
+    return out
+
+
+def _item_from_row(
+    row: MergeCandidate | Workspace,
+    stale_reasons_by_candidate: dict[str, list[StaleReason]],
+) -> MergeQueueItemResponse:
     if isinstance(row, MergeCandidate):
-        return _item_from_candidate(row)
+        return _item_from_candidate(
+            row,
+            stale_reasons=stale_reasons_by_candidate.get(row.id, []),
+        )
     return _item_from_legacy_workspace(row)
 
 
-def _item_from_candidate(candidate: MergeCandidate) -> MergeQueueItemResponse:
+def _item_from_candidate(
+    candidate: MergeCandidate,
+    *,
+    stale_reasons: list[StaleReason],
+) -> MergeQueueItemResponse:
     workspace = candidate.workspace
     latest_event = _latest_event(workspace.events)
     return MergeQueueItemResponse(
@@ -125,6 +162,7 @@ def _item_from_candidate(candidate: MergeCandidate) -> MergeQueueItemResponse:
         merge_blocker_reason=_merge_blocker_reason(candidate),
         readiness=_readiness_from_candidate(candidate),
         canonical=candidate.attempt.is_canonical_for_merge,
+        stale_reasons=[StaleReasonResponse.model_validate(r) for r in stale_reasons],
     )
 
 
@@ -159,6 +197,7 @@ def _item_from_legacy_workspace(workspace: Workspace) -> MergeQueueItemResponse:
         merge_blocker_reason=_merge_blocker_reason_from_workspace(workspace),
         readiness=None,
         canonical=False,
+        stale_reasons=[],
     )
 
 

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -90,10 +90,7 @@ async def list_merge_queue(
     stale_reasons_by_candidate = await _load_active_stale_reasons(session, page_rows)
 
     return MergeQueueListResponse(
-        items=[
-            _item_from_row(row, stale_reasons_by_candidate)
-            for row in page_rows
-        ],
+        items=[_item_from_row(row, stale_reasons_by_candidate) for row in page_rows],
         next_cursor=_encode_cursor(_row_workspace(page_rows[-1]))
         if has_more and page_rows
         else None,
@@ -105,16 +102,10 @@ async def _load_active_stale_reasons(
     session: AsyncSession,
     rows: list[MergeCandidate | Workspace],
 ) -> dict[str, list[StaleReason]]:
-    candidate_ids = [
-        row.id for row in rows if isinstance(row, MergeCandidate)
-    ]
+    candidate_ids = [row.id for row in rows if isinstance(row, MergeCandidate)]
     if not candidate_ids:
         return {}
-    repo = StaleReasonRepository(session)
-    out: dict[str, list[StaleReason]] = {}
-    for candidate_id in candidate_ids:
-        out[candidate_id] = await repo.list_active_for_candidate(candidate_id)
-    return out
+    return await StaleReasonRepository(session).list_active_for_candidates(candidate_ids)
 
 
 def _item_from_row(

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -22,6 +22,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from awf.api.deps import get_db_session
 from awf.api.schemas import (
     ErrorResponse,
+    StaleReasonListResponse,
+    StaleReasonResponse,
     WorkspaceAcceptedResponse,
     WorkspaceCreateRequest,
     WorkspaceCreateV2Request,
@@ -35,7 +37,11 @@ from awf.api.schemas import (
 from awf.common.config import Settings, get_settings
 from awf.db.enums import AgentRuntime, OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
-from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.repositories import (
+    StaleReasonRepository,
+    WorkspaceEventRepository,
+    WorkspaceRepository,
+)
 from awf.profiles.resolver import ProfileResolutionError
 from awf.service.disk import DiskCheck, check_disk_space
 from awf.service.workspaces import (
@@ -282,6 +288,33 @@ async def list_workspace_events(
     )
     return WorkspaceEventListResponse(
         items=[WorkspaceEventResponse.model_validate(row) for row in rows]
+    )
+
+
+@router.get(
+    "/{workspace_id}/stale-reasons",
+    response_model=StaleReasonListResponse,
+)
+async def list_workspace_stale_reasons(
+    workspace_id: str,
+    include_resolved: Annotated[bool, Query()] = False,
+    session: AsyncSession = Depends(get_db_session),
+) -> StaleReasonListResponse:
+    repo = WorkspaceRepository(session)
+    if not await repo.exists(workspace_id):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
+        )
+
+    stale_repo = StaleReasonRepository(session)
+    rows = (
+        await stale_repo.list_for_workspace(workspace_id)
+        if include_resolved
+        else await stale_repo.list_active_for_workspace(workspace_id)
+    )
+    return StaleReasonListResponse(
+        items=[StaleReasonResponse.model_validate(row) for row in rows]
     )
 
 

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -313,9 +313,7 @@ async def list_workspace_stale_reasons(
         if include_resolved
         else await stale_repo.list_active_for_workspace(workspace_id)
     )
-    return StaleReasonListResponse(
-        items=[StaleReasonResponse.model_validate(row) for row in rows]
-    )
+    return StaleReasonListResponse(items=[StaleReasonResponse.model_validate(row) for row in rows])
 
 
 @router.post(

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -305,6 +305,46 @@ class WorkspaceOverviewListResponse(BaseModel):
     has_more: bool = False
 
 
+StaleReasonStatus = Literal["active", "resolved"]
+StaleReasonCode = Literal[
+    "STALE_TARGET_ADVANCED",
+    "STALE_OVERLAP",
+    "STALE_DEPENDENCY",
+    "STALE_BUILD_CONFIG",
+    "STALE_SCHEMA",
+]
+StaleReasonTrigger = Literal[
+    "target_advanced",
+    "path_overlap",
+    "schema_changed",
+    "dependency_changed",
+    "build_config_changed",
+]
+
+
+class StaleReasonResponse(BaseModel):
+    """Public projection of one ``stale_reasons`` row."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    workspace_id: str
+    candidate_id: str | None
+    attempt_id: str | None
+    task_id: str | None
+    trigger_type: StaleReasonTrigger
+    trigger_ref: str | None
+    reason_code: StaleReasonCode
+    explanation: str
+    status: StaleReasonStatus
+    detected_at: datetime
+    resolved_at: datetime | None
+
+
+class StaleReasonListResponse(BaseModel):
+    items: list[StaleReasonResponse]
+
+
 class MergeQueueItemResponse(BaseModel):
     candidate_id: str | None = None
     candidate_status: MergeCandidateStatus | None = None
@@ -327,6 +367,7 @@ class MergeQueueItemResponse(BaseModel):
     merge_blocker_reason: MergeBlockerReason
     readiness: MergeCandidateReadinessResponse | None = None
     canonical: bool
+    stale_reasons: list[StaleReasonResponse] = Field(default_factory=list)
 
 
 class MergeQueueListResponse(BaseModel):

--- a/src/awf/common/ids.py
+++ b/src/awf/common/ids.py
@@ -36,3 +36,7 @@ def new_event_id() -> str:
 
 def new_log_stream_id() -> str:
     return f"log_{uuid4().hex[:24]}"
+
+
+def new_stale_reason_id() -> str:
+    return f"sr_{uuid4().hex[:24]}"

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -477,6 +477,68 @@ class WorkspaceEvent(Base):
     workspace: Mapped[Workspace] = relationship(back_populates="events")
 
 
+class StaleReason(Base):
+    """One structured staleness finding against a candidate / workspace.
+
+    Stale-detection produces these rows whenever the refresh service finds
+    the candidate's validation base is no longer fresh against the target
+    branch. ``status='active'`` rows drive the ``MergeCandidate.stale``
+    flag and the merge-queue ``stale`` blocker reason; rows are flipped
+    to ``status='resolved'`` (with ``resolved_at`` set) when a later
+    refresh shows the trigger no longer applies — the historical record
+    is preserved so console clients can show a timeline.
+    """
+
+    __tablename__ = "stale_reasons"
+    __table_args__ = (
+        Index("ix_stale_reasons_workspace", "workspace_id"),
+        Index("ix_stale_reasons_candidate", "candidate_id"),
+        Index("ix_stale_reasons_status", "status"),
+        Index("ix_stale_reasons_detected_at", "detected_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+    candidate_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("merge_candidates.id"), nullable=True
+    )
+    attempt_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=True
+    )
+    task_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("tasks.id"), nullable=True
+    )
+
+    trigger_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    """Coarse trigger taxonomy: ``target_advanced`` / ``path_overlap`` /
+    ``schema_changed`` / ``dependency_changed`` / ``build_config_changed``.
+    Used by clients that want to group reasons by class without parsing
+    ``reason_code`` strings."""
+
+    trigger_ref: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    """Free-form reference for the trigger. For ``target_advanced`` this
+    is the new target SHA; for path-based triggers it is the matching
+    file path."""
+
+    reason_code: Mapped[str] = mapped_column(String(64), nullable=False)
+    """One of ``STALE_TARGET_ADVANCED`` / ``STALE_OVERLAP`` /
+    ``STALE_DEPENDENCY`` / ``STALE_BUILD_CONFIG`` / ``STALE_SCHEMA``."""
+
+    explanation: Mapped[str] = mapped_column(String(2048), nullable=False)
+    status: Mapped[str] = mapped_column(String(16), nullable=False, default="active")
+    detected_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    resolved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    workspace: Mapped[Workspace] = relationship()
+    candidate: Mapped[MergeCandidate | None] = relationship()
+
+
 class WorkspaceLogStream(Base):
     """Durable index for one workspace log stream.
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -507,9 +507,7 @@ class StaleReason(Base):
     attempt_id: Mapped[str | None] = mapped_column(
         String(36), ForeignKey("task_attempts.id"), nullable=True
     )
-    task_id: Mapped[str | None] = mapped_column(
-        String(36), ForeignKey("tasks.id"), nullable=True
-    )
+    task_id: Mapped[str | None] = mapped_column(String(36), ForeignKey("tasks.id"), nullable=True)
 
     trigger_type: Mapped[str] = mapped_column(String(64), nullable=False)
     """Coarse trigger taxonomy: ``target_advanced`` / ``path_overlap`` /
@@ -531,9 +529,7 @@ class StaleReason(Base):
     detected_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=_now, nullable=False
     )
-    resolved_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), nullable=True
-    )
+    resolved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     workspace: Mapped[Workspace] = relationship()
     candidate: Mapped[MergeCandidate | None] = relationship()

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -183,9 +183,7 @@ class TaskAttemptRepository:
         await self._lock_attempt_number_sequence(task.id)
         max_attempt_number = (
             await self._session.execute(
-                select(func.max(TaskAttempt.attempt_number)).where(
-                    TaskAttempt.task_id == task.id
-                )
+                select(func.max(TaskAttempt.attempt_number)).where(TaskAttempt.task_id == task.id)
             )
         ).scalar_one()
         attempt_number = (max_attempt_number or 0) + 1
@@ -286,8 +284,7 @@ class TaskAttemptRepository:
                 latest_attempt_numbers,
                 and_(
                     TaskAttempt.task_id == latest_attempt_numbers.c.task_id,
-                    TaskAttempt.attempt_number
-                    == latest_attempt_numbers.c.attempt_number,
+                    TaskAttempt.attempt_number == latest_attempt_numbers.c.attempt_number,
                 ),
             )
             .join(Workspace, TaskAttempt.workspace_id == Workspace.id)
@@ -368,7 +365,7 @@ class MergeCandidateRepository:
                         WorkspaceStatus.destroying.value,
                         WorkspaceStatus.destroyed.value,
                     )
-                )
+                ),
             )
             .options(
                 selectinload(MergeCandidate.attempt),
@@ -584,6 +581,29 @@ class StaleReasonRepository:
     ) -> builtins.list[StaleReason]:
         return await self._list_for_candidate(candidate_id, status=self._ACTIVE)
 
+    async def list_active_for_candidates(
+        self,
+        candidate_ids: Iterable[str],
+    ) -> dict[str, builtins.list[StaleReason]]:
+        unique_ids = tuple(dict.fromkeys(candidate_ids))
+        if not unique_ids:
+            return {}
+        stmt = (
+            select(StaleReason)
+            .where(
+                StaleReason.candidate_id.in_(unique_ids),
+                StaleReason.status == self._ACTIVE,
+            )
+            .order_by(StaleReason.detected_at.asc(), StaleReason.id.asc())
+        )
+        rows = list((await self._session.execute(stmt)).scalars())
+        out: dict[str, builtins.list[StaleReason]] = {cid: [] for cid in unique_ids}
+        for row in rows:
+            if row.candidate_id is None:  # pragma: no cover - filtered by WHERE
+                continue
+            out[row.candidate_id].append(row)
+        return out
+
     async def list_for_candidate(
         self,
         candidate_id: str,
@@ -623,9 +643,7 @@ class StaleReasonRepository:
                 candidate_id,
                 status=self._ACTIVE,
             )
-        finding_keys = {
-            (f.reason_code, f.trigger_type, f.trigger_ref) for f in findings
-        }
+        finding_keys = {(f.reason_code, f.trigger_type, f.trigger_ref) for f in findings}
         now = datetime.now(UTC)
 
         newly_resolved: builtins.list[StaleReason] = []
@@ -816,9 +834,7 @@ class WorkspaceRepository:
         branch_base: str,
         owned_paths: list[str],
     ) -> list[OwnedPathConflict]:
-        requested_paths = [
-            path for path in owned_paths if _normalize_owned_path(path) != ""
-        ]
+        requested_paths = [path for path in owned_paths if _normalize_owned_path(path) != ""]
         if not requested_paths:
             return []
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -626,7 +626,7 @@ class StaleReasonRepository:
         self,
         *,
         workspace_id: str,
-        candidate_id: str | None,
+        candidate_id: str,
         attempt_id: str | None,
         task_id: str | None,
         findings: builtins.list[StaleReasonCreate],
@@ -637,12 +637,10 @@ class StaleReasonRepository:
         Idempotent: re-running with the same findings is a no-op (kept rows
         are not re-emitted as ``newly_added``).
         """
-        existing_active: builtins.list[StaleReason] = []
-        if candidate_id is not None:
-            existing_active = await self._list_for_candidate(
-                candidate_id,
-                status=self._ACTIVE,
-            )
+        existing_active = await self._list_for_candidate(
+            candidate_id,
+            status=self._ACTIVE,
+        )
         finding_keys = {(f.reason_code, f.trigger_type, f.trigger_ref) for f in findings}
         now = datetime.now(UTC)
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -28,6 +28,7 @@ from awf.common.ids import (
     new_log_stream_id,
     new_merge_candidate_id,
     new_operation_id,
+    new_stale_reason_id,
     new_task_attempt_id,
     new_task_id,
     new_workspace_id,
@@ -38,6 +39,7 @@ from awf.db.enums import AgentRuntime, OperationStatus, OperationType, Workspace
 from awf.db.models import (
     MergeCandidate,
     Operation,
+    StaleReason,
     Task,
     TaskAttempt,
     Workspace,
@@ -548,6 +550,143 @@ class MergeCandidateRepository:
         )
         await self._session.flush()
         return candidate
+
+
+@dataclass(frozen=True)
+class StaleReasonCreate:
+    """Per-finding payload for ``StaleReasonRepository.replace_active_findings``."""
+
+    reason_code: str
+    trigger_type: str
+    trigger_ref: str | None
+    explanation: str
+
+
+class StaleReasonRepository:
+    """CRUD helpers for the durable ``stale_reasons`` table.
+
+    Used by the staleness refresh service to keep ``status='active'`` rows
+    in lockstep with the latest evaluation against the target branch. Rows
+    are flipped to ``status='resolved'`` (with ``resolved_at`` set) when a
+    finding no longer applies — the historical row stays so console
+    timelines can show recovery, not just degradation.
+    """
+
+    _ACTIVE = "active"
+    _RESOLVED = "resolved"
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def list_active_for_candidate(
+        self,
+        candidate_id: str,
+    ) -> builtins.list[StaleReason]:
+        return await self._list_for_candidate(candidate_id, status=self._ACTIVE)
+
+    async def list_for_candidate(
+        self,
+        candidate_id: str,
+    ) -> builtins.list[StaleReason]:
+        return await self._list_for_candidate(candidate_id, status=None)
+
+    async def list_active_for_workspace(
+        self,
+        workspace_id: str,
+    ) -> builtins.list[StaleReason]:
+        return await self._list_for_workspace(workspace_id, status=self._ACTIVE)
+
+    async def list_for_workspace(
+        self,
+        workspace_id: str,
+    ) -> builtins.list[StaleReason]:
+        return await self._list_for_workspace(workspace_id, status=None)
+
+    async def replace_active_findings(
+        self,
+        *,
+        workspace_id: str,
+        candidate_id: str | None,
+        attempt_id: str | None,
+        task_id: str | None,
+        findings: builtins.list[StaleReasonCreate],
+    ) -> tuple[builtins.list[StaleReason], builtins.list[StaleReason]]:
+        """Make the active findings for ``candidate_id`` exactly match the
+        supplied list. Returns ``(newly_added, newly_resolved)``.
+
+        Idempotent: re-running with the same findings is a no-op (kept rows
+        are not re-emitted as ``newly_added``).
+        """
+        existing_active: builtins.list[StaleReason] = []
+        if candidate_id is not None:
+            existing_active = await self._list_for_candidate(
+                candidate_id,
+                status=self._ACTIVE,
+            )
+        finding_keys = {
+            (f.reason_code, f.trigger_type, f.trigger_ref) for f in findings
+        }
+        now = datetime.now(UTC)
+
+        newly_resolved: builtins.list[StaleReason] = []
+        kept_keys: set[tuple[str, str, str | None]] = set()
+        for row in existing_active:
+            key = (row.reason_code, row.trigger_type, row.trigger_ref)
+            if key in finding_keys:
+                kept_keys.add(key)
+                continue
+            row.status = self._RESOLVED
+            row.resolved_at = now
+            newly_resolved.append(row)
+
+        newly_added: builtins.list[StaleReason] = []
+        for finding in findings:
+            key = (finding.reason_code, finding.trigger_type, finding.trigger_ref)
+            if key in kept_keys:
+                continue
+            row = StaleReason(
+                id=new_stale_reason_id(),
+                workspace_id=workspace_id,
+                candidate_id=candidate_id,
+                attempt_id=attempt_id,
+                task_id=task_id,
+                trigger_type=finding.trigger_type,
+                trigger_ref=finding.trigger_ref,
+                reason_code=finding.reason_code,
+                explanation=finding.explanation,
+                status=self._ACTIVE,
+                detected_at=now,
+                resolved_at=None,
+            )
+            self._session.add(row)
+            newly_added.append(row)
+
+        await self._session.flush()
+        return newly_added, newly_resolved
+
+    async def _list_for_candidate(
+        self,
+        candidate_id: str,
+        *,
+        status: str | None,
+    ) -> builtins.list[StaleReason]:
+        stmt = select(StaleReason).where(StaleReason.candidate_id == candidate_id)
+        if status is not None:
+            stmt = stmt.where(StaleReason.status == status)
+        stmt = stmt.order_by(StaleReason.detected_at.asc(), StaleReason.id.asc())
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def _list_for_workspace(
+        self,
+        workspace_id: str,
+        *,
+        status: str | None,
+    ) -> builtins.list[StaleReason]:
+        stmt = select(StaleReason).where(StaleReason.workspace_id == workspace_id)
+        if status is not None:
+            stmt = stmt.where(StaleReason.status == status)
+        stmt = stmt.order_by(StaleReason.detected_at.asc(), StaleReason.id.asc())
+        return list((await self._session.execute(stmt)).scalars())
 
 
 class WorkspaceRepository:

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -235,19 +235,22 @@ def evaluate_staleness(
         )
         break
 
-    if not findings and target.advanced_commits > 0:
-        if candidate.task_class not in policy.lenient_task_classes:
-            findings.append(
-                StalenessFinding(
-                    reason_code=REASON_TARGET_ADVANCED,
-                    trigger_type=TRIGGER_TARGET_ADVANCED,
-                    trigger_ref=target.head_sha,
-                    explanation=(
-                        f"Target branch '{target.branch}' advanced "
-                        f"{target.advanced_commits} commit(s) past validation base."
-                    ),
-                )
+    if (
+        not findings
+        and target.advanced_commits > 0
+        and candidate.task_class not in policy.lenient_task_classes
+    ):
+        findings.append(
+            StalenessFinding(
+                reason_code=REASON_TARGET_ADVANCED,
+                trigger_type=TRIGGER_TARGET_ADVANCED,
+                trigger_ref=target.head_sha,
+                explanation=(
+                    f"Target branch '{target.branch}' advanced "
+                    f"{target.advanced_commits} commit(s) past validation base."
+                ),
             )
+        )
 
     return findings
 

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -1,0 +1,506 @@
+"""Stale detection engine.
+
+Two layers:
+
+- ``evaluate_staleness`` is a pure function that turns a ``CandidateSnapshot`` +
+  ``TargetBranchState`` + ``StalePolicy`` into a list of structured
+  ``StalenessFinding`` records. No I/O, no SQLAlchemy, easily exercised
+  from the unit tests.
+
+- ``StalenessRefreshService`` wraps the pure function with persistence: it
+  loads the merge candidate, asks an injected ``TargetBranchStateProvider``
+  for the latest target snapshot (or accepts a literal one for tests),
+  reconciles ``stale_reasons`` rows via ``StaleReasonRepository``, flips
+  the ``MergeCandidate.stale`` boolean so the existing merge-queue
+  reads keep working, and emits one ``workspace_events`` row per newly
+  detected finding so console timelines surface the change without
+  having to scrape logs.
+
+Reason codes:
+
+* ``STALE_TARGET_ADVANCED`` — target branch advanced past the candidate's
+  validation base, and policy says freshness must be re-validated for
+  this task class. Default-on for everything except ``docs_task`` /
+  ``test_task`` with no overlapping or sensitive change.
+* ``STALE_OVERLAP``         — owned-path overlap with a path changed on
+  target. Always sensitive: even a docs-class candidate cannot ignore
+  changes to a path it claims to own.
+* ``STALE_SCHEMA``          — a schema / migration / model file changed
+  on target while the candidate is a ``migration_task``.
+* ``STALE_DEPENDENCY``      — a dependency file (``pyproject.toml`` etc.)
+  changed while the candidate is a ``dependency_task`` (or migration_task,
+  since dep changes can break a migration).
+* ``STALE_BUILD_CONFIG``    — a build-config file (``Dockerfile``,
+  ``docker-compose``, ``alembic.ini``) changed while the candidate is a
+  ``build_config_task`` (or migration_task).
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Final
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.common.logging import get_logger
+from awf.db.models import MergeCandidate, StaleReason, TaskAttempt, Workspace
+from awf.db.repositories import (
+    StaleReasonCreate,
+    StaleReasonRepository,
+    WorkspaceEventCreate,
+    WorkspaceRepository,
+)
+
+_log = get_logger(__name__)
+
+
+# ── Pure model ─────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class CandidateSnapshot:
+    """Candidate-side inputs the policy needs to evaluate staleness.
+
+    Pulled out as its own type so the pure ``evaluate_staleness`` function
+    can be unit-tested without a DB session and so the service layer can
+    decide what to feed in (full ``MergeCandidate`` ORM rows, fixtures, etc.).
+    """
+
+    owned_paths: tuple[str, ...]
+    task_class: str | None
+    base_sha: str | None
+
+
+@dataclass(frozen=True)
+class TargetBranchState:
+    """Snapshot of the target branch, captured at refresh time."""
+
+    branch: str
+    head_sha: str
+    changed_paths: tuple[str, ...]
+    """Paths that changed on the target branch since the candidate's
+    ``base_sha`` (i.e. ``git diff --name-only <base_sha>..origin/<branch>``)."""
+
+    advanced_commits: int
+    """Commits the target moved beyond ``base_sha`` (``git rev-list --count``)."""
+
+
+@dataclass(frozen=True)
+class StalenessFinding:
+    """One structured staleness signal produced by ``evaluate_staleness``."""
+
+    reason_code: str
+    trigger_type: str
+    trigger_ref: str | None
+    explanation: str
+
+
+@dataclass(frozen=True)
+class StalePolicy:
+    """Path groups that drive the policy.
+
+    Each entry is matched against changed paths with simple prefix /
+    glob-prefix semantics — same comparator the workspace owned-path
+    conflict check uses, so policy stays consistent with admission control.
+    """
+
+    schema_paths: tuple[str, ...]
+    dependency_paths: tuple[str, ...]
+    build_config_paths: tuple[str, ...]
+    lenient_task_classes: tuple[str, ...] = field(
+        default_factory=lambda: ("docs_task", "test_task")
+    )
+
+
+REASON_TARGET_ADVANCED: Final[str] = "STALE_TARGET_ADVANCED"
+REASON_OVERLAP: Final[str] = "STALE_OVERLAP"
+REASON_SCHEMA: Final[str] = "STALE_SCHEMA"
+REASON_DEPENDENCY: Final[str] = "STALE_DEPENDENCY"
+REASON_BUILD_CONFIG: Final[str] = "STALE_BUILD_CONFIG"
+
+TRIGGER_TARGET_ADVANCED: Final[str] = "target_advanced"
+TRIGGER_PATH_OVERLAP: Final[str] = "path_overlap"
+TRIGGER_SCHEMA_CHANGED: Final[str] = "schema_changed"
+TRIGGER_DEPENDENCY_CHANGED: Final[str] = "dependency_changed"
+TRIGGER_BUILD_CONFIG_CHANGED: Final[str] = "build_config_changed"
+
+DEFAULT_STALE_POLICY: Final[StalePolicy] = StalePolicy(
+    schema_paths=(
+        "migrations/",
+        "src/awf/db/models.py",
+        "src/awf/db/repositories.py",
+        "alembic.ini",
+    ),
+    dependency_paths=(
+        "pyproject.toml",
+        "uv.lock",
+        "requirements.txt",
+        "package.json",
+        "package-lock.json",
+    ),
+    build_config_paths=(
+        "Dockerfile",
+        "docker/",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        ".github/workflows/",
+    ),
+)
+
+
+# ── Pure logic ─────────────────────────────────────────────────────────────
+
+
+def evaluate_staleness(
+    *,
+    candidate: CandidateSnapshot,
+    target: TargetBranchState,
+    policy: StalePolicy = DEFAULT_STALE_POLICY,
+) -> list[StalenessFinding]:
+    """Decide which staleness reasons apply to a candidate against ``target``.
+
+    Returns an empty list when the candidate is fresh.
+    """
+    if candidate.base_sha is None:
+        return []
+    if target.head_sha == candidate.base_sha and target.advanced_commits == 0:
+        return []
+
+    findings: list[StalenessFinding] = []
+
+    schema_changes = _matched(target.changed_paths, policy.schema_paths)
+    dep_changes = _matched(target.changed_paths, policy.dependency_paths)
+    build_changes = _matched(target.changed_paths, policy.build_config_paths)
+    overlap = _matched(target.changed_paths, candidate.owned_paths)
+
+    if candidate.task_class == "migration_task":
+        for path in schema_changes:
+            findings.append(
+                StalenessFinding(
+                    reason_code=REASON_SCHEMA,
+                    trigger_type=TRIGGER_SCHEMA_CHANGED,
+                    trigger_ref=path,
+                    explanation=(
+                        f"Schema/migration path '{path}' changed on target "
+                        f"branch '{target.branch}'."
+                    ),
+                )
+            )
+            break
+
+    if candidate.task_class in {"dependency_task", "migration_task"}:
+        for path in dep_changes:
+            findings.append(
+                StalenessFinding(
+                    reason_code=REASON_DEPENDENCY,
+                    trigger_type=TRIGGER_DEPENDENCY_CHANGED,
+                    trigger_ref=path,
+                    explanation=(
+                        f"Dependency manifest '{path}' changed on target "
+                        f"branch '{target.branch}'."
+                    ),
+                )
+            )
+            break
+
+    if candidate.task_class in {"build_config_task", "migration_task"}:
+        for path in build_changes:
+            findings.append(
+                StalenessFinding(
+                    reason_code=REASON_BUILD_CONFIG,
+                    trigger_type=TRIGGER_BUILD_CONFIG_CHANGED,
+                    trigger_ref=path,
+                    explanation=(
+                        f"Build config '{path}' changed on target "
+                        f"branch '{target.branch}'."
+                    ),
+                )
+            )
+            break
+
+    for path in overlap:
+        findings.append(
+            StalenessFinding(
+                reason_code=REASON_OVERLAP,
+                trigger_type=TRIGGER_PATH_OVERLAP,
+                trigger_ref=path,
+                explanation=(
+                    f"Owned path '{path}' was changed on target "
+                    f"branch '{target.branch}'."
+                ),
+            )
+        )
+        break
+
+    if not findings and target.advanced_commits > 0:
+        if candidate.task_class not in policy.lenient_task_classes:
+            findings.append(
+                StalenessFinding(
+                    reason_code=REASON_TARGET_ADVANCED,
+                    trigger_type=TRIGGER_TARGET_ADVANCED,
+                    trigger_ref=target.head_sha,
+                    explanation=(
+                        f"Target branch '{target.branch}' advanced "
+                        f"{target.advanced_commits} commit(s) past validation base."
+                    ),
+                )
+            )
+
+    return findings
+
+
+def _matched(changed_paths: Sequence[str], patterns: Sequence[str]) -> list[str]:
+    """Return changed paths that match any pattern via prefix / glob-prefix.
+
+    The matcher is intentionally simple: literal equality, ``foo/`` prefix
+    match (anything under ``foo/``), and ``foo/**`` glob-prefix. Matches the
+    workspace owned-path overlap policy in spirit; we don't need full
+    fnmatch semantics yet.
+    """
+    matches: list[str] = []
+    for path in changed_paths:
+        for pattern in patterns:
+            if _path_matches(path, pattern):
+                matches.append(path)
+                break
+    return matches
+
+
+def _path_matches(path: str, pattern: str) -> bool:
+    if not pattern:
+        return False
+    if path == pattern:
+        return True
+    if pattern.endswith("/**"):
+        prefix = pattern[: -len("**")]
+        return path.startswith(prefix) or path == prefix.rstrip("/")
+    if pattern.endswith("/*"):
+        prefix = pattern[: -len("*")]
+        return path.startswith(prefix) and "/" not in path[len(prefix) :]
+    if pattern.endswith("/"):
+        return path.startswith(pattern)
+    if "*" in pattern or "?" in pattern or "[" in pattern:
+        wildcard_idx = min(
+            i for i in (pattern.find("*"), pattern.find("?"), pattern.find("[")) if i >= 0
+        )
+        prefix = pattern[:wildcard_idx]
+        if not prefix:
+            return True
+        return path.startswith(prefix)
+    return path.startswith(pattern + "/")
+
+
+# ── Service layer ──────────────────────────────────────────────────────────
+
+
+class TargetBranchStateProvider(ABC):
+    """Abstraction over "fetch the target branch state".
+
+    Production wires in a git/gh-backed implementation; tests inject a
+    stub so the refresh service is exercisable without subprocesses.
+    """
+
+    @abstractmethod
+    async def fetch(
+        self,
+        *,
+        repo_url: str,
+        branch: str,
+        base_sha: str,
+    ) -> TargetBranchState:
+        ...
+
+
+@dataclass(frozen=True)
+class StalenessRefreshResult:
+    """Outcome of one ``StalenessRefreshService.refresh_candidate`` call."""
+
+    candidate_id: str
+    target: TargetBranchState
+    findings: list[StalenessFinding]
+    newly_added: list[StaleReason]
+    newly_resolved: list[StaleReason]
+    stale: bool
+
+
+class StalenessRefreshService:
+    """Refresh staleness state for one merge candidate."""
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        target_state_provider: TargetBranchStateProvider | None = None,
+        policy: StalePolicy = DEFAULT_STALE_POLICY,
+    ) -> None:
+        self._session = session
+        self._provider = target_state_provider
+        self._policy = policy
+
+    async def refresh_candidate(
+        self,
+        candidate_id: str,
+        *,
+        target: TargetBranchState | None = None,
+    ) -> StalenessRefreshResult:
+        candidate = await _load_candidate(self._session, candidate_id)
+        if candidate is None:
+            raise StalenessRefreshError(
+                f"Merge candidate {candidate_id!r} not found",
+            )
+
+        target_state = target if target is not None else await self._fetch_target(candidate)
+        findings = evaluate_staleness(
+            candidate=_snapshot_for(candidate),
+            target=target_state,
+            policy=self._policy,
+        )
+
+        reasons_repo = StaleReasonRepository(self._session)
+        newly_added, newly_resolved = await reasons_repo.replace_active_findings(
+            workspace_id=candidate.workspace_id,
+            candidate_id=candidate.id,
+            attempt_id=candidate.attempt_id,
+            task_id=candidate.task_id,
+            findings=[
+                StaleReasonCreate(
+                    reason_code=f.reason_code,
+                    trigger_type=f.trigger_type,
+                    trigger_ref=f.trigger_ref,
+                    explanation=f.explanation,
+                )
+                for f in findings
+            ],
+        )
+
+        stale = bool(findings)
+        await self._mark_candidate_stale(candidate, stale=stale)
+
+        if newly_added:
+            await self._emit_events(
+                candidate=candidate,
+                target=target_state,
+                added=newly_added,
+            )
+
+        return StalenessRefreshResult(
+            candidate_id=candidate.id,
+            target=target_state,
+            findings=findings,
+            newly_added=list(newly_added),
+            newly_resolved=list(newly_resolved),
+            stale=stale,
+        )
+
+    async def _fetch_target(self, candidate: MergeCandidate) -> TargetBranchState:
+        if self._provider is None:
+            raise StalenessRefreshError(
+                "No target branch state supplied and no provider injected",
+            )
+        if candidate.base_sha is None:
+            raise StalenessRefreshError(
+                f"Candidate {candidate.id!r} has no validation base_sha to compare",
+            )
+        return await self._provider.fetch(
+            repo_url=candidate.repo_url,
+            branch=candidate.base_branch,
+            base_sha=candidate.base_sha,
+        )
+
+    async def _mark_candidate_stale(
+        self,
+        candidate: MergeCandidate,
+        *,
+        stale: bool,
+    ) -> None:
+        if candidate.stale == stale:
+            return
+        candidate.stale = stale
+        # Re-sync derived readiness flags so the merge-queue blocker reason
+        # picks up the new stale state without an out-of-band refresh.
+        from awf.db.repositories import _sync_candidate_readiness
+
+        _sync_candidate_readiness(
+            candidate,
+            workspace=candidate.workspace,
+            attempt=candidate.attempt,
+        )
+        await self._session.flush()
+
+    async def _emit_events(
+        self,
+        *,
+        candidate: MergeCandidate,
+        target: TargetBranchState,
+        added: Iterable[StaleReason],
+    ) -> None:
+        repo = WorkspaceRepository(self._session)
+        events = [
+            WorkspaceEventCreate(
+                event_type="merge_candidate.stale_detected",
+                reason_code=row.reason_code,
+                payload={
+                    "candidate_id": candidate.id,
+                    "attempt_id": candidate.attempt_id,
+                    "task_id": candidate.task_id,
+                    "trigger_type": row.trigger_type,
+                    "trigger_ref": row.trigger_ref,
+                    "explanation": row.explanation,
+                    "target_branch": target.branch,
+                    "target_head_sha": target.head_sha,
+                    "advanced_commits": target.advanced_commits,
+                    "detected_at": _isoformat(row.detected_at),
+                },
+            )
+            for row in added
+        ]
+        if events:
+            await repo.add_events(candidate.workspace, events=events)
+
+
+class StalenessRefreshError(RuntimeError):
+    """Raised when the refresh service can't proceed (missing inputs/rows)."""
+
+
+def _snapshot_for(candidate: MergeCandidate) -> CandidateSnapshot:
+    workspace: Workspace = candidate.workspace
+    attempt: TaskAttempt = candidate.attempt
+    owned = (
+        tuple(workspace.owned_paths)
+        if workspace.owned_paths
+        else tuple(attempt.owned_paths)
+    )
+    return CandidateSnapshot(
+        owned_paths=owned,
+        task_class=workspace.task_class or attempt.task_class,
+        base_sha=candidate.base_sha,
+    )
+
+
+async def _load_candidate(
+    session: AsyncSession, candidate_id: str
+) -> MergeCandidate | None:
+    from sqlalchemy import select
+    from sqlalchemy.orm import selectinload
+
+    stmt = (
+        select(MergeCandidate)
+        .where(MergeCandidate.id == candidate_id)
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace),
+            selectinload(MergeCandidate.task),
+        )
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -199,8 +199,7 @@ def evaluate_staleness(
                     trigger_type=TRIGGER_DEPENDENCY_CHANGED,
                     trigger_ref=path,
                     explanation=(
-                        f"Dependency manifest '{path}' changed on target "
-                        f"branch '{target.branch}'."
+                        f"Dependency manifest '{path}' changed on target branch '{target.branch}'."
                     ),
                 )
             )
@@ -214,8 +213,7 @@ def evaluate_staleness(
                     trigger_type=TRIGGER_BUILD_CONFIG_CHANGED,
                     trigger_ref=path,
                     explanation=(
-                        f"Build config '{path}' changed on target "
-                        f"branch '{target.branch}'."
+                        f"Build config '{path}' changed on target branch '{target.branch}'."
                     ),
                 )
             )
@@ -228,8 +226,7 @@ def evaluate_staleness(
                 trigger_type=TRIGGER_PATH_OVERLAP,
                 trigger_ref=path,
                 explanation=(
-                    f"Owned path '{path}' was changed on target "
-                    f"branch '{target.branch}'."
+                    f"Owned path '{path}' was changed on target branch '{target.branch}'."
                 ),
             )
         )
@@ -313,8 +310,7 @@ class TargetBranchStateProvider(ABC):
         repo_url: str,
         branch: str,
         base_sha: str,
-    ) -> TargetBranchState:
-        ...
+    ) -> TargetBranchState: ...
 
 
 @dataclass(frozen=True)
@@ -471,11 +467,7 @@ class StalenessRefreshError(RuntimeError):
 def _snapshot_for(candidate: MergeCandidate) -> CandidateSnapshot:
     workspace: Workspace = candidate.workspace
     attempt: TaskAttempt = candidate.attempt
-    owned = (
-        tuple(workspace.owned_paths)
-        if workspace.owned_paths
-        else tuple(attempt.owned_paths)
-    )
+    owned = tuple(workspace.owned_paths) if workspace.owned_paths else tuple(attempt.owned_paths)
     return CandidateSnapshot(
         owned_paths=owned,
         task_class=workspace.task_class or attempt.task_class,
@@ -483,9 +475,7 @@ def _snapshot_for(candidate: MergeCandidate) -> CandidateSnapshot:
     )
 
 
-async def _load_candidate(
-    session: AsyncSession, candidate_id: str
-) -> MergeCandidate | None:
+async def _load_candidate(session: AsyncSession, candidate_id: str) -> MergeCandidate | None:
     from sqlalchemy import select
     from sqlalchemy.orm import selectinload
 

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -154,7 +154,9 @@ class TestMergeQueueList:
             "merge_blocker_reason",
             "readiness",
             "canonical",
+            "stale_reasons",
         }
+        assert item["stale_reasons"] == []
         assert item["candidate_id"].startswith("mc_")
         assert item["candidate_status"] == "open"
         assert item["attempt_id"].startswith("att_")

--- a/tests/unit/api/test_stale_reasons.py
+++ b/tests/unit/api/test_stale_reasons.py
@@ -9,14 +9,12 @@ Stale reasons must be visible to console clients via:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import datetime
 
 import pytest
-from httpx import ASGITransport, AsyncClient
+from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
-from awf.api.app import configure_database, create_app
-from awf.db.base import Base
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.repositories import (
     MergeCandidateRepository,
@@ -24,7 +22,7 @@ from awf.db.repositories import (
     TaskRepository,
     WorkspaceRepository,
 )
-from awf.db.session import make_engine, make_session_factory
+from awf.db.session import make_session_factory
 
 
 @pytest.fixture

--- a/tests/unit/api/test_stale_reasons.py
+++ b/tests/unit/api/test_stale_reasons.py
@@ -1,0 +1,246 @@
+"""API surface tests for stale reasons.
+
+Stale reasons must be visible to console clients via:
+- ``/v1/merge-queue`` items (list of structured reasons + boolean readiness.stale)
+- ``/v1/workspaces/{id}/stale-reasons`` workspace detail endpoint
+- ``workspace_events`` rows so the existing event timeline shows them
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from awf.api.app import configure_database, create_app
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+
+
+@pytest.fixture
+async def factory(engine: AsyncEngine) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield make_session_factory(engine)
+
+
+async def _seed_candidate(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    pr_url: str = "https://github.com/example/svc/pull/77",
+    pr_number: int = 77,
+    branch_name: str = "awf/stale-test",
+    owned_paths: list[str] | None = None,
+    task_class: str | None = "refactor_task",
+    base_sha: str = "a" * 40,
+    updated_at: datetime | None = None,
+) -> tuple[str, str, str]:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/svc.git",
+            branch_base="development",
+            task_title="Stale visibility",
+            task_prompt="Implement.",
+            task_external_id="TICKET-VISIBLE",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+            owned_paths=owned_paths or ["src/awf/api/**"],
+            task_class=task_class,
+        )
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=workspace.task_external_id,
+            idempotency_key=None,
+            task_class=task_class,
+            owned_paths=owned_paths or ["src/awf/api/**"],
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+        ):
+            await repo.transition(workspace, to=target, reason_code="TEST")
+        workspace.branch_name = branch_name
+        workspace.remote_push_branch = branch_name
+        workspace.base_commit = base_sha
+        workspace.pr_url = pr_url
+        workspace.pr_number = pr_number
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.monitoring_pr,
+            reason_code="PR_OPENED",
+        )
+        attempt = await TaskAttemptRepository(session).get_by_workspace_id(workspace.id)
+        assert attempt is not None
+        candidate = await MergeCandidateRepository(session).create_or_update_open_for_attempt(
+            task=task,
+            attempt=attempt,
+            workspace=workspace,
+            head_sha="h" * 40,
+            base_sha=base_sha,
+        )
+        if updated_at is not None:
+            workspace.updated_at = updated_at
+        await session.commit()
+        return workspace.id, attempt.id, candidate.id
+
+
+class TestMergeQueueExposesStaleReasons:
+    @pytest.mark.unit
+    async def test_merge_queue_item_includes_active_stale_reasons_after_refresh(
+        self,
+        client: AsyncClient,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        workspace_id, _attempt_id, candidate_id = await _seed_candidate(factory)
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=2,
+                ),
+            )
+            await session.commit()
+
+        response = await client.get("/v1/merge-queue")
+        assert response.status_code == 200
+        items = response.json()["items"]
+        item = next(it for it in items if it["workspace_id"] == workspace_id)
+        assert item["readiness"]["stale"] is True
+        assert item["merge_blocker_reason"] == "stale"
+
+        reasons = item["stale_reasons"]
+        assert isinstance(reasons, list)
+        assert reasons, "expected at least one stale reason exposed"
+        first = reasons[0]
+        assert {
+            "id",
+            "reason_code",
+            "trigger_type",
+            "trigger_ref",
+            "explanation",
+            "status",
+            "detected_at",
+            "resolved_at",
+        } <= set(first.keys())
+        assert first["status"] == "active"
+        assert first["reason_code"] in {
+            "STALE_OVERLAP",
+            "STALE_TARGET_ADVANCED",
+        }
+
+    @pytest.mark.unit
+    async def test_docs_class_with_non_overlapping_change_keeps_mergeable(
+        self,
+        client: AsyncClient,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        workspace_id, _attempt_id, candidate_id = await _seed_candidate(
+            factory,
+            pr_url="https://github.com/example/svc/pull/78",
+            pr_number=78,
+            branch_name="awf/docs-only",
+            owned_paths=["docs/USAGE.md"],
+            task_class="docs_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=2,
+                ),
+            )
+            await session.commit()
+
+        response = await client.get("/v1/merge-queue")
+        assert response.status_code == 200
+        items = response.json()["items"]
+        item = next(it for it in items if it["workspace_id"] == workspace_id)
+        assert item["readiness"]["stale"] is False
+        assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
+        assert item["stale_reasons"] == []
+
+
+class TestWorkspaceStaleReasonsEndpoint:
+    @pytest.mark.unit
+    async def test_workspace_stale_reasons_endpoint_lists_active_reasons(
+        self,
+        client: AsyncClient,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        workspace_id, _attempt_id, candidate_id = await _seed_candidate(
+            factory,
+            pr_url="https://github.com/example/svc/pull/79",
+            pr_number=79,
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="c" * 40,
+                    changed_paths=("src/awf/api/routes/locks.py",),
+                    advanced_commits=4,
+                ),
+            )
+            await session.commit()
+
+        response = await client.get(f"/v1/workspaces/{workspace_id}/stale-reasons")
+        assert response.status_code == 200
+        body = response.json()
+        assert "items" in body
+        assert any(r["status"] == "active" for r in body["items"])
+        assert all(r["workspace_id"] == workspace_id for r in body["items"])
+
+    @pytest.mark.unit
+    async def test_workspace_stale_reasons_endpoint_returns_empty_for_unknown_workspace(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        response = await client.get("/v1/workspaces/ws_does_not_exist/stale-reasons")
+        assert response.status_code == 404

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -732,6 +732,4 @@ class TestStaleReasonResponseShape:
         response = StaleReasonResponse.model_validate(row)
         dumped: dict[str, Any] = response.model_dump()
         assert set(dumped.keys()) >= _PAYLOAD_SHAPE_KEYS
-        assert isinstance(dumped["detected_at"], datetime) or isinstance(
-            dumped["detected_at"], str
-        )
+        assert isinstance(dumped["detected_at"], (datetime, str))

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -355,6 +355,56 @@ class TestEvaluateStaleness:
         assert "STALE_BUILD_CONFIG" in codes
 
     @pytest.mark.unit
+    def test_no_findings_when_candidate_has_no_base_sha(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=(),
+            task_class=None,
+            base_sha=None,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("README.md",),
+            advanced_commits=2,
+        )
+
+        assert (
+            evaluate_staleness(
+                candidate=candidate,
+                target=target,
+                policy=DEFAULT_STALE_POLICY,
+            )
+            == []
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("path", "pattern", "expected"),
+        [
+            ("a", "", False),
+            ("src/awf/api/routes/health.py", "src/awf/api/**", True),
+            ("src/awf/api", "src/awf/api/**", True),
+            ("src/awf/api/health.py", "src/awf/api/*", True),
+            ("src/awf/api/routes/health.py", "src/awf/api/*", False),
+            ("docker/Dockerfile", "docker/", True),
+            ("docs/USAGE.md", "docs", True),
+            ("README.md", "READ", False),
+            ("a/b/c.py", "a/?/c.py", True),
+        ],
+    )
+    def test_path_matches_glob_semantics(self, path: str, pattern: str, expected: bool) -> None:
+        from awf.service.staleness import _path_matches
+
+        assert _path_matches(path, pattern) is expected
+
+    @pytest.mark.unit
     def test_unknown_class_with_target_advance_uses_target_advanced_default(self) -> None:
         from awf.service.staleness import (
             DEFAULT_STALE_POLICY,
@@ -534,9 +584,7 @@ class TestStalenessRefreshService:
                 workspace_id=workspace_id,
                 limit=200,
             )
-        stale_events = [
-            evt for evt in events if evt.event_type == "merge_candidate.stale_detected"
-        ]
+        stale_events = [evt for evt in events if evt.event_type == "merge_candidate.stale_detected"]
         assert len(stale_events) >= 1
         first = stale_events[0]
         assert first.reason_code == "STALE_OVERLAP"
@@ -604,6 +652,36 @@ class TestStalenessRefreshService:
         assert {r.reason_code for r in reasons} >= {"STALE_OVERLAP"}
         assert result.stale is True
         assert {f.reason_code for f in result.findings} >= {"STALE_OVERLAP"}
+
+
+class TestStalenessRefreshServiceErrorPaths:
+    @pytest.mark.unit
+    async def test_refresh_unknown_candidate_raises(
+        self, factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        from awf.service.staleness import StalenessRefreshError, StalenessRefreshService
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            with pytest.raises(StalenessRefreshError):
+                await service.refresh_candidate("mc_does_not_exist")
+
+    @pytest.mark.unit
+    async def test_refresh_without_target_or_provider_raises(
+        self, factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        from awf.service.staleness import StalenessRefreshError, StalenessRefreshService
+
+        _workspace_id, _attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            with pytest.raises(StalenessRefreshError):
+                await service.refresh_candidate(candidate_id)
 
 
 class TestStaleReasonsRoundTrip:

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -14,7 +14,7 @@ Covers:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import Any
 
 import pytest
@@ -259,7 +259,7 @@ class TestEvaluateStaleness:
         assert "STALE_OVERLAP" in codes
         overlap = next(f for f in findings if f.reason_code == "STALE_OVERLAP")
         assert overlap.trigger_type == "path_overlap"
-        assert "src/awf/api/routes/health.py" == overlap.trigger_ref
+        assert overlap.trigger_ref == "src/awf/api/routes/health.py"
 
     @pytest.mark.unit
     def test_migration_task_schema_change_emits_stale_schema(self) -> None:
@@ -731,7 +731,7 @@ class TestStaleReasonResponseShape:
 
         response = StaleReasonResponse.model_validate(row)
         dumped: dict[str, Any] = response.model_dump()
-        assert _PAYLOAD_SHAPE_KEYS <= set(dumped.keys())
+        assert set(dumped.keys()) >= _PAYLOAD_SHAPE_KEYS
         assert isinstance(dumped["detected_at"], datetime) or isinstance(
             dumped["detected_at"], str
         )

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -1,0 +1,737 @@
+"""Stale detection engine tests.
+
+Covers:
+- Pure staleness evaluation logic (``evaluate_staleness``) — owned-path overlap,
+  schema/dependency/build-config changes, target-advance defaults.
+- ``StalenessRefreshService.refresh_candidate`` — fetching target branch
+  state, persisting structured ``StaleReason`` records, marking the
+  candidate ``stale`` boolean, and resolving findings that no longer
+  apply on the next refresh.
+- Event emission so console clients see the structured reason instead of
+  having to parse log strings.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_open_candidate(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    owned_paths: list[str],
+    task_class: str | None = None,
+    base_sha: str = "a" * 40,
+) -> tuple[str, str, str]:
+    """Build a workspace + task + canonical attempt + open merge candidate."""
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/svc.git",
+            branch_base="development",
+            task_title="Stale fixture",
+            task_prompt="Implement.",
+            task_external_id="TICKET-STALE",
+            agent=AgentRuntime.codex.value,
+            test_commands=[],
+            owned_paths=owned_paths,
+            task_class=task_class,
+        )
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=workspace.task_external_id,
+            idempotency_key=None,
+            task_class=task_class,
+            owned_paths=owned_paths,
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+        ):
+            await repo.transition(workspace, to=target, reason_code="TEST")
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = base_sha
+        workspace.pr_url = "https://github.com/example/svc/pull/41"
+        workspace.pr_number = 41
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.monitoring_pr,
+            reason_code="PR_OPENED",
+        )
+        attempt = await TaskAttemptRepository(session).get_by_workspace_id(workspace.id)
+        assert attempt is not None
+        candidate = await MergeCandidateRepository(session).create_or_update_open_for_attempt(
+            task=task,
+            attempt=attempt,
+            workspace=workspace,
+            head_sha="h" * 40,
+            base_sha=base_sha,
+        )
+        await session.commit()
+        return workspace.id, attempt.id, candidate.id
+
+
+class TestEvaluateStaleness:
+    """Unit tests for the pure ``evaluate_staleness`` function."""
+
+    @pytest.mark.unit
+    def test_no_findings_when_target_unchanged(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("src/awf/api/**",),
+            task_class=None,
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="a" * 40,
+            changed_paths=(),
+            advanced_commits=0,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        assert findings == []
+
+    @pytest.mark.unit
+    def test_target_advanced_default_invalidates_freshness(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("src/awf/api/**",),
+            task_class="refactor_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("docs/UNRELATED.md",),
+            advanced_commits=2,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        codes = [f.reason_code for f in findings]
+        assert "STALE_TARGET_ADVANCED" in codes
+
+    @pytest.mark.unit
+    def test_docs_class_with_non_overlapping_changes_is_not_stale(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("docs/USAGE.md",),
+            task_class="docs_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("src/awf/api/routes/health.py",),
+            advanced_commits=3,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        assert findings == []
+
+    @pytest.mark.unit
+    def test_test_class_with_non_overlapping_changes_is_not_stale(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("tests/unit/api/test_health.py",),
+            task_class="test_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("src/awf/api/routes/locks.py",),
+            advanced_commits=1,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        assert findings == []
+
+    @pytest.mark.unit
+    def test_overlap_emits_stale_overlap_for_any_class(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("src/awf/api/**",),
+            task_class="docs_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("src/awf/api/routes/health.py",),
+            advanced_commits=1,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        codes = [f.reason_code for f in findings]
+        assert "STALE_OVERLAP" in codes
+        overlap = next(f for f in findings if f.reason_code == "STALE_OVERLAP")
+        assert overlap.trigger_type == "path_overlap"
+        assert "src/awf/api/routes/health.py" == overlap.trigger_ref
+
+    @pytest.mark.unit
+    def test_migration_task_schema_change_emits_stale_schema(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("migrations/**",),
+            task_class="migration_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=(
+                "migrations/versions/zzz_unrelated.py",
+                "src/awf/db/models.py",
+            ),
+            advanced_commits=2,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        codes = [f.reason_code for f in findings]
+        assert "STALE_SCHEMA" in codes
+
+    @pytest.mark.unit
+    def test_dependency_task_dependency_change_emits_stale_dependency(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("pyproject.toml",),
+            task_class="dependency_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("uv.lock",),
+            advanced_commits=1,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        codes = [f.reason_code for f in findings]
+        assert "STALE_DEPENDENCY" in codes
+
+    @pytest.mark.unit
+    def test_build_config_task_dockerfile_change_emits_stale_build_config(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=("docker/**",),
+            task_class="build_config_task",
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("docker/Dockerfile.api",),
+            advanced_commits=1,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        codes = [f.reason_code for f in findings]
+        assert "STALE_BUILD_CONFIG" in codes
+
+    @pytest.mark.unit
+    def test_unknown_class_with_target_advance_uses_target_advanced_default(self) -> None:
+        from awf.service.staleness import (
+            DEFAULT_STALE_POLICY,
+            CandidateSnapshot,
+            TargetBranchState,
+            evaluate_staleness,
+        )
+
+        candidate = CandidateSnapshot(
+            owned_paths=(),
+            task_class=None,
+            base_sha="a" * 40,
+        )
+        target = TargetBranchState(
+            branch="development",
+            head_sha="b" * 40,
+            changed_paths=("README.md",),
+            advanced_commits=1,
+        )
+
+        findings = evaluate_staleness(
+            candidate=candidate,
+            target=target,
+            policy=DEFAULT_STALE_POLICY,
+        )
+
+        assert [f.reason_code for f in findings] == ["STALE_TARGET_ADVANCED"]
+
+
+class TestStalenessRefreshService:
+    """Persistence + lifecycle tests for ``StalenessRefreshService``."""
+
+    @pytest.mark.unit
+    async def test_target_advance_creates_active_stale_reason_and_marks_candidate(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        workspace_id, _attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=4,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            from awf.db.repositories import StaleReasonRepository
+
+            repo = StaleReasonRepository(session)
+            reasons = await repo.list_active_for_candidate(candidate_id)
+
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                _attempt_id,
+            )
+
+        assert candidate is not None
+        assert candidate.stale is True
+        assert {r.reason_code for r in reasons} >= {"STALE_OVERLAP"}
+        first = next(r for r in reasons if r.reason_code == "STALE_OVERLAP")
+        assert first.workspace_id == workspace_id
+        assert first.candidate_id == candidate_id
+        assert first.trigger_type == "path_overlap"
+        assert first.status == "active"
+        assert first.detected_at is not None
+        assert first.resolved_at is None
+
+    @pytest.mark.unit
+    async def test_refresh_clears_stale_when_findings_no_longer_apply(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        _workspace_id, attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=2,
+                ),
+            )
+            await session.commit()
+
+        # New target snapshot: rolled back to the original base; no advance.
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="a" * 40,
+                    changed_paths=(),
+                    advanced_commits=0,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            from awf.db.repositories import StaleReasonRepository
+
+            repo = StaleReasonRepository(session)
+            active = await repo.list_active_for_candidate(candidate_id)
+            all_reasons = await repo.list_for_candidate(candidate_id)
+
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                attempt_id,
+            )
+
+        assert candidate is not None
+        assert candidate.stale is False
+        assert active == []
+        # The historical row remains, marked resolved.
+        assert any(r.status == "resolved" for r in all_reasons)
+        resolved = next(r for r in all_reasons if r.status == "resolved")
+        assert resolved.resolved_at is not None
+
+    @pytest.mark.unit
+    async def test_refresh_emits_workspace_event_for_each_finding(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.db.repositories import WorkspaceEventRepository
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        workspace_id, _attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=1,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            events = await WorkspaceEventRepository(session).list(
+                workspace_id=workspace_id,
+                limit=200,
+            )
+        stale_events = [
+            evt for evt in events if evt.event_type == "merge_candidate.stale_detected"
+        ]
+        assert len(stale_events) >= 1
+        first = stale_events[0]
+        assert first.reason_code == "STALE_OVERLAP"
+        assert first.payload is not None
+        assert first.payload["candidate_id"] == candidate_id
+        assert first.payload["trigger_type"] == "path_overlap"
+
+    @pytest.mark.unit
+    async def test_target_state_provider_drives_refresh(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """``StalenessRefreshService`` should accept an injected provider so we
+        do not couple core logic to live ``gh`` calls in tests."""
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+            TargetBranchStateProvider,
+        )
+
+        _workspace_id, attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        recorded: list[tuple[str, str, str]] = []
+
+        class _StubProvider(TargetBranchStateProvider):
+            async def fetch(
+                self,
+                *,
+                repo_url: str,
+                branch: str,
+                base_sha: str,
+            ) -> TargetBranchState:
+                recorded.append((repo_url, branch, base_sha))
+                return TargetBranchState(
+                    branch=branch,
+                    head_sha="z" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=5,
+                )
+
+        async with factory() as session:
+            service = StalenessRefreshService(
+                session,
+                target_state_provider=_StubProvider(),
+            )
+            result = await service.refresh_candidate(candidate_id)
+            await session.commit()
+
+        assert recorded == [("git@github.com:example/svc.git", "development", "a" * 40)]
+        async with factory() as session:
+            from awf.db.repositories import StaleReasonRepository
+
+            reasons = await StaleReasonRepository(session).list_active_for_candidate(
+                candidate_id,
+            )
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                attempt_id,
+            )
+        assert candidate is not None
+        assert candidate.stale is True
+        assert {r.reason_code for r in reasons} >= {"STALE_OVERLAP"}
+        assert result.stale is True
+        assert {f.reason_code for f in result.findings} >= {"STALE_OVERLAP"}
+
+
+class TestStaleReasonsRoundTrip:
+    """End-to-end TDD-style assertions for the durable ``stale_reasons`` table."""
+
+    @pytest.mark.unit
+    async def test_repository_list_excludes_resolved_rows_from_active_view(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.db.repositories import StaleReasonRepository
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        _workspace_id, _attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=1,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="a" * 40,
+                    changed_paths=(),
+                    advanced_commits=0,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            repo = StaleReasonRepository(session)
+            active = await repo.list_active_for_candidate(candidate_id)
+            full = await repo.list_for_candidate(candidate_id)
+
+        assert active == []
+        assert any(r.status == "resolved" for r in full)
+
+
+_PAYLOAD_SHAPE_KEYS = {
+    "id",
+    "workspace_id",
+    "candidate_id",
+    "attempt_id",
+    "task_id",
+    "trigger_type",
+    "trigger_ref",
+    "reason_code",
+    "explanation",
+    "status",
+    "detected_at",
+    "resolved_at",
+}
+
+
+class TestStaleReasonResponseShape:
+    @pytest.mark.unit
+    def test_default_policy_exposes_known_path_groups(self) -> None:
+        from awf.service.staleness import DEFAULT_STALE_POLICY
+
+        assert "migrations/" in tuple(DEFAULT_STALE_POLICY.schema_paths) or any(
+            p.startswith("migrations/") for p in DEFAULT_STALE_POLICY.schema_paths
+        )
+        assert "pyproject.toml" in DEFAULT_STALE_POLICY.dependency_paths
+        assert any(
+            p.startswith("docker/") or "Dockerfile" in p
+            for p in DEFAULT_STALE_POLICY.build_config_paths
+        )
+
+    @pytest.mark.unit
+    async def test_stale_reason_response_has_required_fields(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.api.schemas import StaleReasonResponse
+        from awf.db.repositories import StaleReasonRepository
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        _workspace_id, _attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=1,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            row = (
+                await StaleReasonRepository(session).list_active_for_candidate(
+                    candidate_id,
+                )
+            )[0]
+
+        response = StaleReasonResponse.model_validate(row)
+        dumped: dict[str, Any] = response.model_dump()
+        assert _PAYLOAD_SHAPE_KEYS <= set(dumped.keys())
+        assert isinstance(dumped["detected_at"], datetime) or isinstance(
+            dumped["detected_at"], str
+        )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_b4e19a05b3cf45f58ddfd5a6` (agent: `claude_code`).

**External task ID**: awf-phase15-stale-detection-20260426T161856Z

### Task
Implement the stale detection engine and structured stale reasons.

Required behavior:
- Add stale_reason records or an equivalent durable model with trigger type, trigger ref, affected workspace/attempt, explanation, detected_at, active/resolved status, and reason code.
- Add a refresh operation/service that fetches target branch state, compares candidate base/head against current target, and evaluates stale policy.
- Initial stale triggers: target branch advanced since validation base; overlapping owned path changed on target; dependency/build config changed for sensitive task classes; migration/schema/model path changed for migration_task.
- Mark affected candidates/workspaces blocked with reason codes: STALE_TARGET_ADVANCED, STALE_OVERLAP, STALE_DEPENDENCY, STALE_BUILD_CONFIG, or STALE_SCHEMA.
- Surface stale reasons in /v1/merge-queue, workspace detail/events, and enough API shape for the console to display them.

Acceptance:
- A PR validated against an old target SHA becomes non-mergeable after target branch advances when policy says freshness is invalid.
- Stale reasons are structured and visible, not hidden in logs.
- Non-overlapping docs/test changes can remain mergeable when policy allows.


Strict delivery rules:
- Use TDD: add focused failing tests first and include the red failure output in the first test commit body.
- Implement until the requested validation commands pass.
- Commit with conventional commits.
- Do not push, do not open a PR, and do not switch branches; AWF owns branch lifecycle, push, PR creation, monitoring, comment handling, and merge.
- Keep changes narrowly scoped to this task. If another parallel AWF workspace changes related code, adapt through normal git/rebase workflow rather than reverting unrelated work.

---
Validation: 6 profile command(s) passed inside the workspace container.
