### PR TITLE
feat(validation): persist validation run provenance

### DIFF
--- a/migrations/versions/e6f7a8b9c0d1_validation_runs.py
+++ b/migrations/versions/e6f7a8b9c0d1_validation_runs.py
@@ -1,0 +1,85 @@
+"""Add durable validation run provenance.
+
+Revision ID: e6f7a8b9c0d1
+Revises: c4d5e6f7a8b9
+Create Date: 2026-04-26 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "e6f7a8b9c0d1"
+down_revision: str | Sequence[str] | None = "c4d5e6f7a8b9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "validation_runs",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_id", sa.String(length=36), nullable=True),
+        sa.Column("tier", sa.Integer(), nullable=False),
+        sa.Column("command_set_hash", sa.String(length=64), nullable=False),
+        sa.Column(
+            "commands",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'[]'"),
+        ),
+        sa.Column("base_commit", sa.String(length=64), nullable=True),
+        sa.Column("target_branch", sa.String(length=256), nullable=True),
+        sa.Column("target_head_sha", sa.String(length=64), nullable=True),
+        sa.Column("status", sa.String(length=16), nullable=False),
+        sa.Column("reason_code", sa.String(length=64), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "log_stream_refs",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("CURRENT_TIMESTAMP"),
+        ),
+        sa.ForeignKeyConstraint(["attempt_id"], ["task_attempts.id"]),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_validation_runs_workspace_started",
+        "validation_runs",
+        ["workspace_id", "started_at"],
+    )
+    op.create_index(
+        "ix_validation_runs_workspace_finished",
+        "validation_runs",
+        ["workspace_id", "finished_at"],
+    )
+    op.create_index("ix_validation_runs_attempt", "validation_runs", ["attempt_id"])
+    op.create_index("ix_validation_runs_status", "validation_runs", ["status"])
+    op.create_index("ix_validation_runs_tier", "validation_runs", ["tier"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_validation_runs_tier", table_name="validation_runs")
+    op.drop_index("ix_validation_runs_status", table_name="validation_runs")
+    op.drop_index("ix_validation_runs_attempt", table_name="validation_runs")
+    op.drop_index("ix_validation_runs_workspace_finished", table_name="validation_runs")
+    op.drop_index("ix_validation_runs_workspace_started", table_name="validation_runs")
+    op.drop_table("validation_runs")

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -19,11 +19,17 @@ from awf.api.schemas import (
     MergeCandidateReadinessResponse,
     MergeQueueItemResponse,
     MergeQueueListResponse,
+    ValidationRunSummaryResponse,
     WorkspaceEventResponse,
 )
+from awf.api.validation_runs import validation_run_summary
 from awf.db.enums import WorkspaceStatus
-from awf.db.models import MergeCandidate, Workspace, WorkspaceEvent
-from awf.db.repositories import MergeCandidateRepository, WorkspaceRepository
+from awf.db.models import MergeCandidate, ValidationRun, Workspace, WorkspaceEvent
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    ValidationRunRepository,
+    WorkspaceRepository,
+)
 
 router = APIRouter(prefix="/v1/merge-queue", tags=["merge-queue"])
 
@@ -81,8 +87,17 @@ async def list_merge_queue(
     )
     page_rows = rows[:limit]
     has_more = len(rows) > limit
+    latest_validation_runs = await ValidationRunRepository(session).latest_by_workspace_ids(
+        _row_workspace(row).id for row in page_rows
+    )
     return MergeQueueListResponse(
-        items=[_item_from_row(row) for row in page_rows],
+        items=[
+            _item_from_row(
+                row,
+                latest_validation_runs.get(_row_workspace(row).id),
+            )
+            for row in page_rows
+        ],
         next_cursor=_encode_cursor(_row_workspace(page_rows[-1]))
         if has_more and page_rows
         else None,
@@ -90,13 +105,19 @@ async def list_merge_queue(
     )
 
 
-def _item_from_row(row: MergeCandidate | Workspace) -> MergeQueueItemResponse:
+def _item_from_row(
+    row: MergeCandidate | Workspace,
+    latest_validation_run: ValidationRun | None,
+) -> MergeQueueItemResponse:
     if isinstance(row, MergeCandidate):
-        return _item_from_candidate(row)
-    return _item_from_legacy_workspace(row)
+        return _item_from_candidate(row, latest_validation_run)
+    return _item_from_legacy_workspace(row, latest_validation_run)
 
 
-def _item_from_candidate(candidate: MergeCandidate) -> MergeQueueItemResponse:
+def _item_from_candidate(
+    candidate: MergeCandidate,
+    latest_validation_run: ValidationRun | None,
+) -> MergeQueueItemResponse:
     workspace = candidate.workspace
     latest_event = _latest_event(workspace.events)
     return MergeQueueItemResponse(
@@ -125,10 +146,17 @@ def _item_from_candidate(candidate: MergeCandidate) -> MergeQueueItemResponse:
         merge_blocker_reason=_merge_blocker_reason(candidate),
         readiness=_readiness_from_candidate(candidate),
         canonical=candidate.attempt.is_canonical_for_merge,
+        latest_validation=_latest_validation_summary(
+            latest_validation_run,
+            current_target_head_sha=candidate.head_sha or workspace.monitor_last_commit_sha,
+        ),
     )
 
 
-def _item_from_legacy_workspace(workspace: Workspace) -> MergeQueueItemResponse:
+def _item_from_legacy_workspace(
+    workspace: Workspace,
+    latest_validation_run: ValidationRun | None,
+) -> MergeQueueItemResponse:
     latest_event = _latest_event(workspace.events)
     pr_url = workspace.pr_url
     if pr_url is None:  # pragma: no cover - filtered at repository boundary
@@ -159,6 +187,10 @@ def _item_from_legacy_workspace(workspace: Workspace) -> MergeQueueItemResponse:
         merge_blocker_reason=_merge_blocker_reason_from_workspace(workspace),
         readiness=None,
         canonical=False,
+        latest_validation=_latest_validation_summary(
+            latest_validation_run,
+            current_target_head_sha=workspace.monitor_last_commit_sha,
+        ),
     )
 
 
@@ -215,6 +247,16 @@ def _readiness_from_candidate(candidate: MergeCandidate) -> MergeCandidateReadin
         not_canonical=candidate.not_canonical,
         stale=candidate.stale,
     )
+
+
+def _latest_validation_summary(
+    run: ValidationRun | None,
+    *,
+    current_target_head_sha: str | None,
+) -> ValidationRunSummaryResponse | None:
+    if run is None:
+        return None
+    return validation_run_summary(run, current_target_head_sha=current_target_head_sha)
 
 
 def _encode_cursor(workspace: Workspace) -> str:

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -15,9 +15,13 @@ from awf.api.schemas import (
     ValidationProvenanceItemResponse,
     ValidationProvenanceListResponse,
     ValidationProvenanceStatus,
-    ValidationTier,
 )
-from awf.api.validation_runs import fresh_for_target
+from awf.api.validation_runs import (
+    _json_dict,
+    _validation_status,
+    _validation_tier,
+    fresh_for_target,
+)
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import ValidationRun, Workspace, WorkspaceLogStream
 from awf.db.repositories import (
@@ -187,7 +191,7 @@ def _build_persisted_validation_items(
                     stderr_line_count=stderr.line_count if stderr else 0,
                     opened_at=_ensure_utc(run.started_at),
                     closed_at=_ensure_utc(run.finished_at) if run.finished_at else None,
-                    status=_run_status(run.status),
+                    status=_validation_status(run.status),
                     reason_code=run.reason_code,
                     base_commit=run.base_commit,
                     branch_name=run.target_branch or workspace.branch_name,
@@ -249,30 +253,6 @@ def _command_index(command: dict[str, Any]) -> int:
 def _command_text(command: dict[str, Any]) -> str | None:
     value = command.get("command")
     return value if isinstance(value, str) else None
-
-
-def _run_status(value: str) -> ValidationProvenanceStatus:
-    if value == "running":
-        return "running"
-    if value == "succeeded":
-        return "succeeded"
-    if value == "failed":
-        return "failed"
-    return "unknown"
-
-
-def _validation_tier(value: int) -> ValidationTier:
-    if value == 2:
-        return 2
-    if value == 3:
-        return 3
-    return 1
-
-
-def _json_dict(value: object) -> dict[str, Any]:
-    if isinstance(value, dict):
-        return value
-    return {}
 
 
 def _group_streams(streams: list[WorkspaceLogStream]) -> dict[str, _StreamPair]:

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -14,10 +15,16 @@ from awf.api.schemas import (
     ValidationProvenanceItemResponse,
     ValidationProvenanceListResponse,
     ValidationProvenanceStatus,
+    ValidationTier,
 )
+from awf.api.validation_runs import fresh_for_target
 from awf.db.enums import FailureReason, WorkspaceStatus
-from awf.db.models import Workspace, WorkspaceLogStream
-from awf.db.repositories import WorkspaceLogStreamRepository, WorkspaceRepository
+from awf.db.models import ValidationRun, Workspace, WorkspaceLogStream
+from awf.db.repositories import (
+    ValidationRunRepository,
+    WorkspaceLogStreamRepository,
+    WorkspaceRepository,
+)
 from awf.profiles.models import WorkspaceProfile
 
 router = APIRouter(prefix="/v1/workspaces/{workspace_id}/validation", tags=["validation"])
@@ -60,9 +67,18 @@ async def list_validation_provenance(
             detail={"error_code": "NOT_FOUND", "message": f"No workspace with id {workspace_id}"},
         )
 
-    streams = await WorkspaceLogStreamRepository(session).list_validation_for_workspace(
-        workspace_id
-    )
+    stream_repo = WorkspaceLogStreamRepository(session)
+    validation_runs = await ValidationRunRepository(session).list_for_workspace(workspace_id)
+    streams = await stream_repo.list_validation_for_workspace(workspace_id)
+    if validation_runs:
+        return ValidationProvenanceListResponse(
+            items=_build_persisted_validation_items(
+                workspace,
+                validation_runs,
+                streams,
+            )
+        )
+
     return ValidationProvenanceListResponse(items=_build_validation_items(workspace, streams))
 
 
@@ -129,6 +145,134 @@ def _build_validation_items(
         )
         for record in records
     ]
+
+
+def _build_persisted_validation_items(
+    workspace: Workspace,
+    validation_runs: list[ValidationRun],
+    streams: list[WorkspaceLogStream],
+) -> list[ValidationProvenanceItemResponse]:
+    stream_lookup = {stream.stream_id: stream for stream in streams}
+    current_target_head_sha = _current_target_head_sha(workspace)
+    items: list[ValidationProvenanceItemResponse] = []
+    for run in validation_runs:
+        commands = _run_commands(run)
+        if not commands:
+            commands = [
+                {
+                    "phase": "unknown",
+                    "command_index": 0,
+                    "command": None,
+                    "stream_ids": {},
+                }
+            ]
+        for command in commands:
+            stream_ids = _command_stream_ids(command)
+            stdout = stream_lookup.get(stream_ids.get("stdout") or "")
+            stderr = stream_lookup.get(stream_ids.get("stderr") or "")
+            items.append(
+                ValidationProvenanceItemResponse(
+                    validation_run_id=run.id,
+                    workspace_id=workspace.id,
+                    attempt_id=run.attempt_id,
+                    tier=_validation_tier(run.tier),
+                    command_set_hash=run.command_set_hash,
+                    phase=_command_phase(command),
+                    command_index=_command_index(command),
+                    command=_command_text(command),
+                    stream_ids=stream_ids,
+                    stdout_byte_count=stdout.byte_count if stdout else 0,
+                    stdout_line_count=stdout.line_count if stdout else 0,
+                    stderr_byte_count=stderr.byte_count if stderr else 0,
+                    stderr_line_count=stderr.line_count if stderr else 0,
+                    opened_at=_ensure_utc(run.started_at),
+                    closed_at=_ensure_utc(run.finished_at) if run.finished_at else None,
+                    status=_run_status(run.status),
+                    reason_code=run.reason_code,
+                    base_commit=run.base_commit,
+                    branch_name=run.target_branch or workspace.branch_name,
+                    target_branch=run.target_branch,
+                    target_head_sha=run.target_head_sha,
+                    current_target_head_sha=current_target_head_sha,
+                    started_at=_ensure_utc(run.started_at),
+                    finished_at=_ensure_utc(run.finished_at) if run.finished_at else None,
+                    log_stream_refs=_json_dict(run.log_stream_refs),
+                    fresh_for_target=fresh_for_target(
+                        validation_target_head_sha=run.target_head_sha,
+                        current_target_head_sha=current_target_head_sha,
+                    ),
+                )
+            )
+    return items
+
+
+def _current_target_head_sha(workspace: Workspace) -> str | None:
+    candidates = sorted(
+        workspace.merge_candidates,
+        key=lambda candidate: (candidate.updated_at, candidate.id),
+        reverse=True,
+    )
+    for candidate in candidates:
+        if candidate.head_sha:
+            return candidate.head_sha
+    return workspace.monitor_last_commit_sha
+
+
+def _run_commands(run: ValidationRun) -> list[dict[str, Any]]:
+    return list(run.commands)
+
+
+def _command_stream_ids(command: dict[str, Any]) -> dict[str, str | None]:
+    value = command.get("stream_ids")
+    if not isinstance(value, dict):
+        return {"stdout": None, "stderr": None}
+    stdout = value.get("stdout")
+    stderr = value.get("stderr")
+    return {
+        "stdout": stdout if isinstance(stdout, str) else None,
+        "stderr": stderr if isinstance(stderr, str) else None,
+    }
+
+
+def _command_phase(command: dict[str, Any]) -> str:
+    value = command.get("phase")
+    return _normalize_phase(value) if isinstance(value, str) else "unknown"
+
+
+def _command_index(command: dict[str, Any]) -> int:
+    value = command.get("command_index")
+    if isinstance(value, int):
+        return value
+    return 0
+
+
+def _command_text(command: dict[str, Any]) -> str | None:
+    value = command.get("command")
+    return value if isinstance(value, str) else None
+
+
+def _run_status(value: str) -> ValidationProvenanceStatus:
+    if value == "running":
+        return "running"
+    if value == "succeeded":
+        return "succeeded"
+    if value == "failed":
+        return "failed"
+    return "unknown"
+
+
+def _validation_tier(value: int) -> ValidationTier:
+    if value == 2:
+        return 2
+    if value == 3:
+        return 3
+    return 1
+
+
+def _json_dict(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    return {}
 
 
 def _group_streams(streams: list[WorkspaceLogStream]) -> dict[str, _StreamPair]:

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -27,6 +27,8 @@ MergeBlockerReason = Literal[
     "stale",
 ]
 MergeCandidateStatus = Literal["open", "merged", "closed"]
+ValidationTier = Literal[1, 2, 3]
+ValidationProvenanceStatus = Literal["running", "succeeded", "failed", "unknown"]
 
 
 class MergeCandidateReadinessResponse(BaseModel):
@@ -305,6 +307,23 @@ class WorkspaceOverviewListResponse(BaseModel):
     has_more: bool = False
 
 
+class ValidationRunSummaryResponse(BaseModel):
+    validation_run_id: str
+    attempt_id: str | None = None
+    tier: ValidationTier
+    command_set_hash: str
+    base_commit: str | None = None
+    target_branch: str | None = None
+    target_head_sha: str | None = None
+    current_target_head_sha: str | None = None
+    status: ValidationProvenanceStatus
+    reason_code: str | None = None
+    started_at: datetime
+    finished_at: datetime | None = None
+    log_stream_refs: dict[str, Any] = Field(default_factory=dict)
+    fresh_for_target: bool | None = None
+
+
 class MergeQueueItemResponse(BaseModel):
     candidate_id: str | None = None
     candidate_status: MergeCandidateStatus | None = None
@@ -327,6 +346,7 @@ class MergeQueueItemResponse(BaseModel):
     merge_blocker_reason: MergeBlockerReason
     readiness: MergeCandidateReadinessResponse | None = None
     canonical: bool
+    latest_validation: ValidationRunSummaryResponse | None = None
 
 
 class MergeQueueListResponse(BaseModel):
@@ -406,11 +426,12 @@ class WorkspaceLogReadResponse(BaseModel):
     data: str
 
 
-ValidationProvenanceStatus = Literal["running", "succeeded", "failed", "unknown"]
-
-
 class ValidationProvenanceItemResponse(BaseModel):
+    validation_run_id: str | None = None
     workspace_id: str
+    attempt_id: str | None = None
+    tier: ValidationTier | None = None
+    command_set_hash: str | None = None
     phase: str
     command_index: int
     command: str | None
@@ -422,8 +443,16 @@ class ValidationProvenanceItemResponse(BaseModel):
     opened_at: datetime
     closed_at: datetime | None
     status: ValidationProvenanceStatus
+    reason_code: str | None = None
     base_commit: str | None
     branch_name: str | None
+    target_branch: str | None = None
+    target_head_sha: str | None = None
+    current_target_head_sha: str | None = None
+    started_at: datetime | None = None
+    finished_at: datetime | None = None
+    log_stream_refs: dict[str, Any] = Field(default_factory=dict)
+    fresh_for_target: bool | None = None
 
 
 class ValidationProvenanceListResponse(BaseModel):

--- a/src/awf/api/validation_runs.py
+++ b/src/awf/api/validation_runs.py
@@ -1,0 +1,81 @@
+"""Helpers for exposing durable validation run provenance."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from awf.api.schemas import (
+    ValidationProvenanceStatus,
+    ValidationRunSummaryResponse,
+    ValidationTier,
+)
+from awf.db.models import ValidationRun
+
+
+def validation_run_summary(
+    run: ValidationRun,
+    *,
+    current_target_head_sha: str | None,
+) -> ValidationRunSummaryResponse:
+    status = _validation_status(run.status)
+    return ValidationRunSummaryResponse(
+        validation_run_id=run.id,
+        attempt_id=run.attempt_id,
+        tier=_validation_tier(run.tier),
+        command_set_hash=run.command_set_hash,
+        base_commit=run.base_commit,
+        target_branch=run.target_branch,
+        target_head_sha=run.target_head_sha,
+        current_target_head_sha=current_target_head_sha,
+        status=status,
+        reason_code=run.reason_code,
+        started_at=_ensure_utc(run.started_at),
+        finished_at=_ensure_utc(run.finished_at) if run.finished_at is not None else None,
+        log_stream_refs=_json_dict(run.log_stream_refs),
+        fresh_for_target=fresh_for_target(
+            validation_target_head_sha=run.target_head_sha,
+            current_target_head_sha=current_target_head_sha,
+        ),
+    )
+
+
+def fresh_for_target(
+    *,
+    validation_target_head_sha: str | None,
+    current_target_head_sha: str | None,
+) -> bool | None:
+    if not validation_target_head_sha or not current_target_head_sha:
+        return None
+    return validation_target_head_sha == current_target_head_sha
+
+
+def _validation_status(value: str) -> ValidationProvenanceStatus:
+    if value == "running":
+        return "running"
+    if value == "succeeded":
+        return "succeeded"
+    if value == "failed":
+        return "failed"
+    return "unknown"
+
+
+def _validation_tier(value: int) -> ValidationTier:
+    if value == 2:
+        return 2
+    if value == 3:
+        return 3
+    return 1
+
+
+def _ensure_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _json_dict(value: object) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(k): v for k, v in value.items()}
+    return {}

--- a/src/awf/common/ids.py
+++ b/src/awf/common/ids.py
@@ -26,6 +26,10 @@ def new_merge_candidate_id() -> str:
     return f"mc_{uuid4().hex[:24]}"
 
 
+def new_validation_run_id() -> str:
+    return f"vr_{uuid4().hex[:24]}"
+
+
 def new_operation_id() -> str:
     return f"op_{uuid4().hex[:24]}"
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -19,9 +19,9 @@ import inspect
 import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -44,13 +44,17 @@ from awf.control.validation_fix_cycle import (
 )
 from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import (
+    TaskAttemptRepository,
+    ValidationRunRepository,
+    WorkspaceRepository,
+)
 from awf.node.compose_manager import ComposeManager, ComposeOperationError
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
 from awf.runtime.logs import LogStore
 from awf.runtime.pr_creator import PullRequestCreator, PullRequestError
-from awf.runtime.validation import ValidationRunner
+from awf.runtime.validation import ValidationResult, ValidationRunner
 
 
 class _MonitorRunnerProto(Protocol):
@@ -587,6 +591,7 @@ class WorkspaceExecutor:
         ]
         test_commands_tuple = tuple(validation_commands)
         last_failure_message: str | None = None
+        successful_validation_run_id: str | None = None
         for pass_number in range(max_fix_passes + 1):
             # pass_number == 0 is the initial run (already-committed agent
             # work). 1..N are fix attempts driven by the retry prompt.
@@ -596,6 +601,13 @@ class WorkspaceExecutor:
                 action="validate",
             ):
                 return
+            validation_run_id = await self._start_validation_run(
+                workspace_id=workspace_id,
+                profile=profile,
+                base_commit=base_commit,
+                target_branch=expected_branch,
+                target_head_sha=None,
+            )
             val_result = await self._validation.run_profile_phases(
                 workspace_id=workspace_id,
                 compose_project=compose_project,
@@ -604,7 +616,13 @@ class WorkspaceExecutor:
                 phase_names=("post_agent", "validate"),
                 run_healthchecks=True,
             )
+            await self._finish_validation_run(
+                validation_run_id,
+                status="succeeded" if val_result.all_passed else "failed",
+                reason_code=_validation_run_reason_code(val_result),
+            )
             if val_result.all_passed:
+                successful_validation_run_id = validation_run_id
                 if pass_number > 0:
                     _log.info(
                         "executor.validation_recovered",
@@ -753,6 +771,11 @@ class WorkspaceExecutor:
                 title=pr_title,
                 body=pr_body,
             )
+            if successful_validation_run_id is not None and pr.head_sha:
+                await self._set_validation_run_target_head_sha(
+                    validation_run_id=successful_validation_run_id,
+                    target_head_sha=pr.head_sha,
+                )
         except PullRequestError as exc:
             _log.error(
                 "executor.pr_failed",
@@ -795,6 +818,8 @@ class WorkspaceExecutor:
                 return
             persisted.pr_url = pr.url
             persisted.pr_number = _extract_pr_number(pr.url)
+            if pr.head_sha:
+                persisted.monitor_last_commit_sha = pr.head_sha
             if persisted.task_kind == "feature_branch_pr" and not persisted.remote_push_branch:
                 persisted.remote_push_branch = (
                     pr.branch or persisted.branch_name or f"awf/{workspace_id}"
@@ -1185,6 +1210,65 @@ class WorkspaceExecutor:
             )
             await session.commit()
 
+    async def _start_validation_run(
+        self,
+        *,
+        workspace_id: str,
+        profile: WorkspaceProfile,
+        base_commit: str | None,
+        target_branch: str | None,
+        target_head_sha: str | None,
+    ) -> str:
+        command_records = _validation_run_command_records(
+            profile=profile,
+            phase_names=("post_agent", "validate"),
+            run_healthchecks=True,
+        )
+        async with self._session_factory() as session:
+            attempt = await TaskAttemptRepository(session).get_by_workspace_id(workspace_id)
+            run = await ValidationRunRepository(session).start(
+                workspace_id=workspace_id,
+                attempt_id=attempt.id if attempt is not None else None,
+                tier=1,
+                commands=command_records,
+                base_commit=base_commit,
+                target_branch=target_branch,
+                target_head_sha=target_head_sha,
+                log_stream_refs=_validation_run_log_stream_refs(command_records),
+                started_at=datetime.now(UTC),
+            )
+            await session.commit()
+            return run.id
+
+    async def _finish_validation_run(
+        self,
+        validation_run_id: str,
+        *,
+        status: str,
+        reason_code: str | None,
+    ) -> None:
+        async with self._session_factory() as session:
+            await ValidationRunRepository(session).finish(
+                validation_run_id,
+                status=status,
+                reason_code=reason_code,
+                finished_at=datetime.now(UTC),
+            )
+            await session.commit()
+
+    async def _set_validation_run_target_head_sha(
+        self,
+        *,
+        validation_run_id: str,
+        target_head_sha: str,
+    ) -> None:
+        async with self._session_factory() as session:
+            await ValidationRunRepository(session).update_target_head_sha(
+                validation_run_id,
+                target_head_sha=target_head_sha,
+            )
+            await session.commit()
+
 
 _PR_NUMBER_RE = re.compile(r"/pull/(\d+)(?:/|$)")
 
@@ -1295,3 +1379,67 @@ def _validation_command_count(ws: Workspace) -> int:
         profile = WorkspaceProfile.model_validate(ws.resolved_profile)
         return len(profile.phases.post_agent) + len(profile.phases.validate_commands)
     return len(ws.test_commands)
+
+
+def _validation_run_command_records(
+    *,
+    profile: WorkspaceProfile,
+    phase_names: tuple[str, ...],
+    run_healthchecks: bool,
+) -> list[dict[str, Any]]:
+    ordered: list[tuple[str, str]] = []
+    if run_healthchecks:
+        ordered.extend(
+            ("healthcheck", healthcheck.command) for healthcheck in profile.validation.healthchecks
+        )
+    ordered.extend(
+        (phase, command.command) for phase, command in profile.phases.commands_for(phase_names)
+    )
+
+    records: list[dict[str, Any]] = []
+    phase_indices: dict[str, int] = {}
+    for phase, command in ordered:
+        phase_indices[phase] = phase_indices.get(phase, 0) + 1
+        command_index = phase_indices[phase]
+        label = f"{command_index:02d}_{phase}"
+        records.append(
+            {
+                "phase": phase,
+                "command_index": command_index,
+                "command": command,
+                "stream_ids": {
+                    "stdout": f"validation.{label}.stdout",
+                    "stderr": f"validation.{label}.stderr",
+                },
+            }
+        )
+    return records
+
+
+def _validation_run_log_stream_refs(
+    command_records: list[dict[str, Any]],
+) -> dict[str, list[dict[str, str | None]]]:
+    refs: list[dict[str, str | None]] = []
+    for command in command_records:
+        stream_ids = command.get("stream_ids")
+        if not isinstance(stream_ids, dict):
+            refs.append({"stdout": None, "stderr": None})
+            continue
+        stdout = stream_ids.get("stdout")
+        stderr = stream_ids.get("stderr")
+        refs.append(
+            {
+                "stdout": stdout if isinstance(stdout, str) else None,
+                "stderr": stderr if isinstance(stderr, str) else None,
+            }
+        )
+    return {"commands": refs}
+
+
+def _validation_run_reason_code(result: ValidationResult) -> str:
+    if result.all_passed:
+        return "VALIDATION_OK"
+    first_failure = result.first_failure
+    if first_failure is None:
+        return "VALIDATION_FAILED"
+    return first_failure.reason_code

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -608,14 +608,34 @@ class WorkspaceExecutor:
                 target_branch=expected_branch,
                 target_head_sha=None,
             )
-            val_result = await self._validation.run_profile_phases(
-                workspace_id=workspace_id,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                profile=profile,
-                phase_names=("post_agent", "validate"),
-                run_healthchecks=True,
-            )
+            try:
+                val_result = await self._validation.run_profile_phases(
+                    workspace_id=workspace_id,
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    profile=profile,
+                    phase_names=("post_agent", "validate"),
+                    run_healthchecks=True,
+                )
+            except Exception as exc:
+                _log.exception(
+                    "executor.validation_run_unexpected_failed",
+                    workspace_id=workspace_id,
+                    validation_run_id=validation_run_id,
+                )
+                await self._finish_validation_run(
+                    validation_run_id,
+                    status="failed",
+                    reason_code="VALIDATION_INFRASTRUCTURE_ERROR",
+                )
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.validating,
+                    failure_reason=FailureReason.infrastructure_failure,
+                    message=f"unexpected error during validation run: {exc!r}"[:2000],
+                    reason_code="VALIDATION_INFRASTRUCTURE_ERROR",
+                )
+                return
             await self._finish_validation_run(
                 validation_run_id,
                 status="succeeded" if val_result.all_passed else "failed",

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -791,11 +791,6 @@ class WorkspaceExecutor:
                 title=pr_title,
                 body=pr_body,
             )
-            if successful_validation_run_id is not None and pr.head_sha:
-                await self._set_validation_run_target_head_sha(
-                    validation_run_id=successful_validation_run_id,
-                    target_head_sha=pr.head_sha,
-                )
         except PullRequestError as exc:
             _log.error(
                 "executor.pr_failed",
@@ -870,6 +865,20 @@ class WorkspaceExecutor:
                     persisted, to=WorkspaceStatus.completed, reason_code="PR_OPENED"
                 )
                 await session.commit()
+
+        if successful_validation_run_id is not None and pr.head_sha:
+            try:
+                await self._set_validation_run_target_head_sha(
+                    validation_run_id=successful_validation_run_id,
+                    target_head_sha=pr.head_sha,
+                )
+            except Exception:
+                _log.exception(
+                    "executor.validation_run_target_head_sha_update_failed",
+                    workspace_id=workspace_id,
+                    validation_run_id=successful_validation_run_id,
+                    target_head_sha=pr.head_sha,
+                )
 
         if monitor is not None:
             _log.info(

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -243,7 +243,7 @@ class Workspace(Base):
     validation_runs: Mapped[list[ValidationRun]] = relationship(
         back_populates="workspace",
         cascade="all, delete-orphan",
-        lazy="selectin",
+        lazy="raise",
         order_by="ValidationRun.started_at",
     )
 
@@ -362,7 +362,7 @@ class TaskAttempt(Base):
     )
     validation_runs: Mapped[list[ValidationRun]] = relationship(
         back_populates="attempt",
-        lazy="selectin",
+        lazy="raise",
         order_by="ValidationRun.started_at",
     )
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -240,6 +240,12 @@ class Workspace(Base):
         lazy="selectin",
         order_by="MergeCandidate.updated_at",
     )
+    validation_runs: Mapped[list[ValidationRun]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="ValidationRun.started_at",
+    )
 
 
 class Task(Base):
@@ -354,6 +360,11 @@ class TaskAttempt(Base):
         lazy="selectin",
         uselist=False,
     )
+    validation_runs: Mapped[list[ValidationRun]] = relationship(
+        back_populates="attempt",
+        lazy="selectin",
+        order_by="ValidationRun.started_at",
+    )
 
 
 class MergeCandidate(Base):
@@ -412,6 +423,64 @@ class MergeCandidate(Base):
     task: Mapped[Task] = relationship(back_populates="merge_candidates")
     attempt: Mapped[TaskAttempt] = relationship(back_populates="merge_candidate")
     workspace: Mapped[Workspace] = relationship(back_populates="merge_candidates")
+
+
+class ValidationRun(Base):
+    """Durable validation provenance for one configured command execution pass."""
+
+    __tablename__ = "validation_runs"
+    __table_args__ = (
+        Index("ix_validation_runs_workspace_started", "workspace_id", "started_at"),
+        Index("ix_validation_runs_workspace_finished", "workspace_id", "finished_at"),
+        Index("ix_validation_runs_attempt", "attempt_id"),
+        Index("ix_validation_runs_status", "status"),
+        Index("ix_validation_runs_tier", "tier"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+    attempt_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=True
+    )
+
+    tier: Mapped[int] = mapped_column(Integer, nullable=False)
+    command_set_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    commands: Mapped[list[dict[str, Any]]] = mapped_column(
+        JSON, nullable=False, default=list, server_default=text("'[]'")
+    )
+
+    base_commit: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    target_branch: Mapped[str | None] = mapped_column(String(256), nullable=True)
+    target_head_sha: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    status: Mapped[str] = mapped_column(String(16), nullable=False)
+    reason_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    log_stream_refs: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, server_default=text("'{}'")
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_now,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=_now,
+        onupdate=_now,
+        nullable=False,
+        server_default=text("CURRENT_TIMESTAMP"),
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="validation_runs")
+    attempt: Mapped[TaskAttempt | None] = relationship(back_populates="validation_runs")
 
 
 class Operation(Base):

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import builtins
 import hashlib
+import json
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -30,6 +31,7 @@ from awf.common.ids import (
     new_operation_id,
     new_task_attempt_id,
     new_task_id,
+    new_validation_run_id,
     new_workspace_id,
 )
 from awf.control.state_machine import WorkspaceStateMachine
@@ -40,6 +42,7 @@ from awf.db.models import (
     Operation,
     Task,
     TaskAttempt,
+    ValidationRun,
     Workspace,
     WorkspaceEvent,
     WorkspaceLogStream,
@@ -68,6 +71,13 @@ class WorkspaceEventCreate:
     event_type: str
     reason_code: str | None = None
     payload: dict[str, Any] | None = None
+
+
+def validation_command_set_hash(commands: list[dict[str, Any]]) -> str:
+    """Stable hash for the configured command metadata in a validation run."""
+
+    payload = json.dumps(commands, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _resolve_session_dialect_name(
@@ -550,6 +560,110 @@ class MergeCandidateRepository:
         return candidate
 
 
+class ValidationRunRepository:
+    """CRUD helpers for durable validation provenance rows."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def start(
+        self,
+        *,
+        workspace_id: str,
+        attempt_id: str | None,
+        tier: int,
+        commands: list[dict[str, Any]],
+        base_commit: str | None,
+        target_branch: str | None,
+        target_head_sha: str | None,
+        log_stream_refs: dict[str, Any],
+        started_at: datetime | None = None,
+    ) -> ValidationRun:
+        now = started_at or datetime.now(UTC)
+        run = ValidationRun(
+            id=new_validation_run_id(),
+            workspace_id=workspace_id,
+            attempt_id=attempt_id,
+            tier=tier,
+            command_set_hash=validation_command_set_hash(commands),
+            commands=commands,
+            base_commit=base_commit,
+            target_branch=target_branch,
+            target_head_sha=target_head_sha,
+            status="running",
+            reason_code=None,
+            started_at=now,
+            finished_at=None,
+            log_stream_refs=log_stream_refs,
+        )
+        self._session.add(run)
+        await self._session.flush()
+        return run
+
+    async def get(self, validation_run_id: str) -> ValidationRun | None:
+        return await self._session.get(ValidationRun, validation_run_id)
+
+    async def finish(
+        self,
+        validation_run_id: str,
+        *,
+        status: str,
+        reason_code: str | None,
+        finished_at: datetime | None = None,
+    ) -> ValidationRun | None:
+        run = await self.get(validation_run_id)
+        if run is None:
+            return None
+        run.status = status
+        run.reason_code = reason_code
+        run.finished_at = finished_at or datetime.now(UTC)
+        await self._session.flush()
+        return run
+
+    async def update_target_head_sha(
+        self,
+        validation_run_id: str,
+        *,
+        target_head_sha: str | None,
+    ) -> ValidationRun | None:
+        run = await self.get(validation_run_id)
+        if run is None:
+            return None
+        run.target_head_sha = target_head_sha
+        await self._session.flush()
+        return run
+
+    async def list_for_workspace(self, workspace_id: str) -> builtins.list[ValidationRun]:
+        stmt = (
+            select(ValidationRun)
+            .where(ValidationRun.workspace_id == workspace_id)
+            .order_by(ValidationRun.started_at, ValidationRun.id)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def latest_by_workspace_ids(
+        self,
+        workspace_ids: Iterable[str],
+    ) -> dict[str, ValidationRun]:
+        unique_workspace_ids = tuple(dict.fromkeys(workspace_ids))
+        if not unique_workspace_ids:
+            return {}
+
+        stmt = (
+            select(ValidationRun)
+            .where(ValidationRun.workspace_id.in_(unique_workspace_ids))
+            .order_by(
+                ValidationRun.workspace_id,
+                ValidationRun.started_at.desc(),
+                ValidationRun.id.desc(),
+            )
+        )
+        latest: dict[str, ValidationRun] = {}
+        for run in (await self._session.execute(stmt)).scalars():
+            latest.setdefault(run.workspace_id, run)
+        return latest
+
+
 class WorkspaceRepository:
     """CRUD + state transitions for workspaces.
 
@@ -978,6 +1092,8 @@ class WorkspaceRepository:
                 task=task,
                 attempt=attempt,
                 workspace=workspace,
+                head_sha=workspace.monitor_last_commit_sha,
+                base_sha=workspace.base_commit,
             )
             return
 

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -649,19 +649,28 @@ class ValidationRunRepository:
         if not unique_workspace_ids:
             return {}
 
+        ranked_runs = (
+            select(
+                ValidationRun.id.label("validation_run_id"),
+                func.row_number()
+                .over(
+                    partition_by=ValidationRun.workspace_id,
+                    order_by=(
+                        ValidationRun.started_at.desc(),
+                        ValidationRun.id.desc(),
+                    ),
+                )
+                .label("run_rank"),
+            )
+            .where(ValidationRun.workspace_id.in_(unique_workspace_ids))
+            .subquery()
+        )
         stmt = (
             select(ValidationRun)
-            .where(ValidationRun.workspace_id.in_(unique_workspace_ids))
-            .order_by(
-                ValidationRun.workspace_id,
-                ValidationRun.started_at.desc(),
-                ValidationRun.id.desc(),
-            )
+            .join(ranked_runs, ValidationRun.id == ranked_runs.c.validation_run_id)
+            .where(ranked_runs.c.run_rank == 1)
         )
-        latest: dict[str, ValidationRun] = {}
-        for run in (await self._session.execute(stmt)).scalars():
-            latest.setdefault(run.workspace_id, run)
-        return latest
+        return {run.workspace_id: run for run in (await self._session.execute(stmt)).scalars()}
 
 
 class WorkspaceRepository:

--- a/src/awf/runtime/pr_creator.py
+++ b/src/awf/runtime/pr_creator.py
@@ -54,6 +54,7 @@ def _redact_credentials(text: str) -> str:
 class PullRequestResult:
     url: str
     branch: str
+    head_sha: str | None = None
 
 
 class PullRequestError(Exception):
@@ -92,7 +93,7 @@ class PullRequestCreator:
         # local branch was empty relative to base (bad commit step), or
         # (c) HEAD was detached / on a different branch. These three
         # logs answer all three questions:
-        await self._log_pre_push_diagnostics(
+        head_sha = await self._log_pre_push_diagnostics(
             worktree_path=worktree_path,
             branch_name=branch_name,
             base_branch=base_branch,
@@ -163,7 +164,7 @@ class PullRequestCreator:
 
         url = url_match.group(0)
         _log.info("pr.created", branch=branch_name, url=url)
-        return PullRequestResult(url=url, branch=branch_name)
+        return PullRequestResult(url=url, branch=branch_name, head_sha=head_sha)
 
     async def _log_pre_push_diagnostics(
         self,
@@ -171,7 +172,7 @@ class PullRequestCreator:
         worktree_path: Path,
         branch_name: str,
         base_branch: str,
-    ) -> None:
+    ) -> str | None:
         """Capture the local git state right before the push fires.
 
         Three queries, one structured log line:
@@ -248,3 +249,4 @@ class PullRequestCreator:
             commits_ahead_rc=ahead_of_base.returncode,
             base_branch=base_branch,
         )
+        return head_sha.stdout.strip() or None

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -44,6 +44,7 @@ class ValidationCommandResult:
     stderr_path: Path
     phase: str = "validate"
     reason_code: str = "COMMAND_FAILED"
+    stream_ids: dict[str, str | None] = field(default_factory=dict)
 
     @property
     def ok(self) -> bool:
@@ -216,11 +217,16 @@ class ValidationRunner:
         ]
         started = time.monotonic()
         reason_code = "COMMAND_FAILED"
+        base_stream_id = f"validation.{label}"
+        stream_ids: dict[str, str | None] = {
+            "stdout": f"{base_stream_id}.stdout",
+            "stderr": f"{base_stream_id}.stderr",
+        }
         sinks = None
         if self._log_store is not None:
             sinks = await self._log_store.open_command_streams(
                 workspace_id=artifacts_dir.name,
-                base_stream_id=f"validation.{label}",
+                base_stream_id=base_stream_id,
                 source="validation",
                 name=f"{phase} {label}",
             )
@@ -284,6 +290,7 @@ class ValidationRunner:
             stderr_path=stderr_path,
             phase=phase,
             reason_code=reason_code,
+            stream_ids=stream_ids,
         )
 
 

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.db.enums import AgentRuntime, WorkspaceStatus
@@ -93,6 +95,104 @@ async def _create_queue_workspace(
         return workspace.id
 
 
+async def _attempt_id_for_workspace(engine: AsyncEngine, workspace_id: str) -> str:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        result = await session.execute(
+            text("SELECT id FROM task_attempts WHERE workspace_id = :workspace_id"),
+            {"workspace_id": workspace_id},
+        )
+        attempt_id = result.scalar_one()
+        assert isinstance(attempt_id, str)
+        return attempt_id
+
+
+async def _insert_validation_run(
+    engine: AsyncEngine,
+    *,
+    run_id: str,
+    workspace_id: str,
+    attempt_id: str,
+    target_head_sha: str,
+    status: str = "succeeded",
+    finished_at: datetime = datetime(2026, 4, 26, 12, 5, tzinfo=UTC),
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO validation_runs (
+                    id,
+                    workspace_id,
+                    attempt_id,
+                    tier,
+                    command_set_hash,
+                    commands,
+                    base_commit,
+                    target_branch,
+                    target_head_sha,
+                    status,
+                    reason_code,
+                    started_at,
+                    finished_at,
+                    log_stream_refs
+                )
+                VALUES (
+                    :id,
+                    :workspace_id,
+                    :attempt_id,
+                    1,
+                    :command_set_hash,
+                    :commands,
+                    'base123',
+                    'codex/merge-queue',
+                    :target_head_sha,
+                    :status,
+                    'VALIDATION_OK',
+                    :started_at,
+                    :finished_at,
+                    :log_stream_refs
+                )
+                """
+            ),
+            {
+                "id": run_id,
+                "workspace_id": workspace_id,
+                "attempt_id": attempt_id,
+                "target_head_sha": target_head_sha,
+                "status": status,
+                "command_set_hash": "b" * 64,
+                "commands": json.dumps(
+                    [
+                        {
+                            "phase": "validate",
+                            "command_index": 1,
+                            "command": "pytest -q",
+                            "stream_ids": {
+                                "stdout": "validation.01_validate.stdout",
+                                "stderr": "validation.01_validate.stderr",
+                            },
+                        }
+                    ]
+                ),
+                "started_at": datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
+                "finished_at": finished_at,
+                "log_stream_refs": json.dumps(
+                    {
+                        "commands": [
+                            {
+                                "stdout": "validation.01_validate.stdout",
+                                "stderr": "validation.01_validate.stderr",
+                            }
+                        ]
+                    }
+                ),
+            },
+        )
+        await session.commit()
+
+
 class TestMergeQueueList:
     @pytest.mark.unit
     async def test_lists_active_pr_workspaces_newest_updated_first_with_required_shape(
@@ -154,6 +254,7 @@ class TestMergeQueueList:
             "merge_blocker_reason",
             "readiness",
             "canonical",
+            "latest_validation",
         }
         assert item["candidate_id"].startswith("mc_")
         assert item["candidate_status"] == "open"
@@ -180,6 +281,7 @@ class TestMergeQueueList:
             "not_canonical": False,
             "stale": False,
         }
+        assert item["latest_validation"] is None
         assert newer_id not in {row["workspace_id"] for row in body["items"]}
 
     @pytest.mark.unit
@@ -384,3 +486,58 @@ class TestMergeQueueList:
             "stale": False,
         }
         assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
+
+    @pytest.mark.unit
+    async def test_exposes_latest_validation_provenance_and_freshness(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_queue_workspace(
+            engine,
+            title="Validation provenance",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/22",
+            branch_name="codex/merge-queue",
+            updated_at=datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
+        )
+        attempt_id = await _attempt_id_for_workspace(engine, workspace_id)
+        await _insert_validation_run(
+            engine,
+            run_id="vr_222222222222222222222222",
+            workspace_id=workspace_id,
+            attempt_id=attempt_id,
+            target_head_sha="old-head",
+        )
+
+        response = await client.get("/v1/merge-queue")
+
+        assert response.status_code == 200
+        item = next(
+            item
+            for item in response.json()["items"]
+            if item["workspace_id"] == workspace_id
+        )
+        assert item["latest_validation"] == {
+            "validation_run_id": "vr_222222222222222222222222",
+            "attempt_id": attempt_id,
+            "tier": 1,
+            "command_set_hash": "b" * 64,
+            "base_commit": "base123",
+            "target_branch": "codex/merge-queue",
+            "target_head_sha": "old-head",
+            "current_target_head_sha": "head123",
+            "status": "succeeded",
+            "reason_code": "VALIDATION_OK",
+            "started_at": "2026-04-26T12:00:00Z",
+            "finished_at": "2026-04-26T12:05:00Z",
+            "log_stream_refs": {
+                "commands": [
+                    {
+                        "stdout": "validation.01_validate.stdout",
+                        "stderr": "validation.01_validate.stderr",
+                    }
+                ]
+            },
+            "fresh_for_target": False,
+        }

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime, timedelta
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.db.enums import FailureReason, WorkspaceStatus
@@ -158,6 +160,83 @@ async def _mark_workspace_validation_failed(
         await session.commit()
 
 
+async def _insert_validation_run(
+    engine: AsyncEngine,
+    *,
+    run_id: str,
+    workspace_id: str,
+    attempt_id: str | None = None,
+    tier: int = 1,
+    command_set_hash: str = "0" * 64,
+    commands: list[dict] | None = None,
+    base_commit: str | None = "base-persisted",
+    target_branch: str | None = "awf/persisted-validation",
+    target_head_sha: str | None = "target-persisted",
+    status: str = "succeeded",
+    reason_code: str | None = "VALIDATION_OK",
+    started_at: datetime = datetime(2026, 4, 26, 13, 0, tzinfo=UTC),
+    finished_at: datetime | None = datetime(2026, 4, 26, 13, 2, tzinfo=UTC),
+    log_stream_refs: dict | None = None,
+) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO validation_runs (
+                    id,
+                    workspace_id,
+                    attempt_id,
+                    tier,
+                    command_set_hash,
+                    commands,
+                    base_commit,
+                    target_branch,
+                    target_head_sha,
+                    status,
+                    reason_code,
+                    started_at,
+                    finished_at,
+                    log_stream_refs
+                )
+                VALUES (
+                    :id,
+                    :workspace_id,
+                    :attempt_id,
+                    :tier,
+                    :command_set_hash,
+                    :commands,
+                    :base_commit,
+                    :target_branch,
+                    :target_head_sha,
+                    :status,
+                    :reason_code,
+                    :started_at,
+                    :finished_at,
+                    :log_stream_refs
+                )
+                """
+            ),
+            {
+                "id": run_id,
+                "workspace_id": workspace_id,
+                "attempt_id": attempt_id,
+                "tier": tier,
+                "command_set_hash": command_set_hash,
+                "commands": json.dumps(commands or []),
+                "base_commit": base_commit,
+                "target_branch": target_branch,
+                "target_head_sha": target_head_sha,
+                "status": status,
+                "reason_code": reason_code,
+                "started_at": started_at,
+                "finished_at": finished_at,
+                "log_stream_refs": json.dumps(log_stream_refs or {}),
+            },
+        )
+        await session.commit()
+
+
 @pytest.mark.unit
 async def test_validation_provenance_groups_streams_and_resolves_profile_commands(
     client: AsyncClient,
@@ -222,6 +301,100 @@ async def test_validation_provenance_groups_streams_and_resolves_profile_command
     assert first["status"] == "succeeded"
     assert first["base_commit"] == "abc123def456"
     assert first["branch_name"] == "codex/validation-provenance"
+
+
+@pytest.mark.unit
+async def test_validation_provenance_prefers_persisted_validation_runs(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace(client)
+    await _mark_workspace_completed(engine, workspace_id)
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.cmd_01",
+        phase="validate",
+        stdout_bytes=999,
+        stdout_lines=99,
+        stderr_bytes=0,
+        stderr_lines=0,
+    )
+    await _create_stream_pair(
+        engine,
+        workspace_id=workspace_id,
+        base_stream_id="validation.run_01",
+        phase="validate",
+        stdout_bytes=42,
+        stdout_lines=3,
+        stderr_bytes=7,
+        stderr_lines=1,
+    )
+    await _insert_validation_run(
+        engine,
+        run_id="vr_111111111111111111111111",
+        workspace_id=workspace_id,
+        tier=2,
+        command_set_hash="a" * 64,
+        commands=[
+            {
+                "phase": "validate",
+                "command_index": 1,
+                "command": "npm test",
+                "stream_ids": {
+                    "stdout": "validation.run_01.stdout",
+                    "stderr": "validation.run_01.stderr",
+                },
+            }
+        ],
+        log_stream_refs={
+            "commands": [
+                {
+                    "stdout": "validation.run_01.stdout",
+                    "stderr": "validation.run_01.stderr",
+                }
+            ]
+        },
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["items"]) == 1
+    item = body["items"][0]
+    assert item["validation_run_id"] == "vr_111111111111111111111111"
+    assert item["tier"] == 2
+    assert item["command_set_hash"] == "a" * 64
+    assert item["phase"] == "validate"
+    assert item["command_index"] == 1
+    assert item["command"] == "npm test"
+    assert item["stream_ids"] == {
+        "stdout": "validation.run_01.stdout",
+        "stderr": "validation.run_01.stderr",
+    }
+    assert item["stdout_byte_count"] == 42
+    assert item["stdout_line_count"] == 3
+    assert item["stderr_byte_count"] == 7
+    assert item["stderr_line_count"] == 1
+    assert item["status"] == "succeeded"
+    assert item["reason_code"] == "VALIDATION_OK"
+    assert item["base_commit"] == "base-persisted"
+    assert item["branch_name"] == "awf/persisted-validation"
+    assert item["target_branch"] == "awf/persisted-validation"
+    assert item["target_head_sha"] == "target-persisted"
+    assert item["current_target_head_sha"] is None
+    assert item["fresh_for_target"] is None
+    assert item["started_at"] == "2026-04-26T13:00:00Z"
+    assert item["finished_at"] == "2026-04-26T13:02:00Z"
+    assert item["log_stream_refs"] == {
+        "commands": [
+            {
+                "stdout": "validation.run_01.stdout",
+                "stderr": "validation.run_01.stderr",
+            }
+        ]
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -7,11 +7,13 @@ since each call is distinguishable by its argv.
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.adapters import registry as _registry  # noqa: F401 - populates adapter registry
@@ -220,6 +222,106 @@ class TestHappyPath:
             assert ("running", "validating") in transitions
             assert ("validating", "pushing") in transitions
             assert ("pushing", "completed") in transitions
+
+    @pytest.mark.unit
+    async def test_records_tier1_validation_run_provenance(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            test_commands=["ruff check .", "pytest -q"],
+        )
+        fake.queue_result(returncode=0)  # adapter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="f\n")  # diff --cached
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor ok
+        fake.queue_result(returncode=0, stdout="ruff ok")  # validation cmd 1
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation cmd 2
+        _queue_pre_push_diagnostics(fake)
+        fake.queue_result(returncode=0)  # push
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        async with factory() as session:
+            rows = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT
+                            workspace_id,
+                            attempt_id,
+                            tier,
+                            command_set_hash,
+                            commands,
+                            base_commit,
+                            target_branch,
+                            target_head_sha,
+                            status,
+                            reason_code,
+                            started_at,
+                            finished_at,
+                            log_stream_refs
+                        FROM validation_runs
+                        WHERE workspace_id = :workspace_id
+                        """
+                    ),
+                    {"workspace_id": ws_id},
+                )
+            ).mappings().all()
+
+        assert len(rows) == 1
+        run = rows[0]
+        assert run["workspace_id"] == ws_id
+        assert run["attempt_id"] is None
+        assert run["tier"] == 1
+        assert isinstance(run["command_set_hash"], str)
+        assert len(run["command_set_hash"]) == 64
+        assert json.loads(run["commands"]) == [
+            {
+                "phase": "validate",
+                "command_index": 1,
+                "command": "ruff check .",
+                "stream_ids": {
+                    "stdout": "validation.01_validate.stdout",
+                    "stderr": "validation.01_validate.stderr",
+                },
+            },
+            {
+                "phase": "validate",
+                "command_index": 2,
+                "command": "pytest -q",
+                "stream_ids": {
+                    "stdout": "validation.02_validate.stdout",
+                    "stderr": "validation.02_validate.stderr",
+                },
+            },
+        ]
+        assert run["base_commit"] == "a" * 40
+        assert run["target_branch"] == f"awf/{ws_id}"
+        assert run["target_head_sha"] is None
+        assert run["status"] == "succeeded"
+        assert run["reason_code"] == "VALIDATION_OK"
+        assert run["started_at"] is not None
+        assert run["finished_at"] is not None
+        assert json.loads(run["log_stream_refs"]) == {
+            "commands": [
+                {
+                    "stdout": "validation.01_validate.stdout",
+                    "stderr": "validation.01_validate.stderr",
+                },
+                {
+                    "stdout": "validation.02_validate.stdout",
+                    "stderr": "validation.02_validate.stderr",
+                },
+            ]
+        }
 
 
 class TestFailurePaths:

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -305,7 +305,7 @@ class TestHappyPath:
         ]
         assert run["base_commit"] == "a" * 40
         assert run["target_branch"] == f"awf/{ws_id}"
-        assert run["target_head_sha"] is None
+        assert run["target_head_sha"] == "deadbeef01"
         assert run["status"] == "succeeded"
         assert run["reason_code"] == "VALIDATION_OK"
         assert run["started_at"] is not None

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -30,7 +30,7 @@ from awf.common.commands import FakeCommandRunner
 from awf.control.executor import ExecutorConfig, WorkspaceExecutor, _call_pr_monitor_factory
 from awf.db.base import Base
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import ValidationRunRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.node.compose_manager import ComposeManager
 from awf.profiles.models import ProfileMonitor, WorkspaceProfile
@@ -110,6 +110,22 @@ class _RecordingValidation:
         **_kwargs: Any,
     ) -> SimpleNamespace:
         self.calls.append(phase_names)
+        return SimpleNamespace(all_passed=True, first_failure=None)
+
+
+class _ExplodingValidation:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, ...]] = []
+
+    async def run_profile_phases(
+        self,
+        *,
+        phase_names: tuple[str, ...],
+        **_kwargs: Any,
+    ) -> SimpleNamespace:
+        self.calls.append(phase_names)
+        if phase_names == ("post_agent", "validate"):
+            raise RuntimeError("docker compose validation failed")
         return SimpleNamespace(all_passed=True, first_failure=None)
 
 
@@ -715,6 +731,44 @@ class TestCommitStepRuntimeError:
             assert ws is not None
             assert ws.status == WorkspaceStatus.failed.value
             assert "commit step failed" in (ws.failure_message or "")
+
+
+class TestValidationInfrastructureError:
+    @pytest.mark.unit
+    async def test_validation_runner_exception_finishes_validation_run(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        validation = _ExplodingValidation()
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="a.py\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+
+        executor = _make_executor(fake, factory, tmp_path, validation=validation)
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert "unexpected error during validation run" in (ws.failure_message or "")
+
+            runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+            assert len(runs) == 1
+            run = runs[0]
+            assert run.status == "failed"
+            assert run.reason_code == "VALIDATION_INFRASTRUCTURE_ERROR"
+            assert run.finished_at is not None
+
+        assert validation.calls == [("setup", "pre_agent"), ("post_agent", "validate")]
 
 
 class TestPullRequestUnexpectedError:

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -343,9 +343,7 @@ class TestUnexpectedErrorDuringAgentRun:
 
 class TestOperatorControlRaces:
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
-    )
+    @pytest.mark.parametrize("final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed])
     async def test_execute_rechecks_after_claim_before_setup(
         self,
         final_status: WorkspaceStatus,
@@ -382,9 +380,7 @@ class TestOperatorControlRaces:
             assert ws.failure_reason is None
 
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed]
-    )
+    @pytest.mark.parametrize("final_status", [WorkspaceStatus.cancelled, WorkspaceStatus.destroyed])
     async def test_resume_pr_monitor_rechecks_after_load_before_compose(
         self,
         final_status: WorkspaceStatus,
@@ -816,6 +812,52 @@ class TestPullRequestUnexpectedError:
             assert ws.failure_reason == "infrastructure_failure"
             assert "unexpected error during PR creation" in (ws.failure_message or "")
             assert "FileNotFoundError" in (ws.failure_message or "")
+
+    @pytest.mark.unit
+    async def test_validation_target_sha_update_failure_keeps_open_pr(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        async def _fail_target_sha_update(
+            *,
+            validation_run_id: str,
+            target_head_sha: str,
+        ) -> None:
+            raise RuntimeError("metadata database temporarily unavailable")
+
+        ws_id = await _seed_ready(factory)
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="")
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="tests ok")
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")
+        fake.queue_result(returncode=0, stdout="awf/x\n")
+        fake.queue_result(returncode=0, stdout="abc1234 commit\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/7\n")
+
+        executor = _make_executor(fake, factory, tmp_path)
+        executor._set_validation_run_target_head_sha = _fail_target_sha_update  # type: ignore[method-assign]
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.pr_url == "https://github.com/x/y/pull/7"
+            assert ws.pr_number == 7
+            assert ws.monitor_last_commit_sha == "deadbeef01"
+
+            runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+            assert len(runs) == 1
+            assert runs[0].status == "succeeded"
+            assert runs[0].target_head_sha is None
 
 
 class TestPrMonitorFactoryPath:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,7 +26,13 @@ from awf.db.base import Base
 from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace, WorkspaceEvent
-from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.repositories import (
+    TaskAttemptRepository,
+    TaskRepository,
+    ValidationRunRepository,
+    WorkspaceEventRepository,
+    WorkspaceRepository,
+)
 from awf.db.session import make_engine, make_session_factory
 
 
@@ -169,6 +176,76 @@ class TestCreate:
         assert events[0].event_type == "workspace.created"
         assert events[0].new_state == WorkspaceStatus.requested.value
         assert events[0].reason_code == "CREATED"
+
+
+class TestRelationshipLoading:
+    @pytest.mark.unit
+    async def test_list_does_not_eager_load_validation_runs(self) -> None:
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        factory = make_session_factory(engine)
+        async with factory() as s:
+            workspace = await WorkspaceRepository(s).create(
+                repo_url="git@github.com:example/a.git",
+                branch_base="main",
+                task_title="validation provenance",
+                task_prompt="run validation",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            task = await TaskRepository(s).create_or_get(
+                repo_url=workspace.repo_url,
+                base_branch=workspace.branch_base,
+                title=workspace.task_title,
+                prompt=workspace.task_prompt,
+                external_id=None,
+                idempotency_key=None,
+                task_class=None,
+                owned_paths=[],
+            )
+            attempt = await TaskAttemptRepository(s).create_for_workspace(
+                task=task,
+                workspace=workspace,
+            )
+            await ValidationRunRepository(s).start(
+                workspace_id=workspace.id,
+                attempt_id=attempt.id,
+                tier=1,
+                commands=[],
+                base_commit=None,
+                target_branch=None,
+                target_head_sha=None,
+                log_stream_refs={},
+            )
+            await s.commit()
+
+        statements: list[str] = []
+
+        def record_sql(
+            conn: object,
+            cursor: object,
+            statement: str,
+            parameters: object,
+            context: object,
+            executemany: bool,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            statements.append(" ".join(statement.lower().split()))
+
+        event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+        try:
+            async with factory() as s:
+                rows = await WorkspaceRepository(s).list()
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+            await engine.dispose()
+
+        assert len(rows) == 1
+        assert not [
+            statement for statement in statements if "from validation_runs" in statement
+        ]
 
 
 class TestMonitorPolicyMigration:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -25,7 +25,7 @@ from awf.control.state_machine import InvalidWorkspaceTransitionError
 from awf.db.base import Base
 from awf.db.dialect import SESSION_DIALECT_NAME_KEY
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.models import Workspace, WorkspaceEvent
+from awf.db.models import ValidationRun, Workspace, WorkspaceEvent
 from awf.db.repositories import (
     TaskAttemptRepository,
     TaskRepository,
@@ -246,6 +246,123 @@ class TestRelationshipLoading:
         assert not [
             statement for statement in statements if "from validation_runs" in statement
         ]
+
+
+class TestValidationRunRepository:
+    @pytest.mark.unit
+    async def test_latest_by_workspace_ids_uses_window_query(
+        self,
+    ) -> None:
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+        factory = make_session_factory(engine)
+        async with factory() as s:
+            ws_repo = WorkspaceRepository(s)
+            first_workspace = await ws_repo.create(
+                repo_url="git@github.com:example/a.git",
+                branch_base="main",
+                task_title="first",
+                task_prompt="run validation",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            second_workspace = await ws_repo.create(
+                repo_url="git@github.com:example/b.git",
+                branch_base="main",
+                task_title="second",
+                task_prompt="run validation",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            ignored_workspace = await ws_repo.create(
+                repo_url="git@github.com:example/c.git",
+                branch_base="main",
+                task_title="ignored",
+                task_prompt="run validation",
+                agent=AgentRuntime.codex.value,
+                test_commands=[],
+            )
+            validation_repo = ValidationRunRepository(s)
+            await validation_repo.start(
+                workspace_id=first_workspace.id,
+                attempt_id=None,
+                tier=1,
+                commands=[],
+                base_commit=None,
+                target_branch=None,
+                target_head_sha=None,
+                log_stream_refs={},
+                started_at=datetime(2026, 1, 1, tzinfo=UTC),
+            )
+            latest_first = await validation_repo.start(
+                workspace_id=first_workspace.id,
+                attempt_id=None,
+                tier=1,
+                commands=[],
+                base_commit=None,
+                target_branch=None,
+                target_head_sha=None,
+                log_stream_refs={},
+                started_at=datetime(2026, 1, 2, tzinfo=UTC),
+            )
+            latest_second = await validation_repo.start(
+                workspace_id=second_workspace.id,
+                attempt_id=None,
+                tier=1,
+                commands=[],
+                base_commit=None,
+                target_branch=None,
+                target_head_sha=None,
+                log_stream_refs={},
+                started_at=datetime(2026, 1, 3, tzinfo=UTC),
+            )
+            await validation_repo.start(
+                workspace_id=ignored_workspace.id,
+                attempt_id=None,
+                tier=1,
+                commands=[],
+                base_commit=None,
+                target_branch=None,
+                target_head_sha=None,
+                log_stream_refs={},
+                started_at=datetime(2026, 1, 4, tzinfo=UTC),
+            )
+            first_workspace_id = first_workspace.id
+            second_workspace_id = second_workspace.id
+            latest_first_id = latest_first.id
+            latest_second_id = latest_second.id
+            await s.commit()
+
+        statements: list[str] = []
+
+        def record_sql(
+            conn: object,
+            cursor: object,
+            statement: str,
+            parameters: object,
+            context: object,
+            executemany: bool,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            statements.append(" ".join(statement.lower().split()))
+
+        event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+        try:
+            async with factory() as s:
+                latest = await ValidationRunRepository(s).latest_by_workspace_ids(
+                    [first_workspace_id, second_workspace_id, first_workspace_id]
+                )
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+            await engine.dispose()
+
+        assert set(latest) == {first_workspace_id, second_workspace_id}
+        assert latest[first_workspace_id].id == latest_first_id
+        assert latest[second_workspace_id].id == latest_second_id
+        assert len([obj for obj in latest.values() if isinstance(obj, ValidationRun)]) == 2
+        assert any("row_number() over" in statement for statement in statements)
 
 
 class TestMonitorPolicyMigration:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e2c3271254cc4966b8c9640b` (agent: `codex`).

**External task ID**: awf-phase15-validation-run-provenance-20260426T161856Z

### Task
Implement first-class persisted validation run provenance.

Required behavior:
- Add durable validation_run records instead of relying only on log-derived validation provenance.
- Persist validation_run_id, workspace_id, attempt_id where available, tier, command set hash, base commit, target branch/head SHA where available, status, reason code, started_at, finished_at, and log stream references.
- Record Tier 1 for normal profile/request validation in the existing validation execution path.
- Represent Tier 2/Tier 3 metadata in schema/model/API even if this slice only records configured command executions.
- Update GET /v1/workspaces/{id}/validation to prefer persisted validation runs, with log-derived fallback for old rows.
- Expose latest validation provenance fields on /v1/merge-queue without breaking existing response fields.

Acceptance:
- The API can answer what validation ran, when, where, against which base/target SHA, at which tier, and whether it is still fresh enough for the current target snapshot.
- Existing validation logs and console views remain compatible.


Strict delivery rules:
- Use TDD: add focused failing tests first and include the red failure output in the first test commit body.
- Implement until the requested validation commands pass.
- Commit with conventional commits.
- Do not push, do not open a PR, and do not switch branches; AWF owns branch lifecycle, push, PR creation, monitoring, comment handling, and merge.
- Keep changes narrowly scoped to this task. If another parallel AWF workspace changes related code, adapt through normal git/rebase workflow rather than reverting unrelated work.

---
Validation: 6 profile command(s) passed inside the workspace container.
