### PR TITLE
feat(queue): persist local queue decisions and resource reservations

### DIFF
--- a/migrations/versions/a8b9c0d1e2f3_scheduler_decisions_reservations.py
+++ b/migrations/versions/a8b9c0d1e2f3_scheduler_decisions_reservations.py
@@ -1,0 +1,113 @@
+"""Add scheduler decision and resource reservation records.
+
+Revision ID: a8b9c0d1e2f3
+Revises: f7a8b9c0d1e2
+Create Date: 2026-04-26 18:30:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "a8b9c0d1e2f3"
+down_revision: str | Sequence[str] | None = "f7a8b9c0d1e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "queue_decisions",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_id", sa.String(length=36), nullable=False),
+        sa.Column("task_id", sa.String(length=36), nullable=False),
+        sa.Column("decision", sa.String(length=16), nullable=False),
+        sa.Column("reason_code", sa.String(length=64), nullable=False),
+        sa.Column("class_priority", sa.Integer(), nullable=False),
+        sa.Column("computed_priority", sa.Integer(), nullable=False),
+        sa.Column("age_boost", sa.Integer(), nullable=False),
+        sa.Column("retry_bonus", sa.Integer(), nullable=False),
+        sa.Column(
+            "resource_summary",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column(
+            "overlap_risk_summary",
+            sa.JSON(),
+            nullable=False,
+            server_default=sa.text("'{}'"),
+        ),
+        sa.Column("decided_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["attempt_id"], ["task_attempts.id"]),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_queue_decisions_workspace", "queue_decisions", ["workspace_id"])
+    op.create_index("ix_queue_decisions_attempt", "queue_decisions", ["attempt_id"])
+    op.create_index("ix_queue_decisions_task", "queue_decisions", ["task_id"])
+    op.create_index("ix_queue_decisions_decision", "queue_decisions", ["decision"])
+    op.create_index("ix_queue_decisions_decided_at", "queue_decisions", ["decided_at"])
+
+    op.create_table(
+        "resource_reservations",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("workspace_id", sa.String(length=36), nullable=False),
+        sa.Column("attempt_id", sa.String(length=36), nullable=False),
+        sa.Column("node_id", sa.String(length=64), nullable=False),
+        sa.Column("steady_cpu", sa.Float(), nullable=False),
+        sa.Column("steady_memory_gb", sa.Float(), nullable=False),
+        sa.Column("peak_cpu", sa.Float(), nullable=False),
+        sa.Column("peak_memory_gb", sa.Float(), nullable=False),
+        sa.Column("disk_mb", sa.Integer(), nullable=True),
+        sa.Column("phase", sa.String(length=32), nullable=False),
+        sa.Column("reserved_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("released_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["attempt_id"], ["task_attempts.id"]),
+        sa.ForeignKeyConstraint(["workspace_id"], ["workspaces.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_resource_reservations_workspace",
+        "resource_reservations",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_resource_reservations_attempt",
+        "resource_reservations",
+        ["attempt_id"],
+    )
+    op.create_index(
+        "ix_resource_reservations_node_active",
+        "resource_reservations",
+        ["node_id", "released_at"],
+    )
+    op.create_index(
+        "ix_resource_reservations_reserved_at",
+        "resource_reservations",
+        ["reserved_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_resource_reservations_reserved_at", table_name="resource_reservations")
+    op.drop_index("ix_resource_reservations_node_active", table_name="resource_reservations")
+    op.drop_index("ix_resource_reservations_attempt", table_name="resource_reservations")
+    op.drop_index("ix_resource_reservations_workspace", table_name="resource_reservations")
+    op.drop_table("resource_reservations")
+
+    op.drop_index("ix_queue_decisions_decided_at", table_name="queue_decisions")
+    op.drop_index("ix_queue_decisions_decision", table_name="queue_decisions")
+    op.drop_index("ix_queue_decisions_task", table_name="queue_decisions")
+    op.drop_index("ix_queue_decisions_attempt", table_name="queue_decisions")
+    op.drop_index("ix_queue_decisions_workspace", table_name="queue_decisions")
+    op.drop_table("queue_decisions")

--- a/src/awf/api/routes/workspaces.py
+++ b/src/awf/api/routes/workspaces.py
@@ -154,6 +154,7 @@ async def create_workspace_v2(
             session,
             payload,
             idempotency_key=idempotency_key,
+            settings=settings,
         )
     except ProfileResolutionError as exc:
         return JSONResponse(

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -113,7 +113,7 @@ class WorkspaceV2Resources(BaseModel):
     steady_state_memory_gb: float | None = Field(default=None, gt=0)
     peak_cpu_cores: float | None = Field(default=None, gt=0)
     peak_memory_gb: float | None = Field(default=None, gt=0)
-    disk_mb: int | None = Field(default=None, ge=0)
+    disk_mb: int | None = Field(default=None, gt=0)
 
 
 class WorkspaceCreateV2Request(BaseModel):

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -80,6 +80,7 @@ class WorkspaceV2Task(BaseModel):
     agent: AgentRuntime = Field(default=AgentRuntime.codex)
     external_id: Annotated[str | None, Field(default=None, max_length=128)]
     task_class: TaskClass | None = None
+    priority: int = Field(default=0, ge=0, le=100)
     owned_paths: list[OwnedPath] = Field(default_factory=list, max_length=128)
     auto_merge: bool = True
     initial_review_grace_period_seconds: float | None = Field(
@@ -108,6 +109,11 @@ class WorkspaceV2Resources(BaseModel):
 
     cpu: float | None = Field(default=None, gt=0)
     memory: Annotated[str | None, Field(default=None, max_length=32)]
+    steady_state_cpu_cores: float | None = Field(default=None, gt=0)
+    steady_state_memory_gb: float | None = Field(default=None, gt=0)
+    peak_cpu_cores: float | None = Field(default=None, gt=0)
+    peak_memory_gb: float | None = Field(default=None, gt=0)
+    disk_mb: int | None = Field(default=None, ge=0)
 
 
 class WorkspaceCreateV2Request(BaseModel):
@@ -124,6 +130,32 @@ class WorkspaceCreateV2Request(BaseModel):
     resources: WorkspaceV2Resources = Field(
         default_factory=lambda: WorkspaceV2Resources(cpu=None, memory=None)
     )
+
+
+class QueueDecisionSummaryResponse(BaseModel):
+    id: str
+    decision: str
+    reason_code: str
+    class_priority: int
+    computed_priority: int
+    age_boost: int
+    retry_bonus: int
+    resource_summary: dict[str, Any]
+    overlap_risk_summary: dict[str, Any]
+    decided_at: datetime
+
+
+class ResourceReservationSummaryResponse(BaseModel):
+    id: str
+    node_id: str
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+    disk_mb: int | None
+    phase: str
+    reserved_at: datetime
+    released_at: datetime | None
 
 
 class WorkspaceResponse(BaseModel):
@@ -164,6 +196,9 @@ class WorkspaceResponse(BaseModel):
     pr_url: str | None
     failure_reason: str | None
     failure_message: str | None
+
+    latest_queue_decision: QueueDecisionSummaryResponse | None = None
+    active_resource_reservation: ResourceReservationSummaryResponse | None = None
 
     created_at: datetime
     updated_at: datetime

--- a/src/awf/common/ids.py
+++ b/src/awf/common/ids.py
@@ -22,6 +22,14 @@ def new_task_attempt_id() -> str:
     return f"att_{uuid4().hex[:24]}"
 
 
+def new_queue_decision_id() -> str:
+    return f"qd_{uuid4().hex[:24]}"
+
+
+def new_resource_reservation_id() -> str:
+    return f"rr_{uuid4().hex[:24]}"
+
+
 def new_merge_candidate_id() -> str:
     return f"mc_{uuid4().hex[:24]}"
 

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -35,6 +35,9 @@ from sqlalchemy import (
     text,
     true,
 )
+from sqlalchemy import (
+    inspect as sa_inspect,
+)
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from awf.db.base import Base, _now
@@ -235,6 +238,18 @@ class Workspace(Base):
         lazy="selectin",
         uselist=False,
     )
+    queue_decisions: Mapped[list[QueueDecision]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="QueueDecision.decided_at",
+    )
+    resource_reservations: Mapped[list[ResourceReservation]] = relationship(
+        back_populates="workspace",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="ResourceReservation.reserved_at",
+    )
     merge_candidates: Mapped[list[MergeCandidate]] = relationship(
         back_populates="workspace",
         cascade="all, delete-orphan",
@@ -247,6 +262,29 @@ class Workspace(Base):
         lazy="raise",
         order_by="ValidationRun.started_at",
     )
+
+    @property
+    def latest_queue_decision(self) -> dict[str, Any] | None:
+        if "queue_decisions" in sa_inspect(self).unloaded:
+            return None
+        if not self.queue_decisions:
+            return None
+        latest = max(self.queue_decisions, key=lambda item: (item.decided_at, item.id))
+        return _queue_decision_summary(latest)
+
+    @property
+    def active_resource_reservation(self) -> dict[str, Any] | None:
+        if "resource_reservations" in sa_inspect(self).unloaded:
+            return None
+        active = [
+            reservation
+            for reservation in self.resource_reservations
+            if reservation.released_at is None
+        ]
+        if not active:
+            return None
+        latest = max(active, key=lambda item: (item.reserved_at, item.id))
+        return _resource_reservation_summary(latest)
 
 
 class Task(Base):
@@ -361,11 +399,109 @@ class TaskAttempt(Base):
         lazy="selectin",
         uselist=False,
     )
+    queue_decisions: Mapped[list[QueueDecision]] = relationship(
+        back_populates="attempt",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="QueueDecision.decided_at",
+    )
+    resource_reservations: Mapped[list[ResourceReservation]] = relationship(
+        back_populates="attempt",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="ResourceReservation.reserved_at",
+    )
     validation_runs: Mapped[list[ValidationRun]] = relationship(
         back_populates="attempt",
         lazy="raise",
         order_by="ValidationRun.started_at",
     )
+
+
+class QueueDecision(Base):
+    """Durable scheduler admission and ordering decision for one attempt."""
+
+    __tablename__ = "queue_decisions"
+    __table_args__ = (
+        Index("ix_queue_decisions_workspace", "workspace_id"),
+        Index("ix_queue_decisions_attempt", "attempt_id"),
+        Index("ix_queue_decisions_task", "task_id"),
+        Index("ix_queue_decisions_decision", "decision"),
+        Index("ix_queue_decisions_decided_at", "decided_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+    attempt_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=False
+    )
+    task_id: Mapped[str] = mapped_column(String(36), ForeignKey("tasks.id"), nullable=False)
+
+    decision: Mapped[str] = mapped_column(String(16), nullable=False)
+    reason_code: Mapped[str] = mapped_column(String(64), nullable=False)
+    class_priority: Mapped[int] = mapped_column(Integer, nullable=False)
+    computed_priority: Mapped[int] = mapped_column(Integer, nullable=False)
+    age_boost: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    retry_bonus: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    resource_summary: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    overlap_risk_summary: Mapped[dict[str, Any]] = mapped_column(
+        JSON, nullable=False, default=dict, server_default=text("'{}'")
+    )
+    decided_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="queue_decisions")
+    attempt: Mapped[TaskAttempt] = relationship(back_populates="queue_decisions")
+    task: Mapped[Task] = relationship()
+
+
+class ResourceReservation(Base):
+    """Local node resource reservation for one workspace attempt."""
+
+    __tablename__ = "resource_reservations"
+    __table_args__ = (
+        Index("ix_resource_reservations_workspace", "workspace_id"),
+        Index("ix_resource_reservations_attempt", "attempt_id"),
+        Index("ix_resource_reservations_node_active", "node_id", "released_at"),
+        Index("ix_resource_reservations_reserved_at", "reserved_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), nullable=False
+    )
+    attempt_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("task_attempts.id"), nullable=False
+    )
+
+    node_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    steady_cpu: Mapped[float] = mapped_column(Float, nullable=False)
+    steady_memory_gb: Mapped[float] = mapped_column(Float, nullable=False)
+    peak_cpu: Mapped[float] = mapped_column(Float, nullable=False)
+    peak_memory_gb: Mapped[float] = mapped_column(Float, nullable=False)
+    disk_mb: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    phase: Mapped[str] = mapped_column(String(32), nullable=False)
+    reserved_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    released_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=_now, onupdate=_now, nullable=False
+    )
+
+    workspace: Mapped[Workspace] = relationship(back_populates="resource_reservations")
+    attempt: Mapped[TaskAttempt] = relationship(back_populates="resource_reservations")
 
 
 class MergeCandidate(Base):
@@ -638,3 +774,33 @@ class WorkspaceLogStream(Base):
     closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     workspace: Mapped[Workspace] = relationship(back_populates="log_streams")
+
+
+def _queue_decision_summary(decision: QueueDecision) -> dict[str, Any]:
+    return {
+        "id": decision.id,
+        "decision": decision.decision,
+        "reason_code": decision.reason_code,
+        "class_priority": decision.class_priority,
+        "computed_priority": decision.computed_priority,
+        "age_boost": decision.age_boost,
+        "retry_bonus": decision.retry_bonus,
+        "resource_summary": decision.resource_summary,
+        "overlap_risk_summary": decision.overlap_risk_summary,
+        "decided_at": decision.decided_at,
+    }
+
+
+def _resource_reservation_summary(reservation: ResourceReservation) -> dict[str, Any]:
+    return {
+        "id": reservation.id,
+        "node_id": reservation.node_id,
+        "steady_cpu": reservation.steady_cpu,
+        "steady_memory_gb": reservation.steady_memory_gb,
+        "peak_cpu": reservation.peak_cpu,
+        "peak_memory_gb": reservation.peak_memory_gb,
+        "disk_mb": reservation.disk_mb,
+        "phase": reservation.phase,
+        "reserved_at": reservation.reserved_at,
+        "released_at": reservation.released_at,
+    }

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -469,28 +469,19 @@ class ResourceReservationRepository:
         *,
         released_at: datetime | None = None,
     ) -> builtins.list[ResourceReservation]:
-        rows = await self._active_for_workspace_update(workspace_id)
-        if not rows:
-            return []
         release_time = released_at or datetime.now(UTC)
-        for row in rows:
-            row.released_at = release_time
-        await self._session.flush()
-        return rows
-
-    async def _active_for_workspace_update(
-        self,
-        workspace_id: str,
-    ) -> builtins.list[ResourceReservation]:
-        stmt = (
-            select(ResourceReservation)
+        result = await self._session.execute(
+            update(ResourceReservation)
             .where(
                 ResourceReservation.workspace_id == workspace_id,
                 ResourceReservation.released_at.is_(None),
             )
-            .order_by(ResourceReservation.reserved_at.asc(), ResourceReservation.id.asc())
+            .values(released_at=release_time)
+            .returning(ResourceReservation)
         )
-        return list((await self._session.execute(stmt)).scalars())
+        rows = list(result.scalars())
+        rows.sort(key=lambda row: (row.reserved_at, row.id))
+        return rows
 
 
 class MergeCandidateRepository:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -1663,6 +1663,7 @@ def _sync_candidate_readiness(
     *,
     workspace: Workspace,
     attempt: TaskAttempt,
+    sync_validation_staleness: bool = True,
 ) -> None:
     from awf.runtime.merge_eligibility import compute_stale_reason
 
@@ -1676,14 +1677,15 @@ def _sync_candidate_readiness(
     }
     not_canonical = not is_canonical
 
-    stale_reason, _ = compute_stale_reason(workspace)
-    # If there's an active stale reason, update it. If the reason clears, clear it.
-    if stale_reason is not None:
-        candidate.stale = True
-        candidate.stale_reason = stale_reason
-    elif stale_reason is None and candidate.stale_reason in ("validation_insufficient_tier",):
-        candidate.stale = False
-        candidate.stale_reason = None
+    if sync_validation_staleness:
+        stale_reason, _ = compute_stale_reason(workspace)
+        # If there's an active stale reason, update it. If the reason clears, clear it.
+        if stale_reason is not None:
+            candidate.stale = True
+            candidate.stale_reason = stale_reason
+        elif stale_reason is None and candidate.stale_reason in ("validation_insufficient_tier",):
+            candidate.stale = False
+            candidate.stale_reason = None
 
     candidate.completed = is_completed
     candidate.failed_or_cancelled = failed_or_cancelled

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -29,6 +29,8 @@ from awf.common.ids import (
     new_log_stream_id,
     new_merge_candidate_id,
     new_operation_id,
+    new_queue_decision_id,
+    new_resource_reservation_id,
     new_stale_reason_id,
     new_task_attempt_id,
     new_task_id,
@@ -41,6 +43,8 @@ from awf.db.enums import AgentRuntime, OperationStatus, OperationType, Workspace
 from awf.db.models import (
     MergeCandidate,
     Operation,
+    QueueDecision,
+    ResourceReservation,
     StaleReason,
     Task,
     TaskAttempt,
@@ -322,6 +326,170 @@ class TaskAttemptRepository:
             stmt = stmt.where(TaskAttempt.repo_url == repo_url)
 
         stmt = stmt.order_by(TaskAttempt.created_at.desc(), TaskAttempt.id.desc()).limit(limit)
+        return list((await self._session.execute(stmt)).scalars())
+
+
+class QueueDecisionRepository:
+    """CRUD helpers for durable scheduler admission decisions."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        *,
+        workspace_id: str,
+        task_id: str,
+        attempt_id: str,
+        decision: str,
+        reason_code: str,
+        class_priority: int,
+        computed_priority: int,
+        age_boost: int,
+        retry_bonus: int,
+        resource_summary: dict[str, Any],
+        overlap_risk_summary: dict[str, Any],
+        decided_at: datetime | None = None,
+    ) -> QueueDecision:
+        row = QueueDecision(
+            id=new_queue_decision_id(),
+            workspace_id=workspace_id,
+            task_id=task_id,
+            attempt_id=attempt_id,
+            decision=decision,
+            reason_code=reason_code,
+            class_priority=class_priority,
+            computed_priority=computed_priority,
+            age_boost=age_boost,
+            retry_bonus=retry_bonus,
+            resource_summary=dict(resource_summary),
+            overlap_risk_summary=dict(overlap_risk_summary),
+            decided_at=decided_at or datetime.now(UTC),
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return row
+
+    async def list_for_workspace(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+    ) -> builtins.list[QueueDecision]:
+        stmt = (
+            select(QueueDecision)
+            .where(QueueDecision.workspace_id == workspace_id)
+            .order_by(QueueDecision.decided_at.desc(), QueueDecision.id.desc())
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def list_for_attempt(
+        self,
+        attempt_id: str,
+        *,
+        limit: int = 50,
+    ) -> builtins.list[QueueDecision]:
+        stmt = (
+            select(QueueDecision)
+            .where(QueueDecision.attempt_id == attempt_id)
+            .order_by(QueueDecision.decided_at.desc(), QueueDecision.id.desc())
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
+
+class ResourceReservationRepository:
+    """CRUD helpers for local resource reservation records."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        *,
+        workspace_id: str,
+        attempt_id: str,
+        node_id: str,
+        steady_cpu: float,
+        steady_memory_gb: float,
+        peak_cpu: float,
+        peak_memory_gb: float,
+        disk_mb: int | None,
+        phase: str,
+        reserved_at: datetime | None = None,
+    ) -> ResourceReservation:
+        row = ResourceReservation(
+            id=new_resource_reservation_id(),
+            workspace_id=workspace_id,
+            attempt_id=attempt_id,
+            node_id=node_id,
+            steady_cpu=steady_cpu,
+            steady_memory_gb=steady_memory_gb,
+            peak_cpu=peak_cpu,
+            peak_memory_gb=peak_memory_gb,
+            disk_mb=disk_mb,
+            phase=phase,
+            reserved_at=reserved_at or datetime.now(UTC),
+            released_at=None,
+        )
+        self._session.add(row)
+        await self._session.flush()
+        return row
+
+    async def list_for_workspace(
+        self,
+        workspace_id: str,
+        *,
+        limit: int = 50,
+    ) -> builtins.list[ResourceReservation]:
+        stmt = (
+            select(ResourceReservation)
+            .where(ResourceReservation.workspace_id == workspace_id)
+            .order_by(ResourceReservation.reserved_at.desc(), ResourceReservation.id.desc())
+            .limit(limit)
+        )
+        return list((await self._session.execute(stmt)).scalars())
+
+    async def active_for_workspace(self, workspace_id: str) -> ResourceReservation | None:
+        stmt = (
+            select(ResourceReservation)
+            .where(
+                ResourceReservation.workspace_id == workspace_id,
+                ResourceReservation.released_at.is_(None),
+            )
+            .order_by(ResourceReservation.reserved_at.desc(), ResourceReservation.id.desc())
+            .limit(1)
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def release_active_for_workspace(
+        self,
+        workspace_id: str,
+        *,
+        released_at: datetime | None = None,
+    ) -> builtins.list[ResourceReservation]:
+        rows = await self._active_for_workspace_update(workspace_id)
+        if not rows:
+            return []
+        release_time = released_at or datetime.now(UTC)
+        for row in rows:
+            row.released_at = release_time
+        await self._session.flush()
+        return rows
+
+    async def _active_for_workspace_update(
+        self,
+        workspace_id: str,
+    ) -> builtins.list[ResourceReservation]:
+        stmt = (
+            select(ResourceReservation)
+            .where(
+                ResourceReservation.workspace_id == workspace_id,
+                ResourceReservation.released_at.is_(None),
+            )
+            .order_by(ResourceReservation.reserved_at.asc(), ResourceReservation.id.asc())
+        )
         return list((await self._session.execute(stmt)).scalars())
 
 
@@ -1201,6 +1369,10 @@ class WorkspaceRepository:
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
             workspace.monitor_started_at = datetime.now(UTC)
         await self._sync_merge_candidate_lifecycle(workspace, attempt=attempt, to=to)
+        if _releases_resource_reservation(to):
+            await ResourceReservationRepository(self._session).release_active_for_workspace(
+                workspace.id
+            )
 
         workspace.events.append(
             WorkspaceEvent(
@@ -1256,6 +1428,11 @@ class WorkspaceRepository:
         if to == WorkspaceStatus.monitoring_pr and workspace.monitor_started_at is None:
             workspace.monitor_started_at = now
         await self._sync_merge_candidate_lifecycle(workspace, attempt=attempt, to=to)
+        if _releases_resource_reservation(to):
+            await ResourceReservationRepository(self._session).release_active_for_workspace(
+                workspace.id,
+                released_at=now,
+            )
 
         workspace.events.append(
             WorkspaceEvent(
@@ -1470,6 +1647,15 @@ def _candidate_terminal_close_reason(status: WorkspaceStatus) -> str:
     if status == WorkspaceStatus.cancelled:
         return "WORKSPACE_CANCELLED"
     return f"WORKSPACE_{status.value.upper()}"
+
+
+def _releases_resource_reservation(status: WorkspaceStatus) -> bool:
+    return status in {
+        WorkspaceStatus.completed,
+        WorkspaceStatus.failed,
+        WorkspaceStatus.cancelled,
+        WorkspaceStatus.destroyed,
+    }
 
 
 def _sync_candidate_readiness(

--- a/src/awf/runtime/merge_eligibility.py
+++ b/src/awf/runtime/merge_eligibility.py
@@ -9,7 +9,11 @@ from awf.db.models import Workspace
 def _task_class_tier(task_class: str | None) -> int:
     if task_class == TaskClass.migration_task.value:
         return 3
-    if task_class in (TaskClass.refactor_task.value, TaskClass.dependency_task.value, TaskClass.build_config_task.value):
+    if task_class in (
+        TaskClass.refactor_task.value,
+        TaskClass.dependency_task.value,
+        TaskClass.build_config_task.value,
+    ):
         return 2
     return 1
 
@@ -21,9 +25,12 @@ def compute_stale_reason(workspace: Workspace) -> tuple[str | None, str | None]:
 
     rebase_time = None
     for op in operations:
-        if op.type == "rebase" and op.status == "succeeded":
-            if rebase_time is None or op.created_at > rebase_time:
-                rebase_time = op.created_at
+        if (
+            op.type == "rebase"
+            and op.status == "succeeded"
+            and (rebase_time is None or op.created_at > rebase_time)
+        ):
+            rebase_time = op.created_at
 
     has_rebased = rebase_time is not None
 
@@ -32,7 +39,7 @@ def compute_stale_reason(workspace: Workspace) -> tuple[str | None, str | None]:
         required_tier = max(required_tier, 2)
 
     actual_tier = 1
-    
+
     default_op_tier = 1
     if workspace.resolved_profile and "validation" in workspace.resolved_profile:
         default_op_tier = workspace.resolved_profile["validation"].get("requested_tier", 1)
@@ -43,12 +50,15 @@ def compute_stale_reason(workspace: Workspace) -> tuple[str | None, str | None]:
             if isinstance(op.payload, dict):
                 if isinstance(op.payload.get("requested_tier"), int):
                     op_tier = op.payload["requested_tier"]
-                elif isinstance(op.payload.get("validation"), dict) and isinstance(op.payload["validation"].get("requested_tier"), int):
+                elif isinstance(op.payload.get("validation"), dict) and isinstance(
+                    op.payload["validation"].get("requested_tier"),
+                    int,
+                ):
                     op_tier = op.payload["validation"]["requested_tier"]
-            
+
             if rebase_time and op.created_at > rebase_time:
                 op_tier = max(op_tier, 2)
-                
+
             actual_tier = max(actual_tier, op_tier)
 
     if actual_tier < required_tier:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -557,36 +557,48 @@ class PullRequestMonitorRunner:
                         compose_file=compose_file,
                         monitor_log=monitor_log,
                     )
-                else:
-                    has_failed_rebase = any(op.type == "rebase" and op.status == "failed" for op in ws.operations)
-                    if req_action == "rebase" and has_failed_rebase:
-                        return await self._execute(
-                            action=NotifyHuman(message=f"Agent could not resolve {stale_reason}. Rebase conflicted. Manual intervention required."),
+
+                has_failed_rebase = any(
+                    op.type == "rebase" and op.status == "failed" for op in ws.operations
+                )
+                if req_action == "rebase" and has_failed_rebase:
+                    return await self._execute(
+                        action=NotifyHuman(
+                            message=(
+                                f"Agent could not resolve {stale_reason}. "
+                                "Rebase conflicted. Manual intervention required."
+                            )
+                        ),
+                        workspace_id=workspace_id,
+                        repo_url=repo_url,
+                        repo=repo,
+                        pr_number=pr_number,
+                        status=status,
+                        state=state,
+                        base_branch=base_branch,
+                        remote_branch=remote_branch,
+                        compose_project=compose_project,
+                        compose_file=compose_file,
+                        monitor_log=monitor_log,
+                    )
+
+                async with self._deps.session_factory() as s:
+                    from awf.db.repositories import OperationRepository, WorkspaceRepository
+
+                    _ws = await WorkspaceRepository(s).get(workspace_id)
+                    if _ws is not None:
+                        await OperationRepository(s).create(
                             workspace_id=workspace_id,
-                            repo_url=repo_url,
-                            repo=repo,
-                            pr_number=pr_number,
-                            status=status,
-                            state=state,
-                            base_branch=base_branch,
-                            remote_branch=remote_branch,
-                            compose_project=compose_project,
-                            compose_file=compose_file,
-                            monitor_log=monitor_log,
+                            operation_type=req_action or "validate",
+                            payload={"reason": stale_reason},
                         )
-                    else:
-                        async with self._deps.session_factory() as s:
-                            from awf.db.repositories import OperationRepository, WorkspaceRepository
-                            _ws = await WorkspaceRepository(s).get(workspace_id)
-                            if _ws is not None:
-                                await OperationRepository(s).create(
-                                    workspace_id=workspace_id,
-                                    operation_type=req_action or "validate",
-                                    payload={"reason": stale_reason},
-                                )
-                                await WorkspaceRepository(s).transition(_ws, to=WorkspaceStatus.ready, reason_code="RECOVERY_DISPATCH")
-                                await s.commit()
-                        return True
+                        await WorkspaceRepository(s).transition(
+                            _ws,
+                            to=WorkspaceStatus.ready,
+                            reason_code="RECOVERY_DISPATCH",
+                        )
+                        await s.commit()
+                return True
 
             grace_wait_seconds = _initial_review_grace_wait_seconds(
                 state,

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.config import Settings
 from awf.db.enums import FailureReason, WorkspaceStatus
-from awf.db.models import Workspace
+from awf.db.models import ResourceReservation, Workspace
 from awf.service.disk import DiskCheck, DiskUsage, check_disk_space
 
 DEFAULT_SUMMARY_WINDOW_HOURS = 24
@@ -389,7 +389,8 @@ async def summarize_resource_saturation_for_session(
         peak_cpu=settings.workspace_peak_cpu,
         peak_memory_gb=settings.workspace_peak_memory_gb,
     )
-    reserved_resources = _reserved_resources(
+    reserved_resources = await _reserved_resources_for_session(
+        session,
         workspace_counts.active_total,
         resource_defaults=resource_defaults,
     )
@@ -608,18 +609,51 @@ def _workspace_saturation_counts(status_counts: dict[str, int]) -> WorkspaceSatu
     )
 
 
-def _reserved_resources(
+async def _reserved_resources_for_session(
+    session: AsyncSession,
     active_workspace_count: int,
     *,
     resource_defaults: WorkspaceResourceDefaults,
 ) -> ReservedResources:
+    persisted = await _active_reservation_totals(session)
+    fallback_count = max(0, active_workspace_count - persisted["workspace_count"])
     return ReservedResources(
         active_workspace_count=active_workspace_count,
-        steady_cpu=active_workspace_count * resource_defaults.steady_cpu,
-        steady_memory_gb=active_workspace_count * resource_defaults.steady_memory_gb,
-        peak_cpu=active_workspace_count * resource_defaults.peak_cpu,
-        peak_memory_gb=active_workspace_count * resource_defaults.peak_memory_gb,
+        steady_cpu=persisted["steady_cpu"] + fallback_count * resource_defaults.steady_cpu,
+        steady_memory_gb=(
+            persisted["steady_memory_gb"]
+            + fallback_count * resource_defaults.steady_memory_gb
+        ),
+        peak_cpu=persisted["peak_cpu"] + fallback_count * resource_defaults.peak_cpu,
+        peak_memory_gb=(
+            persisted["peak_memory_gb"] + fallback_count * resource_defaults.peak_memory_gb
+        ),
     )
+
+
+async def _active_reservation_totals(session: AsyncSession) -> dict[str, float | int]:
+    stmt = (
+        select(
+            func.count(func.distinct(ResourceReservation.workspace_id)),
+            func.coalesce(func.sum(ResourceReservation.steady_cpu), 0.0),
+            func.coalesce(func.sum(ResourceReservation.steady_memory_gb), 0.0),
+            func.coalesce(func.sum(ResourceReservation.peak_cpu), 0.0),
+            func.coalesce(func.sum(ResourceReservation.peak_memory_gb), 0.0),
+        )
+        .join(Workspace, ResourceReservation.workspace_id == Workspace.id)
+        .where(
+            ResourceReservation.released_at.is_(None),
+            ~Workspace.status.in_(TERMINAL_WORKSPACE_STATUSES),
+        )
+    )
+    row = (await session.execute(stmt)).one()
+    return {
+        "workspace_count": int(row[0] or 0),
+        "steady_cpu": float(row[1] or 0.0),
+        "steady_memory_gb": float(row[2] or 0.0),
+        "peak_cpu": float(row[3] or 0.0),
+        "peak_memory_gb": float(row[4] or 0.0),
+    }
 
 
 def _resource_concurrency(

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -632,19 +632,40 @@ async def _reserved_resources_for_session(
 
 
 async def _active_reservation_totals(session: AsyncSession) -> dict[str, float | int]:
-    stmt = (
+    latest_active_reservations = (
         select(
-            func.count(func.distinct(ResourceReservation.workspace_id)),
-            func.coalesce(func.sum(ResourceReservation.steady_cpu), 0.0),
-            func.coalesce(func.sum(ResourceReservation.steady_memory_gb), 0.0),
-            func.coalesce(func.sum(ResourceReservation.peak_cpu), 0.0),
-            func.coalesce(func.sum(ResourceReservation.peak_memory_gb), 0.0),
+            ResourceReservation.workspace_id.label("workspace_id"),
+            ResourceReservation.steady_cpu.label("steady_cpu"),
+            ResourceReservation.steady_memory_gb.label("steady_memory_gb"),
+            ResourceReservation.peak_cpu.label("peak_cpu"),
+            ResourceReservation.peak_memory_gb.label("peak_memory_gb"),
+            func.row_number()
+            .over(
+                partition_by=ResourceReservation.workspace_id,
+                order_by=(
+                    ResourceReservation.reserved_at.desc(),
+                    ResourceReservation.id.desc(),
+                ),
+            )
+            .label("reservation_rank"),
         )
         .join(Workspace, ResourceReservation.workspace_id == Workspace.id)
         .where(
             ResourceReservation.released_at.is_(None),
             ~Workspace.status.in_(TERMINAL_WORKSPACE_STATUSES),
         )
+        .subquery()
+    )
+    stmt = (
+        select(
+            func.count(latest_active_reservations.c.workspace_id),
+            func.coalesce(func.sum(latest_active_reservations.c.steady_cpu), 0.0),
+            func.coalesce(func.sum(latest_active_reservations.c.steady_memory_gb), 0.0),
+            func.coalesce(func.sum(latest_active_reservations.c.peak_cpu), 0.0),
+            func.coalesce(func.sum(latest_active_reservations.c.peak_memory_gb), 0.0),
+        )
+        .select_from(latest_active_reservations)
+        .where(latest_active_reservations.c.reservation_rank == 1)
     )
     row = (await session.execute(stmt)).one()
     return {

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -415,9 +415,10 @@ class StalenessRefreshService:
         *,
         stale: bool,
     ) -> None:
-        if candidate.stale == stale:
+        if candidate.stale == stale and candidate.stale_reason is None:
             return
         candidate.stale = stale
+        candidate.stale_reason = None
         # Re-sync derived readiness flags so the merge-queue blocker reason
         # picks up the new stale state without an out-of-band refresh.
         from awf.db.repositories import _sync_candidate_readiness
@@ -426,6 +427,7 @@ class StalenessRefreshService:
             candidate,
             workspace=candidate.workspace,
             attempt=candidate.attempt,
+            sync_validation_staleness=False,
         )
         await self._session.flush()
 

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -415,14 +415,17 @@ class StalenessRefreshService:
         *,
         stale: bool,
     ) -> None:
-        if candidate.stale == stale and candidate.stale_reason is None:
+        from awf.db.repositories import _sync_candidate_readiness
+        from awf.runtime.merge_eligibility import compute_stale_reason
+
+        validation_reason, _ = compute_stale_reason(candidate.workspace)
+        next_stale = stale or validation_reason is not None
+        if candidate.stale == next_stale and candidate.stale_reason == validation_reason:
             return
-        candidate.stale = stale
-        candidate.stale_reason = None
+        candidate.stale = next_stale
+        candidate.stale_reason = validation_reason
         # Re-sync derived readiness flags so the merge-queue blocker reason
         # picks up the new stale state without an out-of-band refresh.
-        from awf.db.repositories import _sync_candidate_readiness
-
         _sync_candidate_readiness(
             candidate,
             workspace=candidate.workspace,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -24,11 +24,14 @@ from awf.api.schemas import (
     WorkspaceRuntimeResponse,
     WorkspaceWarningResponse,
 )
+from awf.common.config import Settings, get_settings
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import Operation, Task, TaskAttempt, Workspace
 from awf.db.repositories import (
     OperationRepository,
     OwnedPathOverlap,
+    QueueDecisionRepository,
+    ResourceReservationRepository,
     TaskAttemptRepository,
     TaskRepository,
     WorkspaceEventRepository,
@@ -63,10 +66,29 @@ OWNED_PATH_OVERLAP_PAYLOAD_FIELDS = (
     "existing_path",
     "requested_path",
 )
+QUEUE_DECISION_ADMITTED = "admitted"
+QUEUE_DECISION_ADMITTED_LOCAL_REASON = "ADMITTED_LOCAL"
+RESOURCE_RESERVATION_PHASE_WORKSPACE = "workspace_lifecycle"
 RETRYABLE_WORKSPACE_STATUSES = (
     WorkspaceStatus.failed,
     WorkspaceStatus.cancelled,
 )
+TASK_CLASS_PRIORITIES = {
+    "migration_task": 5,
+    "dependency_task": 4,
+    "build_config_task": 3,
+    "refactor_task": 2,
+    "test_task": 1,
+    "docs_task": 0,
+}
+TASK_CLASS_BIASES = {
+    "migration_task": 15,
+    "dependency_task": 12,
+    "build_config_task": 10,
+    "refactor_task": 4,
+    "test_task": 2,
+    "docs_task": 0,
+}
 
 
 class WorkspaceRetryError(Exception):
@@ -114,6 +136,28 @@ class WorkspaceRetryResult:
     new_workspace: Workspace
     operation: Operation
     attempt_number: int
+
+
+@dataclass(frozen=True)
+class ResourceReservationPlan:
+    node_id: str
+    steady_cpu: float
+    steady_memory_gb: float
+    peak_cpu: float
+    peak_memory_gb: float
+    disk_mb: int | None
+    phase: str = RESOURCE_RESERVATION_PHASE_WORKSPACE
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "steady_cpu": self.steady_cpu,
+            "steady_memory_gb": self.steady_memory_gb,
+            "peak_cpu": self.peak_cpu,
+            "peak_memory_gb": self.peak_memory_gb,
+            "disk_mb": self.disk_mb,
+            "phase": self.phase,
+        }
 
 
 class WorkspaceService:
@@ -379,8 +423,10 @@ async def create_workspace_v2_row(
     payload: WorkspaceCreateV2Request,
     *,
     idempotency_key: str | None = None,
+    settings: Settings | None = None,
 ) -> Workspace:
     """Persist one v2 workspace request without committing the session."""
+    resolved_settings = settings or get_settings()
     repo = WorkspaceRepository(session)
     overlaps = await repo.find_active_owned_path_overlaps(
         repo_url=payload.repo.url,
@@ -425,7 +471,37 @@ async def create_workspace_v2_row(
         ),
         owned_paths=payload.task.owned_paths,
     )
-    await TaskAttemptRepository(session).create_for_workspace(task=task, workspace=ws)
+    attempt = await TaskAttemptRepository(session).create_for_workspace(task=task, workspace=ws)
+    reservation_plan = resource_reservation_plan(payload, settings=resolved_settings)
+    await ResourceReservationRepository(session).create(
+        workspace_id=ws.id,
+        attempt_id=attempt.id,
+        node_id=reservation_plan.node_id,
+        steady_cpu=reservation_plan.steady_cpu,
+        steady_memory_gb=reservation_plan.steady_memory_gb,
+        peak_cpu=reservation_plan.peak_cpu,
+        peak_memory_gb=reservation_plan.peak_memory_gb,
+        disk_mb=reservation_plan.disk_mb,
+        phase=reservation_plan.phase,
+    )
+    await QueueDecisionRepository(session).create(
+        workspace_id=ws.id,
+        task_id=task.id,
+        attempt_id=attempt.id,
+        decision=QUEUE_DECISION_ADMITTED,
+        reason_code=QUEUE_DECISION_ADMITTED_LOCAL_REASON,
+        class_priority=task_class_priority(ws.task_class),
+        computed_priority=computed_priority(
+            base_priority=payload.task.priority,
+            task_class=ws.task_class,
+            age_boost=0,
+            retry_bonus=0,
+        ),
+        age_boost=0,
+        retry_bonus=0,
+        resource_summary=reservation_plan.summary(),
+        overlap_risk_summary=overlap_risk_summary(overlaps),
+    )
     await _record_owned_path_overlap_risk(repo, ws, overlaps)
     await session.flush()
     return ws
@@ -600,6 +676,108 @@ def owned_path_overlap_warning_payload(overlaps: list[OwnedPathOverlap]) -> dict
         "workspace_ids": list(workspace_ids),
         "overlaps": overlap_items,
     }
+
+
+def overlap_risk_summary(overlaps: list[OwnedPathOverlap]) -> dict[str, Any]:
+    if not overlaps:
+        return {
+            "warning_code": None,
+            "overlap_count": 0,
+            "workspace_ids": [],
+            "overlaps": [],
+        }
+    payload = owned_path_overlap_warning_payload(overlaps)
+    return {
+        "warning_code": OWNED_PATH_OVERLAP_RISK_CODE,
+        "overlap_count": len(overlaps),
+        "workspace_ids": payload["workspace_ids"],
+        "overlaps": payload["overlaps"],
+    }
+
+
+def task_class_priority(task_class: str | None) -> int:
+    return TASK_CLASS_PRIORITIES.get(task_class or "", 0)
+
+
+def computed_priority(
+    *,
+    base_priority: int,
+    task_class: str | None,
+    age_boost: int,
+    retry_bonus: int,
+) -> int:
+    return (
+        base_priority
+        + TASK_CLASS_BIASES.get(task_class or "", 0)
+        + age_boost
+        + retry_bonus
+    )
+
+
+def resource_reservation_plan(
+    payload: WorkspaceCreateV2Request,
+    *,
+    settings: Settings,
+) -> ResourceReservationPlan:
+    resources = payload.resources
+    legacy_memory_gb = _parse_memory_gb(resources.memory)
+    return ResourceReservationPlan(
+        node_id=settings.worker_node_id or "local",
+        steady_cpu=(
+            resources.steady_state_cpu_cores
+            if resources.steady_state_cpu_cores is not None
+            else resources.cpu
+            if resources.cpu is not None
+            else settings.workspace_steady_cpu
+        ),
+        steady_memory_gb=(
+            resources.steady_state_memory_gb
+            if resources.steady_state_memory_gb is not None
+            else legacy_memory_gb
+            if legacy_memory_gb is not None
+            else settings.workspace_steady_memory_gb
+        ),
+        peak_cpu=(
+            resources.peak_cpu_cores
+            if resources.peak_cpu_cores is not None
+            else resources.cpu
+            if resources.cpu is not None
+            else settings.workspace_peak_cpu
+        ),
+        peak_memory_gb=(
+            resources.peak_memory_gb
+            if resources.peak_memory_gb is not None
+            else legacy_memory_gb
+            if legacy_memory_gb is not None
+            else settings.workspace_peak_memory_gb
+        ),
+        disk_mb=resources.disk_mb,
+    )
+
+
+def _parse_memory_gb(value: str | None) -> float | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower().replace(" ", "")
+    if normalized == "":
+        return None
+    multipliers = {
+        "gb": 1.0,
+        "g": 1.0,
+        "mb": 1.0 / 1024.0,
+        "m": 1.0 / 1024.0,
+    }
+    for suffix, multiplier in multipliers.items():
+        if normalized.endswith(suffix):
+            number = normalized[: -len(suffix)]
+            try:
+                return float(number) * multiplier
+            except ValueError:
+                return None
+    try:
+        return float(normalized)
+    except ValueError:
+        return None
 
 
 def owned_path_overlap_warnings(workspace: Workspace) -> list[WorkspaceWarningResponse]:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -25,6 +25,7 @@ from awf.api.schemas import (
     WorkspaceWarningResponse,
 )
 from awf.common.config import Settings, get_settings
+from awf.common.logging import get_logger
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import Operation, Task, TaskAttempt, Workspace
 from awf.db.repositories import (
@@ -89,6 +90,7 @@ TASK_CLASS_BIASES = {
     "test_task": 2,
     "docs_task": 0,
 }
+_log = get_logger(__name__)
 
 
 class WorkspaceRetryError(Exception):
@@ -775,9 +777,15 @@ def _parse_memory_gb(value: str | None) -> float | None:
             except ValueError:
                 return None
     try:
-        return float(normalized)
+        memory_gb = float(normalized)
     except ValueError:
         return None
+    _log.warning(
+        "workspace.resources.memory_unit_missing",
+        raw_value=normalized,
+        interpreted_unit="gb",
+    )
+    return memory_gb
 
 
 def owned_path_overlap_warnings(workspace: Workspace) -> list[WorkspaceWarningResponse]:

--- a/tests/unit/api/test_metrics_capacity.py
+++ b/tests/unit/api/test_metrics_capacity.py
@@ -13,7 +13,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine
 from awf.api.app import configure_database, create_app
 from awf.common.config import Settings, get_settings
 from awf.db.enums import WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import (
+    ResourceReservationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
 from awf.db.session import make_session_factory
 from awf.service.disk import DiskCheck
 
@@ -23,7 +28,7 @@ async def _workspace(
     *,
     status: WorkspaceStatus,
     updated_at: datetime,
-) -> None:
+) -> str:
     factory = make_session_factory(engine)
     async with factory() as session:
         workspace = await WorkspaceRepository(session).create(
@@ -37,6 +42,58 @@ async def _workspace(
         workspace.status = status.value
         workspace.updated_at = updated_at
         await session.commit()
+        return workspace.id
+
+
+async def _workspace_with_reservation(
+    engine: AsyncEngine,
+    *,
+    status: WorkspaceStatus,
+    updated_at: datetime,
+    steady_cpu: float,
+    steady_memory_gb: float,
+    peak_cpu: float,
+    peak_memory_gb: float,
+) -> str:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/metrics-api.git",
+            branch_base="main",
+            task_title=f"{status.value} reserved workspace",
+            task_prompt="Collect workspace reliability metrics.",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = status.value
+        workspace.updated_at = updated_at
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=None,
+            idempotency_key=f"metrics-api-reservation:{workspace.id}",
+            task_class=workspace.task_class,
+            owned_paths=list(workspace.owned_paths),
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        await ResourceReservationRepository(session).create(
+            workspace_id=workspace.id,
+            attempt_id=attempt.id,
+            node_id="local",
+            steady_cpu=steady_cpu,
+            steady_memory_gb=steady_memory_gb,
+            peak_cpu=peak_cpu,
+            peak_memory_gb=peak_memory_gb,
+            disk_mb=None,
+            phase="workspace_lifecycle",
+        )
+        await session.commit()
+        return workspace.id
 
 
 def _disk_check(
@@ -140,6 +197,56 @@ async def test_resource_saturation_endpoint_reports_local_capacity_inputs(
     assert body["admission"]["ok"] is True
     assert body["admission"]["status"] == "saturated"
     assert body["admission"]["reason"] == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_uses_persisted_active_reservations(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+    engine: AsyncEngine,
+) -> None:
+    app, client = metrics_app_and_client
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-metrics-work",
+        min_free_disk_bytes=700,
+        workspace_steady_cpu=3.0,
+        workspace_steady_memory_gb=10.0,
+        workspace_peak_cpu=6.0,
+        workspace_peak_memory_gb=16.0,
+    )
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = lambda provider_settings: _disk_check(
+        provider_settings,
+        ok=True,
+    )
+    now = datetime.now(UTC)
+    await _workspace_with_reservation(
+        engine,
+        status=WorkspaceStatus.running,
+        updated_at=now - timedelta(minutes=5),
+        steady_cpu=4.0,
+        steady_memory_gb=12.0,
+        peak_cpu=8.0,
+        peak_memory_gb=24.0,
+    )
+    await _workspace(
+        engine,
+        status=WorkspaceStatus.ready,
+        updated_at=now - timedelta(minutes=4),
+    )
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["workspace_counts"]["active_total"] == 2
+    assert body["reserved_resources"] == {
+        "active_workspace_count": 2,
+        "steady_cpu": 7.0,
+        "steady_memory_gb": 22.0,
+        "peak_cpu": 14.0,
+        "peak_memory_gb": 40.0,
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -447,6 +447,17 @@ class TestCreateWorkspaceV2PolicyMetadata:
         assert reservation["released_at"] is None
 
     @pytest.mark.unit
+    async def test_rejects_zero_disk_reservation(self, client: AsyncClient) -> None:
+        payload = {
+            **_V2_MINIMAL_BODY,
+            "resources": {"disk_mb": 0},
+        }
+
+        response = await client.post("/v2/workspaces", json=payload)
+
+        assert response.status_code == 422
+
+    @pytest.mark.unit
     async def test_legacy_v1_defaults_policy_metadata(self, client: AsyncClient) -> None:
         ws_id = await _create_workspace(client)
 

--- a/tests/unit/api/test_workspaces.py
+++ b/tests/unit/api/test_workspaces.py
@@ -396,6 +396,57 @@ class TestCreateWorkspaceV2PolicyMetadata:
         assert listed.json()[0]["owned_paths"] == ["src/awf/**/*.py", "tests/unit/**"]
 
     @pytest.mark.unit
+    async def test_workspace_response_exposes_latest_decision_and_active_reservation(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        payload = {
+            **_V2_MINIMAL_BODY,
+            "task": {
+                **_V2_MINIMAL_BODY["task"],
+                "task_class": "dependency_task",
+                "priority": 25,
+                "owned_paths": ["pyproject.toml", "uv.lock"],
+            },
+            "resources": {
+                "steady_state_cpu_cores": 4.0,
+                "steady_state_memory_gb": 12.0,
+                "peak_cpu_cores": 8.0,
+                "peak_memory_gb": 24.0,
+                "disk_mb": 4096,
+            },
+        }
+
+        create = await client.post("/v2/workspaces", json=payload)
+        assert create.status_code == 202
+
+        ws_id = create.json()["workspace_id"]
+        response = await client.get(f"/v1/workspaces/{ws_id}")
+
+        assert response.status_code == 200
+        body = response.json()
+        decision = body["latest_queue_decision"]
+        reservation = body["active_resource_reservation"]
+        assert decision["id"].startswith("qd_")
+        assert decision["decision"] == "admitted"
+        assert decision["reason_code"] == "ADMITTED_LOCAL"
+        assert decision["class_priority"] == 4
+        assert decision["computed_priority"] == 37
+        assert decision["age_boost"] == 0
+        assert decision["retry_bonus"] == 0
+        assert decision["resource_summary"]["peak_cpu"] == 8.0
+        assert decision["overlap_risk_summary"]["overlap_count"] == 0
+        assert reservation["id"].startswith("rr_")
+        assert reservation["node_id"] == "local"
+        assert reservation["steady_cpu"] == 4.0
+        assert reservation["steady_memory_gb"] == 12.0
+        assert reservation["peak_cpu"] == 8.0
+        assert reservation["peak_memory_gb"] == 24.0
+        assert reservation["disk_mb"] == 4096
+        assert reservation["phase"] == "workspace_lifecycle"
+        assert reservation["released_at"] is None
+
+    @pytest.mark.unit
     async def test_legacy_v1_defaults_policy_metadata(self, client: AsyncClient) -> None:
         ws_id = await _create_workspace(client)
 

--- a/tests/unit/db/test_migration_graph.py
+++ b/tests/unit/db/test_migration_graph.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -16,4 +20,68 @@ def test_alembic_revision_graph_has_single_head() -> None:
     config.set_main_option("script_location", str(repo_root / "migrations"))
     script = ScriptDirectory.from_config(config)
 
-    assert script.get_heads() == ["f7a8b9c0d1e2"]
+    assert script.get_heads() == ["a8b9c0d1e2f3"]
+
+
+@pytest.mark.unit
+def test_alembic_upgrade_head_creates_scheduler_record_tables(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    db_path = tmp_path / "awf.db"
+    env = {
+        **os.environ,
+        "AWF_DATABASE_URL": f"sqlite+aiosqlite:///{db_path}",
+    }
+
+    monkeypatch.chdir(repo_root)
+    subprocess.run(
+        [sys.executable, "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"],
+        cwd=repo_root,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    with sqlite3.connect(db_path) as conn:
+        tables = {
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        }
+        queue_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(queue_decisions)")
+        }
+        reservation_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(resource_reservations)")
+        }
+
+    assert {"queue_decisions", "resource_reservations"} <= tables
+    assert {
+        "id",
+        "workspace_id",
+        "attempt_id",
+        "task_id",
+        "decision",
+        "reason_code",
+        "class_priority",
+        "computed_priority",
+        "resource_summary",
+        "overlap_risk_summary",
+        "decided_at",
+    } <= queue_columns
+    assert {
+        "id",
+        "workspace_id",
+        "attempt_id",
+        "node_id",
+        "steady_cpu",
+        "steady_memory_gb",
+        "peak_cpu",
+        "peak_memory_gb",
+        "disk_mb",
+        "phase",
+        "reserved_at",
+        "released_at",
+    } <= reservation_columns

--- a/tests/unit/db/test_scheduler_records.py
+++ b/tests/unit/db/test_scheduler_records.py
@@ -1,0 +1,157 @@
+"""Durable scheduler decision and reservation records."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime
+from awf.db.repositories import (
+    QueueDecisionRepository,
+    ResourceReservationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = make_session_factory(engine)
+    async with factory() as s:
+        yield s
+
+    await engine.dispose()
+
+
+async def _attempt(session: AsyncSession) -> tuple[str, str, str]:
+    workspace = await WorkspaceRepository(session).create(
+        repo_url="git@github.com:example/scheduler.git",
+        branch_base="main",
+        task_title="Persist scheduler records",
+        task_prompt="Make admission decisions durable.",
+        agent=AgentRuntime.codex.value,
+        task_class="migration_task",
+        owned_paths=["migrations/**"],
+        test_commands=["pytest -q"],
+    )
+    task = await TaskRepository(session).create_or_get(
+        repo_url=workspace.repo_url,
+        base_branch=workspace.branch_base,
+        title=workspace.task_title,
+        prompt=workspace.task_prompt,
+        external_id="SCHED-1",
+        idempotency_key=None,
+        task_class=workspace.task_class,
+        owned_paths=list(workspace.owned_paths),
+    )
+    attempt = await TaskAttemptRepository(session).create_for_workspace(
+        task=task,
+        workspace=workspace,
+    )
+    return workspace.id, task.id, attempt.id
+
+
+@pytest.mark.unit
+async def test_queue_decision_repository_creates_and_lists_decisions(
+    session: AsyncSession,
+) -> None:
+    workspace_id, task_id, attempt_id = await _attempt(session)
+    decided_at = datetime(2026, 4, 26, 12, 30, tzinfo=UTC)
+
+    decision = await QueueDecisionRepository(session).create(
+        workspace_id=workspace_id,
+        task_id=task_id,
+        attempt_id=attempt_id,
+        decision="admitted",
+        reason_code="ADMITTED_LOCAL",
+        class_priority=5,
+        computed_priority=57,
+        age_boost=2,
+        retry_bonus=3,
+        resource_summary={
+            "node_id": "local",
+            "steady_cpu": 3.0,
+            "steady_memory_gb": 10.0,
+            "peak_cpu": 6.0,
+            "peak_memory_gb": 16.0,
+        },
+        overlap_risk_summary={
+            "warning_code": "OWNED_PATH_OVERLAP_RISK",
+            "overlap_count": 1,
+            "workspace_ids": ["ws_existing"],
+        },
+        decided_at=decided_at,
+    )
+    await session.commit()
+
+    rows = await QueueDecisionRepository(session).list_for_workspace(workspace_id)
+
+    assert [row.id for row in rows] == [decision.id]
+    assert decision.id.startswith("qd_")
+    assert rows[0].workspace_id == workspace_id
+    assert rows[0].task_id == task_id
+    assert rows[0].attempt_id == attempt_id
+    assert rows[0].decision == "admitted"
+    assert rows[0].reason_code == "ADMITTED_LOCAL"
+    assert rows[0].class_priority == 5
+    assert rows[0].computed_priority == 57
+    assert rows[0].age_boost == 2
+    assert rows[0].retry_bonus == 3
+    assert rows[0].resource_summary["peak_cpu"] == 6.0
+    assert rows[0].overlap_risk_summary["workspace_ids"] == ["ws_existing"]
+    assert rows[0].decided_at == decided_at
+
+
+@pytest.mark.unit
+async def test_resource_reservation_repository_tracks_active_and_released_rows(
+    session: AsyncSession,
+) -> None:
+    workspace_id, _task_id, attempt_id = await _attempt(session)
+    reserved_at = datetime(2026, 4, 26, 13, 0, tzinfo=UTC)
+    released_at = datetime(2026, 4, 26, 14, 0, tzinfo=UTC)
+
+    reservation = await ResourceReservationRepository(session).create(
+        workspace_id=workspace_id,
+        attempt_id=attempt_id,
+        node_id="local",
+        steady_cpu=4.0,
+        steady_memory_gb=12.0,
+        peak_cpu=8.0,
+        peak_memory_gb=24.0,
+        disk_mb=4096,
+        phase="workspace_lifecycle",
+        reserved_at=reserved_at,
+    )
+    assert reservation.id.startswith("rr_")
+    assert reservation.released_at is None
+    assert (await ResourceReservationRepository(session).active_for_workspace(workspace_id)).id == (
+        reservation.id
+    )
+
+    released = await ResourceReservationRepository(session).release_active_for_workspace(
+        workspace_id,
+        released_at=released_at,
+    )
+    rows = await ResourceReservationRepository(session).list_for_workspace(workspace_id)
+
+    assert [row.id for row in released] == [reservation.id]
+    assert rows[0].node_id == "local"
+    assert rows[0].steady_cpu == 4.0
+    assert rows[0].steady_memory_gb == 12.0
+    assert rows[0].peak_cpu == 8.0
+    assert rows[0].peak_memory_gb == 24.0
+    assert rows[0].disk_mb == 4096
+    assert rows[0].phase == "workspace_lifecycle"
+    assert rows[0].reserved_at == reserved_at
+    assert rows[0].released_at == released_at
+    assert await ResourceReservationRepository(session).active_for_workspace(workspace_id) is None

--- a/tests/unit/db/test_scheduler_records.py
+++ b/tests/unit/db/test_scheduler_records.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.db.base import Base
@@ -155,3 +156,55 @@ async def test_resource_reservation_repository_tracks_active_and_released_rows(
     assert rows[0].reserved_at == reserved_at
     assert rows[0].released_at == released_at
     assert await ResourceReservationRepository(session).active_for_workspace(workspace_id) is None
+
+
+@pytest.mark.unit
+async def test_resource_reservation_release_uses_single_update_returning(
+    session: AsyncSession,
+) -> None:
+    workspace_id, _task_id, attempt_id = await _attempt(session)
+    reserved_at = datetime(2026, 4, 26, 13, 0, tzinfo=UTC)
+    released_at = datetime(2026, 4, 26, 14, 0, tzinfo=UTC)
+
+    reservation = await ResourceReservationRepository(session).create(
+        workspace_id=workspace_id,
+        attempt_id=attempt_id,
+        node_id="local",
+        steady_cpu=4.0,
+        steady_memory_gb=12.0,
+        peak_cpu=8.0,
+        peak_memory_gb=24.0,
+        disk_mb=4096,
+        phase="workspace_lifecycle",
+        reserved_at=reserved_at,
+    )
+    await session.commit()
+
+    statements: list[str] = []
+
+    def record_sql(
+        conn: object,
+        cursor: object,
+        statement: str,
+        parameters: object,
+        context: object,
+        executemany: bool,
+    ) -> None:
+        del conn, cursor, parameters, context, executemany
+        statements.append(" ".join(statement.lower().split()))
+
+    engine = session.bind
+    assert engine is not None
+    event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+    try:
+        released = await ResourceReservationRepository(session).release_active_for_workspace(
+            workspace_id,
+            released_at=released_at,
+        )
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+
+    assert [row.id for row in released] == [reservation.id]
+    assert len(statements) == 1
+    assert statements[0].startswith("update resource_reservations ")
+    assert " returning " in statements[0]

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -74,6 +74,7 @@ async def _reservation_for_workspace(
     peak_cpu: float,
     peak_memory_gb: float,
     disk_mb: int | None = None,
+    reserved_at: datetime | None = None,
     released_at: datetime | None = None,
 ) -> None:
     async with session_factory() as session:
@@ -89,10 +90,13 @@ async def _reservation_for_workspace(
             task_class=workspace.task_class,
             owned_paths=list(workspace.owned_paths),
         )
-        attempt = await TaskAttemptRepository(session).create_for_workspace(
-            task=task,
-            workspace=workspace,
-        )
+        attempt_repo = TaskAttemptRepository(session)
+        attempt = await attempt_repo.get_by_workspace_id(workspace.id)
+        if attempt is None:
+            attempt = await attempt_repo.create_for_workspace(
+                task=task,
+                workspace=workspace,
+            )
         reservation = await ResourceReservationRepository(session).create(
             workspace_id=workspace.id,
             attempt_id=attempt.id,
@@ -103,6 +107,7 @@ async def _reservation_for_workspace(
             peak_memory_gb=peak_memory_gb,
             disk_mb=disk_mb,
             phase="workspace_lifecycle",
+            reserved_at=reserved_at,
         )
         reservation.released_at = released_at
         await session.commit()
@@ -661,6 +666,61 @@ async def test_resource_saturation_prefers_active_reservations_and_falls_back_fo
     assert summary.reserved_resources.steady_memory_gb == 22.0
     assert summary.reserved_resources.peak_cpu == 14.0
     assert summary.reserved_resources.peak_memory_gb == 40.0
+
+
+@pytest.mark.unit
+async def test_resource_saturation_uses_latest_active_reservation_per_workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_resource_saturation
+
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        workspace_steady_cpu=3.0,
+        workspace_steady_memory_gb=10.0,
+        workspace_peak_cpu=6.0,
+        workspace_peak_memory_gb=16.0,
+    )
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.running,
+        updated_at=now,
+    )
+    await _reservation_for_workspace(
+        session_factory,
+        workspace_id,
+        steady_cpu=4.0,
+        steady_memory_gb=12.0,
+        peak_cpu=8.0,
+        peak_memory_gb=24.0,
+        disk_mb=4096,
+        reserved_at=now - timedelta(minutes=5),
+    )
+    await _reservation_for_workspace(
+        session_factory,
+        workspace_id,
+        steady_cpu=6.0,
+        steady_memory_gb=14.0,
+        peak_cpu=10.0,
+        peak_memory_gb=28.0,
+        disk_mb=4096,
+        reserved_at=now,
+    )
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_check=_disk_check(),
+        now=now,
+    )
+
+    assert summary.reserved_resources.active_workspace_count == 1
+    assert summary.reserved_resources.steady_cpu == 6.0
+    assert summary.reserved_resources.steady_memory_gb == 14.0
+    assert summary.reserved_resources.peak_cpu == 10.0
+    assert summary.reserved_resources.peak_memory_gb == 28.0
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -12,7 +12,12 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
 
 from awf.common.config import Settings
 from awf.db.enums import FailureReason, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import (
+    ResourceReservationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
 from awf.db.session import make_session_factory
 from awf.service.disk import DiskCheck
 
@@ -58,6 +63,49 @@ async def _workspace(
         workspace.pr_url = pr_url
         await session.commit()
         return workspace.id
+
+
+async def _reservation_for_workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    *,
+    steady_cpu: float,
+    steady_memory_gb: float,
+    peak_cpu: float,
+    peak_memory_gb: float,
+    disk_mb: int | None = None,
+    released_at: datetime | None = None,
+) -> None:
+    async with session_factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=None,
+            idempotency_key=f"metrics-reservation:{workspace.id}",
+            task_class=workspace.task_class,
+            owned_paths=list(workspace.owned_paths),
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        reservation = await ResourceReservationRepository(session).create(
+            workspace_id=workspace.id,
+            attempt_id=attempt.id,
+            node_id="local",
+            steady_cpu=steady_cpu,
+            steady_memory_gb=steady_memory_gb,
+            peak_cpu=peak_cpu,
+            peak_memory_gb=peak_memory_gb,
+            disk_mb=disk_mb,
+            phase="workspace_lifecycle",
+        )
+        reservation.released_at = released_at
+        await session.commit()
 
 
 def _zero_status_counts() -> dict[str, int]:
@@ -547,6 +595,72 @@ async def test_resource_saturation_reports_active_counts_and_configured_defaults
     assert summary.admission.ok is True
     assert summary.admission.status == "saturated"
     assert summary.admission.reason == "WORKER_EXECUTION_CONCURRENCY_SATURATED"
+
+
+@pytest.mark.unit
+async def test_resource_saturation_prefers_active_reservations_and_falls_back_for_old_rows(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_resource_saturation
+
+    settings = Settings(
+        _env_file=None,
+        work_dir="/tmp/awf-work",
+        workspace_steady_cpu=3.0,
+        workspace_steady_memory_gb=10.0,
+        workspace_peak_cpu=6.0,
+        workspace_peak_memory_gb=16.0,
+    )
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    reserved_workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.running,
+        updated_at=now,
+    )
+    legacy_workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.ready,
+        updated_at=now,
+    )
+    released_workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.completed,
+        updated_at=now,
+    )
+    await _reservation_for_workspace(
+        session_factory,
+        reserved_workspace_id,
+        steady_cpu=4.0,
+        steady_memory_gb=12.0,
+        peak_cpu=8.0,
+        peak_memory_gb=24.0,
+        disk_mb=4096,
+    )
+    await _reservation_for_workspace(
+        session_factory,
+        released_workspace_id,
+        steady_cpu=100.0,
+        steady_memory_gb=100.0,
+        peak_cpu=100.0,
+        peak_memory_gb=100.0,
+        disk_mb=8192,
+        released_at=now,
+    )
+
+    summary = await summarize_resource_saturation(
+        session_factory,
+        settings=settings,
+        disk_check=_disk_check(),
+        now=now,
+    )
+
+    assert legacy_workspace_id
+    assert summary.workspace_counts.active_total == 2
+    assert summary.reserved_resources.active_workspace_count == 2
+    assert summary.reserved_resources.steady_cpu == 7.0
+    assert summary.reserved_resources.steady_memory_gb == 22.0
+    assert summary.reserved_resources.peak_cpu == 14.0
+    assert summary.reserved_resources.peak_memory_gb == 40.0
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_scheduler_records.py
+++ b/tests/unit/service/test_scheduler_records.py
@@ -1,0 +1,130 @@
+"""Workspace service persistence for admission decisions and reservations."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import WorkspaceCreateV2Request
+from awf.db.base import Base
+from awf.db.repositories import (
+    QueueDecisionRepository,
+    ResourceReservationRepository,
+    TaskAttemptRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+from awf.service.workspaces import WorkspaceService
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+def _request() -> WorkspaceCreateV2Request:
+    return WorkspaceCreateV2Request(
+        repo={"url": "git@github.com:example/service.git", "base_branch": "main"},
+        task={
+            "title": "Persist admission",
+            "prompt": "Persist scheduler admission and reservation state.",
+            "agent": "codex",
+            "kind": "feature_branch_pr",
+            "task_class": "dependency_task",
+            "priority": 25,
+            "owned_paths": ["pyproject.toml", "uv.lock"],
+        },
+        workspace={"profile_ref": "auto", "profile": None},
+        validation={"commands": ["uv run pytest -q"], "requested_tier": 2},
+        resources={
+            "steady_state_cpu_cores": 4.0,
+            "steady_state_memory_gb": 12.0,
+            "peak_cpu_cores": 8.0,
+            "peak_memory_gb": 24.0,
+            "disk_mb": 4096,
+        },
+    )
+
+
+@pytest.mark.unit
+async def test_create_v2_writes_admitted_decision_and_local_reservation(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    service = WorkspaceService(factory)
+
+    created = await service.create_v2(_request())
+
+    async with factory() as session:
+        attempt = await TaskAttemptRepository(session).get_by_workspace_id(created.id)
+        decisions = await QueueDecisionRepository(session).list_for_workspace(created.id)
+        reservations = await ResourceReservationRepository(session).list_for_workspace(created.id)
+
+    assert attempt is not None
+    assert len(decisions) == 1
+    assert decisions[0].workspace_id == created.id
+    assert decisions[0].task_id == attempt.task_id
+    assert decisions[0].attempt_id == attempt.id
+    assert decisions[0].decision == "admitted"
+    assert decisions[0].reason_code == "ADMITTED_LOCAL"
+    assert decisions[0].class_priority == 4
+    assert decisions[0].computed_priority == 37
+    assert decisions[0].age_boost == 0
+    assert decisions[0].retry_bonus == 0
+    assert decisions[0].resource_summary == {
+        "node_id": "local",
+        "steady_cpu": 4.0,
+        "steady_memory_gb": 12.0,
+        "peak_cpu": 8.0,
+        "peak_memory_gb": 24.0,
+        "disk_mb": 4096,
+        "phase": "workspace_lifecycle",
+    }
+    assert decisions[0].overlap_risk_summary == {
+        "warning_code": None,
+        "overlap_count": 0,
+        "workspace_ids": [],
+        "overlaps": [],
+    }
+
+    assert len(reservations) == 1
+    assert reservations[0].workspace_id == created.id
+    assert reservations[0].attempt_id == attempt.id
+    assert reservations[0].node_id == "local"
+    assert reservations[0].steady_cpu == 4.0
+    assert reservations[0].steady_memory_gb == 12.0
+    assert reservations[0].peak_cpu == 8.0
+    assert reservations[0].peak_memory_gb == 24.0
+    assert reservations[0].disk_mb == 4096
+    assert reservations[0].phase == "workspace_lifecycle"
+    assert reservations[0].released_at is None
+
+
+@pytest.mark.unit
+async def test_terminal_workspace_control_releases_active_reservation(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async def noop_stopper(_compose_project_name: str | None) -> None:
+        return None
+
+    service = WorkspaceService(factory, project_stopper=noop_stopper)
+    created = await service.create_v2(_request())
+
+    await service.cancel_workspace(
+        created.id,
+        reason="operator cancellation",
+        stop_stack=False,
+    )
+
+    async with factory() as session:
+        reservation = (await ResourceReservationRepository(session).list_for_workspace(created.id))[0]
+        active = await ResourceReservationRepository(session).active_for_workspace(created.id)
+
+    assert active is None
+    assert reservation.released_at is not None

--- a/tests/unit/service/test_scheduler_records.py
+++ b/tests/unit/service/test_scheduler_records.py
@@ -15,6 +15,7 @@ from awf.db.repositories import (
     TaskAttemptRepository,
 )
 from awf.db.session import make_engine, make_session_factory
+from awf.service import workspaces
 from awf.service.workspaces import WorkspaceService
 
 
@@ -128,3 +129,24 @@ async def test_terminal_workspace_control_releases_active_reservation(
 
     assert active is None
     assert reservation.released_at is not None
+
+
+@pytest.mark.unit
+def test_legacy_numeric_memory_without_unit_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    warnings: list[tuple[str, dict[str, object]]] = []
+
+    class Logger:
+        def warning(self, event: str, **kwargs: object) -> None:
+            warnings.append((event, kwargs))
+
+    monkeypatch.setattr(workspaces, "_log", Logger())
+
+    parsed = workspaces._parse_memory_gb("1024")
+
+    assert parsed == 1024.0
+    assert warnings == [
+        (
+            "workspace.resources.memory_unit_missing",
+            {"raw_value": "1024", "interpreted_unit": "gb"},
+        ),
+    ]

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -488,7 +488,7 @@ class TestStalenessRefreshService:
         assert first.resolved_at is None
 
     @pytest.mark.unit
-    async def test_refresh_clears_stale_when_findings_no_longer_apply(
+    async def test_refresh_preserves_existing_validation_stale_reason(
         self,
         factory: async_sessionmaker[AsyncSession],
     ) -> None:
@@ -501,6 +501,58 @@ class TestStalenessRefreshService:
             factory,
             owned_paths=["src/awf/api/**"],
             task_class="refactor_task",
+        )
+
+        async with factory() as session:
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                attempt_id,
+            )
+            assert candidate is not None
+            assert candidate.stale is True
+            assert candidate.stale_reason == "validation_insufficient_tier"
+
+        async with factory() as session:
+            service = StalenessRefreshService(session)
+            await service.refresh_candidate(
+                candidate_id,
+                target=TargetBranchState(
+                    branch="development",
+                    head_sha="b" * 40,
+                    changed_paths=("src/awf/api/routes/health.py",),
+                    advanced_commits=1,
+                ),
+            )
+            await session.commit()
+
+        async with factory() as session:
+            from awf.db.repositories import StaleReasonRepository
+
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                attempt_id,
+            )
+            reasons = await StaleReasonRepository(session).list_active_for_candidate(
+                candidate_id,
+            )
+
+        assert candidate is not None
+        assert candidate.stale is True
+        assert candidate.stale_reason == "validation_insufficient_tier"
+        assert {r.reason_code for r in reasons} >= {"STALE_OVERLAP"}
+
+    @pytest.mark.unit
+    async def test_refresh_clears_stale_when_findings_no_longer_apply(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        from awf.service.staleness import (
+            StalenessRefreshService,
+            TargetBranchState,
+        )
+
+        _workspace_id, attempt_id, candidate_id = await _seed_open_candidate(
+            factory,
+            owned_paths=["src/awf/api/**"],
+            task_class="docs_task",
         )
 
         async with factory() as session:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_5080dbb7abf54033b3f1a333` (agent: `codex`).

**External task ID**: awf-prd15-queue-reservations-20260426T175117Z

### Task
Read AGENTS.md and docs/awf_prd_v2.2.md before editing. Work strictly TDD: add failing tests first, confirm the failure when practical, implement, then run validation. Use conventional commits. Do not push; AWF owns push, PR creation, monitoring, and auto-merge. Target branch is codex/awf-post-merge-fixes, so auto_merge must stay true. Preserve existing behavior unless the prompt explicitly tightens the contract. If you touch Alembic migrations, final `uv run --python 3.12 --extra dev alembic heads` must print exactly one head.

PRD gap: AWF can report capacity, but it does not yet persist scheduler admission decisions or resource reservations as first-class objects. Implement the local single-node version and skip multi-node placement.

Behavior:
- Add `queue_decisions` records tied to task attempts/workspaces, capturing decision (`admitted`, `queued`, `blocked`), reason code, class priority, computed priority, age boost, retry bonus, resource summary, overlap-risk summary, and decided_at.
- Add `resource_reservations` records tied to attempts/workspaces with node_id, steady CPU/memory, peak CPU/memory, disk MB if available, reservation phase, reserved_at, released_at.
- On v2 workspace creation, persist an admitted queue decision and a local resource reservation using request resource overrides or service defaults. Owned-path overlaps must be advisory metadata, not admission blockers.
- Release/mark reservation on terminal workspace states where the lifecycle already centralizes transitions.
- Expose reservation/decision summary in merge queue or workspace/task API where it best fits without breaking existing clients.
- Update resource saturation metrics to prefer persisted active reservations where available, falling back to existing default active-count calculation for old rows.
- Add an Alembic migration. Final migration graph must have exactly one head; update `tests/unit/db/test_migration_graph.py` if the new head changes.

TDD requirements:
- DB/model tests for creating/listing queue decisions and reservations.
- Service tests showing v2 creation writes both records and terminal transition releases reservation.
- Metrics/API tests showing persisted reservations affect reserved resource totals.
- Migration test proving `alembic upgrade head` works.

---
Validation: 7 profile command(s) passed inside the workspace container.
