### PR TITLE
feat(validation): enforce workspace coverage policy

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -12,6 +12,10 @@ awf:
     coverage:
       minimum_percent: 99
       enforce: true
+      provider: python
+      command:
+        command: uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+        timeout_seconds: 900
   phases:
     setup:
       - command: uv sync --extra dev

--- a/src/awf/api/routes/validation.py
+++ b/src/awf/api/routes/validation.py
@@ -21,6 +21,7 @@ from awf.api.validation_runs import (
     _validation_status,
     _validation_tier,
     fresh_for_target,
+    validation_coverage_fields,
 )
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.models import ValidationRun, Workspace, WorkspaceLogStream
@@ -43,7 +44,8 @@ _PHASE_ORDER = {
     "healthcheck": 2,
     "post_agent": 3,
     "validate": 4,
-    "cleanup": 5,
+    "coverage": 5,
+    "cleanup": 6,
     "unknown": 99,
 }
 _SUCCESS_WORKSPACE_STATUSES = {
@@ -205,6 +207,7 @@ def _build_persisted_validation_items(
                         validation_target_head_sha=run.target_head_sha,
                         current_target_head_sha=current_target_head_sha,
                     ),
+                    **validation_coverage_fields(run),
                 )
             )
     return items
@@ -338,9 +341,15 @@ def _command_lookup(workspace: Workspace) -> dict[tuple[str, int], str]:
             "healthcheck",
             "post_agent",
             "validate",
+            "coverage",
             "cleanup",
         ):
             phase_key = _normalize_phase(phase_name)
+            if phase_name == "coverage":
+                coverage_command = profile.validation.coverage.command
+                if coverage_command is not None:
+                    lookup.setdefault((phase_key, 1), coverage_command.command)
+                continue
             if phase_name == "healthcheck":
                 for index, healthcheck in enumerate(
                     profile.validation.healthchecks,

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -380,6 +380,10 @@ class ValidationRunSummaryResponse(BaseModel):
     finished_at: datetime | None = None
     log_stream_refs: dict[str, Any] = Field(default_factory=dict)
     fresh_for_target: bool | None = None
+    coverage_percent: float | None = None
+    coverage_minimum_percent: float | None = None
+    coverage_status: str | None = None
+    coverage_reason_code: str | None = None
 
 
 StaleReasonStatus = Literal["active", "resolved"]

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -554,6 +554,10 @@ class ValidationProvenanceItemResponse(BaseModel):
     finished_at: datetime | None = None
     log_stream_refs: dict[str, Any] = Field(default_factory=dict)
     fresh_for_target: bool | None = None
+    coverage_percent: float | None = None
+    coverage_minimum_percent: float | None = None
+    coverage_status: str | None = None
+    coverage_reason_code: str | None = None
 
 
 class ValidationProvenanceListResponse(BaseModel):

--- a/src/awf/api/validation_runs.py
+++ b/src/awf/api/validation_runs.py
@@ -38,6 +38,7 @@ def validation_run_summary(
             validation_target_head_sha=run.target_head_sha,
             current_target_head_sha=current_target_head_sha,
         ),
+        **validation_coverage_fields(run),
     )
 
 

--- a/src/awf/api/validation_runs.py
+++ b/src/awf/api/validation_runs.py
@@ -79,3 +79,25 @@ def _json_dict(value: object) -> dict[str, Any]:
     if isinstance(value, Mapping):
         return {str(k): v for k, v in value.items()}
     return {}
+
+
+def validation_coverage_fields(run: ValidationRun) -> dict[str, Any]:
+    coverage = _json_dict(_json_dict(run.log_stream_refs).get("coverage"))
+    return {
+        "coverage_percent": _json_float(coverage.get("percent")),
+        "coverage_minimum_percent": _json_float(coverage.get("minimum_percent")),
+        "coverage_status": _json_str(coverage.get("status")),
+        "coverage_reason_code": _json_str(coverage.get("reason_code")),
+    }
+
+
+def _json_float(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _json_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -650,6 +650,7 @@ class WorkspaceExecutor:
                 validation_run_id,
                 status="succeeded" if val_result.all_passed else "failed",
                 reason_code=_validation_run_reason_code(val_result),
+                coverage=_validation_run_coverage_metadata(val_result),
             )
             if val_result.all_passed:
                 successful_validation_run_id = validation_run_id
@@ -659,6 +660,7 @@ class WorkspaceExecutor:
                     validation_run_id=validation_run_id,
                     requested_tier=validation_tier,
                     reason_code="VALIDATION_OK",
+                    coverage=_validation_run_coverage_metadata(val_result),
                 )
                 if pass_number > 0:
                     _log.info(
@@ -676,9 +678,7 @@ class WorkspaceExecutor:
                 fix_pass=pass_number,
                 max_fix_passes=max_fix_passes,
             )
-            last_failure_message = (
-                f"validation failed: {first_fail.command}" if first_fail else "validation failed"
-            )
+            last_failure_message = _validation_failure_message(val_result)
 
             if pass_number >= max_fix_passes or first_fail is None:
                 # Exhausted our budget (or no failure details to anchor a
@@ -689,6 +689,7 @@ class WorkspaceExecutor:
                     validation_run_id=validation_run_id,
                     requested_tier=validation_tier,
                     reason_code=_validation_run_reason_code(val_result),
+                    coverage=_validation_run_coverage_metadata(val_result),
                     error_message=last_failure_message,
                 )
                 await self._mark_failed(
@@ -1310,6 +1311,7 @@ class WorkspaceExecutor:
         requested_tier: int,
         reason_code: str | None,
         error_message: str | None = None,
+        coverage: dict[str, object] | None = None,
     ) -> None:
         async with self._session_factory() as session:
             repo = OperationRepository(session)
@@ -1330,6 +1332,8 @@ class WorkspaceExecutor:
                 "requested_tier": requested_tier,
                 "reason_code": reason_code,
             }
+            if coverage is not None:
+                result["coverage"] = coverage
             for operation in [*pending, *running]:
                 payload = dict(operation.payload or {})
                 payload.setdefault("requested_tier", requested_tier)
@@ -1349,6 +1353,7 @@ class WorkspaceExecutor:
         *,
         status: str,
         reason_code: str | None,
+        coverage: dict[str, object] | None = None,
     ) -> None:
         async with self._session_factory() as session:
             await ValidationRunRepository(session).finish(
@@ -1356,6 +1361,7 @@ class WorkspaceExecutor:
                 status=status,
                 reason_code=reason_code,
                 finished_at=datetime.now(UTC),
+                coverage=coverage,
             )
             await session.commit()
 
@@ -1480,7 +1486,8 @@ def _failure_reason_for_phase(first_fail: object | None) -> FailureReason:
 def _validation_command_count(ws: Workspace) -> int:
     if ws.resolved_profile:
         profile = WorkspaceProfile.model_validate(ws.resolved_profile)
-        return len(profile.phases.post_agent) + len(profile.phases.validate_commands)
+        coverage_count = 1 if profile.validation.coverage.command is not None else 0
+        return len(profile.phases.post_agent) + len(profile.phases.validate_commands) + coverage_count
     return len(ws.test_commands)
 
 
@@ -1498,6 +1505,8 @@ def _validation_run_command_records(
     ordered.extend(
         (phase, command.command) for phase, command in profile.phases.commands_for(phase_names)
     )
+    if "validate" in phase_names and profile.validation.coverage.command is not None:
+        ordered.append(("coverage", profile.validation.coverage.command.command))
 
     records: list[dict[str, Any]] = []
     phase_indices: dict[str, int] = {}
@@ -1556,7 +1565,34 @@ def _validation_run_log_stream_refs(
 def _validation_run_reason_code(result: ValidationResult) -> str:
     if result.all_passed:
         return "VALIDATION_OK"
+    if result.coverage is not None and not result.coverage.ok:
+        return result.coverage.reason_code
     first_failure = result.first_failure
     if first_failure is None:
         return "VALIDATION_FAILED"
     return first_failure.reason_code
+
+
+def _validation_run_coverage_metadata(result: ValidationResult) -> dict[str, object] | None:
+    if result.coverage is None:
+        return None
+    return result.coverage.as_metadata()
+
+
+def _validation_failure_message(result: ValidationResult) -> str:
+    coverage = result.coverage
+    if coverage is not None and not coverage.ok:
+        if coverage.reason_code == "COVERAGE_BELOW_THRESHOLD" and coverage.percent is not None:
+            return (
+                "validation failed: coverage "
+                f"{coverage.percent:.1f}% is below required {coverage.minimum_percent:.1f}%"
+            )
+        if coverage.reason_code == "COVERAGE_NOT_FOUND":
+            return "validation failed: coverage output was not found"
+        if coverage.reason_code == "COVERAGE_COMMAND_FAILED":
+            return "validation failed: coverage command failed"
+        if coverage.reason_code == "COVERAGE_PROVIDER_UNSUPPORTED":
+            return f"validation failed: unsupported coverage provider {coverage.provider}"
+
+    first_fail = result.first_failure
+    return f"validation failed: {first_fail.command}" if first_fail else "validation failed"

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -778,6 +778,7 @@ class ValidationRunRepository:
         status: str,
         reason_code: str | None,
         finished_at: datetime | None = None,
+        coverage: dict[str, Any] | None = None,
     ) -> ValidationRun | None:
         run = await self.get(validation_run_id)
         if run is None:
@@ -785,6 +786,10 @@ class ValidationRunRepository:
         run.status = status
         run.reason_code = reason_code
         run.finished_at = finished_at or datetime.now(UTC)
+        if coverage is not None:
+            log_stream_refs = dict(run.log_stream_refs or {})
+            log_stream_refs["coverage"] = dict(coverage)
+            run.log_stream_refs = log_stream_refs
         await self._session.flush()
         return run
 

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -105,15 +105,26 @@ class ProfileHealthCheck(BaseModel):
 class ProfileCoverage(BaseModel):
     """Repository coverage policy expected from validation.
 
-    The phase commands still decide how coverage is measured. This profile
-    field records the required threshold so schedulers, prompts, and future
-    merge policy can treat coverage as an explicit contract instead of prose.
+    The phase commands still decide the baseline validation surface. Coverage
+    collection is explicit: when ``command`` is set, AWF runs it and parses the
+    provider's output instead of inventing a number from test success.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     minimum_percent: float = Field(default=0.0, ge=0.0, le=100.0)
     enforce: bool = True
+    provider: Annotated[str, Field(min_length=1, max_length=64)] = "python"
+    command: ProfileCommand | None = None
+
+    @field_validator("command", mode="before")
+    @classmethod
+    def _coerce_command(cls, value: object) -> object:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            return ProfileCommand.from_shell(value)
+        return value
 
 
 class ProfileValidation(BaseModel):

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -14,14 +14,15 @@ callers that pass raw command strings. New code should call
 from __future__ import annotations
 
 import asyncio
+import re
 import shlex
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from awf.common.commands import AsyncCommandRunner, CommandResult
 from awf.common.logging import get_logger
-from awf.profiles.models import ProfileCommand, WorkspaceProfile
+from awf.profiles.models import ProfileCommand, ProfileCoverage, WorkspaceProfile
 from awf.runtime.logs import LogStore
 
 _log = get_logger(__name__)
@@ -30,6 +31,10 @@ _log = get_logger(__name__)
 # created during setup is picked up automatically by later Python commands.
 _VENV_ACTIVATE_PREAMBLE = (
     "[ -f /workspace/.venv/bin/activate ] && . /workspace/.venv/bin/activate; "
+)
+_COVERAGE_TOTAL_RE = re.compile(r"(?im)^\s*TOTAL\b.*?(?P<percent>\d+(?:\.\d+)?)%\s*$")
+_COVERAGE_SUMMARY_RE = re.compile(
+    r"(?i)\b(?:total\s+coverage|coverage)\D+(?P<percent>\d+(?:\.\d+)?)%"
 )
 
 
@@ -45,10 +50,40 @@ class ValidationCommandResult:
     phase: str = "validate"
     reason_code: str = "COMMAND_FAILED"
     stream_ids: dict[str, str | None] = field(default_factory=dict)
+    policy_failed: bool = False
 
     @property
     def ok(self) -> bool:
-        return self.returncode == 0
+        return self.returncode == 0 and not self.policy_failed
+
+
+@dataclass(frozen=True)
+class ValidationCoverageResult:
+    """Coverage measurement parsed from an explicit provider command."""
+
+    provider: str
+    percent: float | None
+    minimum_percent: float
+    enforce: bool
+    status: str
+    reason_code: str
+    command_result: ValidationCommandResult | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.status != "failed"
+
+    def as_metadata(self) -> dict[str, object]:
+        metadata: dict[str, object] = {
+            "provider": self.provider,
+            "minimum_percent": float(self.minimum_percent),
+            "enforce": self.enforce,
+            "status": self.status,
+            "reason_code": self.reason_code,
+        }
+        if self.percent is not None:
+            metadata["percent"] = float(self.percent)
+        return metadata
 
 
 @dataclass(frozen=True)
@@ -57,10 +92,13 @@ class ValidationResult:
 
     migration: ValidationCommandResult | None = None
     commands: list[ValidationCommandResult] = field(default_factory=list)
+    coverage: ValidationCoverageResult | None = None
 
     @property
     def all_passed(self) -> bool:
         if self.migration is not None and not self.migration.ok:
+            return False
+        if self.coverage is not None and not self.coverage.ok:
             return False
         return all(c.ok for c in self.commands)
 
@@ -68,7 +106,12 @@ class ValidationResult:
     def first_failure(self) -> ValidationCommandResult | None:
         if self.migration is not None and not self.migration.ok:
             return self.migration
-        return next((c for c in self.commands if not c.ok), None)
+        first_command_failure = next((c for c in self.commands if not c.ok), None)
+        if first_command_failure is not None:
+            return first_command_failure
+        if self.coverage is not None and not self.coverage.ok:
+            return self.coverage.command_result
+        return None
 
 
 class ValidationRunner:
@@ -116,6 +159,7 @@ class ValidationRunner:
             commands=commands,
             healthchecks=[],
             legacy_command_labels=True,
+            coverage=None,
         )
 
     async def run_profile_phases(
@@ -130,6 +174,7 @@ class ValidationRunner:
     ) -> ValidationResult:
         """Run the selected profile phases in order."""
         healthchecks = profile.validation.healthchecks if run_healthchecks else []
+        coverage = profile.validation.coverage if "validate" in set(phase_names) else None
         return await self._run_commands(
             workspace_id=workspace_id,
             compose_project=compose_project,
@@ -143,6 +188,7 @@ class ValidationRunner:
                 for h in healthchecks
             ],
             legacy_command_labels=False,
+            coverage=coverage,
         )
 
     async def _run_commands(
@@ -154,6 +200,7 @@ class ValidationRunner:
         commands: list[tuple[str, ProfileCommand]],
         healthchecks: list[tuple[str, ProfileCommand]],
         legacy_command_labels: bool,
+        coverage: ProfileCoverage | None,
     ) -> ValidationResult:
         workspace_artifacts = self._artifacts_dir / workspace_id
         workspace_artifacts.mkdir(parents=True, exist_ok=True)
@@ -188,7 +235,97 @@ class ValidationRunner:
                 )
                 return ValidationResult(commands=results)
 
-        return ValidationResult(commands=results)
+        coverage_result: ValidationCoverageResult | None = None
+        if coverage is not None and _coverage_requested(coverage):
+            coverage_result = await self._collect_coverage(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                coverage=coverage,
+                artifacts_dir=workspace_artifacts,
+                results=results,
+                phase_indices=phase_indices,
+            )
+
+        return ValidationResult(commands=results, coverage=coverage_result)
+
+    async def _collect_coverage(
+        self,
+        *,
+        workspace_id: str,
+        compose_project: str,
+        compose_file: Path,
+        coverage: ProfileCoverage,
+        artifacts_dir: Path,
+        results: list[ValidationCommandResult],
+        phase_indices: dict[str, int],
+    ) -> ValidationCoverageResult:
+        if coverage.provider != "python":
+            return ValidationCoverageResult(
+                provider=coverage.provider,
+                percent=None,
+                minimum_percent=coverage.minimum_percent,
+                enforce=coverage.enforce,
+                status="failed" if coverage.enforce else "unsupported",
+                reason_code="COVERAGE_PROVIDER_UNSUPPORTED",
+            )
+
+        command_result: ValidationCommandResult | None = None
+        if coverage.command is not None:
+            phase_indices["coverage"] = phase_indices.get("coverage", 0) + 1
+            label = f"{phase_indices['coverage']:02d}_coverage"
+            command_result = await self._exec(
+                compose_project=compose_project,
+                compose_file=compose_file,
+                cli_args=["sh", "-lc", _VENV_ACTIVATE_PREAMBLE + coverage.command.command],
+                label=label,
+                artifacts_dir=artifacts_dir,
+                phase="coverage",
+                timeout_seconds=coverage.command.timeout_seconds,
+            )
+            output = (
+                command_result.stdout_path.read_text(encoding="utf-8", errors="replace")
+                + "\n"
+                + command_result.stderr_path.read_text(encoding="utf-8", errors="replace")
+            )
+        else:
+            output = _combined_command_output(results)
+
+        percent = _parse_python_coverage_percent(output)
+        reason_code = _coverage_reason_code(
+            percent=percent,
+            minimum_percent=coverage.minimum_percent,
+            command_result=command_result,
+        )
+        status = _coverage_status(reason_code=reason_code, enforce=coverage.enforce)
+        policy_failed = status == "failed"
+        if command_result is not None:
+            command_result = replace(
+                command_result,
+                reason_code=reason_code,
+                policy_failed=policy_failed,
+            )
+            results.append(command_result)
+
+        _log.info(
+            "validation.coverage_collected",
+            workspace_id=workspace_id,
+            provider=coverage.provider,
+            percent=percent,
+            minimum_percent=coverage.minimum_percent,
+            enforce=coverage.enforce,
+            reason_code=reason_code,
+            status=status,
+        )
+        return ValidationCoverageResult(
+            provider=coverage.provider,
+            percent=percent,
+            minimum_percent=coverage.minimum_percent,
+            enforce=coverage.enforce,
+            status=status,
+            reason_code=reason_code,
+            command_result=command_result,
+        )
 
     async def _exec(
         self,
@@ -301,3 +438,52 @@ def _display_command(cli_args: list[str]) -> str:
             shell_cmd = shell_cmd[len(_VENV_ACTIVATE_PREAMBLE) :]
         return shell_cmd
     return " ".join(shlex.quote(a) for a in cli_args)
+
+
+def _coverage_requested(coverage: ProfileCoverage) -> bool:
+    return coverage.command is not None or coverage.minimum_percent > 0
+
+
+def _combined_command_output(results: list[ValidationCommandResult]) -> str:
+    parts: list[str] = []
+    for result in results:
+        parts.append(result.stdout_path.read_text(encoding="utf-8", errors="replace"))
+        parts.append(result.stderr_path.read_text(encoding="utf-8", errors="replace"))
+    return "\n".join(parts)
+
+
+def _parse_python_coverage_percent(output: str) -> float | None:
+    matches = list(_COVERAGE_TOTAL_RE.finditer(output))
+    if matches:
+        return float(matches[-1].group("percent"))
+
+    summary_matches = list(_COVERAGE_SUMMARY_RE.finditer(output))
+    if summary_matches:
+        return float(summary_matches[-1].group("percent"))
+
+    return None
+
+
+def _coverage_reason_code(
+    *,
+    percent: float | None,
+    minimum_percent: float,
+    command_result: ValidationCommandResult | None,
+) -> str:
+    if percent is None:
+        if command_result is not None and command_result.returncode != 0:
+            return "COVERAGE_COMMAND_FAILED"
+        return "COVERAGE_NOT_FOUND"
+    if percent < minimum_percent:
+        return "COVERAGE_BELOW_THRESHOLD"
+    if command_result is not None and command_result.returncode != 0:
+        return "COVERAGE_COMMAND_FAILED"
+    return "COVERAGE_OK"
+
+
+def _coverage_status(*, reason_code: str, enforce: bool) -> str:
+    if reason_code == "COVERAGE_OK":
+        return "passed"
+    if enforce:
+        return "failed"
+    return "reported"

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -283,15 +283,13 @@ class ValidationRunner:
                 phase="coverage",
                 timeout_seconds=coverage.command.timeout_seconds,
             )
-            output = (
-                command_result.stdout_path.read_text(encoding="utf-8", errors="replace")
-                + "\n"
-                + command_result.stderr_path.read_text(encoding="utf-8", errors="replace")
-            )
+            coverage_outputs = [command_result]
         else:
-            output = _combined_command_output(results)
+            coverage_outputs = results
 
-        percent = _parse_python_coverage_percent(output)
+        percent = _parse_python_coverage_percent_from_files(
+            _coverage_output_paths(coverage_outputs)
+        )
         reason_code = _coverage_reason_code(
             percent=percent,
             minimum_percent=coverage.minimum_percent,
@@ -444,24 +442,28 @@ def _coverage_requested(coverage: ProfileCoverage) -> bool:
     return coverage.command is not None or coverage.minimum_percent > 0
 
 
-def _combined_command_output(results: list[ValidationCommandResult]) -> str:
-    parts: list[str] = []
+def _coverage_output_paths(results: list[ValidationCommandResult]) -> list[Path]:
+    paths: list[Path] = []
     for result in results:
-        parts.append(result.stdout_path.read_text(encoding="utf-8", errors="replace"))
-        parts.append(result.stderr_path.read_text(encoding="utf-8", errors="replace"))
-    return "\n".join(parts)
+        paths.extend((result.stdout_path, result.stderr_path))
+    return paths
 
 
-def _parse_python_coverage_percent(output: str) -> float | None:
-    matches = list(_COVERAGE_TOTAL_RE.finditer(output))
-    if matches:
-        return float(matches[-1].group("percent"))
+def _parse_python_coverage_percent_from_files(paths: list[Path]) -> float | None:
+    total_percent: float | None = None
+    summary_percent: float | None = None
+    for path in paths:
+        with path.open("r", encoding="utf-8", errors="replace") as stream:
+            for line in stream:
+                total_match = _COVERAGE_TOTAL_RE.search(line)
+                if total_match:
+                    total_percent = float(total_match.group("percent"))
+                    continue
+                summary_match = _COVERAGE_SUMMARY_RE.search(line)
+                if summary_match:
+                    summary_percent = float(summary_match.group("percent"))
 
-    summary_matches = list(_COVERAGE_SUMMARY_RE.finditer(output))
-    if summary_matches:
-        return float(summary_matches[-1].group("percent"))
-
-    return None
+    return total_percent if total_percent is not None else summary_percent
 
 
 def _coverage_reason_code(

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -114,7 +114,19 @@ async def _insert_validation_run(
     target_head_sha: str,
     status: str = "succeeded",
     finished_at: datetime = datetime(2026, 4, 26, 12, 5, tzinfo=UTC),
+    coverage: dict[str, object] | None = None,
 ) -> None:
+    log_stream_refs: dict[str, object] = {
+        "commands": [
+            {
+                "stdout": "validation.01_validate.stdout",
+                "stderr": "validation.01_validate.stderr",
+            }
+        ]
+    }
+    if coverage is not None:
+        log_stream_refs["coverage"] = coverage
+
     factory = make_session_factory(engine)
     async with factory() as session:
         await session.execute(
@@ -176,16 +188,7 @@ async def _insert_validation_run(
                 ),
                 "started_at": datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
                 "finished_at": finished_at,
-                "log_stream_refs": json.dumps(
-                    {
-                        "commands": [
-                            {
-                                "stdout": "validation.01_validate.stdout",
-                                "stderr": "validation.01_validate.stderr",
-                            }
-                        ]
-                    }
-                ),
+                "log_stream_refs": json.dumps(log_stream_refs),
             },
         )
         await session.commit()
@@ -538,4 +541,55 @@ class TestMergeQueueList:
                 ]
             },
             "fresh_for_target": False,
+            "coverage_percent": None,
+            "coverage_minimum_percent": None,
+            "coverage_status": None,
+            "coverage_reason_code": None,
         }
+
+    @pytest.mark.unit
+    async def test_latest_validation_summary_exposes_coverage_policy(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        workspace_id = await _create_queue_workspace(
+            engine,
+            title="Coverage provenance",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/23",
+            branch_name="codex/merge-queue",
+            updated_at=datetime(2026, 4, 26, 12, 0, tzinfo=UTC),
+        )
+        attempt_id = await _attempt_id_for_workspace(engine, workspace_id)
+        await _insert_validation_run(
+            engine,
+            run_id="vr_232323232323232323232323",
+            workspace_id=workspace_id,
+            attempt_id=attempt_id,
+            target_head_sha="head123",
+            status="failed",
+            coverage={
+                "provider": "python",
+                "percent": 98.4,
+                "minimum_percent": 99.0,
+                "enforce": True,
+                "status": "failed",
+                "reason_code": "COVERAGE_BELOW_THRESHOLD",
+            },
+        )
+
+        response = await client.get("/v1/merge-queue")
+
+        assert response.status_code == 200
+        item = next(
+            item for item in response.json()["items"] if item["workspace_id"] == workspace_id
+        )
+        assert item["latest_validation"] is not None
+        assert item["latest_validation"]["coverage_percent"] == 98.4
+        assert item["latest_validation"]["coverage_minimum_percent"] == 99.0
+        assert item["latest_validation"]["coverage_status"] == "failed"
+        assert (
+            item["latest_validation"]["coverage_reason_code"]
+            == "COVERAGE_BELOW_THRESHOLD"
+        )

--- a/tests/unit/api/test_validation_provenance.py
+++ b/tests/unit/api/test_validation_provenance.py
@@ -398,6 +398,45 @@ async def test_validation_provenance_prefers_persisted_validation_runs(
 
 
 @pytest.mark.unit
+async def test_validation_provenance_reports_persisted_coverage_policy(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    workspace_id = await _create_v1_workspace(client)
+    await _mark_workspace_validation_failed(
+        engine,
+        workspace_id,
+        message="validation failed: coverage 98.4% is below required 99.0%",
+    )
+    await _insert_validation_run(
+        engine,
+        run_id="vr_222222222222222222222222",
+        workspace_id=workspace_id,
+        status="failed",
+        reason_code="COVERAGE_BELOW_THRESHOLD",
+        log_stream_refs={
+            "coverage": {
+                "provider": "python",
+                "percent": 98.4,
+                "minimum_percent": 99.0,
+                "enforce": True,
+                "status": "failed",
+                "reason_code": "COVERAGE_BELOW_THRESHOLD",
+            }
+        },
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/validation")
+
+    assert response.status_code == 200
+    item = response.json()["items"][0]
+    assert item["coverage_percent"] == 98.4
+    assert item["coverage_minimum_percent"] == 99.0
+    assert item["coverage_status"] == "failed"
+    assert item["coverage_reason_code"] == "COVERAGE_BELOW_THRESHOLD"
+
+
+@pytest.mark.unit
 async def test_validation_provenance_resolves_profile_commands_by_phase_index(
     client: AsyncClient,
     engine: AsyncEngine,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -100,6 +100,7 @@ async def _seed_ready_workspace(
     test_commands: list[str] | None = None,
     requires_database: bool = False,
     compose_file_path: str | None = None,
+    resolved_profile: dict | None = None,
 ) -> str:
     """Insert a workspace already in the ``ready`` state for the executor to pick up."""
     async with factory() as s:
@@ -112,6 +113,7 @@ async def _seed_ready_workspace(
             agent=agent,
             test_commands=test_commands or ["pytest -q"],
             requires_database=requires_database,
+            resolved_profile=resolved_profile,
         )
         # Walk through the transitions: requested → provisioning → ready.
         await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
@@ -527,6 +529,144 @@ class TestFailurePaths:
             assert ws is not None
             assert ws.status == WorkspaceStatus.failed.value
             assert ws.failure_reason == "validation_failure"
+
+    @pytest.mark.unit
+    async def test_coverage_below_threshold_fails_validation_with_structured_reason(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+        pr = PullRequestCreator(fake)
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=fake,
+            compose=compose,
+            validation=validation,
+            pr_creator=pr,
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "work" / "worktrees",
+                compose_projects_root=tmp_path / "work" / "compose",
+                default_models={
+                    AgentRuntime.codex: "gpt-5",
+                    AgentRuntime.claude_code: "sonnet",
+                    AgentRuntime.gemini: "gemini-2.5-pro",
+                },
+                max_validation_fix_passes=0,
+            ),
+        )
+        ws_id = await _seed_ready_workspace(
+            factory,
+            test_commands=[],
+            resolved_profile={
+                "name": "coverage-executor",
+                "phases": {"validate": ["pytest -q"]},
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 99,
+                        "enforce": True,
+                        "command": "pytest --cov=awf --cov-report=term",
+                    }
+                },
+            },
+        )
+        async with factory() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO operations (
+                        id,
+                        workspace_id,
+                        type,
+                        status,
+                        payload,
+                        created_at
+                    )
+                    VALUES (
+                        'op_validate_coverage',
+                        :workspace_id,
+                        'validate',
+                        'pending',
+                        '{"reason":"manual_validate"}',
+                        :created_at
+                    )
+                    """
+                ),
+                {"workspace_id": ws_id, "created_at": datetime.now(UTC)},
+            )
+            await session.commit()
+
+        fake.queue_result(returncode=0, stdout="codex finished")  # adapter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="CHANGELOG.md\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor ok
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation cmd
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name        Stmts   Miss  Cover\n"
+                "-------------------------------\n"
+                "TOTAL         100      2    98%\n"
+            ),
+        )  # coverage cmd
+
+        await executor.execute(ws_id)
+
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).get(ws_id)
+            assert workspace is not None
+            run = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT status, reason_code, log_stream_refs
+                        FROM validation_runs
+                        WHERE workspace_id = :workspace_id
+                        """
+                    ),
+                    {"workspace_id": ws_id},
+                )
+            ).mappings().one()
+            operation = (
+                await session.execute(
+                    text(
+                        """
+                        SELECT status, error_code, result
+                        FROM operations
+                        WHERE id = 'op_validate_coverage'
+                        """
+                    )
+                )
+            ).mappings().one()
+
+        assert workspace.status == WorkspaceStatus.failed.value
+        assert workspace.failure_reason == "validation_failure"
+        assert "coverage" in (workspace.failure_message or "").lower()
+        assert run["status"] == "failed"
+        assert run["reason_code"] == "COVERAGE_BELOW_THRESHOLD"
+        assert json.loads(run["log_stream_refs"])["coverage"] == {
+            "provider": "python",
+            "percent": 98.0,
+            "minimum_percent": 99.0,
+            "enforce": True,
+            "status": "failed",
+            "reason_code": "COVERAGE_BELOW_THRESHOLD",
+        }
+        assert operation["status"] == "failed"
+        assert operation["error_code"] == "COVERAGE_BELOW_THRESHOLD"
+        assert json.loads(operation["result"])["coverage"] == {
+            "provider": "python",
+            "percent": 98.0,
+            "minimum_percent": 99.0,
+            "enforce": True,
+            "status": "failed",
+            "reason_code": "COVERAGE_BELOW_THRESHOLD",
+        }
 
     @pytest.mark.unit
     async def test_push_failure_marks_failed_with_infrastructure_reason(

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -44,11 +44,24 @@ def test_profile_schema_accepts_validation_coverage_policy() -> None:
     profile = WorkspaceProfile.model_validate(
         {
             "name": "awf-self",
-            "validation": {"coverage": {"minimum_percent": 99}},
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99,
+                    "enforce": True,
+                    "command": {
+                        "command": "uv run pytest --cov=awf --cov-report=term",
+                        "timeout_seconds": 900,
+                    },
+                }
+            },
         }
     )
 
     assert profile.validation.coverage.minimum_percent == 99
+    assert profile.validation.coverage.enforce is True
+    assert profile.validation.coverage.command is not None
+    assert profile.validation.coverage.command.command == "uv run pytest --cov=awf --cov-report=term"
+    assert profile.validation.coverage.command.timeout_seconds == 900
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -132,6 +132,101 @@ class TestFailureStopsEarly:
         assert len(fake.calls) == 1
 
 
+class TestCoverageEnforcement:
+    @pytest.mark.unit
+    async def test_runs_configured_python_coverage_command_and_records_percent(
+        self, runner: tuple[FakeCommandRunner, ValidationRunner]
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(returncode=0, stdout="tests ok")
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name        Stmts   Miss  Cover\n"
+                "-------------------------------\n"
+                "TOTAL         100      5    95%\n"
+            ),
+        )
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "coverage-pass",
+                "phases": {"validate": ["pytest -q"]},
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 90,
+                        "enforce": True,
+                        "command": "pytest --cov=awf --cov-report=term",
+                    }
+                },
+            }
+        )
+
+        result = await val.run_profile_phases(
+            workspace_id="ws_coverage_pass",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase_names=("validate",),
+        )
+
+        assert result.all_passed
+        assert result.coverage is not None
+        assert result.coverage.percent == 95
+        assert result.coverage.minimum_percent == 90
+        assert result.coverage.reason_code == "COVERAGE_OK"
+        assert [(command.phase, command.command) for command in result.commands] == [
+            ("validate", "pytest -q"),
+            ("coverage", "pytest --cov=awf --cov-report=term"),
+        ]
+        assert result.commands[-1].stdout_path.name == "01_coverage.stdout"
+        assert "pytest --cov=awf --cov-report=term" in fake.calls[-1].args[-1]
+
+    @pytest.mark.unit
+    async def test_fails_when_configured_coverage_is_below_threshold(
+        self, runner: tuple[FakeCommandRunner, ValidationRunner]
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(returncode=0, stdout="tests ok")
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name        Stmts   Miss  Cover\n"
+                "-------------------------------\n"
+                "TOTAL         100     12    88%\n"
+            ),
+        )
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "coverage-fail",
+                "phases": {"validate": ["pytest -q"]},
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 90,
+                        "enforce": True,
+                        "command": "pytest --cov=awf --cov-report=term",
+                    }
+                },
+            }
+        )
+
+        result = await val.run_profile_phases(
+            workspace_id="ws_coverage_fail",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase_names=("validate",),
+        )
+
+        assert not result.all_passed
+        assert result.coverage is not None
+        assert result.coverage.percent == 88
+        assert result.coverage.minimum_percent == 90
+        assert result.coverage.reason_code == "COVERAGE_BELOW_THRESHOLD"
+        assert result.first_failure is not None
+        assert result.first_failure.phase == "coverage"
+        assert result.first_failure.reason_code == "COVERAGE_BELOW_THRESHOLD"
+
+
 class TestMigration:
     @pytest.mark.unit
     async def test_requires_database_no_longer_injects_alembic(

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -226,6 +226,51 @@ class TestCoverageEnforcement:
         assert result.first_failure.phase == "coverage"
         assert result.first_failure.reason_code == "COVERAGE_BELOW_THRESHOLD"
 
+    @pytest.mark.unit
+    async def test_coverage_without_command_streams_artifacts_instead_of_eager_reads(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name        Stmts   Miss  Cover\n"
+                "-------------------------------\n"
+                "TOTAL         100      4    96%\n"
+            ),
+        )
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "coverage-from-validation-artifacts",
+                "phases": {"validate": ["pytest --cov=awf --cov-report=term"]},
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 90,
+                        "enforce": True,
+                    }
+                },
+            }
+        )
+
+        def fail_read_text(self: Path, *args: object, **kwargs: object) -> str:
+            raise AssertionError(f"coverage parser eagerly read {self}")
+
+        monkeypatch.setattr(Path, "read_text", fail_read_text)
+
+        result = await val.run_profile_phases(
+            workspace_id="ws_coverage_streaming_parse",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase_names=("validate",),
+        )
+
+        assert result.all_passed
+        assert result.coverage is not None
+        assert result.coverage.percent == 96
+
 
 class TestMigration:
     @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ef711a2007c84db4be18969c` (agent: `codex`).


### Task
Implement PRD-backed coverage enforcement for AWF workspace profiles using strict TDD.

Goal: `.awf/workspace.yml` already declares `validation.coverage.minimum_percent: 99` and `enforce: true`, but AWF should actually enforce this when validation runs. Add the smallest industrial-grade implementation that makes coverage policy real.

Required behavior:
- Extend/confirm WorkspaceProfile validation coverage config supports `minimum_percent` and `enforce`.
- During validation, if coverage enforcement is enabled, collect coverage from configured Python pytest/coverage output or add a profile-driven coverage command path that is explicit and deterministic. Do not silently fake coverage.
- Persist/report coverage percent and threshold in validation provenance or validation API response where appropriate.
- Fail validation with a structured reason when coverage is below threshold.
- Preserve compatibility for profiles without coverage config.
- Keep implementation generic enough for later non-Python coverage providers; a Python provider is enough in this slice.

TDD contract:
1. Add failing focused tests first and commit the red tests with failure output in the commit body.
2. Implement until green.
3. Run the validation commands below.
4. Commit locally with conventional commits.
5. Do not push, do not create a PR, and do not switch branches; AWF owns that.

Validation commands:
- uv run --python 3.12 --extra dev ruff check src/awf tests/unit
- uv run --python 3.12 --extra dev mypy src/awf
- uv run --python 3.12 --extra dev pytest tests/unit/profiles tests/unit/runtime tests/unit/api -q

---
Validation: 6 profile command(s) passed inside the workspace container.
