### PR TITLE
feat(ops): add service-mode remonitor and recovery API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1079,6 +1079,7 @@ The console uses these AWF endpoints:
 - `GET /v1/workspaces/{id}/events` for the workspace timeline.
 - `GET /v1/workspaces/{id}/operations` for active and completed operations.
 - `GET /v1/workspaces/{id}/logs` and `GET /v1/workspaces/{id}/logs/{stream_id}` for log metadata and tail reads.
+- `POST /v1/workspaces/{id}/remonitor` for audited operator PR-monitor recovery; CLI: `awf workspace remonitor <id> --idempotency-key <key>`.
 - `WebSocket /v1/workspaces/{id}/ws`, proxied as browser-safe SSE at `/api/awf/workspaces/{id}/stream`, for live events and log frames.
 
 Recent dogfood observability slices added:

--- a/src/awf/api/routes/controls.py
+++ b/src/awf/api/routes/controls.py
@@ -14,6 +14,8 @@ from awf.service.controls import (
     WorkspaceControlError,
     WorkspaceControlService,
     WorkspaceNotFoundError,
+    WorkspaceRemonitorMissingPrUrlError,
+    WorkspaceRemonitorStateError,
     default_cleaner,
     stop_project_containers,
 )
@@ -64,6 +66,25 @@ async def stop_workspace(
         raise _http_error(exc) from exc
 
 
+@router.post("/remonitor", response_model=WorkspaceControlResponse)
+async def remonitor_workspace(
+    workspace_id: str,
+    payload: WorkspaceControlRequest,
+    idempotency_key: str | None = Header(default=None, alias="Idempotency-Key"),
+    if_match: str | None = Header(default=None, alias="If-Match"),
+    session: AsyncSession = Depends(get_db_session),
+) -> WorkspaceControlResponse:
+    try:
+        return await _controls(session).remonitor_workspace(
+            workspace_id,
+            reason=payload.reason,
+            idempotency_key=_require_idempotency_key(idempotency_key),
+            expected_version=_parse_if_match(if_match),
+        )
+    except WorkspaceControlError as exc:
+        raise _http_error(exc) from exc
+
+
 @router.delete("", response_model=WorkspaceControlResponse)
 async def destroy_workspace(
     workspace_id: str,
@@ -98,9 +119,16 @@ def _controls(session: AsyncSession) -> WorkspaceControlService:
 def _http_error(exc: WorkspaceControlError) -> HTTPException:
     if isinstance(exc, WorkspaceNotFoundError):
         status_code = status.HTTP_404_NOT_FOUND
+    elif isinstance(exc, WorkspaceRemonitorMissingPrUrlError):
+        status_code = status.HTTP_400_BAD_REQUEST
     elif isinstance(
         exc,
-        (ActiveWorkspaceDestroyError, IdempotencyConflictError, VersionConflictError),
+        (
+            ActiveWorkspaceDestroyError,
+            IdempotencyConflictError,
+            VersionConflictError,
+            WorkspaceRemonitorStateError,
+        ),
     ):
         status_code = status.HTTP_409_CONFLICT
     else:  # pragma: no cover - future control error subclasses

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -387,6 +387,41 @@ def workspace_retry(
     _handle_response(response, fmt)
 
 
+@workspace_app.command("remonitor")
+def workspace_remonitor(
+    workspace_id: str = typer.Argument(...),
+    reason: str | None = typer.Option(None, "--reason", help="Operator audit reason."),
+    idempotency_key: str = typer.Option(
+        ...,
+        "--idempotency-key",
+        help="Required idempotency key for this mutating control.",
+    ),
+    if_match: int | None = typer.Option(
+        None,
+        "--if-match",
+        help="Optional expected workspace version.",
+    ),
+    api_token: str | None = _api_token_option(),
+    base_url: str | None = typer.Option(None, "--base-url"),
+    fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+) -> None:
+    """Request PR monitor recovery for a monitoring workspace."""
+    headers = {
+        **_api_token_headers(api_token),
+        "Idempotency-Key": idempotency_key,
+    }
+    if if_match is not None:
+        headers["If-Match"] = str(if_match)
+    response = _call(
+        "POST",
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        base_url=_base_url(base_url),
+        json={"reason": reason},
+        headers=headers,
+    )
+    _handle_response(response, fmt)
+
+
 @workspace_app.command("list")
 def workspace_list(
     limit: int = typer.Option(50, "--limit"),

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -66,6 +66,7 @@ class OperationType(StrEnum):
     retry = "retry"
     cancel = "cancel"
     stop = "stop"
+    remonitor = "remonitor"
     destroy = "destroy"
 
 

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from datetime import datetime
 from pathlib import Path
 from typing import Protocol
 
@@ -317,16 +318,7 @@ class WorkspaceControlService:
             payload=operation_payload,
             idempotency_key=idempotency_key,
         )
-        claims_reset = {
-            "monitor_claim": (
-                workspace.monitor_claimed_by is not None
-                or workspace.monitor_claim_expires_at is not None
-            ),
-            "execution_claim": (
-                workspace.execution_claimed_by is not None
-                or workspace.execution_claim_expires_at is not None
-            ),
-        }
+        claims_reset = _claim_reset_snapshot(workspace)
         workspace.monitor_claimed_by = None
         workspace.monitor_claim_expires_at = None
         workspace.execution_claimed_by = None
@@ -630,6 +622,23 @@ def _operation_payload(
     if expected_version is not None:
         operation_payload["expected_version"] = expected_version
     return operation_payload
+
+
+def _claim_reset_snapshot(workspace: Workspace) -> dict[str, str | None]:
+    return {
+        "monitor_claimed_by": workspace.monitor_claimed_by,
+        "monitor_claim_expires_at": _json_datetime(workspace.monitor_claim_expires_at),
+        "execution_claimed_by": workspace.execution_claimed_by,
+        "execution_claim_expires_at": _json_datetime(
+            workspace.execution_claim_expires_at
+        ),
+    }
+
+
+def _json_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    return value.isoformat()
 
 
 def _is_active(status_value: WorkspaceStatus) -> bool:

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -109,6 +109,29 @@ class WorkspaceStackStopError(WorkspaceControlError):
         )
 
 
+class WorkspaceRemonitorMissingPrUrlError(WorkspaceControlError):
+    def __init__(self, workspace: Workspace) -> None:
+        super().__init__(
+            error_code="WORKSPACE_PR_URL_REQUIRED",
+            message="Workspace remonitor requires an existing PR URL.",
+            detail={"status": workspace.status},
+        )
+
+
+class WorkspaceRemonitorStateError(WorkspaceControlError):
+    def __init__(self, workspace: Workspace) -> None:
+        super().__init__(
+            error_code="WORKSPACE_STATE_NOT_REMONITORABLE",
+            message="Workspace is not in a state eligible for remonitor recovery.",
+            detail={
+                "status": workspace.status,
+                "eligible_statuses": [
+                    status.value for status in _REMONITOR_ELIGIBLE_STATUSES
+                ],
+            },
+        )
+
+
 class WorkspaceControlService:
     """Business logic for sensitive workspace lifecycle controls."""
 
@@ -250,6 +273,88 @@ class WorkspaceControlService:
             operation_id=operation.id,
             status=WorkspaceStatus(workspace.status),
             message="workspace stack stopped",
+        )
+
+    async def remonitor_workspace(
+        self,
+        workspace_id: str,
+        *,
+        reason: str | None,
+        idempotency_key: str | None = None,
+        expected_version: int | None = None,
+    ) -> WorkspaceControlResponse:
+        repo = WorkspaceRepository(self._session)
+        operations = OperationRepository(self._session)
+        payload: dict[str, object | None] = {"reason": reason}
+        operation_payload = _operation_payload(payload, expected_version=expected_version)
+        workspace, replay = await self._prepare_operation(
+            repo,
+            operations,
+            workspace_id=workspace_id,
+            operation_type=OperationType.remonitor,
+            payload=operation_payload,
+            idempotency_key=idempotency_key,
+            expected_version=expected_version,
+        )
+        if replay is not None:
+            return _control_response(
+                workspace=workspace,
+                operation=replay,
+                message="workspace PR monitor recovery requested",
+            )
+
+        if not workspace.pr_url:
+            raise WorkspaceRemonitorMissingPrUrlError(workspace)
+
+        current = WorkspaceStatus(workspace.status)
+        if current not in _REMONITOR_ELIGIBLE_STATUSES:
+            raise WorkspaceRemonitorStateError(workspace)
+
+        operation = await operations.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.remonitor,
+            status=OperationStatus.running,
+            payload=operation_payload,
+            idempotency_key=idempotency_key,
+        )
+        claims_reset = {
+            "monitor_claim": (
+                workspace.monitor_claimed_by is not None
+                or workspace.monitor_claim_expires_at is not None
+            ),
+            "execution_claim": (
+                workspace.execution_claimed_by is not None
+                or workspace.execution_claim_expires_at is not None
+            ),
+        }
+        workspace.monitor_claimed_by = None
+        workspace.monitor_claim_expires_at = None
+        workspace.execution_claimed_by = None
+        workspace.execution_claim_expires_at = None
+        workspace.version += 1
+        await repo.add_event(
+            workspace,
+            event_type="workspace.remonitor_requested",
+            reason_code="OPERATOR_REMONITOR",
+            payload={
+                "reason": reason,
+                "operation_id": operation.id,
+                "claims_reset": claims_reset,
+            },
+        )
+        await operations.finish(
+            operation,
+            status=OperationStatus.succeeded,
+            result={
+                "status": workspace.status,
+                "claims_reset": claims_reset,
+            },
+        )
+        return WorkspaceControlResponse(
+            workspace_id=workspace_id,
+            operation_id=operation.id,
+            status=WorkspaceStatus(workspace.status),
+            message="workspace PR monitor recovery requested",
         )
 
     async def destroy_workspace(
@@ -537,3 +642,6 @@ def _is_active(status_value: WorkspaceStatus) -> bool:
         WorkspaceStatus.pushing,
         WorkspaceStatus.monitoring_pr,
     }
+
+
+_REMONITOR_ELIGIBLE_STATUSES = frozenset({WorkspaceStatus.monitoring_pr})

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -22,6 +22,7 @@ from awf.node.git_manager import GitManager
 
 ProjectStopper = Callable[[str | None], Awaitable[None]]
 CleanerFactory = Callable[[], "WorkspaceCleanerProtocol"]
+_REMONITOR_ELIGIBLE_STATUSES = frozenset({WorkspaceStatus.monitoring_pr})
 
 
 class WorkspaceCleanerProtocol(Protocol):
@@ -651,6 +652,3 @@ def _is_active(status_value: WorkspaceStatus) -> bool:
         WorkspaceStatus.pushing,
         WorkspaceStatus.monitoring_pr,
     }
-
-
-_REMONITOR_ELIGIBLE_STATUSES = frozenset({WorkspaceStatus.monitoring_pr})

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -304,12 +304,12 @@ class WorkspaceControlService:
                 message="workspace PR monitor recovery requested",
             )
 
-        if not workspace.pr_url:
-            raise WorkspaceRemonitorMissingPrUrlError(workspace)
-
         current = WorkspaceStatus(workspace.status)
         if current not in _REMONITOR_ELIGIBLE_STATUSES:
             raise WorkspaceRemonitorStateError(workspace)
+
+        if not workspace.pr_url:
+            raise WorkspaceRemonitorMissingPrUrlError(workspace)
 
         operation = await operations.create(
             workspace_id=workspace_id,

--- a/tests/unit/api/test_workspace_controls_idempotency.py
+++ b/tests/unit/api/test_workspace_controls_idempotency.py
@@ -83,10 +83,14 @@ async def _seed_monitoring_workspace(
                 to=WorkspaceStatus.monitoring_pr,
                 reason_code="SEED",
             )
-        elif final_status == WorkspaceStatus.completed:
+        elif final_status in {
+            WorkspaceStatus.completed,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+        }:
             await repo.transition(
                 workspace,
-                to=WorkspaceStatus.completed,
+                to=final_status,
                 reason_code="SEED",
             )
         else:
@@ -563,6 +567,45 @@ async def test_remonitor_rejects_incompatible_state_with_structured_conflict(
         "message": "Workspace is not in a state eligible for remonitor recovery.",
         "detail": {
             "status": WorkspaceStatus.completed.value,
+            "eligible_statuses": [WorkspaceStatus.monitoring_pr.value],
+        },
+    }
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "final_status",
+    [
+        WorkspaceStatus.completed,
+        WorkspaceStatus.failed,
+        WorkspaceStatus.cancelled,
+    ],
+)
+async def test_remonitor_rejects_incompatible_state_before_missing_pr_url(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    final_status: WorkspaceStatus,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(
+        engine,
+        with_pr_url=False,
+        final_status=final_status,
+    )
+    headers = {**_auth(monkeypatch), "Idempotency-Key": f"remonitor-{final_status}"}
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error_code": "WORKSPACE_STATE_NOT_REMONITORABLE",
+        "message": "Workspace is not in a state eligible for remonitor recovery.",
+        "detail": {
+            "status": final_status.value,
             "eligible_statuses": [WorkspaceStatus.monitoring_pr.value],
         },
     }

--- a/tests/unit/api/test_workspace_controls_idempotency.py
+++ b/tests/unit/api/test_workspace_controls_idempotency.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +26,10 @@ _BODY = {
     "agent": "codex",
     "test_commands": ["pytest -q"],
 }
+_ACTIVE_CLAIM_EXPIRES_AT = datetime(2026, 4, 26, 12, 30, tzinfo=UTC)
+_ACTIVE_CLAIM_EXPIRES_AT_JSON = _ACTIVE_CLAIM_EXPIRES_AT.replace(
+    tzinfo=None
+).isoformat()
 
 
 @pytest.fixture(autouse=True)
@@ -89,11 +93,10 @@ async def _seed_monitoring_workspace(
             raise AssertionError(f"unsupported seed status {final_status}")
 
         if with_active_claims:
-            future = datetime.now(UTC) + timedelta(hours=1)
             workspace.monitor_claimed_by = "dead-monitor-worker"
-            workspace.monitor_claim_expires_at = future
+            workspace.monitor_claim_expires_at = _ACTIVE_CLAIM_EXPIRES_AT
             workspace.execution_claimed_by = "dead-execution-worker"
-            workspace.execution_claim_expires_at = future
+            workspace.execution_claim_expires_at = _ACTIVE_CLAIM_EXPIRES_AT
         await session.commit()
         return workspace.id
 
@@ -427,8 +430,10 @@ async def test_remonitor_resets_only_claims_and_records_audit_rows(
     assert operation.result == {
         "status": WorkspaceStatus.monitoring_pr.value,
         "claims_reset": {
-            "monitor_claim": True,
-            "execution_claim": True,
+            "monitor_claimed_by": "dead-monitor-worker",
+            "monitor_claim_expires_at": _ACTIVE_CLAIM_EXPIRES_AT_JSON,
+            "execution_claimed_by": "dead-execution-worker",
+            "execution_claim_expires_at": _ACTIVE_CLAIM_EXPIRES_AT_JSON,
         },
     }
     remonitor_event = next(
@@ -441,8 +446,10 @@ async def test_remonitor_resets_only_claims_and_records_audit_rows(
         "reason": "operator recovery",
         "operation_id": payload["operation_id"],
         "claims_reset": {
-            "monitor_claim": True,
-            "execution_claim": True,
+            "monitor_claimed_by": "dead-monitor-worker",
+            "monitor_claim_expires_at": _ACTIVE_CLAIM_EXPIRES_AT_JSON,
+            "execution_claimed_by": "dead-execution-worker",
+            "execution_claim_expires_at": _ACTIVE_CLAIM_EXPIRES_AT_JSON,
         },
     }
 

--- a/tests/unit/api/test_workspace_controls_idempotency.py
+++ b/tests/unit/api/test_workspace_controls_idempotency.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -12,7 +13,9 @@ from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
 import awf.api.routes.controls as controls_route
 from awf.common.config import get_settings
-from awf.db.models import Operation, WorkspaceEvent
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Operation, Workspace, WorkspaceEvent
+from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 
 _BODY = {
@@ -36,6 +39,63 @@ async def _create_workspace(client: AsyncClient) -> str:
     response = await client.post("/v1/workspaces", json=_BODY)
     assert response.status_code == 202
     return str(response.json()["workspace_id"])
+
+
+async def _seed_monitoring_workspace(
+    engine: AsyncEngine,
+    *,
+    with_pr_url: bool = True,
+    final_status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
+    with_active_claims: bool = False,
+) -> str:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/remonitor.git",
+            branch_base="development",
+            task_title="Remonitor a workspace",
+            task_prompt="Recover the PR monitor.",
+            agent="codex",
+            test_commands=["pytest -q"],
+        )
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = "a" * 40
+        workspace.compose_project_name = f"awf_{workspace.id}"
+        workspace.compose_file_path = f"/tmp/awf/{workspace.id}/compose.yml"
+        await repo.transition(workspace, to=WorkspaceStatus.ready, reason_code="SEED")
+        await repo.transition(workspace, to=WorkspaceStatus.running, reason_code="SEED")
+        await repo.transition(workspace, to=WorkspaceStatus.validating, reason_code="SEED")
+        await repo.transition(workspace, to=WorkspaceStatus.pushing, reason_code="SEED")
+        if with_pr_url:
+            workspace.pr_url = "https://github.com/example/remonitor/pull/42"
+            workspace.pr_number = 42
+            workspace.monitor_last_commit_sha = "b" * 40
+        if final_status == WorkspaceStatus.monitoring_pr:
+            await repo.transition(
+                workspace,
+                to=WorkspaceStatus.monitoring_pr,
+                reason_code="SEED",
+            )
+        elif final_status == WorkspaceStatus.completed:
+            await repo.transition(
+                workspace,
+                to=WorkspaceStatus.completed,
+                reason_code="SEED",
+            )
+        else:
+            raise AssertionError(f"unsupported seed status {final_status}")
+
+        if with_active_claims:
+            future = datetime.now(UTC) + timedelta(hours=1)
+            workspace.monitor_claimed_by = "dead-monitor-worker"
+            workspace.monitor_claim_expires_at = future
+            workspace.execution_claimed_by = "dead-execution-worker"
+            workspace.execution_claim_expires_at = future
+        await session.commit()
+        return workspace.id
 
 
 def _auth(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
@@ -252,6 +312,253 @@ async def test_stale_if_match_rejects_without_mutating(
     assert after_counts == before_counts
     assert stop_calls == []
     assert cleaner_calls == []
+
+
+@pytest.mark.unit
+async def test_remonitor_requires_idempotency_key(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(engine)
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=_auth(monkeypatch),
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "error_code": "INVALID_REQUEST",
+        "message": "Idempotency-Key header is required for this endpoint.",
+    }
+
+
+@pytest.mark.unit
+async def test_remonitor_replay_same_key_returns_same_operation_without_duplicate_rows(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(
+        engine,
+        with_active_claims=True,
+    )
+    headers = {**_auth(monkeypatch), "Idempotency-Key": "remonitor-same-key"}
+
+    first = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+    before_counts = await _counts(engine, workspace_id)
+    replay = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+    after_counts = await _counts(engine, workspace_id)
+
+    assert first.status_code == 200
+    assert replay.status_code == 200
+    assert replay.json()["operation_id"] == first.json()["operation_id"]
+    assert after_counts == before_counts
+
+
+@pytest.mark.unit
+async def test_remonitor_resets_only_claims_and_records_audit_rows(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(
+        engine,
+        with_active_claims=True,
+    )
+    headers = {
+        **_auth(monkeypatch),
+        "Idempotency-Key": "remonitor-claims",
+        "If-Match": "7",
+    }
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["workspace_id"] == workspace_id
+    assert payload["status"] == WorkspaceStatus.monitoring_pr.value
+    assert payload["message"] == "workspace PR monitor recovery requested"
+
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await session.get(Workspace, workspace_id)
+        operation = await session.get(Operation, payload["operation_id"])
+        events = (
+            await session.execute(
+                select(WorkspaceEvent)
+                .where(WorkspaceEvent.workspace_id == workspace_id)
+                .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
+            )
+        ).scalars().all()
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.monitoring_pr.value
+    assert workspace.version == 8
+    assert workspace.pr_url == "https://github.com/example/remonitor/pull/42"
+    assert workspace.branch_name == f"awf/{workspace_id}"
+    assert workspace.remote_push_branch == workspace.branch_name
+    assert workspace.monitor_claimed_by is None
+    assert workspace.monitor_claim_expires_at is None
+    assert workspace.execution_claimed_by is None
+    assert workspace.execution_claim_expires_at is None
+    assert operation is not None
+    assert operation.type == "remonitor"
+    assert operation.status == "succeeded"
+    assert operation.idempotency_key == "remonitor-claims"
+    assert operation.payload == {
+        "reason": "operator recovery",
+        "expected_version": 7,
+    }
+    assert operation.result == {
+        "status": WorkspaceStatus.monitoring_pr.value,
+        "claims_reset": {
+            "monitor_claim": True,
+            "execution_claim": True,
+        },
+    }
+    remonitor_event = next(
+        event for event in events if event.reason_code == "OPERATOR_REMONITOR"
+    )
+    assert remonitor_event.event_type == "workspace.remonitor_requested"
+    assert remonitor_event.old_state == WorkspaceStatus.monitoring_pr.value
+    assert remonitor_event.new_state == WorkspaceStatus.monitoring_pr.value
+    assert remonitor_event.payload == {
+        "reason": "operator recovery",
+        "operation_id": payload["operation_id"],
+        "claims_reset": {
+            "monitor_claim": True,
+            "execution_claim": True,
+        },
+    }
+
+
+@pytest.mark.unit
+async def test_remonitor_same_key_with_different_reason_returns_idempotency_conflict(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(engine)
+    headers = {**_auth(monkeypatch), "Idempotency-Key": "remonitor-conflict"}
+
+    first = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+    conflict = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "different recovery reason"},
+        headers=headers,
+    )
+
+    assert first.status_code == 200
+    assert conflict.status_code == 409
+    assert conflict.json()["detail"]["error_code"] == "IDEMPOTENCY_CONFLICT"
+
+
+@pytest.mark.unit
+async def test_remonitor_stale_if_match_rejects_without_mutating(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(engine, with_active_claims=True)
+    before_counts = await _counts(engine, workspace_id)
+    headers = {
+        **_auth(monkeypatch),
+        "Idempotency-Key": "remonitor-stale-version",
+        "If-Match": "0",
+    }
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+    after_counts = await _counts(engine, workspace_id)
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error_code": "VERSION_CONFLICT",
+        "message": "Workspace version does not match If-Match.",
+        "detail": {"expected_version": 0, "actual_version": 7},
+    }
+    assert after_counts == before_counts
+
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await session.get(Workspace, workspace_id)
+    assert workspace is not None
+    assert workspace.monitor_claimed_by == "dead-monitor-worker"
+    assert workspace.execution_claimed_by == "dead-execution-worker"
+
+
+@pytest.mark.unit
+async def test_remonitor_rejects_missing_pr_url_with_structured_bad_request(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(engine, with_pr_url=False)
+    headers = {**_auth(monkeypatch), "Idempotency-Key": "remonitor-missing-pr"}
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "error_code": "WORKSPACE_PR_URL_REQUIRED",
+        "message": "Workspace remonitor requires an existing PR URL.",
+        "detail": {"status": WorkspaceStatus.monitoring_pr.value},
+    }
+
+
+@pytest.mark.unit
+async def test_remonitor_rejects_incompatible_state_with_structured_conflict(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await _seed_monitoring_workspace(
+        engine,
+        final_status=WorkspaceStatus.completed,
+    )
+    headers = {**_auth(monkeypatch), "Idempotency-Key": "remonitor-completed"}
+
+    response = await client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        json={"reason": "operator recovery"},
+        headers=headers,
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == {
+        "error_code": "WORKSPACE_STATE_NOT_REMONITORABLE",
+        "message": "Workspace is not in a state eligible for remonitor recovery.",
+        "detail": {
+            "status": WorkspaceStatus.completed.value,
+            "eligible_statuses": [WorkspaceStatus.monitoring_pr.value],
+        },
+    }
 
 
 async def _call_control(

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -221,6 +221,62 @@ class TestWorkspaceRetry:
         )
 
 
+class TestWorkspaceRemonitor:
+    @pytest.mark.unit
+    def test_posts_remonitor_request_with_sensitive_control_headers(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("AWF_API_TOKEN", "env-secret")
+        response = _mock_response(
+            status_code=200,
+            payload={
+                "workspace_id": "ws_monitor",
+                "operation_id": "op_remonitor",
+                "status": "monitoring_pr",
+                "message": "workspace PR monitor recovery requested",
+            },
+        )
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "remonitor",
+                    "ws_monitor",
+                    "--reason",
+                    "operator recovery",
+                    "--idempotency-key",
+                    "remonitor-cli-key",
+                    "--if-match",
+                    "7",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "op_remonitor" in result.stdout
+        assert "env-secret" not in result.stdout
+        assert "env-secret" not in result.stderr
+        assert mock.call_args[0] == (
+            "POST",
+            "http://localhost:8000/v1/workspaces/ws_monitor/remonitor",
+        )
+        assert mock.call_args.kwargs["json"] == {"reason": "operator recovery"}
+        assert mock.call_args.kwargs["headers"] == {
+            "Authorization": "Bearer env-secret",
+            "Idempotency-Key": "remonitor-cli-key",
+            "If-Match": "7",
+        }
+
+    @pytest.mark.unit
+    def test_remonitor_cli_requires_idempotency_key_before_http_call(self) -> None:
+        with patch("awf.cli.main.httpx.request") as mock:
+            result = _runner.invoke(app, ["workspace", "remonitor", "ws_monitor"])
+
+        assert result.exit_code != 0
+        mock.assert_not_called()
+
+
 class TestWorkspaceList:
     @pytest.mark.unit
     def test_passes_limit_as_query_param(self) -> None:

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -25,6 +25,7 @@ from awf.db.session import make_engine, make_session_factory
 from awf.node.git_manager import GitManager
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
+from awf.service.controls import WorkspaceControlService
 
 
 def _git(args: list[str], cwd: Path) -> None:
@@ -295,6 +296,19 @@ class _RecordingRuntimeInspector:
     async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
         self.calls.append(compose_project_name)
         return self._snapshots[compose_project_name]
+
+
+async def _noop_project_stop(_compose_project_name: str | None) -> None:
+    return None
+
+
+class _UnexpectedCleaner:
+    async def cleanup(self, **_kwargs: object) -> list[str]:
+        raise AssertionError("remonitor must not run workspace cleanup")
+
+
+def _unexpected_cleaner_factory() -> _UnexpectedCleaner:
+    return _UnexpectedCleaner()
 
 
 class TestRunOnce:
@@ -864,6 +878,54 @@ class TestRunOnceMonitorRecovery:
         await worker.wait_for_execution_tasks()
 
         assert executor.calls == []
+        assert executor.resume_calls == [monitor_id]
+
+    @pytest.mark.unit
+    async def test_operator_remonitor_clears_active_claim_so_worker_resumes(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "claimed-monitor"
+        )
+        async with session_factory() as s:
+            workspace = await WorkspaceRepository(s).get(monitor_id)
+            assert workspace is not None
+            future = datetime.now(UTC) + timedelta(hours=1)
+            workspace.monitor_claimed_by = "dead-monitor-worker"
+            workspace.monitor_claim_expires_at = future
+            workspace.execution_claimed_by = "dead-execution-worker"
+            workspace.execution_claim_expires_at = future
+            await s.commit()
+
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=3),
+        )
+
+        assert await worker.run_once() == 0
+        assert executor.resume_calls == []
+
+        async with session_factory() as s:
+            result = await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).remonitor_workspace(
+                monitor_id,
+                reason="operator recovery",
+                idempotency_key="remonitor-worker-resume",
+            )
+            await s.commit()
+
+        assert result.status == WorkspaceStatus.monitoring_pr
+
+        assert await worker.run_once() == 1
+        await worker.wait_for_execution_tasks()
         assert executor.resume_calls == [monitor_id]
 
     @pytest.mark.unit

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -538,7 +538,7 @@ class TestStalenessRefreshService:
         _workspace_id, attempt_id, candidate_id = await _seed_open_candidate(
             factory,
             owned_paths=["src/awf/api/**"],
-            task_class="docs_task",
+            task_class="refactor_task",
         )
 
         async with factory() as session:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8c794efbe4e04496b1507438` (agent: `codex`).


### Task
Implement a proper service-mode operator remonitor/recovery API for AWF using strict TDD.

Context: during dogfood we had to manually repair service Postgres rows to reattach PR monitors. That is not industrial-grade. The existing `scripts/remonitor_workspace.py` is SQLite/runner-era compatibility; local-service Postgres mode needs an audited API/CLI operation.

Required behavior:
- Add an idempotent mutating endpoint such as `POST /v1/workspaces/{workspace_id}/remonitor` protected like other sensitive controls.
- Require `Idempotency-Key`; support `If-Match` where consistent with existing controls.
- Validate the workspace has a PR URL and is in an eligible state for remonitor/recovery. Return structured 409/400 errors for missing PR URL, incompatible state, or idempotency mismatch.
- Create an Operation row for remonitor/recovery and emit a workspace event with a clear reason code such as `OPERATOR_REMONITOR`.
- Reset only the monitor/execution claim fields needed for the worker to resume monitoring. Do not destroy worktrees or alter PR branches.
- Make the worker/executor consume the operation or otherwise reliably resume the PR monitor without direct SQL.
- Add CLI support if the existing CLI control surface makes this straightforward; otherwise document the API and leave CLI for a follow-up.
- Preserve existing cancel/stop/destroy behavior and idempotency tests.

TDD contract:
1. Add failing focused tests first and commit the red tests with failure output in the commit body.
2. Implement until green.
3. Run the validation commands below.
4. Commit locally with conventional commits.
5. Do not push, do not create a PR, and do not switch branches; AWF owns that.

Validation commands:
- uv run --python 3.12 --extra dev ruff check src/awf/api src/awf/service src/awf/control src/awf/cli tests/unit/api tests/unit/service tests/unit/control tests/unit/cli
- uv run --python 3.12 --extra dev mypy src/awf/api src/awf/service src/awf/control src/awf/cli
- uv run --python 3.12 --extra dev pytest tests/unit/api tests/unit/service tests/unit/control tests/unit/cli -q

---
Validation: 6 profile command(s) passed inside the workspace container.
