### PR TITLE
feat(queue): enforce merge candidate ordering in the PR monitor

### DIFF
--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -7,7 +7,7 @@ import binascii
 import json
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi import status as fastapi_status
@@ -17,6 +17,8 @@ from awf.api.deps import get_db_session
 from awf.api.schemas import (
     MergeBlockerReason,
     MergeCandidateReadinessResponse,
+    MergeQueueBlockerResponse,
+    MergeQueueBlockerState,
     MergeQueueItemResponse,
     MergeQueueListResponse,
     StaleReasonResponse,
@@ -31,6 +33,10 @@ from awf.db.repositories import (
     StaleReasonRepository,
     ValidationRunRepository,
     WorkspaceRepository,
+)
+from awf.service.merge_queue import (
+    MergeQueueBlocker,
+    list_merge_queue_blockers_for_candidate,
 )
 
 router = APIRouter(prefix="/v1/merge-queue", tags=["merge-queue"])
@@ -94,6 +100,7 @@ async def list_merge_queue(
     )
 
     stale_reasons_by_candidate = await _load_active_stale_reasons(session, page_rows)
+    blockers_by_candidate = await _load_queue_blockers(session, page_rows)
 
     return MergeQueueListResponse(
         items=[
@@ -101,6 +108,7 @@ async def list_merge_queue(
                 row,
                 latest_validation_runs.get(_row_workspace(row).id),
                 stale_reasons_by_candidate,
+                blockers_by_candidate,
             )
             for row in page_rows
         ],
@@ -121,16 +129,32 @@ async def _load_active_stale_reasons(
     return await StaleReasonRepository(session).list_active_for_candidates(candidate_ids)
 
 
+async def _load_queue_blockers(
+    session: AsyncSession,
+    rows: list[MergeCandidate | Workspace],
+) -> dict[str, list[MergeQueueBlocker]]:
+    candidate_ids = [row.id for row in rows if isinstance(row, MergeCandidate)]
+    blockers_by_candidate: dict[str, list[MergeQueueBlocker]] = {}
+    for candidate_id in candidate_ids:
+        blockers_by_candidate[candidate_id] = await list_merge_queue_blockers_for_candidate(
+            session,
+            candidate_id=candidate_id,
+        )
+    return blockers_by_candidate
+
+
 def _item_from_row(
     row: MergeCandidate | Workspace,
     latest_validation_run: ValidationRun | None,
     stale_reasons_by_candidate: dict[str, list[StaleReason]],
+    blockers_by_candidate: dict[str, list[MergeQueueBlocker]],
 ) -> MergeQueueItemResponse:
     if isinstance(row, MergeCandidate):
         return _item_from_candidate(
             row,
             latest_validation_run,
             stale_reasons=stale_reasons_by_candidate.get(row.id, []),
+            queue_blockers=blockers_by_candidate.get(row.id, []),
         )
     return _item_from_legacy_workspace(row, latest_validation_run)
 
@@ -140,10 +164,11 @@ def _item_from_candidate(
     latest_validation_run: ValidationRun | None,
     *,
     stale_reasons: list[StaleReason],
+    queue_blockers: list[MergeQueueBlocker],
 ) -> MergeQueueItemResponse:
     workspace = candidate.workspace
     latest_event = _latest_event(workspace.events)
-    reason, action = _merge_blocker_reason(candidate)
+    reason, action = _merge_blocker_reason(candidate, queue_blockers=queue_blockers)
     return MergeQueueItemResponse(
         candidate_id=candidate.id,
         candidate_status=candidate.status,
@@ -171,6 +196,7 @@ def _item_from_candidate(
         required_next_action=action,
         readiness=_readiness_from_candidate(candidate),
         canonical=candidate.attempt.is_canonical_for_merge,
+        queue_blockers=[_queue_blocker_response(blocker) for blocker in queue_blockers],
         latest_validation=_latest_validation_summary(
             latest_validation_run,
             current_target_head_sha=candidate.head_sha or workspace.monitor_last_commit_sha,
@@ -215,6 +241,7 @@ def _item_from_legacy_workspace(
         required_next_action=action,
         readiness=None,
         canonical=False,
+        queue_blockers=[],
         latest_validation=_latest_validation_summary(
             latest_validation_run,
             current_target_head_sha=workspace.monitor_last_commit_sha,
@@ -233,7 +260,26 @@ def _latest_event(events: list[WorkspaceEvent]) -> WorkspaceEvent | None:
     return events[-1] if events else None
 
 
-def _merge_blocker_reason(candidate: MergeCandidate) -> tuple[MergeBlockerReason, str | None]:
+def _queue_blocker_response(blocker: MergeQueueBlocker) -> MergeQueueBlockerResponse:
+    return MergeQueueBlockerResponse(
+        candidate_id=blocker.candidate_id,
+        workspace_id=blocker.workspace_id,
+        attempt_id=blocker.attempt_id,
+        task_id=blocker.task_id,
+        title=blocker.title,
+        pr_url=blocker.pr_url,
+        pr_number=blocker.pr_number,
+        status=WorkspaceStatus(blocker.status),
+        blocker_state=cast(MergeQueueBlockerState, blocker.blocker_state),
+        reason_code=blocker.reason_code,
+    )
+
+
+def _merge_blocker_reason(
+    candidate: MergeCandidate,
+    *,
+    queue_blockers: list[MergeQueueBlocker],
+) -> tuple[MergeBlockerReason, str | None]:
     if candidate.completed:
         return "completed", None
     if candidate.failed_or_cancelled:
@@ -248,6 +294,8 @@ def _merge_blocker_reason(candidate: MergeCandidate) -> tuple[MergeBlockerReason
         return "manual_merge_required", None
     if candidate.waiting_for_monitor:
         return "waiting_for_monitor", None
+    if queue_blockers:
+        return "waiting_for_older_candidate", "wait_for_queue"
     if candidate.ready:
         return "ready_to_merge_or_waiting_for_github", None
     return "workspace_not_terminal", None

--- a/src/awf/api/routes/merge_queue.py
+++ b/src/awf/api/routes/merge_queue.py
@@ -36,7 +36,7 @@ from awf.db.repositories import (
 )
 from awf.service.merge_queue import (
     MergeQueueBlocker,
-    list_merge_queue_blockers_for_candidate,
+    list_merge_queue_blockers_for_candidates,
 )
 
 router = APIRouter(prefix="/v1/merge-queue", tags=["merge-queue"])
@@ -134,13 +134,10 @@ async def _load_queue_blockers(
     rows: list[MergeCandidate | Workspace],
 ) -> dict[str, list[MergeQueueBlocker]]:
     candidate_ids = [row.id for row in rows if isinstance(row, MergeCandidate)]
-    blockers_by_candidate: dict[str, list[MergeQueueBlocker]] = {}
-    for candidate_id in candidate_ids:
-        blockers_by_candidate[candidate_id] = await list_merge_queue_blockers_for_candidate(
-            session,
-            candidate_id=candidate_id,
-        )
-    return blockers_by_candidate
+    return await list_merge_queue_blockers_for_candidates(
+        session,
+        candidate_ids=candidate_ids,
+    )
 
 
 def _item_from_row(

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -20,6 +20,7 @@ MergeBlockerReason = Literal[
     "ready_to_merge_or_waiting_for_github",
     "manual_merge_required",
     "waiting_for_monitor",
+    "waiting_for_older_candidate",
     "workspace_not_terminal",
     "completed",
     "failed_or_cancelled",
@@ -27,6 +28,7 @@ MergeBlockerReason = Literal[
     "stale",
 ]
 MergeCandidateStatus = Literal["open", "merged", "closed"]
+MergeQueueBlockerState = Literal["merge_eligible", "monitor_owned_recovery"]
 ValidationTier = Literal[1, 2, 3]
 ValidationProvenanceStatus = Literal["running", "succeeded", "failed", "unknown"]
 
@@ -422,6 +424,19 @@ class StaleReasonListResponse(BaseModel):
     items: list[StaleReasonResponse]
 
 
+class MergeQueueBlockerResponse(BaseModel):
+    candidate_id: str
+    workspace_id: str
+    attempt_id: str
+    task_id: str
+    title: str
+    pr_url: str
+    pr_number: int | None
+    status: WorkspaceStatus
+    blocker_state: MergeQueueBlockerState
+    reason_code: str
+
+
 class MergeQueueItemResponse(BaseModel):
     candidate_id: str | None = None
     candidate_status: MergeCandidateStatus | None = None
@@ -445,6 +460,7 @@ class MergeQueueItemResponse(BaseModel):
     required_next_action: str | None = None
     readiness: MergeCandidateReadinessResponse | None = None
     canonical: bool
+    queue_blockers: list[MergeQueueBlockerResponse] = Field(default_factory=list)
     latest_validation: ValidationRunSummaryResponse | None = None
     stale_reasons: list[StaleReasonResponse] = Field(default_factory=list)
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -74,6 +74,10 @@ from awf.runtime.pr_monitor import (
     decide,
 )
 from awf.service.gc import run_workspace_filesystem_gc
+from awf.service.merge_queue import (
+    MergeQueueBlocker,
+    list_merge_queue_blockers_for_workspace,
+)
 
 _log = get_logger(__name__)
 
@@ -590,7 +594,7 @@ class PullRequestMonitorRunner:
                         await OperationRepository(s).create(
                             workspace_id=workspace_id,
                             operation_type=req_action or "validate",
-                            payload={"reason": stale_reason},
+                            payload={"source": "pr_monitor", "reason": stale_reason},
                         )
                         await WorkspaceRepository(s).transition(
                             _ws,
@@ -619,6 +623,20 @@ class PullRequestMonitorRunner:
                 await self._deps.sleep(grace_wait_seconds)
                 return False
 
+            queue_blockers = await self._merge_queue_blockers_for_workspace(workspace_id)
+            if queue_blockers:
+                await self._wait_for_merge_queue(
+                    blockers=queue_blockers,
+                    workspace_id=workspace_id,
+                    repo_url=repo_url,
+                    base_branch=base_branch,
+                    pr_number=pr_number,
+                    status=status,
+                    state=state,
+                    monitor_log=monitor_log,
+                )
+                return False
+
             await self._record_merge_coordination_event(
                 "monitor.merge_critical_section_waiting",
                 monitor_log=monitor_log,
@@ -634,6 +652,7 @@ class PullRequestMonitorRunner:
             merge_blocker: GitHubClientError | None = None
             recheck_error: GitHubClientError | None = None
             merge_status = status
+            queue_blockers_after_lock: list[MergeQueueBlocker] = []
             async with self._merge_coordinator.serialized_merge(
                 repo_url=repo_url,
                 base_branch=base_branch,
@@ -687,12 +706,29 @@ class PullRequestMonitorRunner:
                             merge_status = checked_status
 
                 if recheck_error is None and fresh_action is None:
-                    try:
-                        merge_sha = await self._deps.gh.merge_pr(
-                            repo=repo, pr_number=pr_number
-                        )
-                    except GitHubClientError as exc:
-                        merge_blocker = exc
+                    queue_blockers_after_lock = (
+                        await self._merge_queue_blockers_for_workspace(workspace_id)
+                    )
+                    if not queue_blockers_after_lock:
+                        try:
+                            merge_sha = await self._deps.gh.merge_pr(
+                                repo=repo, pr_number=pr_number
+                            )
+                        except GitHubClientError as exc:
+                            merge_blocker = exc
+
+            if queue_blockers_after_lock:
+                await self._wait_for_merge_queue(
+                    blockers=queue_blockers_after_lock,
+                    workspace_id=workspace_id,
+                    repo_url=repo_url,
+                    base_branch=base_branch,
+                    pr_number=pr_number,
+                    status=merge_status,
+                    state=state,
+                    monitor_log=monitor_log,
+                )
+                return False
 
             if recheck_error is not None:
                 await self._terminate_failed(
@@ -798,6 +834,61 @@ class PullRequestMonitorRunner:
         }
         _log.info(event, **payload)
         await self._write_monitor_log(monitor_log, {"event": event, **payload})
+
+    async def _merge_queue_blockers_for_workspace(
+        self,
+        workspace_id: str,
+    ) -> list[MergeQueueBlocker]:
+        async with self._deps.session_factory() as s:
+            return await list_merge_queue_blockers_for_workspace(
+                s,
+                workspace_id=workspace_id,
+            )
+
+    async def _wait_for_merge_queue(
+        self,
+        *,
+        blockers: list[MergeQueueBlocker],
+        workspace_id: str,
+        repo_url: str,
+        base_branch: str,
+        pr_number: int,
+        status: PRStatus,
+        state: MonitorState,
+        monitor_log: WorkspaceLogSink | None,
+    ) -> None:
+        blocker = blockers[0]
+        payload = blocker.event_payload(repo_url=repo_url, base_branch=base_branch)
+        log_payload = {
+            "workspace_id": workspace_id,
+            "pr_number": pr_number,
+            "head_sha": status.head_sha[:10],
+            "blocker_count": len(blockers),
+            **payload,
+        }
+        _log.info("monitor.merge_queue_waiting", **log_payload)
+        await self._write_monitor_log(
+            monitor_log,
+            {"event": "monitor.merge_queue_waiting", **log_payload},
+        )
+
+        key = _merge_queue_wait_key(
+            head_sha=status.head_sha,
+            blocker_candidate_id=blocker.candidate_id,
+        )
+        if state.threads_addressed_ids.get(key) != "waiting":
+            await self._append_workspace_events(
+                workspace_id=workspace_id,
+                events=[
+                    WorkspaceEventCreate(
+                        event_type="workspace.merge_queue_waiting",
+                        reason_code=blocker.reason_code,
+                        payload=payload,
+                    )
+                ],
+            )
+            state.mark_addressed(key, "waiting")
+        await self._deps.sleep(self._config.poll_interval_seconds)
 
     async def _post_human_notification_once(
         self,
@@ -1807,6 +1898,10 @@ def _merge_rejection_reason(stderr: str) -> str:
 def _notification_key(*, head_sha: str, blocker_reason: str | None) -> str:
     reason = blocker_reason or "ready-to-merge"
     return f"__awf_notify__:{head_sha}:{reason}"
+
+
+def _merge_queue_wait_key(*, head_sha: str, blocker_candidate_id: str) -> str:
+    return f"__awf_merge_queue_wait__:{head_sha}:{blocker_candidate_id}"
 
 
 def _initial_review_grace_started_key(pr_number: int) -> str:

--- a/src/awf/service/merge_queue.py
+++ b/src/awf/service/merge_queue.py
@@ -194,7 +194,7 @@ def _is_monitor_recovery_operation(operation: Operation) -> bool:
     payload = operation.payload
     if not isinstance(payload, dict):
         return False
-    return payload.get("source") == "pr_monitor" or isinstance(payload.get("reason"), str)
+    return payload.get("source") == "pr_monitor"
 
 
 def _workspace_status(workspace: Workspace) -> WorkspaceStatus | None:

--- a/src/awf/service/merge_queue.py
+++ b/src/awf/service/merge_queue.py
@@ -48,13 +48,13 @@ class MergeQueueBlocker:
             "reason_code": self.reason_code,
             "repo_url": repo_url,
             "base_branch": base_branch,
-            "blocked_candidate_id": self.candidate_id,
-            "blocked_workspace_id": self.workspace_id,
-            "blocked_pr_url": self.pr_url,
-            "blocked_pr_number": self.pr_number,
-            "blocked_title": self.title,
-            "blocked_status": self.status,
-            "blocked_state": self.blocker_state,
+            "blocker_candidate_id": self.candidate_id,
+            "blocker_workspace_id": self.workspace_id,
+            "blocker_pr_url": self.pr_url,
+            "blocker_pr_number": self.pr_number,
+            "blocker_title": self.title,
+            "blocker_status": self.status,
+            "blocker_state": self.blocker_state,
         }
 
 

--- a/src/awf/service/merge_queue.py
+++ b/src/awf/service/merge_queue.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from sqlalchemy import and_, or_, select
@@ -78,6 +79,51 @@ async def list_merge_queue_blockers_for_candidate(
     return blockers
 
 
+async def list_merge_queue_blockers_for_candidates(
+    session: AsyncSession,
+    *,
+    candidate_ids: Iterable[str],
+) -> dict[str, list[MergeQueueBlocker]]:
+    """Return older same repo/base blockers for a batch of candidates."""
+
+    candidate_id_list = list(dict.fromkeys(candidate_ids))
+    blockers_by_candidate: dict[str, list[MergeQueueBlocker]] = {
+        candidate_id: [] for candidate_id in candidate_id_list
+    }
+    if not candidate_id_list:
+        return blockers_by_candidate
+
+    candidates = await _load_candidates(session, candidate_id_list)
+    merge_ready_candidates = [
+        candidate for candidate in candidates if _is_merge_ready_candidate(candidate)
+    ]
+    if not merge_ready_candidates:
+        return blockers_by_candidate
+
+    blocker_pool = await _load_older_open_candidate_pool(session, merge_ready_candidates)
+    blocker_pool_by_repo_base: dict[tuple[str, str], list[MergeCandidate]] = {}
+    for blocker_candidate in blocker_pool:
+        key = (blocker_candidate.repo_url, blocker_candidate.base_branch)
+        blocker_pool_by_repo_base.setdefault(key, []).append(blocker_candidate)
+
+    for candidate in merge_ready_candidates:
+        blockers = blockers_by_candidate[candidate.id]
+        repo_base = (candidate.repo_url, candidate.base_branch)
+        for blocker_candidate in blocker_pool_by_repo_base.get(repo_base, []):
+            if blocker_candidate.id == candidate.id or not _is_older_candidate(
+                blocker_candidate,
+                candidate,
+            ):
+                continue
+            blocker_state = _blocking_state(blocker_candidate)
+            if blocker_state is None:
+                continue
+            blockers.append(
+                _blocker_from_candidate(blocker_candidate, blocker_state=blocker_state)
+            )
+    return blockers_by_candidate
+
+
 async def list_merge_queue_blockers_for_workspace(
     session: AsyncSession,
     *,
@@ -87,6 +133,22 @@ async def list_merge_queue_blockers_for_workspace(
     if candidate is None:
         return []
     return await list_merge_queue_blockers_for_candidate(session, candidate_id=candidate.id)
+
+
+async def _load_candidates(
+    session: AsyncSession,
+    candidate_ids: list[str],
+) -> list[MergeCandidate]:
+    stmt = (
+        select(MergeCandidate)
+        .where(MergeCandidate.id.in_(candidate_ids))
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace).selectinload(Workspace.operations),
+            selectinload(MergeCandidate.task),
+        )
+    )
+    return list((await session.execute(stmt)).scalars())
 
 
 async def _load_candidate(
@@ -155,6 +217,68 @@ async def _load_older_open_candidates(
         .order_by(MergeCandidate.created_at.asc(), MergeCandidate.id.asc())
     )
     return list((await session.execute(stmt)).scalars())
+
+
+async def _load_older_open_candidate_pool(
+    session: AsyncSession,
+    candidates: list[MergeCandidate],
+) -> list[MergeCandidate]:
+    latest_candidate_by_repo_base: dict[tuple[str, str], MergeCandidate] = {}
+    for candidate in candidates:
+        key = (candidate.repo_url, candidate.base_branch)
+        latest_candidate = latest_candidate_by_repo_base.get(key)
+        if latest_candidate is None or _is_older_candidate(latest_candidate, candidate):
+            latest_candidate_by_repo_base[key] = candidate
+
+    repo_base_conditions = [
+        and_(
+            MergeCandidate.repo_url == repo_url,
+            MergeCandidate.base_branch == base_branch,
+            or_(
+                MergeCandidate.created_at < candidate.created_at,
+                and_(
+                    MergeCandidate.created_at == candidate.created_at,
+                    MergeCandidate.id < candidate.id,
+                ),
+            ),
+        )
+        for (repo_url, base_branch), candidate in sorted(
+            latest_candidate_by_repo_base.items()
+        )
+    ]
+    if not repo_base_conditions:
+        return []
+
+    stmt = (
+        select(MergeCandidate)
+        .join(TaskAttempt, MergeCandidate.attempt_id == TaskAttempt.id)
+        .where(
+            MergeCandidate.status == "open",
+            TaskAttempt.is_canonical_for_merge.is_(True),
+            or_(*repo_base_conditions),
+        )
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace).selectinload(Workspace.operations),
+            selectinload(MergeCandidate.task),
+        )
+        .order_by(
+            MergeCandidate.repo_url.asc(),
+            MergeCandidate.base_branch.asc(),
+            MergeCandidate.created_at.asc(),
+            MergeCandidate.id.asc(),
+        )
+    )
+    return list((await session.execute(stmt)).scalars())
+
+
+def _is_older_candidate(
+    candidate: MergeCandidate,
+    target: MergeCandidate,
+) -> bool:
+    return candidate.created_at < target.created_at or (
+        candidate.created_at == target.created_at and candidate.id < target.id
+    )
 
 
 def _blocking_state(candidate: MergeCandidate) -> str | None:

--- a/src/awf/service/merge_queue.py
+++ b/src/awf/service/merge_queue.py
@@ -1,0 +1,222 @@
+"""Merge-queue ordering policy helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.models import MergeCandidate, Operation, TaskAttempt, Workspace
+
+MERGE_QUEUE_WAIT_REASON_CODE = "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE"
+
+_RECOVERY_OPERATION_TYPES = {
+    OperationType.validate.value,
+    OperationType.rebase.value,
+}
+_ACTIVE_OPERATION_STATUSES = {
+    OperationStatus.pending.value,
+    OperationStatus.running.value,
+}
+_MONITOR_RECOVERY_STATUSES = {
+    WorkspaceStatus.ready,
+    WorkspaceStatus.running,
+    WorkspaceStatus.validating,
+    WorkspaceStatus.pushing,
+}
+
+
+@dataclass(frozen=True)
+class MergeQueueBlocker:
+    candidate_id: str
+    workspace_id: str
+    attempt_id: str
+    task_id: str
+    title: str
+    pr_url: str
+    pr_number: int | None
+    status: str
+    blocker_state: str
+    reason_code: str = MERGE_QUEUE_WAIT_REASON_CODE
+
+    def event_payload(self, *, repo_url: str, base_branch: str) -> dict[str, object]:
+        return {
+            "reason_code": self.reason_code,
+            "repo_url": repo_url,
+            "base_branch": base_branch,
+            "blocked_candidate_id": self.candidate_id,
+            "blocked_workspace_id": self.workspace_id,
+            "blocked_pr_url": self.pr_url,
+            "blocked_pr_number": self.pr_number,
+            "blocked_title": self.title,
+            "blocked_status": self.status,
+            "blocked_state": self.blocker_state,
+        }
+
+
+async def list_merge_queue_blockers_for_candidate(
+    session: AsyncSession,
+    *,
+    candidate_id: str,
+) -> list[MergeQueueBlocker]:
+    """Return older same repo/base candidates that must integrate first."""
+
+    candidate = await _load_candidate(session, candidate_id)
+    if candidate is None or not _is_merge_ready_candidate(candidate):
+        return []
+
+    rows = await _load_older_open_candidates(session, candidate)
+    blockers: list[MergeQueueBlocker] = []
+    for row in rows:
+        blocker_state = _blocking_state(row)
+        if blocker_state is None:
+            continue
+        blockers.append(_blocker_from_candidate(row, blocker_state=blocker_state))
+    return blockers
+
+
+async def list_merge_queue_blockers_for_workspace(
+    session: AsyncSession,
+    *,
+    workspace_id: str,
+) -> list[MergeQueueBlocker]:
+    candidate = await _load_open_candidate_for_workspace(session, workspace_id)
+    if candidate is None:
+        return []
+    return await list_merge_queue_blockers_for_candidate(session, candidate_id=candidate.id)
+
+
+async def _load_candidate(
+    session: AsyncSession,
+    candidate_id: str,
+) -> MergeCandidate | None:
+    stmt = (
+        select(MergeCandidate)
+        .where(MergeCandidate.id == candidate_id)
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace).selectinload(Workspace.operations),
+            selectinload(MergeCandidate.task),
+        )
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _load_open_candidate_for_workspace(
+    session: AsyncSession,
+    workspace_id: str,
+) -> MergeCandidate | None:
+    stmt = (
+        select(MergeCandidate)
+        .where(
+            MergeCandidate.workspace_id == workspace_id,
+            MergeCandidate.status == "open",
+        )
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace).selectinload(Workspace.operations),
+            selectinload(MergeCandidate.task),
+        )
+        .order_by(MergeCandidate.created_at.desc(), MergeCandidate.id.desc())
+        .limit(1)
+    )
+    return (await session.execute(stmt)).scalar_one_or_none()
+
+
+async def _load_older_open_candidates(
+    session: AsyncSession,
+    candidate: MergeCandidate,
+) -> list[MergeCandidate]:
+    stmt = (
+        select(MergeCandidate)
+        .join(TaskAttempt, MergeCandidate.attempt_id == TaskAttempt.id)
+        .where(
+            MergeCandidate.status == "open",
+            MergeCandidate.repo_url == candidate.repo_url,
+            MergeCandidate.base_branch == candidate.base_branch,
+            MergeCandidate.id != candidate.id,
+            TaskAttempt.is_canonical_for_merge.is_(True),
+            or_(
+                MergeCandidate.created_at < candidate.created_at,
+                and_(
+                    MergeCandidate.created_at == candidate.created_at,
+                    MergeCandidate.id < candidate.id,
+                ),
+            ),
+        )
+        .options(
+            selectinload(MergeCandidate.attempt),
+            selectinload(MergeCandidate.workspace).selectinload(Workspace.operations),
+            selectinload(MergeCandidate.task),
+        )
+        .order_by(MergeCandidate.created_at.asc(), MergeCandidate.id.asc())
+    )
+    return list((await session.execute(stmt)).scalars())
+
+
+def _blocking_state(candidate: MergeCandidate) -> str | None:
+    if _is_merge_ready_candidate(candidate):
+        return "merge_eligible"
+    if _is_monitor_owned_recovery(candidate):
+        return "monitor_owned_recovery"
+    return None
+
+
+def _is_merge_ready_candidate(candidate: MergeCandidate) -> bool:
+    return (
+        candidate.status == "open"
+        and candidate.attempt.is_canonical_for_merge
+        and candidate.workspace.auto_merge
+        and _workspace_status(candidate.workspace) == WorkspaceStatus.monitoring_pr
+        and not candidate.stale
+    )
+
+
+def _is_monitor_owned_recovery(candidate: MergeCandidate) -> bool:
+    workspace_status = _workspace_status(candidate.workspace)
+    return (
+        candidate.status == "open"
+        and candidate.attempt.is_canonical_for_merge
+        and candidate.workspace.auto_merge
+        and workspace_status in _MONITOR_RECOVERY_STATUSES
+        and any(_is_monitor_recovery_operation(op) for op in candidate.workspace.operations)
+    )
+
+
+def _is_monitor_recovery_operation(operation: Operation) -> bool:
+    if operation.type not in _RECOVERY_OPERATION_TYPES:
+        return False
+    if operation.status not in _ACTIVE_OPERATION_STATUSES:
+        return False
+    payload = operation.payload
+    if not isinstance(payload, dict):
+        return False
+    return payload.get("source") == "pr_monitor" or isinstance(payload.get("reason"), str)
+
+
+def _workspace_status(workspace: Workspace) -> WorkspaceStatus | None:
+    try:
+        return WorkspaceStatus(workspace.status)
+    except ValueError:
+        return None
+
+
+def _blocker_from_candidate(
+    candidate: MergeCandidate,
+    *,
+    blocker_state: str,
+) -> MergeQueueBlocker:
+    return MergeQueueBlocker(
+        candidate_id=candidate.id,
+        workspace_id=candidate.workspace_id,
+        attempt_id=candidate.attempt_id,
+        task_id=candidate.task_id,
+        title=candidate.workspace.task_title,
+        pr_url=candidate.pr_url,
+        pr_number=candidate.pr_number,
+        status=candidate.workspace.status,
+        blocker_state=blocker_state,
+    )

--- a/src/awf/service/staleness.py
+++ b/src/awf/service/staleness.py
@@ -419,8 +419,17 @@ class StalenessRefreshService:
         from awf.runtime.merge_eligibility import compute_stale_reason
 
         validation_reason, _ = compute_stale_reason(candidate.workspace)
+        existing_validation_reason = (
+            candidate.stale_reason
+            if candidate.stale_reason == "validation_insufficient_tier"
+            else None
+        )
         next_stale = stale or validation_reason is not None
-        next_stale_reason = validation_reason or ("stale" if stale else None)
+        next_stale_reason = (
+            validation_reason
+            or (existing_validation_reason if stale else None)
+            or ("stale" if stale else None)
+        )
         if candidate.stale != next_stale or candidate.stale_reason != next_stale_reason:
             candidate.stale = next_stale
             candidate.stale_reason = next_stale_reason

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -253,6 +253,7 @@ class TestMergeQueueList:
             "required_next_action",
             "readiness",
             "canonical",
+            "queue_blockers",
             "latest_validation",
             "stale_reasons",
         }
@@ -272,6 +273,7 @@ class TestMergeQueueList:
         assert item["owned_paths"] == ["src/awf/api/**"]
         assert item["last_event"]["event_type"] == "merge_queue.test_marker"
         assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
+        assert item["queue_blockers"] == []
         assert item["canonical"] is True
         assert item["readiness"] == {
             "ready": True,
@@ -486,6 +488,53 @@ class TestMergeQueueList:
             "stale_reason": None,
         }
         assert item["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
+
+    @pytest.mark.unit
+    async def test_exposes_older_candidate_blocker_details(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        older_id = await _create_queue_workspace(
+            engine,
+            title="Older queue candidate",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/61",
+            updated_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        )
+        later_id = await _create_queue_workspace(
+            engine,
+            title="Later queue candidate",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/62",
+            branch_name="codex/later-queue",
+            updated_at=datetime(2026, 4, 21, 12, 0, tzinfo=UTC),
+        )
+
+        response = await client.get("/v1/merge-queue", params={"limit": 20})
+
+        assert response.status_code == 200
+        items = {item["workspace_id"]: item for item in response.json()["items"]}
+        later = items[later_id]
+        older = items[older_id]
+        assert older["merge_blocker_reason"] == "ready_to_merge_or_waiting_for_github"
+        assert older["queue_blockers"] == []
+        assert later["merge_blocker_reason"] == "waiting_for_older_candidate"
+        assert later["required_next_action"] == "wait_for_queue"
+        assert later["queue_blockers"] == [
+            {
+                "candidate_id": older["candidate_id"],
+                "workspace_id": older_id,
+                "attempt_id": older["attempt_id"],
+                "task_id": older["task_id"],
+                "title": "Older queue candidate",
+                "pr_url": "https://github.com/example/console/pull/61",
+                "pr_number": 61,
+                "status": WorkspaceStatus.monitoring_pr.value,
+                "blocker_state": "merge_eligible",
+                "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
+            }
+        ]
 
     @pytest.mark.unit
     async def test_exposes_latest_validation_provenance_and_freshness(

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
@@ -603,6 +603,51 @@ class TestMergeQueueList:
                 "blocker_state": "monitor_owned_recovery",
                 "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
             }
+        ]
+
+    @pytest.mark.unit
+    async def test_loads_queue_blockers_without_per_candidate_queries(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        for index in range(3):
+            await _create_queue_workspace(
+                engine,
+                title=f"Queue candidate {index}",
+                status=WorkspaceStatus.monitoring_pr,
+                pr_url=f"https://github.com/example/console/pull/{70 + index}",
+                branch_name=f"codex/queue-{index}",
+                updated_at=datetime(2026, 4, 21 + index, 12, 0, tzinfo=UTC),
+                candidate_created_at=datetime(2026, 4, 20, 12, index, tzinfo=UTC),
+            )
+
+        statements: list[str] = []
+
+        def record_sql(
+            conn: object,
+            cursor: object,
+            statement: str,
+            parameters: object,
+            context: object,
+            executemany: bool,
+        ) -> None:
+            del conn, cursor, parameters, context, executemany
+            statements.append(" ".join(statement.lower().split()))
+
+        event.listen(engine.sync_engine, "before_cursor_execute", record_sql)
+        try:
+            response = await client.get("/v1/merge-queue", params={"limit": 20})
+        finally:
+            event.remove(engine.sync_engine, "before_cursor_execute", record_sql)
+
+        assert response.status_code == 200
+        assert len(response.json()["items"]) == 3
+        assert not [
+            statement
+            for statement in statements
+            if "from merge_candidates" in statement
+            and "where merge_candidates.id = ?" in statement
         ]
 
     @pytest.mark.unit

--- a/tests/unit/api/test_merge_queue.py
+++ b/tests/unit/api/test_merge_queue.py
@@ -10,8 +10,8 @@ from httpx import AsyncClient
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncEngine
 
-from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceRepository
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
+from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
 
 
@@ -28,6 +28,7 @@ async def _create_queue_workspace(
     task_class: str | None = "test_task",
     owned_paths: list[str] | None = None,
     updated_at: datetime | None = None,
+    candidate_created_at: datetime | None = None,
 ) -> str:
     from awf.db.repositories import MergeCandidateRepository, TaskAttemptRepository, TaskRepository
 
@@ -69,13 +70,16 @@ async def _create_queue_workspace(
         if pr_url is not None:
             attempt.is_canonical_for_merge = True
             candidate_repo = MergeCandidateRepository(session)
-            await candidate_repo.create_or_update_open_for_attempt(
+            candidate = await candidate_repo.create_or_update_open_for_attempt(
                 task=task,
                 attempt=attempt,
                 workspace=workspace,
                 head_sha="head123",
                 base_sha="base123",
             )
+            if candidate_created_at is not None:
+                candidate.created_at = candidate_created_at
+                candidate.updated_at = candidate_created_at
             if status == WorkspaceStatus.completed:
                 await candidate_repo.mark_workspace_merged(workspace.id)
             elif status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
@@ -103,6 +107,18 @@ async def _attempt_id_for_workspace(engine: AsyncEngine, workspace_id: str) -> s
         attempt_id = result.scalar_one()
         assert isinstance(attempt_id, str)
         return attempt_id
+
+
+async def _add_monitor_recovery_operation(engine: AsyncEngine, workspace_id: str) -> None:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        await OperationRepository(session).create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.pending,
+            payload={"source": "pr_monitor", "reason": "validation_insufficient_tier"},
+        )
+        await session.commit()
 
 
 async def _insert_validation_run(
@@ -504,6 +520,7 @@ class TestMergeQueueList:
             status=WorkspaceStatus.monitoring_pr,
             pr_url="https://github.com/example/console/pull/61",
             updated_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+            candidate_created_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
         )
         later_id = await _create_queue_workspace(
             engine,
@@ -512,6 +529,7 @@ class TestMergeQueueList:
             pr_url="https://github.com/example/console/pull/62",
             branch_name="codex/later-queue",
             updated_at=datetime(2026, 4, 21, 12, 0, tzinfo=UTC),
+            candidate_created_at=datetime(2026, 4, 20, 12, 5, tzinfo=UTC),
         )
 
         response = await client.get("/v1/merge-queue", params={"limit": 20})
@@ -535,6 +553,54 @@ class TestMergeQueueList:
                 "pr_number": 61,
                 "status": WorkspaceStatus.monitoring_pr.value,
                 "blocker_state": "merge_eligible",
+                "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
+            }
+        ]
+
+    @pytest.mark.unit
+    async def test_exposes_monitor_owned_recovery_blocker_details(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        older_id = await _create_queue_workspace(
+            engine,
+            title="Older recovery candidate",
+            status=WorkspaceStatus.ready,
+            pr_url="https://github.com/example/console/pull/63",
+            updated_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+            candidate_created_at=datetime(2026, 4, 20, 12, 0, tzinfo=UTC),
+        )
+        await _add_monitor_recovery_operation(engine, older_id)
+        later_id = await _create_queue_workspace(
+            engine,
+            title="Later queue candidate",
+            status=WorkspaceStatus.monitoring_pr,
+            pr_url="https://github.com/example/console/pull/64",
+            branch_name="codex/later-queue",
+            updated_at=datetime(2026, 4, 21, 12, 0, tzinfo=UTC),
+            candidate_created_at=datetime(2026, 4, 20, 12, 5, tzinfo=UTC),
+        )
+
+        response = await client.get("/v1/merge-queue", params={"limit": 20})
+
+        assert response.status_code == 200
+        items = {item["workspace_id"]: item for item in response.json()["items"]}
+        later = items[later_id]
+        older = items[older_id]
+        assert later["merge_blocker_reason"] == "waiting_for_older_candidate"
+        assert later["required_next_action"] == "wait_for_queue"
+        assert later["queue_blockers"] == [
+            {
+                "candidate_id": older["candidate_id"],
+                "workspace_id": older_id,
+                "attempt_id": older["attempt_id"],
+                "task_id": older["task_id"],
+                "title": "Older recovery candidate",
+                "pr_url": "https://github.com/example/console/pull/63",
+                "pr_number": 63,
+                "status": WorkspaceStatus.ready.value,
+                "blocker_state": "monitor_owned_recovery",
                 "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
             }
         ]

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -196,13 +196,13 @@ async def test_monitor_waits_for_older_candidate_without_notify_human(
         "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
         "repo_url": REPO_URL,
         "base_branch": "development",
-        "blocked_candidate_id": older_candidate_id,
-        "blocked_workspace_id": older_workspace_id,
-        "blocked_pr_url": "https://github.com/dimileeh/aira-web/pull/101",
-        "blocked_pr_number": 101,
-        "blocked_title": "Older candidate",
-        "blocked_status": older_status.value,
-        "blocked_state": "monitor_owned_recovery"
+        "blocker_candidate_id": older_candidate_id,
+        "blocker_workspace_id": older_workspace_id,
+        "blocker_pr_url": "https://github.com/dimileeh/aira-web/pull/101",
+        "blocker_pr_number": 101,
+        "blocker_title": "Older candidate",
+        "blocker_status": older_status.value,
+        "blocker_state": "monitor_owned_recovery"
         if recovery_operation
         else "merge_eligible",
     }

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -1,0 +1,279 @@
+"""PR monitor merge-queue ordering tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    OperationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+from awf.runtime.pr_monitor import Merge, MonitorState
+from tests.unit.runtime._monitor_runner_fixtures import FakeAdapter, RecordedSleep, make_runner
+from tests.unit.runtime.test_pr_monitor import _status
+
+REPO_URL = "git@github.com:dimileeh/aira-web.git"
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+async def _seed_monitoring_candidate(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    title: str,
+    pr_number: int,
+    created_at: datetime,
+    status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
+) -> tuple[str, str, str]:
+    async with factory() as session:
+        workspace_repo = WorkspaceRepository(session)
+        workspace = await workspace_repo.create(
+            repo_url=REPO_URL,
+            branch_base="development",
+            task_title=title,
+            task_prompt=f"Implement {title}.",
+            task_external_id=f"RUNTIME-QUEUE-{pr_number}",
+            auto_merge=True,
+            agent=AgentRuntime.claude_code.value,
+            test_commands=["pytest -q"],
+        )
+        workspace.status = status.value
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = "a" * 40
+        workspace.compose_project_name = f"awf_{workspace.id}"
+        workspace.compose_file_path = "/tmp/compose.yml"
+        workspace.pr_url = f"https://github.com/dimileeh/aira-web/pull/{pr_number}"
+        workspace.pr_number = pr_number
+        workspace.monitor_started_at = created_at
+
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=workspace.task_external_id,
+            idempotency_key=None,
+            task_class=None,
+            owned_paths=[],
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        attempt.is_canonical_for_merge = True
+        candidate = await MergeCandidateRepository(session).create_or_update_open_for_attempt(
+            task=task,
+            attempt=attempt,
+            workspace=workspace,
+            head_sha=f"head-{pr_number}",
+            base_sha="base",
+        )
+        candidate.created_at = created_at
+        candidate.updated_at = created_at
+        await session.commit()
+        return workspace.id, attempt.id, candidate.id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("older_status", "recovery_operation"),
+    [
+        (WorkspaceStatus.monitoring_pr, False),
+        (WorkspaceStatus.ready, True),
+    ],
+)
+async def test_monitor_waits_for_older_candidate_without_notify_human(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+    older_status: WorkspaceStatus,
+    recovery_operation: bool,
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    older_workspace_id, _older_attempt_id, older_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Older candidate",
+        pr_number=101,
+        created_at=now,
+        status=older_status,
+    )
+    later_workspace_id, _later_attempt_id, _later_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Later candidate",
+        pr_number=102,
+        created_at=now + timedelta(minutes=5),
+    )
+    if recovery_operation:
+        async with factory() as session:
+            await OperationRepository(session).create(
+                workspace_id=older_workspace_id,
+                operation_type=OperationType.validate,
+                status=OperationStatus.pending,
+                payload={"source": "pr_monitor", "reason": "validation_insufficient_tier"},
+            )
+            await session.commit()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=0,
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=later_workspace_id,
+        repo_url=REPO_URL,
+        repo=RepoRef.from_url(REPO_URL),
+        pr_number=102,
+        status=_status(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{later_workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(later_workspace_id)
+        assert workspace is not None
+        queue_wait_events = [
+            event
+            for event in workspace.events
+            if event.reason_code == "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE"
+        ]
+
+    assert terminal is False
+    assert sleep_fn.calls == [60]
+    assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+    assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
+    assert len(queue_wait_events) == 1
+    assert queue_wait_events[0].event_type == "workspace.merge_queue_waiting"
+    assert queue_wait_events[0].payload == {
+        "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
+        "repo_url": REPO_URL,
+        "base_branch": "development",
+        "blocked_candidate_id": older_candidate_id,
+        "blocked_workspace_id": older_workspace_id,
+        "blocked_pr_url": "https://github.com/dimileeh/aira-web/pull/101",
+        "blocked_pr_number": 101,
+        "blocked_title": "Older candidate",
+        "blocked_status": older_status.value,
+        "blocked_state": "monitor_owned_recovery"
+        if recovery_operation
+        else "merge_eligible",
+    }
+
+
+@pytest.mark.unit
+async def test_monitor_merges_once_older_candidate_is_closed(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    older_workspace_id, _older_attempt_id, _older_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Older candidate",
+        pr_number=201,
+        created_at=now,
+    )
+    later_workspace_id, _later_attempt_id, later_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Later candidate",
+        pr_number=202,
+        created_at=now + timedelta(minutes=5),
+    )
+    async with factory() as session:
+        await MergeCandidateRepository(session).close_open_for_workspace(
+            older_workspace_id,
+            close_reason="TEST_CLOSED",
+        )
+        await session.commit()
+
+    cmd.queue_result(returncode=0)  # gh pr merge
+    cmd.queue_result(returncode=0, stdout="MERGESHA\n")  # merge SHA lookup
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=0,
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=later_workspace_id,
+        repo_url=REPO_URL,
+        repo=RepoRef.from_url(REPO_URL),
+        pr_number=202,
+        status=_status(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{later_workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    async with factory() as session:
+        candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+            _later_attempt_id,
+        )
+        workspace = await WorkspaceRepository(session).get(later_workspace_id)
+
+    assert terminal is True
+    assert any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+    assert sleep_fn.calls == []
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.completed.value
+    assert candidate is not None
+    assert candidate.id == later_candidate_id
+    assert candidate.status == "merged"

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -209,15 +209,17 @@ async def test_monitor_waits_for_older_candidate_without_notify_human(
 
 
 @pytest.mark.unit
-async def test_monitor_merges_once_older_candidate_is_closed(
+@pytest.mark.parametrize("clearing_state", ["merged", "closed", "non_canonical"])
+async def test_monitor_merges_once_older_candidate_stops_blocking(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
     sleep_fn: RecordedSleep,
     tmp_path: Path,
+    clearing_state: str,
 ) -> None:
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
-    older_workspace_id, _older_attempt_id, _older_candidate_id = await _seed_monitoring_candidate(
+    older_workspace_id, older_attempt_id, _older_candidate_id = await _seed_monitoring_candidate(
         factory,
         title="Older candidate",
         pr_number=201,
@@ -230,10 +232,21 @@ async def test_monitor_merges_once_older_candidate_is_closed(
         created_at=now + timedelta(minutes=5),
     )
     async with factory() as session:
-        await MergeCandidateRepository(session).close_open_for_workspace(
-            older_workspace_id,
-            close_reason="TEST_CLOSED",
-        )
+        candidate_repo = MergeCandidateRepository(session)
+        if clearing_state == "merged":
+            await candidate_repo.mark_workspace_merged(older_workspace_id)
+        elif clearing_state == "closed":
+            await candidate_repo.close_open_for_workspace(
+                older_workspace_id,
+                close_reason="TEST_CLOSED",
+            )
+        else:
+            attempt = await TaskAttemptRepository(session).get_by_workspace_id(
+                older_workspace_id,
+            )
+            assert attempt is not None
+            assert attempt.id == older_attempt_id
+            attempt.is_canonical_for_merge = False
         await session.commit()
 
     cmd.queue_result(returncode=0)  # gh pr merge

--- a/tests/unit/service/test_merge_queue_ordering.py
+++ b/tests/unit/service/test_merge_queue_ordering.py
@@ -1,0 +1,226 @@
+"""Merge queue ordering policy tests."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    OperationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_engine, make_session_factory
+from awf.service.merge_queue import list_merge_queue_blockers_for_candidate
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_candidate(
+    session: AsyncSession,
+    *,
+    title: str,
+    pr_number: int,
+    created_at: datetime,
+    status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
+    repo_url: str = "git@github.com:example/service.git",
+    base_branch: str = "development",
+    canonical: bool = True,
+) -> tuple[str, str, str]:
+    workspace_repo = WorkspaceRepository(session)
+    workspace = await workspace_repo.create(
+        repo_url=repo_url,
+        branch_base=base_branch,
+        task_title=title,
+        task_prompt=f"Implement {title}.",
+        task_external_id=f"QUEUE-{pr_number}",
+        auto_merge=True,
+        agent=AgentRuntime.codex.value,
+        test_commands=[],
+    )
+    workspace.status = status.value
+    workspace.branch_name = f"awf/{workspace.id}"
+    workspace.remote_push_branch = workspace.branch_name
+    workspace.pr_url = f"https://github.com/example/service/pull/{pr_number}"
+    workspace.pr_number = pr_number
+
+    task = await TaskRepository(session).create_or_get(
+        repo_url=repo_url,
+        base_branch=base_branch,
+        title=title,
+        prompt=f"Implement {title}.",
+        external_id=f"QUEUE-{pr_number}",
+        idempotency_key=None,
+        task_class=None,
+        owned_paths=[],
+    )
+    attempt = await TaskAttemptRepository(session).create_for_workspace(
+        task=task,
+        workspace=workspace,
+    )
+    attempt.is_canonical_for_merge = canonical
+    candidate = await MergeCandidateRepository(session).create_or_update_open_for_attempt(
+        task=task,
+        attempt=attempt,
+        workspace=workspace,
+        head_sha=f"head-{pr_number}",
+        base_sha="base",
+    )
+    candidate.created_at = created_at
+    candidate.updated_at = created_at
+    await session.flush()
+    return workspace.id, attempt.id, candidate.id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("older_status", "operation_payload", "expected_state"),
+    [
+        (WorkspaceStatus.monitoring_pr, None, "merge_eligible"),
+        (
+            WorkspaceStatus.ready,
+            {"source": "pr_monitor", "reason": "validation_insufficient_tier"},
+            "monitor_owned_recovery",
+        ),
+    ],
+)
+async def test_older_open_candidate_blocks_later_same_repo_base_candidate(
+    factory: async_sessionmaker[AsyncSession],
+    older_status: WorkspaceStatus,
+    operation_payload: dict[str, str] | None,
+    expected_state: str,
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    async with factory() as session:
+        older_workspace_id, _older_attempt_id, older_candidate_id = await _seed_candidate(
+            session,
+            title="Older candidate",
+            pr_number=11,
+            created_at=now,
+            status=older_status,
+        )
+        _later_workspace_id, _later_attempt_id, later_candidate_id = await _seed_candidate(
+            session,
+            title="Later candidate",
+            pr_number=12,
+            created_at=now + timedelta(minutes=5),
+        )
+        if operation_payload is not None:
+            await OperationRepository(session).create(
+                workspace_id=older_workspace_id,
+                operation_type=OperationType.validate,
+                status=OperationStatus.pending,
+                payload=operation_payload,
+            )
+        await session.commit()
+
+    async with factory() as session:
+        blockers = await list_merge_queue_blockers_for_candidate(
+            session,
+            candidate_id=later_candidate_id,
+        )
+
+    assert len(blockers) == 1
+    assert blockers[0].candidate_id == older_candidate_id
+    assert blockers[0].workspace_id == older_workspace_id
+    assert blockers[0].blocker_state == expected_state
+    assert blockers[0].reason_code == "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("clearing_state", ["merged", "closed", "non_canonical"])
+async def test_blocker_clears_when_older_candidate_is_not_open_canonical(
+    factory: async_sessionmaker[AsyncSession],
+    clearing_state: str,
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    async with factory() as session:
+        older_workspace_id, older_attempt_id, _older_candidate_id = await _seed_candidate(
+            session,
+            title="Older candidate",
+            pr_number=21,
+            created_at=now,
+        )
+        _later_workspace_id, _later_attempt_id, later_candidate_id = await _seed_candidate(
+            session,
+            title="Later candidate",
+            pr_number=22,
+            created_at=now + timedelta(minutes=5),
+        )
+        candidate_repo = MergeCandidateRepository(session)
+        if clearing_state == "merged":
+            await candidate_repo.mark_workspace_merged(older_workspace_id)
+        elif clearing_state == "closed":
+            await candidate_repo.close_open_for_workspace(
+                older_workspace_id,
+                close_reason="TEST_CLOSED",
+            )
+        else:
+            attempt = await TaskAttemptRepository(session).get_by_workspace_id(
+                older_workspace_id,
+            )
+            assert attempt is not None
+            assert attempt.id == older_attempt_id
+            attempt.is_canonical_for_merge = False
+        await session.commit()
+
+    async with factory() as session:
+        blockers = await list_merge_queue_blockers_for_candidate(
+            session,
+            candidate_id=later_candidate_id,
+        )
+
+    assert blockers == []
+
+
+@pytest.mark.unit
+async def test_candidates_on_other_repo_or_base_do_not_block(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    async with factory() as session:
+        await _seed_candidate(
+            session,
+            title="Other repo",
+            pr_number=31,
+            created_at=now,
+            repo_url="git@github.com:example/other.git",
+        )
+        await _seed_candidate(
+            session,
+            title="Other base",
+            pr_number=32,
+            created_at=now + timedelta(minutes=1),
+            base_branch="main",
+        )
+        _later_workspace_id, _later_attempt_id, later_candidate_id = await _seed_candidate(
+            session,
+            title="Later candidate",
+            pr_number=33,
+            created_at=now + timedelta(minutes=5),
+        )
+        await session.commit()
+
+    async with factory() as session:
+        blockers = await list_merge_queue_blockers_for_candidate(
+            session,
+            candidate_id=later_candidate_id,
+        )
+
+    assert blockers == []

--- a/tests/unit/service/test_merge_queue_ordering.py
+++ b/tests/unit/service/test_merge_queue_ordering.py
@@ -144,6 +144,42 @@ async def test_older_open_candidate_blocks_later_same_repo_base_candidate(
 
 
 @pytest.mark.unit
+async def test_non_monitor_recovery_operation_does_not_block_later_candidate(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    async with factory() as session:
+        older_workspace_id, _older_attempt_id, _older_candidate_id = await _seed_candidate(
+            session,
+            title="Older manual recovery",
+            pr_number=13,
+            created_at=now,
+            status=WorkspaceStatus.ready,
+        )
+        _later_workspace_id, _later_attempt_id, later_candidate_id = await _seed_candidate(
+            session,
+            title="Later candidate",
+            pr_number=14,
+            created_at=now + timedelta(minutes=5),
+        )
+        await OperationRepository(session).create(
+            workspace_id=older_workspace_id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.pending,
+            payload={"source": "operator", "reason": "manual_validation"},
+        )
+        await session.commit()
+
+    async with factory() as session:
+        blockers = await list_merge_queue_blockers_for_candidate(
+            session,
+            candidate_id=later_candidate_id,
+        )
+
+    assert blockers == []
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("clearing_state", ["merged", "closed", "non_canonical"])
 async def test_blocker_clears_when_older_candidate_is_not_open_canonical(
     factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_merge_queue_ordering.py
+++ b/tests/unit/service/test_merge_queue_ordering.py
@@ -18,7 +18,7 @@ from awf.db.repositories import (
     WorkspaceRepository,
 )
 from awf.db.session import make_engine, make_session_factory
-from awf.service.merge_queue import list_merge_queue_blockers_for_candidate
+from awf.service.merge_queue import MergeQueueBlocker, list_merge_queue_blockers_for_candidate
 
 
 @pytest.fixture
@@ -30,6 +30,40 @@ async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
         yield make_session_factory(engine)
     finally:
         await engine.dispose()
+
+
+@pytest.mark.unit
+def test_blocker_event_payload_uses_blocker_field_names() -> None:
+    blocker = MergeQueueBlocker(
+        candidate_id="candidate-older",
+        workspace_id="workspace-older",
+        attempt_id="attempt-older",
+        task_id="task-older",
+        title="Older candidate",
+        pr_url="https://github.com/example/service/pull/11",
+        pr_number=11,
+        status=WorkspaceStatus.monitoring_pr.value,
+        blocker_state="merge_eligible",
+    )
+
+    payload = blocker.event_payload(
+        repo_url="git@github.com:example/service.git",
+        base_branch="development",
+    )
+
+    assert payload == {
+        "reason_code": "MERGE_QUEUE_WAITING_FOR_OLDER_CANDIDATE",
+        "repo_url": "git@github.com:example/service.git",
+        "base_branch": "development",
+        "blocker_candidate_id": "candidate-older",
+        "blocker_workspace_id": "workspace-older",
+        "blocker_pr_url": "https://github.com/example/service/pull/11",
+        "blocker_pr_number": 11,
+        "blocker_title": "Older candidate",
+        "blocker_status": WorkspaceStatus.monitoring_pr.value,
+        "blocker_state": "merge_eligible",
+    }
+    assert not any(key.startswith("blocked_") for key in payload)
 
 
 async def _seed_candidate(

--- a/tests/unit/service/test_staleness.py
+++ b/tests/unit/service/test_staleness.py
@@ -546,6 +546,15 @@ class TestStalenessRefreshService:
                 attempt_id,
             )
             assert candidate is not None
+            candidate.stale = True
+            candidate.stale_reason = "validation_insufficient_tier"
+            await session.commit()
+
+        async with factory() as session:
+            candidate = await MergeCandidateRepository(session).get_by_attempt_id(
+                attempt_id,
+            )
+            assert candidate is not None
             assert candidate.stale is True
             assert candidate.stale_reason == "validation_insufficient_tier"
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_94c9360012ed4e749bd203d1` (agent: `codex`).

**External task ID**: awf-prd20-merge-queue-ordering-20260426T1938Z

### Task
Implement the next PRD slice for governed integration: merge candidates must not be opportunistically merged out of order when multiple AWF PRs target the same base branch. Strict TDD. First add failing tests proving: (1) the PR monitor does not merge a candidate when an older open merge candidate for the same repo/base is still merge-eligible or in monitor-owned recovery; (2) the monitor emits/records a structured queue-wait reason rather than NotifyHuman; (3) once the blocking candidate is merged/closed/non-canonical, the later candidate can merge; (4) /v1/merge-queue exposes enough blocker detail for the console. Then implement. Preserve the existing merge critical section, freshness gates, comments/checks gates, and auto_merge semantics. Owned-path overlap is advisory and must not block admission. Add focused unit tests under tests/unit/runtime, tests/unit/service, and tests/unit/api as appropriate. Run validation: uv run --python 3.12 --extra dev ruff check src/awf tests/unit; uv run --python 3.12 --extra dev mypy src/awf; uv run --python 3.12 --extra dev pytest tests/unit/runtime tests/unit/service tests/unit/api -q. Commit with conventional commits. Do not push or open/merge PRs manually; AWF owns branch, push, PR, review handling, and merge.

---
Validation: 6 profile command(s) passed inside the workspace container.
