### PR TITLE
feat(metrics): expose dogfood failure root-cause clusters

### DIFF
--- a/docs/awf-plans/ws_48b6ca97ac0b4aa9aab44125.conformance.json
+++ b/docs/awf-plans/ws_48b6ca97ac0b4aa9aab44125.conformance.json
@@ -1,0 +1,1 @@
+{"status":"satisfied","summary":"The implementation accurately aligns with the plan. All changes are present in the designated files, and the corresponding unit tests exist and pass successfully.","gaps":[]}

--- a/docs/awf-plans/ws_48b6ca97ac0b4aa9aab44125.md
+++ b/docs/awf-plans/ws_48b6ca97ac0b4aa9aab44125.md
@@ -1,0 +1,53 @@
+# AWF Observability Improvement: Root Cause Clusters Plan
+
+## Intended Files to Touch
+
+1. **`src/awf/service/metrics.py`**
+   - Add new `RootCauseCluster` dataclass.
+   - Update `FailureAnalysisSummary` dataclass to include `root_cause_clusters: list[RootCauseCluster]`.
+   - Implement `_cluster_root_causes(session, window_start)` or equivalent logic to query failed `Workspace` rows and compute the clusters.
+   - Implement signal detection parsing on `failure_message` to map to "likely phase/root cause" and "actionable next action". Supported signals: `AGENT_AUTH_FAILED`, `model not found or 404`, `missing worktree`, `coverage threshold failure`, `syntax/import errors during validation`, `GitHub transient/auth errors`, `unknown validation failure`.
+   - Parse `agent_model` from the JSON `task_policy` column when present.
+
+2. **`src/awf/api/routes/metrics.py`**
+   - Add `RootCauseClusterResponse(BaseModel)` Pydantic schema.
+   - Update `FailureAnalysisSummaryResponse` to include a `root_cause_clusters: list[RootCauseClusterResponse]` field, defaulting to an empty list for safety.
+
+3. **`tests/unit/service/test_metrics.py`**
+   - Add targeted test methods for root-cause grouping and signal detection logic.
+
+4. **`tests/unit/api/test_failure_analysis.py`**
+   - Update or add tests verifying the serialization of the new `root_cause_clusters` field on the API payload.
+
+## Tests to Write First (TDD)
+
+- **`test_metrics.py`:**
+  - `test_root_cause_clusters_mixed_rows`: Insert mixed failed workspace rows into the DB containing varying `failure_message` values and verify they cluster correctly into the defined signals.
+  - `test_root_cause_clusters_agent_model_extraction`: Validate that `agent_model` is properly extracted from `task_policy` JSON (and omitted gracefully when absent).
+  - `test_root_cause_clusters_empty_history`: Ensure an empty result list is returned when there are no failed workspaces in the window.
+  - `test_existing_failure_groups_unaffected`: Verify `failure_groups` and `latest_examples` remain populated exactly as before.
+
+- **`test_failure_analysis.py`:**
+  - `test_api_route_serialization`: Call the failure analysis endpoint and verify `root_cause_clusters` is serialized correctly in the JSON response payload, maintaining backward-compatibility.
+
+## Validation Commands
+
+To validate the changes strictly without repo-wide formatters:
+
+```bash
+uv run pytest tests/unit/service/test_metrics.py
+uv run pytest tests/unit/api/test_failure_analysis.py
+uv run mypy src/awf/service/metrics.py src/awf/api/routes/metrics.py
+```
+
+## Risks, Assumptions, and Explicit Non-Goals
+
+- **Assumptions**: 
+  - `agent_model` resides within the root keys of the JSON `task_policy` column mapping (e.g. `workspace.task_policy.get("agent_model")`).
+  - Signal detection string matching on `failure_message` can be done using simple substring/Regex matching in Python memory, as the number of failed workspaces within the default summary window (24h) is generally small enough to avoid fetching issues.
+- **Risks**:
+  - Processing JSON fields and long strings inside the application instead of using pure SQL aggregations could have minor performance impacts if the window contains tens of thousands of failed workspaces.
+- **Non-Goals**: 
+  - Do NOT modify the behavior or schema of the existing `failure_groups` and `latest_examples` arrays. 
+  - Do NOT format the entire repository; no repo-wide formatters.
+  - Do NOT modify the React frontend (`apps/console`) as part of this plan.

--- a/src/awf/api/routes/metrics.py
+++ b/src/awf/api/routes/metrics.py
@@ -88,6 +88,18 @@ class FailedWorkspaceExampleResponse(BaseModel):
     updated_at: datetime
 
 
+class RootCauseClusterResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    agent: str
+    agent_model: str | None
+    failure_reason: str
+    likely_cause: str
+    actionable_next_action: str
+    count: int
+    sample_workspace_ids: list[str]
+
+
 class FailureAnalysisSummaryResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -103,6 +115,10 @@ class FailureAnalysisSummaryResponse(BaseModel):
     )
     latest_examples: list[FailedWorkspaceExampleResponse] = Field(
         description="Most recently updated failed workspaces in the requested window.",
+    )
+    root_cause_clusters: list[RootCauseClusterResponse] = Field(
+        default_factory=list,
+        description="Identified root cause clusters from failure signals.",
     )
 
 

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 
 from sqlalchemy import func, select
@@ -100,6 +100,17 @@ class FailedWorkspaceExample:
 
 
 @dataclass(frozen=True)
+class RootCauseCluster:
+    agent: str
+    agent_model: str | None
+    failure_reason: str
+    likely_cause: str
+    actionable_next_action: str
+    count: int
+    sample_workspace_ids: list[str]
+
+
+@dataclass(frozen=True)
 class FailureAnalysisSummary:
     generated_at: datetime
     window_start: datetime
@@ -107,6 +118,7 @@ class FailureAnalysisSummary:
     total_failed_workspaces: int
     failure_groups: list[FailureReasonGroup]
     latest_examples: list[FailedWorkspaceExample]
+    root_cause_clusters: list[RootCauseCluster] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -353,6 +365,7 @@ async def summarize_failure_analysis_for_session(
         window_start=window_start,
         limit=failure_example_limit,
     )
+    clusters = await _cluster_root_causes(session, window_start=window_start)
 
     return FailureAnalysisSummary(
         generated_at=generated_at,
@@ -361,7 +374,74 @@ async def summarize_failure_analysis_for_session(
         total_failed_workspaces=sum(reason_counts.values()),
         failure_groups=_failure_reason_groups(reason_counts),
         latest_examples=latest_examples,
+        root_cause_clusters=clusters,
     )
+
+
+async def _cluster_root_causes(session: AsyncSession, window_start: datetime) -> list[RootCauseCluster]:
+    stmt = select(
+        Workspace.id,
+        Workspace.agent,
+        Workspace.task_policy,
+        Workspace.failure_reason,
+        Workspace.failure_message,
+    ).where(
+        Workspace.status == WorkspaceStatus.failed.value,
+        Workspace.updated_at >= window_start,
+    )
+    result = await session.execute(stmt)
+    rows = result.all()
+
+    clusters: dict[tuple[str, str | None, str, str, str], list[str]] = {}
+
+    for row in rows:
+        agent = row.agent or "unknown"
+        agent_model = row.task_policy.get("agent_model") if row.task_policy else None
+        reason = row.failure_reason or UNKNOWN_FAILURE_REASON
+        msg = row.failure_message or ""
+
+        likely_cause = "Unknown Validation Failure"
+        action = "Review validation logs"
+        
+        if "AGENT_AUTH_FAILED" in msg:
+            likely_cause = "Agent Auth Failed"
+            action = "Check agent credentials"
+        elif "model not found" in msg or "404" in msg:
+            likely_cause = "Model Not Found / 404"
+            action = "Verify model configuration or availability"
+        elif "missing managed worktree during fix loop" in msg:
+            likely_cause = "Missing Managed Worktree"
+            action = "Review fix loop configuration or git identity"
+        elif "coverage threshold failure" in msg:
+            likely_cause = "Coverage Threshold Failure"
+            action = "Update tests to improve coverage or adjust baseline"
+        elif "SyntaxError" in msg or "ImportError" in msg:
+            likely_cause = "Syntax or Import Error"
+            action = "Fix syntax/import issues in generated code"
+        elif "GitHub auth/PR creation failed" in msg:
+            likely_cause = "GitHub Transient/Auth Error"
+            action = "Check GitHub App token or retry"
+        elif reason == FailureReason.agent_failure.value:
+            likely_cause = "Unknown Agent Failure"
+            action = "Review agent logs"
+
+        key = (agent, agent_model, reason, likely_cause, action)
+        if key not in clusters:
+            clusters[key] = []
+        clusters[key].append(row.id)
+
+    return [
+        RootCauseCluster(
+            agent=k[0],
+            agent_model=k[1],
+            failure_reason=k[2],
+            likely_cause=k[3],
+            actionable_next_action=k[4],
+            count=len(wids),
+            sample_workspace_ids=wids[:5],
+        )
+        for k, wids in clusters.items()
+    ]
 
 
 async def summarize_resource_saturation(

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -20,7 +20,7 @@ MAX_SUMMARY_WINDOW_HOURS = 168
 DEFAULT_FAILURE_EXAMPLE_LIMIT = 5
 MIN_FAILURE_EXAMPLE_LIMIT = 1
 MAX_FAILURE_EXAMPLE_LIMIT = 25
-_MAX_CLUSTER_SAMPLE_IDS = 5
+DEFAULT_ROOT_CAUSE_SAMPLE_LIMIT = 5
 UNKNOWN_FAILURE_REASON = "unknown"
 
 TERMINAL_WORKSPACE_STATUSES = frozenset(
@@ -440,7 +440,7 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
             likely_cause=k[3],
             actionable_next_action=k[4],
             count=len(wids),
-            sample_workspace_ids=tuple(wids[:_MAX_CLUSTER_SAMPLE_IDS]),
+            sample_workspace_ids=tuple(wids[:DEFAULT_ROOT_CAUSE_SAMPLE_LIMIT]),
         )
         for k, wids in clusters.items()
     ]

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -20,6 +20,7 @@ MAX_SUMMARY_WINDOW_HOURS = 168
 DEFAULT_FAILURE_EXAMPLE_LIMIT = 5
 MIN_FAILURE_EXAMPLE_LIMIT = 1
 MAX_FAILURE_EXAMPLE_LIMIT = 25
+_MAX_CLUSTER_SAMPLE_IDS = 5
 UNKNOWN_FAILURE_REASON = "unknown"
 
 TERMINAL_WORKSPACE_STATUSES = frozenset(
@@ -441,7 +442,7 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
             likely_cause=k[3],
             actionable_next_action=k[4],
             count=len(wids),
-            sample_workspace_ids=tuple(wids[:5]),
+            sample_workspace_ids=tuple(wids[:_MAX_CLUSTER_SAMPLE_IDS]),
         )
         for k, wids in clusters.items()
     ]

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -430,9 +430,7 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
             action = "Review agent logs"
 
         key = (agent, agent_model, reason, likely_cause, action)
-        if key not in clusters:
-            clusters[key] = []
-        clusters[key].append(row.id)
+        clusters.setdefault(key, []).append(row.id)
 
     return [
         RootCauseCluster(

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -402,7 +402,7 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
 
         likely_cause = "Unknown Validation Failure"
         action = "Review validation logs"
-        
+
         if "AGENT_AUTH_FAILED" in msg:
             likely_cause = "Agent Auth Failed"
             action = "Check agent credentials"

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -406,6 +406,9 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
         if "AGENT_AUTH_FAILED" in msg:
             likely_cause = "Agent Auth Failed"
             action = "Check agent credentials"
+        elif "GitHub auth/PR creation failed" in msg:
+            likely_cause = "GitHub Transient/Auth Error"
+            action = "Check GitHub App token or retry"
         elif "model not found" in msg or "404" in msg:
             likely_cause = "Model Not Found / 404"
             action = "Verify model configuration or availability"
@@ -418,9 +421,6 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
         elif "SyntaxError" in msg or "ImportError" in msg:
             likely_cause = "Syntax or Import Error"
             action = "Fix syntax/import issues in generated code"
-        elif "GitHub auth/PR creation failed" in msg:
-            likely_cause = "GitHub Transient/Auth Error"
-            action = "Check GitHub App token or retry"
         elif reason == FailureReason.agent_failure.value:
             likely_cause = "Unknown Agent Failure"
             action = "Review agent logs"

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -388,6 +388,9 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
     ).where(
         Workspace.status == WorkspaceStatus.failed.value,
         Workspace.updated_at >= window_start,
+    ).order_by(
+        Workspace.updated_at.desc(),
+        Workspace.id,
     )
     result = await session.execute(stmt)
     rows = result.all()

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -107,7 +107,7 @@ class RootCauseCluster:
     likely_cause: str
     actionable_next_action: str
     count: int
-    sample_workspace_ids: list[str]
+    sample_workspace_ids: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -438,7 +438,7 @@ async def _cluster_root_causes(session: AsyncSession, window_start: datetime) ->
             likely_cause=k[3],
             actionable_next_action=k[4],
             count=len(wids),
-            sample_workspace_ids=wids[:5],
+            sample_workspace_ids=tuple(wids[:5]),
         )
         for k, wids in clusters.items()
     ]

--- a/tests/unit/api/test_failure_analysis.py
+++ b/tests/unit/api/test_failure_analysis.py
@@ -25,6 +25,7 @@ async def _workspace(
     agent: str = "codex",
     failure_message: str | None = None,
     pr_url: str | None = None,
+    task_policy: dict | None = None,
 ) -> str:
     factory = make_session_factory(engine)
     async with factory() as session:
@@ -43,6 +44,8 @@ async def _workspace(
         )
         workspace.failure_message = failure_message
         workspace.pr_url = pr_url
+        if task_policy is not None:
+            workspace.task_policy = task_policy
         await session.commit()
         return workspace.id
 
@@ -182,3 +185,41 @@ async def test_failure_summary_validates_limit_bounds(
     )
 
     assert response.status_code == 422
+
+
+@pytest.mark.unit
+async def test_api_route_serialization(
+    client: AsyncClient,
+    engine: AsyncEngine,
+) -> None:
+    from awf.db.enums import WorkspaceStatus, FailureReason
+    
+    now = datetime.now(UTC)
+    
+    workspace = await _workspace(
+        engine,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="missing managed worktree during fix loop",
+        agent="gemini",
+        task_policy={"agent_model": "gemini-1.5-pro"},
+    )
+        
+    response = await client.get("/v1/metrics/failures/summary")
+    
+    assert response.status_code == 200
+    body = response.json()
+    
+    assert "root_cause_clusters" in body
+    clusters = body["root_cause_clusters"]
+    assert len(clusters) == 1
+    cluster = clusters[0]
+    
+    assert cluster["agent"] == "gemini"
+    assert cluster["agent_model"] == "gemini-1.5-pro"
+    assert cluster["failure_reason"] == "validation_failure"
+    assert cluster["likely_cause"] == "Missing Managed Worktree"
+    assert cluster["actionable_next_action"] == "Review fix loop configuration or git identity"
+    assert cluster["count"] == 1
+    assert workspace in cluster["sample_workspace_ids"]

--- a/tests/unit/api/test_failure_analysis.py
+++ b/tests/unit/api/test_failure_analysis.py
@@ -192,10 +192,10 @@ async def test_api_route_serialization(
     client: AsyncClient,
     engine: AsyncEngine,
 ) -> None:
-    from awf.db.enums import WorkspaceStatus, FailureReason
-    
+    from awf.db.enums import FailureReason, WorkspaceStatus
+
     now = datetime.now(UTC)
-    
+
     workspace = await _workspace(
         engine,
         status=WorkspaceStatus.failed,
@@ -205,17 +205,17 @@ async def test_api_route_serialization(
         agent="gemini",
         task_policy={"agent_model": "gemini-1.5-pro"},
     )
-        
+
     response = await client.get("/v1/metrics/failures/summary")
-    
+
     assert response.status_code == 200
     body = response.json()
-    
+
     assert "root_cause_clusters" in body
     clusters = body["root_cause_clusters"]
     assert len(clusters) == 1
     cluster = clusters[0]
-    
+
     assert cluster["agent"] == "gemini"
     assert cluster["agent_model"] == "gemini-1.5-pro"
     assert cluster["failure_reason"] == "validation_failure"

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -1001,7 +1001,7 @@ async def test_root_cause_clusters_mixed_rows(
     from awf.service.metrics import summarize_failure_analysis
 
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
-    
+
     # 1. AGENT_AUTH_FAILED
     await _workspace(
         session_factory,
@@ -1076,10 +1076,10 @@ async def test_root_cause_clusters_mixed_rows(
     )
 
     summary = await summarize_failure_analysis(session_factory, now=now)
-    
+
     assert len(summary.root_cause_clusters) == 7
     cluster_reasons = [c.likely_cause for c in summary.root_cause_clusters]
-    
+
     assert "Agent Auth Failed" in cluster_reasons
     assert "Model Not Found / 404" in cluster_reasons
     assert "Missing Managed Worktree" in cluster_reasons
@@ -1101,7 +1101,7 @@ async def test_root_cause_clusters_agent_model_extraction(
     from awf.service.metrics import summarize_failure_analysis
 
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
-    
+
     await _workspace(
         session_factory,
         status=WorkspaceStatus.failed,
@@ -1111,7 +1111,7 @@ async def test_root_cause_clusters_agent_model_extraction(
         agent="gemini",
         task_policy={"agent_model": "gemini-1.5-pro"},
     )
-    
+
     await _workspace(
         session_factory,
         status=WorkspaceStatus.failed,
@@ -1121,13 +1121,13 @@ async def test_root_cause_clusters_agent_model_extraction(
         agent="gemini",
         task_policy={},
     )
-    
+
     summary = await summarize_failure_analysis(session_factory, now=now)
-    
+
     # Groups should be split by agent_model
     syntax_clusters = [c for c in summary.root_cause_clusters if c.likely_cause == "Syntax or Import Error"]
     assert len(syntax_clusters) == 2
-    
+
     models = {c.agent_model for c in syntax_clusters}
     assert models == {"gemini-1.5-pro", None}
 
@@ -1140,7 +1140,7 @@ async def test_root_cause_clusters_empty_history(
 
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
     summary = await summarize_failure_analysis(session_factory, now=now)
-    
+
     assert summary.root_cause_clusters == []
 
 
@@ -1151,7 +1151,7 @@ async def test_existing_failure_groups_unaffected(
     from awf.service.metrics import summarize_failure_analysis
 
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
-    
+
     await _workspace(
         session_factory,
         status=WorkspaceStatus.failed,
@@ -1160,9 +1160,9 @@ async def test_existing_failure_groups_unaffected(
         failure_message="AGENT_AUTH_FAILED",
         agent="gemini",
     )
-    
+
     summary = await summarize_failure_analysis(session_factory, now=now)
-    
+
     assert len(summary.failure_groups) == 1
     assert summary.failure_groups[0].failure_reason == FailureReason.agent_failure.value
     assert len(summary.latest_examples) == 1

--- a/tests/unit/service/test_metrics.py
+++ b/tests/unit/service/test_metrics.py
@@ -42,6 +42,7 @@ async def _workspace(
     agent: str = "codex",
     failure_message: str | None = None,
     pr_url: str | None = None,
+    task_policy: dict | None = None,
 ) -> str:
     async with session_factory() as session:
         workspace = await WorkspaceRepository(session).create(
@@ -61,6 +62,8 @@ async def _workspace(
         )
         workspace.failure_message = failure_message
         workspace.pr_url = pr_url
+        if task_policy is not None:
+            workspace.task_policy = task_policy
         await session.commit()
         return workspace.id
 
@@ -989,3 +992,178 @@ async def test_workspace_reliability_validates_since_hours(
             settings=Settings(_env_file=None),
             since_hours=since_hours,
         )
+
+
+@pytest.mark.unit
+async def test_root_cause_clusters_mixed_rows(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_failure_analysis
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    
+    # 1. AGENT_AUTH_FAILED
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.agent_failure,
+        failure_message="Some error ... AGENT_AUTH_FAILED ...",
+        agent="gemini",
+    )
+    # 2. model not found or 404
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.agent_failure,
+        failure_message="404 model not found",
+        agent="claude",
+    )
+    # 3. missing worktree
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="missing managed worktree during fix loop",
+        agent="gemini",
+    )
+    # 4. coverage threshold failure
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="coverage threshold failure: expected 80%, got 75%",
+        agent="gemini",
+    )
+    # 5. syntax/import errors during validation
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="SyntaxError: invalid syntax",
+        agent="opencode",
+    )
+    # 6. GitHub transient/auth errors
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.agent_failure,
+        failure_message="GitHub auth/PR creation failed",
+        agent="gemini",
+    )
+    # 7. unknown validation failure
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="Some random pytest failure",
+        agent="gemini",
+    )
+    # 8. Another syntax error to test grouping
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="ImportError: No module named xxx",
+        agent="opencode",
+    )
+
+    summary = await summarize_failure_analysis(session_factory, now=now)
+    
+    assert len(summary.root_cause_clusters) == 7
+    cluster_reasons = [c.likely_cause for c in summary.root_cause_clusters]
+    
+    assert "Agent Auth Failed" in cluster_reasons
+    assert "Model Not Found / 404" in cluster_reasons
+    assert "Missing Managed Worktree" in cluster_reasons
+    assert "Coverage Threshold Failure" in cluster_reasons
+    assert "Syntax or Import Error" in cluster_reasons
+    assert "GitHub Transient/Auth Error" in cluster_reasons
+    assert "Unknown Validation Failure" in cluster_reasons
+
+    # Check grouping
+    syntax_cluster = next(c for c in summary.root_cause_clusters if c.likely_cause == "Syntax or Import Error")
+    assert syntax_cluster.count == 2
+    assert syntax_cluster.agent == "opencode"
+
+
+@pytest.mark.unit
+async def test_root_cause_clusters_agent_model_extraction(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_failure_analysis
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="SyntaxError",
+        agent="gemini",
+        task_policy={"agent_model": "gemini-1.5-pro"},
+    )
+    
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.validation_failure,
+        failure_message="SyntaxError",
+        agent="gemini",
+        task_policy={},
+    )
+    
+    summary = await summarize_failure_analysis(session_factory, now=now)
+    
+    # Groups should be split by agent_model
+    syntax_clusters = [c for c in summary.root_cause_clusters if c.likely_cause == "Syntax or Import Error"]
+    assert len(syntax_clusters) == 2
+    
+    models = {c.agent_model for c in syntax_clusters}
+    assert models == {"gemini-1.5-pro", None}
+
+
+@pytest.mark.unit
+async def test_root_cause_clusters_empty_history(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_failure_analysis
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    summary = await summarize_failure_analysis(session_factory, now=now)
+    
+    assert summary.root_cause_clusters == []
+
+
+@pytest.mark.unit
+async def test_existing_failure_groups_unaffected(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    from awf.service.metrics import summarize_failure_analysis
+
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    
+    await _workspace(
+        session_factory,
+        status=WorkspaceStatus.failed,
+        updated_at=now - timedelta(hours=1),
+        failure_reason=FailureReason.agent_failure,
+        failure_message="AGENT_AUTH_FAILED",
+        agent="gemini",
+    )
+    
+    summary = await summarize_failure_analysis(session_factory, now=now)
+    
+    assert len(summary.failure_groups) == 1
+    assert summary.failure_groups[0].failure_reason == FailureReason.agent_failure.value
+    assert len(summary.latest_examples) == 1
+


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_48b6ca97ac0b4aa9aab44125` (agent: `gemini`).


### Task
Improve AWF observability by exposing root-cause clusters for recent dogfood failures. Problem: recent workspaces failed for different reasons: stale coverage baseline, bad Gemini model id, OpenCode-generated syntax errors, missing managed worktree during fix loop, GitHub auth/PR creation failures, and validation failures. The console/API should make these patterns visible instead of showing only generic agent_failure or validation_failure. Expected behavior: extend the existing failure metrics/summary surface with a backward-compatible root_cause_clusters field. Cluster by agent, agent_model when present, failure_reason, likely phase/root cause, and actionable next action. Initial signal detection must include AGENT_AUTH_FAILED, model not found or 404, missing worktree, coverage threshold failure, syntax/import errors during validation, GitHub transient/auth errors, and unknown validation failure. Include counts and sample workspace IDs per cluster. Keep API backward-compatible. TDD: add focused tests first for mixed failed workspace rows, agent_model extraction from task_policy, empty history, API route serialization, and existing failure_groups/latest_examples remaining populated unchanged. Do not run repo-wide formatters. Do not change files outside the declared owned paths except docs/awf-plans generated by AWF planning.

---
Validation: 7 profile command(s) passed inside the workspace container.
