### PR TITLE
feat(status): expose provider auth readiness diagnostics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,34 @@ AWF_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf
 AWF_GITHUB_TOKEN=
 AWF_GITHUB_DEFAULT_BASE_BRANCH=development
 
+# Claude Code readiness accepts env auth or mounted ~/.claude / ~/.claude.json.
+# Set only the auth mode you use; values are redacted from service status output.
+ANTHROPIC_API_KEY=
+ANTHROPIC_AUTH_TOKEN=
+ANTHROPIC_BASE_URL=
+ANTHROPIC_SMALL_FAST_MODEL=
+CLAUDE_CODE_OAUTH_TOKEN=
+CLAUDE_CODE_USE_BEDROCK=
+CLAUDE_CODE_USE_VERTEX=
+
+# Gemini readiness accepts Gemini/Google env auth, GOOGLE_APPLICATION_CREDENTIALS
+# when the referenced file is visible in the service container, or mounted ~/.gemini.
+GEMINI_API_KEY=
+GEMINI_API_KEY_AUTH_MECHANISM=
+GOOGLE_API_KEY=
+GOOGLE_APPLICATION_CREDENTIALS=
+GOOGLE_GENAI_USE_VERTEXAI=
+GOOGLE_GENAI_USE_GCA=
+GOOGLE_CLOUD_PROJECT=
+GOOGLE_CLOUD_LOCATION=
+GOOGLE_CLOUD_ACCESS_TOKEN=
+
+# OpenCode/Ollama readiness accepts mounted ~/.config/opencode, small ~/.ollama
+# auth files, OLLAMA_API_KEY, and a cheap Ollama /api/version probe.
+AWF_OPENCODE_OLLAMA_BASE_URL=
+OLLAMA_HOST=
+OLLAMA_API_KEY=
+
 # Docker (path to socket or tcp endpoint)
 AWF_DOCKER_HOST=unix:///var/run/docker.sock
 

--- a/README.md
+++ b/README.md
@@ -673,6 +673,14 @@ Docker Desktop's `/run/host-services/ssh-auth.sock` so service-worker Git
 operations can use the operator's loaded SSH keys. Set `AWF_HOST_HOME` if the
 shell running Docker Compose does not expose the operator home as `${HOME}`.
 
+Credential values used by Compose interpolation must be present in the shell
+that starts the stack or in a Compose env file such as `docker/compose/.env`.
+The repo-root `.env` is still useful for Python `awf` commands, but the
+control-plane containers only see values that Docker Compose injects. On macOS,
+`gh` auth stored only in Keychain-backed `~/.config/gh` is not usable inside the
+containers; set `AWF_GITHUB_TOKEN` or `GH_TOKEN`, commonly from
+`gh auth token`, before starting the stack.
+
 The worker reuses the per-workspace Compose file and project created during
 provisioning. It does not launch a second stack for agent execution,
 validation, PR creation, or PR monitoring; those stages run against the same
@@ -691,8 +699,15 @@ Check the service from another terminal:
 
 ```bash
 uv run --python 3.12 --extra dev awf service status
+uv run --python 3.12 --extra dev awf service status --provider github --format pretty
+curl 'http://localhost:8000/readyz?provider=github'
 uv run --python 3.12 --extra dev awf service logs --follow --service worker
 ```
+
+`awf service status` and `/readyz` include an `agent_readiness` section for
+GitHub, Claude Code, Gemini, and OpenCode/Ollama. Missing optional providers
+are warnings by default. Pass `--provider <name>` or `?provider=<name>` to make
+that provider strict for scheduling or rollout checks.
 
 The service-mode default database URL is local Postgres
 (`postgresql+asyncpg://awf:...@localhost:5433/awf`). SQLite remains supported
@@ -910,6 +925,8 @@ and merges; `AWF_GITHUB_TOKEN` is preferred, while `GH_TOKEN` and
 ```bash
 cp .env.example .env
 export AWF_GITHUB_TOKEN="$(gh auth token)"
+# Optional: mirror Compose-interpolated values into docker/compose/.env.
+printf 'AWF_GITHUB_TOKEN=%s\n' "$AWF_GITHUB_TOKEN" > docker/compose/.env
 docker compose -f docker/compose/local-service.yml up --build
 ```
 
@@ -929,6 +946,9 @@ AWF_AGENT_RUNTIME_IMAGE=awf-agent-runtime:latest
 AWF_HOST_WORK_DIR=${HOME}/.awf/service
 AWF_HOST_HOME=${HOME}
 AWF_GITHUB_TOKEN=<token from gh auth token>
+ANTHROPIC_API_KEY=<optional Claude env auth>
+GEMINI_API_KEY=<optional Gemini env auth>
+AWF_OPENCODE_OLLAMA_BASE_URL=http://host.docker.internal:11434/v1
 AWF_AGENT_WALL_TIMEOUT_SECONDS=7200
 AWF_AGENT_IDLE_TIMEOUT_SECONDS=900
 ```
@@ -969,6 +989,26 @@ the worker copies only Codex `auth.json`, `config.toml`, `installation_id`, and
 `${AWF_HOST_WORK_DIR:-${HOME}/.awf/service}/auth/<workspace>/...` before
 launching the workspace stack. AWF does not copy `~/.ollama/models`; workspace
 OpenCode runs talk to the host Ollama daemon through `host.docker.internal`.
+
+Readiness checks use the same service-visible signals without reading secret
+file contents:
+
+- GitHub: `AWF_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`, plus a bounded
+  `gh auth status` check for PR creation, comments, and merges.
+- Claude Code: `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
+  `CLAUDE_CODE_OAUTH_TOKEN`, `~/.claude`, or `~/.claude.json`.
+- Gemini: `GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_CLOUD_ACCESS_TOKEN`,
+  visible `GOOGLE_APPLICATION_CREDENTIALS`, or `~/.gemini`.
+- OpenCode/Ollama: `~/.config/opencode`, selected small `~/.ollama` auth files,
+  `OLLAMA_API_KEY`, and a cheap Ollama `/api/version` reachability probe.
+
+Use strict checks before provider-specific work:
+
+```bash
+uv run --python 3.12 --extra dev awf service status --format pretty
+uv run --python 3.12 --extra dev awf service status --provider claude_code --format pretty
+curl 'http://localhost:8000/readyz?provider=opencode'
+```
 
 Default agent models and effort are centralized in
 `src/awf/adapters/defaults.py`:

--- a/docs/awf-plans/ws_ebc6de17c0414fa4bffd7fe5.conformance.json
+++ b/docs/awf-plans/ws_ebc6de17c0414fa4bffd7fe5.conformance.json
@@ -1,0 +1,1 @@
+{"status":"satisfied","summary":"Implementation matches the saved plan: agent_readiness is wired into /readyz and service status with strict provider handling, provider auth signals are redacted and documented, required tests exist, and focused plus broad validation passed (ruff, mypy, unit tests, coverage 99.04%).","gaps":[]}

--- a/docs/awf-plans/ws_ebc6de17c0414fa4bffd7fe5.md
+++ b/docs/awf-plans/ws_ebc6de17c0414fa4bffd7fe5.md
@@ -1,0 +1,490 @@
+# Plan: Provider Readiness Observability for Local Service Mode
+
+## Goal
+
+Surface missing or unusable GitHub and agent-provider credentials before AWF
+schedules provider-specific work in local service mode.
+
+Expected operator-visible outcome:
+
+- `/readyz` and `awf service status` include an `agent_readiness` section.
+- GitHub reports whether `gh` auth is usable for PR create/comment/merge flows
+  without exposing token values.
+- Claude Code, Gemini, and OpenCode/Ollama report readiness from the same
+  env/file signals that the service worker can see and later mount into
+  workspace containers.
+- Missing optional providers are warnings by default and do not make the whole
+  service unhealthy.
+- A provider-specific strict check converts the selected provider's warning into
+  a readiness failure with stable reason codes.
+- All details are actionable and redacted.
+
+## Current Code Context
+
+The existing observability surfaces are:
+
+- `src/awf/api/routes/health.py`
+  - owns `/healthz` and `/readyz`
+  - currently reports DB, Docker CLI/daemon/Compose, and runtime image checks
+  - uses stable reason codes and `CheckResult`/`ReadyResponse` Pydantic models
+
+- `src/awf/service/status.py`
+  - owns `collect_service_status(...)` for `awf service status`
+  - currently reports API, DB, Docker, runtime image, disk, and orphan workspace
+    checks
+  - already supports injected subprocess, HTTP, socket, disk, and workspace
+    lookup seams for focused tests
+
+- `src/awf/cli/main.py`
+  - exposes `awf service status --format json|pretty`
+  - exits non-zero only when the collected top-level status is not `ok`
+
+- `src/awf/service/config.py`
+  - resolves local service settings, including `AWF_GITHUB_TOKEN` with
+    `GH_TOKEN` and `GITHUB_TOKEN` fallbacks
+  - redacts tokens in `service_config_payload(...)`
+
+- `src/awf/node/auth_mounts.py`
+  - defines the file signals the service worker can see and copy into workspace
+    auth directories:
+    `~/.config/gh`, `~/.claude`, `~/.claude.json`, `~/.gemini`,
+    `~/.config/opencode`, and selected `~/.ollama` auth files
+
+- `docker/compose/local-service.yml` and `.env.example`
+  - already pass GitHub and provider env vars into the API/worker containers
+  - already mount the narrow host credential paths into the service containers
+
+This task should extend those surfaces instead of adding a parallel diagnostic
+command.
+
+## Intended Files And Modules To Touch
+
+Production code:
+
+- `src/awf/service/provider_readiness.py` (new)
+  - Shared provider-readiness collector used by CLI/service status and API
+    readiness.
+  - Defines stable provider names, result payload shape, reason codes, redaction
+    helpers, and injected seams for subprocess, HTTP, env, and filesystem checks.
+
+- `src/awf/service/status.py`
+  - Call the shared collector from `collect_service_status(...)`.
+  - Add `agent_readiness` to the returned payload.
+  - Keep the top-level status `ok` when only optional providers are missing.
+  - Accept a strict provider set and fail only when a selected provider is not
+    ready.
+
+- `src/awf/api/routes/health.py`
+  - Extend `ReadyResponse` with `agent_readiness`.
+  - Run provider readiness alongside existing dependency checks.
+  - Add a repeatable query parameter such as `provider=github` /
+    `provider=claude_code` / `provider=gemini` / `provider=opencode`; when
+    present, those providers are strict and can make `/readyz` return 503.
+  - Preserve existing `/readyz` response shape for `checks`.
+
+- `src/awf/cli/main.py`
+  - Add a repeatable `--provider` option to `awf service status`.
+  - Passing one or more providers requests strict readiness for those providers.
+  - JSON and pretty output should naturally include the new section through the
+    existing emitter.
+
+- `src/awf/service/config.py`
+  - Only touch if the provider collector needs a small typed provider enum or
+    helper to share the GitHub token fallback contract.
+  - Do not add new secret-bearing fields unless required.
+
+- `README.md`
+  - Document local service credential propagation through `.env` and
+    `docker/compose/.env`.
+  - Explicitly call out that macOS keychain-backed `gh` auth is not visible
+    inside Compose containers; operators should set `AWF_GITHUB_TOKEN` or
+    `GH_TOKEN`, commonly from `gh auth token`.
+  - Show how to run default warning-mode status and provider-specific strict
+    status.
+
+- `.env.example`
+  - Add or tighten comments for GitHub, Claude, Gemini, OpenCode/Ollama, and
+    Ollama host/base URL variables.
+
+- `docker/compose/local-service.yml`
+  - Only touch if tests expose a missing env var needed by the readiness
+    contract. Existing provider env pass-through should be preserved.
+
+Tests:
+
+- `tests/unit/service/test_provider_readiness.py` (new)
+- `tests/unit/service/test_status.py`
+- `tests/unit/api/test_health.py`
+- `tests/unit/cli/test_service_cli.py` or `tests/unit/cli/test_cli.py`
+- `tests/integration/test_local_service_compose.py` only if Compose env/docs
+  changes need contract coverage
+
+No planned edits to migrations, DB models, workspace state machine, scheduler,
+executor, PR monitor, merge queue, adapters, lockfiles, coverage thresholds, or
+console code.
+
+## Provider Readiness Contract
+
+Use a top-level section like:
+
+```json
+{
+  "agent_readiness": {
+    "status": "ok",
+    "strict_providers": [],
+    "providers": {
+      "github": {
+        "status": "ok",
+        "ok": true,
+        "severity": "ok",
+        "reason": "GITHUB_AUTH_OK",
+        "capabilities": ["pr_create", "comment", "merge"],
+        "signals": ["AWF_GITHUB_TOKEN", "gh auth status"]
+      }
+    }
+  }
+}
+```
+
+Statuses:
+
+- `ok`: provider has a usable signal.
+- `warn`: provider is optional and missing, incomplete, or not cheaply
+  reachable.
+- `fail`: provider was requested strictly and is not ready.
+
+The `agent_readiness.status` should be:
+
+- `ok` when every provider is ok or only optional warnings exist.
+- `fail` when any strict provider fails.
+
+Reason-code examples:
+
+- GitHub:
+  - `GITHUB_AUTH_OK`
+  - `GITHUB_TOKEN_ENV_MISSING`
+  - `GITHUB_KEYRING_ONLY_NOT_VISIBLE_IN_COMPOSE`
+  - `GITHUB_CLI_NOT_FOUND`
+  - `GITHUB_AUTH_UNUSABLE`
+  - `GITHUB_AUTH_TIMEOUT`
+
+- Claude Code:
+  - `CLAUDE_ENV_AUTH_PRESENT`
+  - `CLAUDE_FILE_AUTH_PRESENT`
+  - `CLAUDE_AUTH_MISSING`
+
+- Gemini:
+  - `GEMINI_ENV_AUTH_PRESENT`
+  - `GEMINI_FILE_AUTH_PRESENT`
+  - `GEMINI_AUTH_MISSING`
+
+- OpenCode/Ollama:
+  - `OPENCODE_FILE_AUTH_PRESENT`
+  - `OLLAMA_FILE_AUTH_PRESENT`
+  - `OLLAMA_ENV_AUTH_PRESENT`
+  - `OLLAMA_HOST_REACHABLE`
+  - `OLLAMA_HOST_UNREACHABLE`
+  - `OPENCODE_OLLAMA_AUTH_MISSING`
+
+Signal rules:
+
+- GitHub is ready when an env token is present and `gh auth status` succeeds
+  under the service-visible env. Do not print or return the token. If no env
+  token exists but `~/.config/gh` exists, report the keyring/file-only warning
+  with an action to set `AWF_GITHUB_TOKEN` or `GH_TOKEN` in Compose.
+- Claude Code is ready when any supported Claude/Anthropic env auth signal is
+  present, or when `~/.claude` or `~/.claude.json` is visible under
+  `AWF_HOST_HOME`.
+- Gemini is ready when Gemini/Google env auth is present, `GOOGLE_APPLICATION_CREDENTIALS`
+  points to a visible file, or `~/.gemini` is visible under `AWF_HOST_HOME`.
+- OpenCode/Ollama is ready when OpenCode config or Ollama auth files are
+  visible and, when an Ollama URL/host is configured or implied by the adapter
+  default, a cheap `GET /api/version` style probe succeeds. A failed reachability
+  probe is a warning unless `opencode` is requested strictly.
+- Every detail string must pass a redaction helper before returning. Do not
+  include raw env values, token substrings, credential URLs, private key
+  contents, or file contents.
+
+## Tests To Write First
+
+Write these as red tests before implementation, using temp homes and injected
+fakes. No test should require real credentials, real `gh`, real Ollama, or
+network access.
+
+1. `test_provider_readiness_all_green`
+
+   Location: `tests/unit/service/test_provider_readiness.py`
+
+   Setup:
+   - Temp `host_home` with Claude, Gemini, OpenCode, and Ollama auth files.
+   - Env contains a fake GitHub token and provider env variables.
+   - Fake `gh auth status` returns success.
+   - Fake Ollama HTTP probe returns a version response.
+
+   Assertions:
+   - `agent_readiness.status == "ok"`
+   - every provider has `ok is True`
+   - GitHub capabilities include PR create/comment/merge
+   - no raw fake secret appears anywhere in the serialized payload
+
+2. `test_provider_readiness_missing_github_token_warns_by_default`
+
+   Setup:
+   - No `AWF_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN`.
+   - No usable `gh` env token.
+   - Other providers can be ready or omitted.
+
+   Assertions:
+   - GitHub provider has `status == "warn"` and `ok is False`
+   - reason is `GITHUB_TOKEN_ENV_MISSING`
+   - overall `agent_readiness.status == "ok"`
+   - the service status top-level status remains `ok` when only this optional
+     warning exists
+
+3. `test_provider_readiness_github_strict_missing_token_fails`
+
+   Setup:
+   - Same as the missing-token case, but request strict provider `github`.
+
+   Assertions:
+   - GitHub provider has `status == "fail"`
+   - overall `agent_readiness.status == "fail"`
+   - `collect_service_status(..., strict_providers={"github"})` returns
+     top-level `status == "fail"`
+   - `/readyz?provider=github` returns HTTP 503
+
+4. `test_provider_readiness_keyring_only_github_warning_is_actionable`
+
+   Setup:
+   - Temp `host_home/.config/gh/hosts.yml` exists.
+   - No GitHub env token.
+   - Fake `gh auth status` returns a keyring-style auth failure or is not run
+     because there is no env token.
+
+   Assertions:
+   - reason is `GITHUB_KEYRING_ONLY_NOT_VISIBLE_IN_COMPOSE`
+   - message/action mentions `AWF_GITHUB_TOKEN` or `GH_TOKEN`
+   - no token-like file contents are returned
+
+5. `test_provider_readiness_claude_env_present`
+
+   Setup:
+   - Env contains `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`.
+   - No Claude auth files.
+
+   Assertions:
+   - Claude provider is `ok`
+   - reason is `CLAUDE_ENV_AUTH_PRESENT`
+   - returned signals name env variable names only, not values
+
+6. `test_provider_readiness_claude_file_present`
+
+   Setup:
+   - Temp `host_home/.claude.json` or `host_home/.claude` exists.
+   - No Claude env.
+
+   Assertions:
+   - Claude provider is `ok`
+   - reason is `CLAUDE_FILE_AUTH_PRESENT`
+   - payload names the path category, not file content
+
+7. `test_provider_readiness_gemini_file_present`
+
+   Setup:
+   - Temp `host_home/.gemini` exists.
+   - No Gemini/Google env.
+
+   Assertions:
+   - Gemini provider is `ok`
+   - reason is `GEMINI_FILE_AUTH_PRESENT`
+
+8. `test_provider_readiness_opencode_ollama_file_present`
+
+   Setup:
+   - Temp `host_home/.config/opencode` and selected `host_home/.ollama`
+     auth files exist.
+   - Fake Ollama probe succeeds or is explicitly not required for this file-only
+     readiness assertion.
+
+   Assertions:
+   - OpenCode provider is `ok`
+   - reason indicates OpenCode/Ollama file auth is present
+   - model blobs under `~/.ollama/models` are not inspected or copied
+
+9. `test_provider_readiness_redacts_secret_values_from_details`
+
+   Setup:
+   - Env includes distinctive fake values like `ghp_super_secret`,
+     `anthropic_secret`, and `gemini_secret`.
+   - Fake subprocess stderr includes a credential URL such as
+     `https://user:ghp_super_secret@github.com/org/repo`.
+
+   Assertions:
+   - serialized payload does not contain any fake secret
+   - detail contains a redacted placeholder
+   - reason code remains actionable
+
+10. API and CLI integration tests
+
+   Locations:
+   - `tests/unit/api/test_health.py`
+   - `tests/unit/cli/test_service_cli.py` or `tests/unit/cli/test_cli.py`
+
+   Assertions:
+   - `/readyz` includes `agent_readiness` while preserving existing `checks`
+     keys and 200 behavior for optional warnings.
+   - `/readyz?provider=github` returns 503 for missing GitHub auth.
+   - `awf service status --format pretty` prints nested provider reason codes.
+   - `awf service status --provider github` exits non-zero when GitHub is not
+     ready.
+
+## Implementation Steps
+
+1. Add `src/awf/service/provider_readiness.py`.
+
+   Keep it mostly pure and injectable:
+
+   - input: `ServiceSettings`, `environ`, `strict_providers`, optional command
+     runner, optional HTTP probe, optional filesystem/path helpers
+   - output: JSON-serializable dict with `status`, `strict_providers`, and
+     `providers`
+   - stable provider names: `github`, `claude_code`, `gemini`, `opencode`
+   - strict provider validation rejects unknown provider names with a clear CLI
+     error or API 422
+
+2. Implement redaction centrally.
+
+   Redact:
+
+   - exact configured secret values from known env keys
+   - URL credentials matching `https://user[:password]@host`
+   - token-looking substrings with common prefixes such as `ghp_`, `github_pat_`,
+     `sk-ant-`, and long bearer-style strings
+
+   Prefer returning signal names and path categories so redaction is a last
+   guard, not the primary safety mechanism.
+
+3. Implement GitHub readiness.
+
+   - Build the GitHub env from service settings and the current environment.
+   - If no token is visible:
+     - if `host_home/.config/gh` exists, return keyring-only Compose warning
+     - otherwise return missing-token warning
+   - If a token is visible, run a bounded `gh auth status` check with the token
+     in env and no token in args.
+   - Map missing binary, timeout, non-zero exit, and success to stable reason
+     codes.
+   - Report capabilities `pr_create`, `comment`, and `merge` as the AWF uses
+     those through `gh`.
+
+4. Implement Claude/Gemini/OpenCode file/env checks.
+
+   - Reuse the same host-home path assumptions as `auth_mounts.py`.
+   - Check presence and readability/type only; never read secret file contents.
+   - For `GOOGLE_APPLICATION_CREDENTIALS`, only report that the path exists.
+   - For Ollama, normalize `OLLAMA_HOST`, `AWF_OPENCODE_OLLAMA_BASE_URL`, or the
+     adapter default into a cheap version endpoint probe. Use a short timeout and
+     treat probe failures as optional warnings unless strict.
+
+5. Wire service status.
+
+   - Extend `collect_service_status(...)` with `strict_providers` and provider
+     test seams.
+   - Gather provider readiness concurrently with existing checks where practical.
+   - Compute top-level status from hard dependency checks plus strict-provider
+     failures only. Optional provider warnings should not fail the service.
+
+6. Wire API readiness.
+
+   - Add `agent_readiness` to `ReadyResponse`.
+   - Add a repeatable `provider` query parameter.
+   - Convert unknown provider names to a structured 422 response if using string
+     validation, or use an enum-like literal to let FastAPI validate.
+   - Include provider readiness in the 503 decision only for strict provider
+     failures.
+
+7. Wire CLI.
+
+   - Add `--provider` as a repeatable option on `service status`.
+   - Pass the selected providers to `collect_service_status(...)`.
+   - Existing JSON/pretty output should require little or no custom formatting.
+
+8. Update docs.
+
+   - README setup section: show `.env` and optional `docker/compose/.env`
+     patterns for credential propagation.
+   - Explain that Docker Compose interpolation cannot see tokens stored only in
+     macOS Keychain-backed `gh` auth; set `AWF_GITHUB_TOKEN=$(gh auth token)` in
+     the environment or Compose env file.
+   - List Claude, Gemini, OpenCode/Ollama env and file signals used by readiness.
+   - Show commands:
+     - `awf service status --format pretty`
+     - `awf service status --provider github --format pretty`
+     - `curl 'http://localhost:8000/readyz?provider=github'`
+
+## Validation Commands
+
+Run focused red/green tests first:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_provider_readiness.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_status.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/api/test_health.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_service_cli.py tests/unit/cli/test_cli.py -q
+```
+
+If `docker/compose/local-service.yml` changes:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/integration/test_local_service_compose.py -q
+```
+
+Then run the Python/control-plane checks from `AGENTS.md`:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest tests/unit -q
+```
+
+Because this touches service readiness and shared observability, run coverage
+before final delivery:
+
+```bash
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+```
+
+Console validation is not needed unless console files are unexpectedly touched.
+
+## Risks And Assumptions
+
+- `gh auth status` can require network or a keyring helper depending on the
+  auth mode. Keep it bounded and map failures to reason codes instead of raw
+  stderr.
+- File presence is a readiness signal, not proof that the provider account can
+  use a specific model. Model entitlement remains a runtime/provider concern.
+- `~/.config/gh` may contain a usable token on Linux but only keychain metadata
+  on macOS. In local service Compose, an explicit env token is the reliable
+  signal AWF can propagate.
+- Ollama host probing must be cheap. Do not pull models, list large model data,
+  run inference, or read `~/.ollama/models`.
+- The API and CLI currently use different command-runner abstractions. The new
+  shared collector should accept small adapters rather than coupling API
+  readiness to the CLI's synchronous subprocess seam.
+- Optional-provider warnings should be visible but should not take down generic
+  local service readiness. Strict provider checks are the scheduling gate for
+  provider-specific work.
+- Existing pretty output recursively prints dicts. Deep provider payloads should
+  stay compact so terminal output remains readable.
+
+## Explicit Non-Goals
+
+- Do not schedule, block, or mutate existing workspaces in this slice.
+- Do not add real secret leasing or cloud secret broker behavior.
+- Do not validate model entitlement, Anthropic/Gemini billing, or Ollama Cloud
+  account permissions by making paid/model calls.
+- Do not read or return credential file contents.
+- Do not add retries that hide auth failures.
+- Do not lower coverage, `fail_under`, `.awf` coverage config, `pyproject`
+  coverage config, or quality gates.
+- Do not push, rebase, switch branches, or manually open/merge PRs.

--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -294,7 +294,7 @@ async def readyz(
         asyncio.to_thread(
             collect_agent_readiness,
             service_settings,
-            strict_providers=strict_providers,
+            validated_strict_providers=strict_providers,
         ),
     )
     checks = {

--- a/src/awf/api/routes/health.py
+++ b/src/awf/api/routes/health.py
@@ -18,13 +18,19 @@ import asyncio
 import contextlib
 from typing import Any
 
-from fastapi import APIRouter, Request, Response, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel
 from sqlalchemy import text
 
 from awf import __version__
 from awf.common.commands import AsyncCommandRunner, AsyncioSubprocessRunner, CommandResult
 from awf.common.config import get_settings
+from awf.service.config import resolve_service_settings
+from awf.service.provider_readiness import (
+    ProviderReadinessError,
+    collect_agent_readiness,
+    validate_provider_names,
+)
 
 router = APIRouter(tags=["system"])
 
@@ -61,6 +67,7 @@ class ReadyResponse(BaseModel):
     version: str
     status: str
     checks: dict[str, CheckResult]
+    agent_readiness: dict[str, Any]
 
 
 @router.get("/healthz", response_model=HealthResponse)
@@ -248,8 +255,21 @@ async def _check_agent_runtime_image(runner: AsyncCommandRunner, image: str) -> 
 
 
 @router.get("/readyz", response_model=ReadyResponse)
-async def readyz(request: Request, response: Response) -> ReadyResponse:
+async def readyz(
+    request: Request,
+    response: Response,
+    provider: list[str] = Query(default=[]),
+) -> ReadyResponse:
+    try:
+        strict_providers = validate_provider_names(provider)
+    except ProviderReadinessError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=str(exc),
+        ) from exc
+
     settings = get_settings()
+    service_settings = resolve_service_settings(settings)
     runner = _get_command_runner_for_request(request)
     factory = getattr(request.app.state, "db_session_factory", None)
 
@@ -258,12 +278,24 @@ async def readyz(request: Request, response: Response) -> ReadyResponse:
     # k8s/uptime probe with multiple slow deps would otherwise hit 25s and
     # time out at the orchestrator). Each check already returns a structured
     # CheckResult on failure, so gather() never sees an exception.
-    db_check, cli_check, daemon_check, compose_check, image_check = await asyncio.gather(
+    (
+        db_check,
+        cli_check,
+        daemon_check,
+        compose_check,
+        image_check,
+        agent_readiness,
+    ) = await asyncio.gather(
         _check_db(factory),
         _check_docker_cli(runner),
         _check_docker_daemon(runner),
         _check_docker_compose(runner),
         _check_agent_runtime_image(runner, settings.agent_runtime_image),
+        asyncio.to_thread(
+            collect_agent_readiness,
+            service_settings,
+            strict_providers=strict_providers,
+        ),
     )
     checks = {
         "db": db_check,
@@ -273,7 +305,7 @@ async def readyz(request: Request, response: Response) -> ReadyResponse:
         "agent_runtime_image": image_check,
     }
 
-    overall_ok = all(check.ok for check in checks.values())
+    overall_ok = all(check.ok for check in checks.values()) and agent_readiness["status"] == "ok"
     if not overall_ok:
         response.status_code = status.HTTP_503_SERVICE_UNAVAILABLE
 
@@ -282,4 +314,5 @@ async def readyz(request: Request, response: Response) -> ReadyResponse:
         version=__version__,
         status="ok" if overall_ok else "fail",
         checks=checks,
+        agent_readiness=agent_readiness,
     )

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -179,12 +179,33 @@ def worker(
 @service_app.command("status")
 def service_status(
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
+    provider: list[str] = typer.Option(
+        [],
+        "--provider",
+        help=(
+            "Repeatable provider strictness check: github, claude_code, gemini, "
+            "or opencode."
+        ),
+    ),
 ) -> None:
     """Check local AWF service dependencies."""
     from awf.service.config import resolve_service_settings
+    from awf.service.provider_readiness import ProviderReadinessError, validate_provider_names
     from awf.service.status import collect_service_status
 
-    payload = asyncio.run(collect_service_status(resolve_service_settings()))
+    try:
+        strict_providers = validate_provider_names(provider)
+    except ProviderReadinessError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    payload = asyncio.run(
+        collect_service_status(
+            resolve_service_settings(),
+            strict_providers=strict_providers,
+            provider_environ=os.environ,
+        )
+    )
     _emit(payload, fmt)
     if payload.get("status") != "ok":
         raise typer.Exit(code=1)

--- a/src/awf/service/provider_readiness.py
+++ b/src/awf/service/provider_readiness.py
@@ -108,13 +108,23 @@ def collect_agent_readiness(
     *,
     environ: Mapping[str, str] | None = None,
     strict_providers: Iterable[str] | None = None,
+    validated_strict_providers: set[ProviderName] | None = None,
     run_subprocess: SubprocessRun | None = None,
     http_get: HttpGet | None = None,
 ) -> dict[str, Any]:
-    """Return redacted local-service readiness for agent provider credentials."""
+    """Return redacted local-service readiness for agent provider credentials.
+
+    ``strict_providers`` accepts raw operator input and is validated here.
+    ``validated_strict_providers`` is for callers that already validated the
+    names before entering a concurrent readiness fan-out.
+    """
 
     env = os.environ if environ is None else environ
-    strict = validate_provider_names(strict_providers or ())
+    strict = (
+        set(validated_strict_providers)
+        if validated_strict_providers is not None
+        else validate_provider_names(strict_providers or ())
+    )
     host_home = Path(settings.host_home or "~").expanduser()
     secrets = _secret_values(settings, env)
     resolved_run = run_subprocess or _run_subprocess

--- a/src/awf/service/provider_readiness.py
+++ b/src/awf/service/provider_readiness.py
@@ -116,7 +116,7 @@ def collect_agent_readiness(
 
     env = os.environ if environ is None else environ
     strict = validate_provider_names(strict_providers or ())
-    host_home = Path(settings.host_home).expanduser()
+    host_home = Path(settings.host_home or "~").expanduser()
     secrets = _secret_values(settings, env)
     resolved_run = run_subprocess or _run_subprocess
     resolved_http_get = http_get or _http_get

--- a/src/awf/service/provider_readiness.py
+++ b/src/awf/service/provider_readiness.py
@@ -1,0 +1,600 @@
+"""Credential readiness checks for local service agent providers."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any, Literal, Protocol
+from urllib.parse import urlsplit, urlunsplit
+
+import httpx
+
+from awf.adapters.opencode import DEFAULT_OLLAMA_OPENAI_BASE_URL
+from awf.service.config import ServiceSettings
+
+ProviderName = Literal["github", "claude_code", "gemini", "opencode"]
+
+PROVIDER_NAMES: tuple[ProviderName, ...] = (
+    "github",
+    "claude_code",
+    "gemini",
+    "opencode",
+)
+
+_GITHUB_TIMEOUT_SECONDS = 5.0
+_HTTP_TIMEOUT_SECONDS = 2.0
+_REDACTION = "<redacted>"
+_OLLAMA_AUTH_FILES = ("config.json", "id_ed25519", "id_ed25519.pub")
+
+_GITHUB_TOKEN_ENV_KEYS = ("AWF_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN")
+_CLAUDE_ENV_KEYS = (
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+)
+_GEMINI_ENV_KEYS = (
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_CLOUD_ACCESS_TOKEN",
+)
+_OPENCODE_ENV_KEYS = ("OLLAMA_API_KEY",)
+_KNOWN_SECRET_ENV_KEYS = frozenset(
+    (
+        *_GITHUB_TOKEN_ENV_KEYS,
+        *_CLAUDE_ENV_KEYS,
+        *_GEMINI_ENV_KEYS,
+        *_OPENCODE_ENV_KEYS,
+        "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+    )
+)
+
+_URL_CREDENTIAL_RE = re.compile(r"(https?://)([^/\s:@]+(?::[^/\s@]+)?@)")
+_TOKEN_RE = re.compile(
+    r"(?<![A-Za-z0-9])("
+    r"gh[pousr]_[A-Za-z0-9_]{8,}|"
+    r"github_pat_[A-Za-z0-9_]{8,}|"
+    r"sk-ant-[A-Za-z0-9_-]{8,}|"
+    r"AIza[A-Za-z0-9_-]{12,}|"
+    r"xox[baprs]-[A-Za-z0-9-]{8,}|"
+    r"[A-Za-z0-9_-]{40,}"
+    r")(?![A-Za-z0-9])"
+)
+
+
+class CompletedProcessLike(Protocol):
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+class SubprocessRun(Protocol):
+    def __call__(  # pragma: no cover - Protocol method declaration only.
+        self,
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: Literal[True],
+        timeout: float,
+        env: Mapping[str, str],
+    ) -> CompletedProcessLike: ...
+
+
+class HttpResponseLike(Protocol):
+    @property
+    def status_code(self) -> int: ...  # pragma: no cover - Protocol declaration only.
+
+    @property
+    def text(self) -> str: ...  # pragma: no cover - Protocol declaration only.
+
+
+class HttpGet(Protocol):
+    def __call__(  # pragma: no cover - Protocol method declaration only.
+        self,
+        url: str,
+        *,
+        timeout: float,
+    ) -> HttpResponseLike: ...
+
+
+class ProviderReadinessError(ValueError):
+    """Raised when a strict provider selector is not recognized."""
+
+
+def collect_agent_readiness(
+    settings: ServiceSettings,
+    *,
+    environ: Mapping[str, str] | None = None,
+    strict_providers: Iterable[str] | None = None,
+    run_subprocess: SubprocessRun | None = None,
+    http_get: HttpGet | None = None,
+) -> dict[str, Any]:
+    """Return redacted local-service readiness for agent provider credentials."""
+
+    env = os.environ if environ is None else environ
+    strict = validate_provider_names(strict_providers or ())
+    host_home = Path(settings.host_home).expanduser()
+    secrets = _secret_values(settings, env)
+    resolved_run = run_subprocess or _run_subprocess
+    resolved_http_get = http_get or _http_get
+
+    providers: dict[str, dict[str, Any]] = {
+        "github": _check_github(
+            settings,
+            environ=env,
+            host_home=host_home,
+            strict="github" in strict,
+            run_subprocess=resolved_run,
+            secrets=secrets,
+        ),
+        "claude_code": _check_claude(
+            environ=env,
+            host_home=host_home,
+            strict="claude_code" in strict,
+            secrets=secrets,
+        ),
+        "gemini": _check_gemini(
+            environ=env,
+            host_home=host_home,
+            strict="gemini" in strict,
+            secrets=secrets,
+        ),
+        "opencode": _check_opencode(
+            environ=env,
+            host_home=host_home,
+            strict="opencode" in strict,
+            http_get=resolved_http_get,
+            secrets=secrets,
+        ),
+    }
+    return {
+        "status": "fail"
+        if any(provider["status"] == "fail" for provider in providers.values())
+        else "ok",
+        "strict_providers": _ordered_names(strict),
+        "providers": providers,
+    }
+
+
+def validate_provider_names(values: Iterable[str]) -> set[ProviderName]:
+    """Normalize and validate provider names accepted by strict checks."""
+
+    providers: set[ProviderName] = set()
+    unknown: list[str] = []
+    for raw in values:
+        normalized = raw.strip().lower().replace("-", "_")
+        if normalized == "claude":
+            normalized = "claude_code"
+        if normalized in PROVIDER_NAMES:
+            providers.add(normalized)
+        elif normalized:
+            unknown.append(raw)
+    if unknown:
+        expected = ", ".join(PROVIDER_NAMES)
+        raise ProviderReadinessError(
+            f"unknown provider(s): {', '.join(sorted(unknown))}; expected one of: {expected}"
+        )
+    return providers
+
+
+def _check_github(
+    settings: ServiceSettings,
+    *,
+    environ: Mapping[str, str],
+    host_home: Path,
+    strict: bool,
+    run_subprocess: SubprocessRun,
+    secrets: frozenset[str],
+) -> dict[str, Any]:
+    token, token_signal = _github_token(settings, environ)
+    if not token:
+        if (host_home / ".config" / "gh").exists():
+            return _provider_result(
+                ok=False,
+                strict=strict,
+                reason="GITHUB_KEYRING_ONLY_NOT_VISIBLE_IN_COMPOSE",
+                message=(
+                    "GitHub CLI config is visible, but local service containers cannot "
+                    "use keychain-only gh auth. Set AWF_GITHUB_TOKEN or GH_TOKEN in the "
+                    "Compose environment."
+                ),
+                action=(
+                    "Run `export AWF_GITHUB_TOKEN=\"$(gh auth token)\"` before "
+                    "starting Compose, or put AWF_GITHUB_TOKEN/GH_TOKEN in "
+                    "docker/compose/.env."
+                ),
+                signals=["~/.config/gh"],
+                secrets=secrets,
+            )
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="GITHUB_TOKEN_ENV_MISSING",
+            message=(
+                "No service-visible GitHub token was found. Set AWF_GITHUB_TOKEN, "
+                "GH_TOKEN, or GITHUB_TOKEN so AWF can create PRs, comment, and merge."
+            ),
+            action="Set AWF_GITHUB_TOKEN from `gh auth token` before starting the service.",
+            secrets=secrets,
+        )
+
+    gh_env = {**dict(environ), "AWF_GITHUB_TOKEN": token, "GH_TOKEN": token, "GITHUB_TOKEN": token}
+    args = ["gh", "auth", "status", "--hostname", "github.com"]
+    try:
+        result = run_subprocess(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_GITHUB_TIMEOUT_SECONDS,
+            env=gh_env,
+        )
+    except FileNotFoundError:
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="GITHUB_CLI_NOT_FOUND",
+            message="GitHub token is present, but the gh CLI is not installed in the service.",
+            action="Install gh in the service image or rebuild docker/control-plane.Dockerfile.",
+            signals=[token_signal],
+            capabilities=["pr_create", "comment", "merge"],
+            secrets=secrets,
+        )
+    except subprocess.TimeoutExpired:
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="GITHUB_AUTH_TIMEOUT",
+            message=f"`gh auth status` exceeded {_GITHUB_TIMEOUT_SECONDS:g}s.",
+            signals=[token_signal, "gh auth status"],
+            capabilities=["pr_create", "comment", "merge"],
+            secrets=secrets,
+        )
+    except Exception as exc:
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="GITHUB_AUTH_UNUSABLE",
+            message="GitHub CLI auth check failed before it could complete.",
+            detail=f"{type(exc).__name__}: {exc}",
+            signals=[token_signal, "gh auth status"],
+            capabilities=["pr_create", "comment", "merge"],
+            secrets=secrets,
+        )
+
+    if result.returncode != 0:
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="GITHUB_AUTH_UNUSABLE",
+            message="GitHub CLI auth is not usable for local service PR operations.",
+            detail=result.stderr or result.stdout or "gh auth status exited non-zero",
+            signals=[token_signal, "gh auth status"],
+            capabilities=["pr_create", "comment", "merge"],
+            secrets=secrets,
+        )
+
+    return _provider_result(
+        ok=True,
+        strict=strict,
+        reason="GITHUB_AUTH_OK",
+        message="GitHub CLI auth is usable for PR creation, comments, and merges.",
+        signals=[token_signal, "gh auth status"],
+        capabilities=["pr_create", "comment", "merge"],
+        secrets=secrets,
+    )
+
+
+def _check_claude(
+    *,
+    environ: Mapping[str, str],
+    host_home: Path,
+    strict: bool,
+    secrets: frozenset[str],
+) -> dict[str, Any]:
+    signal = _first_present_env(environ, _CLAUDE_ENV_KEYS)
+    if signal is not None:
+        return _provider_result(
+            ok=True,
+            strict=strict,
+            reason="CLAUDE_ENV_AUTH_PRESENT",
+            message="Claude Code auth is visible through service environment variables.",
+            signals=[signal],
+            secrets=secrets,
+        )
+
+    signals = _existing_path_signals(
+        (
+            (host_home / ".claude", "~/.claude"),
+            (host_home / ".claude.json", "~/.claude.json"),
+        )
+    )
+    if signals:
+        return _provider_result(
+            ok=True,
+            strict=strict,
+            reason="CLAUDE_FILE_AUTH_PRESENT",
+            message="Claude Code auth files are visible to the local service.",
+            signals=signals,
+            secrets=secrets,
+        )
+
+    return _provider_result(
+        ok=False,
+        strict=strict,
+        reason="CLAUDE_AUTH_MISSING",
+        message=(
+            "No Claude Code auth signal was visible. Set ANTHROPIC_API_KEY, "
+            "ANTHROPIC_AUTH_TOKEN, CLAUDE_CODE_OAUTH_TOKEN, or mount ~/.claude."
+        ),
+        secrets=secrets,
+    )
+
+
+def _check_gemini(
+    *,
+    environ: Mapping[str, str],
+    host_home: Path,
+    strict: bool,
+    secrets: frozenset[str],
+) -> dict[str, Any]:
+    signal = _first_present_env(environ, _GEMINI_ENV_KEYS)
+    if signal is not None:
+        return _provider_result(
+            ok=True,
+            strict=strict,
+            reason="GEMINI_ENV_AUTH_PRESENT",
+            message="Gemini auth is visible through service environment variables.",
+            signals=[signal],
+            secrets=secrets,
+        )
+
+    credentials = environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if credentials and Path(credentials).expanduser().is_file():
+        return _provider_result(
+            ok=True,
+            strict=strict,
+            reason="GEMINI_ENV_AUTH_PRESENT",
+            message="Google application credentials are visible to the local service.",
+            signals=["GOOGLE_APPLICATION_CREDENTIALS"],
+            secrets=secrets,
+        )
+
+    if (host_home / ".gemini").is_dir():
+        return _provider_result(
+            ok=True,
+            strict=strict,
+            reason="GEMINI_FILE_AUTH_PRESENT",
+            message="Gemini auth files are visible to the local service.",
+            signals=["~/.gemini"],
+            secrets=secrets,
+        )
+
+    message = (
+        "No Gemini auth signal was visible. Set GEMINI_API_KEY, GOOGLE_API_KEY, "
+        "GOOGLE_APPLICATION_CREDENTIALS, or mount ~/.gemini."
+    )
+    if credentials:
+        message = (
+            "GOOGLE_APPLICATION_CREDENTIALS is set but the file is not visible to "
+            "the local service. Mount the file or use GEMINI_API_KEY/GOOGLE_API_KEY."
+        )
+    return _provider_result(
+        ok=False,
+        strict=strict,
+        reason="GEMINI_AUTH_MISSING",
+        message=message,
+        signals=["GOOGLE_APPLICATION_CREDENTIALS"] if credentials else None,
+        secrets=secrets,
+    )
+
+
+def _check_opencode(
+    *,
+    environ: Mapping[str, str],
+    host_home: Path,
+    strict: bool,
+    http_get: HttpGet,
+    secrets: frozenset[str],
+) -> dict[str, Any]:
+    opencode_config = (host_home / ".config" / "opencode").is_dir()
+    ollama_files = [
+        filename
+        for filename in _OLLAMA_AUTH_FILES
+        if (host_home / ".ollama" / filename).is_file()
+    ]
+    env_signal = _first_present_env(environ, _OPENCODE_ENV_KEYS)
+    signals: list[str] = []
+    if opencode_config:
+        signals.append("~/.config/opencode")
+    if ollama_files:
+        signals.append("~/.ollama auth files")
+    if env_signal is not None:
+        signals.append(env_signal)
+
+    if not signals:
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="OPENCODE_OLLAMA_AUTH_MISSING",
+            message=(
+                "No OpenCode/Ollama auth signal was visible. Mount ~/.config/opencode, "
+                "mount small ~/.ollama auth files, or set OLLAMA_API_KEY."
+            ),
+            secrets=secrets,
+        )
+
+    version_url = _ollama_version_url(environ)
+    probe = _probe_ollama(version_url, http_get=http_get, secrets=secrets)
+    if not probe["ok"]:
+        probe_detail = probe.get("detail")
+        return _provider_result(
+            ok=False,
+            strict=strict,
+            reason="OLLAMA_HOST_UNREACHABLE",
+            message=(
+                "OpenCode/Ollama auth is visible, but the Ollama host did not answer "
+                "a cheap /api/version readiness probe."
+            ),
+            detail=probe_detail if isinstance(probe_detail, str) else None,
+            signals=[*signals, "ollama /api/version"],
+            secrets=secrets,
+        )
+
+    reason = "OPENCODE_FILE_AUTH_PRESENT"
+    if not opencode_config and ollama_files:
+        reason = "OLLAMA_FILE_AUTH_PRESENT"
+    elif not opencode_config and env_signal is not None:
+        reason = "OLLAMA_ENV_AUTH_PRESENT"
+
+    return _provider_result(
+        ok=True,
+        strict=strict,
+        reason=reason,
+        message="OpenCode/Ollama auth is visible and the Ollama host is reachable.",
+        signals=[*signals, "OLLAMA_HOST_REACHABLE"],
+        secrets=secrets,
+    )
+
+
+def _provider_result(
+    *,
+    ok: bool,
+    strict: bool,
+    reason: str,
+    message: str,
+    secrets: frozenset[str],
+    signals: Iterable[str] | None = None,
+    capabilities: Iterable[str] | None = None,
+    detail: str | None = None,
+    action: str | None = None,
+) -> dict[str, Any]:
+    status_value = "ok" if ok else "fail" if strict else "warn"
+    payload: dict[str, Any] = {
+        "ok": ok,
+        "status": status_value,
+        "severity": "ok" if ok else "error" if strict else "warning",
+        "reason": reason,
+        "message": _redact(message, secrets),
+    }
+    if signals:
+        payload["signals"] = list(signals)
+    if capabilities:
+        payload["capabilities"] = list(capabilities)
+    if detail:
+        payload["detail"] = _redact(_truncate(detail), secrets)
+    if action:
+        payload["action"] = _redact(action, secrets)
+    return payload
+
+
+def _github_token(settings: ServiceSettings, environ: Mapping[str, str]) -> tuple[str | None, str]:
+    for key in _GITHUB_TOKEN_ENV_KEYS:
+        value = environ.get(key)
+        if value:
+            return value, key
+    if settings.github_token:
+        return settings.github_token, "AWF_GITHUB_TOKEN"
+    return None, "AWF_GITHUB_TOKEN"
+
+
+def _first_present_env(environ: Mapping[str, str], keys: Iterable[str]) -> str | None:
+    return next((key for key in keys if environ.get(key)), None)
+
+
+def _existing_path_signals(candidates: Iterable[tuple[Path, str]]) -> list[str]:
+    return [signal for path, signal in candidates if path.exists()]
+
+
+def _secret_values(settings: ServiceSettings, environ: Mapping[str, str]) -> frozenset[str]:
+    values = {
+        value
+        for key, value in environ.items()
+        if key.upper() in _KNOWN_SECRET_ENV_KEYS and len(value) >= 4
+    }
+    if settings.github_token and len(settings.github_token) >= 4:
+        values.add(settings.github_token)
+    return frozenset(values)
+
+
+def _redact(value: str, secrets: frozenset[str]) -> str:
+    redacted = value
+    for secret in sorted(secrets, key=len, reverse=True):
+        redacted = redacted.replace(secret, _REDACTION)
+    redacted = _URL_CREDENTIAL_RE.sub(r"\1<redacted>@", redacted)
+    return _TOKEN_RE.sub(_REDACTION, redacted)
+
+
+def _truncate(value: str, *, limit: int = 240) -> str:
+    stripped = value.strip()
+    if len(stripped) <= limit:
+        return stripped
+    return stripped[: limit - 1] + "…"
+
+
+def _ollama_version_url(environ: Mapping[str, str]) -> str:
+    raw = (
+        environ.get("AWF_OPENCODE_OLLAMA_BASE_URL")
+        or environ.get("OLLAMA_HOST")
+        or DEFAULT_OLLAMA_OPENAI_BASE_URL
+    ).strip()
+    if "://" not in raw:
+        raw = f"http://{raw}"
+    parts = urlsplit(raw)
+    path = parts.path.rstrip("/")
+    if path.endswith("/v1"):
+        path = path[: -len("/v1")]
+    path = f"{path}/api/version" if path else "/api/version"
+    return urlunsplit((parts.scheme, parts.netloc, path, "", ""))
+
+
+def _probe_ollama(
+    url: str,
+    *,
+    http_get: HttpGet,
+    secrets: frozenset[str],
+) -> dict[str, Any]:
+    try:
+        response = http_get(url, timeout=_HTTP_TIMEOUT_SECONDS)
+    except Exception as exc:
+        return {
+            "ok": False,
+            "detail": _redact(f"{type(exc).__name__}: {exc}", secrets),
+        }
+    if 200 <= response.status_code < 400:
+        return {"ok": True}
+    detail = response.text or f"HTTP {response.status_code}"
+    return {
+        "ok": False,
+        "detail": _redact(f"HTTP {response.status_code}: {detail}", secrets),
+    }
+
+
+def _ordered_names(providers: set[ProviderName]) -> list[str]:
+    return [provider for provider in PROVIDER_NAMES if provider in providers]
+
+
+def _run_subprocess(
+    args: list[str],
+    *,
+    check: bool,
+    capture_output: bool,
+    text: Literal[True],
+    timeout: float,
+    env: Mapping[str, str],
+) -> CompletedProcessLike:
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _http_get(url: str, *, timeout: float) -> HttpResponseLike:
+    return httpx.get(url, timeout=timeout)

--- a/src/awf/service/provider_readiness.py
+++ b/src/awf/service/provider_readiness.py
@@ -58,8 +58,7 @@ _TOKEN_RE = re.compile(
     r"github_pat_[A-Za-z0-9_]{8,}|"
     r"sk-ant-[A-Za-z0-9_-]{8,}|"
     r"AIza[A-Za-z0-9_-]{12,}|"
-    r"xox[baprs]-[A-Za-z0-9-]{8,}|"
-    r"[A-Za-z0-9_-]{40,}"
+    r"xox[baprs]-[A-Za-z0-9-]{8,}"
     r")(?![A-Za-z0-9])"
 )
 

--- a/src/awf/service/provider_readiness.py
+++ b/src/awf/service/provider_readiness.py
@@ -573,7 +573,7 @@ def _probe_ollama(
             "ok": False,
             "detail": _redact(f"{type(exc).__name__}: {exc}", secrets),
         }
-    if 200 <= response.status_code < 400:
+    if 200 <= response.status_code < 300:
         return {"ok": True}
     detail = response.text or f"HTTP {response.status_code}"
     return {

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -7,7 +7,7 @@ import contextlib
 import json
 import os
 import subprocess
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Literal, Protocol
@@ -19,6 +19,8 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.session import make_engine
 from awf.service.config import ServiceSettings
 from awf.service.disk import DiskUsage, check_disk_space
+from awf.service.provider_readiness import HttpGet as ProviderHttpGet
+from awf.service.provider_readiness import collect_agent_readiness
 
 _CHECK_TIMEOUT_SECONDS = 5.0
 _ORPHAN_EXAMPLE_LIMIT = 5
@@ -115,6 +117,9 @@ async def collect_service_status(
     socket_exists: SocketExists | None = None,
     disk_usage: DiskUsage | None = None,
     workspace_id_lookup: WorkspaceIdLookup | None = None,
+    strict_providers: Iterable[str] | None = None,
+    provider_environ: Mapping[str, str] | None = None,
+    provider_http_get: ProviderHttpGet | None = None,
 ) -> dict[str, object]:
     """Collect service dependency status without requiring Docker in tests."""
 
@@ -133,9 +138,26 @@ async def collect_service_status(
     workspace_lookup_task: asyncio.Task[WorkspaceIdView] = asyncio.create_task(
         _await_workspace_view()
     )
+    provider_task: asyncio.Task[dict[str, Any]] = asyncio.create_task(
+        asyncio.to_thread(
+            collect_agent_readiness,
+            settings,
+            environ=provider_environ,
+            strict_providers=strict_providers,
+            run_subprocess=resolved_run,
+            http_get=provider_http_get,
+        )
+    )
 
     try:
-        api_check, db_check, docker_check, image_check, disk_check = await asyncio.gather(
+        (
+            api_check,
+            db_check,
+            docker_check,
+            image_check,
+            disk_check,
+            agent_readiness,
+        ) = await asyncio.gather(
             _check_api(settings, resolved_api_get),
             resolved_db_probe(settings.database_url),
             asyncio.to_thread(_check_docker, settings, resolved_run, resolved_socket_exists),
@@ -146,11 +168,12 @@ async def collect_service_status(
                 min_free_bytes=settings.min_free_disk_bytes,
                 disk_usage=disk_usage,
             ),
+            provider_task,
         )
         ps_result = await ps_task
         workspace_view = await workspace_lookup_task
     finally:
-        for pending in (ps_task, workspace_lookup_task):
+        for pending in (ps_task, workspace_lookup_task, provider_task):
             if not pending.done():
                 pending.cancel()
             with contextlib.suppress(BaseException):
@@ -164,11 +187,15 @@ async def collect_service_status(
         "disk": disk_check.to_dict(),
         "orphan_workspaces": orphan_check,
     }
-    overall_ok = all(bool(check["ok"]) for check in checks.values())
+    overall_ok = (
+        all(bool(check["ok"]) for check in checks.values())
+        and agent_readiness["status"] == "ok"
+    )
     return {
         "service": settings.service_name,
         "status": "ok" if overall_ok else "fail",
         "checks": checks,
+        "agent_readiness": agent_readiness,
     }
 
 

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -23,6 +23,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 import awf.api.routes.health as health_route
+import awf.service.provider_readiness as provider_readiness
 from awf import __version__
 from awf.api.app import configure_database, create_app
 from awf.common.commands import AsyncioSubprocessRunner, CommandResult, FakeCommandRunner
@@ -196,6 +197,31 @@ async def test_readyz_strict_github_provider_missing_auth_returns_503(
     assert body["agent_readiness"]["providers"]["github"]["reason"] == (
         "GITHUB_TOKEN_ENV_MISSING"
     )
+
+
+@pytest.mark.unit
+async def test_readyz_reuses_validated_provider_names(
+    ready_app_and_client: tuple[Any, AsyncClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+    validation_calls: list[tuple[str, ...]] = []
+    original_validate = provider_readiness.validate_provider_names
+
+    def _count_validation(values: Any) -> set[provider_readiness.ProviderName]:
+        validation_calls.append(tuple(values))
+        return original_validate(values)
+
+    monkeypatch.setattr(health_route, "validate_provider_names", _count_validation)
+    monkeypatch.setattr(provider_readiness, "validate_provider_names", _count_validation)
+
+    response = await client.get("/readyz?provider=github")
+
+    assert response.status_code == 503
+    assert validation_calls == [("github",)]
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_health.py
+++ b/tests/unit/api/test_health.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncIterator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
@@ -26,6 +27,22 @@ from awf import __version__
 from awf.api.app import configure_database, create_app
 from awf.common.commands import AsyncioSubprocessRunner, CommandResult, FakeCommandRunner
 from awf.db.session import make_session_factory
+
+_PROVIDER_ENV_KEYS = (
+    "AWF_GITHUB_TOKEN",
+    "GH_TOKEN",
+    "GITHUB_TOKEN",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_AUTH_TOKEN",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_ACCESS_TOKEN",
+    "OLLAMA_API_KEY",
+    "AWF_OPENCODE_OLLAMA_BASE_URL",
+    "OLLAMA_HOST",
+)
 
 # ---- /healthz ---------------------------------------------------------------
 
@@ -72,12 +89,23 @@ def _queue_all_ok(runner: FakeCommandRunner) -> None:
 
 
 @pytest.fixture
-async def ready_app_and_client(engine: AsyncEngine) -> AsyncIterator[tuple[Any, AsyncClient]]:
+async def ready_app_and_client(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> AsyncIterator[tuple[Any, AsyncClient]]:
     """App + client pair so tests can mutate ``app.state`` (inject command runner)."""
+    for key in _PROVIDER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("AWF_HOST_HOME", str(tmp_path / "home"))
+    health_route.get_settings.cache_clear()
     app = create_app(use_lifespan=False)
     configure_database(app, make_session_factory(engine))
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
-        yield app, c
+    try:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as c:
+            yield app, c
+    finally:
+        health_route.get_settings.cache_clear()
 
 
 # ---- /readyz: happy path ----------------------------------------------------
@@ -125,6 +153,49 @@ async def test_readyz_response_shape_matches_contract(
         assert check["ok"] is True, f"{name} should be ok"
         assert check["status"] == "ok"
         assert check.get("reason") is None
+    assert body["agent_readiness"]["status"] == "ok"
+    assert body["agent_readiness"]["providers"]["github"]["reason"] == (
+        "GITHUB_TOKEN_ENV_MISSING"
+    )
+
+
+@pytest.mark.unit
+async def test_readyz_provider_warnings_remain_200(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz")
+    body = response.json()
+
+    assert response.status_code == 200
+    assert body["status"] == "ok"
+    assert body["agent_readiness"]["status"] == "ok"
+    assert body["agent_readiness"]["providers"]["github"]["status"] == "warn"
+
+
+@pytest.mark.unit
+async def test_readyz_strict_github_provider_missing_auth_returns_503(
+    ready_app_and_client: tuple[Any, AsyncClient],
+) -> None:
+    app, client = ready_app_and_client
+    runner = FakeCommandRunner()
+    _queue_all_ok(runner)
+    app.state.command_runner = runner
+
+    response = await client.get("/readyz?provider=github")
+    body = response.json()
+
+    assert response.status_code == 503
+    assert body["status"] == "fail"
+    assert body["agent_readiness"]["status"] == "fail"
+    assert body["agent_readiness"]["providers"]["github"]["status"] == "fail"
+    assert body["agent_readiness"]["providers"]["github"]["reason"] == (
+        "GITHUB_TOKEN_ENV_MISSING"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -565,7 +565,7 @@ class TestServiceStatusOrphanReporting:
         settings = object()
         monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
 
-        async def _collect(received: object) -> dict[str, object]:
+        async def _collect(received: object, **_kwargs: object) -> dict[str, object]:
             assert received is settings
             return {
                 "service": "awf",

--- a/tests/unit/cli/test_service_cli.py
+++ b/tests/unit/cli/test_service_cli.py
@@ -527,6 +527,7 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
         github_token=None,
         worker_poll_interval_seconds=0.1,
         worker_max_concurrent_provisions=1,
+        host_home=str(tmp_path / "home"),
     )
 
     status = asyncio.run(
@@ -537,6 +538,7 @@ def test_service_status_uses_mocked_api_db_docker_and_image_checks(tmp_path: Pat
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: True,
             disk_usage=_ok_disk_usage,
+            provider_environ={},
         )
     )
 
@@ -627,6 +629,7 @@ def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> N
         github_token=None,
         worker_poll_interval_seconds=0.1,
         worker_max_concurrent_provisions=1,
+        host_home=str(tmp_path / "home"),
     )
 
     status = asyncio.run(
@@ -637,6 +640,7 @@ def test_service_status_runs_dependency_checks_concurrently(tmp_path: Path) -> N
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: True,
             disk_usage=_ok_disk_usage,
+            provider_environ={},
         )
     )
 
@@ -678,6 +682,7 @@ def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> N
         github_token=None,
         worker_poll_interval_seconds=0.1,
         worker_max_concurrent_provisions=1,
+        host_home=str(tmp_path / "home"),
     )
 
     status = asyncio.run(
@@ -688,6 +693,7 @@ def test_service_status_reports_failures_from_mocked_checks(tmp_path: Path) -> N
             run_subprocess=_run_subprocess,
             socket_exists=lambda _path: False,
             disk_usage=_ok_disk_usage,
+            provider_environ={},
         )
     )
 
@@ -708,7 +714,7 @@ def test_service_status_pretty_output_includes_disk_check(
     settings = object()
     monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
 
-    async def _collect(received: object) -> dict[str, object]:
+    async def _collect(received: object, **_kwargs: object) -> dict[str, object]:
         assert received is settings
         return {
             "service": "awf",
@@ -731,6 +737,86 @@ def test_service_status_pretty_output_includes_disk_check(
     assert result.exit_code == 0, result.output
     assert "checks.disk.free_bytes: 300" in result.stdout
     assert "checks.disk.threshold_bytes: 200" in result.stdout
+
+
+@pytest.mark.unit
+def test_service_status_pretty_output_includes_provider_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from awf.service import config as config_mod
+    from awf.service import status as status_mod
+
+    settings = object()
+    monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
+
+    async def _collect(received: object, **kwargs: object) -> dict[str, object]:
+        assert received is settings
+        assert kwargs["strict_providers"] == set()
+        return {
+            "service": "awf",
+            "status": "ok",
+            "checks": {},
+            "agent_readiness": {
+                "status": "ok",
+                "strict_providers": [],
+                "providers": {
+                    "github": {
+                        "ok": False,
+                        "status": "warn",
+                        "reason": "GITHUB_TOKEN_ENV_MISSING",
+                    }
+                },
+            },
+        }
+
+    monkeypatch.setattr(status_mod, "collect_service_status", _collect)
+
+    result = _runner.invoke(app, ["service", "status", "--format", "pretty"])
+
+    assert result.exit_code == 0, result.output
+    assert "agent_readiness.providers.github.reason: GITHUB_TOKEN_ENV_MISSING" in result.stdout
+
+
+@pytest.mark.unit
+def test_service_status_provider_option_requests_strict_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from awf.service import config as config_mod
+    from awf.service import status as status_mod
+
+    settings = object()
+    monkeypatch.setattr(config_mod, "resolve_service_settings", lambda: settings)
+
+    async def _collect(received: object, **kwargs: object) -> dict[str, object]:
+        assert received is settings
+        assert kwargs["strict_providers"] == {"github"}
+        return {
+            "service": "awf",
+            "status": "fail",
+            "checks": {},
+            "agent_readiness": {
+                "status": "fail",
+                "strict_providers": ["github"],
+                "providers": {
+                    "github": {
+                        "ok": False,
+                        "status": "fail",
+                        "reason": "GITHUB_TOKEN_ENV_MISSING",
+                    }
+                },
+            },
+        }
+
+    monkeypatch.setattr(status_mod, "collect_service_status", _collect)
+
+    result = _runner.invoke(
+        app,
+        ["service", "status", "--provider", "github", "--format", "pretty"],
+    )
+
+    assert result.exit_code == 1, result.output
+    assert "agent_readiness.providers.github.status: fail" in result.stdout
+    assert "GITHUB_TOKEN_ENV_MISSING" in result.stdout
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_provider_readiness.py
+++ b/tests/unit/service/test_provider_readiness.py
@@ -531,3 +531,38 @@ def test_provider_readiness_redacts_secret_values_from_details(tmp_path: Path) -
     assert "anthropic_secret" not in serialized
     assert "gemini_secret" not in serialized
     assert "<redacted>" in serialized
+
+
+@pytest.mark.unit
+def test_provider_readiness_preserves_long_diagnostic_ids_in_details(
+    tmp_path: Path,
+) -> None:
+    github_secret = "ghp_diagnostic_secret"
+    image_digest = "a" * 64
+    container_id = "b" * 40
+    error_payload_id = "payload_" + ("c" * 40)
+
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        assert args == ["gh", "auth", "status", "--hostname", "github.com"]
+        return _completed(
+            returncode=1,
+            stderr=(
+                f"failed for token {github_secret}; "
+                f"image sha256:{image_digest}; "
+                f"container {container_id}; "
+                f"payload {error_payload_id}"
+            ),
+        )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_GITHUB_TOKEN": github_secret},
+        run_subprocess=_run,
+    )
+
+    detail = payload["providers"]["github"]["detail"]
+    assert github_secret not in detail
+    assert "<redacted>" in detail
+    assert image_digest in detail
+    assert container_id in detail
+    assert error_payload_id in detail

--- a/tests/unit/service/test_provider_readiness.py
+++ b/tests/unit/service/test_provider_readiness.py
@@ -1,0 +1,504 @@
+"""Provider credential readiness checks for local service mode."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import awf.service.provider_readiness as provider_readiness
+from awf.service.config import ServiceSettings
+from awf.service.provider_readiness import (
+    ProviderReadinessError,
+    collect_agent_readiness,
+    validate_provider_names,
+)
+
+
+def _settings(tmp_path: Path, *, github_token: str | None = None) -> ServiceSettings:
+    return ServiceSettings(
+        service_name="awf",
+        env="local",
+        api_base_url="http://localhost:8000",
+        database_url="sqlite+aiosqlite:///:memory:",
+        docker_host=f"unix://{tmp_path / 'docker.sock'}",
+        agent_runtime_image="awf-agent-runtime:latest",
+        work_dir=str(tmp_path / "work"),
+        api_token=None,
+        github_token=github_token,
+        worker_poll_interval_seconds=0.1,
+        worker_max_concurrent_provisions=1,
+        host_home=str(tmp_path / "home"),
+    )
+
+
+def _completed(*, returncode: int = 0, stdout: str = "", stderr: str = "") -> Any:
+    return SimpleNamespace(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def _unexpected_subprocess(args: list[str], **_kwargs: object) -> Any:
+    raise AssertionError(f"unexpected subprocess call: {args}")
+
+
+def _ollama_ok(url: str, *, timeout: float) -> Any:
+    assert timeout > 0
+    assert url == "http://ollama.local:11434/api/version"
+    return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
+
+
+@pytest.mark.unit
+def test_provider_readiness_validates_aliases_and_rejects_unknown() -> None:
+    assert validate_provider_names(["claude", "opencode", ""]) == {
+        "claude_code",
+        "opencode",
+    }
+
+    with pytest.raises(ProviderReadinessError, match="unknown provider"):
+        validate_provider_names(["github", "bogus"])
+
+
+@pytest.mark.unit
+def test_provider_readiness_all_green(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".gemini").mkdir()
+    (home / ".config" / "opencode").mkdir(parents=True)
+    (home / ".ollama").mkdir()
+    (home / ".ollama" / "config.json").write_text("ollama-file-secret")
+    github_secret = "ghp_green_secret"
+    anthropic_secret = "sk-ant-green-secret"
+    gemini_secret = "gemini_green_secret"
+    ollama_secret = "ollama_green_secret"
+    env = {
+        "AWF_GITHUB_TOKEN": github_secret,
+        "ANTHROPIC_API_KEY": anthropic_secret,
+        "GEMINI_API_KEY": gemini_secret,
+        "OLLAMA_API_KEY": ollama_secret,
+        "AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1",
+    }
+    subprocess_calls: list[list[str]] = []
+
+    def _run(args: list[str], **kwargs: object) -> Any:
+        subprocess_calls.append(args)
+        assert args == ["gh", "auth", "status", "--hostname", "github.com"]
+        assert github_secret not in args
+        subprocess_env = kwargs["env"]
+        assert isinstance(subprocess_env, dict)
+        assert subprocess_env["GH_TOKEN"] == github_secret
+        return _completed(stdout="logged in\n")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ=env,
+        run_subprocess=_run,
+        http_get=_ollama_ok,
+    )
+
+    assert payload["status"] == "ok"
+    providers = payload["providers"]
+    assert set(providers) == {"github", "claude_code", "gemini", "opencode"}
+    assert all(provider["ok"] is True for provider in providers.values())
+    assert providers["github"]["capabilities"] == ["pr_create", "comment", "merge"]
+    assert subprocess_calls == [["gh", "auth", "status", "--hostname", "github.com"]]
+    serialized = json.dumps(payload, sort_keys=True)
+    for secret in (github_secret, anthropic_secret, gemini_secret, ollama_secret):
+        assert secret not in serialized
+
+
+@pytest.mark.unit
+def test_provider_readiness_missing_github_token_warns_by_default(tmp_path: Path) -> None:
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["status"] == "warn"
+    assert github["ok"] is False
+    assert github["reason"] == "GITHUB_TOKEN_ENV_MISSING"
+    assert payload["status"] == "ok"
+
+
+@pytest.mark.unit
+def test_provider_readiness_github_strict_missing_token_fails(tmp_path: Path) -> None:
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        strict_providers={"github"},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["status"] == "fail"
+    assert github["ok"] is False
+    assert github["reason"] == "GITHUB_TOKEN_ENV_MISSING"
+    assert payload["status"] == "fail"
+    assert payload["strict_providers"] == ["github"]
+
+
+@pytest.mark.unit
+def test_provider_readiness_keyring_only_github_warning_is_actionable(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    gh_config = home / ".config" / "gh"
+    gh_config.mkdir(parents=True)
+    (gh_config / "hosts.yml").write_text("oauth_token: ghp_file_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["reason"] == "GITHUB_KEYRING_ONLY_NOT_VISIBLE_IN_COMPOSE"
+    assert "AWF_GITHUB_TOKEN" in str(github)
+    assert "GH_TOKEN" in str(github)
+    assert "ghp_file_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_github_settings_token_cli_missing(tmp_path: Path) -> None:
+    github_secret = "github_pat_settings_secret"
+
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        assert args == ["gh", "auth", "status", "--hostname", "github.com"]
+        raise FileNotFoundError("gh")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path, github_token=github_secret),
+        environ={},
+        run_subprocess=_run,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["reason"] == "GITHUB_CLI_NOT_FOUND"
+    assert github["signals"] == ["AWF_GITHUB_TOKEN"]
+    assert github_secret not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_github_auth_timeout(tmp_path: Path) -> None:
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        raise subprocess.TimeoutExpired(args, timeout=5)
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_GITHUB_TOKEN": "ghp_timeout_secret"},
+        run_subprocess=_run,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["reason"] == "GITHUB_AUTH_TIMEOUT"
+    assert "ghp_timeout_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_github_runner_exception_is_redacted(tmp_path: Path) -> None:
+    def _run(_args: list[str], **_kwargs: object) -> Any:
+        raise RuntimeError("transport failed for ghp_exception_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_GITHUB_TOKEN": "ghp_exception_secret"},
+        run_subprocess=_run,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["reason"] == "GITHUB_AUTH_UNUSABLE"
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "ghp_exception_secret" not in serialized
+    assert "<redacted>" in serialized
+
+
+@pytest.mark.unit
+def test_provider_readiness_claude_env_present(tmp_path: Path) -> None:
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"ANTHROPIC_API_KEY": "anthropic_secret"},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["ok"] is True
+    assert claude["reason"] == "CLAUDE_ENV_AUTH_PRESENT"
+    assert claude["signals"] == ["ANTHROPIC_API_KEY"]
+    assert "anthropic_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_claude_file_present(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text('{"token":"claude_file_secret"}')
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["ok"] is True
+    assert claude["reason"] == "CLAUDE_FILE_AUTH_PRESENT"
+    assert "claude_file_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_gemini_file_present(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".gemini").mkdir(parents=True)
+    (home / ".gemini" / "oauth_creds.json").write_text("gemini_file_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    gemini = payload["providers"]["gemini"]
+    assert gemini["ok"] is True
+    assert gemini["reason"] == "GEMINI_FILE_AUTH_PRESENT"
+    assert "gemini_file_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_gemini_google_application_credentials_visible(
+    tmp_path: Path,
+) -> None:
+    credentials = tmp_path / "google.json"
+    credentials.write_text("google_file_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"GOOGLE_APPLICATION_CREDENTIALS": str(credentials)},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    gemini = payload["providers"]["gemini"]
+    assert gemini["ok"] is True
+    assert gemini["reason"] == "GEMINI_ENV_AUTH_PRESENT"
+    assert gemini["signals"] == ["GOOGLE_APPLICATION_CREDENTIALS"]
+    assert "google_file_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_gemini_missing_google_application_credentials_is_actionable(
+    tmp_path: Path,
+) -> None:
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"GOOGLE_APPLICATION_CREDENTIALS": str(tmp_path / "missing.json")},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    gemini = payload["providers"]["gemini"]
+    assert gemini["ok"] is False
+    assert gemini["reason"] == "GEMINI_AUTH_MISSING"
+    assert gemini["signals"] == ["GOOGLE_APPLICATION_CREDENTIALS"]
+    assert "file is not visible" in gemini["message"]
+
+
+@pytest.mark.unit
+def test_provider_readiness_opencode_ollama_file_present(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".config" / "opencode").mkdir(parents=True)
+    (home / ".config" / "opencode" / "config.json").write_text("opencode_file_secret")
+    (home / ".ollama" / "models").mkdir(parents=True)
+    (home / ".ollama" / "config.json").write_text("ollama_file_secret")
+    (home / ".ollama" / "models" / "blob").write_text("model_blob_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1"},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_ollama_ok,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["ok"] is True
+    assert opencode["reason"] == "OPENCODE_FILE_AUTH_PRESENT"
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "opencode_file_secret" not in serialized
+    assert "ollama_file_secret" not in serialized
+    assert "model_blob_secret" not in serialized
+
+
+@pytest.mark.unit
+def test_provider_readiness_opencode_ollama_unreachable_fails_when_strict(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    (home / ".config" / "opencode").mkdir(parents=True)
+
+    def _http_get(_url: str, *, timeout: float) -> Any:
+        assert timeout > 0
+        raise RuntimeError("connection refused")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1"},
+        strict_providers={"opencode"},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_http_get,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["status"] == "fail"
+    assert opencode["reason"] == "OLLAMA_HOST_UNREACHABLE"
+    assert "connection refused" in opencode["detail"]
+
+
+@pytest.mark.unit
+def test_provider_readiness_opencode_ollama_file_reason_without_opencode_config(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    (home / ".ollama").mkdir(parents=True)
+    (home / ".ollama" / "id_ed25519").write_text("ollama_private_key_secret")
+    urls: list[str] = []
+
+    def _http_get(url: str, *, timeout: float) -> Any:
+        urls.append(url)
+        return SimpleNamespace(status_code=200, text="ok")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"OLLAMA_HOST": "ollama.local:11434"},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_http_get,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["ok"] is True
+    assert opencode["reason"] == "OLLAMA_FILE_AUTH_PRESENT"
+    assert urls == ["http://ollama.local:11434/api/version"]
+    assert "ollama_private_key_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_opencode_env_only_reason_when_ollama_reachable(
+    tmp_path: Path,
+) -> None:
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={
+            "OLLAMA_API_KEY": "ollama_env_secret",
+            "AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1",
+        },
+        run_subprocess=_unexpected_subprocess,
+        http_get=_ollama_ok,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["ok"] is True
+    assert opencode["reason"] == "OLLAMA_ENV_AUTH_PRESENT"
+    assert "ollama_env_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_opencode_http_error_detail_is_redacted(tmp_path: Path) -> None:
+    def _http_get(_url: str, *, timeout: float) -> Any:
+        return SimpleNamespace(status_code=401, text="bad token ghp_ollama_secret")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={
+            "OLLAMA_API_KEY": "ghp_ollama_secret",
+            "AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1",
+        },
+        run_subprocess=_unexpected_subprocess,
+        http_get=_http_get,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["reason"] == "OLLAMA_HOST_UNREACHABLE"
+    serialized = json.dumps(payload, sort_keys=True)
+    assert "ghp_ollama_secret" not in serialized
+    assert "<redacted>" in serialized
+
+
+@pytest.mark.unit
+def test_provider_readiness_truncates_verbose_details(tmp_path: Path) -> None:
+    def _run(_args: list[str], **_kwargs: object) -> Any:
+        return _completed(returncode=1, stderr="failure " * 50)
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_GITHUB_TOKEN": "ghp_verbose_secret"},
+        run_subprocess=_run,
+    )
+
+    detail = payload["providers"]["github"]["detail"]
+    assert isinstance(detail, str)
+    assert len(detail) == 240
+    assert detail.endswith("\N{HORIZONTAL ELLIPSIS}")
+
+
+@pytest.mark.unit
+def test_provider_readiness_default_subprocess_and_http_wrappers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    completed = _completed(stdout="ok")
+    calls: list[tuple[list[str], float]] = []
+
+    def _subprocess_run(args: list[str], **kwargs: object) -> Any:
+        calls.append((args, kwargs["timeout"]))
+        return completed
+
+    def _httpx_get(url: str, *, timeout: float) -> Any:
+        assert url == "http://example.test/api/version"
+        assert timeout == 1.5
+        return SimpleNamespace(status_code=200, text="ok")
+
+    monkeypatch.setattr(provider_readiness.subprocess, "run", _subprocess_run)
+    monkeypatch.setattr(provider_readiness.httpx, "get", _httpx_get)
+
+    assert provider_readiness._run_subprocess(
+        ["gh", "auth", "status"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=1.5,
+        env={},
+    ) is completed
+    assert calls == [(["gh", "auth", "status"], 1.5)]
+    assert provider_readiness._http_get("http://example.test/api/version", timeout=1.5).text == "ok"
+
+
+@pytest.mark.unit
+def test_provider_readiness_redacts_secret_values_from_details(tmp_path: Path) -> None:
+    github_secret = "ghp_super_secret"
+    env = {
+        "AWF_GITHUB_TOKEN": github_secret,
+        "ANTHROPIC_API_KEY": "anthropic_secret",
+        "GEMINI_API_KEY": "gemini_secret",
+    }
+
+    def _run(args: list[str], **_kwargs: object) -> Any:
+        assert args == ["gh", "auth", "status", "--hostname", "github.com"]
+        return _completed(
+            returncode=1,
+            stderr=(
+                "failed cloning https://user:ghp_super_secret@github.com/org/repo "
+                "with bearer anthropic_secret and gemini_secret"
+            ),
+        )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ=env,
+        run_subprocess=_run,
+    )
+
+    github = payload["providers"]["github"]
+    assert github["reason"] == "GITHUB_AUTH_UNUSABLE"
+    serialized = json.dumps(payload, sort_keys=True)
+    assert github_secret not in serialized
+    assert "anthropic_secret" not in serialized
+    assert "gemini_secret" not in serialized
+    assert "<redacted>" in serialized

--- a/tests/unit/service/test_provider_readiness.py
+++ b/tests/unit/service/test_provider_readiness.py
@@ -19,7 +19,12 @@ from awf.service.provider_readiness import (
 )
 
 
-def _settings(tmp_path: Path, *, github_token: str | None = None) -> ServiceSettings:
+def _settings(
+    tmp_path: Path,
+    *,
+    github_token: str | None = None,
+    host_home: str | None = None,
+) -> ServiceSettings:
     return ServiceSettings(
         service_name="awf",
         env="local",
@@ -32,7 +37,7 @@ def _settings(tmp_path: Path, *, github_token: str | None = None) -> ServiceSett
         github_token=github_token,
         worker_poll_interval_seconds=0.1,
         worker_max_concurrent_provisions=1,
-        host_home=str(tmp_path / "home"),
+        host_home=str(tmp_path / "home") if host_home is None else host_home,
     )
 
 
@@ -159,6 +164,30 @@ def test_provider_readiness_keyring_only_github_warning_is_actionable(tmp_path: 
     assert "AWF_GITHUB_TOKEN" in str(github)
     assert "GH_TOKEN" in str(github)
     assert "ghp_file_secret" not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+def test_provider_readiness_empty_host_home_defaults_to_user_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    (home / ".claude.json").write_text('{"token":"claude_file_secret"}')
+    monkeypatch.chdir(cwd)
+    monkeypatch.setenv("HOME", str(home))
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path, host_home=""),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["ok"] is True
+    assert claude["reason"] == "CLAUDE_FILE_AUTH_PRESENT"
+    assert "claude_file_secret" not in json.dumps(payload, sort_keys=True)
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_provider_readiness.py
+++ b/tests/unit/service/test_provider_readiness.py
@@ -383,6 +383,29 @@ def test_provider_readiness_opencode_ollama_unreachable_fails_when_strict(
 
 
 @pytest.mark.unit
+def test_provider_readiness_opencode_ollama_redirect_fails(tmp_path: Path) -> None:
+    def _http_get(_url: str, *, timeout: float) -> Any:
+        assert timeout > 0
+        return SimpleNamespace(status_code=302, text="redirect to login")
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={
+            "OLLAMA_API_KEY": "ollama_env_secret",
+            "AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local:11434/v1",
+        },
+        strict_providers={"opencode"},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_http_get,
+    )
+
+    opencode = payload["providers"]["opencode"]
+    assert opencode["status"] == "fail"
+    assert opencode["reason"] == "OLLAMA_HOST_UNREACHABLE"
+    assert opencode["detail"] == "HTTP 302: redirect to login"
+
+
+@pytest.mark.unit
 def test_provider_readiness_opencode_ollama_file_reason_without_opencode_config(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -51,6 +51,7 @@ def _settings(tmp_path: Path, *, min_free_disk_bytes: int = 200) -> ServiceSetti
         github_token=None,
         worker_poll_interval_seconds=0.1,
         worker_max_concurrent_provisions=1,
+        host_home=str(tmp_path / "home"),
         min_free_disk_bytes=min_free_disk_bytes,
     )
 
@@ -178,6 +179,7 @@ def test_service_status_includes_ok_disk_check_from_mocked_usage(tmp_path: Path)
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 
@@ -194,6 +196,51 @@ def test_service_status_includes_ok_disk_check_from_mocked_usage(tmp_path: Path)
 
 
 @pytest.mark.unit
+def test_service_status_provider_warnings_do_not_fail_by_default(tmp_path: Path) -> None:
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
+        )
+    )
+
+    assert status["status"] == "ok"
+    readiness = status["agent_readiness"]
+    assert readiness["status"] == "ok"
+    assert readiness["providers"]["github"]["status"] == "warn"
+    assert readiness["providers"]["github"]["reason"] == "GITHUB_TOKEN_ENV_MISSING"
+
+
+@pytest.mark.unit
+def test_service_status_strict_provider_failure_sets_top_level_fail(tmp_path: Path) -> None:
+    status = asyncio.run(
+        collect_service_status(
+            _settings(tmp_path),
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_make_run_subprocess(),
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
+            strict_providers={"github"},
+        )
+    )
+
+    assert status["status"] == "fail"
+    readiness = status["agent_readiness"]
+    assert readiness["status"] == "fail"
+    assert readiness["providers"]["github"]["status"] == "fail"
+    assert readiness["providers"]["github"]["reason"] == "GITHUB_TOKEN_ENV_MISSING"
+
+
+@pytest.mark.unit
 def test_service_status_fails_when_disk_is_below_threshold(tmp_path: Path) -> None:
     status = asyncio.run(
         collect_service_status(
@@ -204,6 +251,7 @@ def test_service_status_fails_when_disk_is_below_threshold(tmp_path: Path) -> No
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 
@@ -227,6 +275,7 @@ def test_orphan_check_reports_no_orphans_when_no_awf_containers(tmp_path: Path) 
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 
@@ -277,6 +326,7 @@ def test_orphan_check_treats_active_workspace_containers_as_expected(tmp_path: P
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -316,6 +366,7 @@ def test_orphan_check_flags_terminal_workspace_with_running_container(tmp_path: 
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -367,6 +418,7 @@ def test_orphan_check_flags_workspace_missing_from_db(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -402,6 +454,7 @@ def test_orphan_check_skips_non_awf_compose_projects(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 
@@ -440,6 +493,7 @@ def test_orphan_check_marks_unknown_when_db_unavailable(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -486,6 +540,7 @@ def test_orphan_check_unavailable_when_docker_ps_fails(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -523,6 +578,7 @@ def test_collect_status_cancels_pending_auxiliary_tasks_on_probe_error(tmp_path:
                 socket_exists=lambda _path: True,
                 disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
                 workspace_id_lookup=slow_workspace_lookup,
+                provider_environ={},
             )
         )
 
@@ -552,6 +608,7 @@ def test_orphan_check_extracts_labels_via_docker_template(tmp_path: Path) -> Non
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 
@@ -591,6 +648,7 @@ def test_orphan_check_handles_label_value_with_comma(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_ws_lookup,
+            provider_environ={},
         )
     )
 
@@ -613,6 +671,7 @@ def test_orphan_check_handles_missing_docker_binary(tmp_path: Path) -> None:
             socket_exists=lambda _path: True,
             disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
             workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
         )
     )
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ebc6de17c0414fa4bffd7fe5` (agent: `codex`).


### Task
Implement provider/service readiness observability for AWF local service mode.

Context:
After rebuilding the local service, the worker could be healthy while GitHub/Claude/Gemini/OpenCode credentials were not actually visible in the service container. That caused failed dogfood runs. AWF should surface this before scheduling provider-specific work.

Required behavior:
- Extend service status/readiness internals and CLI/API output with a provider_auth or agent_readiness section.
- Report GitHub CLI auth usable for PR creation/comment/merge without leaking tokens.
- Report Claude Code readiness using env/file auth signals available to the service/workspace model.
- Report Gemini readiness using env/file auth signals.
- Report OpenCode/Ollama readiness using mounted config/auth files and Ollama base URL/host reachability when cheap and safe.
- Return actionable reason codes and messages, not raw secret values.
- Keep missing optional providers as warnings unless the operator asks for a provider-specific strict check.
- Add docs for local service `.env`/`docker/compose/.env` credential propagation, especially that macOS keychain-backed gh auth needs AWF_GITHUB_TOKEN/GH_TOKEN in Compose.

TDD requirements:
- Write failing tests first.
- Use focused mocks/temp homes; do not require real credentials in tests.
- Cover all-green, missing GitHub token, keyring-only GitHub warning, Claude env present, Claude file present, Gemini file present, OpenCode/Ollama file present, and redaction.
- Do not lower coverage, fail_under, .awf coverage config, pyproject coverage config, or quality gates.
- Do not push; AWF owns push, PR creation, monitoring, comments, and merge.

---
Validation: 7 profile command(s) passed inside the workspace container.
