### PR TITLE
fix(monitor): make PR recovery grace-aware and validate-only

### DIFF
--- a/docs/awf-plans/ws_2a64b2c190a24e63915f519f.md
+++ b/docs/awf-plans/ws_2a64b2c190a24e63915f519f.md
@@ -1,0 +1,412 @@
+# Plan — Reliability Fix for AWF PR Monitor Recovery
+
+## Goal
+
+Two interrelated reliability bugs in the AWF PR monitor's recovery path:
+
+1. **Grace-vs-recovery ordering.** When the monitor decides a PR is otherwise
+   merge-ready but `compute_stale_reason` returns a non-`None` reason, today's
+   `Merge` handler dispatches `RECOVERY_DISPATCH` before checking the one-time
+   initial-review grace window. The grace window (default 900 s) was added to
+   give slow first-pass reviewers time to comment before AWF acts; firing
+   recovery during the window short-circuits that contract — the workspace
+   leaves `monitoring_pr` and re-enters the executor pipeline before reviewers
+   are heard.
+
+2. **Recovery dispatched through the feature-execution path.** The current
+   dispatch transitions the workspace `monitoring_pr → ready` and creates a
+   `validate`/`rebase` `Operation` with `payload={"source": "pr_monitor", …}`.
+   The control worker then picks the workspace up like any new `ready`
+   workspace and invokes `WorkspaceExecutor.execute`, which runs
+   `_run_agent_task_with_optional_planning`. That step rewrites the planning
+   artifacts (`docs/awf-plans/<ws>.md` + conformance JSON) and re-invokes the
+   coding CLI with the original `task_prompt`. For monitor-driven recovery
+   (which exists to refresh validation, not to redo the feature), this is
+   wrong: the agent has no business re-implementing the feature mid-merge.
+
+The fix preserves every existing terminal/non-terminal behaviour for normal
+feature execution, manual-merge mode, comment handling, CI gates, stale
+blockers, merge-queue blockers, and the pre-merge settle. The only change is
+to the recovery sub-path: grace wins first, and a structured recovery branch
+runs validation/rebase only.
+
+## Intended files / modules to touch
+
+Implementation files (only touched after red tests exist):
+
+- `src/awf/runtime/pr_monitor_runner.py`
+  - In `_execute(...)` `Merge` handler (currently lines ~630-693), reorder so
+    the **initial-review grace check** runs **before** the
+    `compute_stale_reason` branch. While grace is active and a stale reason
+    is detected, emit a structured event/log (`monitor.grace_defers_recovery`)
+    and sleep for the same `min(poll_interval, remaining_grace)` window the
+    existing grace path uses; do **not** create the `Operation` row and do
+    **not** transition the workspace.
+  - When grace has elapsed and recovery is dispatched, emit a structured
+    `monitor.recovery_dispatched` event/log alongside the existing
+    `RECOVERY_DISPATCH` transition. Payload: `reason_code`, `req_action`
+    (validate/rebase), `pr_number`, `head_sha`. The `OperationRepository.create`
+    payload gains an explicit `recovery_mode: "validate_only" | "rebase_only"`
+    discriminator the executor will read.
+  - Keep the `auto_merge=False → Abort(stale)` arm exactly as today. Manual
+    merge mode is invariant; the grace check still runs but does not change
+    the outcome (auto_merge=False never dispatches recovery, it aborts).
+  - Keep the `req_action == "rebase" + has_failed_rebase → NotifyHuman` arm
+    exactly as today.
+- `src/awf/control/executor.py`
+  - Add a small predicate `_pending_monitor_recovery(ws) -> dict | None` that
+    inspects `ws.operations` for an active (`pending`/`running`) row whose
+    `payload["source"] == "pr_monitor"` and returns the `payload` (or `None`).
+  - In `WorkspaceExecutor.execute` after `_claim_ready` and the first
+    `_recheck_status`, branch on `_pending_monitor_recovery(ws)`:
+    - **None (normal feature path)**: existing behaviour unchanged. The
+      feature task prompt + planning + execution + conformance all still run.
+    - **Recovery**: skip Step 1 (`_run_agent_task_with_optional_planning`) and
+      Step 1b (post-agent commit / branch-drift / orphan-history checks).
+      Setup phases (`profile.run_profile_phases(("setup", "pre_agent"))`)
+      still run because the validation phase needs the container hot. Then
+      proceed directly to Step 2 (validation, with its existing fix-cycle —
+      the fix-cycle prompt is *not* the original feature task prompt; it is
+      `build_fix_prompt(...)` from `validation_fix_cycle.py`, which is the
+      intended monitor-recovery agent path), Step 3 (push, which is a no-op
+      if validation produced no new commits), and Step 4 (handoff back to
+      `monitoring_pr`).
+    - The recovery branch must **not** call
+      `_run_agent_task_with_optional_planning` and must **not** touch
+      planning artifacts (`render_workspace_path(planning.plan_path, …)`,
+      conformance report path). It logs `executor.monitor_recovery_started`
+      with the recovery payload (reason, mode) and, on a clean validation
+      pass, `executor.monitor_recovery_completed`.
+  - When recovery enters validation, the `validate` `Operation` row (the one
+    `pr_monitor_runner.py` created at dispatch) is transitioned
+    `pending → running` at the start of validation and
+    `running → succeeded`/`failed` at the end so observability tooling sees
+    the recovery's lifecycle without scraping logs.
+- `src/awf/runtime/events.py` is already wired through
+  `WorkspaceRepository.add_events`; no change. New event types are
+  string-typed; the schema is freeform `payload` JSON, so no migration.
+
+Files that are deliberately **not** touched:
+
+- `src/awf/runtime/pr_monitor.py` — the pure decision core. The grace
+  window is a runner-side wait, not a `MonitorAction`. The existing
+  `Merge → AddressComments → SyncBase → ReportCiFailure → Abort(stale)`
+  vocabulary is sufficient.
+- `src/awf/control/state_machine.py` — `monitoring_pr → ready` remains the
+  recovery-dispatch transition. We do not introduce a new `recovering`
+  status; that would be a much bigger change for the same effect.
+- `src/awf/control/worker.py` — the worker still dispatches `ready`
+  workspaces through `executor.execute`. The recovery branch lives inside
+  `execute`, so the worker's contract (`ready → drive to terminal`) is
+  unchanged.
+- `src/awf/db/models.py`, `migrations/` — no schema change. The
+  `Operation.payload` JSON gains the new `recovery_mode` key without a
+  migration; existing rows are unaffected.
+- `pyproject.toml`, `.awf/`, lockfiles, coverage thresholds — untouched.
+- README, SKILL.md, tutorials — untouched.
+
+## Tests to write first (failing → commit → implement)
+
+All tests are committed before any implementation file is edited. Each test
+asserts a behaviour that would currently fail on `main`.
+
+### Unit — monitor runner grace ordering
+
+File: `tests/unit/runtime/test_pr_monitor_recovery_grace.py` (new).
+
+1. `test_initial_review_grace_defers_stale_recovery_dispatch` —
+   - Seed a workspace in `monitoring_pr` with `auto_merge=True`,
+     `task_class="refactor_task"`, no validate operations. This triggers
+     `compute_stale_reason → ("validation_insufficient_tier", "validate")`.
+   - Drive the runner with `initial_review_grace_period_seconds=900` and
+     a `monitor_started_at` recent enough that grace is still active.
+   - Assert: no `Operation` row was created, the workspace is **still** in
+     `monitoring_pr`, the runner's recorded sleep matches
+     `min(poll_interval, remaining_grace)`, and a workspace event /
+     `monitor.grace_defers_recovery` log line was emitted with the stale
+     reason in its payload.
+
+2. `test_grace_elapsed_then_stale_recovery_dispatches_with_event` —
+   - Same seed but `monitor_started_at` set far enough in the past that
+     grace is elapsed.
+   - Assert: `Operation(type="validate", payload["source"]=="pr_monitor",
+     payload["reason"]=="validation_insufficient_tier",
+     payload["recovery_mode"]=="validate_only")` is created, workspace is
+     transitioned `monitoring_pr → ready` with `reason_code="RECOVERY_DISPATCH"`,
+     and a `monitor.recovery_dispatched` event/log fired.
+
+3. `test_manual_merge_mode_aborts_stale_regardless_of_grace` —
+   - `auto_merge=False`, stale validation, grace still active.
+   - Assert: workspace transitions to `failed` with
+     `reason_code=AbortReason.stale.value`. No grace deferral, no recovery
+     dispatch. (Reaffirms the task requirement: "manual merge mode remains
+     unchanged".)
+
+4. `test_failed_rebase_with_stale_notifies_human_under_grace` —
+   - `req_action == "rebase"` (forced by stubbing `compute_stale_reason`)
+     with a prior failed rebase op and grace still active.
+   - Assert: NotifyHuman fires (existing behaviour). Grace does **not**
+     suppress NotifyHuman. (Edge-case regression guard.)
+
+### Unit — executor recovery branch
+
+File: `tests/unit/control/test_executor_monitor_recovery.py` (new).
+
+5. `test_executor_skips_planning_and_agent_run_when_recovery_dispatched` —
+   - Seed a workspace in `ready` whose `operations` contain
+     `Operation(type="validate", status="pending",
+     payload={"source": "pr_monitor", "reason": "validation_insufficient_tier",
+     "recovery_mode": "validate_only"})`.
+   - Stub `AgentAdapter` so `adapter.run` records every prompt it receives.
+   - Run `executor.execute(workspace_id)` to completion.
+   - Assert:
+     - The recorded prompts contain **no** copy of `ws.task_prompt`.
+     - The recorded prompts contain **no** `build_planning_prompt(...)`,
+       `build_execution_prompt(...)`, or `build_conformance_prompt(...)`
+       output (assertion done by string-substring match on a known
+       sentinel from each prompt builder).
+     - The fix-cycle prompt path may still be invoked (this is allowed —
+       it is `build_fix_prompt`, not the feature prompt) when validation
+       fails on the first pass.
+     - The plan file declared by the workspace's profile (e.g.
+       `docs/awf-plans/<workspace_id>.md`) is **not** modified during
+       the recovery run (assert via `Path.stat().st_mtime` snapshot
+       before/after, or by writing a sentinel into the file before the
+       run and verifying it survives).
+     - The workspace ends in `monitoring_pr` (or `failed` if validation
+       fails — the test parametrises both).
+
+6. `test_executor_recovery_marks_validate_operation_lifecycle` —
+   - Same seed; stub validation to succeed.
+   - Assert: the `Operation` row transitions `pending → running →
+     succeeded` and stores the `validation_run_id` reference (or at least
+     ends with status `succeeded`).
+   - On a stubbed validation failure (exhausted fix passes), assert the
+     operation ends with status `failed`.
+
+7. `test_executor_normal_path_unchanged_when_no_recovery_op` —
+   - Seed a workspace in `ready` with no `pr_monitor` operations.
+   - Assert: existing planning/agent flow runs (the planning prompt is
+     observed in `adapter.run` calls). This is a regression guard — the
+     branch must not accidentally short-circuit normal feature execution.
+
+### Integration — end-to-end runner with monitor-recovery cycle
+
+File: `tests/integration/runtime/test_pr_monitor_recovery_cycle.py` (new),
+or extend the existing
+`tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py::test_stale_auto_merge_dispatches_validation_recovery`
+in place.
+
+8. `test_recovery_round_trip_does_not_rewrite_plan_files` —
+   - Drive the monitor through one full cycle:
+     `monitoring_pr (stale, grace elapsed) → RECOVERY_DISPATCH → ready →
+     running → validating → pushing → monitoring_pr`.
+   - Pre-write a sentinel plan file under
+     `worktrees/<id>/docs/awf-plans/<id>.md`.
+   - Assert that after the cycle, the sentinel content is byte-identical
+     to what was written, no conformance report was created/modified, and
+     the post-recovery workspace is back in `monitoring_pr` with the
+     `validate` operation marked `succeeded`.
+
+9. `test_recovery_does_not_run_baseline_coverage_preflight_or_planning_phase` —
+   - Same scenario as (8); assert no `baseline_coverage` profile-phase
+     run was emitted and no planning prompt was sent to the adapter.
+
+### Coverage / quality regression guard
+
+10. Run `uv run --python 3.12 --extra dev pytest --cov=awf --cov-branch
+    --cov-report=term-missing tests/` and verify the resulting coverage
+    is `>=` the current `fail_under` (99). New code is covered by the
+    new tests above; the existing
+    `test_stale_auto_merge_dispatches_validation_recovery` test is
+    updated, not removed, to assert the new payload key
+    (`recovery_mode == "validate_only"`).
+
+## Implementation steps
+
+Strict TDD order. Each step ends with a commit on the current AWF branch.
+
+1. **Add the failing tests** above (sections 1-9). Verify they are red:
+   `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_recovery_grace.py
+   tests/unit/control/test_executor_monitor_recovery.py
+   tests/integration/runtime/test_pr_monitor_recovery_cycle.py -q`.
+   Commit message: `test(monitor): cover grace-before-recovery and
+   validation-only recovery (failing)`.
+
+2. **Reorder grace check vs stale-recovery dispatch in
+   `pr_monitor_runner.py`.** Inside the `Merge` handler:
+   - Move the `_initial_review_grace_wait_seconds` block (currently
+     lines 720-737) so it runs **before** the `compute_stale_reason`
+     check (currently lines 631-693).
+   - When the grace block returns a non-zero wait AND `compute_stale_reason`
+     would have returned a stale reason, emit
+     `monitor.grace_defers_recovery` (workspace event +
+     monitor.log JSON) with `{stale_reason, req_action,
+     wait_seconds, grace_seconds}` so operators can see the deferral
+     without grepping. Compute `compute_stale_reason` once at the top
+     of the handler so we can include the reason in the log without a
+     second DB read.
+   - Sleep + return as today; no `Operation` row, no transition.
+   - Add a guard test invariant: `_persist_state` must be called even
+     on the grace-defer path (the grace state-keys mutate the
+     `threads_addressed_ids` dict).
+
+3. **Add `monitor.recovery_dispatched` event + payload discriminator
+   in `pr_monitor_runner.py`.** When recovery dispatch fires, the
+   `Operation.payload` must include
+   `{"source": "pr_monitor", "reason": <reason>, "recovery_mode":
+   "validate_only"}` (or `"rebase_only"` if/when the rebase path is
+   wired). Emit a `monitor.recovery_dispatched` workspace event and
+   `_log.info("monitor.recovery_dispatched", …)` with
+   `{workspace_id, pr_number, reason, req_action, recovery_mode,
+   head_sha}`.
+
+4. **Add `_pending_monitor_recovery(ws)` predicate in
+   `executor.py`.** Pure function: scan `ws.operations` for any row with
+   `status in ("pending", "running")` and
+   `payload.get("source") == "pr_monitor"`, return the matching payload
+   (or `None`). Export at module scope so tests can call it directly.
+
+5. **Branch in `WorkspaceExecutor.execute` to skip planning/agent
+   under recovery.** After `_claim_ready` + `_recheck_status`:
+   - Compute `recovery = _pending_monitor_recovery(ws)`.
+   - If recovery is set:
+     - Run setup phases as today.
+     - Skip Step 1 (`_run_agent_task_with_optional_planning`) entirely
+       — do **not** call `adapter.run` with the feature prompt.
+     - Skip Step 1b (post-agent commit, branch-drift recovery,
+       orphan-history reset). Rationale: nothing has touched the
+       worktree since the last push; HEAD already advanced past
+       `base_commit`; nothing to commit.
+     - Mark the recovery `Operation` `pending → running`.
+     - Continue with Step 2 (validation, with the existing fix-cycle).
+     - Continue with Steps 3 + 4 (push + handoff). `pr_creator.push_and_open`
+       already detects the existing PR and updates it.
+     - Mark the recovery `Operation` `running → succeeded` on a clean
+       validation pass; `running → failed` on exhaustion. The
+       `_finish_pending_validate_operations` helper already does most of
+       this for the normal flow; reuse it.
+     - Emit `executor.monitor_recovery_started` and
+       `executor.monitor_recovery_completed` (or `_failed`) log lines
+       with the recovery payload so the recovery's effect is observable.
+   - If recovery is None: existing flow, byte-identical.
+
+6. **Wire the recovery_mode discriminator end-to-end.** The executor
+   reads `recovery["recovery_mode"]` and dispatches:
+   - `"validate_only"` → run validation phases only (the default).
+   - `"rebase_only"` → invoke the rebase helper before validation.
+     (For this slice, `req_action == "rebase"` does not yet route
+     here — the existing code has a `has_failed_rebase` short-circuit
+     that fires NotifyHuman; this slice keeps that behaviour. The
+     discriminator is recorded in the payload so a future change can
+     enable the rebase path without another schema or state change.)
+
+7. **Verify the new tests are now green** and confirm
+   `pytest -q` is fully green for the whole suite. Run
+   `mypy src tests` and `ruff check src tests` to keep the existing
+   gates in place. Then run the full coverage check
+   `uv run --python 3.12 --extra dev pytest --cov=awf --cov-branch
+   --cov-fail-under=99 tests/` and confirm the threshold still holds.
+   Commit message: `feat(monitor): defer recovery during grace and
+   keep recovery validation-only`.
+
+8. **Update the existing test that already asserts the old payload
+   shape.** The test
+   `tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py::test_stale_auto_merge_dispatches_validation_recovery`
+   currently asserts
+   `payload == {"source": "pr_monitor", "reason": "validation_insufficient_tier"}`.
+   Extend it (in the same commit as step 7) to also assert
+   `recovery_mode == "validate_only"`. Do **not** remove the test —
+   it still pins the dispatch path.
+
+## Validation commands
+
+Run from `/workspace` on the current AWF branch.
+
+- Failing-tests-first verification:
+  - `uv run --python 3.12 --extra dev pytest -q
+    tests/unit/runtime/test_pr_monitor_recovery_grace.py
+    tests/unit/control/test_executor_monitor_recovery.py
+    tests/integration/runtime/test_pr_monitor_recovery_cycle.py`
+    expected to fail before implementation, pass after.
+- Full unit + integration suite: `uv run --python 3.12 --extra dev pytest -q tests/`.
+- Static gates: `uv run --python 3.12 --extra dev mypy src tests`,
+  `uv run --python 3.12 --extra dev ruff check src tests`.
+- Coverage gate: `uv run --python 3.12 --extra dev pytest --cov=awf
+  --cov-branch --cov-fail-under=99 tests/` to confirm the
+  `fail_under` threshold survives.
+- Manual sanity: `uv run --python 3.12 --extra dev pytest -q tests/unit/runtime/test_pr_monitor_initial_review_grace.py
+  tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+  tests/unit/control/test_executor_validation_fix_cycle.py
+  tests/unit/control/test_executor.py` — the directly affected suites.
+
+## Risks, assumptions, and explicit non-goals
+
+### Risks
+
+- **Worktree state on the recovery dispatch.** The recovery skip
+  presumes the worktree is in a clean, post-push state (i.e. nothing
+  uncommitted, HEAD advanced beyond `base_commit`). If a previous
+  recovery iteration left dirty files (e.g. a validation fix-cycle
+  CLI exit during a partial commit), the existing `_commit_dirty_worktree`
+  helper at the top of validation already covers this — recovery
+  re-uses that. No additional cleanup needed.
+- **Operation lifecycle ordering.** The recovery branch must transition
+  `pending → running` before validation starts and update it on every
+  validation attempt, or the merge-queue blocker logic in
+  `service/merge_queue.py::_is_monitor_owned_recovery` will continue
+  to flag the workspace as recovering long after it's done. Mitigation:
+  add an explicit `pending → running` flush at the top of the recovery
+  branch, mirroring the normal validate path.
+- **Grace + bot fleets.** A PR with both stale validation AND active
+  bot reviewers will hit `AddressComments` first (gate 2 in `decide`
+  comes before any merge gating). The grace deferral only applies on
+  the `Merge` action arm — comments still get addressed during grace.
+  This matches the intent of the grace window (give reviewers time to
+  comment, not to delay every monitor action).
+- **Idempotency of recovery dispatch.** If the runner crashes
+  between `Operation.create` and `WorkspaceRepository.transition`,
+  the next monitor poll might create a second pending operation.
+  Existing `OperationRepository.create` does not deduplicate. Mitigation:
+  before creating the recovery op, check
+  `OperationRepository.list_active(workspace_id)` for an existing
+  pr_monitor recovery row and short-circuit if present. Test (5) above
+  asserts this idempotence.
+
+### Assumptions
+
+- `compute_stale_reason` only returns `(None, None)` or
+  `("validation_insufficient_tier", "validate")` today; no
+  `"rebase"` action paths exist yet. The plan keeps the existing
+  rebase guard (`has_failed_rebase → NotifyHuman`) intact and reserves
+  `recovery_mode == "rebase_only"` for a future slice.
+- `pr_creator.push_and_open` is idempotent against an existing PR — it
+  updates the PR's head SHA via push and returns the existing PR URL.
+  Verified by the existing `had_existing_pr_url` branch in
+  `executor.py:1092`.
+- The validation fix-cycle prompt (`build_fix_prompt`) is **not** the
+  feature task prompt and is therefore acceptable in the recovery
+  path. Verified at `validation_fix_cycle.py:116-178`.
+- `ws.monitor_started_at` is reliably set by the runner the first time
+  it persists state; therefore `_initial_review_grace_wait_seconds`
+  has a stable origin even across restarts.
+
+### Explicit non-goals
+
+- **No new workspace status.** A `recovery_validating` or
+  `recovering` status would be cleaner conceptually but requires
+  state-machine, repository, API-schema, and migration changes for
+  no behavioural gain over the operation-driven branch.
+- **No new TaskKind.** Recovery is not a task; it is a transient
+  re-run of validation against an existing PR.
+- **No rebase enablement.** The plan reserves the `rebase_only`
+  recovery mode but does not flip
+  `compute_stale_reason` to ever return `(_, "rebase")`. That stays
+  for a future slice.
+- **No change to the comment-addressing fix cycle**, the SyncBase
+  flow, the CI-fix flow, or the merge critical section.
+- **No coverage-threshold change.** `fail_under` and the AWF
+  `.awf/workspace.yml` coverage config are untouched; new code
+  is covered by tests written first.
+- **No push or PR creation by the agent.** AWF still owns push,
+  PR creation, comments, and merge.

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -98,6 +98,32 @@ _log = get_logger(__name__)
 
 WORKTREE_MISSING_REASON_CODE = "WORKTREE_MISSING"
 
+_MONITOR_RECOVERY_ACTIVE_OPERATION_STATUSES = {
+    OperationStatus.pending.value,
+    OperationStatus.running.value,
+}
+
+
+def _pending_monitor_recovery(workspace: Any) -> dict[str, Any] | None:
+    """Return the active pr_monitor recovery payload (or ``None``).
+
+    The PR monitor's RECOVERY_DISPATCH path creates an Operation row
+    with ``payload["source"] == "pr_monitor"``; the executor uses this
+    as the discriminator that separates monitor-driven recovery from
+    a fresh feature-execution pass.
+    """
+    operations = getattr(workspace, "operations", None) or []
+    for operation in operations:
+        if operation.status not in _MONITOR_RECOVERY_ACTIVE_OPERATION_STATUSES:
+            continue
+        payload = operation.payload
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("source") != "pr_monitor":
+            continue
+        return payload
+    return None
+
 
 @dataclass(frozen=True)
 class ExecutorConfig:
@@ -209,6 +235,12 @@ class WorkspaceExecutor:
         worktree_path = self._config.worktrees_root / workspace_id
 
         # ── Step 1: agent CLI runs the task inside the container ────────────
+        # When the PR monitor's RECOVERY_DISPATCH path delivered this
+        # workspace, the executor must NOT re-run planning, the agent
+        # CLI, or any post-agent commit hooks — those would rewrite the
+        # plan artifact and re-implement the feature mid-merge. Recovery
+        # only re-runs validation against the already-pushed work.
+        recovery = _pending_monitor_recovery(ws)
         baseline_coverage: ValidationCoverageResult | None = None
         try:
             agent = AgentRuntime(ws.agent)
@@ -232,6 +264,17 @@ class WorkspaceExecutor:
             )
             if not setup_result.all_passed:
                 first_fail = setup_result.first_failure
+                if recovery is not None:
+                    await self._finish_pending_monitor_recovery_operations(
+                        workspace_id=workspace_id,
+                        status=OperationStatus.failed,
+                        reason_code="MONITOR_RECOVERY_SETUP_FAILED",
+                        error_message=(
+                            f"profile setup failed: {first_fail.command}"
+                            if first_fail is not None
+                            else "profile setup failed"
+                        )[:2000],
+                    )
                 await self._mark_failed(
                     workspace_id=workspace_id,
                     from_status=WorkspaceStatus.running,
@@ -243,35 +286,43 @@ class WorkspaceExecutor:
                     )[:2000],
                 )
                 return
-            baseline_coverage = await self._run_baseline_coverage_preflight(
-                workspace_id=workspace_id,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                profile=profile,
-            )
-            if not await self._recheck_status(
-                workspace_id,
-                expected=WorkspaceStatus.running,
-                action="agent_run",
-            ):
-                return
-            planning_error = await self._run_agent_task_with_optional_planning(
-                adapter=adapter,
-                workspace=ws,
-                profile=profile,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                worktree_path=worktree_path,
-                model=default_model,
-            )
-            if planning_error is not None:
-                await self._mark_failed(
+            if recovery is None:
+                baseline_coverage = await self._run_baseline_coverage_preflight(
                     workspace_id=workspace_id,
-                    from_status=WorkspaceStatus.running,
-                    failure_reason=FailureReason.agent_failure,
-                    message=planning_error[:2000],
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    profile=profile,
                 )
-                return
+                if not await self._recheck_status(
+                    workspace_id,
+                    expected=WorkspaceStatus.running,
+                    action="agent_run",
+                ):
+                    return
+                planning_error = await self._run_agent_task_with_optional_planning(
+                    adapter=adapter,
+                    workspace=ws,
+                    profile=profile,
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    worktree_path=worktree_path,
+                    model=default_model,
+                )
+                if planning_error is not None:
+                    await self._mark_failed(
+                        workspace_id=workspace_id,
+                        from_status=WorkspaceStatus.running,
+                        failure_reason=FailureReason.agent_failure,
+                        message=planning_error[:2000],
+                    )
+                    return
+            else:
+                _log.info(
+                    "executor.monitor_recovery_started",
+                    workspace_id=workspace_id,
+                    recovery_mode=recovery.get("recovery_mode"),
+                    reason=recovery.get("reason"),
+                )
             agent_exit_note = None
         except ComposeExecCleanupError as exc:
             _log.error(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -317,6 +317,14 @@ class WorkspaceExecutor:
                     )
                     return
             else:
+                # The monitor created the recovery Operation in ``pending``;
+                # flush it to ``running`` before validation so observability
+                # tooling sees a real ``started_at`` (otherwise the row jumps
+                # straight from pending → succeeded/failed when the validate
+                # finalizer fires, with started_at == finished_at).
+                await self._start_pending_monitor_recovery_operations(
+                    workspace_id=workspace_id,
+                )
                 _log.info(
                     "executor.monitor_recovery_started",
                     workspace_id=workspace_id,
@@ -1828,6 +1836,36 @@ class WorkspaceExecutor:
             )
             await session.commit()
             return run.id
+
+    async def _start_pending_monitor_recovery_operations(
+        self,
+        *,
+        workspace_id: str,
+    ) -> None:
+        """Flush pending pr_monitor recovery operations to ``running``.
+
+        The monitor's RECOVERY_DISPATCH path creates the validate
+        Operation in ``pending``; without an explicit transition the row
+        would jump straight to ``succeeded``/``failed`` with
+        ``started_at == finished_at``, which loses the recovery
+        lifecycle for observability tooling.
+        """
+        async with self._session_factory() as session:
+            repo = OperationRepository(session)
+            pending = await repo.list_for_workspace(
+                workspace_id,
+                status=OperationStatus.pending,
+                limit=100,
+            )
+            now = datetime.now(UTC)
+            for operation in pending:
+                payload = operation.payload
+                if not isinstance(payload, dict) or payload.get("source") != "pr_monitor":
+                    continue
+                operation.status = OperationStatus.running.value
+                if operation.started_at is None:
+                    operation.started_at = now
+            await session.commit()
 
     async def _finish_pending_monitor_recovery_operations(
         self,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -430,235 +430,165 @@ class WorkspaceExecutor:
         expected_branch = ws.branch_name or f"awf/{workspace_id}"
 
         try:
-            # ── Branch-drift recovery ──────────────────────────────────
-            # Agent CLIs (Claude Code, Codex) sometimes run
-            # ``git checkout -b <descriptive-name>`` mid-session as part
-            # of "good git hygiene" — they don't know AWF already
-            # created the right branch for them. If they commit on the
-            # drifted branch, ``pr_creator.push_and_open`` pushes the
-            # original (empty) AWF branch to origin and ``gh pr create``
-            # fails with "No commits between development and awf/ws_...".
-            #
-            # Incident 2026-04-24 (T41 Phase 3, ws_9ca6134a): agent
-            # switched to ``awf/t41-phase3-github-app-install-flow``
-            # and committed there. AWF's push of the empty
-            # ``awf/ws_9ca6134a...`` created a no-op PR. Agent's work
-            # stranded in the worktree.
-            #
-            # Recovery: if HEAD's branch diverged, fast-forward the
-            # expected branch to the agent's tip. Both branches share
-            # the same base commit (the worktree was created fresh
-            # from origin/<base>), so this is a safe pointer update.
-            current_branch_r = await _git_in_worktree(["rev-parse", "--abbrev-ref", "HEAD"])
-            # If rev-parse itself failed (corrupted git state, missing
-            # HEAD, etc.) we can't reliably detect drift. Fail loudly
-            # rather than silently skip — a working tree that can't
-            # resolve HEAD is broken enough that continuing to push
-            # would produce nonsense anyway.
-            if not current_branch_r.ok:
-                raise RuntimeError(
-                    "branch drift check: ``git rev-parse --abbrev-ref HEAD`` "
-                    f"failed with exit {current_branch_r.returncode}: "
-                    f"{current_branch_r.stderr!r}"
-                )
-            current_branch = (current_branch_r.stdout or "").strip()
-            if current_branch and current_branch != expected_branch:
-                _log.warning(
-                    "executor.branch_drift_detected",
-                    workspace_id=workspace_id,
-                    current_branch=current_branch,
-                    expected_branch=expected_branch,
-                )
-                agent_head_r = await _git_in_worktree(["rev-parse", "HEAD"])
-                agent_head = (agent_head_r.stdout or "").strip()
-                if not agent_head_r.ok or not agent_head:
+            if recovery is None:
+                # ── Branch-drift recovery ──────────────────────────────────
+                # Agent CLIs (Claude Code, Codex) sometimes run
+                # ``git checkout -b <descriptive-name>`` mid-session as part
+                # of "good git hygiene" — they don't know AWF already
+                # created the right branch for them. If they commit on the
+                # drifted branch, ``pr_creator.push_and_open`` pushes the
+                # original (empty) AWF branch to origin and ``gh pr create``
+                # fails with "No commits between development and awf/ws_...".
+                #
+                # Incident 2026-04-24 (T41 Phase 3, ws_9ca6134a): agent
+                # switched to ``awf/t41-phase3-github-app-install-flow``
+                # and committed there. AWF's push of the empty
+                # ``awf/ws_9ca6134a...`` created a no-op PR. Agent's work
+                # stranded in the worktree.
+                #
+                # Recovery: if HEAD's branch diverged, fast-forward the
+                # expected branch to the agent's tip. Both branches share
+                # the same base commit (the worktree was created fresh
+                # from origin/<base>), so this is a safe pointer update.
+                current_branch_r = await _git_in_worktree(["rev-parse", "--abbrev-ref", "HEAD"])
+                # If rev-parse itself failed (corrupted git state, missing
+                # HEAD, etc.) we can't reliably detect drift. Fail loudly
+                # rather than silently skip — a working tree that can't
+                # resolve HEAD is broken enough that continuing to push
+                # would produce nonsense anyway.
+                if not current_branch_r.ok:
                     raise RuntimeError(
-                        f"branch drift detected (current={current_branch} "
-                        f"expected={expected_branch}) but agent HEAD could not "
-                        f"be resolved: {agent_head_r.stderr!r}"
+                        "branch drift check: ``git rev-parse --abbrev-ref HEAD`` "
+                        f"failed with exit {current_branch_r.returncode}: "
+                        f"{current_branch_r.stderr!r}"
                     )
-                # Preserve uncommitted changes. The executor's core
-                # contract is "salvage whatever the agent left on
-                # disk" — including edits not yet committed on the
-                # drifted branch. ``status --porcelain`` with
-                # ``--untracked-files=all`` catches both staged,
-                # unstaged, and untracked files. If any exist, stash
-                # them (with ``-u`` to include untracked) before the
-                # ``switch`` so they don't get lost. Pop after the
-                # fast-forward so they end up on top of the agent's
-                # commits on the expected branch.
-                status_r = await _git_in_worktree(
-                    ["status", "--porcelain=v1", "--untracked-files=all"]
-                )
-                if not status_r.ok:
-                    raise RuntimeError(
-                        f"branch drift recovery: ``git status`` failed: {status_r.stderr!r}"
-                    )
-                has_wip = bool(status_r.stdout.strip())
-                stash_created = False
-                if has_wip:
-                    stash_r = await _git_in_worktree(
-                        [
-                            "stash",
-                            "push",
-                            "--include-untracked",
-                            "--message",
-                            f"awf-drift-recovery-{workspace_id}",
-                        ]
-                    )
-                    if not stash_r.ok:
-                        raise RuntimeError(
-                            f"branch drift recovery: ``git stash push`` failed: "
-                            f"{stash_r.stderr!r} (refusing to switch with dirty "
-                            f"worktree that couldn't be stashed)"
-                        )
-                    stash_created = True
-
-                # Switch to the expected branch. It should exist
-                # locally — AWF created it at worktree-add time.
-                switch_r = await _git_in_worktree(["switch", expected_branch])
-                if not switch_r.ok:
-                    # Best-effort: try to restore stashed WIP so it's
-                    # not silently lost before bailing out.
-                    if stash_created:
-                        await _git_in_worktree(["stash", "pop"])
-                    raise RuntimeError(
-                        f"branch drift recovery: could not switch back to "
-                        f"{expected_branch}: {switch_r.stderr!r}"
-                    )
-                # Fast-forward the expected branch to the agent's tip
-                # using ``merge --ff-only``. The two branches share
-                # the same base (AWF created the worktree fresh from
-                # ``origin/<base>``) and the agent only added commits
-                # on top, so ff must succeed. ``merge --ff-only`` over
-                # ``reset --hard`` because the latter would also wipe
-                # any WIP the user has in the working tree if the
-                # stash step above silently did nothing (e.g. if
-                # ``status`` missed an edge case).
-                merge_r = await _git_in_worktree(["merge", "--ff-only", agent_head])
-                if not merge_r.ok:
-                    if stash_created:
-                        await _git_in_worktree(["stash", "pop"])
-                    raise RuntimeError(
-                        f"branch drift recovery: ``merge --ff-only "
-                        f"{agent_head[:10]}`` failed: {merge_r.stderr!r}"
-                    )
-
-                if stash_created:
-                    pop_r = await _git_in_worktree(["stash", "pop"])
-                    if not pop_r.ok:
-                        # A pop conflict means the agent's WIP and the
-                        # fast-forwarded commits touch the same
-                        # regions. That's a real problem for the
-                        # workspace — the WIP is left in the stash
-                        # under a named entry, but we can't auto-merge
-                        # it. Fail loudly so the operator knows to
-                        # inspect.
-                        raise RuntimeError(
-                            f"branch drift recovery: ``git stash pop`` failed "
-                            f"(WIP conflicts with recovered commits): "
-                            f"{pop_r.stderr!r}"
-                        )
-
-                _log.info(
-                    "executor.branch_drift_recovered",
-                    workspace_id=workspace_id,
-                    recovered_from=current_branch,
-                    recovered_to=expected_branch,
-                    head_sha=agent_head,
-                    wip_stashed=has_wip,
-                )
-
-            await _git_in_worktree(["add", "-A"])
-            cached = await _git_in_worktree(["diff", "--cached", "--name-only"])
-            if cached.stdout.strip():
-                violations = find_protected_quality_gate_changes(
-                    changed_paths=_git_name_lines(cached.stdout),
-                    owned_paths=list(ws.owned_paths),
-                )
-                if violations:
-                    await self._mark_failed(
+                current_branch = (current_branch_r.stdout or "").strip()
+                if current_branch and current_branch != expected_branch:
+                    _log.warning(
+                        "executor.branch_drift_detected",
                         workspace_id=workspace_id,
-                        from_status=WorkspaceStatus.running,
-                        failure_reason=FailureReason.policy_failure,
-                        reason_code="QUALITY_GATE_POLICY_CHANGED",
-                        message=quality_gate_violation_message(violations)[:2000],
+                        current_branch=current_branch,
+                        expected_branch=expected_branch,
                     )
-                    return
-                commit_msg = f"awf: {ws.task_title}"[:72]
-                commit_body = f"Authored by AWF workspace {workspace_id} (agent: {ws.agent}).\n"
-                commit_result = await self._runner.run(
-                    [
-                        "git",
-                        *git_safe_directory_config_args(worktree_path),
-                        "-C",
-                        str(worktree_path),
-                        *git_identity_config_args(),
-                        "commit",
-                        "-m",
-                        commit_msg,
-                        "-m",
-                        commit_body,
-                    ],
-                )
-                if not commit_result.ok:
-                    raise RuntimeError(
-                        f"post-agent commit failed (exit={commit_result.returncode}): "
-                        f"{commit_result.stderr}"
+                    agent_head_r = await _git_in_worktree(["rev-parse", "HEAD"])
+                    agent_head = (agent_head_r.stdout or "").strip()
+                    if not agent_head_r.ok or not agent_head:
+                        raise RuntimeError(
+                            f"branch drift detected (current={current_branch} "
+                            f"expected={expected_branch}) but agent HEAD could not "
+                            f"be resolved: {agent_head_r.stderr!r}"
+                        )
+                    # Preserve uncommitted changes. The executor's core
+                    # contract is "salvage whatever the agent left on
+                    # disk" — including edits not yet committed on the
+                    # drifted branch. ``status --porcelain`` with
+                    # ``--untracked-files=all`` catches both staged,
+                    # unstaged, and untracked files. If any exist, stash
+                    # them (with ``-u`` to include untracked) before the
+                    # ``switch`` so they don't get lost. Pop after the
+                    # fast-forward so they end up on top of the agent's
+                    # commits on the expected branch.
+                    status_r = await _git_in_worktree(
+                        ["status", "--porcelain=v1", "--untracked-files=all"]
                     )
-            # Regardless of whether we just committed, verify HEAD has advanced
-            # past the base commit. If not, the agent produced no change.
-            rev_count = await _git_in_worktree(["rev-list", "--count", f"{base_commit}..HEAD"])
-            if not rev_count.ok or int(rev_count.stdout.strip() or "0") == 0:
-                base_short = base_commit[:10] if base_commit else "unknown"
-                message = (
-                    f"agent exited without producing any commits on the feature branch "
-                    f"(base={base_short})"
-                )
-                if agent_exit_note is not None:
-                    message = f"{message}; {agent_exit_note}"
-                await self._mark_failed(
-                    workspace_id=workspace_id,
-                    from_status=WorkspaceStatus.running,
-                    failure_reason=FailureReason.agent_failure,
-                    message=message,
-                )
-                return
+                    if not status_r.ok:
+                        raise RuntimeError(
+                            f"branch drift recovery: ``git status`` failed: {status_r.stderr!r}"
+                        )
+                    has_wip = bool(status_r.stdout.strip())
+                    stash_created = False
+                    if has_wip:
+                        stash_r = await _git_in_worktree(
+                            [
+                                "stash",
+                                "push",
+                                "--include-untracked",
+                                "--message",
+                                f"awf-drift-recovery-{workspace_id}",
+                            ]
+                        )
+                        if not stash_r.ok:
+                            raise RuntimeError(
+                                f"branch drift recovery: ``git stash push`` failed: "
+                                f"{stash_r.stderr!r} (refusing to switch with dirty "
+                                f"worktree that couldn't be stashed)"
+                            )
+                        stash_created = True
 
-            # Some agents sever git history (e.g. by accidentally running
-            # ``git checkout --orphan`` or by re-initialising the repo).
-            # rev-list counts HIGH in that case (every HEAD commit is "new"
-            # w.r.t. base because there's no shared ancestor), so the
-            # previous check wouldn't notice. Without this guard, the push
-            # succeeds but ``gh pr create`` dies with a cryptic
-            # ``branch has no history in common with <base>`` error.
-            #
-            # Recovery: ``git reset --soft <base>`` moves HEAD to the base
-            # commit while leaving the index untouched — the index still
-            # reflects the orphan's tree. A fresh ``git commit`` then
-            # produces a single commit on top of base that contains the
-            # cumulative diff, and the branch is reattached to a valid
-            # ancestry so the PR can be opened normally.
-            #
-            # Invariant: ``base_commit`` is always populated by
-            # ``_claim_ready`` before this block runs. The ``assert`` both
-            # documents and satisfies mypy.
-            ancestor = await _git_in_worktree(["merge-base", "--is-ancestor", base_commit, "HEAD"])
-            if not ancestor.ok:
-                _log.warning(
-                    "executor.orphan_history_detected",
-                    workspace_id=workspace_id,
-                    base_commit=base_commit,
-                )
-                reset = await _git_in_worktree(["reset", "--soft", base_commit])
-                if reset.ok:
-                    recovery_msg = f"awf: {ws.task_title} (recovered from orphan)"[:72]
-                    recovery_body = (
-                        f"AWF detected orphan history on workspace {workspace_id} "
-                        f"(agent: {ws.agent}) and squashed the cumulative diff "
-                        f"onto base commit {base_commit[:10]}.\n"
+                    # Switch to the expected branch. It should exist
+                    # locally — AWF created it at worktree-add time.
+                    switch_r = await _git_in_worktree(["switch", expected_branch])
+                    if not switch_r.ok:
+                        # Best-effort: try to restore stashed WIP so it's
+                        # not silently lost before bailing out.
+                        if stash_created:
+                            await _git_in_worktree(["stash", "pop"])
+                        raise RuntimeError(
+                            f"branch drift recovery: could not switch back to "
+                            f"{expected_branch}: {switch_r.stderr!r}"
+                        )
+                    # Fast-forward the expected branch to the agent's tip
+                    # using ``merge --ff-only``. The two branches share
+                    # the same base (AWF created the worktree fresh from
+                    # ``origin/<base>``) and the agent only added commits
+                    # on top, so ff must succeed. ``merge --ff-only`` over
+                    # ``reset --hard`` because the latter would also wipe
+                    # any WIP the user has in the working tree if the
+                    # stash step above silently did nothing (e.g. if
+                    # ``status`` missed an edge case).
+                    merge_r = await _git_in_worktree(["merge", "--ff-only", agent_head])
+                    if not merge_r.ok:
+                        if stash_created:
+                            await _git_in_worktree(["stash", "pop"])
+                        raise RuntimeError(
+                            f"branch drift recovery: ``merge --ff-only "
+                            f"{agent_head[:10]}`` failed: {merge_r.stderr!r}"
+                        )
+
+                    if stash_created:
+                        pop_r = await _git_in_worktree(["stash", "pop"])
+                        if not pop_r.ok:
+                            # A pop conflict means the agent's WIP and the
+                            # fast-forwarded commits touch the same
+                            # regions. That's a real problem for the
+                            # workspace — the WIP is left in the stash
+                            # under a named entry, but we can't auto-merge
+                            # it. Fail loudly so the operator knows to
+                            # inspect.
+                            raise RuntimeError(
+                                f"branch drift recovery: ``git stash pop`` failed "
+                                f"(WIP conflicts with recovered commits): "
+                                f"{pop_r.stderr!r}"
+                            )
+
+                    _log.info(
+                        "executor.branch_drift_recovered",
+                        workspace_id=workspace_id,
+                        recovered_from=current_branch,
+                        recovered_to=expected_branch,
+                        head_sha=agent_head,
+                        wip_stashed=has_wip,
                     )
-                    recover_commit = await self._runner.run(
+
+                await _git_in_worktree(["add", "-A"])
+                cached = await _git_in_worktree(["diff", "--cached", "--name-only"])
+                if cached.stdout.strip():
+                    violations = find_protected_quality_gate_changes(
+                        changed_paths=_git_name_lines(cached.stdout),
+                        owned_paths=list(ws.owned_paths),
+                    )
+                    if violations:
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.running,
+                            failure_reason=FailureReason.policy_failure,
+                            reason_code="QUALITY_GATE_POLICY_CHANGED",
+                            message=quality_gate_violation_message(violations)[:2000],
+                        )
+                        return
+                    commit_msg = f"awf: {ws.task_title}"[:72]
+                    commit_body = f"Authored by AWF workspace {workspace_id} (agent: {ws.agent}).\n"
+                    commit_result = await self._runner.run(
                         [
                             "git",
                             *git_safe_directory_config_args(worktree_path),
@@ -667,34 +597,105 @@ class WorkspaceExecutor:
                             *git_identity_config_args(),
                             "commit",
                             "-m",
-                            recovery_msg,
+                            commit_msg,
                             "-m",
-                            recovery_body,
+                            commit_body,
                         ],
                     )
-                    if recover_commit.ok:
-                        ancestor = await _git_in_worktree(
-                            ["merge-base", "--is-ancestor", base_commit, "HEAD"]
+                    if not commit_result.ok:
+                        raise RuntimeError(
+                            f"post-agent commit failed (exit={commit_result.returncode}): "
+                            f"{commit_result.stderr}"
                         )
-                if not ancestor.ok:
+                # Regardless of whether we just committed, verify HEAD has advanced
+                # past the base commit. If not, the agent produced no change.
+                rev_count = await _git_in_worktree(["rev-list", "--count", f"{base_commit}..HEAD"])
+                if not rev_count.ok or int(rev_count.stdout.strip() or "0") == 0:
+                    base_short = base_commit[:10] if base_commit else "unknown"
+                    message = (
+                        f"agent exited without producing any commits on the feature branch "
+                        f"(base={base_short})"
+                    )
+                    if agent_exit_note is not None:
+                        message = f"{message}; {agent_exit_note}"
                     await self._mark_failed(
                         workspace_id=workspace_id,
                         from_status=WorkspaceStatus.running,
                         failure_reason=FailureReason.agent_failure,
-                        message=(
-                            "agent severed git history — HEAD does not descend from "
-                            f"base commit {base_commit[:10] if base_commit else 'unknown'}, "
-                            "and automatic recovery (reset --soft + fresh commit) also failed. "
-                            "The coding CLI likely ran `git checkout --orphan` or reinitialised "
-                            "the repo; inspect the worktree manually."
-                        ),
+                        message=message,
                     )
                     return
-                _log.info(
-                    "executor.orphan_history_recovered",
-                    workspace_id=workspace_id,
-                    base_commit=base_commit,
-                )
+
+                # Some agents sever git history (e.g. by accidentally running
+                # ``git checkout --orphan`` or by re-initialising the repo).
+                # rev-list counts HIGH in that case (every HEAD commit is "new"
+                # w.r.t. base because there's no shared ancestor), so the
+                # previous check wouldn't notice. Without this guard, the push
+                # succeeds but ``gh pr create`` dies with a cryptic
+                # ``branch has no history in common with <base>`` error.
+                #
+                # Recovery: ``git reset --soft <base>`` moves HEAD to the base
+                # commit while leaving the index untouched — the index still
+                # reflects the orphan's tree. A fresh ``git commit`` then
+                # produces a single commit on top of base that contains the
+                # cumulative diff, and the branch is reattached to a valid
+                # ancestry so the PR can be opened normally.
+                #
+                # Invariant: ``base_commit`` is always populated by
+                # ``_claim_ready`` before this block runs. The ``assert`` both
+                # documents and satisfies mypy.
+                ancestor = await _git_in_worktree(["merge-base", "--is-ancestor", base_commit, "HEAD"])
+                if not ancestor.ok:
+                    _log.warning(
+                        "executor.orphan_history_detected",
+                        workspace_id=workspace_id,
+                        base_commit=base_commit,
+                    )
+                    reset = await _git_in_worktree(["reset", "--soft", base_commit])
+                    if reset.ok:
+                        recovery_msg = f"awf: {ws.task_title} (recovered from orphan)"[:72]
+                        recovery_body = (
+                            f"AWF detected orphan history on workspace {workspace_id} "
+                            f"(agent: {ws.agent}) and squashed the cumulative diff "
+                            f"onto base commit {base_commit[:10]}.\n"
+                        )
+                        recover_commit = await self._runner.run(
+                            [
+                                "git",
+                                *git_safe_directory_config_args(worktree_path),
+                                "-C",
+                                str(worktree_path),
+                                *git_identity_config_args(),
+                                "commit",
+                                "-m",
+                                recovery_msg,
+                                "-m",
+                                recovery_body,
+                            ],
+                        )
+                        if recover_commit.ok:
+                            ancestor = await _git_in_worktree(
+                                ["merge-base", "--is-ancestor", base_commit, "HEAD"]
+                            )
+                    if not ancestor.ok:
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.running,
+                            failure_reason=FailureReason.agent_failure,
+                            message=(
+                                "agent severed git history — HEAD does not descend from "
+                                f"base commit {base_commit[:10] if base_commit else 'unknown'}, "
+                                "and automatic recovery (reset --soft + fresh commit) also failed. "
+                                "The coding CLI likely ran `git checkout --orphan` or reinitialised "
+                                "the repo; inspect the worktree manually."
+                            ),
+                        )
+                        return
+                    _log.info(
+                        "executor.orphan_history_recovered",
+                        workspace_id=workspace_id,
+                        base_commit=base_commit,
+                    )
         except Exception as exc:  # unexpected — mark infrastructure
             _log.exception("executor.commit_step_failed", workspace_id=workspace_id)
             await self._mark_failed(
@@ -1827,6 +1828,40 @@ class WorkspaceExecutor:
             )
             await session.commit()
             return run.id
+
+    async def _finish_pending_monitor_recovery_operations(
+        self,
+        *,
+        workspace_id: str,
+        status: OperationStatus,
+        reason_code: str | None,
+        error_message: str | None = None,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = OperationRepository(session)
+            pending = await repo.list_for_workspace(
+                workspace_id,
+                status=OperationStatus.pending,
+                limit=100,
+            )
+            running = await repo.list_for_workspace(
+                workspace_id,
+                status=OperationStatus.running,
+                limit=100,
+            )
+            result = {"reason_code": reason_code}
+            for operation in [*pending, *running]:
+                payload = operation.payload
+                if not isinstance(payload, dict) or payload.get("source") != "pr_monitor":
+                    continue
+                await repo.finish(
+                    operation,
+                    status=status,
+                    result=result,
+                    error_code=reason_code if status == OperationStatus.failed else None,
+                    error_message=error_message,
+                )
+            await session.commit()
 
     async def _finish_pending_validate_operations(
         self,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -744,7 +744,11 @@ class PullRequestMonitorRunner:
                 # recovery branch handles this row: ``validate_only``
                 # runs validation against the already-committed work,
                 # ``rebase_only`` is reserved for a future slice that
-                # routes the rebase path through here as well.
+                # routes the rebase path through here as well. Until
+                # that slice lands the executor only runs validation in
+                # the recovery branch, so the operation type is always
+                # ``validate`` — otherwise a ``rebase``-typed row would
+                # leak forever (the validate finisher queries by type).
                 recovery_mode = (
                     "rebase_only" if req_action == "rebase" else "validate_only"
                 )
@@ -777,7 +781,7 @@ class PullRequestMonitorRunner:
                             return True
                         await OperationRepository(s).create(
                             workspace_id=workspace_id,
-                            operation_type=req_action or "validate",
+                            operation_type="validate",
                             payload=operation_payload,
                         )
                         await WorkspaceRepository(s).transition(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -45,7 +45,7 @@ from awf.common.compose_exec import (
 )
 from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.common.logging import get_logger
-from awf.db.enums import FailureReason, WorkspaceStatus
+from awf.db.enums import FailureReason, OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventCreate, WorkspaceRepository
 from awf.runtime.logs import LogStore, WorkspaceLogSink
@@ -758,6 +758,23 @@ class PullRequestMonitorRunner:
 
                     _ws = await WorkspaceRepository(s).get(workspace_id)
                     if _ws is not None:
+                        # Idempotency: if a pr_monitor recovery op is
+                        # already active for this workspace, skip the
+                        # dispatch so a runner restart cannot create a
+                        # duplicate row before the executor finishes
+                        # the prior one.
+                        active_recovery = any(
+                            op.status
+                            in (
+                                OperationStatus.pending.value,
+                                OperationStatus.running.value,
+                            )
+                            and isinstance(op.payload, dict)
+                            and op.payload.get("source") == "pr_monitor"
+                            for op in _ws.operations
+                        )
+                        if active_recovery:
+                            return True
                         await OperationRepository(s).create(
                             workspace_id=workspace_id,
                             operation_type=req_action or "validate",

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -633,27 +633,32 @@ class PullRequestMonitorRunner:
             ws = await self._load_workspace(workspace_id)
             stale_reason, req_action = compute_stale_reason(ws)
 
-            if stale_reason is not None:
-                if not ws.auto_merge:
-                    return await self._execute(
-                        action=Abort(AbortReason.stale),
-                        workspace_id=workspace_id,
-                        repo_url=repo_url,
-                        repo=repo,
-                        pr_number=pr_number,
-                        status=status,
-                        state=state,
-                        base_branch=base_branch,
-                        remote_branch=remote_branch,
-                        compose_project=compose_project,
-                        compose_file=compose_file,
-                        monitor_log=monitor_log,
-                    )
+            # Manual-merge mode short-circuits to Abort regardless of
+            # grace state — operator-driven workspaces never dispatch
+            # automated recovery.
+            if stale_reason is not None and not ws.auto_merge:
+                return await self._execute(
+                    action=Abort(AbortReason.stale),
+                    workspace_id=workspace_id,
+                    repo_url=repo_url,
+                    repo=repo,
+                    pr_number=pr_number,
+                    status=status,
+                    state=state,
+                    base_branch=base_branch,
+                    remote_branch=remote_branch,
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    monitor_log=monitor_log,
+                )
 
+            # An unrecoverable failed rebase still needs human eyes —
+            # grace cannot fix it.
+            if stale_reason is not None and req_action == "rebase":
                 has_failed_rebase = any(
                     op.type == "rebase" and op.status == "failed" for op in ws.operations
                 )
-                if req_action == "rebase" and has_failed_rebase:
+                if has_failed_rebase:
                     return await self._execute(
                         action=NotifyHuman(
                             message=(
@@ -674,6 +679,80 @@ class PullRequestMonitorRunner:
                         monitor_log=monitor_log,
                     )
 
+            # Initial-review grace wins over recovery dispatch. Otherwise
+            # the workspace would leave ``monitoring_pr`` and re-enter
+            # the executor pipeline before slow first-pass reviewers had
+            # any chance to comment — defeating the contract added with
+            # the grace window.
+            grace_wait_seconds = _initial_review_grace_wait_seconds(
+                state,
+                pr_number=pr_number,
+                now=time.monotonic(),
+                grace_seconds=self._config.initial_review_grace_period_seconds,
+                poll_interval_seconds=self._config.poll_interval_seconds,
+            )
+            if grace_wait_seconds > 0:
+                if stale_reason is not None:
+                    grace_defer_payload: dict[str, object] = {
+                        "stale_reason": stale_reason,
+                        "req_action": req_action,
+                        "wait_seconds": grace_wait_seconds,
+                        "grace_seconds": (
+                            self._config.initial_review_grace_period_seconds
+                        ),
+                        "pr_number": pr_number,
+                        "head_sha": status.head_sha,
+                    }
+                    _log.info(
+                        "monitor.grace_defers_recovery",
+                        workspace_id=workspace_id,
+                        **grace_defer_payload,
+                    )
+                    await self._write_monitor_log(
+                        monitor_log,
+                        {
+                            "event": "monitor.grace_defers_recovery",
+                            "workspace_id": workspace_id,
+                            **grace_defer_payload,
+                        },
+                    )
+                    await self._append_workspace_events(
+                        workspace_id=workspace_id,
+                        events=[
+                            WorkspaceEventCreate(
+                                event_type="monitor.grace_defers_recovery",
+                                reason_code="GRACE_DEFERS_RECOVERY",
+                                payload=grace_defer_payload,
+                            )
+                        ],
+                    )
+                else:
+                    _log.info(
+                        "monitor.initial_review_grace_waiting",
+                        workspace_id=workspace_id,
+                        pr_number=pr_number,
+                        wait_seconds=grace_wait_seconds,
+                        grace_seconds=self._config.initial_review_grace_period_seconds,
+                        head_sha=status.head_sha[:10],
+                    )
+                await self._deps.sleep(grace_wait_seconds)
+                return False
+
+            if stale_reason is not None:
+                # Grace has elapsed (or is disabled) — dispatch recovery.
+                # ``recovery_mode`` discriminates how the executor's
+                # recovery branch handles this row: ``validate_only``
+                # runs validation against the already-committed work,
+                # ``rebase_only`` is reserved for a future slice that
+                # routes the rebase path through here as well.
+                recovery_mode = (
+                    "rebase_only" if req_action == "rebase" else "validate_only"
+                )
+                operation_payload: dict[str, object] = {
+                    "source": "pr_monitor",
+                    "reason": stale_reason,
+                    "recovery_mode": recovery_mode,
+                }
                 async with self._deps.session_factory() as s:
                     from awf.db.repositories import OperationRepository, WorkspaceRepository
 
@@ -682,7 +761,7 @@ class PullRequestMonitorRunner:
                         await OperationRepository(s).create(
                             workspace_id=workspace_id,
                             operation_type=req_action or "validate",
-                            payload={"source": "pr_monitor", "reason": stale_reason},
+                            payload=operation_payload,
                         )
                         await WorkspaceRepository(s).transition(
                             _ws,
@@ -690,6 +769,36 @@ class PullRequestMonitorRunner:
                             reason_code="RECOVERY_DISPATCH",
                         )
                         await s.commit()
+                dispatch_payload: dict[str, object] = {
+                    "pr_number": pr_number,
+                    "head_sha": status.head_sha,
+                    "reason": stale_reason,
+                    "req_action": req_action,
+                    "recovery_mode": recovery_mode,
+                }
+                _log.info(
+                    "monitor.recovery_dispatched",
+                    workspace_id=workspace_id,
+                    **dispatch_payload,
+                )
+                await self._write_monitor_log(
+                    monitor_log,
+                    {
+                        "event": "monitor.recovery_dispatched",
+                        "workspace_id": workspace_id,
+                        **dispatch_payload,
+                    },
+                )
+                await self._append_workspace_events(
+                    workspace_id=workspace_id,
+                    events=[
+                        WorkspaceEventCreate(
+                            event_type="monitor.recovery_dispatched",
+                            reason_code="RECOVERY_DISPATCH",
+                            payload=dispatch_payload,
+                        )
+                    ],
+                )
                 return True
 
             policy_blocked = await self._refresh_scope_policy_for_merge(
@@ -716,25 +825,6 @@ class PullRequestMonitorRunner:
                     compose_file=compose_file,
                     monitor_log=monitor_log,
                 )
-
-            grace_wait_seconds = _initial_review_grace_wait_seconds(
-                state,
-                pr_number=pr_number,
-                now=time.monotonic(),
-                grace_seconds=self._config.initial_review_grace_period_seconds,
-                poll_interval_seconds=self._config.poll_interval_seconds,
-            )
-            if grace_wait_seconds > 0:
-                _log.info(
-                    "monitor.initial_review_grace_waiting",
-                    workspace_id=workspace_id,
-                    pr_number=pr_number,
-                    wait_seconds=grace_wait_seconds,
-                    grace_seconds=self._config.initial_review_grace_period_seconds,
-                    head_sha=status.head_sha[:10],
-                )
-                await self._deps.sleep(grace_wait_seconds)
-                return False
 
             queue_blockers = await self._merge_queue_blockers_for_workspace(workspace_id)
             if queue_blockers:

--- a/tests/integration/runtime/test_pr_monitor_recovery_cycle.py
+++ b/tests/integration/runtime/test_pr_monitor_recovery_cycle.py
@@ -1,0 +1,331 @@
+"""End-to-end integration: monitor recovery cycle preserves plan files.
+
+The monitor decides a stale workspace needs validation recovery. After
+grace elapses, RECOVERY_DISPATCH transitions the workspace through
+ready → running → validating → pushing → monitoring_pr without ever
+re-running planning, the feature task prompt, or the agent. The plan
+file content survives the cycle byte-identical.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters.base import AgentAdapter, AgentRunError, AgentRunResult
+from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.common.github_client import GitHubClient
+from awf.db.base import Base
+from awf.db.enums import (
+    AgentRuntime,
+    OperationStatus,
+    OperationType,
+    TaskClass,
+    WorkspaceStatus,
+)
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.runtime.pr_monitor import MonitorConfig
+from awf.runtime.pr_monitor_runner import (
+    MonitorRunnerConfig,
+    PullRequestMonitorRunner,
+    _initial_review_grace_started_key,
+)
+
+
+@dataclass
+class _FakeAdapter(AgentAdapter):
+    runtime = AgentRuntime.claude_code
+    _queued: list[AgentRunResult] = field(default_factory=list)
+    calls: list[str] = field(default_factory=list)
+    workspace_ids: list[str | None] = field(default_factory=list)
+
+    def __init__(self) -> None:  # type: ignore[override]
+        super().__init__(runner=None)  # type: ignore[arg-type]
+        self._queued = []
+        self.calls = []
+        self.workspace_ids = []
+
+    @property
+    def name(self) -> AgentRuntime:  # type: ignore[override]
+        return AgentRuntime.claude_code
+
+    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+        return []
+
+    def queue(self, *, stdout: str = "", returncode: int = 0) -> None:
+        self._queued.append(AgentRunResult(returncode=returncode, stdout=stdout, stderr=""))
+
+    async def run(  # type: ignore[override]
+        self,
+        *,
+        compose_project: str,
+        compose_file: Path,
+        prompt: str,
+        model: str | None = None,
+        workspace_id: str | None = None,
+    ) -> AgentRunResult:
+        self.calls.append(prompt)
+        self.workspace_ids.append(workspace_id)
+        if not self._queued:
+            return AgentRunResult(returncode=0, stdout="ok", stderr="")
+        r = self._queued.pop(0)
+        if r.returncode != 0:
+            raise AgentRunError(
+                agent=AgentRuntime.claude_code,
+                result=CommandResult(returncode=r.returncode, stdout=r.stdout, stderr=r.stderr),
+            )
+        return r
+
+
+class _RecordedSleep:
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, seconds: float) -> None:
+        self.calls.append(seconds)
+
+
+def _pr_payload(*, head_sha: str = "abc1234567890def") -> str:
+    return json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 42,
+                        "headRefOid": head_sha,
+                        "mergeable": "MERGEABLE",
+                        "mergeStateStatus": "CLEAN",
+                        "isDraft": False,
+                        "closed": False,
+                        "merged": False,
+                        "baseRef": {"name": "development", "target": {"oid": "base0"}},
+                        "commits": {
+                            "nodes": [
+                                {
+                                    "commit": {
+                                        "statusCheckRollup": {
+                                            "state": "SUCCESS",
+                                            "contexts": {"nodes": []},
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "reviewThreads": {"nodes": []},
+                        "reviews": {"nodes": []},
+                        "comments": {"nodes": []},
+                    }
+                }
+            }
+        }
+    )
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+async def _seed_monitoring_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    pr_number: int = 42,
+) -> str:
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            branch_base="development",
+            task_title="recovery cycle",
+            task_prompt="implement-thing",
+            agent="claude_code",
+            test_commands=["pytest -q"],
+            requires_database=False,
+        )
+        for target in (
+            WorkspaceStatus.provisioning,
+            WorkspaceStatus.ready,
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+            WorkspaceStatus.monitoring_pr,
+        ):
+            await repo.transition(ws, to=target, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.remote_push_branch = ws.branch_name
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.pr_url = f"https://github.com/dimileeh/aira-web/pull/{pr_number}"
+        ws.pr_number = pr_number
+        ws.task_class = TaskClass.refactor_task.value
+        ws.auto_merge = True
+        # Mark the initial-review grace window as already elapsed so the
+        # monitor proceeds straight to recovery dispatch.
+        ws.monitor_threads_addressed = {
+            "__awf_initial_review_grace_done__:42": "elapsed",
+        }
+        await s.commit()
+        return ws.id
+
+
+@pytest.mark.unit
+async def test_recovery_round_trip_does_not_rewrite_plan_files(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Drive the monitor through one cycle past RECOVERY_DISPATCH:
+    `monitoring_pr` (stale, grace elapsed) → recovery operation row.
+    Verify the dispatch payload, that the runner did not invoke the
+    feature task prompt, and that the plan file content survives.
+    """
+    workspace_id = await _seed_monitoring_workspace(factory)
+
+    worktrees_root = tmp_path / "worktrees"
+    workspace_dir = worktrees_root / workspace_id
+    plan_dir = workspace_dir / "docs" / "awf-plans"
+    plan_dir.mkdir(parents=True, exist_ok=True)
+    plan_path = plan_dir / f"{workspace_id}.md"
+    sentinel = "# Plan — DO NOT REWRITE\n"
+    plan_path.write_text(sentinel, encoding="utf-8")
+
+    cmd = FakeCommandRunner()
+    sleep_fn = _RecordedSleep()
+    adapter = _FakeAdapter()
+
+    cmd.queue_result(returncode=0)  # git fetch origin <base>
+    cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+    cmd.queue_result(returncode=0, stdout=_pr_payload())  # PR snapshot — green
+
+    runner = PullRequestMonitorRunner(
+        session_factory=factory,
+        runner=cmd,
+        adapter=adapter,
+        gh=GitHubClient(cmd),
+        monitor_config=MonitorConfig(
+            auto_merge=True,
+            poll_interval_seconds=60,
+            initial_review_grace_period_seconds=900,
+            pre_merge_settle_seconds=0,
+        ),
+        runner_config=MonitorRunnerConfig(max_outer_iterations=3, max_fix_cycle_passes=3),
+        sleep=sleep_fn,
+        worktrees_root=worktrees_root,
+    )
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.ready.value
+        ops = await OperationRepository(s).list_all(workspace_id=workspace_id)
+
+    pr_monitor_ops = [
+        op
+        for op in ops
+        if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+    ]
+    assert len(pr_monitor_ops) == 1
+    op = pr_monitor_ops[0]
+    assert op.type == OperationType.validate.value
+    assert op.payload == {
+        "source": "pr_monitor",
+        "reason": "validation_insufficient_tier",
+        "recovery_mode": "validate_only",
+    }
+    assert op.status == OperationStatus.pending.value
+
+    # The agent adapter must not have been invoked at all (recovery
+    # runs via the executor, which we did not run in this test). The
+    # monitor itself never invokes the feature task prompt.
+    assert adapter.calls == []
+    # The plan file survives byte-identical.
+    assert plan_path.read_text(encoding="utf-8") == sentinel
+
+
+@pytest.mark.unit
+async def test_grace_window_keeps_workspace_in_monitoring_pr(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When grace is still active and the PR is otherwise merge-ready,
+    the runner sleeps and stays in monitoring_pr — no recovery
+    operation is created."""
+    workspace_id = await _seed_monitoring_workspace(factory)
+    # Reset grace state so it appears active.
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {}
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    sleep_fn = _RecordedSleep()
+    adapter = _FakeAdapter()
+
+    cmd.queue_result(returncode=0)  # git fetch origin <base>
+    cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+    cmd.queue_result(returncode=0, stdout=_pr_payload())  # green PR
+
+    runner = PullRequestMonitorRunner(
+        session_factory=factory,
+        runner=cmd,
+        adapter=adapter,
+        gh=GitHubClient(cmd),
+        monitor_config=MonitorConfig(
+            auto_merge=True,
+            poll_interval_seconds=60,
+            initial_review_grace_period_seconds=900,
+            pre_merge_settle_seconds=0,
+        ),
+        runner_config=MonitorRunnerConfig(max_outer_iterations=1, max_fix_cycle_passes=3),
+        sleep=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        # Workspace stayed in monitoring_pr (max_outer_iterations=1
+        # so the grace defer ran once, then loop exited via the iter cap).
+        assert ws.status in {
+            WorkspaceStatus.monitoring_pr.value,
+            WorkspaceStatus.failed.value,  # iter cap fail is acceptable
+        }
+        ops = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        # No recovery operation was created during the grace window.
+        pr_monitor_ops = [
+            op
+            for op in ops
+            if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+        ]
+        assert pr_monitor_ops == []
+        # The grace started key is persisted so it doesn't restart on the
+        # next iteration after the runner restarts.
+        threads = ws.monitor_threads_addressed or {}
+        assert _initial_review_grace_started_key(42) in threads
+
+    # The runner slept for the grace remainder (capped to poll_interval=60).
+    assert sleep_fn.calls and sleep_fn.calls[0] == 60

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -298,7 +298,10 @@ async def test_executor_recovery_marks_validate_operation_succeeded_on_clean_pas
 ) -> None:
     """The validate Operation row created by the monitor's
     RECOVERY_DISPATCH must transition pending → succeeded when
-    validation passes."""
+    validation passes. ``started_at`` must be earlier than
+    ``finished_at`` so observability tooling sees a real lifecycle
+    rather than a row that jumped straight from pending to a terminal
+    status."""
 
     executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
     ws_id = await _seed_ready_workspace_with_recovery(factory)
@@ -320,6 +323,9 @@ async def test_executor_recovery_marks_validate_operation_succeeded_on_clean_pas
     assert op.status == OperationStatus.succeeded.value
     assert isinstance(op.result, dict)
     assert "validation_run_id" in op.result
+    assert op.started_at is not None
+    assert op.finished_at is not None
+    assert op.started_at < op.finished_at
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -329,6 +329,54 @@ async def test_executor_recovery_marks_validate_operation_succeeded_on_clean_pas
 
 
 @pytest.mark.unit
+async def test_executor_recovery_closes_operation_row_for_rebase_only_mode(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When the monitor dispatches recovery with ``recovery_mode='rebase_only'``,
+    the recovery Operation row must still be closed cleanly by the
+    executor's recovery branch.
+
+    Until the future rebase slice lands the runner always creates the
+    recovery op as ``OperationType.validate`` (the executor's recovery
+    branch only runs validation today, and its finisher queries by
+    type). A ``rebase``-typed row would leak forever as ``running`` —
+    the very bug fixed in commit 666cba6. This test guards the contract
+    from the executor side: the ``rebase_only`` payload discriminator
+    must not change which operation rows the executor closes.
+    """
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(
+        factory, recovery_mode="rebase_only"
+    )
+
+    fake.queue_result(returncode=0, stdout="tests ok")  # validation
+    _queue_push_and_pr(fake)
+
+    await executor.execute(ws_id)
+
+    async with factory() as s:
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+    pr_monitor_ops = [
+        op
+        for op in ops
+        if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+    ]
+    assert len(pr_monitor_ops) == 1
+    op = pr_monitor_ops[0]
+    assert op.type == OperationType.validate.value
+    assert op.payload is not None
+    assert op.payload.get("recovery_mode") == "rebase_only"
+    assert op.status == OperationStatus.succeeded.value
+    assert isinstance(op.result, dict)
+    assert "validation_run_id" in op.result
+    assert op.started_at is not None
+    assert op.finished_at is not None
+    assert op.started_at < op.finished_at
+
+
+@pytest.mark.unit
 async def test_executor_recovery_marks_validate_operation_failed_when_validation_fails(
     fake: FakeCommandRunner,
     factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1,0 +1,477 @@
+"""Executor recovery branch — validation-only path for monitor-driven dispatch.
+
+Recovery dispatched by the PR monitor (workspaces with a pending
+`pr_monitor` validate operation) must NOT re-run planning/agent/feature
+execution. The executor must skip Step 1 (`_run_agent_task_with_optional_planning`),
+skip Step 1b (post-agent commit + branch-drift recovery), and proceed
+directly to validation, push, and monitor handoff. The validation
+fix-cycle prompt is allowed because it is `build_fix_prompt`, not the
+feature task prompt.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters import registry as _registry  # noqa: F401 — populates registry
+from awf.common.commands import FakeCommandRunner
+from awf.control.executor import (
+    ExecutorConfig,
+    WorkspaceExecutor,
+    _pending_monitor_recovery,
+)
+from awf.db.base import Base
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.node.compose_manager import ComposeManager
+from awf.runtime.pr_creator import PullRequestCreator
+from awf.runtime.validation import ValidationRunner
+
+from .executor_paths import _test_worktree_path, _test_worktrees_root
+
+_TEMPLATE = Path(__file__).resolve().parents[3] / "docker" / "compose" / "workspace.base.yml.j2"
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'awf.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture
+def fake() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+_FEATURE_TASK_PROMPT = "Implement the customer feature flag wiring for the staging dashboard."
+
+
+def _make_executor(
+    *,
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    max_fix_passes: int = 5,
+) -> WorkspaceExecutor:
+    compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+    validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+    pr = PullRequestCreator(fake)
+    return WorkspaceExecutor(
+        session_factory=factory,
+        runner=fake,
+        compose=compose,
+        validation=validation,
+        pr_creator=pr,
+        config=ExecutorConfig(
+            worktrees_root=tmp_path / "work" / "worktrees",
+            compose_projects_root=tmp_path / "work" / "compose",
+            default_models={
+                AgentRuntime.codex: "gpt-5",
+                AgentRuntime.claude_code: "sonnet",
+                AgentRuntime.gemini: "gemini-2.5-pro",
+            },
+            max_validation_fix_passes=max_fix_passes,
+        ),
+    )
+
+
+async def _seed_ready_workspace_with_recovery(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    pr_url: str = "https://github.com/x/y/pull/1",
+    pr_number: int = 1,
+    create_worktree: bool = True,
+    recovery_mode: str = "validate_only",
+) -> str:
+    """Insert a workspace already in ``ready`` with a pending `pr_monitor`
+    validate operation — the shape the monitor's RECOVERY_DISPATCH path
+    leaves behind.
+    """
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-agent.git",
+            branch_base="development",
+            task_title="recovery test",
+            task_prompt=_FEATURE_TASK_PROMPT,
+            agent="codex",
+            test_commands=["pytest -q"],
+            requires_database=False,
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.pr_url = pr_url
+        ws.pr_number = pr_number
+        ws.remote_push_branch = ws.branch_name
+        # walk through the executor pipeline once, then re-enter ready via
+        # RECOVERY_DISPATCH (mirrors the monitor's transition).
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="RECOVERY_DISPATCH")
+        await OperationRepository(s).create(
+            workspace_id=ws.id,
+            operation_type=OperationType.validate,
+            payload={
+                "source": "pr_monitor",
+                "reason": "validation_insufficient_tier",
+                "recovery_mode": recovery_mode,
+            },
+        )
+        await s.commit()
+        if create_worktree:
+            (_test_worktrees_root(factory) / ws.id).mkdir(parents=True, exist_ok=True)
+        return ws.id
+
+
+async def _seed_ready_workspace_no_recovery(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    create_worktree: bool = True,
+) -> str:
+    """Seed a workspace in ``ready`` WITHOUT any pr_monitor recovery
+    operation (regression guard for the normal feature-execution path)."""
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-agent.git",
+            branch_base="development",
+            task_title="normal feature",
+            task_prompt=_FEATURE_TASK_PROMPT,
+            agent="codex",
+            test_commands=["pytest -q"],
+            requires_database=False,
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="X")
+        await s.commit()
+        if create_worktree:
+            (_test_worktrees_root(factory) / ws.id).mkdir(parents=True, exist_ok=True)
+        return ws.id
+
+
+def _queue_push_and_pr(
+    fake: FakeCommandRunner, *, pr_url: str = "https://github.com/x/y/pull/1"
+) -> None:
+    fake.queue_result(returncode=0, stdout="deadbeef01\n")  # rev-parse HEAD
+    fake.queue_result(returncode=0, stdout="awf/ws_test\n")  # abbrev-ref HEAD
+    fake.queue_result(returncode=0, stdout="abc1234 work\n")  # log ahead-of-base
+    fake.queue_result(returncode=0)  # git push
+    fake.queue_result(returncode=0, stdout=pr_url)  # gh pr create
+
+
+def _all_adapter_args(fake: FakeCommandRunner) -> list[list[str]]:
+    """Every `docker compose exec ... codex ...` invocation."""
+    return [c.args for c in fake.calls if "exec" in c.args and "codex" in c.args]
+
+
+def _all_adapter_prompts(fake: FakeCommandRunner) -> str:
+    """Concatenate every adapter prompt invocation into a single string for substring search."""
+    return "\n".join(" ".join(args) for args in _all_adapter_args(fake))
+
+
+@pytest.mark.unit
+def test_pending_monitor_recovery_predicate_returns_payload_when_pending() -> None:
+    """The predicate must surface the recovery payload when an active
+    pr_monitor operation exists, and return ``None`` otherwise."""
+
+    class _FakeOperation:
+        def __init__(self, *, status: str, payload: dict[str, object] | None) -> None:
+            self.status = status
+            self.payload = payload
+            self.type = OperationType.validate.value
+
+    class _FakeWorkspace:
+        def __init__(self, ops: list[_FakeOperation]) -> None:
+            self.operations = ops
+
+    pending = _FakeOperation(
+        status=OperationStatus.pending.value,
+        payload={"source": "pr_monitor", "recovery_mode": "validate_only"},
+    )
+    running = _FakeOperation(
+        status=OperationStatus.running.value,
+        payload={"source": "pr_monitor", "recovery_mode": "validate_only"},
+    )
+    succeeded = _FakeOperation(
+        status=OperationStatus.succeeded.value,
+        payload={"source": "pr_monitor", "recovery_mode": "validate_only"},
+    )
+    operator = _FakeOperation(
+        status=OperationStatus.pending.value,
+        payload={"source": "operator"},
+    )
+
+    assert _pending_monitor_recovery(_FakeWorkspace([pending])) == pending.payload
+    assert _pending_monitor_recovery(_FakeWorkspace([running])) == running.payload
+    assert _pending_monitor_recovery(_FakeWorkspace([succeeded])) is None
+    assert _pending_monitor_recovery(_FakeWorkspace([operator])) is None
+    assert _pending_monitor_recovery(_FakeWorkspace([])) is None
+
+
+@pytest.mark.unit
+async def test_executor_skips_planning_and_agent_run_when_recovery_dispatched(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The recovery branch must NOT call adapter.run with the feature
+    task prompt or with any of the planning/execution/conformance
+    prompts, and must NOT touch the plan file."""
+
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(factory)
+
+    # Pre-write a sentinel plan file so we can verify recovery does not
+    # overwrite it.
+    plan_path = (
+        _test_worktree_path(factory, ws_id) / "docs" / "awf-plans" / f"{ws_id}.md"
+    )
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel = "# pre-existing plan content — must survive monitor recovery\n"
+    plan_path.write_text(sentinel, encoding="utf-8")
+
+    # Recovery skips Step 1/1b. Validation runs once and passes; push +
+    # PR update is a no-op against the existing PR URL.
+    fake.queue_result(returncode=0, stdout="tests ok")  # validation
+    _queue_push_and_pr(fake, pr_url="https://github.com/x/y/pull/1")
+
+    await executor.execute(ws_id)
+
+    # No adapter prompts at all on a clean validation pass — recovery
+    # never enters Step 1, never enters the fix-cycle.
+    adapter_invocations = _all_adapter_args(fake)
+    assert adapter_invocations == []
+
+    prompts = _all_adapter_prompts(fake)
+    # Even if a future revision wires the fix-cycle prompt in, the
+    # feature task prompt and planning prompts must NEVER appear.
+    assert _FEATURE_TASK_PROMPT not in prompts
+    assert "## Planning phase" not in prompts
+    assert "## Execution phase" not in prompts
+    assert "## Conformance phase" not in prompts
+
+    # The plan file is byte-identical (no rewrite).
+    assert plan_path.read_text(encoding="utf-8") == sentinel
+
+    # Workspace handed off to monitor (no monitor wired in this test ⇒ completed).
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        assert ws is not None
+        assert ws.status in {
+            WorkspaceStatus.completed.value,
+            WorkspaceStatus.monitoring_pr.value,
+        }
+        # The recovery operation is closed cleanly.
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+        recovery_ops = [
+            op
+            for op in ops
+            if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+        ]
+        assert len(recovery_ops) == 1
+        assert recovery_ops[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
+async def test_executor_recovery_marks_validate_operation_succeeded_on_clean_pass(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The validate Operation row created by the monitor's
+    RECOVERY_DISPATCH must transition pending → succeeded when
+    validation passes."""
+
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(factory)
+
+    fake.queue_result(returncode=0, stdout="tests ok")  # validation
+    _queue_push_and_pr(fake)
+
+    await executor.execute(ws_id)
+
+    async with factory() as s:
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+    pr_monitor_ops = [
+        op
+        for op in ops
+        if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+    ]
+    assert len(pr_monitor_ops) == 1
+    op = pr_monitor_ops[0]
+    assert op.status == OperationStatus.succeeded.value
+    assert isinstance(op.result, dict)
+    assert "validation_run_id" in op.result
+
+
+@pytest.mark.unit
+async def test_executor_recovery_marks_validate_operation_failed_when_validation_fails(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When the recovery validation pass exhausts the fix budget,
+    the validate operation row must end in `failed` so observability
+    tooling reflects reality."""
+
+    # max_fix_passes=0 → exactly one validation attempt; if it fails,
+    # the workspace transitions to ``failed``.
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=0)
+    ws_id = await _seed_ready_workspace_with_recovery(factory)
+
+    fake.queue_result(
+        returncode=1,
+        stdout="FAILED tests/foo.py::test_bar",
+        stderr="AssertionError",
+    )
+
+    await executor.execute(ws_id)
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+    pr_monitor_ops = [
+        op
+        for op in ops
+        if isinstance(op.payload, dict) and op.payload.get("source") == "pr_monitor"
+    ]
+    assert len(pr_monitor_ops) == 1
+    assert pr_monitor_ops[0].status == OperationStatus.failed.value
+
+
+@pytest.mark.unit
+async def test_executor_normal_path_unchanged_when_no_recovery_op(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Regression guard: workspaces without a pr_monitor recovery op
+    must continue running planning/agent/feature execution as before.
+    """
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_no_recovery(factory)
+
+    # Standard initial-execution sequence (mirrors test_executor.py).
+    fake.queue_result(returncode=0, stdout="codex finished")  # adapter
+    fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+    fake.queue_result(returncode=0)  # git add
+    fake.queue_result(returncode=0, stdout="CHANGELOG.md\n")  # cached diff
+    fake.queue_result(returncode=0)  # git commit
+    fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+    fake.queue_result(returncode=0)  # merge-base --is-ancestor ok
+    fake.queue_result(returncode=0, stdout="tests ok")  # validation
+    _queue_push_and_pr(fake)
+
+    await executor.execute(ws_id)
+
+    # The feature task prompt must be present in adapter invocations
+    # (this is the normal execution path).
+    adapter_invocations = _all_adapter_args(fake)
+    assert len(adapter_invocations) == 1
+    prompts = _all_adapter_prompts(fake)
+    assert _FEATURE_TASK_PROMPT in prompts
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+
+
+@pytest.mark.unit
+async def test_executor_recovery_does_not_run_planning_when_planning_profile_required(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Even when the workspace's profile mandates planning, recovery
+    must skip plan/execute/compare entirely. This is the strongest
+    form of the "do not rewrite plan files" rule."""
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.create(
+            repo_url="git@github.com:dimileeh/aira-agent.git",
+            branch_base="development",
+            task_title="recovery planned",
+            task_prompt=_FEATURE_TASK_PROMPT,
+            agent="codex",
+            test_commands=["pytest -q"],
+            requires_database=False,
+            resolved_profile={
+                "name": "planned",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 1,
+                    "enforce_plan_only_changes": True,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
+        ws.branch_name = f"awf/{ws.id}"
+        ws.base_commit = "a" * 40
+        ws.compose_project_name = f"awf_{ws.id}"
+        ws.pr_url = "https://github.com/x/y/pull/1"
+        ws.pr_number = 1
+        ws.remote_push_branch = ws.branch_name
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.running, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="X")
+        await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="RECOVERY_DISPATCH")
+        await OperationRepository(s).create(
+            workspace_id=ws.id,
+            operation_type=OperationType.validate,
+            payload={
+                "source": "pr_monitor",
+                "reason": "validation_insufficient_tier",
+                "recovery_mode": "validate_only",
+            },
+        )
+        await s.commit()
+        ws_id = ws.id
+        (_test_worktrees_root(factory) / ws_id).mkdir(parents=True, exist_ok=True)
+
+    plan_path = (
+        _test_worktree_path(factory, ws_id) / "docs" / "awf-plans" / f"{ws_id}.md"
+    )
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan_path.write_text("# pre-existing plan\n", encoding="utf-8")
+    plan_mtime_before = plan_path.stat().st_mtime
+
+    fake.queue_result(returncode=0, stdout="tests ok")  # validation
+    _queue_push_and_pr(fake)
+
+    await executor.execute(ws_id)
+
+    prompts = _all_adapter_prompts(fake)
+    assert "## Planning phase" not in prompts
+    assert "## Execution phase" not in prompts
+    assert "## Conformance phase" not in prompts
+    assert plan_path.read_text(encoding="utf-8") == "# pre-existing plan\n"
+    assert plan_path.stat().st_mtime == plan_mtime_before

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -12,7 +12,6 @@ feature task prompt.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -7,6 +7,7 @@ dispatched (`recovery_mode = "validate_only"`).
 
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 
@@ -33,7 +34,6 @@ from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
     make_runner,
-    pr_payload,
     seed_monitoring_workspace,
 )
 
@@ -101,10 +101,10 @@ async def test_initial_review_grace_defers_stale_recovery_dispatch(
         initial_review_grace_period_seconds=900,
     )
 
-    state = MonitorState(started_at=1_000.0)
+    # Seed the state with a monotonic timestamp ~now so grace is active.
+    state = MonitorState(started_at=time.monotonic())
 
-    # Use the private dispatcher directly so we can control "now" via
-    # state.started_at (the helper computes wait = grace - (now - started)).
+    # Use the private dispatcher directly so we can control state.
     # By passing a Merge action with a still-active grace window the
     # dispatcher must honour grace before checking stale.
     terminal = await runner._execute(
@@ -145,13 +145,11 @@ async def test_initial_review_grace_defers_stale_recovery_dispatch(
         assert payload.get("stale_reason") == "validation_insufficient_tier"
         assert payload.get("req_action") == "validate"
 
-    # The grace bookkeeping key was persisted so the wait does not
-    # restart on the next iteration.
-    async with factory() as s:
-        ws = await WorkspaceRepository(s).get(workspace_id)
-        assert ws is not None
-        threads = ws.monitor_threads_addressed or {}
-        assert _initial_review_grace_started_key(42) in threads
+    # The grace bookkeeping key is in-memory on the state; the main
+    # ``run()`` loop calls ``_persist_state`` after the dispatcher
+    # returns, but here we exercise ``_execute`` directly so we only
+    # check the in-memory mutation.
+    assert _initial_review_grace_started_key(42) in state.threads_addressed_ids
 
 
 @pytest.mark.unit
@@ -252,7 +250,7 @@ async def test_manual_merge_mode_aborts_stale_regardless_of_grace(
 
     # Grace would still be active (started_at ~now), but manual merge
     # mode must abort instead of waiting.
-    state = MonitorState(started_at=1_000.0)
+    state = MonitorState(started_at=time.monotonic())
 
     terminal = await runner._execute(
         action=Merge(),
@@ -349,7 +347,7 @@ async def test_failed_rebase_with_stale_notifies_human_under_grace(
     original_module_compute = merge_eligibility.compute_stale_reason
     merge_eligibility.compute_stale_reason = fake_compute_stale_reason  # type: ignore[assignment]
     try:
-        state = MonitorState(started_at=1_000.0)
+        state = MonitorState(started_at=time.monotonic())
         terminal = await runner._execute(
             action=Merge(),
             workspace_id=workspace_id,

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -1,0 +1,384 @@
+"""Grace-before-recovery ordering for the PR monitor runner.
+
+Covers the rule "initial-review grace wins over stale recovery" and
+the structured payload the runner now writes when recovery is finally
+dispatched (`recovery_mode = "validate_only"`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.base import Base
+from awf.db.enums import OperationType, TaskClass, WorkspaceStatus
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
+from awf.runtime.pr_monitor import (
+    AbortReason,
+    CheckState,
+    Merge,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+)
+from awf.runtime.pr_monitor_runner import _initial_review_grace_started_key
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = make_engine(f"sqlite+aiosqlite:///{tmp_path / 'monitor.db'}")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield make_session_factory(engine)
+    finally:
+        await engine.dispose()
+
+
+def _green_pr_status() -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+
+async def _mark_refactor_task(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    *,
+    auto_merge: bool,
+) -> None:
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        ws.task_class = TaskClass.refactor_task.value
+        ws.auto_merge = auto_merge
+        await s.commit()
+
+
+@pytest.mark.unit
+async def test_initial_review_grace_defers_stale_recovery_dispatch(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Grace must win over the stale-recovery dispatch — no Operation
+    is created and the workspace stays in monitoring_pr while grace
+    is active. This is the core regression guard for the dogfood
+    incident where validation recovery fired during the grace window.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    state = MonitorState(started_at=1_000.0)
+
+    # Use the private dispatcher directly so we can control "now" via
+    # state.started_at (the helper computes wait = grace - (now - started)).
+    # By passing a Merge action with a still-active grace window the
+    # dispatcher must honour grace before checking stale.
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    # Did NOT terminate, did NOT create an Operation, did NOT transition.
+    assert terminal is False
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        assert operations == []
+
+    # Slept for the grace remainder (capped by poll_interval=60).
+    assert sleep_fn.calls == [60]
+
+    # Recovery deferral surfaced as a workspace event so operators can
+    # diagnose the wait without tailing logs.
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        events = [e for e in ws.events if e.event_type == "monitor.grace_defers_recovery"]
+        assert len(events) == 1
+        payload = events[0].payload or {}
+        assert payload.get("stale_reason") == "validation_insufficient_tier"
+        assert payload.get("req_action") == "validate"
+
+    # The grace bookkeeping key was persisted so the wait does not
+    # restart on the next iteration.
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        threads = ws.monitor_threads_addressed or {}
+        assert _initial_review_grace_started_key(42) in threads
+
+
+@pytest.mark.unit
+async def test_grace_elapsed_then_stale_recovery_dispatches_with_event(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """After grace elapses, the runner dispatches recovery with a
+    `recovery_mode="validate_only"` payload discriminator and emits a
+    `monitor.recovery_dispatched` event."""
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    # Pre-mark grace as already elapsed.
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.ready.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+    assert len(operations) == 1
+    operation = operations[0]
+    assert operation.type == OperationType.validate.value
+    assert operation.payload == {
+        "source": "pr_monitor",
+        "reason": "validation_insufficient_tier",
+        "recovery_mode": "validate_only",
+    }
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert len(events) == 1
+        payload = events[0].payload or {}
+        assert payload.get("reason") == "validation_insufficient_tier"
+        assert payload.get("req_action") == "validate"
+        assert payload.get("recovery_mode") == "validate_only"
+        assert payload.get("pr_number") == 42
+
+
+@pytest.mark.unit
+async def test_manual_merge_mode_aborts_stale_regardless_of_grace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """auto_merge=False must take the Abort(stale) path — grace is
+    irrelevant for manual-merge mode (the existing dogfood semantics
+    must remain intact)."""
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=False)
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    # Grace would still be active (started_at ~now), but manual merge
+    # mode must abort instead of waiting.
+    state = MonitorState(started_at=1_000.0)
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_message == f"monitor: abort ({AbortReason.stale.value})"
+        # No recovery operation was created.
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        assert operations == []
+        # No grace-defer event fired in manual merge.
+        events = [e for e in ws.events if e.event_type == "monitor.grace_defers_recovery"]
+        assert events == []
+
+
+@pytest.mark.unit
+async def test_failed_rebase_with_stale_notifies_human_under_grace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When `compute_stale_reason` returns `(_, "rebase")` and a prior
+    rebase op failed, the runner posts a NotifyHuman comment — grace
+    must NOT suppress that, since the workspace is unrecoverable
+    without operator help."""
+    import datetime
+    from sqlalchemy.exc import StatementError  # noqa: F401
+
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+
+    # Seed a failed rebase operation so the rebase guard fires.
+    async with factory() as s:
+        await OperationRepository(s).create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.rebase,
+            payload={"source": "operator"},
+        )
+        # Mark it failed via direct UPDATE, bypassing the .finish() helper
+        # which expects an existing operation object.
+        from awf.db.models import Operation
+        from sqlalchemy import select, update
+
+        await s.execute(
+            update(Operation)
+            .where(Operation.workspace_id == workspace_id)
+            .values(status="failed", finished_at=datetime.datetime.now(datetime.UTC)),
+        )
+        await s.commit()
+
+    cmd.queue_result(returncode=0)  # gh pr comment
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    # Force compute_stale_reason to claim the action is "rebase" —
+    # otherwise the default refactor path returns "validate".
+    import awf.runtime.pr_monitor_runner as pr_monitor_runner
+
+    original_compute = pr_monitor_runner.__dict__.get("compute_stale_reason")
+    monkeypatched: dict[str, object] = {}
+
+    def fake_compute_stale_reason(ws):  # type: ignore[no-untyped-def]
+        return ("validation_insufficient_tier", "rebase")
+
+    # Patch the imported reference inside the function; the runner
+    # imports compute_stale_reason inline so we patch via its module.
+    import awf.runtime.merge_eligibility as merge_eligibility
+
+    original_module_compute = merge_eligibility.compute_stale_reason
+    merge_eligibility.compute_stale_reason = fake_compute_stale_reason  # type: ignore[assignment]
+    try:
+        state = MonitorState(started_at=1_000.0)
+        terminal = await runner._execute(
+            action=Merge(),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=_green_pr_status(),
+            state=state,
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+    finally:
+        merge_eligibility.compute_stale_reason = original_module_compute  # type: ignore[assignment]
+        del monkeypatched
+        del original_compute
+
+    assert terminal is False
+    # NotifyHuman fired (gh pr comment).
+    assert cmd.calls
+    assert cmd.calls[0].args[:3] == ["gh", "pr", "comment"]
+    # No recovery operation was created (NotifyHuman short-circuits before
+    # the dispatch block).
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        # Only the seeded rebase op exists.
+        ops = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        assert [op.type for op in ops] == [OperationType.rebase.value]

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -385,6 +385,91 @@ async def test_failed_rebase_with_stale_notifies_human_under_grace(
 
 
 @pytest.mark.unit
+async def test_rebase_req_action_dispatches_validate_typed_recovery_op(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When ``req_action == "rebase"`` and no prior failed rebase exists,
+    the dispatch must still create a ``validate``-typed Operation row.
+
+    The executor's recovery branch only runs validation today, and its
+    success/failure paths close pending ops via the validate finisher
+    (which queries by ``OperationType.validate``). A ``rebase``-typed
+    row would therefore leak forever as ``running``. ``recovery_mode``
+    in the payload remains the discriminator for the future rebase
+    slice.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+
+    cmd.queue_result(returncode=0)  # any optional gh call
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    import awf.runtime.merge_eligibility as merge_eligibility
+
+    def fake_compute_stale_reason(ws):  # type: ignore[no-untyped-def]
+        return ("validation_insufficient_tier", "rebase")
+
+    original_module_compute = merge_eligibility.compute_stale_reason
+    merge_eligibility.compute_stale_reason = fake_compute_stale_reason  # type: ignore[assignment]
+    try:
+        # Pre-mark grace as elapsed so the dispatch block runs.
+        state = MonitorState(started_at=0.0)
+        state.mark_addressed(
+            _initial_review_grace_started_key(42),
+            f"{0.0:.6f}",
+        )
+        terminal = await runner._execute(
+            action=Merge(),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=_green_pr_status(),
+            state=state,
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+    finally:
+        merge_eligibility.compute_stale_reason = original_module_compute  # type: ignore[assignment]
+
+    assert terminal is True
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.ready.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+    assert len(operations) == 1
+    operation = operations[0]
+    # Operation type is ``validate`` even though req_action was ``rebase``
+    # — otherwise the validate finisher (which queries by type) would
+    # never close it on the executor's success path.
+    assert operation.type == OperationType.validate.value
+    # The ``rebase_only`` recovery_mode survives in the payload as the
+    # discriminator the future rebase slice can read.
+    assert operation.payload == {
+        "source": "pr_monitor",
+        "reason": "validation_insufficient_tier",
+        "recovery_mode": "rebase_only",
+    }
+
+
+@pytest.mark.unit
 async def test_recovery_dispatch_is_idempotent_when_active_recovery_op_exists(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -17,7 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import RepoRef
 from awf.db.base import Base
-from awf.db.enums import OperationType, TaskClass, WorkspaceStatus
+from awf.db.enums import OperationStatus, OperationType, TaskClass, WorkspaceStatus
 from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
 from awf.runtime.pr_monitor import (
@@ -382,3 +382,87 @@ async def test_failed_rebase_with_stale_notifies_human_under_grace(
         # Only the seeded rebase op exists.
         ops = await OperationRepository(s).list_all(workspace_id=workspace_id)
         assert [op.type for op in ops] == [OperationType.rebase.value]
+
+
+@pytest.mark.unit
+async def test_recovery_dispatch_is_idempotent_when_active_recovery_op_exists(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A second dispatch must NOT create a duplicate pr_monitor op when
+    one is already active. Defends against a runner restart re-entering
+    the dispatch branch before the executor has finished the prior op.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+
+    # Pre-seed an active (pending) pr_monitor recovery op so the runner
+    # finds it on entry to the dispatch block.
+    async with factory() as s:
+        await OperationRepository(s).create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.validate,
+            payload={
+                "source": "pr_monitor",
+                "reason": "validation_insufficient_tier",
+                "recovery_mode": "validate_only",
+            },
+        )
+        await s.commit()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+
+    # Pre-mark grace as elapsed so the dispatch block runs.
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        # Workspace stays in monitoring_pr — the existing pending op is
+        # owned by an earlier dispatch that already transitioned (or is
+        # racing to transition); the duplicate-create guard MUST NOT
+        # transition again or it would corrupt state.
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        # Only the pre-seeded operation exists — no duplicate was created.
+        assert len(operations) == 1
+        assert operations[0].payload == {
+            "source": "pr_monitor",
+            "reason": "validation_insufficient_tier",
+            "recovery_mode": "validate_only",
+        }
+        assert operations[0].status == OperationStatus.pending.value
+        # No monitor.recovery_dispatched event fires the second time
+        # (the original dispatch already emitted it).
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert events == []

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -292,6 +292,7 @@ async def test_failed_rebase_with_stale_notifies_human_under_grace(
     must NOT suppress that, since the workspace is unrecoverable
     without operator help."""
     import datetime
+
     from sqlalchemy.exc import StatementError  # noqa: F401
 
     cmd = FakeCommandRunner()
@@ -309,8 +310,9 @@ async def test_failed_rebase_with_stale_notifies_human_under_grace(
         )
         # Mark it failed via direct UPDATE, bypassing the .finish() helper
         # which expects an existing operation object.
+        from sqlalchemy import update
+
         from awf.db.models import Operation
-        from sqlalchemy import select, update
 
         await s.execute(
             update(Operation)

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -401,7 +401,11 @@ async def test_stale_auto_merge_dispatches_validation_recovery(
     assert [(op.type, op.payload) for op in operations] == [
         (
             OperationType.validate.value,
-            {"source": "pr_monitor", "reason": "validation_insufficient_tier"},
+            {
+                "source": "pr_monitor",
+                "reason": "validation_insufficient_tier",
+                "recovery_mode": "validate_only",
+            },
         )
     ]
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_2a64b2c190a24e63915f519f` (agent: `claude_code`).


### Task
Implement a reliability fix for AWF PR monitoring recovery.

Context:
Recent dogfood showed that the PR monitor can dispatch stale/validation recovery before the initial review grace window has elapsed. It also currently routes monitor-owned validation recovery through a normal ready/running executor path, which can rerun Plan -> Execute -> Compare and rewrite plan artifacts during merge recovery. That is wrong: initial review grace should win before recovery or merge, and monitor recovery should be a controlled recovery operation, not a fresh feature implementation pass.

Required behavior:
- When PR monitor decides a PR is otherwise merge-ready but stale/validation recovery is needed, an active initial review grace window must cause the monitor to wait instead of dispatching recovery.
- Once the one-time grace window has elapsed, recovery may run if needed.
- Recovery must not invoke the agent with the original feature task prompt or regenerate/rewrite planning artifacts.
- Prefer a validate/rebase-only recovery path. If a larger executor split is needed, implement the smallest safe slice that prevents normal feature execution and records a structured blocker/recovery operation instead of silently re-entering Plan -> Execute.
- Preserve auto_merge/manual_merge behavior, comment handling, CI gates, stale blockers, and final pre-merge settle behavior.
- Add observable events/logs that explain when grace defers recovery and when recovery is validation-only or blocked.

TDD requirements:
- Write failing tests first and commit them before implementation.
- Cover grace-before-recovery ordering.
- Cover that recovery does not call the feature agent prompt and does not rewrite plan files.
- Cover manual merge mode remains unchanged.
- Do not lower coverage, fail_under, .awf coverage config, pyproject coverage config, or quality gates.
- Do not push; AWF owns push, PR creation, monitoring, comments, and merge.

---
Validation: 7 profile command(s) passed inside the workspace container.
