### PR TITLE
fix(planning): detect committed plan artifacts correctly

### DIFF
--- a/docs/awf-plans/ws_0afdc1fdeea04b4b9d764724.conformance.json
+++ b/docs/awf-plans/ws_0afdc1fdeea04b4b9d764724.conformance.json
@@ -1,0 +1,5 @@
+{
+  "status": "satisfied",
+  "summary": "The implementation fully achieves the saved plan. _run_agent_task_with_optional_planning now captures a pre-planning HEAD SHA, unions committed changes (git diff --name-only <base>..HEAD) with dirty/untracked changes (porcelain), and uses the combined set for both the plan-artifact check and the enforce_plan_only_changes check. A new _committed_paths_since helper was added. All four required TDD test scenarios (committed plan accepted, committed plan + code rejected as outside plan, dirty plan still accepted, dirty extra still rejected) are present in test_executor_coverage_edges.py and passing. Ruff and mypy are clean and coverage thresholds were not lowered.",
+  "gaps": []
+}

--- a/docs/awf-plans/ws_0afdc1fdeea04b4b9d764724.md
+++ b/docs/awf-plans/ws_0afdc1fdeea04b4b9d764724.md
@@ -1,0 +1,140 @@
+# Implementation Plan: Fix AWF Plan Guard for Committed Plans
+
+## Root Cause
+
+`_run_agent_task_with_optional_planning` in `src/awf/control/executor.py` checks whether the planning phase produced the required plan file by calling `_changed_paths`, which runs `git status --porcelain`. If an agent commits the plan file during planning, the worktree becomes clean and `_changed_paths` returns an empty set. The guard then incorrectly reports:
+
+> "planning phase did not create or modify required plan file ..."
+
+This strand committed work and fails the workspace even though the plan artifact exists.
+
+## Intended Files/Modules to Touch
+
+- `src/awf/control/executor.py`
+  - Modify `_run_agent_task_with_optional_planning` to detect plan-path changes from **committed** files in addition to dirty/untracked files.
+  - Modify `_changed_paths` or add a new helper `_committed_paths_since` that returns paths changed between a starting commitish and HEAD.
+- `tests/unit/control/test_executor_coverage_edges.py`
+  - Add focused unit tests for the new behavior.
+
+## Tests to Write First (TDD)
+
+1. **committed-plan accepted**
+   - Agent writes and commits the plan file during planning.
+   - `git status --porcelain` returns empty.
+   - Guard detects the committed plan via `git diff --name-only <base>..HEAD` and allows execution to proceed.
+
+2. **committed-plan-plus-code rejected as outside-plan**
+   - Agent commits the plan file *and* a source file during planning.
+   - `enforce_plan_only_changes=true`.
+   - Guard detects the extra committed file and fails with the *outside-plan* message, not the misleading missing-plan message.
+
+3. **dirty plan file still accepted**
+   - Agent leaves the plan file as an untracked/dirty file (original happy path).
+   - Guard continues to accept it.
+
+4. **dirty extra file still rejected**
+   - Agent leaves plan file plus an extra dirty file.
+   - `enforce_plan_only_changes=true`.
+   - Guard continues to reject with the outside-plan message.
+
+## Validation Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_executor_coverage_edges.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_executor.py -q
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+```
+
+If coverage report is needed after touching core behavior:
+
+```bash
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+```
+
+## Detailed Fix Design
+
+### Step 1: Snapshot the pre-planning baseline
+
+Before invoking the planning adapter, capture the current HEAD SHA:
+
+```python
+baseline_sha = await _git_in_worktree(["rev-parse", "HEAD"])
+```
+
+If the SHA cannot be resolved, fall through to the existing `_changed_paths`-only behavior (worktree is likely fresh).
+
+### Step 2: Union committed and dirty changes
+
+After the planning adapter returns, collect:
+
+- `dirty_paths = await self._changed_paths(worktree_path)`  # porcelain output
+- `committed_paths = await self._committed_paths(worktree_path, since=baseline_sha)`  # new helper
+
+The helper runs:
+
+```bash
+git diff --name-only <baseline_sha>..HEAD
+```
+
+and returns a `set[Path]` of repo-relative changed paths. If the command fails (e.g. fresh repo with no commits), return an empty set.
+
+### Step 3: Combined plan-path check
+
+Use the union for the plan-file check:
+
+```python
+planning_changes = dirty_paths | committed_paths
+if plan_path not in planning_changes:
+    return "planning phase did not create or modify required plan file ..."
+```
+
+### Step 4: Combined outside-plan check
+
+For `enforce_plan_only_changes`, the set of *new* changes introduced during planning is:
+
+```python
+extra = sorted(planning_changes - {plan_path})
+```
+
+This detects both:
+- Dirty untracked/modified files outside the plan path (existing behavior), and
+- Committed files outside the plan path (new behavior).
+
+### Step 5: Preserve conformance-phase deviation check
+
+The post-execution / post-compare checks already use `_changed_paths` (porcelain). They are **not** affected by commits made during planning because the planning-phase commits happened before execution. The execution and compare phases may add their own dirty files, which porcelain continues to capture correctly. No changes needed there.
+
+## Risks and Assumptions
+
+- Assumption: The worktree has a valid git history and `HEAD` resolves before planning. If not, the committed-paths helper returns empty set and behavior degrades to the old porcelain-only check (safe fallback).
+- Assumption: Agents do not rewrite history during planning (e.g. `git rebase`). If they do, `diff --name-only` still reports changed paths, which is acceptable for the guard.
+- Risk: `git diff --name-only <sha>..HEAD` with a large number of commits is fast and safe; it only lists filenames.
+- Risk: If the baseline SHA is the same as HEAD after planning (no commits), the diff returns empty, and we rely on porcelain. This is correct.
+
+## Explicit Non-Goals
+
+- Do not add git-history-rewriting detection or recovery.
+- Do not change the conformance-phase deviation logic.
+- Do not weaken or lower coverage thresholds, `fail_under`, profile coverage requirements, or PRD quality gates.
+- Do not modify docs, migrations, lockfiles, or config other than the requested plan file.
+
+## Commit Message
+
+```
+fix(executor): planning guard now detects committed plans
+
+Root cause: _run_agent_task_with_optional_planning only checked
+`git status --porcelain`, so if an agent committed the plan file
+during planning the worktree was clean and AWF falsely reported
+"planning phase did not create or modify required plan file".
+
+Fix: capture the pre-planning HEAD SHA, then union committed
+changes (`git diff --name-only <base>..HEAD`) with dirty/untracked
+changes (porcelain) when checking for the plan artifact and when
+enforcing plan-only changes. A model that commits code during the
+planning phase now gets the correct "outside plan" error instead
+of the misleading "missing plan" error.
+
+Refs: ws_15fcdd21401d4d0495747d03
+```

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1617,6 +1617,19 @@ class WorkspaceExecutor:
             return f"planning profile is invalid: {exc}"
 
         before_plan = await self._changed_paths(worktree_path)
+        baseline_sha: str | None = None
+        rev_r = await self._runner.run(
+            [
+                "git",
+                *git_safe_directory_config_args(worktree_path),
+                "-C",
+                str(worktree_path),
+                "rev-parse",
+                "HEAD",
+            ]
+        )
+        if rev_r.ok and rev_r.stdout.strip():
+            baseline_sha = rev_r.stdout.strip()
         await adapter.run(
             compose_project=compose_project,
             compose_file=compose_file,
@@ -1627,7 +1640,13 @@ class WorkspaceExecutor:
             model=model,
             workspace_id=workspace.id,
         )
-        after_plan = await self._changed_paths(worktree_path)
+        dirty_paths = await self._changed_paths(worktree_path)
+        committed_paths = (
+            await self._committed_paths_since(worktree_path, baseline_sha)
+            if baseline_sha is not None
+            else set()
+        )
+        after_plan = dirty_paths | committed_paths
         if plan_path not in after_plan:
             return f"planning phase did not create or modify required plan file `{plan_path}`"
         if planning.enforce_plan_only_changes:
@@ -1719,6 +1738,22 @@ class WorkspaceExecutor:
                 f"git status failed while checking workspace changes: {result.stderr}"
             )
         return changed_paths_from_porcelain(result.stdout)
+
+    async def _committed_paths_since(self, worktree_path: Path, since: str) -> set[Path]:
+        result = await self._runner.run(
+            [
+                "git",
+                *git_safe_directory_config_args(worktree_path),
+                "-C",
+                str(worktree_path),
+                "diff",
+                "--name-only",
+                f"{since}..HEAD",
+            ]
+        )
+        if not result.ok:
+            return set()
+        return {Path(line.strip()) for line in result.stdout.splitlines() if line.strip()}
 
     async def _claim_ready(
         self,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1752,7 +1752,9 @@ class WorkspaceExecutor:
             ]
         )
         if not result.ok:
-            return set()
+            raise RuntimeError(
+                f"git diff --name-only failed while checking committed paths: {result.stderr}"
+            )
         return {Path(line.strip()) for line in result.stdout.splitlines() if line.strip()}
 
     async def _claim_ready(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -485,6 +485,7 @@ class TestHappyPath:
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/awf/oops.py\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
 
         await executor.execute(ws_id)
 

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -352,11 +352,13 @@ class TestHappyPath:
         )
 
         fake.queue_result(returncode=0, stdout="")  # changed paths before planning
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD baseline
         fake.queue_result(returncode=0, stdout="plan written")  # planning adapter
         fake.queue_result(  # changed paths after planning
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.md\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
         fake.queue_result(returncode=0, stdout="implemented")  # execution adapter
         fake.queue_result(  # changed paths before compare
             returncode=0,
@@ -422,8 +424,10 @@ class TestHappyPath:
         )
 
         fake.queue_result(returncode=0, stdout="")  # before planning
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
         fake.queue_result(returncode=0, stdout="plan written")  # planning
         fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
         fake.queue_result(returncode=0, stdout="implemented")  # initial execute
         fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
         fake.queue_result(  # compare says not done
@@ -475,6 +479,7 @@ class TestHappyPath:
         )
 
         fake.queue_result(returncode=0, stdout="")  # before planning
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
         fake.queue_result(returncode=0, stdout="plan plus code")  # planning
         fake.queue_result(  # after planning
             returncode=0,

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -271,6 +271,8 @@ async def test_baseline_coverage_preflight_returns_logged_policy_result(
 async def test_planning_required_fails_when_plan_file_is_not_changed(tmp_path: Path) -> None:
     runner = FakeCommandRunner()
     runner.queue_result(returncode=0, stdout="")
+    runner.queue_result(returncode=0, stdout="sha1\n")
+    runner.queue_result(returncode=0, stdout="")
     runner.queue_result(returncode=0, stdout="")
     executor = _executor_with_runner(runner, tmp_path)
     adapter = _PlanningAdapter("plan written elsewhere")
@@ -329,11 +331,13 @@ async def test_planning_required_reports_invalid_rendered_paths(tmp_path: Path) 
 @pytest.mark.unit
 async def test_planning_required_rejects_extra_plan_phase_changes(tmp_path: Path) -> None:
     runner = FakeCommandRunner()
-    runner.queue_result(returncode=0, stdout="")
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD
     runner.queue_result(
         returncode=0,
         stdout="?? docs/awf-plans/ws_plan_extra.md\n?? src/changed.py\n",
-    )
+    )  # dirty_paths
+    runner.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
     executor = _executor_with_runner(runner, tmp_path)
     adapter = _PlanningAdapter("plan plus code")
     profile = WorkspaceProfile.model_validate(
@@ -366,9 +370,11 @@ async def test_planning_required_rejects_extra_plan_phase_changes(tmp_path: Path
 @pytest.mark.unit
 async def test_conformance_phase_rejects_extra_report_phase_changes(tmp_path: Path) -> None:
     runner = FakeCommandRunner()
-    runner.queue_result(returncode=0, stdout="")
-    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_compare.md\n")
-    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_compare.md\n")
+    runner.queue_result(returncode=0, stdout="")  # before_plan (1)
+    runner.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD (2)
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_compare.md\n")  # dirty after plan (3)
+    runner.queue_result(returncode=0, stdout="")  # committed_paths_since (empty) (4)
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_compare.md\n")  # before_compare (5)
     runner.queue_result(
         returncode=0,
         stdout=(
@@ -376,7 +382,7 @@ async def test_conformance_phase_rejects_extra_report_phase_changes(tmp_path: Pa
             "?? docs/awf-plans/ws_compare.json\n"
             "?? src/side_effect.py\n"
         ),
-    )
+    )  # after_compare (6)
     executor = _executor_with_runner(runner, tmp_path)
     adapter = _PlanningAdapter(
         "plan",
@@ -416,13 +422,16 @@ async def test_planning_required_reports_unsatisfied_conformance_after_iteration
     tmp_path: Path,
 ) -> None:
     runner = FakeCommandRunner()
-    runner.queue_result(returncode=0, stdout="")
-    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_unsat.md\n")
-    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_unsat.md\n")
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_unsat.md\n")  # dirty after plan
+    runner.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_unsat.md\n")  # before_compare
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_unsat.md\n")  # after_compare (first)
     runner.queue_result(
         returncode=0,
         stdout="?? docs/awf-plans/ws_unsat.md\n?? docs/awf-plans/ws_unsat.json\n",
-    )
+    )  # after_compare (second)
     executor = _executor_with_runner(runner, tmp_path)
     adapter = _PlanningAdapter(
         "plan",
@@ -764,6 +773,224 @@ def test_call_pr_monitor_factory_surfaces_bind_error() -> None:
             profile=profile,
             workspace=object(),  # type: ignore[arg-type]
         )
+
+
+@pytest.mark.unit
+async def test_planning_required_accepts_committed_plan_file(tmp_path: Path) -> None:
+    runner = FakeCommandRunner()
+    # before_plan (clean)
+    runner.queue_result(returncode=0, stdout="")
+    # rev-parse HEAD -> baseline sha
+    runner.queue_result(returncode=0, stdout="abc1234\n")
+    # dirty after planning (still clean because agent committed)
+    runner.queue_result(returncode=0, stdout="")
+    # git diff --name-only <base>..HEAD -> plan file
+    runner.queue_result(returncode=0, stdout="docs/awf-plans/ws_plan_commit.md\n")
+    # before_compare
+    runner.queue_result(returncode=0, stdout="")
+    # after_compare
+    runner.queue_result(returncode=0, stdout="")
+    executor = _executor_with_runner(runner, tmp_path)
+    adapter = _PlanningAdapter(
+        "plan committed",
+        "implemented",
+        '{"status":"satisfied","summary":"ok","gaps":[]}',
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planning-committed",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.json",
+                "max_iterations": 0,
+            },
+        }
+    )
+
+    message = await executor._run_agent_task_with_optional_planning(
+        adapter=adapter,  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_plan_commit", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+    )
+
+    assert message is None
+    assert len(adapter.prompts) == 3
+
+
+@pytest.mark.unit
+async def test_planning_required_rejects_committed_code_as_outside_plan(tmp_path: Path) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=0, stdout="base5678\n")  # rev-parse HEAD
+    runner.queue_result(returncode=0, stdout="")  # dirty after planning (clean)
+    runner.queue_result(
+        returncode=0,
+        stdout=(
+            "docs/awf-plans/ws_plan_code.md\n"
+            "src/awf/executor.py\n"
+        ),
+    )  # committed paths since baseline
+    executor = _executor_with_runner(runner, tmp_path)
+    adapter = _PlanningAdapter("plan plus code")
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planning-code-committed",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.json",
+                "enforce_plan_only_changes": True,
+            },
+        }
+    )
+
+    message = await executor._run_agent_task_with_optional_planning(
+        adapter=adapter,  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_plan_code", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+    )
+
+    assert message == (
+        "planning phase changed files outside `docs/awf-plans/ws_plan_code.md`: "
+        "src/awf/executor.py"
+    )
+
+
+@pytest.mark.unit
+async def test_planning_required_falls_back_to_porcelain_when_no_baseline_sha(
+    tmp_path: Path,
+) -> None:
+    # Fresh repo or detached state where rev-parse HEAD fails.
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=128, stderr="fatal: not a git repository")  # rev-parse HEAD fails
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_plan_fallback.md\n")  # dirty after planning
+    runner.queue_result(returncode=0, stdout="")  # before_compare
+    runner.queue_result(returncode=0, stdout="")  # after_compare
+    executor = _executor_with_runner(runner, tmp_path)
+    adapter = _PlanningAdapter(
+        "plan fallback",
+        "implemented",
+        '{"status":"satisfied","summary":"ok","gaps":[]}',
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planning-fallback",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.json",
+                "max_iterations": 0,
+            },
+        }
+    )
+
+    message = await executor._run_agent_task_with_optional_planning(
+        adapter=adapter,  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_plan_fallback", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+    )
+
+    assert message is None
+    # No git diff --name-only call should have been issued because rev-parse failed.
+    diff_calls = [call for call in runner.calls if "diff" in call.args and "--name-only" in call.args]
+    assert not diff_calls
+
+
+@pytest.mark.unit
+async def test_planning_required_dirty_plan_still_accepted(tmp_path: Path) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=0, stdout="old_sha\n")  # rev-parse HEAD
+    runner.queue_result(returncode=0, stdout="?? docs/awf-plans/ws_plan_dirty.md\n")  # dirty after planning
+    runner.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
+    runner.queue_result(returncode=0, stdout="")  # before_compare
+    runner.queue_result(returncode=0, stdout="")  # after_compare
+    executor = _executor_with_runner(runner, tmp_path)
+    adapter = _PlanningAdapter(
+        "dirty plan",
+        "implemented",
+        '{"status":"satisfied","summary":"ok","gaps":[]}',
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planning-dirty",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.json",
+                "max_iterations": 0,
+            },
+        }
+    )
+
+    message = await executor._run_agent_task_with_optional_planning(
+        adapter=adapter,  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_plan_dirty", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+    )
+
+    assert message is None
+    # Because no new commits, the diff call should return empty; porcelain still carries the plan.
+    diff_calls = [call for call in runner.calls if "diff" in call.args and "--name-only" in call.args]
+    assert diff_calls
+
+
+@pytest.mark.unit
+async def test_planning_required_dirty_extra_file_still_rejected(tmp_path: Path) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # before_plan
+    runner.queue_result(returncode=0, stdout="base_sha\n")  # rev-parse HEAD
+    runner.queue_result(
+        returncode=0,
+        stdout="?? docs/awf-plans/ws_plan_extra_dirty.md\n?? src/extra.py\n",
+    )  # after_plan
+    runner.queue_result(returncode=0, stdout="")  # committed_paths_since (empty)
+    executor = _executor_with_runner(runner, tmp_path)
+    adapter = _PlanningAdapter("dirty extra")
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planning-extra-dirty",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.json",
+                "enforce_plan_only_changes": True,
+            },
+        }
+    )
+
+    message = await executor._run_agent_task_with_optional_planning(
+        adapter=adapter,  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_plan_extra_dirty", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+    )
+
+    assert message == (
+        "planning phase changed files outside `docs/awf-plans/ws_plan_extra_dirty.md`: "
+        "src/extra.py"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -474,6 +474,16 @@ async def test_changed_paths_raises_when_git_status_fails(tmp_path: Path) -> Non
 
 
 @pytest.mark.unit
+async def test_committed_paths_since_raises_when_git_diff_fails(tmp_path: Path) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=128, stderr="bad object")
+    executor = _executor_with_runner(runner, tmp_path)
+
+    with pytest.raises(RuntimeError, match="git diff --name-only failed"):
+        await executor._committed_paths_since(tmp_path / "worktree", "baseline-sha")
+
+
+@pytest.mark.unit
 def test_baseline_coverage_ratchet_accepts_no_regression(tmp_path: Path) -> None:
     command = _command_result(tmp_path, returncode=1)
     result = ValidationResult(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_0afdc1fdeea04b4b9d764724` (agent: `opencode`).

**External task ID**: pre-gke-p0-planning-guard-kimi

### Task
Fix the AWF Plan -> Execute -> Compare guard exposed by workspace ws_15fcdd21401d4d0495747d03.

Observed failure: an OpenCode/DeepSeek workspace created docs/awf-plans/ws_15fcdd21401d4d0495747d03.md and committed a complete implementation, but AWF marked the workspace failed with: planning phase did not create or modify required plan file. Root cause hypothesis: _run_agent_task_with_optional_planning only checks git status --porcelain after the planning call, so if an agent commits the plan file during planning, the worktree is clean and AWF falsely thinks the plan was missing. The correct behavior is:

1. The planning guard must detect plan-path changes whether they are dirty/untracked OR committed during the planning call.
2. If enforce_plan_only_changes=true, the guard must also detect committed files outside the plan path and fail with the existing outside-plan message, not the misleading missing-plan message.
3. Plan-only committed changes should be accepted as a valid planning artifact, allowing execution to proceed.
4. The fix must preserve current behavior for dirty/untracked plan files and dirty/untracked extra files.
5. Do not weaken Plan -> Execute -> Compare semantics. A model that implements code during the planning phase should still fail plan-only enforcement; the error should be accurate.
6. Add focused TDD tests first in tests/unit/control, covering committed-plan accepted, committed-plan-plus-code rejected as outside plan, and old dirty-file cases still passing/failing as before.
7. Do not lower coverage thresholds, fail_under, profile coverage requirements, or PRD quality gates. Add meaningful tests.
8. Commit with a conventional message and summarize the root cause and fix.

Useful files: src/awf/control/executor.py, src/awf/runtime/planning.py, tests/unit/control/test_executor_coverage_edges.py, tests/unit/control/test_executor.py.

---
Validation: 7 profile command(s) passed inside the workspace container.
