### PR TITLE
fix: harden PR monitor against stale git mirrors

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -7,6 +7,7 @@ awf:
   runtime:
     environment:
       PYTHONUNBUFFERED: "1"
+      AWF_TEST_DATABASE_URL: "postgresql+asyncpg://awf:awf_dev@host.docker.internal:5433/awf"
   security:
     egress:
       mode: open

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ AWF_API_TOKEN=local-dev-token
 # Database (control-plane Postgres)
 AWF_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf
 
+# Test database server. The Postgres integration suite creates and drops a
+# temporary database on this server; it does not downgrade the live AWF DB.
+AWF_TEST_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf
+
 # GitHub (for PR creation). Local service containers cannot read macOS Keychain
 # backed gh auth. Prefer AWF_GITHUB_TOKEN; GH_TOKEN/GITHUB_TOKEN are accepted
 # fallbacks by docker/compose/local-service.yml and service settings.

--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -93,6 +93,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `gh auth login`
 **Docs Link:** [docs/REASON_CATALOG.md#github_token_env_missing](#github_token_env_missing)
 
+### GIT_FETCH_BASE_FAILED
+**Problem:** The PR monitor could not refresh the target branch ref for a workspace.
+**Likely Cause:** The shared git mirror has a broken AWF ref, network access to the remote failed, or the target branch no longer exists.
+**Operator Fix:** Inspect the workspace monitor log and run `git fsck` on the AWF mirror. If AWF reports a repaired orphan ref, restart or remonitor the workspace; otherwise repair GitHub/network access before retrying.
+**Related Command:** `awf workspace logs <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#git_fetch_base_failed](#git_fetch_base_failed)
+
 ### INSUFFICIENT_DISK
 **Problem:** Free disk is below the configured AWF threshold.
 **Likely Cause:** Too many stopped containers, volumes, or large workspaces.

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -71,6 +71,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
       isDraft
       closed
       merged
+      mergeCommit { oid }
       baseRef { name target { ... on Commit { oid } } }
       commits(last: 1) {
         nodes {
@@ -347,6 +348,7 @@ class GitHubClient:
             changed_paths=changed_paths,
             closed=bool(pr.get("closed")),
             merged=bool(pr.get("merged")),
+            merge_commit_sha=_clean_optional_str(_dig(pr, "mergeCommit", "oid")),
         )
 
     async def _fetch_changed_paths(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -15,9 +15,11 @@ triage. Explicit ``cleanup(workspace_id)`` is a separate operation.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import inspect
 import re
+import shlex
 import time
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, replace
@@ -41,6 +43,7 @@ from awf.common.commands import AsyncCommandRunner, CommandResult
 from awf.common.compose_exec import (
     EXEC_PROCESS_CLEANUP_FAILED,
     ComposeExecCleanupError,
+    build_tracked_compose_exec,
     cleanup_failure_message,
 )
 from awf.common.git_identity import git_identity_config_args, git_safe_directory_config_args
@@ -78,6 +81,7 @@ from awf.db.repositories import (
     sync_candidate_readiness,
 )
 from awf.node.compose_manager import ComposeManager, ComposeOperationError
+from awf.node.git_manager import mirror_path_for_worktree, repair_agent_writable_worktree
 from awf.profiles.models import WorkspaceProfile
 from awf.profiles.resolver import resolve_workspace_profile
 from awf.runtime.alembic_validation import (
@@ -164,6 +168,9 @@ _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
 _AUDIT_PR_CREATED_EVENT = "workspace.audit.pr_created"
 _GIT_PUSH_FAILED_REASON_CODE = "GIT_PUSH_FAILED"
 _PR_CREATE_FAILED_REASON_CODE = "PR_CREATE_FAILED"
+GIT_AGENT_WRITABILITY_FAILED_REASON_CODE = "GIT_AGENT_WRITABILITY_FAILED"
+GIT_OBJECT_MISSING_REASON_CODE = "GIT_OBJECT_MISSING"
+GIT_OBJECT_MISSING_RECOVERED_REASON_CODE = "GIT_OBJECT_MISSING_RECOVERED"
 
 _RECOVERY_ACTIVE_OPERATION_STATUSES = {
     OperationStatus.pending.value,
@@ -206,6 +213,125 @@ class _PlanningRunFailure:
     message: str
     reason_code: str | None = None
     details: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class _GitObjectRecoveryResult:
+    broken_head_sha: str | None
+    recovered_head_sha: str
+    strategy: str = "filesystem_tree_commit"
+
+
+def _git_error_indicates_missing_head_object(text: str) -> bool:
+    lower = text.lower()
+    return (
+        "bad object head" in lower
+        or "not a valid object name head" in lower
+        or "could not parse object 'head'" in lower
+    )
+
+
+def _agent_git_writability_preflight_script(workspace_id: str) -> str:
+    quoted_workspace_id = shlex.quote(workspace_id)
+    return f"""
+set -eu
+workspace_id={quoted_workspace_id}
+git status --porcelain >/dev/null
+blob=$(printf 'awf git preflight %s\\n' "$workspace_id" | git hash-object -w --stdin)
+git cat-file -e "$blob^{{blob}}"
+ref="refs/awf/preflight/$workspace_id"
+git update-ref "$ref" HEAD
+git update-ref -d "$ref"
+""".strip()
+
+
+async def _recover_missing_head_from_filesystem(
+    *,
+    runner: AsyncCommandRunner,
+    workspace_id: str,
+    worktree_path: Path,
+    base_commit: str,
+    branch_name: str,
+) -> _GitObjectRecoveryResult | None:
+    """Rebuild a valid AWF branch commit from files when HEAD points to a missing object."""
+    mirror_path = mirror_path_for_worktree(worktree_path)
+    if mirror_path is None:
+        return None
+    branch_ref = branch_name if branch_name.startswith("refs/") else f"refs/heads/{branch_name}"
+    broken_head_sha = _read_ref_sha(mirror_path, branch_ref)
+
+    async def mirror_git(args: list[str]) -> CommandResult:
+        return await runner.run(["git", "--git-dir", str(mirror_path), *args])
+
+    async def worktree_git(args: list[str]) -> CommandResult:
+        return await runner.run(
+            [
+                "git",
+                *git_safe_directory_config_args(worktree_path),
+                "-C",
+                str(worktree_path),
+                *args,
+            ]
+        )
+
+    base_ok = await mirror_git(["cat-file", "-e", f"{base_commit}^{{commit}}"])
+    if not base_ok.ok:
+        return None
+    reset_ref = await mirror_git(["update-ref", branch_ref, base_commit])
+    if not reset_ref.ok:
+        return None
+    reset_index = await worktree_git(["reset", "--mixed", "HEAD"])
+    if not reset_index.ok:
+        return None
+    add = await worktree_git(["add", "-A"])
+    if not add.ok:
+        return None
+    diff = await worktree_git(["diff", "--cached", "--quiet"])
+    if diff.returncode == 0:
+        return None
+    if diff.returncode not in {0, 1}:
+        return None
+    commit = await runner.run(
+        [
+            "git",
+            *git_safe_directory_config_args(worktree_path),
+            "-C",
+            str(worktree_path),
+            *git_identity_config_args(),
+            "commit",
+            "-m",
+            f"awf: recover {workspace_id} from missing git object"[:72],
+            "-m",
+            (
+                f"AWF recovered workspace {workspace_id} after HEAD pointed at "
+                "a commit object missing from the canonical mirror. The commit "
+                f"squashes the workspace filesystem state onto base {base_commit[:10]}."
+            ),
+        ]
+    )
+    if not commit.ok:
+        return None
+    repair_agent_writable_worktree(mirror_path, worktree_path)
+    status = await worktree_git(["status", "--porcelain=v1", "--untracked-files=all"])
+    if not status.ok:
+        return None
+    head = await worktree_git(["rev-parse", "HEAD"])
+    recovered_head_sha = head.stdout.strip()
+    if not head.ok or not recovered_head_sha:
+        return None
+    return _GitObjectRecoveryResult(
+        broken_head_sha=broken_head_sha,
+        recovered_head_sha=recovered_head_sha,
+    )
+
+
+def _read_ref_sha(mirror_path: Path, ref: str) -> str | None:
+    ref_path = mirror_path / ref
+    try:
+        value = ref_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return value or None
 
 
 def _build_planning_scope_failure(
@@ -787,6 +913,14 @@ class WorkspaceExecutor:
                     ws.task_prompt = salvage_result.prompt_override
         rebase_recovery_result: _RebaseRecoveryResult | None = None
         baseline_coverage: ValidationCoverageResult | None = None
+        profile: WorkspaceProfile | None = None
+        agent_exit_note: str | None = None
+        agent_run_reason_code: str | None = None
+        agent_run_details: Mapping[str, Any] | None = None
+        expected_branch = ws.branch_name or f"awf/{workspace_id}"
+        adapter: AgentAdapter | None = None
+        defaults: AgentDefaults | None = None
+        default_model: str | None = None
         try:
             agent = AgentRuntime(ws.agent)
             defaults = self._defaults_for(agent)
@@ -840,6 +974,13 @@ class WorkspaceExecutor:
                 )
                 return
             if recovery is None:
+                if not await self._run_agent_git_writability_preflight(
+                    workspace_id=workspace_id,
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    worktree_path=worktree_path,
+                ):
+                    return
                 baseline_coverage = await self._run_baseline_coverage_preflight(
                     workspace_id=workspace_id,
                     compose_project=compose_project,
@@ -903,9 +1044,6 @@ class WorkspaceExecutor:
                     recovery_mode=recovery.get("recovery_mode"),
                     reason=recovery.get("reason"),
                 )
-            agent_exit_note = None
-            agent_run_reason_code = None
-            agent_run_details = None
         except ComposeExecCleanupError as exc:
             _log.error(
                 "executor.exec_process_cleanup_failed",
@@ -952,13 +1090,45 @@ class WorkspaceExecutor:
                 returncode=exc.result.returncode,
                 reason_code=exc.reason_code,
             )
+            await self._repair_agent_git_ownership(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                reason="agent_nonzero_exit_salvage",
+            )
         except Exception as exc:  # unexpected — surface with generic reason
-            _log.exception("executor.unexpected_in_agent", workspace_id=workspace_id)
+            if _git_error_indicates_missing_head_object(str(exc)):
+                if await self._recover_missing_git_head_or_mark_failed(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    base_commit=ws.base_commit,
+                    branch_name=expected_branch,
+                    from_status=WorkspaceStatus.running,
+                    stage="agent_run",
+                    error=exc,
+                ):
+                    agent_exit_note = (
+                        "AWF recovered a missing Git HEAD object during the agent run; "
+                        "continuing to salvage filesystem work"
+                    )
+                    agent_run_reason_code = GIT_OBJECT_MISSING_RECOVERED_REASON_CODE
+                    agent_run_details = {"recovered_stage": "agent_run"}
+                else:
+                    return
+            else:
+                _log.exception("executor.unexpected_in_agent", workspace_id=workspace_id)
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.running,
+                    failure_reason=FailureReason.infrastructure_failure,
+                    message=f"unexpected error during agent run: {exc!r}"[:2000],
+                )
+                return
+        if adapter is None:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,
                 failure_reason=FailureReason.infrastructure_failure,
-                message=f"unexpected error during agent run: {exc!r}"[:2000],
+                message="executor could not initialize agent adapter before post-agent capture",
             )
             return
 
@@ -1015,7 +1185,6 @@ class WorkspaceExecutor:
                 ]
             )
 
-        expected_branch = ws.branch_name or f"awf/{workspace_id}"
         has_known_non_plan_output = False
 
         try:
@@ -1159,7 +1328,17 @@ class WorkspaceExecutor:
                         wip_stashed=has_wip,
                     )
 
-                await _git_in_worktree(["add", "-A"])
+                add_result = await _git_in_worktree(["add", "-A"])
+                await self._repair_agent_git_ownership(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    reason="post_agent_git_add",
+                )
+                if not add_result.ok:
+                    raise RuntimeError(
+                        f"post-agent git add failed (exit={add_result.returncode}): "
+                        f"{add_result.stderr}"
+                    )
                 cached = await _git_in_worktree(["diff", "--cached", "--name-only"])
                 if cached.stdout.strip():
                     staged_paths = _git_name_lines(cached.stdout)
@@ -1212,6 +1391,11 @@ class WorkspaceExecutor:
                             "-m",
                             commit_body,
                         ],
+                    )
+                    await self._repair_agent_git_ownership(
+                        workspace_id=workspace_id,
+                        worktree_path=worktree_path,
+                        reason="post_agent_git_commit",
                     )
                     if not commit_result.ok:
                         raise RuntimeError(
@@ -1273,6 +1457,11 @@ class WorkspaceExecutor:
                         base_commit=base_commit,
                     )
                     reset = await _git_in_worktree(["reset", "--soft", base_commit])
+                    await self._repair_agent_git_ownership(
+                        workspace_id=workspace_id,
+                        worktree_path=worktree_path,
+                        reason="orphan_history_reset",
+                    )
                     if reset.ok:
                         recovery_msg = f"awf: {ws.task_title} (recovered from orphan)"[:72]
                         recovery_body = (
@@ -1293,6 +1482,11 @@ class WorkspaceExecutor:
                                 "-m",
                                 recovery_body,
                             ],
+                        )
+                        await self._repair_agent_git_ownership(
+                            workspace_id=workspace_id,
+                            worktree_path=worktree_path,
+                            reason="orphan_history_recovery_commit",
                         )
                         if recover_commit.ok:
                             ancestor = await _git_in_worktree(
@@ -1346,14 +1540,31 @@ class WorkspaceExecutor:
                     )
                     return
         except Exception as exc:  # unexpected — mark infrastructure
-            _log.exception("executor.commit_step_failed", workspace_id=workspace_id)
-            await self._mark_failed(
-                workspace_id=workspace_id,
-                from_status=WorkspaceStatus.running,
-                failure_reason=FailureReason.infrastructure_failure,
-                message=f"post-agent commit step failed: {exc!r}"[:2000],
-            )
-            return
+            if _git_error_indicates_missing_head_object(str(exc)):
+                if await self._recover_missing_git_head_or_mark_failed(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    base_commit=ws.base_commit,
+                    branch_name=expected_branch,
+                    from_status=WorkspaceStatus.running,
+                    stage="post_agent_commit",
+                    error=exc,
+                ):
+                    _log.warning(
+                        "executor.commit_step_missing_head_recovered",
+                        workspace_id=workspace_id,
+                    )
+                else:
+                    return
+            else:
+                _log.exception("executor.commit_step_failed", workspace_id=workspace_id)
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.running,
+                    failure_reason=FailureReason.infrastructure_failure,
+                    message=f"post-agent commit step failed: {exc!r}"[:2000],
+                )
+                return
 
         # ── Step 2: validation (tests + optional Alembic), with fix-cycle ──
         if not await self._transition_if_current(
@@ -1737,6 +1948,11 @@ class WorkspaceExecutor:
             # here (HEAD already descends from base after the initial run
             # succeeded); zero-change fix passes are allowed.
             fix_add = await _git_in_worktree(["add", "-A"])
+            await self._repair_agent_git_ownership(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                reason="validation_fix_git_add",
+            )
             if not fix_add.ok:
                 _log.warning(
                     "executor.fix_pass_add_failed",
@@ -1827,6 +2043,11 @@ class WorkspaceExecutor:
                         "-m",
                         commit_body,
                     ],
+                )
+                await self._repair_agent_git_ownership(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    reason="validation_fix_git_commit",
                 )
                 if not fix_commit.ok:
                     _log.warning(
@@ -2354,6 +2575,168 @@ class WorkspaceExecutor:
     async def _load_workspace(self, workspace_id: str) -> Workspace | None:
         async with self._session_factory() as session:
             return await WorkspaceRepository(session).get(workspace_id)
+
+    async def _repair_agent_git_ownership(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        reason: str,
+    ) -> bool:
+        try:
+            await asyncio.to_thread(repair_agent_writable_worktree, None, worktree_path)
+        except Exception:
+            _log.exception(
+                "executor.agent_git_ownership_repair_failed",
+                workspace_id=workspace_id,
+                worktree_path=str(worktree_path),
+                reason=reason,
+            )
+            return False
+        return True
+
+    async def _run_agent_git_writability_preflight(
+        self,
+        *,
+        workspace_id: str,
+        compose_project: str,
+        compose_file: Path,
+        worktree_path: Path,
+    ) -> bool:
+        # Unit tests often use a plain temp directory as a fake worktree. Real
+        # AWF-linked worktrees always have a .git control file, so keep the
+        # production preflight active without making those fakes shell out.
+        if not (worktree_path / ".git").exists():
+            return True
+        if not compose_file.exists():
+            return True
+        if not await self._repair_agent_git_ownership(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            reason="agent_git_writability_preflight",
+        ):
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "agent Git writability preflight failed before container "
+                    "execution: control-plane ownership repair raised an error"
+                ),
+                reason_code=GIT_AGENT_WRITABILITY_FAILED_REASON_CODE,
+            )
+            return False
+
+        invocation = build_tracked_compose_exec(
+            compose_project=compose_project,
+            compose_file=compose_file,
+            cli_args=[
+                "sh",
+                "-lc",
+                _agent_git_writability_preflight_script(workspace_id),
+            ],
+            source="executor",
+            label="agent_git_writability_preflight",
+        )
+        result = await self._runner.run(invocation.args, input_bytes=b"")
+        if result.ok:
+            _log.info(
+                "executor.agent_git_writability_preflight_ok",
+                workspace_id=workspace_id,
+            )
+            return True
+        output = (result.stderr.strip() or result.stdout.strip() or "<no output>")[:1200]
+        await self._mark_failed(
+            workspace_id=workspace_id,
+            from_status=WorkspaceStatus.running,
+            failure_reason=FailureReason.infrastructure_failure,
+            message=(
+                "agent Git writability preflight failed "
+                f"(exit={result.returncode}): {output}"
+            )[:2000],
+            reason_code=GIT_AGENT_WRITABILITY_FAILED_REASON_CODE,
+            details={
+                "returncode": result.returncode,
+                "stdout": result.stdout[:1000],
+                "stderr": result.stderr[:1000],
+            },
+        )
+        return False
+
+    async def _recover_missing_git_head_or_mark_failed(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        base_commit: str | None,
+        branch_name: str,
+        from_status: WorkspaceStatus,
+        stage: str,
+        error: BaseException,
+    ) -> bool:
+        if base_commit is None:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=from_status,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "Git object recovery failed: workspace HEAD points at a "
+                    "missing object and base_commit is not available"
+                ),
+                reason_code=GIT_OBJECT_MISSING_REASON_CODE,
+            )
+            return False
+        recovery = await _recover_missing_head_from_filesystem(
+            runner=self._runner,
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            base_commit=base_commit,
+            branch_name=branch_name,
+        )
+        if recovery is None:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=from_status,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "Git object recovery failed: workspace HEAD points at a "
+                    f"missing object during {stage}, and AWF could not rebuild "
+                    f"a valid commit from the filesystem state: {error!r}"
+                )[:2000],
+                reason_code=GIT_OBJECT_MISSING_REASON_CODE,
+            )
+            return False
+        await self._record_git_object_recovery_event(
+            workspace_id=workspace_id,
+            stage=stage,
+            recovery=recovery,
+        )
+        return True
+
+    async def _record_git_object_recovery_event(
+        self,
+        *,
+        workspace_id: str,
+        stage: str,
+        recovery: _GitObjectRecoveryResult,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            if ws is None:  # pragma: no cover - destroyed mid-flight
+                return
+            await repo.add_event(
+                ws,
+                event_type="workspace.git_object_missing_recovered",
+                reason_code=GIT_OBJECT_MISSING_RECOVERED_REASON_CODE,
+                payload={
+                    "stage": stage,
+                    "strategy": recovery.strategy,
+                    "broken_head_sha": recovery.broken_head_sha,
+                    "recovered_head_sha": recovery.recovered_head_sha,
+                },
+            )
+            await session.commit()
 
     async def _recover_feature_branch_remote_push_branch(
         self,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1553,7 +1553,7 @@ class WorkspaceExecutor:
                 if await self._recover_missing_git_head_or_mark_failed(
                     workspace_id=workspace_id,
                     worktree_path=worktree_path,
-                    base_commit=ws.base_commit,
+                    base_commit=base_commit,
                     branch_name=expected_branch,
                     from_status=WorkspaceStatus.running,
                     stage="post_agent_commit",
@@ -2723,11 +2723,29 @@ class WorkspaceExecutor:
                 reason_code=GIT_OBJECT_MISSING_REASON_CODE,
             )
             return False
-        await self._record_git_object_recovery_event(
-            workspace_id=workspace_id,
-            stage=stage,
-            recovery=recovery,
-        )
+        try:
+            await self._record_git_object_recovery_event(
+                workspace_id=workspace_id,
+                stage=stage,
+                recovery=recovery,
+            )
+        except Exception as exc:
+            _log.exception(
+                "executor.git_object_recovery_event_record_failed",
+                workspace_id=workspace_id,
+                stage=stage,
+            )
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=from_status,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "Git object recovery failed: rebuilt HEAD during "
+                    f"{stage}, but could not record the recovery event: {exc!r}"
+                )[:2000],
+                reason_code=GIT_OBJECT_MISSING_REASON_CODE,
+            )
+            return False
         return True
 
     async def _record_git_object_recovery_event(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2703,13 +2703,32 @@ class WorkspaceExecutor:
                 reason_code=GIT_OBJECT_MISSING_REASON_CODE,
             )
             return False
-        recovery = await _recover_missing_head_from_filesystem(
-            runner=self._runner,
-            workspace_id=workspace_id,
-            worktree_path=worktree_path,
-            base_commit=base_commit,
-            branch_name=branch_name,
-        )
+        try:
+            recovery = await _recover_missing_head_from_filesystem(
+                runner=self._runner,
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                base_commit=base_commit,
+                branch_name=branch_name,
+            )
+        except Exception as exc:
+            _log.exception(
+                "executor.git_object_filesystem_recovery_failed",
+                workspace_id=workspace_id,
+                stage=stage,
+            )
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=from_status,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "Git object recovery failed: workspace HEAD points at a "
+                    f"missing object during {stage}, but AWF could not run "
+                    f"filesystem recovery: {exc!r}"
+                )[:2000],
+                reason_code=GIT_OBJECT_MISSING_REASON_CODE,
+            )
+            return False
         if recovery is None:
             await self._mark_failed(
                 workspace_id=workspace_id,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1563,6 +1563,14 @@ class WorkspaceExecutor:
                         "executor.commit_step_missing_head_recovered",
                         workspace_id=workspace_id,
                     )
+                    if not await self._verify_recovered_post_agent_commit(
+                        workspace_id=workspace_id,
+                        worktree_path=worktree_path,
+                        base_commit=base_commit,
+                        owned_paths=list(ws.owned_paths),
+                        expected_status=WorkspaceStatus.running,
+                    ):
+                        return
                 else:
                     return
             else:
@@ -3559,6 +3567,76 @@ class WorkspaceExecutor:
                 f"git diff --name-only failed while checking committed paths: {result.stderr}"
             )
         return {Path(line.strip()) for line in result.stdout.splitlines() if line.strip()}
+
+    async def _verify_recovered_post_agent_commit(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        base_commit: str,
+        owned_paths: list[str],
+        expected_status: WorkspaceStatus,
+    ) -> bool:
+        changed_paths = sorted(
+            path.as_posix()
+            for path in await self._committed_paths_since(worktree_path, base_commit)
+        )
+        if not changed_paths:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=expected_status,
+                failure_reason=FailureReason.agent_failure,
+                message=(
+                    "AWF recovered a missing Git HEAD object but recovered no "
+                    f"committed paths relative to base {base_commit[:10]}"
+                )[:2000],
+                reason_code=GIT_OBJECT_MISSING_RECOVERED_REASON_CODE,
+                details={"recovered_stage": "post_agent_commit"},
+            )
+            return False
+        if await self._fail_if_plan_only_paths(
+            workspace_id=workspace_id,
+            changed_paths=changed_paths,
+            expected_status=expected_status,
+        ):
+            return False
+        violations = find_protected_quality_gate_changes(
+            changed_paths=changed_paths,
+            owned_paths=owned_paths,
+        )
+        if violations:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=expected_status,
+                failure_reason=FailureReason.policy_failure,
+                reason_code="QUALITY_GATE_POLICY_CHANGED",
+                message=quality_gate_violation_message(violations)[:2000],
+            )
+            return False
+        ancestor = await self._runner.run(
+            [
+                "git",
+                *git_safe_directory_config_args(worktree_path),
+                "-C",
+                str(worktree_path),
+                "merge-base",
+                "--is-ancestor",
+                base_commit,
+                "HEAD",
+            ]
+        )
+        if not ancestor.ok:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=expected_status,
+                failure_reason=FailureReason.agent_failure,
+                message=(
+                    "AWF recovered a missing Git HEAD object but recovered HEAD "
+                    f"does not descend from base commit {base_commit[:10]}"
+                )[:2000],
+            )
+            return False
+        return True
 
     async def _fail_if_plan_only_paths(
         self,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -287,9 +287,9 @@ async def _recover_missing_head_from_filesystem(
     if not add.ok:
         return None
     diff = await worktree_git(["diff", "--cached", "--quiet"])
-    if diff.returncode == 0:
-        return None
     if diff.returncode not in {0, 1}:
+        return None
+    if diff.returncode == 0:
         return None
     commit = await runner.run(
         [
@@ -311,10 +311,7 @@ async def _recover_missing_head_from_filesystem(
     )
     if not commit.ok:
         return None
-    repair_agent_writable_worktree(mirror_path, worktree_path)
-    status = await worktree_git(["status", "--porcelain=v1", "--untracked-files=all"])
-    if not status.ok:
-        return None
+    await asyncio.to_thread(repair_agent_writable_worktree, mirror_path, worktree_path)
     head = await worktree_git(["rev-parse", "HEAD"])
     recovered_head_sha = head.stdout.strip()
     if not head.ok or not recovered_head_sha:
@@ -330,8 +327,20 @@ def _read_ref_sha(mirror_path: Path, ref: str) -> str | None:
     try:
         value = ref_path.read_text(encoding="utf-8").strip()
     except OSError:
+        value = ""
+    if value:
+        return value
+    packed_refs = mirror_path / "packed-refs"
+    try:
+        for line in packed_refs.read_text(encoding="utf-8").splitlines():
+            if not line or line.startswith(("#", "^")):
+                continue
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[1] == ref:
+                return parts[0]
+    except OSError:
         return None
-    return value or None
+    return None
 
 
 def _build_planning_scope_failure(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1563,7 +1563,7 @@ class WorkspaceExecutor:
                         "executor.commit_step_missing_head_recovered",
                         workspace_id=workspace_id,
                     )
-                    if not await self._verify_recovered_post_agent_commit(
+                    if not await self._verify_recovered_post_agent_commit_or_mark_failed(
                         workspace_id=workspace_id,
                         worktree_path=worktree_path,
                         base_commit=base_commit,
@@ -3637,6 +3637,40 @@ class WorkspaceExecutor:
             )
             return False
         return True
+
+    async def _verify_recovered_post_agent_commit_or_mark_failed(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        base_commit: str,
+        owned_paths: list[str],
+        expected_status: WorkspaceStatus,
+    ) -> bool:
+        try:
+            return await self._verify_recovered_post_agent_commit(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                base_commit=base_commit,
+                owned_paths=owned_paths,
+                expected_status=expected_status,
+            )
+        except Exception as exc:
+            _log.exception(
+                "executor.commit_step_missing_head_recovery_verification_failed",
+                workspace_id=workspace_id,
+            )
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=expected_status,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=(
+                    "post-agent missing HEAD recovery verification failed: "
+                    f"{exc!r}"
+                )[:2000],
+                reason_code=GIT_OBJECT_MISSING_REASON_CODE,
+            )
+            return False
 
     async def _fail_if_plan_only_paths(
         self,

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -31,6 +31,9 @@ from awf.common.logging import get_logger
 
 _log = get_logger(__name__)
 
+AGENT_RUNTIME_UID = 1000
+AGENT_RUNTIME_GID = 1000
+
 
 class GitOperationError(Exception):
     """Raised when a git subprocess exits non-zero or a precondition fails.
@@ -437,13 +440,10 @@ class GitManager:
             return
         if os.geteuid() != 0:
             return
-        targets = _agent_writable_git_targets(
-            layout_mirror=layout_mirror,
-            worktree_path=worktree_path,
-        )
         await asyncio.to_thread(
-            _chown_targets,
-            targets,
+            repair_agent_writable_worktree,
+            layout_mirror,
+            worktree_path,
             self._worktree_owner_uid,
             self._worktree_owner_gid,
         )
@@ -491,6 +491,56 @@ def _agent_writable_git_targets(
     if worktrees.exists():
         targets.append(_ChownTarget(worktrees, recursive=False))
     return tuple(targets)
+
+
+def repair_agent_writable_worktree(
+    layout_mirror: Path | None,
+    worktree_path: Path,
+    uid: int = AGENT_RUNTIME_UID,
+    gid: int = AGENT_RUNTIME_GID,
+) -> None:
+    """Repair linked-worktree Git ownership for the agent-runtime user.
+
+    The mirror object DB is intentionally repaired in directories-only mode:
+    loose object files and pack files may be immutable through Docker Desktop
+    on macOS, while fanout directories must be writable on Linux so the agent
+    can add new objects.
+    """
+    if os.geteuid() != 0:
+        return
+    mirror = layout_mirror or mirror_path_for_worktree(worktree_path)
+    if mirror is None:
+        targets = [_ChownTarget(worktree_path, recursive=True)]
+        linked_git_dir = _linked_worktree_git_dir(worktree_path)
+        if linked_git_dir is not None:
+            targets.append(_ChownTarget(linked_git_dir, recursive=True))
+    else:
+        targets = list(
+            _agent_writable_git_targets(
+                layout_mirror=mirror,
+                worktree_path=worktree_path,
+            )
+        )
+    _chown_targets(tuple(targets), uid, gid)
+
+
+def mirror_path_for_worktree(worktree_path: Path) -> Path | None:
+    """Return the bare mirror path backing a linked worktree, when discoverable."""
+    linked_git_dir = _linked_worktree_git_dir(worktree_path)
+    if linked_git_dir is None:
+        return None
+    commondir = linked_git_dir / "commondir"
+    if commondir.is_file():
+        try:
+            raw = commondir.read_text(encoding="utf-8").strip()
+        except OSError:
+            raw = ""
+        if raw:
+            common = Path(raw)
+            if not common.is_absolute():
+                common = linked_git_dir / common
+            return common.resolve()
+    return linked_git_dir.parent.parent.resolve()
 
 
 def _linked_worktree_git_dir(worktree_path: Path) -> Path | None:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -189,6 +189,8 @@ class MonitorState:
 
     iter_count: int = 0
     last_push_sha: str | None = None  # SHA at the time of last push
+    sync_base_no_progress_signature: str | None = None
+    sync_base_no_progress_count: int = 0
     # thread_id → one of:
     # "fix_committed" / "false_positive" / "defer" / "agent_failed"
     threads_addressed_ids: dict[str, str] = field(default_factory=dict)
@@ -238,6 +240,12 @@ class MonitorConfig:
     exceeded this age. This is observability only; pending checks still
     block merge through the ordinary WaitForCI path."""
 
+    max_no_progress_sync_base_attempts: int = 3
+    """Abort or move to still-actionable review feedback after this many
+    consecutive no-op SyncBase attempts for the same PR snapshot. This
+    prevents stale git mirrors or unreproducible GitHub DIRTY states from
+    burning monitor iterations forever."""
+
 
 # ── Actions — the vocabulary decide() returns to the runner ────────────────
 
@@ -253,6 +261,8 @@ class AbortReason(StrEnum):
     pr_closed_externally = "pr_closed_externally"
     no_progress_on_comments = "no_progress_on_comments"
     merge_conflict_unresolvable = "merge_conflict_unresolvable"
+    merge_conflict_not_reproduced = "merge_conflict_not_reproduced"
+    base_sync_no_progress = "base_sync_no_progress"
     stale = "stale"
     """GitHub reports mergeStateStatus == DIRTY after every other gate is
     clean — git can't auto-resolve and the CLI already had its chance."""
@@ -368,6 +378,29 @@ def _needs_comment_attention(verdict: str | None) -> bool:
     return verdict is None or verdict == "agent_failed"
 
 
+def sync_base_no_progress_signature(status: PRStatus) -> str:
+    """Stable identity for a SyncBase snapshot that made no local progress."""
+
+    mergeable = status.mergeable.value
+    merge_state = status.merge_state_status.value if status.merge_state_status else "UNKNOWN"
+    return (
+        f"{status.head_sha}|{mergeable}|{merge_state}|"
+        f"base_behind={status.base_behind_count}"
+    )
+
+
+def _sync_base_no_progress_exhausted(
+    status: PRStatus,
+    state: MonitorState,
+    config: MonitorConfig,
+) -> bool:
+    return (
+        config.max_no_progress_sync_base_attempts > 0
+        and state.sync_base_no_progress_signature == sync_base_no_progress_signature(status)
+        and state.sync_base_no_progress_count >= config.max_no_progress_sync_base_attempts
+    )
+
+
 # ── The decision function ──────────────────────────────────────────────────
 
 
@@ -423,6 +456,20 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     if status.closed:
         return Abort(reason=AbortReason.pr_closed_externally)
 
+    # Pre-compute actionable comments so a no-progress DIRTY loop can break
+    # back to review repair instead of starving new feedback forever.
+    new_threads = tuple(
+        t
+        for t in status.unresolved_inline_threads
+        if _needs_comment_attention(state.threads_addressed_ids.get(t.thread_id))
+    )
+    new_reviews = tuple(
+        c
+        for c in status.unresolved_review_comments
+        if not c.blocks_merge
+        and _needs_comment_attention(state.threads_addressed_ids.get(c.comment_id))
+    )
+
     # 1. Base-behind / DIRTY check runs BEFORE comments. Rationale: on a
     # PR with an active bot-review fleet (Greptile/CodeRabbit/Bugbot/
     # Codex/etc.) every push triggers a new wave of comments —
@@ -450,23 +497,20 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
         MergeStateStatus.BEHIND,
         MergeStateStatus.DIRTY,
     ):
+        if _sync_base_no_progress_exhausted(status, state, config):
+            if status.merge_state_status == MergeStateStatus.DIRTY and (
+                new_threads or new_reviews
+            ):
+                return AddressComments(threads=new_threads, review_comments=new_reviews)
+            if status.merge_state_status == MergeStateStatus.DIRTY:
+                return Abort(reason=AbortReason.merge_conflict_not_reproduced)
+            return Abort(reason=AbortReason.base_sync_no_progress)
         return SyncBase()
 
     # 2. Unresolved comments, filtered to those we haven't handled yet.
     # Policy/checklist blockers remain visible to the merge gate, but are
     # not sent to the coding CLI: no code edit can click a review-bot
     # "Trigger review" checkbox or change organization review settings.
-    new_threads = tuple(
-        t
-        for t in status.unresolved_inline_threads
-        if _needs_comment_attention(state.threads_addressed_ids.get(t.thread_id))
-    )
-    new_reviews = tuple(
-        c
-        for c in status.unresolved_review_comments
-        if not c.blocks_merge
-        and _needs_comment_attention(state.threads_addressed_ids.get(c.comment_id))
-    )
     if new_threads or new_reviews:
         return AddressComments(threads=new_threads, review_comments=new_reviews)
 
@@ -515,6 +559,8 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # comment fixes; contrast with BEHIND/DIRTY (step 1) which must run
     # first to break the push→comment→push loop.
     if status.mergeable == MergeableState.CONFLICTING:
+        if _sync_base_no_progress_exhausted(status, state, config):
+            return Abort(reason=AbortReason.merge_conflict_not_reproduced)
         return SyncBase()
 
     # 7. Branch protection / required-review blocker → hand off to human

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -174,6 +174,7 @@ class PRStatus:
     changed_paths: tuple[str, ...] = ()
     closed: bool = False
     merged: bool = False
+    merge_commit_sha: str | None = None
 
 
 # ── State — small, serialisable, lives on the workspace row ────────────────

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -190,6 +190,7 @@ _GIT_PUSH_FAILED_REASON = "GIT_PUSH_FAILED"
 _GIT_FETCH_BASE_FAILED_REASON = "GIT_FETCH_BASE_FAILED"
 _GIT_BASE_BEHIND_FAILED_REASON = "GIT_BASE_BEHIND_FAILED"
 _GIT_MIRROR_BROKEN_REF_REMOVED_REASON = "GIT_MIRROR_BROKEN_REF_REMOVED"
+_GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
 _PROTECTED_SCOPE_REPAIR_FAILED_REASON = "PROTECTED_SCOPE_REPAIR_FAILED"
 _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
 _AUDIT_MERGE_ATTEMPT_EVENT = "workspace.audit.merge_attempt"
@@ -1731,6 +1732,7 @@ class PullRequestMonitorRunner:
             merge_operation: MonitorOperationHandle | None = None
             recheck_error: GitHubClientError | None = None
             recheck_base_error: BaseFetchError | None = None
+            recheck_behind_error: BaseBehindCountError | None = None
             merge_status = status
             queue_blockers_after_lock: list[MergeQueueBlocker] = []
             merge_gate_after_lock: _MergeGateResult | None = None
@@ -1760,6 +1762,8 @@ class PullRequestMonitorRunner:
                         recheck_error = exc
                     except BaseFetchError as exc:
                         recheck_base_error = exc
+                    except BaseBehindCountError as exc:
+                        recheck_behind_error = exc
                     else:
                         checked_action = decide(checked_status, state, self._config)
                         if not isinstance(checked_action, Merge):
@@ -1787,6 +1791,7 @@ class PullRequestMonitorRunner:
                 if (
                     recheck_error is None
                     and recheck_base_error is None
+                    and recheck_behind_error is None
                     and fresh_action is None
                 ):
                     queue_blockers_after_lock = await self._merge_queue_blockers_for_workspace(
@@ -1940,6 +1945,17 @@ class PullRequestMonitorRunner:
                         f"{recheck_base_error}"
                     )[:2000],
                     reason_code=_GIT_FETCH_BASE_FAILED_REASON,
+                )
+                return True
+
+            if recheck_behind_error is not None:
+                await self._terminate_failed(
+                    workspace_id,
+                    message=(
+                        "monitor: could not calculate base-behind count during "
+                        f"pre-merge recheck: {recheck_behind_error}"
+                    )[:2000],
+                    reason_code=_GIT_BASE_BEHIND_FAILED_REASON,
                 )
                 return True
 
@@ -3532,20 +3548,22 @@ class PullRequestMonitorRunner:
         would make ``base_behind_count`` stale and can livelock SyncBase.
         """
         result = await self._fetch_base_once(worktree_path=worktree_path, base_branch=base_branch)
-        if result.ok:
-            return
-        if await self._repair_orphaned_broken_awf_ref(
-            workspace_id=workspace_id,
-            worktree_path=worktree_path,
-            stderr=result.stderr,
-        ):
-            retry = await self._fetch_base_once(
+        repairs_attempted = 0
+        while not result.ok and repairs_attempted < _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS:
+            repaired = await self._repair_orphaned_broken_awf_ref(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                stderr=result.stderr,
+            )
+            if not repaired:
+                break
+            repairs_attempted += 1
+            result = await self._fetch_base_once(
                 worktree_path=worktree_path,
                 base_branch=base_branch,
             )
-            if retry.ok:
-                return
-            result = retry
+        if result.ok:
+            return
         raise BaseFetchError(_git_failure_message("git fetch base", result))
 
     async def _fetch_base_once(self, *, worktree_path: Path, base_branch: str) -> CommandResult:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -3550,11 +3550,26 @@ class PullRequestMonitorRunner:
         result = await self._fetch_base_once(worktree_path=worktree_path, base_branch=base_branch)
         repairs_attempted = 0
         while not result.ok and repairs_attempted < _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS:
-            repaired = await self._repair_orphaned_broken_awf_ref(
-                workspace_id=workspace_id,
-                worktree_path=worktree_path,
-                stderr=result.stderr,
-            )
+            try:
+                repaired = await self._repair_orphaned_broken_awf_ref(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    stderr=result.stderr,
+                )
+            except Exception as exc:
+                _log.exception(
+                    "monitor.git_mirror_broken_ref_repair_failed",
+                    workspace_id=workspace_id,
+                    base_branch=base_branch,
+                    repairs_attempted=repairs_attempted,
+                )
+                raise BaseFetchError(
+                    redact_audit_text(
+                        "git fetch base failed: broken AWF ref repair failed "
+                        f"after fetch failure: {exc!r}",
+                        limit=2000,
+                    )
+                ) from exc
             if not repaired:
                 break
             repairs_attempted += 1

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -91,6 +91,7 @@ from awf.runtime.pr_monitor import (
     WaitForCI,
     _is_bot_author,
     decide,
+    sync_base_no_progress_signature,
 )
 from awf.runtime.pr_monitor_operations import (
     MonitorOperationHandle,
@@ -186,6 +187,9 @@ _TRANSIENT_GITHUB_ERROR_MARKERS = (
 _GITHUB_TRANSIENT_RETRY_REASON = "GITHUB_TRANSIENT_RETRY"
 _PR_MONITOR_AUDIT_ACTOR = "pr_monitor"
 _GIT_PUSH_FAILED_REASON = "GIT_PUSH_FAILED"
+_GIT_FETCH_BASE_FAILED_REASON = "GIT_FETCH_BASE_FAILED"
+_GIT_BASE_BEHIND_FAILED_REASON = "GIT_BASE_BEHIND_FAILED"
+_GIT_MIRROR_BROKEN_REF_REMOVED_REASON = "GIT_MIRROR_BROKEN_REF_REMOVED"
 _PROTECTED_SCOPE_REPAIR_FAILED_REASON = "PROTECTED_SCOPE_REPAIR_FAILED"
 _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
 _AUDIT_MERGE_ATTEMPT_EVENT = "workspace.audit.merge_attempt"
@@ -207,6 +211,23 @@ _TOKEN_RE = re.compile(
     r"xox[baprs]-[A-Za-z0-9-]{8,}"
     r")(?![A-Za-z0-9])"
 )
+_BROKEN_AWF_REF_RE = re.compile(r"refs/heads/awf/(ws_[A-Za-z0-9_-]+)")
+_SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY = "__awf_sync_base_no_progress_signature"
+_SYNC_BASE_NO_PROGRESS_COUNT_KEY = "__awf_sync_base_no_progress_count"
+_TERMINAL_WORKSPACE_STATUSES = {
+    WorkspaceStatus.completed.value,
+    WorkspaceStatus.failed.value,
+    WorkspaceStatus.cancelled.value,
+    WorkspaceStatus.destroyed.value,
+}
+
+
+class BaseFetchError(Exception):
+    """Base branch refresh failed; PR monitor must not use stale refs."""
+
+
+class BaseBehindCountError(Exception):
+    """Base-behind calculation failed; PR monitor must not assume zero."""
 
 
 @dataclass
@@ -830,6 +851,40 @@ class PullRequestMonitorRunner:
                         workspace_id=workspace_id,
                         base_branch=ws.branch_base,
                     )
+                except BaseFetchError as exc:
+                    await self._write_monitor_log(
+                        monitor_log,
+                        {
+                            "event": "monitor.failed",
+                            "workspace_id": workspace_id,
+                            "reason": "base_fetch_failed",
+                            "message": str(exc)[:400],
+                        },
+                    )
+                    await self._terminate_failed(
+                        workspace_id,
+                        message=f"monitor: could not refresh base branch: {exc}"[:2000],
+                        reason_code=_GIT_FETCH_BASE_FAILED_REASON,
+                    )
+                    return
+                except BaseBehindCountError as exc:
+                    await self._write_monitor_log(
+                        monitor_log,
+                        {
+                            "event": "monitor.failed",
+                            "workspace_id": workspace_id,
+                            "reason": "base_behind_count_failed",
+                            "message": str(exc)[:400],
+                        },
+                    )
+                    await self._terminate_failed(
+                        workspace_id,
+                        message=f"monitor: could not calculate base-behind count: {exc}"[
+                            :2000
+                        ],
+                        reason_code=_GIT_BASE_BEHIND_FAILED_REASON,
+                    )
+                    return
                 except GitHubClientError as exc:
                     if await self._wait_after_transient_github_error(
                         exc,
@@ -1162,6 +1217,25 @@ class PullRequestMonitorRunner:
                     error_message="Provider recovery triggered fallback",
                 )
                 raise
+            except BaseFetchError as exc:
+                await self._finish_monitor_operation(
+                    operation,
+                    status=OperationStatus.failed,
+                    result={
+                        "status": "failed",
+                        "outcome": "base_fetch_failed",
+                        "reason_code": _GIT_FETCH_BASE_FAILED_REASON,
+                        "pushed": False,
+                    },
+                    error_code=_GIT_FETCH_BASE_FAILED_REASON,
+                    error_message=str(exc),
+                )
+                await self._terminate_failed(
+                    workspace_id,
+                    message=f"monitor: could not refresh base branch: {exc}"[:2000],
+                    reason_code=_GIT_FETCH_BASE_FAILED_REASON,
+                )
+                return True
             except ComposeExecCleanupError as exc:
                 await self._finish_monitor_operation(
                     operation,
@@ -1217,6 +1291,11 @@ class PullRequestMonitorRunner:
                     "outcome": "base_synced",
                     "pushed": push_result.pushed,
                 },
+            )
+            self._record_sync_base_progress(
+                state=state,
+                status=status,
+                push_result=push_result,
             )
             await self._record_pr_monitor_audit_event(
                 workspace_id=workspace_id,
@@ -3081,7 +3160,11 @@ class PullRequestMonitorRunner:
         # "You have not concluded your merge". Abort first; the command
         # exits non-zero when there's nothing to abort, which we ignore.
         await _git("merge", "--abort")
-        await _git("fetch", "origin", base_branch)
+        await self._fetch_base(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            base_branch=base_branch,
+        )
         rc, _stdout, stderr = await _git("merge", "--no-edit", f"origin/{base_branch}")
         if rc != 0:
             # Conflicts — enumerate them for the prompt.
@@ -3394,23 +3477,119 @@ class PullRequestMonitorRunner:
             "before it commits or pushes."
         )
 
-    async def _fetch_base(self, *, worktree_path: Path, base_branch: str) -> None:
+    def _record_sync_base_progress(
+        self,
+        *,
+        state: MonitorState,
+        status: PRStatus,
+        push_result: _GitPushResult,
+    ) -> None:
+        if push_result.pushed or push_result.failed:
+            state.sync_base_no_progress_signature = None
+            state.sync_base_no_progress_count = 0
+            return
+        signature = sync_base_no_progress_signature(status)
+        if state.sync_base_no_progress_signature == signature:
+            state.sync_base_no_progress_count += 1
+        else:
+            state.sync_base_no_progress_signature = signature
+            state.sync_base_no_progress_count = 1
+
+    async def _fetch_base(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        base_branch: str,
+    ) -> None:
         """``git fetch origin <base>`` — refreshes the worktree's
         remote-tracking ref so the subsequent rev-list is accurate.
 
-        Non-fatal on failure (offline, transient network, etc.). The
-        decide() gate will fall back to GitHub's mergeStateStatus if
-        the local count is wrong."""
-        await self._deps.runner.run(
+        Fetch is authoritative. If AWF cannot refresh this ref, continuing
+        would make ``base_behind_count`` stale and can livelock SyncBase.
+        """
+        result = await self._fetch_base_once(worktree_path=worktree_path, base_branch=base_branch)
+        if result.ok:
+            return
+        if await self._repair_orphaned_broken_awf_ref(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            stderr=result.stderr,
+        ):
+            retry = await self._fetch_base_once(
+                worktree_path=worktree_path,
+                base_branch=base_branch,
+            )
+            if retry.ok:
+                return
+            result = retry
+        raise BaseFetchError(_git_failure_message("git fetch base", result))
+
+    async def _fetch_base_once(self, *, worktree_path: Path, base_branch: str) -> CommandResult:
+        return await self._deps.runner.run(
             [
                 "git",
                 "-C",
                 str(worktree_path),
                 "fetch",
                 "origin",
-                base_branch,
+                f"+refs/heads/{base_branch}:refs/remotes/origin/{base_branch}",
             ]
         )
+
+    async def _repair_orphaned_broken_awf_ref(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        stderr: str,
+    ) -> bool:
+        match = _BROKEN_AWF_REF_RE.search(stderr or "")
+        if match is None:
+            return False
+        broken_workspace_id = match.group(1)
+        broken_ref = f"refs/heads/awf/{broken_workspace_id}"
+        if not await self._can_remove_broken_awf_ref(broken_workspace_id):
+            _log.warning(
+                "monitor.git_mirror_broken_ref_active_workspace",
+                workspace_id=workspace_id,
+                broken_workspace_id=broken_workspace_id,
+                broken_ref=broken_ref,
+            )
+            return False
+        delete_result = await self._deps.runner.run(
+            ["git", "-C", str(worktree_path), "update-ref", "-d", broken_ref]
+        )
+        if not delete_result.ok:
+            _log.warning(
+                "monitor.git_mirror_broken_ref_delete_failed",
+                workspace_id=workspace_id,
+                broken_ref=broken_ref,
+                stderr=(delete_result.stderr or "")[:400],
+            )
+            return False
+        await self._deps.runner.run(["git", "-C", str(worktree_path), "worktree", "prune"])
+        await self._append_workspace_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type="workspace.git_mirror_repaired",
+                    reason_code=_GIT_MIRROR_BROKEN_REF_REMOVED_REASON,
+                    payload={
+                        "broken_ref": broken_ref,
+                        "broken_workspace_id": broken_workspace_id,
+                    },
+                )
+            ],
+        )
+        return True
+
+    async def _can_remove_broken_awf_ref(self, broken_workspace_id: str) -> bool:
+        async with self._deps.session_factory() as session:
+            workspace = await WorkspaceRepository(session).get(broken_workspace_id)
+            if workspace is None:
+                return True
+            return workspace.status in _TERMINAL_WORKSPACE_STATUSES
 
     async def _count_base_behind(self, *, worktree_path: Path, base_branch: str) -> int:
         r = await self._deps.runner.run(
@@ -3424,11 +3603,13 @@ class PullRequestMonitorRunner:
             ]
         )
         if not r.ok:
-            return 0
+            raise BaseBehindCountError(_git_failure_message("git rev-list base behind", r))
         try:
             return int(r.stdout.strip() or "0")
-        except ValueError:
-            return 0
+        except ValueError as exc:
+            raise BaseBehindCountError(
+                f"git rev-list base behind returned non-integer output: {r.stdout[:200]!r}"
+            ) from exc
 
     async def _rev_parse_head(self, worktree_path: Path) -> str:
         r = await self._deps.runner.run(["git", "-C", str(worktree_path), "rev-parse", "HEAD"])
@@ -3566,7 +3747,11 @@ class PullRequestMonitorRunner:
         weaker data than ordinary polling.
         """
         worktree_path = self._worktrees_root / workspace_id
-        await self._fetch_base(worktree_path=worktree_path, base_branch=base_branch)
+        await self._fetch_base(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            base_branch=base_branch,
+        )
         base_behind = await self._count_base_behind(
             worktree_path=worktree_path,
             base_branch=base_branch,
@@ -3705,6 +3890,18 @@ class PullRequestMonitorRunner:
             elapsed = (now_wall - started_dt).total_seconds()
             started_at = now_monotonic - max(elapsed, 0.0)
         threads_addressed = dict(ws.monitor_threads_addressed or {})
+        sync_base_no_progress_signature = threads_addressed.pop(
+            _SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY,
+            None,
+        )
+        sync_base_no_progress_count_raw = threads_addressed.pop(
+            _SYNC_BASE_NO_PROGRESS_COUNT_KEY,
+            "0",
+        )
+        try:
+            sync_base_no_progress_count = int(sync_base_no_progress_count_raw)
+        except (TypeError, ValueError):
+            sync_base_no_progress_count = 0
         if ws.pr_number is not None:
             threads_addressed = _initial_review_grace_state_for_runtime(
                 threads_addressed,
@@ -3722,6 +3919,8 @@ class PullRequestMonitorRunner:
         return MonitorState(
             iter_count=ws.monitor_iter_count,
             last_push_sha=ws.monitor_last_commit_sha,
+            sync_base_no_progress_signature=sync_base_no_progress_signature,
+            sync_base_no_progress_count=sync_base_no_progress_count,
             threads_addressed_ids=threads_addressed,
             started_at=started_at,
         )
@@ -3746,6 +3945,16 @@ class PullRequestMonitorRunner:
                     pr_number=ws.pr_number,
                     now_monotonic=now_monotonic,
                     now_wall_seconds=now_wall.timestamp(),
+                )
+            if (
+                state.sync_base_no_progress_signature is not None
+                and state.sync_base_no_progress_count > 0
+            ):
+                threads_addressed[_SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY] = (
+                    state.sync_base_no_progress_signature
+                )
+                threads_addressed[_SYNC_BASE_NO_PROGRESS_COUNT_KEY] = str(
+                    state.sync_base_no_progress_count
                 )
             ws.monitor_iter_count = state.iter_count
             ws.monitor_threads_addressed = threads_addressed
@@ -4270,6 +4479,14 @@ def _redact_and_truncate_github_error(value: str, *, limit: int = 400) -> str:
     if len(redacted) <= limit:
         return redacted
     return redacted[: limit - 3] + "..."
+
+
+def _git_failure_message(operation: str, result: CommandResult) -> str:
+    detail = result.stderr.strip() or result.stdout.strip() or "<no output>"
+    return redact_audit_text(
+        f"{operation} failed with exit code {result.returncode}: {detail}",
+        limit=2000,
+    )
 
 
 def _is_transient_github_client_error(exc: GitHubClientError) -> bool:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1281,6 +1281,11 @@ class PullRequestMonitorRunner:
                     monitor_log=monitor_log,
                     evidence=push_result.failure_evidence(),
                 )
+                self._record_sync_base_progress(
+                    state=state,
+                    status=status,
+                    push_result=push_result,
+                )
                 state.iter_count += 1
                 return False
             await self._finish_monitor_operation(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1104,7 +1104,7 @@ class PullRequestMonitorRunner:
             )
             await self._terminate_completed(
                 workspace_id,
-                pr_merge_sha=None,
+                pr_merge_sha=status.merge_commit_sha or status.head_sha,
                 repo_url=repo_url,
                 base_branch=base_branch,
                 compose_project=compose_project,
@@ -1730,6 +1730,7 @@ class PullRequestMonitorRunner:
             merge_blocker: GitHubClientError | None = None
             merge_operation: MonitorOperationHandle | None = None
             recheck_error: GitHubClientError | None = None
+            recheck_base_error: BaseFetchError | None = None
             merge_status = status
             queue_blockers_after_lock: list[MergeQueueBlocker] = []
             merge_gate_after_lock: _MergeGateResult | None = None
@@ -1757,6 +1758,8 @@ class PullRequestMonitorRunner:
                         )
                     except GitHubClientError as exc:
                         recheck_error = exc
+                    except BaseFetchError as exc:
+                        recheck_base_error = exc
                     else:
                         checked_action = decide(checked_status, state, self._config)
                         if not isinstance(checked_action, Merge):
@@ -1781,7 +1784,11 @@ class PullRequestMonitorRunner:
                         else:
                             merge_status = checked_status
 
-                if recheck_error is None and fresh_action is None:
+                if (
+                    recheck_error is None
+                    and recheck_base_error is None
+                    and fresh_action is None
+                ):
                     queue_blockers_after_lock = await self._merge_queue_blockers_for_workspace(
                         workspace_id
                     )
@@ -1924,6 +1931,17 @@ class PullRequestMonitorRunner:
                 if handled is None:  # pragma: no cover - defensive invariant
                     raise RuntimeError("merge gate blocker was not handled")
                 return handled
+
+            if recheck_base_error is not None:
+                await self._terminate_failed(
+                    workspace_id,
+                    message=(
+                        f"monitor: could not refresh base branch during pre-merge recheck: "
+                        f"{recheck_base_error}"
+                    )[:2000],
+                    reason_code=_GIT_FETCH_BASE_FAILED_REASON,
+                )
+                return True
 
             if recheck_error is not None:
                 if await self._wait_after_transient_github_error(

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -25,7 +25,7 @@ from awf.db.session import make_engine, make_session_factory
 from awf.node.auth_mounts import ServiceAuthMountResolver
 from awf.node.cleanup import WorkspaceCleaner
 from awf.node.compose_manager import ComposeManager
-from awf.node.git_manager import GitManager
+from awf.node.git_manager import AGENT_RUNTIME_GID, AGENT_RUNTIME_UID, GitManager
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 from awf.node.secret_mounts import LocalSecretLeaseMountResolver
 from awf.node.stack_launcher import ComposeStackLauncher
@@ -48,8 +48,6 @@ from awf.service.target_branch_monitor import (
 )
 
 _log = get_logger(__name__)
-_AGENT_RUNTIME_UID = 1000
-_AGENT_RUNTIME_GID = 1000
 
 
 @dataclass(frozen=True)
@@ -71,8 +69,8 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     git = GitManager(
         work_dir / "git",
         env=git_env,
-        worktree_owner_uid=_AGENT_RUNTIME_UID,
-        worktree_owner_gid=_AGENT_RUNTIME_GID,
+        worktree_owner_uid=AGENT_RUNTIME_UID,
+        worktree_owner_gid=AGENT_RUNTIME_GID,
     )
     compose = ComposeManager(work_dir=work_dir, template_path=template)
     runtime_cleaner = WorkspaceCleaner(git=git, compose=compose)
@@ -121,8 +119,8 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     auth_mount_resolver = ServiceAuthMountResolver(
         host_home=host_home,
         work_dir=work_dir,
-        workspace_owner_uid=_AGENT_RUNTIME_UID,
-        workspace_owner_gid=_AGENT_RUNTIME_GID,
+        workspace_owner_uid=AGENT_RUNTIME_UID,
+        workspace_owner_gid=AGENT_RUNTIME_GID,
     )
     secret_lease_resolver = LocalSecretLeaseMountResolver(
         host_home=host_home,

--- a/tests/integration/runtime/test_pr_monitor_runner.py
+++ b/tests/integration/runtime/test_pr_monitor_runner.py
@@ -110,6 +110,7 @@ def _pr_payload(
     *,
     closed: bool = False,
     merged: bool = False,
+    merge_commit_sha: str = "mergecommit1234567890",
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
@@ -129,6 +130,7 @@ def _pr_payload(
                         "isDraft": False,
                         "closed": closed,
                         "merged": merged,
+                        "mergeCommit": {"oid": merge_commit_sha} if merged else None,
                         "baseRef": {"name": "development", "target": {"oid": "base0"}},
                         "commits": {
                             "nodes": [{"commit": {"statusCheckRollup": {"state": check_state}}}]
@@ -514,7 +516,7 @@ class TestMergeBlockedFallsBackToNotify:
             ws = await WorkspaceRepository(s).get(ws_id)
             assert ws is not None
             assert ws.status == WorkspaceStatus.completed.value
-            assert ws.pr_merge_sha is None
+            assert ws.pr_merge_sha == "mergecommit1234567890"
         # gh pr comment was invoked with the human-attention body.
         comment_args = next(c.args for c in cmd.calls if c.args[:3] == ["gh", "pr", "comment"])
         body = comment_args[comment_args.index("--body") + 1]

--- a/tests/integration/runtime/test_pr_monitor_runner.py
+++ b/tests/integration/runtime/test_pr_monitor_runner.py
@@ -1531,7 +1531,7 @@ class TestAgentRunErrorResilience:
 
 class TestBaseBehindEdges:
     @pytest.mark.unit
-    async def test_rev_list_error_treats_base_as_up_to_date(
+    async def test_rev_list_error_fails_monitor_instead_of_assuming_up_to_date(
         self,
         factory: async_sessionmaker[AsyncSession],
         cmd: FakeCommandRunner,
@@ -1539,14 +1539,10 @@ class TestBaseBehindEdges:
         sleep_fn: RecordedSleep,
         tmp_path: Path,
     ) -> None:
-        """Failed rev-list (e.g. origin/<base> not yet fetched) should not
-        trip the monitor — we just get base_behind=0 and carry on."""
+        """Failed rev-list means AWF cannot trust local base freshness."""
         ws_id = await _seed_monitoring_workspace(factory)
         cmd.queue_result(returncode=0)  # git fetch origin <base>
         cmd.queue_result(returncode=1, stderr="unknown revision")  # base-behind fails
-        cmd.queue_result(returncode=0, stdout=_pr_payload())  # PR green
-        cmd.queue_result(returncode=0)  # merge
-        cmd.queue_result(returncode=0, stdout="M\n")
         runner = _make_runner(
             factory=factory,
             cmd=cmd,
@@ -1562,10 +1558,12 @@ class TestBaseBehindEdges:
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             assert ws is not None
-            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_message is not None
+            assert "unknown revision" in ws.failure_message
 
     @pytest.mark.unit
-    async def test_rev_list_garbage_output_treats_base_as_up_to_date(
+    async def test_rev_list_garbage_output_fails_monitor_instead_of_assuming_zero(
         self,
         factory: async_sessionmaker[AsyncSession],
         cmd: FakeCommandRunner,
@@ -1576,9 +1574,6 @@ class TestBaseBehindEdges:
         ws_id = await _seed_monitoring_workspace(factory)
         cmd.queue_result(returncode=0)  # git fetch origin <base>
         cmd.queue_result(returncode=0, stdout="not-a-number\n")  # garbage
-        cmd.queue_result(returncode=0, stdout=_pr_payload())
-        cmd.queue_result(returncode=0)
-        cmd.queue_result(returncode=0, stdout="M\n")
         runner = _make_runner(
             factory=factory,
             cmd=cmd,
@@ -1594,7 +1589,9 @@ class TestBaseBehindEdges:
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             assert ws is not None
-            assert ws.status == WorkspaceStatus.completed.value
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_message is not None
+            assert "not-a-number" in ws.failure_message
 
 
 class TestResumePreservesMonitorStartedAt:

--- a/tests/integration/test_alembic_postgres.py
+++ b/tests/integration/test_alembic_postgres.py
@@ -1,8 +1,8 @@
 """Integration test: Alembic migrations apply cleanly against real Postgres.
 
-Runs against ``AWF_DATABASE_URL`` (expected to point at a live Postgres instance
-in CI). Skipped locally if no Postgres URL is configured, so developers don't
-need to run ``docker compose up postgres`` just to run the test suite.
+Runs against the live Postgres server configured by ``AWF_TEST_DATABASE_URL`` or
+``AWF_DATABASE_URL``. The test creates a temporary database on that server so
+the migration round-trip never downgrades the operator's real AWF database.
 
 What this covers:
 - asyncpg driver + ``async_engine_from_config`` path in migrations/env.py
@@ -13,30 +13,77 @@ What this covers:
 
 from __future__ import annotations
 
+import asyncio
 import os
 import subprocess
+import uuid
 from pathlib import Path
 
+import asyncpg
 import pytest
+from sqlalchemy.engine import URL, make_url
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
-def _database_url() -> str | None:
-    url = os.environ.get("AWF_DATABASE_URL")
-    if url and url.startswith("postgresql"):
-        return url
-    return None
+def _postgres_database_url() -> URL:
+    raw_url = os.environ.get("AWF_TEST_DATABASE_URL") or os.environ.get("AWF_DATABASE_URL")
+    if not raw_url:
+        pytest.fail(
+            "AWF_TEST_DATABASE_URL or AWF_DATABASE_URL must point at a live PostgreSQL "
+            "server for the full integration suite."
+        )
+    url = make_url(raw_url)
+    if url.get_backend_name() != "postgresql":
+        pytest.fail(
+            "AWF_TEST_DATABASE_URL/AWF_DATABASE_URL must use a PostgreSQL backend for "
+            "the full integration suite."
+        )
+    return url
+
+
+def _asyncpg_url(url: URL) -> str:
+    return url.set(drivername="postgresql").render_as_string(hide_password=False)
+
+
+def _maintenance_database_url(url: URL) -> URL:
+    return url.set(database="postgres")
+
+
+async def _create_database(maintenance_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(dsn=_asyncpg_url(maintenance_url))
+    try:
+        await conn.execute(f'CREATE DATABASE "{database_name}"')
+    finally:
+        await conn.close()
+
+
+async def _drop_database(maintenance_url: URL, database_name: str) -> None:
+    conn = await asyncpg.connect(dsn=_asyncpg_url(maintenance_url))
+    try:
+        await conn.execute(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = $1 AND pid <> pg_backend_pid()
+            """,
+            database_name,
+        )
+        await conn.execute(f'DROP DATABASE IF EXISTS "{database_name}"')
+    finally:
+        await conn.close()
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(
-    _database_url() is None,
-    reason="AWF_DATABASE_URL not set to a postgres URL (CI-only by default)",
-)
 def test_alembic_upgrade_downgrade_upgrade_on_postgres() -> None:
     """Apply → revert → re-apply the full migration chain against live Postgres."""
-    env = {**os.environ}
+    configured_url = _postgres_database_url()
+    maintenance_url = _maintenance_database_url(configured_url)
+    database_name = f"awf_test_alembic_{os.getpid()}_{uuid.uuid4().hex[:8]}"
+    database_url = configured_url.set(database=database_name)
+    asyncio.run(_create_database(maintenance_url, database_name))
+
+    env = {**os.environ, "AWF_DATABASE_URL": database_url.render_as_string(hide_password=False)}
     cwd = str(_REPO_ROOT)
 
     def _alembic(*args: str) -> subprocess.CompletedProcess[str]:
@@ -49,13 +96,15 @@ def test_alembic_upgrade_downgrade_upgrade_on_postgres() -> None:
             text=True,
         )
 
-    # Start from a known-clean state — if CI re-runs on the same DB, make sure
-    # prior state doesn't leak in.
-    _alembic("downgrade", "base")
+    try:
+        # Start from a known-clean state.
+        _alembic("downgrade", "base")
 
-    # Full chain up.
-    _alembic("upgrade", "head")
-    # Full chain back down.
-    _alembic("downgrade", "base")
-    # And up again — proves the down migrations are correct inverses.
-    _alembic("upgrade", "head")
+        # Full chain up.
+        _alembic("upgrade", "head")
+        # Full chain back down.
+        _alembic("downgrade", "base")
+        # And up again — proves the down migrations are correct inverses.
+        _alembic("upgrade", "head")
+    finally:
+        asyncio.run(_drop_database(maintenance_url, database_name))

--- a/tests/unit/api/test_route_error_edges.py
+++ b/tests/unit/api/test_route_error_edges.py
@@ -1,0 +1,242 @@
+"""Focused API route error-edge tests."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+import awf.api.routes.artifacts as artifact_routes
+import awf.api.routes.validation as validation_routes
+import awf.api.routes.workspaces as workspace_routes
+from awf.api.schemas import WorkspaceCreateV2Request
+from awf.db.repositories import TaskExternalIdConflictError
+from awf.service.bounded_list import InvalidBoundedListCursorError
+from awf.service.disk import DiskCheck
+
+
+def _admission_ok_disk_check() -> DiskCheck:
+    return DiskCheck(
+        path="/tmp",
+        checked_path="/tmp",
+        total_bytes=100,
+        used_bytes=1,
+        free_bytes=99,
+        percent_free=99.0,
+        threshold_bytes=1,
+        ok=True,
+        status="ok",
+        reason="SUFFICIENT_DISK",
+    )
+
+
+@pytest.mark.unit
+async def test_artifact_list_route_reports_invalid_cursor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        artifact_routes,
+        "list_workspace_artifacts_metadata",
+        AsyncMock(side_effect=InvalidBoundedListCursorError("bad cursor")),
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await artifact_routes.list_workspace_artifacts(
+            "ws_artifacts",
+            cursor="bad",
+            session=object(),  # type: ignore[arg-type]
+        )
+
+    assert exc_info.value.status_code == 400
+    assert exc_info.value.detail["error_code"] == "INVALID_CURSOR"
+
+
+@pytest.mark.unit
+async def test_validation_provenance_route_reports_invalid_cursor_and_missing_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    list_mock = AsyncMock(side_effect=InvalidBoundedListCursorError("bad cursor"))
+    monkeypatch.setattr(validation_routes, "list_validation_provenance_response", list_mock)
+
+    with pytest.raises(HTTPException) as invalid_cursor:
+        await validation_routes.list_validation_provenance(
+            "ws_validation",
+            cursor="bad",
+            session=object(),  # type: ignore[arg-type]
+        )
+    assert invalid_cursor.value.status_code == 400
+    assert invalid_cursor.value.detail["error_code"] == "INVALID_CURSOR"
+
+    list_mock.side_effect = None
+    list_mock.return_value = None
+    with pytest.raises(HTTPException) as missing_workspace:
+        await validation_routes.list_validation_provenance(
+            "ws_missing",
+            session=object(),  # type: ignore[arg-type]
+        )
+    assert missing_workspace.value.status_code == 404
+    assert missing_workspace.value.detail["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_workspace_stale_reason_route_reports_cursor_and_missing_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    list_mock = AsyncMock(side_effect=InvalidBoundedListCursorError("bad cursor"))
+    monkeypatch.setattr(workspace_routes, "list_workspace_stale_reasons_response", list_mock)
+
+    with pytest.raises(HTTPException) as invalid_cursor:
+        await workspace_routes.list_workspace_stale_reasons(
+            "ws_stale",
+            cursor="bad",
+            session=object(),  # type: ignore[arg-type]
+        )
+    assert invalid_cursor.value.status_code == 400
+    assert invalid_cursor.value.detail["error_code"] == "INVALID_CURSOR"
+
+    list_mock.side_effect = None
+    list_mock.return_value = None
+    with pytest.raises(HTTPException) as missing_workspace:
+        await workspace_routes.list_workspace_stale_reasons(
+            "ws_missing",
+            session=object(),  # type: ignore[arg-type]
+        )
+    assert missing_workspace.value.status_code == 404
+    assert missing_workspace.value.detail["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_workspace_secret_leases_route_reports_missing_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Repository:
+        def __init__(self, _session: object) -> None:
+            return None
+
+        async def exists(self, workspace_id: str) -> bool:
+            assert workspace_id == "ws_missing"
+            return False
+
+    monkeypatch.setattr(workspace_routes, "WorkspaceRepository", _Repository)
+
+    with pytest.raises(HTTPException) as missing_workspace:
+        await workspace_routes.get_workspace_secret_leases(
+            "ws_missing",
+            session=object(),  # type: ignore[arg-type]
+        )
+
+    assert missing_workspace.value.status_code == 404
+    assert missing_workspace.value.detail["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_workspace_v2_create_reports_task_external_id_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = WorkspaceCreateV2Request(
+        repo={"url": "https://github.com/example/repo.git", "base_branch": "main"},
+        task={"title": "conflict", "prompt": "implement it", "external_id": "task-123"},
+    )
+
+    async def raise_conflict(*_args: object, **_kwargs: object) -> object:
+        raise TaskExternalIdConflictError("task-123")
+
+    class _Repository:
+        def __init__(self, _session: object) -> None:
+            return None
+
+        async def get_by_idempotency_key(self, _key: str) -> object | None:
+            return None
+
+    monkeypatch.setattr(workspace_routes, "WorkspaceRepository", _Repository)
+    monkeypatch.setattr(workspace_routes, "create_workspace_v2_row", raise_conflict)
+    monkeypatch.setattr(
+        workspace_routes,
+        "_workspace_admission_disk_check",
+        AsyncMock(return_value=_admission_ok_disk_check()),
+    )
+
+    response = await workspace_routes.create_workspace_v2(
+        payload,
+        request=SimpleNamespace(),  # type: ignore[arg-type]
+        settings=SimpleNamespace(),  # type: ignore[arg-type]
+        session=object(),  # type: ignore[arg-type]
+    )
+
+    assert response.status_code == 409
+    body = json.loads(response.body)
+    assert body["error_code"] == "TASK_EXTERNAL_ID_CONFLICT"
+    assert body["detail"] == {"external_id": "task-123"}
+
+
+@pytest.mark.unit
+def test_workspace_override_reason_matching_uses_redacted_parts_as_wildcards() -> None:
+    assert not workspace_routes._override_reasons_match(  # noqa: SLF001
+        "operator checked <redacted> manually",
+        None,
+        stored_redaction_parts=["operator checked ", " manually"],
+    )
+    assert workspace_routes._override_reasons_match(  # noqa: SLF001
+        "operator checked <redacted> manually",
+        "operator checked rotated-token-value manually",
+        stored_redaction_parts=["operator checked ", " manually"],
+    )
+    assert not workspace_routes._override_reasons_match(  # noqa: SLF001
+        "operator checked <redacted> manually",
+        "operator checked rotated-token-value manually",
+        stored_redaction_parts=["stale prefix ", " manually"],
+    )
+    assert not workspace_routes._override_reasons_match(  # noqa: SLF001
+        "operator checked <redacted> manually",
+        "operator checked rotated-token-value manually",
+        stored_redaction_parts=None,
+    )
+
+
+@pytest.mark.unit
+def test_workspace_stored_provider_readiness_override_handles_sparse_snapshots() -> None:
+    no_preflight = SimpleNamespace(task_policy={})
+    legacy_override = SimpleNamespace(
+        task_policy={
+            "provider_readiness_preflight": {
+                "override_used": True,
+                "override_reason": 42,
+            }
+        }
+    )
+    redacted_override = SimpleNamespace(
+        task_policy={
+            "provider_readiness_preflight": {
+                "override_requested": True,
+                "override_reason": "operator checked <redacted>",
+                "override_reason_redaction_parts": ["operator checked ", ""],
+            }
+        }
+    )
+    malformed_parts = SimpleNamespace(
+        task_policy={
+            "provider_readiness_preflight": {
+                "override_requested": True,
+                "override_reason_redaction_parts": ["only-one-part"],
+            }
+        }
+    )
+
+    assert workspace_routes._stored_task_provider_readiness_override(  # noqa: SLF001
+        no_preflight  # type: ignore[arg-type]
+    ) == (False, None)
+    assert workspace_routes._stored_task_provider_readiness_override_redaction_parts(  # noqa: SLF001
+        no_preflight  # type: ignore[arg-type]
+    ) is None
+    assert workspace_routes._stored_task_provider_readiness_override(  # noqa: SLF001
+        legacy_override  # type: ignore[arg-type]
+    ) == (True, None)
+    assert workspace_routes._stored_task_provider_readiness_override_redaction_parts(  # noqa: SLF001
+        redacted_override  # type: ignore[arg-type]
+    ) == ["operator checked ", ""]
+    assert workspace_routes._stored_task_provider_readiness_override_redaction_parts(  # noqa: SLF001
+        malformed_parts  # type: ignore[arg-type]
+    ) is None

--- a/tests/unit/common/test_common_polish.py
+++ b/tests/unit/common/test_common_polish.py
@@ -106,6 +106,16 @@ class TestSettings:
         assert s.service_name == "awf"
         assert s.env == "local"
 
+    @pytest.mark.unit
+    def test_empty_network_posture_cutoff_is_unset(self) -> None:
+        settings = Settings(
+            _env_file=None,
+            database_url="postgresql+asyncpg://awf:awf_dev@localhost:5433/awf",
+            network_posture_open_legacy_cutoff="",
+        )
+
+        assert settings.network_posture_open_legacy_cutoff is None
+
 
 class TestRedaction:
     @pytest.mark.unit

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -57,6 +57,7 @@ def _sample_pr_payload(
     head_sha: str = "abc123",
     closed: bool = False,
     merged: bool = False,
+    merge_commit_sha: str = "mergecommit1234567890",
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
@@ -82,6 +83,7 @@ def _sample_pr_payload(
                         "isDraft": False,
                         "closed": closed,
                         "merged": merged,
+                        "mergeCommit": {"oid": merge_commit_sha} if merged else None,
                         "baseRef": {"name": "development", "target": {"oid": "base0"}},
                         "commits": {
                             "nodes": [
@@ -846,6 +848,7 @@ class TestFetchPrStatus:
         )
         assert status.closed is True
         assert status.merged is True
+        assert status.merge_commit_sha == "mergecommit1234567890"
 
     @pytest.mark.unit
     async def test_graphql_argv_shape(self) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -1823,6 +1823,46 @@ async def test_recover_missing_git_head_or_mark_failed_handles_terminal_paths(
 
 
 @pytest.mark.unit
+async def test_recover_missing_git_head_or_mark_failed_fails_when_event_recording_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+    recovery = _GitObjectRecoveryResult(
+        broken_head_sha="b" * 40,
+        recovered_head_sha="c" * 40,
+    )
+    monkeypatch.setattr(
+        executor_mod,
+        "_recover_missing_head_from_filesystem",
+        AsyncMock(return_value=recovery),
+    )
+    executor._record_git_object_recovery_event = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("database unavailable")
+    )
+
+    recovered = await executor._recover_missing_git_head_or_mark_failed(
+        workspace_id="ws_recovery_event_failed",
+        worktree_path=tmp_path,
+        base_commit="a" * 40,
+        branch_name="awf/ws_recovery_event_failed",
+        from_status=WorkspaceStatus.running,
+        stage="post_agent_commit",
+        error=RuntimeError("fatal: bad object HEAD"),
+    )
+
+    assert not recovered
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["workspace_id"] == "ws_recovery_event_failed"
+    assert kwargs["failure_reason"] == FailureReason.infrastructure_failure
+    assert kwargs["reason_code"] == GIT_OBJECT_MISSING_REASON_CODE
+    assert "could not record the recovery event" in kwargs["message"]
+    assert "database unavailable" in kwargs["message"]
+
+
+@pytest.mark.unit
 async def test_record_git_object_recovery_event_persists_workspace_event(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -832,6 +832,7 @@ async def test_final_coverage_gate_reuses_exact_fresh_evidence(
     assert result.evidence_status == "reused"
     assert result.source_run_id == source_run_id
     assert validation.calls == []
+    await engine.dispose()
 
 
 @pytest.mark.unit
@@ -1661,6 +1662,18 @@ def test_read_ref_sha_returns_none_for_missing_ref(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_read_ref_sha_reads_packed_ref_when_loose_ref_is_missing(tmp_path: Path) -> None:
+    sha = "a" * 40
+    (tmp_path / "packed-refs").write_text(
+        "# pack-refs with: peeled fully-peeled sorted\n"
+        f"{sha} refs/heads/awf/ws_packed\n",
+        encoding="utf-8",
+    )
+
+    assert _read_ref_sha(tmp_path, "refs/heads/awf/ws_packed") == sha
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("queued", "expected_call_count"),
     [
@@ -1682,7 +1695,7 @@ def test_read_ref_sha_returns_none_for_missing_ref(tmp_path: Path) -> None:
                 (0, "", ""),
                 (1, "", ""),
                 (0, "", ""),
-                (1, "", "status failed"),
+                (1, "", "head failed"),
             ],
             7,
         ),
@@ -1695,22 +1708,8 @@ def test_read_ref_sha_returns_none_for_missing_ref(tmp_path: Path) -> None:
                 (1, "", ""),
                 (0, "", ""),
                 (0, "", ""),
-                (1, "", "head failed"),
             ],
-            8,
-        ),
-        (
-            [
-                (0, "", ""),
-                (0, "", ""),
-                (0, "", ""),
-                (0, "", ""),
-                (1, "", ""),
-                (0, "", ""),
-                (0, "", ""),
-                (0, "", ""),
-            ],
-            8,
+            7,
         ),
     ],
 )

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -1539,13 +1539,9 @@ async def test_agent_git_writability_preflight_runs_inside_agent_container(
     assert runner.calls
     call = runner.calls[0]
     assert call.input_bytes == b""
-    assert call.args[:5] == [
-        "docker",
-        "compose",
-        "--project-name",
-        "awf_ws_preflight",
-        "--file",
-    ]
+    assert call.args[:2] == ["docker", "compose"]
+    assert call.args[call.args.index("-p") + 1] == "awf_ws_preflight"
+    assert call.args[call.args.index("-f") + 1] == str(compose_file)
     assert "agent_git_writability_preflight" not in " ".join(call.args[:10])
     assert "git hash-object -w --stdin" in " ".join(call.args)
 

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -14,6 +14,8 @@ import awf.control.executor as executor_mod
 from awf.adapters.base import AgentDefaults
 from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
 from awf.control.executor import (
+    GIT_OBJECT_MISSING_RECOVERED_REASON_CODE,
+    PLAN_ONLY_OUTPUT_REASON_CODE,
     ExecutorConfig,
     WorkspaceExecutor,
     _agent_defaults_for_workspace,
@@ -1871,6 +1873,126 @@ async def test_record_git_object_recovery_event_persists_workspace_event(
     assert len(recovery_events) == 1
     assert recovery_events[0].reason_code == "GIT_OBJECT_MISSING_RECOVERED"
     assert recovery_events[0].payload["stage"] == "agent_run"
+
+
+@pytest.mark.unit
+async def test_verify_recovered_post_agent_commit_rejects_protected_paths(
+    tmp_path: Path,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path(".awf/workspace.yml")}
+    )
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._verify_recovered_post_agent_commit(
+        workspace_id="ws_recovered_policy",
+        worktree_path=tmp_path / "worktree",
+        base_commit="a" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["failure_reason"] == FailureReason.policy_failure
+    assert kwargs["reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+
+
+@pytest.mark.unit
+async def test_verify_recovered_post_agent_commit_rejects_empty_recovery(
+    tmp_path: Path,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._committed_paths_since = AsyncMock(return_value=set())  # type: ignore[method-assign]
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._verify_recovered_post_agent_commit(
+        workspace_id="ws_recovered_empty",
+        worktree_path=tmp_path / "worktree",
+        base_commit="d" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["failure_reason"] == FailureReason.agent_failure
+    assert kwargs["reason_code"] == GIT_OBJECT_MISSING_RECOVERED_REASON_CODE
+    assert kwargs["details"] == {"recovered_stage": "post_agent_commit"}
+
+
+@pytest.mark.unit
+async def test_verify_recovered_post_agent_commit_rejects_plan_only_recovery(
+    tmp_path: Path,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("docs/awf-plans/ws_plan_only.md")}
+    )
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._verify_recovered_post_agent_commit(
+        workspace_id="ws_recovered_plan_only",
+        worktree_path=tmp_path / "worktree",
+        base_commit="e" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["failure_reason"] == FailureReason.agent_failure
+    assert kwargs["reason_code"] == PLAN_ONLY_OUTPUT_REASON_CODE
+
+
+@pytest.mark.unit
+async def test_verify_recovered_post_agent_commit_rejects_orphaned_history(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=1, stderr="not an ancestor")
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("src/app.py")}
+    )
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._verify_recovered_post_agent_commit(
+        workspace_id="ws_recovered_orphan",
+        worktree_path=tmp_path / "worktree",
+        base_commit="b" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["failure_reason"] == FailureReason.agent_failure
+    assert "does not descend from base commit" in kwargs["message"]
+
+
+@pytest.mark.unit
+async def test_verify_recovered_post_agent_commit_accepts_policy_clean_commit(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0)
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("src/app.py")}
+    )
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert await executor._verify_recovered_post_agent_commit(
+        workspace_id="ws_recovered_clean",
+        worktree_path=tmp_path / "worktree",
+        base_commit="c" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -1859,6 +1859,41 @@ async def test_recover_missing_git_head_or_mark_failed_fails_when_event_recordin
 
 
 @pytest.mark.unit
+async def test_recover_missing_git_head_or_mark_failed_fails_when_filesystem_recovery_raises(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+    executor._record_git_object_recovery_event = AsyncMock()  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        executor_mod,
+        "_recover_missing_head_from_filesystem",
+        AsyncMock(side_effect=RuntimeError("repair exploded")),
+    )
+
+    recovered = await executor._recover_missing_git_head_or_mark_failed(
+        workspace_id="ws_recovery_raised",
+        worktree_path=tmp_path,
+        base_commit="a" * 40,
+        branch_name="awf/ws_recovery_raised",
+        from_status=WorkspaceStatus.running,
+        stage="agent_run",
+        error=RuntimeError("fatal: bad object HEAD"),
+    )
+
+    assert not recovered
+    executor._record_git_object_recovery_event.assert_not_awaited()  # type: ignore[attr-defined]
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["workspace_id"] == "ws_recovery_raised"
+    assert kwargs["failure_reason"] == FailureReason.infrastructure_failure
+    assert kwargs["reason_code"] == GIT_OBJECT_MISSING_REASON_CODE
+    assert "could not run filesystem recovery" in kwargs["message"]
+    assert "repair exploded" in kwargs["message"]
+
+
+@pytest.mark.unit
 async def test_record_git_object_recovery_event_persists_workspace_event(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -14,6 +14,7 @@ import awf.control.executor as executor_mod
 from awf.adapters.base import AgentDefaults
 from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
 from awf.control.executor import (
+    GIT_OBJECT_MISSING_REASON_CODE,
     GIT_OBJECT_MISSING_RECOVERED_REASON_CODE,
     PLAN_ONLY_OUTPUT_REASON_CODE,
     ExecutorConfig,
@@ -1993,6 +1994,32 @@ async def test_verify_recovered_post_agent_commit_accepts_policy_clean_commit(
     )
 
     executor._mark_failed.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
+async def test_recovered_post_agent_commit_verification_exceptions_mark_failed(
+    tmp_path: Path,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._verify_recovered_post_agent_commit = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("git diff failed")
+    )
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._verify_recovered_post_agent_commit_or_mark_failed(
+        workspace_id="ws_recovered_verify_error",
+        worktree_path=tmp_path / "worktree",
+        base_commit="f" * 40,
+        owned_paths=[],
+        expected_status=WorkspaceStatus.running,
+    )
+
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["from_status"] == WorkspaceStatus.running
+    assert kwargs["failure_reason"] == FailureReason.infrastructure_failure
+    assert kwargs["reason_code"] == GIT_OBJECT_MISSING_REASON_CODE
+    assert "git diff failed" in kwargs["message"]
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -10,11 +12,12 @@ import pytest
 
 import awf.control.executor as executor_mod
 from awf.adapters.base import AgentDefaults
-from awf.common.commands import FakeCommandRunner
+from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
 from awf.control.executor import (
     ExecutorConfig,
     WorkspaceExecutor,
     _agent_defaults_for_workspace,
+    _agent_git_writability_preflight_script,
     _agent_model_for_workspace,
     _agent_pr_identity,
     _apply_baseline_coverage_ratchet,
@@ -26,11 +29,15 @@ from awf.control.executor import (
     _failure_salvage_payload,
     _format_failing_test_evidence,
     _get_active_recovery_payload,
+    _git_error_indicates_missing_head_object,
+    _GitObjectRecoveryResult,
     _MonitorRebaseRecoveryError,
     _profile_with_planning_iteration_default,
     _raw_profile_has_explicit_planning_max_iterations,
+    _read_ref_sha,
     _read_text_if_present,
     _RebaseRecoveryResult,
+    _recover_missing_head_from_filesystem,
     _validate_only_recovery_needs_existing_pr_push,
     _validation_command_count,
     _validation_failure_message,
@@ -47,6 +54,7 @@ from awf.db.repositories import (
     TaskAttemptRepository,
     TaskRepository,
     ValidationRunRepository,
+    WorkspaceEventRepository,
     WorkspaceRepository,
 )
 from awf.db.session import make_engine, make_session_factory
@@ -1484,6 +1492,478 @@ async def test_changed_paths_raises_when_git_status_fails(tmp_path: Path) -> Non
 
     with pytest.raises(RuntimeError, match="git status failed"):
         await executor._changed_paths(tmp_path / "worktree")
+
+
+@pytest.mark.unit
+def test_git_error_indicates_missing_head_object() -> None:
+    assert _git_error_indicates_missing_head_object("fatal: bad object HEAD\n")
+    assert _git_error_indicates_missing_head_object("fatal: not a valid object name HEAD\n")
+    assert not _git_error_indicates_missing_head_object("fatal: not a git repository\n")
+
+
+@pytest.mark.unit
+def test_agent_git_writability_preflight_script_exercises_object_and_ref_writes() -> None:
+    script = _agent_git_writability_preflight_script("ws_preflight")
+
+    assert "git status --porcelain" in script
+    assert "git hash-object -w --stdin" in script
+    assert "git cat-file -e \"$blob^{blob}\"" in script
+    assert "git update-ref \"$ref\" HEAD" in script
+    assert "git update-ref -d \"$ref\"" in script
+
+
+@pytest.mark.unit
+async def test_agent_git_writability_preflight_runs_inside_agent_container(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    executor = _executor_with_runner(runner, tmp_path)
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+    (worktree_path / ".git").write_text("gitdir: /tmp/mirror/worktrees/ws_preflight\n")
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    ok = await executor._run_agent_git_writability_preflight(
+        workspace_id="ws_preflight",
+        compose_project="awf_ws_preflight",
+        compose_file=compose_file,
+        worktree_path=worktree_path,
+    )
+
+    assert ok is True
+    assert runner.calls
+    call = runner.calls[0]
+    assert call.input_bytes == b""
+    assert call.args[:5] == [
+        "docker",
+        "compose",
+        "--project-name",
+        "awf_ws_preflight",
+        "--file",
+    ]
+    assert "agent_git_writability_preflight" not in " ".join(call.args[:10])
+    assert "git hash-object -w --stdin" in " ".join(call.args)
+
+
+@pytest.mark.unit
+async def test_agent_git_writability_preflight_skips_non_provisioned_fakes(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    executor = _executor_with_runner(runner, tmp_path)
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+
+    assert await executor._run_agent_git_writability_preflight(
+        workspace_id="ws_no_git",
+        compose_project="awf_ws_no_git",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+    )
+
+    (worktree_path / ".git").write_text("gitdir: /tmp/mirror/worktrees/ws_no_git\n")
+    assert await executor._run_agent_git_writability_preflight(
+        workspace_id="ws_no_compose",
+        compose_project="awf_ws_no_compose",
+        compose_file=tmp_path / "missing-compose.yml",
+        worktree_path=worktree_path,
+    )
+    assert runner.calls == []
+
+
+@pytest.mark.unit
+async def test_agent_git_writability_preflight_fails_when_repair_fails(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    executor = _executor_with_runner(runner, tmp_path)
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+    (worktree_path / ".git").write_text("gitdir: /tmp/mirror/worktrees/ws_repair_fail\n")
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+    executor._repair_agent_git_ownership = AsyncMock(return_value=False)  # type: ignore[method-assign]
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+
+    ok = await executor._run_agent_git_writability_preflight(
+        workspace_id="ws_repair_fail",
+        compose_project="awf_ws_repair_fail",
+        compose_file=compose_file,
+        worktree_path=worktree_path,
+    )
+
+    assert ok is False
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    assert runner.calls == []
+
+
+@pytest.mark.unit
+async def test_agent_git_writability_preflight_records_container_failure(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=128, stderr="fatal: cannot write object")
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+    worktree_path = tmp_path / "worktree"
+    worktree_path.mkdir()
+    (worktree_path / ".git").write_text("gitdir: /tmp/mirror/worktrees/ws_git_fail\n")
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text("services: {}\n", encoding="utf-8")
+
+    ok = await executor._run_agent_git_writability_preflight(
+        workspace_id="ws_git_fail",
+        compose_project="awf_ws_git_fail",
+        compose_file=compose_file,
+        worktree_path=worktree_path,
+    )
+
+    assert ok is False
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+    kwargs = executor._mark_failed.await_args.kwargs  # type: ignore[attr-defined]
+    assert kwargs["reason_code"] == "GIT_AGENT_WRITABILITY_FAILED"
+    assert kwargs["details"]["stderr"] == "fatal: cannot write object"
+
+
+@pytest.mark.unit
+async def test_repair_agent_git_ownership_reports_repair_exceptions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+
+    def _raise(*_args: object, **_kwargs: object) -> None:
+        raise PermissionError("cannot repair")
+
+    monkeypatch.setattr(executor_mod, "repair_agent_writable_worktree", _raise)
+
+    assert not await executor._repair_agent_git_ownership(
+        workspace_id="ws_repair_exception",
+        worktree_path=tmp_path / "worktree",
+        reason="test",
+    )
+
+
+def _fake_linked_worktree(tmp_path: Path) -> tuple[Path, Path]:
+    mirror = tmp_path / "mirror.git"
+    linked_git_dir = mirror / "worktrees" / "ws_missing_head"
+    linked_git_dir.mkdir(parents=True)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {linked_git_dir}\n", encoding="utf-8")
+    return mirror, worktree
+
+
+@pytest.mark.unit
+def test_read_ref_sha_returns_none_for_missing_ref(tmp_path: Path) -> None:
+    assert _read_ref_sha(tmp_path, "refs/heads/missing") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("queued", "expected_call_count"),
+    [
+        ([(1, "", "base missing")], 1),
+        ([(0, "", ""), (1, "", "update failed")], 2),
+        ([(0, "", ""), (0, "", ""), (1, "", "reset failed")], 3),
+        ([(0, "", ""), (0, "", ""), (0, "", ""), (1, "", "add failed")], 4),
+        ([(0, "", ""), (0, "", ""), (0, "", ""), (0, "", ""), (0, "", "")], 5),
+        ([(0, "", ""), (0, "", ""), (0, "", ""), (0, "", ""), (2, "", "diff failed")], 5),
+        (
+            [(0, "", ""), (0, "", ""), (0, "", ""), (0, "", ""), (1, "", ""), (1, "", "commit failed")],
+            6,
+        ),
+        (
+            [
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (1, "", ""),
+                (0, "", ""),
+                (1, "", "status failed"),
+            ],
+            7,
+        ),
+        (
+            [
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (1, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (1, "", "head failed"),
+            ],
+            8,
+        ),
+        (
+            [
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (1, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+                (0, "", ""),
+            ],
+            8,
+        ),
+    ],
+)
+async def test_missing_head_recovery_returns_none_for_each_unrecoverable_step(
+    tmp_path: Path,
+    queued: list[tuple[int, str, str]],
+    expected_call_count: int,
+) -> None:
+    _mirror, worktree = _fake_linked_worktree(tmp_path)
+    runner = FakeCommandRunner()
+    for returncode, stdout, stderr in queued:
+        runner.queue_result(returncode=returncode, stdout=stdout, stderr=stderr)
+
+    result = await _recover_missing_head_from_filesystem(
+        runner=runner,
+        workspace_id="ws_missing_head",
+        worktree_path=worktree,
+        base_commit="a" * 40,
+        branch_name="awf/ws_missing_head",
+    )
+
+    assert result is None
+    assert len(runner.calls) == expected_call_count
+
+
+@pytest.mark.unit
+async def test_missing_head_recovery_returns_none_without_linked_git_dir(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    result = await _recover_missing_head_from_filesystem(
+        runner=runner,
+        workspace_id="ws_missing_head",
+        worktree_path=worktree,
+        base_commit="a" * 40,
+        branch_name="awf/ws_missing_head",
+    )
+
+    assert result is None
+    assert runner.calls == []
+
+
+@pytest.mark.unit
+async def test_recover_missing_git_head_or_mark_failed_handles_terminal_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    executor._mark_failed = AsyncMock()  # type: ignore[method-assign]
+    executor._record_git_object_recovery_event = AsyncMock()  # type: ignore[method-assign]
+
+    assert not await executor._recover_missing_git_head_or_mark_failed(
+        workspace_id="ws_no_base",
+        worktree_path=tmp_path,
+        base_commit=None,
+        branch_name="awf/ws_no_base",
+        from_status=WorkspaceStatus.running,
+        stage="agent_run",
+        error=RuntimeError("fatal: bad object HEAD"),
+    )
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+
+    executor._mark_failed.reset_mock()  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        executor_mod,
+        "_recover_missing_head_from_filesystem",
+        AsyncMock(return_value=None),
+    )
+    assert not await executor._recover_missing_git_head_or_mark_failed(
+        workspace_id="ws_unrecoverable",
+        worktree_path=tmp_path,
+        base_commit="a" * 40,
+        branch_name="awf/ws_unrecoverable",
+        from_status=WorkspaceStatus.running,
+        stage="post_agent_commit",
+        error=RuntimeError("fatal: bad object HEAD"),
+    )
+    executor._mark_failed.assert_awaited_once()  # type: ignore[attr-defined]
+
+    executor._mark_failed.reset_mock()  # type: ignore[attr-defined]
+    recovery = _GitObjectRecoveryResult(
+        broken_head_sha="b" * 40,
+        recovered_head_sha="c" * 40,
+    )
+    monkeypatch.setattr(
+        executor_mod,
+        "_recover_missing_head_from_filesystem",
+        AsyncMock(return_value=recovery),
+    )
+    assert await executor._recover_missing_git_head_or_mark_failed(
+        workspace_id="ws_recovered",
+        worktree_path=tmp_path,
+        base_commit="a" * 40,
+        branch_name="awf/ws_recovered",
+        from_status=WorkspaceStatus.running,
+        stage="post_agent_commit",
+        error=RuntimeError("fatal: bad object HEAD"),
+    )
+    executor._mark_failed.assert_not_awaited()  # type: ignore[attr-defined]
+    executor._record_git_object_recovery_event.assert_awaited_once_with(  # type: ignore[attr-defined]
+        workspace_id="ws_recovered",
+        stage="post_agent_commit",
+        recovery=recovery,
+    )
+
+
+@pytest.mark.unit
+async def test_record_git_object_recovery_event_persists_workspace_event(
+    tmp_path: Path,
+) -> None:
+    engine = make_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.create(
+            repo_url="git@github.com:x/y.git",
+            branch_base="development",
+            task_title="recover",
+            task_prompt="recover",
+            agent="codex",
+            test_commands=[],
+            requires_database=False,
+        )
+        await session.commit()
+        workspace_id = ws.id
+
+    executor = WorkspaceExecutor(
+        session_factory=factory,
+        runner=FakeCommandRunner(),
+        compose=object(),  # type: ignore[arg-type]
+        validation=object(),  # type: ignore[arg-type]
+        pr_creator=object(),  # type: ignore[arg-type]
+        config=ExecutorConfig(
+            worktrees_root=tmp_path / "worktrees",
+            compose_projects_root=tmp_path / "compose",
+        ),
+    )
+    await executor._record_git_object_recovery_event(
+        workspace_id=workspace_id,
+        stage="agent_run",
+        recovery=_GitObjectRecoveryResult(
+            broken_head_sha="b" * 40,
+            recovered_head_sha="c" * 40,
+        ),
+    )
+
+    async with factory() as session:
+        events = await WorkspaceEventRepository(session).list(workspace_id=workspace_id)
+    await engine.dispose()
+    recovery_events = [
+        event for event in events if event.event_type == "workspace.git_object_missing_recovered"
+    ]
+
+    assert len(recovery_events) == 1
+    assert recovery_events[0].reason_code == "GIT_OBJECT_MISSING_RECOVERED"
+    assert recovery_events[0].payload["stage"] == "agent_run"
+
+
+@pytest.mark.unit
+async def test_missing_head_recovery_rebuilds_canonical_commit_from_filesystem(
+    tmp_path: Path,
+) -> None:
+    origin = tmp_path / "origin"
+    mirror = tmp_path / "mirror.git"
+    worktree = tmp_path / "worktree"
+    alternate_objects = tmp_path / "alternate-objects"
+    alternate_objects.mkdir()
+
+    subprocess.run(["git", "init", "-q", "-b", "main", str(origin)], check=True)
+    subprocess.run(["git", "-C", str(origin), "config", "user.name", "AWF Test"], check=True)
+    subprocess.run(["git", "-C", str(origin), "config", "user.email", "awf@test.local"], check=True)
+    (origin / "README.md").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(origin), "add", "."], check=True)
+    subprocess.run(["git", "-C", str(origin), "commit", "-q", "-m", "base"], check=True)
+    base_commit = subprocess.run(
+        ["git", "-C", str(origin), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    subprocess.run(["git", "clone", "--mirror", str(origin), str(mirror)], check=True)
+    subprocess.run(
+        [
+            "git",
+            "--git-dir",
+            str(mirror),
+            "worktree",
+            "add",
+            "-b",
+            "awf/ws_missing_object",
+            str(worktree),
+            "main",
+        ],
+        check=True,
+    )
+
+    (worktree / "IMPLEMENTATION.md").write_text("agent work\n", encoding="utf-8")
+    env = {
+        **os.environ,
+        "GIT_OBJECT_DIRECTORY": str(alternate_objects),
+        "GIT_ALTERNATE_OBJECT_DIRECTORIES": str(mirror / "objects"),
+        "GIT_AUTHOR_NAME": "AWF Agent",
+        "GIT_AUTHOR_EMAIL": "awf@example.com",
+        "GIT_COMMITTER_NAME": "AWF Agent",
+        "GIT_COMMITTER_EMAIL": "awf@example.com",
+    }
+    subprocess.run(["git", "-C", str(worktree), "add", "IMPLEMENTATION.md"], check=True, env=env)
+    subprocess.run(
+        ["git", "-C", str(worktree), "commit", "-q", "-m", "hidden alternate commit"],
+        check=True,
+        env=env,
+    )
+
+    broken = subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert broken.returncode != 0
+    assert "bad object HEAD" in broken.stderr
+
+    result = await _recover_missing_head_from_filesystem(
+        runner=AsyncioSubprocessRunner(),
+        workspace_id="ws_missing_object",
+        worktree_path=worktree,
+        base_commit=base_commit,
+        branch_name="awf/ws_missing_object",
+    )
+
+    assert result is not None
+    assert result.recovered_head_sha
+    assert result.broken_head_sha != result.recovered_head_sha
+    status = subprocess.run(
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert status.stdout == ""
+    changed = subprocess.run(
+        ["git", "-C", str(worktree), "diff", "--name-only", f"{base_commit}..HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert changed.stdout.splitlines() == ["IMPLEMENTATION.md"]
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_validation_fix_cycle.py
+++ b/tests/unit/control/test_validation_fix_cycle.py
@@ -195,6 +195,26 @@ class TestBuildFixPrompt:
         assert "raise coverage" not in prompt.lower()
         assert "add meaningful tests for the relevant code paths" not in prompt.lower()
 
+    @pytest.mark.unit
+    def test_retry_prompt_prioritizes_failing_tests_before_coverage_work_when_both_fail(
+        self,
+    ) -> None:
+        prompt = build_fix_prompt(
+            self._ctx(
+                failed_command="pytest --cov=awf --cov-report=term",
+                reason_code="COVERAGE_BELOW_THRESHOLD",
+                coverage_percent=98.7,
+                coverage_minimum_percent=99.0,
+                failing_test_node_ids=("tests/unit/test_widget.py::test_handles_edges",),
+                failing_test_evidence=(
+                    "FAILED tests/unit/test_widget.py::test_handles_edges - AssertionError",
+                ),
+            )
+        ).lower()
+
+        assert "fix the failing pytest tests first, then revisit coverage" in prompt
+        assert "tests/unit/test_widget.py::test_handles_edges" in prompt
+
 
 class TestValidationFixContext:
     @pytest.mark.unit

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -1957,7 +1957,7 @@ class TestRunOnceExecution:
             asyncio.gather(
                 worker_a.wait_for_execution_tasks(), worker_b.wait_for_execution_tasks()
             ),
-            timeout=0.5,
+            timeout=5.0,
         )
 
         assert calls == [ready_id]

--- a/tests/unit/docs/test_catalog_coverage.py
+++ b/tests/unit/docs/test_catalog_coverage.py
@@ -72,6 +72,19 @@ ALLOWLIST = {
 }
 
 
+def _extract_reason_code_value(
+    val_node: ast.expr,
+    file_constants: dict[str, str],
+) -> str | None:
+    if isinstance(val_node, ast.Constant) and isinstance(val_node.value, str):
+        return val_node.value
+    if isinstance(val_node, ast.Name) and val_node.id in file_constants:
+        return file_constants[val_node.id]
+    if isinstance(val_node, ast.JoinedStr):
+        return ast.unparse(val_node)
+    return None
+
+
 def test_catalog_coverage() -> None:
     """Ensure all public reason codes are documented in the REASON_CATALOG.md."""
     if not CATALOG_PATH.exists():
@@ -92,44 +105,44 @@ def test_catalog_coverage() -> None:
             # Map file-level constants to their string values
             file_constants: dict[str, str] = {}
             for node in ast.walk(tree):
-                if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                if (
+                    isinstance(node, ast.Assign)
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
                     for target in node.targets:
                         if isinstance(target, ast.Name):
                             file_constants[target.id] = node.value.value
 
-            def _extract_val(
-                val_node: ast.expr,
-                file_constants: dict[str, str] = file_constants,
-            ) -> str | None:
-                if isinstance(val_node, ast.Constant) and isinstance(val_node.value, str):
-                    return val_node.value
-                if isinstance(val_node, ast.Name) and val_node.id in file_constants:
-                    return file_constants[val_node.id]
-                if isinstance(val_node, ast.JoinedStr):
-                    return ast.unparse(val_node)
-                return None
-
             for node in ast.walk(tree):
                 # keyword arg: error_code="XYZ" or error_code=CONSTANT
                 if isinstance(node, ast.keyword) and node.arg == "error_code":
-                    extracted = _extract_val(node.value)
+                    extracted = _extract_reason_code_value(node.value, file_constants)
                     if extracted:
                         all_reason_codes.add(extracted)
 
                 # assignment: error_code = "XYZ" or self.error_code = "XYZ"
                 elif isinstance(node, ast.Assign):
                     for target in node.targets:
-                        if (isinstance(target, ast.Name) and target.id == "error_code") or \
-                           (isinstance(target, ast.Attribute) and target.attr == "error_code"):
-                            extracted = _extract_val(node.value)
+                        if (
+                            isinstance(target, ast.Name)
+                            and target.id == "error_code"
+                        ) or (
+                            isinstance(target, ast.Attribute)
+                            and target.attr == "error_code"
+                        ):
+                            extracted = _extract_reason_code_value(
+                                node.value,
+                                file_constants,
+                            )
                             if extracted:
                                 all_reason_codes.add(extracted)
 
                 # dict key: {"error_code": "XYZ"} or {"error_code": CONSTANT}
                 elif isinstance(node, ast.Dict):
-                    for key, val in zip(node.keys, node.values, strict=True):
+                    for key, val in zip(node.keys, node.values, strict=False):
                         if isinstance(key, ast.Constant) and key.value == "error_code":
-                            extracted = _extract_val(val)
+                            extracted = _extract_reason_code_value(val, file_constants)
                             if extracted:
                                 all_reason_codes.add(extracted)
         except SyntaxError:

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -387,6 +387,127 @@ def test_chown_tree_returns_after_chowning_plain_file(
     assert chowned == [file_path]
 
 
+@pytest.mark.unit
+def test_chown_tree_directories_only_repairs_object_fanout_dirs_not_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    objects = tmp_path / "objects"
+    fanout = objects / "c4"
+    pack = objects / "pack"
+    fanout.mkdir(parents=True)
+    pack.mkdir()
+    loose_object = fanout / "abcdef"
+    loose_object.write_text("object\n", encoding="utf-8")
+    pack_file = pack / "pack-test.pack"
+    pack_file.write_text("pack\n", encoding="utf-8")
+    chowned: list[Path] = []
+
+    monkeypatch.setattr(
+        os,
+        "chown",
+        lambda path, _uid, _gid: chowned.append(Path(path)),
+    )
+
+    git_manager._chown_tree(objects, 1000, 1000, directories_only=True)  # noqa: SLF001
+
+    assert objects in chowned
+    assert fanout in chowned
+    assert pack in chowned
+    assert loose_object not in chowned
+    assert pack_file not in chowned
+
+
+@pytest.mark.unit
+def test_repair_agent_writable_worktree_falls_back_when_mirror_is_unknown(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    captured: list[tuple[tuple[git_manager._ChownTarget, ...], int, int]] = []  # noqa: SLF001
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        git_manager,
+        "_chown_targets",
+        lambda targets, uid, gid: captured.append((targets, uid, gid)),
+    )
+
+    git_manager.repair_agent_writable_worktree(None, worktree, uid=123, gid=456)
+
+    assert captured == [
+        ((git_manager._ChownTarget(worktree, recursive=True),), 123, 456)  # noqa: SLF001
+    ]
+
+
+@pytest.mark.unit
+def test_repair_agent_writable_worktree_fallback_repairs_linked_git_dir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    linked_git_dir = tmp_path / "mirror.git" / "worktrees" / "ws"
+    linked_git_dir.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {linked_git_dir}\n", encoding="utf-8")
+    captured: list[tuple[git_manager._ChownTarget, ...]] = []  # noqa: SLF001
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(git_manager, "mirror_path_for_worktree", lambda _path: None)
+    monkeypatch.setattr(
+        git_manager,
+        "_chown_targets",
+        lambda targets, _uid, _gid: captured.append(targets),
+    )
+
+    git_manager.repair_agent_writable_worktree(None, worktree)
+
+    assert captured == [
+        (
+            git_manager._ChownTarget(worktree, recursive=True),  # noqa: SLF001
+            git_manager._ChownTarget(linked_git_dir, recursive=True),  # noqa: SLF001
+        )
+    ]
+
+
+@pytest.mark.unit
+def test_mirror_path_for_worktree_handles_commondir_and_unreadable_commondir(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mirror = tmp_path / "mirror.git"
+    linked_git_dir = mirror / "worktrees" / "ws"
+    linked_git_dir.mkdir(parents=True)
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    (worktree / ".git").write_text(f"gitdir: {linked_git_dir}\n", encoding="utf-8")
+
+    assert git_manager.mirror_path_for_worktree(worktree) == mirror.resolve()
+
+    (linked_git_dir / "commondir").write_text("../..", encoding="utf-8")
+    assert git_manager.mirror_path_for_worktree(worktree) == mirror.resolve()
+
+    absolute_common_dir = tmp_path / "absolute-common.git"
+    absolute_common_dir.mkdir()
+    (linked_git_dir / "commondir").write_text(str(absolute_common_dir), encoding="utf-8")
+    assert git_manager.mirror_path_for_worktree(worktree) == absolute_common_dir.resolve()
+
+    original_read_text = Path.read_text
+
+    def _raise_for_commondir(path: Path, *args: object, **kwargs: object) -> str:
+        if path == linked_git_dir / "commondir":
+            raise OSError("unreadable")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _raise_for_commondir)
+    assert git_manager.mirror_path_for_worktree(worktree) == mirror.resolve()
+
+    no_git = tmp_path / "no-git"
+    no_git.mkdir()
+    assert git_manager.mirror_path_for_worktree(no_git) is None
+
+
 class TestAgentWorktreeWritable:
     """Regression coverage for the local UID/GID strategy.
 

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -124,6 +124,7 @@ def pr_payload(
     head_sha: str = "abc1234567890def",
     closed: bool = False,
     merged: bool = False,
+    merge_commit_sha: str = "mergecommit1234567890",
     mergeable: str = "MERGEABLE",
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
@@ -144,6 +145,7 @@ def pr_payload(
                         "isDraft": False,
                         "closed": closed,
                         "merged": merged,
+                        "mergeCommit": {"oid": merge_commit_sha} if merged else None,
                         "baseRef": {"name": "development", "target": {"oid": "base0"}},
                         "commits": {
                             "nodes": [

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -511,7 +511,7 @@ class TestMonitorActionLogging:
             ws = await WorkspaceRepository(s).get(ws_id)
             assert ws is not None
             assert ws.status == WorkspaceStatus.completed.value
-            assert ws.pr_merge_sha is None
+            assert ws.pr_merge_sha == "mergecommit1234567890"
 
     @pytest.mark.unit
     async def test_short_circuit_completed_emits_log_line(

--- a/tests/unit/runtime/test_monitor_completion_gc.py
+++ b/tests/unit/runtime/test_monitor_completion_gc.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import structlog
@@ -15,6 +16,7 @@ from awf.db.base import Base
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import SecretLeaseIssue, SecretLeaseRepository, WorkspaceRepository
 from awf.db.session import make_engine, make_session_factory
+from awf.service.gc import WorkspaceGCWorktreeRemoveResult
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
@@ -55,6 +57,18 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _mock_worktree_remove_success() -> object:
+    return patch(
+        "awf.service.gc._default_worktree_remover",
+        new=AsyncMock(
+            return_value=WorkspaceGCWorktreeRemoveResult(
+                status="succeeded",
+                reason_code="WORKTREE_REMOVE_SUCCEEDED",
+            )
+        ),
+    )
+
+
 async def _seed_old_completed_pr_workspace(
     factory: async_sessionmaker[AsyncSession],
     *,
@@ -74,7 +88,7 @@ async def _seed_old_completed_pr_workspace(
         workspace.updated_at = updated_at
         workspace.pr_url = "https://github.com/dimileeh/aira-web/pull/42"
         workspace.pr_number = 42
-        workspace.pr_merge_sha = "m" * 40
+        workspace.pr_merge_sha = "mergecommit1234567890"
         await session.commit()
         return workspace.id
 
@@ -160,6 +174,7 @@ async def test_completed_monitor_defers_recent_workspace_pressure_dir_cleanup(
         ws = await WorkspaceRepository(session).get(ws_id)
         assert ws is not None
         assert ws.status == WorkspaceStatus.completed.value
+        assert ws.pr_merge_sha == "mergecommit1234567890"
 
 
 @pytest.mark.unit
@@ -191,7 +206,7 @@ async def test_completed_monitor_filesystem_gc_logs_success_for_retained_old_wor
         worktrees_root=worktrees_root,
     )
 
-    with structlog.testing.capture_logs() as captured:
+    with _mock_worktree_remove_success(), structlog.testing.capture_logs() as captured:
         await runner._gc_completed_workspace_filesystem(ws_id)
 
     assert not worktree.exists()
@@ -267,7 +282,7 @@ async def test_completed_monitor_filesystem_gc_logs_structured_delete_errors(
         worktrees_root=worktrees_root,
     )
 
-    with structlog.testing.capture_logs() as captured:
+    with _mock_worktree_remove_success(), structlog.testing.capture_logs() as captured:
         await runner._gc_completed_workspace_filesystem(ws_id)
 
     assert worktree.exists()
@@ -370,8 +385,6 @@ async def test_completed_monitor_filesystem_gc_logs_failure_on_reservation_relea
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
-    from unittest.mock import AsyncMock, patch
-
     from awf.service.gc import (
         WorkspaceGCCandidate,
         WorkspaceGCPath,

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -68,6 +68,20 @@ class TestAddressThread:
         assert "inside the file under review" in prompt
 
     @pytest.mark.unit
+    def test_thread_evidence_location_keeps_path_when_line_is_absent(self) -> None:
+        thread = ReviewThread(
+            thread_id="T",
+            path="src/app.py",
+            line=None,
+            body_excerpt="check the file",
+        )
+        prompt = address_thread_prompt(pr_number=7, repo_slug="a/b", thread=thread)
+
+        assert "- location: a/b#7 src/app.py" in prompt
+        assert "- path: src/app.py" in prompt
+        assert "- line:" not in prompt
+
+    @pytest.mark.unit
     def test_review_thread_adversarial_body_is_quoted_evidence_not_policy(self) -> None:
         thread = ReviewThread(
             thread_id="PRRT_attack",

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -20,6 +20,7 @@ from awf.runtime.planning import (
     ConformanceStallKind,
     ConformanceStallPolicy,
     PlanConformanceStatus,
+    _evidence_strings,
     _gaps_from_payload,
     build_agent_task_prompt,
     build_conformance_failure_evidence,
@@ -668,6 +669,51 @@ def test_classify_conformance_stall_returns_no_output_for_idle_timeout() -> None
 
 
 @pytest.mark.unit
+def test_classify_conformance_stall_returns_none_without_history() -> None:
+    assert (
+        classify_conformance_stall(
+            history=[],
+            policy=_stall_policy(),
+            plan_path=Path("docs/awf-plans/ws_empty.md"),
+            report_path=Path("docs/awf-plans/ws_empty.conformance.json"),
+            latest_error=None,
+        )
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_classify_conformance_stall_uses_error_stdout_when_stderr_is_empty() -> None:
+    history = [
+        _iter_record(
+            iteration=0,
+            elapsed_seconds=600.0,
+            report_digest=None,
+            worktree_changed=False,
+            stdout="",
+            error_reason_code="AGENT_TIMEOUT",
+        )
+    ]
+    error = AgentRunError(
+        agent=AgentRuntime.codex,
+        result=CommandResult(returncode=124, stdout="stdout-only failure", stderr=""),
+        reason_code="AGENT_TIMEOUT",
+    )
+
+    evidence = classify_conformance_stall(
+        history=history,
+        policy=_stall_policy(over_duration_seconds=300),
+        plan_path=Path("docs/awf-plans/ws_stdout.md"),
+        report_path=Path("docs/awf-plans/ws_stdout.conformance.json"),
+        latest_error=error,
+    )
+
+    assert evidence is not None
+    assert evidence.kind == ConformanceStallKind.over_duration
+    assert "stdout-only failure" in evidence.last_output_excerpt
+
+
+@pytest.mark.unit
 def test_classify_conformance_stall_redacts_secrets_in_last_output_excerpt() -> None:
     # Stall evidence is persisted as durable failure details and surfaced into
     # recovery prompts; raw agent stderr/stdout can include provider tokens or
@@ -710,6 +756,11 @@ def test_classify_conformance_stall_redacts_secrets_in_last_output_excerpt() -> 
     )
     assert leaked_token not in payload["last_output_excerpt"]
     assert "<redacted>" in payload["last_output_excerpt"]
+
+
+@pytest.mark.unit
+def test_evidence_strings_ignores_non_list_payloads() -> None:
+    assert _evidence_strings({"gaps": ["not", "a", "list"]}) == ()
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -65,6 +65,7 @@ def _review(
 
 def _status(
     *,
+    head_sha: str = "abc123",
     mergeable: MergeableState = MergeableState.MERGEABLE,
     check_state: CheckState = CheckState.SUCCESS,
     inline: tuple[ReviewThread, ...] = (),
@@ -77,7 +78,7 @@ def _status(
 ) -> PRStatus:
     return PRStatus(
         number=42,
-        head_sha="abc123",
+        head_sha=head_sha,
         mergeable=mergeable,
         check_state=check_state,
         unresolved_inline_threads=inline,
@@ -556,16 +557,99 @@ class TestMergeStateStatus:
 
     @pytest.mark.unit
     def test_dirty_keeps_syncing_even_after_many_attempts(self) -> None:
-        """Volume isn't a terminal condition: even at iter_count=1000 with
-        DIRTY the monitor keeps issuing SyncBase. Operator intervention
-        (closing / rebasing the PR) is how a genuinely-stuck conflict
-        gets resolved; the monitor itself never gives up."""
+        """Volume alone is not terminal; only repeated no-progress syncs
+        for the same PR snapshot trip the guard."""
         action = decide(
             _status(merge_state_status=MergeStateStatus.DIRTY),
             MonitorState(iter_count=1000),
             MonitorConfig(),
         )
         assert isinstance(action, SyncBase)
+
+    @pytest.mark.unit
+    def test_dirty_no_progress_syncs_abort_instead_of_looping_forever(self) -> None:
+        status = _status(
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.CONFLICTING,
+            merge_state_status=MergeStateStatus.DIRTY,
+        )
+        action = decide(
+            status,
+            MonitorState(
+                sync_base_no_progress_signature=(
+                    "abc1234567890def|CONFLICTING|DIRTY|base_behind=0"
+                ),
+                sync_base_no_progress_count=3,
+            ),
+            MonitorConfig(max_no_progress_sync_base_attempts=3),
+        )
+
+        assert isinstance(action, Abort)
+        assert action.reason == AbortReason.merge_conflict_not_reproduced
+
+    @pytest.mark.unit
+    def test_dirty_no_progress_allows_new_review_comments_once(self) -> None:
+        status = _status(
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.CONFLICTING,
+            merge_state_status=MergeStateStatus.DIRTY,
+            inline=(_thread(tid="T_new"),),
+        )
+        action = decide(
+            status,
+            MonitorState(
+                sync_base_no_progress_signature=(
+                    "abc1234567890def|CONFLICTING|DIRTY|base_behind=0"
+                ),
+                sync_base_no_progress_count=3,
+            ),
+            MonitorConfig(max_no_progress_sync_base_attempts=3),
+        )
+
+        assert isinstance(action, AddressComments)
+        assert [thread.thread_id for thread in action.threads] == ["T_new"]
+
+    @pytest.mark.unit
+    def test_behind_no_progress_aborts_with_base_sync_reason(self) -> None:
+        status = _status(
+            head_sha="abc1234567890def",
+            base_behind=1,
+            merge_state_status=MergeStateStatus.BEHIND,
+        )
+        action = decide(
+            status,
+            MonitorState(
+                sync_base_no_progress_signature=(
+                    "abc1234567890def|MERGEABLE|BEHIND|base_behind=1"
+                ),
+                sync_base_no_progress_count=3,
+            ),
+            MonitorConfig(max_no_progress_sync_base_attempts=3),
+        )
+
+        assert isinstance(action, Abort)
+        assert action.reason == AbortReason.base_sync_no_progress
+
+    @pytest.mark.unit
+    def test_legacy_conflicting_no_progress_aborts_without_rerunning_sync(self) -> None:
+        status = _status(
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.CONFLICTING,
+            merge_state_status=MergeStateStatus.CLEAN,
+        )
+        action = decide(
+            status,
+            MonitorState(
+                sync_base_no_progress_signature=(
+                    "abc1234567890def|CONFLICTING|CLEAN|base_behind=0"
+                ),
+                sync_base_no_progress_count=3,
+            ),
+            MonitorConfig(max_no_progress_sync_base_attempts=3),
+        )
+
+        assert isinstance(action, Abort)
+        assert action.reason == AbortReason.merge_conflict_not_reproduced
 
     @pytest.mark.unit
     def test_blocked_notifies_human_even_with_auto_merge(self) -> None:

--- a/tests/unit/runtime/test_pr_monitor_manual_merge.py
+++ b/tests/unit/runtime/test_pr_monitor_manual_merge.py
@@ -293,6 +293,7 @@ async def test_manual_merge_external_merge_completes_with_monitor_done_and_clean
     assert ws.status == WorkspaceStatus.completed.value
     assert events[-1].new_state == WorkspaceStatus.completed.value
     assert events[-1].reason_code == "MONITOR_DONE"
+    assert ws.pr_merge_sha == "mergecommit1234567890"
     assert candidate.status == "merged"
     assert candidate.merged_at is not None
     assert not candidate.manual_merge_required

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -1532,6 +1532,55 @@ async def test_execute_sync_base_records_no_progress_noop(
 
 
 @pytest.mark.unit
+async def test_execute_sync_base_failed_push_resets_no_progress_streak(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd.queue_result(returncode=0)  # merge --abort
+    cmd.queue_result(returncode=0)  # fetch
+    cmd.queue_result(returncode=0)  # merge
+    cmd.queue_result(returncode=1, stderr="push rejected")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    state = MonitorState(
+        sync_base_no_progress_signature=(
+            "abc1234567890def|CONFLICTING|DIRTY|base_behind=0"
+        ),
+        sync_base_no_progress_count=2,
+    )
+
+    terminal = await runner._execute(
+        action=SyncBase(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status(
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.CONFLICTING,
+            merge_state_status=MergeStateStatus.DIRTY,
+        ),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert state.sync_base_no_progress_signature is None
+    assert state.sync_base_no_progress_count == 0
+
+
+@pytest.mark.unit
 async def test_sync_base_progress_increments_same_snapshot_and_resets_on_failure(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -64,12 +64,15 @@ from awf.runtime.pr_monitor import (
     WaitForCI,
 )
 from awf.runtime.pr_monitor_runner import (
+    BaseBehindCountError,
+    BaseFetchError,
     MonitorRunnerConfig,
     ProviderRecoveryFallbackError,
     ProviderRecoveryRetryError,
     PullRequestMonitorRunner,
     _as_utc,
     _collect_defer_items,
+    _GitPushResult,
     _infer_service_work_dir,
     _initial_review_grace_done_key,
     _initial_review_grace_started_key,
@@ -134,6 +137,34 @@ def _green_status(*, pr_number: int = 42, head_sha: str = "abc1234567890def") ->
 
 def _gh_pr_merge_calls(cmd: FakeCommandRunner) -> list[list[str]]:
     return [call.args for call in cmd.calls if call.args[:3] == ["gh", "pr", "merge"]]
+
+
+class _CapturingGH:
+    def __init__(self, status: PRStatus | None = None) -> None:
+        self.status = status or _green_status()
+        self.base_behind_counts: list[int] = []
+        self.failing_log_requests: list[tuple[RepoRef, int, str]] = []
+
+    async def fetch_pr_status(
+        self,
+        *,
+        repo: RepoRef,
+        pr_number: int,
+        base_behind_count: int,
+    ) -> PRStatus:
+        del repo, pr_number
+        self.base_behind_counts.append(base_behind_count)
+        return replace(self.status, base_behind_count=base_behind_count)
+
+    async def fetch_failing_check_logs(
+        self,
+        *,
+        repo: RepoRef,
+        pr_number: int,
+        head_sha: str,
+    ) -> tuple[CheckFailure, ...]:
+        self.failing_log_requests.append((repo, pr_number, head_sha))
+        return ()
 
 
 def _provider_recovery_policy(
@@ -1218,6 +1249,404 @@ async def test_sync_base_provider_failure_records_recovery_and_source_cooldown(
     assert [operation for operation in operations if operation.type == "retry"] == []
     assert len(recovery_events) == 1
     assert recovery_events[0]["provider_recovery"]["retry_after_seconds"] == 120
+
+
+@pytest.mark.unit
+async def test_fetch_status_repairs_orphaned_broken_awf_ref_before_counting_base(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(
+        returncode=128,
+        stderr="fatal: bad object refs/heads/awf/ws_deadbeef1234567890",
+    )
+    cmd.queue_result(returncode=0)  # update-ref -d broken orphan branch
+    cmd.queue_result(returncode=0)  # worktree prune stale metadata
+    cmd.queue_result(returncode=0)  # retry fetch with explicit base refspec
+    cmd.queue_result(returncode=0, stdout="2\n")  # rev-list HEAD..origin/base
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    gh = _CapturingGH()
+    runner._deps.gh = gh  # type: ignore[assignment]
+
+    status = await runner._fetch_status_for_decision(
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        workspace_id="ws_current",
+        base_branch="development",
+    )
+
+    assert status.base_behind_count == 2
+    assert gh.base_behind_counts == [2]
+    assert cmd.calls[0].args[-3:] == [
+        "fetch",
+        "origin",
+        "+refs/heads/development:refs/remotes/origin/development",
+    ]
+    assert cmd.calls[1].args[-3:] == [
+        "update-ref",
+        "-d",
+        "refs/heads/awf/ws_deadbeef1234567890",
+    ]
+    assert cmd.calls[2].args[-2:] == ["worktree", "prune"]
+    assert cmd.calls[3].args[-3:] == [
+        "fetch",
+        "origin",
+        "+refs/heads/development:refs/remotes/origin/development",
+    ]
+
+
+@pytest.mark.unit
+async def test_fetch_status_refuses_to_delete_broken_ref_for_active_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    broken_workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(
+        returncode=128,
+        stderr=f"fatal: bad object refs/heads/awf/{broken_workspace_id}",
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.gh = _CapturingGH()  # type: ignore[assignment]
+
+    with pytest.raises(BaseFetchError) as exc:
+        await runner._fetch_status_for_decision(
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            workspace_id=broken_workspace_id,
+            base_branch="development",
+        )
+
+    assert "refs/heads/awf/" in str(exc.value)
+    assert len(cmd.calls) == 1
+
+
+@pytest.mark.unit
+async def test_fetch_status_keeps_failure_when_broken_ref_delete_fails(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(
+        returncode=128,
+        stderr="fatal: bad object refs/heads/awf/ws_deletefail123456",
+    )
+    cmd.queue_result(returncode=1, stderr="cannot lock ref")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.gh = _CapturingGH()  # type: ignore[assignment]
+
+    with pytest.raises(BaseFetchError) as exc:
+        await runner._fetch_status_for_decision(
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            workspace_id="ws_current",
+            base_branch="development",
+        )
+
+    assert "bad object refs/heads/awf/ws_deletefail123456" in str(exc.value)
+    assert len(cmd.calls) == 2
+
+
+@pytest.mark.unit
+async def test_fetch_status_keeps_failure_when_retry_fetch_still_fails(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(
+        returncode=128,
+        stderr="fatal: bad object refs/heads/awf/ws_retryfail123456",
+    )
+    cmd.queue_result(returncode=0)  # update-ref -d broken orphan branch
+    cmd.queue_result(returncode=0)  # worktree prune
+    cmd.queue_result(returncode=128, stderr="fatal: remote hung up")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.gh = _CapturingGH()  # type: ignore[assignment]
+
+    with pytest.raises(BaseFetchError) as exc:
+        await runner._fetch_status_for_decision(
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            workspace_id="ws_current",
+            base_branch="development",
+        )
+
+    assert "remote hung up" in str(exc.value)
+    assert len(cmd.calls) == 4
+
+
+@pytest.mark.unit
+async def test_run_fails_workspace_when_base_fetch_cannot_be_refreshed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=128, stderr="fatal: could not fetch base")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.gh = _CapturingGH()  # type: ignore[assignment]
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        assert workspace.status == WorkspaceStatus.failed.value
+        assert workspace.failure_reason == "infrastructure_failure"
+        assert workspace.failure_message is not None
+        assert "could not refresh base branch" in workspace.failure_message
+
+
+@pytest.mark.unit
+async def test_base_behind_count_failure_is_explicit_not_zero(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=128, stderr="fatal: bad object")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    with pytest.raises(BaseBehindCountError):
+        await runner._count_base_behind(
+            worktree_path=tmp_path / "worktrees" / "ws_count",
+            base_branch="development",
+        )
+
+
+@pytest.mark.unit
+async def test_sync_base_no_progress_state_is_persisted_across_restarts(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    await runner._persist_state(
+        workspace_id,
+        MonitorState(
+            sync_base_no_progress_signature="abc|CONFLICTING|DIRTY|base_behind=0",
+            sync_base_no_progress_count=2,
+            threads_addressed_ids={"T1": "fix_committed"},
+        ),
+    )
+
+    workspace = await runner._load_workspace(workspace_id)
+    state = runner._load_state(workspace)
+
+    assert state.sync_base_no_progress_signature == "abc|CONFLICTING|DIRTY|base_behind=0"
+    assert state.sync_base_no_progress_count == 2
+    assert state.threads_addressed_ids == {"T1": "fix_committed"}
+
+
+@pytest.mark.unit
+async def test_execute_sync_base_records_no_progress_noop(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd.queue_result(returncode=0)  # merge --abort
+    cmd.queue_result(returncode=0)  # fetch
+    cmd.queue_result(returncode=0)  # merge
+    cmd.queue_result(returncode=0, stderr="Everything up-to-date")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=SyncBase(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status(
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.CONFLICTING,
+            merge_state_status=MergeStateStatus.DIRTY,
+        ),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert state.sync_base_no_progress_signature == (
+        "abc1234567890def|CONFLICTING|DIRTY|base_behind=0"
+    )
+    assert state.sync_base_no_progress_count == 1
+
+
+@pytest.mark.unit
+async def test_sync_base_progress_increments_same_snapshot_and_resets_on_failure(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    status = _status(
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.CONFLICTING,
+        merge_state_status=MergeStateStatus.DIRTY,
+    )
+    state = MonitorState(
+        sync_base_no_progress_signature=(
+            "abc1234567890def|CONFLICTING|DIRTY|base_behind=0"
+        ),
+        sync_base_no_progress_count=1,
+    )
+
+    runner._record_sync_base_progress(
+        state=state,
+        status=status,
+        push_result=_GitPushResult(pushed=False, failed=False, returncode=0),
+    )
+    assert state.sync_base_no_progress_count == 2
+
+    runner._record_sync_base_progress(
+        state=state,
+        status=status,
+        push_result=_GitPushResult(pushed=False, failed=True, returncode=128),
+    )
+    assert state.sync_base_no_progress_signature is None
+    assert state.sync_base_no_progress_count == 0
+
+
+@pytest.mark.unit
+async def test_load_state_ignores_invalid_persisted_no_progress_count(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.monitor_threads_addressed = {
+            "__awf_sync_base_no_progress_signature": "sig",
+            "__awf_sync_base_no_progress_count": "not-an-int",
+            "T1": "defer",
+        }
+        await session.commit()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    workspace = await runner._load_workspace(workspace_id)
+    state = runner._load_state(workspace)
+
+    assert state.sync_base_no_progress_signature == "sig"
+    assert state.sync_base_no_progress_count == 0
+    assert state.threads_addressed_ids == {"T1": "defer"}
+
+
+@pytest.mark.unit
+async def test_execute_sync_base_base_fetch_failure_finishes_operation_and_fails_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _raise_base_fetch_error(**_kwargs: object) -> object:
+        raise BaseFetchError("broken mirror")
+
+    mocker.patch.object(runner, "_run_sync_base", _raise_base_fetch_error)
+
+    terminal = await runner._execute(
+        action=SyncBase(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status(merge_state_status=MergeStateStatus.DIRTY),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
+    assert terminal is True
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.failed.value
+    assert workspace.failure_message is not None
+    assert "broken mirror" in workspace.failure_message
+    assert operations[0].status == OperationStatus.failed.value
+    assert operations[0].error_code == "GIT_FETCH_BASE_FAILED"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+import pytest_mock
 import structlog
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -43,6 +44,7 @@ from awf.runtime.pr_monitor import (
 )
 from awf.runtime.pr_monitor_runner import (
     BaseBehindCountError,
+    BaseFetchError,
     MonitorRunnerConfig,
     ProviderRecoveryRetryError,
     PullRequestMonitorRunner,
@@ -834,6 +836,53 @@ async def test_pre_merge_recheck_github_error_fails_workspace(
         assert ws is not None
         assert ws.status == WorkspaceStatus.failed.value
         assert "pre-merge recheck" in (ws.failure_message or "")
+
+
+@pytest.mark.unit
+async def test_pre_merge_recheck_base_fetch_error_fails_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        pre_merge_settle_seconds=2,
+    )
+    mocker.patch.object(
+        runner,
+        "_fetch_status_for_decision",
+        mocker.AsyncMock(side_effect=BaseFetchError("base fetch died")),
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert sleep_fn.calls == [2]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert "could not refresh base branch" in (ws.failure_message or "")
+        assert ws.events[-1].reason_code == "GIT_FETCH_BASE_FAILED"
 
 
 @pytest.mark.unit
@@ -3547,6 +3596,27 @@ async def test_merge_gate_legacy_head_support_modern_fallback_and_typeerror(
     )
     assert modern_calls == [("ws_modern", True, "head1")]
 
+    plain_calls: list[tuple[str, bool]] = []
+
+    async def plain_gate(
+        workspace_id: str,
+        *,
+        check_policy: bool = False,
+    ) -> object:
+        plain_calls.append((workspace_id, check_policy))
+        return sentinel
+
+    monkeypatch.setattr(runner, "_merge_gate_for_workspace", plain_gate)
+    assert (
+        await runner._merge_gate_with_legacy_head_support(
+            "ws_plain",
+            check_policy=True,
+            current_head_sha=None,
+        )
+        is sentinel
+    )
+    assert plain_calls == [("ws_plain", True)]
+
     legacy_calls: list[tuple[str, bool]] = []
 
     async def legacy_gate(
@@ -3722,6 +3792,102 @@ async def test_protected_scope_repair_returns_none_when_recheck_fails(
         is None
     )
     assert len(adapter.calls) == 1
+
+
+@pytest.mark.unit
+async def test_commit_dirty_worktree_stops_when_protected_scope_repair_fails(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=" M .github/workflows/ci.yml\n")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _repair_fails(**_kwargs: object) -> object | None:
+        return None
+
+    monkeypatch.setattr(
+        runner,
+        "_repair_protected_scope_changes_before_commit",
+        _repair_fails,
+    )
+
+    assert not await runner._commit_dirty_worktree(
+        workspace_id=workspace_id,
+        message="fix: repair protected scope",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+    assert len(cmd.calls) == 1
+
+
+@pytest.mark.unit
+async def test_protected_scope_repair_raises_provider_retry_before_cli(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await session.commit()
+
+    adapter = FakeAdapter()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    mocker.patch.object(
+        runner,
+        "_provider_recovery_suppresses_cli",
+        mocker.AsyncMock(return_value=True),
+    )
+
+    with pytest.raises(ProviderRecoveryRetryError):
+        await runner._repair_protected_scope_changes_before_commit(
+            workspace_id=workspace_id,
+            status_stdout=" M .github/workflows/ci.yml\n",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+        )
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
+async def test_protected_scope_violations_skip_empty_status(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    assert (
+        await runner._protected_scope_violations_for_status(
+            workspace_id="ws_without_changes",
+            status_stdout="",
+        )
+        == []
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -2949,6 +2949,48 @@ async def test_fetch_base_repairs_multiple_broken_awf_refs_before_failing_worksp
 
 
 @pytest.mark.unit
+async def test_fetch_base_wraps_broken_ref_repair_exceptions_as_base_fetch_error(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    fetch_base_once = mocker.patch.object(
+        runner,
+        "_fetch_base_once",
+        mocker.AsyncMock(
+            return_value=CommandResult(
+                returncode=1,
+                stdout="",
+                stderr="fatal: bad object refs/heads/awf/ws_old",
+            )
+        ),
+    )
+    repair = mocker.patch.object(
+        runner,
+        "_repair_orphaned_broken_awf_ref",
+        mocker.AsyncMock(side_effect=RuntimeError("database unavailable")),
+    )
+
+    with pytest.raises(BaseFetchError, match="broken AWF ref repair failed") as exc:
+        await runner._fetch_base(
+            workspace_id="ws_current",
+            worktree_path=tmp_path / "worktrees" / "ws_current",
+            base_branch="development",
+        )
+
+    assert "database unavailable" in str(exc.value)
+    assert fetch_base_once.await_count == 1
+    repair.assert_awaited_once()
+
+
+@pytest.mark.unit
 async def test_missing_workspace_terminal_helpers_return_without_side_effects(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -886,6 +886,53 @@ async def test_pre_merge_recheck_base_fetch_error_fails_workspace(
 
 
 @pytest.mark.unit
+async def test_pre_merge_recheck_base_behind_error_fails_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        pre_merge_settle_seconds=2,
+    )
+    mocker.patch.object(
+        runner,
+        "_fetch_status_for_decision",
+        mocker.AsyncMock(side_effect=BaseBehindCountError("rev-list died")),
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert sleep_fn.calls == [2]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert "could not calculate base-behind count" in (ws.failure_message or "")
+        assert ws.events[-1].reason_code == "GIT_BASE_BEHIND_FAILED"
+
+
+@pytest.mark.unit
 async def test_pre_merge_recheck_transient_github_error_retries_later(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -2855,6 +2902,50 @@ async def test_git_helpers_handle_bad_base_count_and_push_rejection_recovery(
 
     assert cmd.calls[-2].args[-2:] == ["origin", "awf/ws_git"]
     assert cmd.calls[-1].args[-2:] == ["--hard", "origin/awf/ws_git"]
+
+
+@pytest.mark.unit
+async def test_fetch_base_repairs_multiple_broken_awf_refs_before_failing_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    fetch_base_once = mocker.patch.object(
+        runner,
+        "_fetch_base_once",
+        mocker.AsyncMock(
+            side_effect=[
+                CommandResult(returncode=1, stdout="", stderr="bad ref ws_old_1"),
+                CommandResult(returncode=1, stdout="", stderr="bad ref ws_old_2"),
+                CommandResult(returncode=0, stdout="", stderr=""),
+            ]
+        ),
+    )
+    repair = mocker.patch.object(
+        runner,
+        "_repair_orphaned_broken_awf_ref",
+        mocker.AsyncMock(side_effect=[True, True]),
+    )
+
+    await runner._fetch_base(
+        workspace_id="ws_current",
+        worktree_path=tmp_path / "worktrees" / "ws_current",
+        base_branch="development",
+    )
+
+    assert fetch_base_once.await_count == 3
+    assert repair.await_count == 2
+    assert [call.kwargs["stderr"] for call in repair.await_args_list] == [
+        "bad ref ws_old_1",
+        "bad ref ws_old_2",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -42,6 +42,7 @@ from awf.runtime.pr_monitor import (
     SyncBase,
 )
 from awf.runtime.pr_monitor_runner import (
+    BaseBehindCountError,
     MonitorRunnerConfig,
     ProviderRecoveryRetryError,
     PullRequestMonitorRunner,
@@ -2477,7 +2478,7 @@ async def test_monitor_sync_base_cleanup_failure_terminates_without_push(
     assert terminal is True
     assert [call.args[-2:] for call in cmd.calls] == [
         ["merge", "--abort"],
-        ["origin", "development"],
+        ["origin", "+refs/heads/development:refs/remotes/origin/development"],
         ["--no-edit", "origin/development"],
         ["status", "--porcelain"],
     ]
@@ -2731,7 +2732,7 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
     assert "src/conflict.py" in adapter.calls[0]
     assert [call.args[-2:] for call in cmd.calls[:2]] == [
         ["merge", "--abort"],
-        ["origin", "development"],
+        ["origin", "+refs/heads/development:refs/remotes/origin/development"],
     ]
     assert cmd.calls[-1].args[-2:] == ["origin", "HEAD:refs/heads/awf/ws_sync_conflict"]
 
@@ -2797,8 +2798,10 @@ async def test_git_helpers_handle_bad_base_count_and_push_rejection_recovery(
     )
     worktree = tmp_path / "worktrees" / "ws_git"
 
-    assert await runner._count_base_behind(worktree_path=worktree, base_branch="main") == 0
-    assert await runner._count_base_behind(worktree_path=worktree, base_branch="main") == 0
+    with pytest.raises(BaseBehindCountError):
+        await runner._count_base_behind(worktree_path=worktree, base_branch="main")
+    with pytest.raises(BaseBehindCountError):
+        await runner._count_base_behind(worktree_path=worktree, base_branch="main")
     assert await runner._git_push(worktree_path=worktree, remote_branch="awf/ws_git") is False
 
     assert cmd.calls[-2].args[-2:] == ["origin", "awf/ws_git"]

--- a/tests/unit/service/test_artifacts.py
+++ b/tests/unit/service/test_artifacts.py
@@ -8,6 +8,10 @@ from typing import Any
 import pytest
 
 import awf.service.artifacts as artifacts_module
+from awf.common.config import get_settings
+from awf.db.base import Base
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_engine, make_session_factory
 from awf.service.artifacts import (
     ArtifactNotFoundError,
     ArtifactPathError,
@@ -29,6 +33,25 @@ class TestArtifactService:
         assert workspace_artifact_dir(tmp_path / "awf-state", "ws_123") == (
             tmp_path / "awf-state" / "artifacts" / "ws_123"
         )
+
+    @pytest.mark.unit
+    def test_workspace_artifact_dir_private_helper_uses_explicit_or_settings_work_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        monkeypatch.setenv("AWF_WORK_DIR", str(tmp_path / "settings-work"))
+        get_settings.cache_clear()
+        try:
+            assert artifacts_module._workspace_artifact_dir(  # noqa: SLF001
+                "ws_123",
+                work_dir=tmp_path / "explicit-work",
+            ) == tmp_path / "explicit-work" / "artifacts" / "ws_123"
+            assert artifacts_module._workspace_artifact_dir("ws_123") == (  # noqa: SLF001
+                tmp_path / "settings-work" / "artifacts" / "ws_123"
+            )
+        finally:
+            get_settings.cache_clear()
 
     @pytest.mark.unit
     def test_safe_nested_relative_path_resolves_download_metadata(self, tmp_path: Path) -> None:
@@ -272,6 +295,252 @@ class TestArtifactService:
         assert items[0].workspace_id == "ws_artifacts"
         assert items[0].kind == "txt"
         assert items[0].content_type == "text/plain"
+
+    @pytest.mark.unit
+    def test_listing_skips_file_lost_between_classification_and_stat(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        flaky = artifact_dir / "flaky.txt"
+        flaky.write_text("flaky\n", encoding="utf-8")
+        flaky_resolved = flaky.resolve()
+        original_resolve = Path.resolve
+        original_is_file = Path.is_file
+        original_stat = Path.stat
+
+        def resolve_candidate(self: Path, *args: Any, **kwargs: Any) -> Path:
+            if self == flaky:
+                return flaky_resolved
+            return original_resolve(self, *args, **kwargs)
+
+        def is_file_candidate(self: Path, *args: Any, **kwargs: Any) -> bool:
+            if self == flaky_resolved:
+                return True
+            return original_is_file(self, *args, **kwargs)
+
+        def stat_candidate(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if self == flaky_resolved:
+                raise FileNotFoundError(str(self))
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", resolve_candidate)
+        monkeypatch.setattr(Path, "is_file", is_file_candidate)
+        monkeypatch.setattr(Path, "stat", stat_candidate)
+
+        assert list_artifacts("ws_artifacts", artifact_dir) == []
+
+    @pytest.mark.unit
+    def test_private_listing_helpers_return_response_models_and_pages(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        (artifact_dir / "a.txt").write_text("a\n", encoding="utf-8")
+        (artifact_dir / "b.txt").write_text("b\n", encoding="utf-8")
+
+        items = artifacts_module._list_artifacts("ws_artifacts", artifact_dir)  # noqa: SLF001
+        page = artifacts_module._list_artifacts_page(  # noqa: SLF001
+            "ws_artifacts",
+            artifact_dir,
+            limit=1,
+            cursor=None,
+        )
+
+        assert [item.relative_path for item in items] == ["a.txt", "b.txt"]
+        assert items[0].path.endswith("/a.txt")
+        assert page.items[0].relative_path == "a.txt"
+        assert page.has_more is True
+        assert page.next_cursor is not None
+
+    @pytest.mark.unit
+    def test_listing_skips_entries_that_change_during_traversal(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        flaky_dir = artifact_dir / "flaky-dir"
+        flaky_dir.mkdir()
+        flaky_file = artifact_dir / "flaky-file.txt"
+        flaky_file.write_text("file\n", encoding="utf-8")
+        stable = artifact_dir / "stable.txt"
+        stable.write_text("stable\n", encoding="utf-8")
+        original_resolve = Path.resolve
+        original_is_symlink = Path.is_symlink
+
+        symlink_checks: dict[Path, int] = {}
+
+        def is_symlink_candidate(self: Path) -> bool:
+            if self == flaky_file:
+                symlink_checks[self] = symlink_checks.get(self, 0) + 1
+                return symlink_checks[self] > 1
+            return original_is_symlink(self)
+
+        def resolve_candidate(self: Path, *args: Any, **kwargs: Any) -> Path:
+            if self == flaky_dir:
+                raise OSError("directory disappeared")
+            return original_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "is_symlink", is_symlink_candidate)
+        monkeypatch.setattr(Path, "resolve", resolve_candidate)
+
+        assert [item.relative_path for item in list_artifacts("ws_artifacts", artifact_dir)] == [
+            "stable.txt"
+        ]
+
+    @pytest.mark.unit
+    def test_directory_entry_push_fails_closed_on_iterdir_and_is_dir_errors(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        flaky = artifact_dir / "flaky"
+        flaky.write_text("file\n", encoding="utf-8")
+        original_iterdir = Path.iterdir
+        original_is_dir = Path.is_dir
+
+        def iterdir_candidate(self: Path) -> Any:
+            if self == artifact_dir:
+                raise OSError("cannot list")
+            return original_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", iterdir_candidate)
+        assert list_artifacts("ws_artifacts", artifact_dir) == []
+
+        monkeypatch.setattr(Path, "iterdir", original_iterdir)
+
+        def is_dir_candidate(self: Path, *args: Any, **kwargs: Any) -> bool:
+            if self == flaky:
+                raise OSError("cannot classify")
+            return original_is_dir(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "is_dir", is_dir_candidate)
+        assert list_artifacts("ws_artifacts", artifact_dir) == []
+
+    @pytest.mark.unit
+    def test_listing_skips_directory_and_file_races_without_leaving_artifact_root(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        valid_dir = artifact_dir / "valid-dir"
+        valid_dir.mkdir()
+        (valid_dir / "nested.txt").write_text("nested\n", encoding="utf-8")
+        dir_becomes_symlink = artifact_dir / "dir-becomes-symlink"
+        dir_becomes_symlink.mkdir()
+        dir_outside = artifact_dir / "dir-outside"
+        dir_outside.mkdir()
+        file_outside = artifact_dir / "file-outside.txt"
+        file_outside.write_text("outside\n", encoding="utf-8")
+        file_stat_error = artifact_dir / "file-stat-error.txt"
+        file_stat_error.write_text("stat error\n", encoding="utf-8")
+        outside_dir = tmp_path / "outside-dir"
+        outside_dir.mkdir()
+        outside_file = tmp_path / "outside-file.txt"
+        outside_file.write_text("outside\n", encoding="utf-8")
+        (artifact_dir / "symlink-skipped-in-push").symlink_to(outside_file)
+        file_stat_error_resolved = file_stat_error.resolve()
+        original_is_symlink = Path.is_symlink
+        original_resolve = Path.resolve
+        original_stat = Path.stat
+        symlink_checks: dict[Path, int] = {}
+
+        def is_symlink_candidate(self: Path) -> bool:
+            if self == dir_becomes_symlink:
+                symlink_checks[self] = symlink_checks.get(self, 0) + 1
+                return symlink_checks[self] > 1
+            return original_is_symlink(self)
+
+        def resolve_candidate(self: Path, *args: Any, **kwargs: Any) -> Path:
+            if self == dir_outside:
+                return outside_dir
+            if self == file_outside:
+                return outside_file
+            return original_resolve(self, *args, **kwargs)
+
+        def stat_candidate(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if self == file_stat_error_resolved:
+                raise OSError("cannot stat")
+            return original_stat(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "is_symlink", is_symlink_candidate)
+        monkeypatch.setattr(Path, "resolve", resolve_candidate)
+        monkeypatch.setattr(Path, "stat", stat_candidate)
+
+        assert [item.relative_path for item in list_artifacts("ws_artifacts", artifact_dir)] == [
+            "valid-dir/nested.txt"
+        ]
+
+    @pytest.mark.unit
+    async def test_list_workspace_artifacts_metadata_returns_none_for_missing_workspace(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = make_session_factory(engine)
+        try:
+            async with factory() as session:
+                assert (
+                    await artifacts_module.list_workspace_artifacts_metadata(
+                        session,
+                        workspace_id="ws_missing",
+                        work_dir=tmp_path / "work",
+                    )
+                    is None
+                )
+        finally:
+            await engine.dispose()
+
+    @pytest.mark.unit
+    async def test_list_workspace_artifacts_metadata_pages_existing_workspace(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        engine = make_engine("sqlite+aiosqlite:///:memory:")
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+        factory = make_session_factory(engine)
+        work_dir = tmp_path / "work"
+        try:
+            async with factory() as session:
+                repo = WorkspaceRepository(session)
+                ws = await repo.create(
+                    repo_url="git@github.com:x/y.git",
+                    branch_base="main",
+                    task_title="artifacts",
+                    task_prompt="artifacts",
+                    agent="codex",
+                    test_commands=[],
+                    requires_database=False,
+                )
+                artifact_dir = workspace_artifact_dir(work_dir, ws.id)
+                artifact_dir.mkdir(parents=True)
+                (artifact_dir / "report.txt").write_text("report\n", encoding="utf-8")
+                await session.commit()
+
+                response = await artifacts_module.list_workspace_artifacts_metadata(
+                    session,
+                    workspace_id=ws.id,
+                    work_dir=work_dir,
+                    limit=1,
+                )
+        finally:
+            await engine.dispose()
+
+        assert response is not None
+        assert [item.relative_path for item in response.items] == ["report.txt"]
+        assert response.has_more is False
 
     @pytest.mark.unit
     def test_resolved_artifact_root_must_remain_a_directory(

--- a/tests/unit/service/test_artifacts.py
+++ b/tests/unit/service/test_artifacts.py
@@ -333,6 +333,46 @@ class TestArtifactService:
         assert list_artifacts("ws_artifacts", artifact_dir) == []
 
     @pytest.mark.unit
+    def test_listing_skips_file_when_explicit_stat_fails(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        artifact_dir = tmp_path / "artifacts" / "ws_artifacts"
+        artifact_dir.mkdir(parents=True)
+        stat_error = artifact_dir / "stat-error.txt"
+        stat_error.write_text("flaky\n", encoding="utf-8")
+        stable = artifact_dir / "stable.txt"
+        stable.write_text("kept\n", encoding="utf-8")
+        stat_error_resolved = stat_error.resolve()
+        original_resolve = Path.resolve
+        stat_failures = 0
+
+        class FlakyResolvedArtifact:
+            def is_relative_to(self, _root: Path) -> bool:
+                return True
+
+            def is_file(self) -> bool:
+                return True
+
+            def stat(self) -> Any:
+                nonlocal stat_failures
+                stat_failures += 1
+                raise OSError("cannot stat artifact")
+
+        def resolve_candidate(self: Path, *args: Any, **kwargs: Any) -> Any:
+            if self == stat_error_resolved:
+                return FlakyResolvedArtifact()
+            return original_resolve(self, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "resolve", resolve_candidate)
+
+        assert [item.relative_path for item in list_artifacts("ws_artifacts", artifact_dir)] == [
+            "stable.txt"
+        ]
+        assert stat_failures == 1
+
+    @pytest.mark.unit
     def test_private_listing_helpers_return_response_models_and_pages(
         self,
         tmp_path: Path,

--- a/tests/unit/service/test_bootstrap.py
+++ b/tests/unit/service/test_bootstrap.py
@@ -36,6 +36,11 @@ def _settings(tmp_path: Path) -> ServiceSettings:
     )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_local_compose_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(bootstrap, "local_service_environ", lambda: {})
+
+
 async def _ok_status_collector(
     settings: ServiceSettings,
     **kwargs: object,

--- a/tests/unit/service/test_bounded_list.py
+++ b/tests/unit/service/test_bounded_list.py
@@ -1,4 +1,4 @@
-"""Bounded-list cursor helper tests."""
+"""Bounded list pagination cursor tests."""
 
 from __future__ import annotations
 
@@ -10,8 +10,71 @@ import pytest
 
 from awf.service.bounded_list import (
     InvalidBoundedListCursorError,
+    bounded_list_limit,
     decode_bounded_list_cursor,
+    encode_bounded_list_cursor,
+    paginate_bounded_iterable,
+    paginate_bounded_list,
 )
+
+
+@pytest.mark.unit
+def test_paginate_bounded_list_clamps_limit_and_returns_cursor() -> None:
+    page = paginate_bounded_list(["a", "b", "c"], limit=10, max_limit=2)
+
+    assert page.items == ["a", "b"]
+    assert page.limit == 2
+    assert page.has_more is True
+    assert page.next_cursor == encode_bounded_list_cursor(2)
+
+
+@pytest.mark.unit
+def test_paginate_bounded_iterable_uses_offset_cursor_without_over_reading() -> None:
+    cursor = encode_bounded_list_cursor(1)
+    page = paginate_bounded_iterable(
+        iter(["a", "b", "c", "d"]),
+        limit=2,
+        max_limit=10,
+        cursor=cursor,
+    )
+
+    assert page.items == ["b", "c"]
+    assert page.cursor == cursor
+    assert page.next_cursor == encode_bounded_list_cursor(3)
+    assert page.has_more is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("limit", [-10, 0, 1, 50])
+def test_bounded_list_limit_clamps_to_valid_range(limit: int) -> None:
+    assert 1 <= bounded_list_limit(limit, 5) <= 5
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"not-base64!",
+        base64.urlsafe_b64encode(b"{not-json"),
+        base64.urlsafe_b64encode(json.dumps({}).encode("utf-8")),
+        base64.urlsafe_b64encode(json.dumps({"o": "1"}).encode("utf-8")),
+        base64.urlsafe_b64encode(json.dumps({"o": True}).encode("utf-8")),
+        base64.urlsafe_b64encode(json.dumps({"o": -1}).encode("utf-8")),
+    ],
+)
+def test_decode_bounded_list_cursor_rejects_malformed_payloads(payload: bytes) -> None:
+    cursor = payload.decode("ascii").rstrip("=")
+
+    with pytest.raises(InvalidBoundedListCursorError):
+        decode_bounded_list_cursor(cursor)
+
+
+@pytest.mark.unit
+def test_decode_bounded_list_cursor_round_trips_unpadded_payload() -> None:
+    cursor = encode_bounded_list_cursor(42)
+
+    assert "=" not in cursor
+    assert decode_bounded_list_cursor(cursor) == 42
 
 
 def _cursor(payload: dict[str, Any]) -> str:

--- a/tests/unit/service/test_gc_more2.py
+++ b/tests/unit/service/test_gc_more2.py
@@ -28,6 +28,7 @@ from awf.service.gc import (
     _default_worktree_remover,
     _pr_has_merged,
     _release_gc_reservations,
+    _run_worktree_remove,
     plan_terminal_workspace_gc,
     run_terminal_workspace_gc,
     run_workspace_filesystem_gc,
@@ -627,6 +628,36 @@ def test_worktree_remove_result_to_dict_with_error():
     assert payload["status"] == "failed"
     assert payload["reason_code"] == "GIT_WORKTREE_REMOVE_FAILED"
     assert payload["error"] == "mirror not accessible"
+
+
+async def test_run_worktree_remove_skips_when_callback_absent() -> None:
+    candidate = WorkspaceGCCandidate(
+        workspace_id="ws_no_remover",
+        status=WorkspaceStatus.completed.value,
+        updated_at=datetime(2026, 4, 26, 12, tzinfo=UTC),
+        age_hours=200,
+        reason_code="COMPLETED_PR_RETENTION_EXPIRED",
+        worktree=WorkspaceGCPath(
+            kind="worktree",
+            path=Path("/tmp/awf/worktrees/ws_no_remover"),
+            exists=True,
+            estimated_bytes=1,
+        ),
+        compose=WorkspaceGCPath(
+            kind="compose",
+            path=Path("/tmp/awf/compose/ws_no_remover"),
+            exists=False,
+            estimated_bytes=0,
+        ),
+        auth=WorkspaceGCPath(
+            kind="auth",
+            path=Path("/tmp/awf/auth/ws_no_remover"),
+            exists=False,
+            estimated_bytes=0,
+        ),
+    )
+
+    assert await _run_worktree_remove(candidate, None) is None
 
 
 async def test_gc_worktree_remover_with_awaitable_callback(

--- a/tests/unit/service/test_provider_readiness.py
+++ b/tests/unit/service/test_provider_readiness.py
@@ -447,6 +447,200 @@ def test_cli_auth_probe_failure_modes_are_structured_and_redacted() -> None:
 
 
 @pytest.mark.unit
+def test_agent_runtime_cli_probe_failure_modes_are_structured_and_redacted(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level(logging.ERROR, logger=provider_readiness.__name__)
+    settings = _settings(tmp_path)
+
+    def _missing(_args: list[str], **_kwargs: object) -> Any:
+        raise FileNotFoundError("docker")
+
+    def _timeout(args: list[str], **_kwargs: object) -> Any:
+        raise subprocess.TimeoutExpired(args, timeout=0.1)
+
+    def _unexpected(_args: list[str], **_kwargs: object) -> Any:
+        raise RuntimeError("runtime probe leaked sk-proj-runtime-secret")
+
+    missing = provider_readiness._probe_agent_runtime_cli(
+        settings,
+        executable="codex",
+        provider="codex",
+        environ={},
+        run_subprocess=_missing,
+        secrets=frozenset(),
+    )
+    timeout = provider_readiness._probe_agent_runtime_cli(
+        settings,
+        executable="claude",
+        provider="claude_code",
+        environ={},
+        run_subprocess=_timeout,
+        secrets=frozenset(),
+    )
+    unexpected = provider_readiness._probe_agent_runtime_cli(
+        settings,
+        executable="gemini",
+        provider="gemini",
+        environ={},
+        run_subprocess=_unexpected,
+        secrets=frozenset({"sk-proj-runtime-secret"}),
+    )
+
+    assert missing["reason_code"] == "DOCKER_CLI_NOT_FOUND"
+    assert timeout["reason_code"] == "CLAUDE_RUNTIME_CLI_PROBE_TIMEOUT"
+    assert unexpected["reason_code"] == "GEMINI_RUNTIME_CLI_PROBE_ERROR"
+    assert "sk-proj-runtime-secret" not in json.dumps(unexpected, sort_keys=True)
+    assert "<redacted>" in unexpected["detail"]
+    assert "provider_readiness.agent_runtime_cli_probe_exception" in caplog.text
+    assert "sk-proj-runtime-secret" not in caplog.text
+
+
+@pytest.mark.unit
+def test_agent_runtime_cli_probe_reports_success_and_missing_cli(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+
+    ok = provider_readiness._probe_agent_runtime_cli(
+        settings,
+        executable="opencode",
+        provider="opencode",
+        environ={},
+        run_subprocess=lambda _args, **_kwargs: _completed(stdout="/usr/bin/opencode\n"),
+        secrets=frozenset(),
+    )
+    missing = provider_readiness._probe_agent_runtime_cli(
+        settings,
+        executable="opencode",
+        provider="opencode",
+        environ={},
+        run_subprocess=lambda _args, **_kwargs: _completed(
+            returncode=127,
+            stderr="opencode: not found with token sk-proj-opencode-secret",
+        ),
+        secrets=frozenset({"sk-proj-opencode-secret"}),
+    )
+
+    assert ok == {
+        "status": "ok",
+        "reason_code": "OPENCODE_RUNTIME_CLI_AVAILABLE",
+        "detail": "/usr/bin/opencode",
+    }
+    assert missing["status"] == "fail"
+    assert missing["reason_code"] == "OPENCODE_RUNTIME_CLI_NOT_FOUND"
+    assert "awf-agent-runtime:latest" in missing["message"]
+    assert "sk-proj-opencode-secret" not in json.dumps(missing, sort_keys=True)
+    assert "<redacted>" in missing["detail"]
+
+
+@pytest.mark.unit
+def test_cli_auth_probe_reports_success_and_unusable_auth() -> None:
+    success = provider_readiness._probe_cli_auth_status(
+        provider_label="Probe",
+        args=["probe", "auth", "status"],
+        failure_reason="PROBE_AUTH_FAILED",
+        timeout_reason="PROBE_AUTH_TIMEOUT",
+        missing_reason="PROBE_CLI_NOT_FOUND",
+        error_reason="PROBE_AUTH_ERROR",
+        environ={},
+        run_subprocess=lambda _args, **_kwargs: _completed(stdout="ok"),
+        secrets=frozenset(),
+    )
+    failure = provider_readiness._probe_cli_auth_status(
+        provider_label="Probe",
+        args=["probe", "auth", "status"],
+        failure_reason="PROBE_AUTH_FAILED",
+        timeout_reason="PROBE_AUTH_TIMEOUT",
+        missing_reason="PROBE_CLI_NOT_FOUND",
+        error_reason="PROBE_AUTH_ERROR",
+        environ={},
+        run_subprocess=lambda _args, **_kwargs: _completed(
+            returncode=1,
+            stderr="invalid token sk-proj-auth-secret",
+        ),
+        secrets=frozenset({"sk-proj-auth-secret"}),
+    )
+
+    assert success == {"status": "ok", "reason_code": "PROBE_AUTH_OK"}
+    assert failure["reason_code"] == "PROBE_AUTH_FAILED"
+    assert "sk-proj-auth-secret" not in json.dumps(failure, sort_keys=True)
+    assert "<redacted>" in failure["detail"]
+
+
+@pytest.mark.unit
+def test_provider_readiness_rejects_unreachable_internal_provider(tmp_path: Path) -> None:
+    with pytest.raises(AssertionError, match="unsupported provider"):
+        provider_readiness._check_provider_readiness(  # type: ignore[arg-type]
+            "not_a_provider",
+            _settings(tmp_path),
+            environ={},
+            host_home=tmp_path / "home",
+            strict=False,
+            run_subprocess=_unexpected_subprocess,
+            http_get=_ollama_ok,
+            secrets=frozenset(),
+        )
+
+
+@pytest.mark.unit
+def test_selected_launch_probe_skips_when_provider_or_model_is_unavailable(
+    tmp_path: Path,
+) -> None:
+    assert provider_readiness._selected_launch_probe(
+        "codex",
+        settings=_settings(tmp_path),
+        provider_result={"ok": False},
+        model="gpt-5.5",
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_ollama_ok,
+        secrets=frozenset(),
+    ) == {"status": "skipped"}
+    assert provider_readiness._selected_launch_probe(
+        "codex",
+        settings=_settings(tmp_path),
+        provider_result={"ok": True},
+        model=None,
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_ollama_ok,
+        secrets=frozenset(),
+    ) == {"status": "skipped"}
+
+
+@pytest.mark.unit
+def test_selected_launch_probe_returns_runtime_failure_and_unavailable_provider(
+    tmp_path: Path,
+) -> None:
+    runtime_failure = provider_readiness._selected_launch_probe(
+        "codex",
+        settings=_settings(tmp_path),
+        provider_result={"ok": True},
+        model="gpt-5.5",
+        environ={},
+        run_subprocess=lambda _args, **_kwargs: _completed(returncode=127, stderr="missing"),
+        http_get=_ollama_ok,
+        secrets=frozenset(),
+    )
+    unavailable = provider_readiness._selected_launch_probe(
+        "docker",
+        settings=_settings(tmp_path),
+        provider_result={"ok": True},
+        model="docker-host",
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+        http_get=_ollama_ok,
+        secrets=frozenset(),
+    )
+
+    assert runtime_failure["reason_code"] == "CODEX_RUNTIME_CLI_NOT_FOUND"
+    assert unavailable == {
+        "status": "unavailable",
+        "reason_code": "PROVIDER_PROBE_UNAVAILABLE",
+    }
+
+
+@pytest.mark.unit
 def test_selected_gemini_preflight_requires_usable_non_secret_probe(
     tmp_path: Path,
 ) -> None:
@@ -618,6 +812,48 @@ def test_preflight_reason_and_message_report_missing_model() -> None:
         probe=probe,
         model=None,
     ) == "No effective model was selected for the workspace agent."
+
+
+@pytest.mark.unit
+def test_provider_readiness_preflight_snapshot_and_text_redaction(tmp_path: Path) -> None:
+    snapshot = {"provider": "codex", "reason_code": "PROVIDER_READY"}
+
+    assert provider_readiness.provider_readiness_preflight_from_task_policy(
+        {"provider_readiness_preflight": snapshot}
+    ) == snapshot
+    assert provider_readiness.provider_readiness_preflight_from_task_policy(
+        {"provider_readiness_preflight": "bad-shape"}
+    ) is None
+    redacted = provider_readiness.redact_launch_preflight_text(
+        _settings(tmp_path),
+        "token sk-proj-redact-text-secret",
+        environ={"OPENAI_API_KEY": "sk-proj-redact-text-secret"},
+    )
+    assert redacted == "token <redacted>"
+
+
+@pytest.mark.unit
+def test_preflight_payload_records_redacted_override_reason_parts() -> None:
+    payload = provider_readiness._launch_preflight_payload(
+        agent="codex",
+        provider="codex",
+        model="gpt-5.5",
+        model_source="default",
+        provider_result={"ok": False, "status": "fail", "reason": "CODEX_AUTH_MISSING"},
+        probe={"status": "skipped"},
+        reason_code="CODEX_AUTH_MISSING",
+        message="missing",
+        override=True,
+        override_reason="operator checked sk-proj-override-secret manually",
+        checked_at=provider_readiness.datetime(2026, 5, 4, tzinfo=provider_readiness.UTC),
+        secrets=frozenset({"sk-proj-override-secret"}),
+    )
+
+    assert payload["override_reason"] == "operator checked <redacted> manually"
+    assert payload["override_reason_redaction_parts"] == [
+        "operator checked ",
+        " manually",
+    ]
 
 
 @pytest.mark.unit
@@ -1753,6 +1989,31 @@ def test_ollama_model_probe_checks_fallback_tags_urls_before_missing() -> None:
 
 
 @pytest.mark.unit
+def test_ollama_model_probe_reports_missing_model_with_probe_failures() -> None:
+    def _http_get(url: str, *, timeout: float) -> Any:
+        assert timeout > 0
+        if url == "http://primary.local/api/tags":
+            return SimpleNamespace(
+                status_code=200,
+                text='{"models":[{"name":"other-model:latest"}]}',
+            )
+        return SimpleNamespace(status_code=503, text="busy")
+
+    result = provider_readiness._probe_ollama_model(
+        ("http://primary.local/api/tags", "http://secondary.local/api/tags"),
+        model="llama3",
+        http_get=_http_get,
+        secrets=frozenset(),
+    )
+
+    assert result["reason_code"] == "OLLAMA_MODEL_NOT_AVAILABLE"
+    assert result["detail"] == (
+        "selected=llama3; available_count=1; "
+        "probe_failures=http://secondary.local/api/tags: HTTP 503: busy"
+    )
+
+
+@pytest.mark.unit
 def test_ollama_model_probe_rejects_invalid_json() -> None:
     def _http_get(_url: str, *, timeout: float) -> Any:
         assert timeout > 0
@@ -1941,6 +2202,66 @@ def test_provider_readiness_preserves_long_diagnostic_ids_in_details(
     assert image_digest in detail
     assert container_id in detail
     assert error_payload_id in detail
+
+
+@pytest.mark.unit
+def test_provider_readiness_redaction_parts_preserve_literal_context() -> None:
+    rendered, parts = provider_readiness._redact_with_redaction_parts(
+        (
+            "prefix sk-proj-literal-secret "
+            "https://user:ghp_url_secret@github.com/org/repo "
+            "and token sk-ant-token-secret suffix"
+        ),
+        frozenset({"sk-proj-literal-secret"}),
+    )
+
+    assert rendered == (
+        "prefix <redacted> https://<redacted>@github.com/org/repo "
+        "and token <redacted> suffix"
+    )
+    assert parts == [
+        "prefix ",
+        " https://",
+        "@github.com/org/repo and token ",
+        " suffix",
+    ]
+
+
+@pytest.mark.unit
+def test_provider_readiness_redaction_segment_helpers_cover_overlap_edges() -> None:
+    segments = [
+        ("literal", "alpha"),
+        ("redaction", ""),
+        ("literal", "beta"),
+        ("literal", ""),
+        ("literal", "gamma"),
+    ]
+
+    assert provider_readiness._replace_literal_redaction_spans(segments, "") is segments
+    assert provider_readiness._slice_redaction_segments(segments, 8, 8) == []
+    assert provider_readiness._slice_redaction_segments(segments, 0, 17) == [
+        ("literal", "alpha"),
+        ("redaction", ""),
+        ("literal", "be"),
+    ]
+    assert provider_readiness._merge_literal_redaction_segments(segments) == [
+        ("literal", "alpha"),
+        ("redaction", ""),
+        ("literal", "betagamma"),
+    ]
+    assert provider_readiness._replace_literal_redaction_spans(
+        [("literal", "unchanged"), ("redaction", ""), ("literal", "alpha-alpha")],
+        "alpha",
+    ) == [
+        ("literal", "unchanged"),
+        ("redaction", ""),
+        ("redaction", ""),
+        ("literal", "-"),
+        ("redaction", ""),
+    ]
+    assert provider_readiness._slice_redaction_segments(segments, 6, 14) == [
+        ("literal", "redacted")
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_smoke.py
+++ b/tests/unit/service/test_smoke.py
@@ -116,19 +116,6 @@ def _config_resolver(api_base_url="http://localhost:8000"):
 
 
 @pytest.mark.unit
-def test_default_config_resolver_includes_console_url_when_configured() -> None:
-    assert _default_config_resolver(
-        SimpleNamespace(
-            api_base_url="http://localhost:8000",
-            console_url="http://localhost:3000",
-        )
-    ) == {
-        "api_base_url": "http://localhost:8000",
-        "console_url": "http://localhost:3000",
-    }
-
-
-@pytest.mark.unit
 class TestCollectSmokeReportLiveMode:
     async def test_all_phases_pass_with_valid_project(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")

--- a/tests/unit/service/test_smoke.py
+++ b/tests/unit/service/test_smoke.py
@@ -116,6 +116,19 @@ def _config_resolver(api_base_url="http://localhost:8000"):
 
 
 @pytest.mark.unit
+def test_default_config_resolver_includes_console_url_when_configured() -> None:
+    assert _default_config_resolver(
+        SimpleNamespace(
+            api_base_url="http://localhost:8000",
+            console_url="http://localhost:3000",
+        )
+    ) == {
+        "api_base_url": "http://localhost:8000",
+        "console_url": "http://localhost:3000",
+    }
+
+
+@pytest.mark.unit
 class TestCollectSmokeReportLiveMode:
     async def test_all_phases_pass_with_valid_project(self, tmp_path: Path) -> None:
         (tmp_path / "pyproject.toml").write_text("[project]\nname = 'demo'\n")

--- a/tests/unit/service/test_status.py
+++ b/tests/unit/service/test_status.py
@@ -10,6 +10,7 @@ import sys
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -31,6 +32,7 @@ from awf.service.status import (
     _docker_socket_path,
     _fail,
     _http_get,
+    _is_legacy_open_default_workspace,
     _orphan_resources_check_payload,
     _run_docker_command,
     _run_subprocess,
@@ -371,6 +373,34 @@ def test_workspace_cleanup_status_reports_plan_unavailable_without_engine_dispos
 
 
 @pytest.mark.unit
+def test_workspace_cleanup_status_disposes_engine_when_plan_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    disposed = False
+
+    class _Engine:
+        async def dispose(self) -> None:
+            nonlocal disposed
+            disposed = True
+
+    async def fail_plan(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        raise RuntimeError("planner failed")
+
+    monkeypatch.setattr(status_mod, "make_engine", lambda _url: _Engine())
+    monkeypatch.setattr(status_mod, "make_session_factory", lambda _engine: object())
+    monkeypatch.setattr(status_mod, "plan_terminal_workspace_gc", fail_plan)
+
+    cleanup = asyncio.run(collect_workspace_cleanup_status(_settings(tmp_path)))
+
+    assert cleanup["ok"] is True
+    assert cleanup["status"] == "unavailable"
+    assert cleanup["reason"] == "CLEANUP_PLAN_UNAVAILABLE"
+    assert "planner failed" in cleanup["detail"]
+    assert disposed is True
+
+
+@pytest.mark.unit
 def test_status_db_helpers_handle_engine_construction_failures(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -386,6 +416,53 @@ def test_status_db_helpers_handle_engine_construction_failures(
     assert db["ok"] is False
     assert db["reason"] == "DB_CONNECTION_FAILED"
     assert view.available is False
+
+
+@pytest.mark.unit
+def test_check_database_disposes_engine_when_probe_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    disposed = False
+
+    class _Connection:
+        async def __aenter__(self) -> _Connection:
+            return self
+
+        async def __aexit__(self, *_exc: object) -> None:
+            return None
+
+        async def execute(self, *_args: object, **_kwargs: object) -> None:
+            raise RuntimeError("select failed")
+
+    class _Engine:
+        def connect(self) -> _Connection:
+            return _Connection()
+
+        async def dispose(self) -> None:
+            nonlocal disposed
+            disposed = True
+
+    monkeypatch.setattr(status_mod, "make_engine", lambda _url: _Engine())
+
+    db = asyncio.run(check_database("sqlite+aiosqlite:///fake.db"))
+
+    assert db["ok"] is False
+    assert db["reason"] == "DB_CONNECTION_FAILED"
+    assert "select failed" in str(db["detail"])
+    assert disposed is True
+
+
+@pytest.mark.unit
+def test_legacy_open_default_treats_non_datetime_rows_as_legacy() -> None:
+    cutoff = datetime(2026, 5, 4, tzinfo=UTC)
+
+    assert (
+        _is_legacy_open_default_workspace(
+            "legacy-string-created-at",
+            legacy_open_default_cutoff=cutoff,
+        )
+        is True
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_support_bundle.py
+++ b/tests/unit/service/test_support_bundle.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-import awf.service.support_bundle as support_bundle_module
+from awf.service import support_bundle as support_bundle_mod
 from awf.service.config import ServiceSettings
 from awf.service.support_bundle import (
     BUNDLE_FILENAME_PREFIX,
@@ -142,6 +142,23 @@ def _mock_failure_summary() -> dict[str, object]:
         "latest_examples": [],
         "root_cause_clusters": [],
     }
+
+
+class SecretEcho:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+    def __str__(self) -> str:
+        return f"opaque {self.value}"
+
+
+@dataclass
+class FailureSummaryPayload:
+    generated_at: str
+    since_hours: int
+    latest_examples: list[object]
+    root_cause_clusters: list[object]
+    opaque_detail: object
 
 
 @pytest.mark.unit
@@ -414,67 +431,64 @@ def test_support_bundle_degrades_when_db_unreachable(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_support_bundle_degrades_when_status_and_doctor_collectors_fail(
-    tmp_path: Path,
-) -> None:
+def test_support_bundle_degrades_when_status_and_doctor_collectors_fail(tmp_path: Path) -> None:
     settings = _settings(tmp_path)
+    secret = "sk-support-bundle-secret"
 
-    async def _bad_status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
-        raise RuntimeError("status collector down")
+    async def _status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
+        raise RuntimeError(f"status failed with {secret}")
 
-    async def _bad_doctor_collector(_: ServiceSettings, **_kw: object) -> DoctorReportProxy:
-        raise RuntimeError("doctor collector down")
+    async def _doctor_collector(_: ServiceSettings, **_kw: object) -> DoctorReportProxy:
+        raise RuntimeError(f"doctor failed with {secret}")
 
-    async def _failure_collector(**_: object) -> object:
-        return object()
+    async def _failure_collector(**_: object) -> dict[str, object]:
+        return _mock_failure_summary()
 
     bundle = asyncio.run(
         collect_support_bundle(
             settings,
             strict_providers=frozenset(),
             provider_environ={},
-            environ={},
-            status_collector=_bad_status_collector,
-            doctor_collector=_bad_doctor_collector,
+            environ={"OPENAI_API_KEY": secret},
+            status_collector=_status_collector,
+            doctor_collector=_doctor_collector,
             failure_analysis_collector=_failure_collector,
         )
     )
 
+    assert bundle["provider_readiness_summary"] == {"status": "fail"}
     service_status = bundle["service_status"]
-    doctor_report = bundle["doctor_report"]
-    recent = bundle["recent_failure_summary"]
     assert isinstance(service_status, dict)
     assert service_status["status"] == "fail"
-    assert "status collector down" in str(service_status["detail"])
+    assert service_status["detail"] == "status failed with <redacted>"
+    doctor_report = bundle["doctor_report"]
     assert isinstance(doctor_report, dict)
     assert doctor_report["status"] == "fail"
-    assert "doctor collector down" in str(doctor_report["detail"])
-    assert isinstance(recent, dict)
-    assert recent["degraded"] is True
-    assert "object" in str(recent["error"])
+    assert doctor_report["detail"] == "doctor failed with <redacted>"
 
 
 @pytest.mark.unit
-def test_support_bundle_accepts_plain_doctor_mapping_and_default_failure_collector(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
+def test_support_bundle_accepts_plain_doctor_mapping_and_non_mapping_checks(tmp_path: Path) -> None:
     settings = _settings(tmp_path)
 
     async def _status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
-        return _green_status()
+        return {
+            "service": "awf",
+            "status": "ok",
+            "checks": "not-a-check-map",
+            "agent_readiness": {"status": "warn", "providers": {}},
+        }
 
     async def _doctor_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
-        return {"service": "awf", "status": "warn", "diagnostics": []}
+        return {
+            "service": "awf",
+            "status": "warn",
+            "summary": {"ok": 0, "warn": 1, "fail": 0},
+            "diagnostics": [{"id": "config", "status": "warn"}],
+        }
 
-    async def _default_failure_collector(_: ServiceSettings, *, since_hours: int) -> dict[str, object]:
-        return {"since_hours": since_hours, "latest_examples": "not-a-list"}
-
-    monkeypatch.setattr(
-        support_bundle_module,
-        "_default_failure_analysis_collector",
-        _default_failure_collector,
-    )
+    async def _failure_collector(**_: object) -> dict[str, object]:
+        return _mock_failure_summary()
 
     bundle = asyncio.run(
         collect_support_bundle(
@@ -484,98 +498,186 @@ def test_support_bundle_accepts_plain_doctor_mapping_and_default_failure_collect
             environ={},
             status_collector=_status_collector,
             doctor_collector=_doctor_collector,
-            failure_window_hours=7,
+            failure_analysis_collector=_failure_collector,
         )
     )
 
-    assert bundle["doctor_report"] == {"service": "awf", "status": "warn", "diagnostics": []}
-    recent = bundle["recent_failure_summary"]
-    assert isinstance(recent, dict)
-    assert recent["since_hours"] == 7
-
-
-@dataclass
-class _DataclassFailureSummary:
-    latest_examples: list[object]
-    root_cause_clusters: list[object]
+    assert bundle["doctor_report"] == {
+        "service": "awf",
+        "status": "warn",
+        "summary": {"ok": 0, "warn": 1, "fail": 0},
+        "diagnostics": [{"id": "config", "status": "warn"}],
+    }
+    assert bundle["orphan_cleanup_posture"] == {
+        "workspace_cleanup": {},
+        "orphan_resources": {},
+        "stranded_workspaces": {},
+    }
 
 
 @pytest.mark.unit
-def test_support_bundle_sanitizes_dataclass_and_non_mapping_examples() -> None:
-    summary = _DataclassFailureSummary(
+def test_support_bundle_sanitizes_dataclass_failure_summary(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    secret = "sk-support-dataclass-secret"
+    summary = FailureSummaryPayload(
+        generated_at=datetime.now(UTC).isoformat(),
+        since_hours=24,
         latest_examples=[
-            "not-a-mapping",
-            {"workspace_id": "ws_1", "stdout": "secret output"},
+            {
+                "workspace_id": "ws_secret",
+                "failure_reason": "agent_failure",
+                "reason_code": "AGENT_FAILURE",
+                "status": "failed",
+                "updated_at": datetime.now(UTC).isoformat(),
+                "task_prompt": f"secret prompt {secret}",
+            },
+            f"raw example {secret}",
         ],
         root_cause_clusters=[
-            "not-a-mapping",
-            {"failure_reason": "agent_failure", "task_prompt": "secret prompt"},
+            {
+                "failure_reason": "agent_failure",
+                "reason_code": "AGENT_FAILURE",
+                "count": 1,
+                "sample_workspace_ids": ["ws_secret"],
+                "stdout": f"secret output {secret}",
+            },
+            SecretEcho(secret),
         ],
+        opaque_detail=SecretEcho(secret),
     )
 
-    sanitized = support_bundle_module._sanitize_failure_summary(summary, frozenset())
+    async def _status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
+        return _green_status()
 
-    assert sanitized["latest_examples"] == [{}, {"workspace_id": "ws_1"}]
-    assert sanitized["root_cause_clusters"] == [
-        {},
-        {"failure_reason": "agent_failure"},
-    ]
+    async def _doctor_collector(_: ServiceSettings, **_kw: object) -> DoctorReportProxy:
+        return _green_doctor()
+
+    async def _failure_collector(**_: object) -> FailureSummaryPayload:
+        return summary
+
+    bundle = asyncio.run(
+        collect_support_bundle(
+            settings,
+            strict_providers=frozenset(),
+            provider_environ={},
+            environ={"OPENAI_API_KEY": secret},
+            status_collector=_status_collector,
+            doctor_collector=_doctor_collector,
+            failure_analysis_collector=_failure_collector,
+        )
+    )
+
+    recent = bundle["recent_failure_summary"]
+    assert isinstance(recent, dict)
+    assert recent["opaque_detail"] == "opaque <redacted>"
+    assert recent["latest_examples"][0] == {
+        "workspace_id": "ws_secret",
+        "failure_reason": "agent_failure",
+        "reason_code": "AGENT_FAILURE",
+        "status": "failed",
+        "updated_at": summary.latest_examples[0]["updated_at"],
+    }
+    assert recent["latest_examples"][1] == {}
+    assert recent["root_cause_clusters"][0] == {
+        "failure_reason": "agent_failure",
+        "reason_code": "AGENT_FAILURE",
+        "count": 1,
+        "sample_workspace_ids": ["ws_secret"],
+    }
+    assert recent["root_cause_clusters"][1] == {}
+    assert secret not in json.dumps(bundle, sort_keys=True, default=str)
 
 
 @pytest.mark.unit
-def test_support_bundle_redacts_unknown_object_values() -> None:
-    class SecretishObject:
-        def __str__(self) -> str:
-            return "value sk-objectsecret123456"
+def test_support_bundle_marks_opaque_failure_summary_degraded(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    secret = "sk-support-opaque-secret"
 
-    redacted = support_bundle_module._redact_value(
-        {"nested": SecretishObject()},
-        frozenset({"sk-objectsecret123456"}),
+    async def _status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
+        return _green_status()
+
+    async def _doctor_collector(_: ServiceSettings, **_kw: object) -> DoctorReportProxy:
+        return _green_doctor()
+
+    async def _failure_collector(**_: object) -> SecretEcho:
+        return SecretEcho(secret)
+
+    bundle = asyncio.run(
+        collect_support_bundle(
+            settings,
+            strict_providers=frozenset(),
+            provider_environ={},
+            environ={"OPENAI_API_KEY": secret},
+            status_collector=_status_collector,
+            doctor_collector=_doctor_collector,
+            failure_analysis_collector=_failure_collector,
+        )
     )
 
-    assert redacted == {"nested": "value <redacted>"}
+    recent = bundle["recent_failure_summary"]
+    assert isinstance(recent, dict)
+    assert recent == {"error": "opaque <redacted>", "degraded": True}
 
 
 @pytest.mark.unit
-def test_default_failure_analysis_collector_disposes_engine(
+def test_support_bundle_uses_default_failure_analysis_collector(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     settings = _settings(tmp_path)
-    disposed = False
-    fake_session_factory = object()
+    calls: dict[str, object] = {}
 
     class FakeEngine:
         async def dispose(self) -> None:
-            nonlocal disposed
-            disposed = True
+            calls["disposed"] = True
 
-    async def _summarize(session_factory: object, *, since_hours: int) -> dict[str, object]:
-        assert session_factory is fake_session_factory
-        return {"since_hours": since_hours}
+    fake_engine = FakeEngine()
+    fake_session_factory = object()
 
+    def _make_engine(database_url: str) -> FakeEngine:
+        calls["database_url"] = database_url
+        return fake_engine
+
+    def _make_session_factory(engine: FakeEngine) -> object:
+        calls["session_engine"] = engine
+        return fake_session_factory
+
+    async def _summarize_failure_analysis(session_factory: object, *, since_hours: int) -> dict[str, object]:
+        calls["session_factory"] = session_factory
+        calls["since_hours"] = since_hours
+        return _mock_failure_summary()
+
+    monkeypatch.setattr(support_bundle_mod, "make_engine", _make_engine)
+    monkeypatch.setattr(support_bundle_mod, "make_session_factory", _make_session_factory)
     monkeypatch.setattr(
-        support_bundle_module,
-        "make_engine",
-        lambda _database_url: FakeEngine(),
-    )
-    monkeypatch.setattr(
-        support_bundle_module,
-        "make_session_factory",
-        lambda _engine: fake_session_factory,
-    )
-    monkeypatch.setattr(
-        support_bundle_module,
+        support_bundle_mod,
         "summarize_failure_analysis",
-        _summarize,
+        _summarize_failure_analysis,
     )
 
-    result = asyncio.run(
-        support_bundle_module._default_failure_analysis_collector(
+    async def _status_collector(_: ServiceSettings, **_kw: object) -> dict[str, object]:
+        return _green_status()
+
+    async def _doctor_collector(_: ServiceSettings, **_kw: object) -> DoctorReportProxy:
+        return _green_doctor()
+
+    bundle = asyncio.run(
+        collect_support_bundle(
             settings,
-            since_hours=11,
+            strict_providers=frozenset(),
+            provider_environ={},
+            environ={},
+            failure_window_hours=72,
+            status_collector=_status_collector,
+            doctor_collector=_doctor_collector,
         )
     )
 
-    assert result == {"since_hours": 11}
-    assert disposed is True
+    assert calls == {
+        "database_url": settings.database_url,
+        "session_engine": fake_engine,
+        "session_factory": fake_session_factory,
+        "since_hours": 72,
+        "disposed": True,
+    }
+    assert bundle["recent_failure_summary"]["since_hours"] == 24

--- a/tests/unit/service/test_task_attempts.py
+++ b/tests/unit/service/test_task_attempts.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import select
@@ -12,6 +14,7 @@ from awf.api.schemas import WorkspaceCreateV2Request
 from awf.db.base import Base
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.session import make_engine, make_session_factory
+from awf.service.tasks import _pricing_from_workspace
 from awf.service.workspaces import WorkspaceService
 
 
@@ -86,6 +89,39 @@ async def test_create_v2_creates_task_and_attempt(
     assert attempts[0].repo_url == "git@github.com:example/app.git"
     assert attempts[0].base_branch == "development"
     assert attempts[0].title == "Add task attempts"
+
+
+@pytest.mark.unit
+def test_pricing_from_workspace_serializes_current_profile_pricing() -> None:
+    timestamp = datetime.now(UTC)
+    workspace = SimpleNamespace(
+        resolved_profile={
+            "pricing": {
+                "pricing": {
+                    "provider": "openai",
+                    "model": "gpt-5.5",
+                    "currency": "USD",
+                    "unit": "per_1M_tokens",
+                    "price_per_unit": 1.25,
+                    "timestamp": timestamp.isoformat(),
+                    "version": 2,
+                }
+            }
+        }
+    )
+
+    pricing = _pricing_from_workspace(workspace)  # type: ignore[arg-type]
+
+    assert pricing == {
+        "provider": "openai",
+        "model": "gpt-5.5",
+        "currency": "USD",
+        "unit": "per_1M_tokens",
+        "price_per_unit": 1.25,
+        "timestamp": timestamp,
+        "version": 2,
+        "is_current": True,
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_response.py
+++ b/tests/unit/service/test_workspace_response.py
@@ -10,6 +10,7 @@ import pytest
 
 from awf.api.schemas import WorkspaceResponse
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.models import Workspace
 from awf.profiles.models import WorkspaceProfile
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
@@ -1330,6 +1331,22 @@ def test_profile_requested_validation_tier_ignores_non_integer_profile_value() -
 @pytest.mark.unit
 def test_loaded_collection_returns_empty_for_none_relationship() -> None:
     workspace = SimpleNamespace(operations=None)
+
+    assert _loaded_collection(workspace, "operations") == []
+
+
+@pytest.mark.unit
+def test_loaded_collection_returns_empty_for_unloaded_orm_relationship() -> None:
+    workspace = Workspace(
+        id="ws_unloaded_relationship",
+        status=WorkspaceStatus.requested.value,
+        repo_url="git@github.com:example/project.git",
+        branch_base="main",
+        task_title="Unloaded relationship",
+        task_prompt="Verify validation projection does not lazy-load relationships.",
+        agent="codex",
+        test_commands=[],
+    )
 
     assert _loaded_collection(workspace, "operations") == []
 


### PR DESCRIPTION
## Summary

- Make PR monitor base refresh authoritative instead of treating failed fetch/rev-list as up to date.
- Repair orphaned broken AWF workspace refs in the shared mirror, while refusing to delete refs for active workspaces.
- Persist and cap no-progress `SyncBase` loops so `DIRTY` / conflicting PRs fail clearly instead of spinning indefinitely.
- Keep the Postgres-backed coverage/test hardening and workspace ownership fixes from this branch.

## Root Cause

A broken local AWF ref in the shared git mirror caused base fetch to fail. AWF ignored that failure, computed `base_behind=0` from stale refs, then looped on GitHub `DIRTY` / `CONFLICTING` state with no-op `SyncBase` operations.

## Validation

- `uv run --python 3.12 --extra dev ruff check src/awf tests`
- `uv run --python 3.12 --extra dev mypy src/awf`
- `AWF_TEST_DATABASE_URL=postgresql+asyncpg://awf:awf_dev@localhost:5433/awf uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing`
- Full coverage result before merging latest base updates: `4216 passed`, total coverage `99.05%`.
