### PR TITLE
REST CLI MCP contract alignment tests

### DIFF
--- a/docs/awf-plans/ws_797d2f7d48a748a0b3566d21.md
+++ b/docs/awf-plans/ws_797d2f7d48a748a0b3566d21.md
@@ -1,0 +1,415 @@
+# Plan: P1 MCP And Project Onboarding Client Parity – Contract tests proving REST API, CLI, and MCP stay aligned
+
+Workspace: `ws_797d2f7d48a748a0b3566d21`
+Slice: TODO/pre-gke-industrial-readiness.md → P1 MCP And Project Onboarding Client Parity →
+"Add contract tests proving REST API, CLI, and MCP stay aligned: request payloads,
+response payloads, reason codes, idempotency keys, `If-Match` / workspace-version
+concurrency, auth failures, and structured error semantics must not drift across the
+three clients."
+
+## Goal
+
+Make the AWF parity matrix executable: stand up a single fixture-driven contract suite
+that exercises a representative slice of capabilities through all three client surfaces
+(REST, CLI, MCP) and asserts they agree on the eight contract dimensions named in the
+TODO line. The suite must:
+
+- Treat REST as the canonical schema source of truth and validate every captured
+  request/response payload through the shared `awf.api.schemas` Pydantic models so
+  drift surfaces as one deep-equality failure rather than a brittle string mismatch.
+- Reuse the parity matrix in `docs/MCP_CLIENT_PARITY.md` as the row driver where
+  applicable, so adding a row in the matrix later forces a corresponding contract row.
+- Fail loudly today when MCP, CLI, or REST diverges from the contract; if a small,
+  safe surface fix is needed to make a contract row green, ship it in this slice.
+  Larger gaps (e.g., adding `If-Match` to MCP control tools, or new MCP tools for
+  refresh/rebase) stay documented as `MCP partial`/`MCP missing/backlog` rows backed
+  by their existing `TODO§` slice references and remain owned by parallel workspaces.
+
+This slice is test-driven and infrastructure-light. It does **not** add new MCP tools,
+new CLI commands, or new REST endpoints. It does **not** rewrite the parity matrix.
+
+## Scope And Non-Goals
+
+In scope:
+
+1. New `tests/unit/contract/` package with a shared conftest, helper utilities, and
+   four contract test modules (request payload, response payload, reason code +
+   structured error envelope, idempotency / If-Match concurrency / auth failure).
+2. One small test-mode helper that lets the contract suite invoke MCP control tools
+   with the same authenticated session as the REST client, reusing the existing
+   `WorkspaceService` pattern from `tests/unit/mcp/test_mcp_operator_surfaces.py`.
+3. **Conditional**: smallest safe surface fix in `src/awf/mcp/server.py` if a contract
+   test exposes that the MCP error envelope drops the `detail` payload that REST
+   carries for the same exception (see §"Anticipated Surface Drift Fixes" below). The
+   change is constrained to a single helper and only happens to make a failing contract
+   test green.
+4. Update `TODO/pre-gke-industrial-readiness.md` only to mark this slice's checkbox
+   with implementation-backed evidence (test files, validation results).
+
+Explicitly out of scope (to avoid coordination overlap with active workspaces):
+
+- Adding `expected_version` / `If-Match` parameters to MCP control tools — owned by
+  the `TODO§P1-if-match-parity` slice and the active workspace
+  `ws_1f89a8c10b1d497d9c912ccb` ("MCP safe operator action tools").
+- Adding new MCP tools for `refresh`, `rebase`, `retry`, or artifact content download.
+- Adding new CLI commands to fill `CLI absent` cells — owned by the active workspace
+  `ws_e7365dffc3a243a2b8f7e775` ("CLI command coverage alignment").
+- Restructuring `docs/MCP_CLIENT_PARITY.md` columns or row content. The matrix is
+  consumed read-only as a row driver.
+- Editing existing tests in `tests/unit/api/`, `tests/unit/cli/`, `tests/unit/mcp/`.
+  All new contract tests live in `tests/unit/contract/`. Existing tests in those
+  paths are owned by parallel workspaces (advisory overlap warning).
+- Lowering the 99% coverage gate, the 1024-char reason cap, or any other quality
+  guardrail.
+
+## Current State And Drift Survey
+
+Source files surveyed (line counts in parens):
+
+- `src/awf/api/app.py` — FastAPI app builder; 16 routers wired; `create_app(use_lifespan=False)` used by all unit tests.
+- `src/awf/api/routes/controls.py` (277) — cancel/stop/remonitor/refresh/validate/rebase/destroy. All accept `Idempotency-Key` and `If-Match` headers. `_http_error` maps `WorkspaceControlError` subclasses to 400/404/409 with `{detail: {error_code, message, detail}}`.
+- `src/awf/api/routes/workspaces.py` — create/list/get/adopt-pr/retry/events/overview/stale-reasons. The `adopt-pr` handler returns `JSONResponse(content=ErrorResponse(...).model_dump())` — a **flat** `{error_code, message, detail}` envelope, in contrast to the `HTTPException`-driven flow used by `controls.py`.
+- `src/awf/api/deps.py` — `require_api_token` raises 401 `UNAUTHORIZED` with `{detail: {error_code, message}}` and `WWW-Authenticate: Bearer`; raises 503 `API_TOKEN_NOT_CONFIGURED` when `AWF_API_TOKEN` is unset.
+- `src/awf/api/schemas.py` (1479) — canonical Pydantic models. `ErrorResponse` at line 1471 is `{error_code, message, detail}`. `WorkspaceControlRequest`, `WorkspaceOperationRequest`, `WorkspaceControlResponse`, `OperationResponse`, `PullRequestMonitorAdoptionRequest/Response`, `WorkspaceCreateRequest`, `WorkspaceCreateV2Request` are the contract models.
+- `src/awf/cli/main.py` (1655) — Typer app. `_call(method, path, *, base_url, **kwargs)` invokes `httpx.request` against `AWF_CLI_BASE_URL` (default `http://localhost:8000`). Auth via `_api_token_headers(override)` reading `--api-token` then env `AWF_API_TOKEN`. `Idempotency-Key` is forwarded as a header. `--if-match` exists today only on `awf workspace remonitor` (line 1315). `awf workspace adopt-pr` exists. `src/awf/cli/main.py` is omitted from coverage.
+- `src/awf/mcp/server.py` (1404) — `build_mcp_server(*, service: WorkspaceService, ...)` registers 35 tools. Control tools (`awf_cancel_workspace`, `awf_stop_workspace`, `awf_destroy_workspace`, `awf_remonitor_workspace`, `awf_request_workspace_validation`) accept optional `idempotency_key: str` but **not** `expected_version`. `_tool_error(exc)` at line 1127 builds `ErrorResponse(error_code=exc.error_code, message=exc.message)` and **drops** `exc.detail`. Contrast `_workspace_error_result` at line 1148 which **keeps** `detail=exc.detail` — drift between two MCP error envelope helpers.
+- `src/awf/service/controls.py` (1785) — central `WorkspaceControlError` hierarchy. Error codes: `NOT_FOUND`, `WORKSPACE_ACTIVE`, `IDEMPOTENCY_CONFLICT`, `VERSION_CONFLICT`, `STACK_STOP_FAILED`, `WORKSPACE_PR_URL_REQUIRED`, `WORKSPACE_STATE_NOT_REMONITORABLE`, `WORKSPACE_STATE_NOT_REFRESHABLE`, `WORKSPACE_STATE_NOT_VALIDATABLE`, `WORKSPACE_STATE_NOT_REBASEABLE`, `MERGE_CANDIDATE_NOT_FOUND`, `WORKSPACE_REBASE_CONFLICT`, `WORKSPACE_OPERATION_CONFLICT`, `CLEANUP_FAILED`. `VersionConflictError.detail` carries `{expected_version, actual_version}` — this is the field MCP currently drops.
+- `src/awf/service/pr_monitor_adoption.py` — `PRMonitorAdoptionError` codes: `PR_ADOPTION_INPUT_REQUIRED`, `INVALID_GITHUB_REPO`, `PR_NOT_FOUND`, `PR_ALREADY_CLOSED`, `PR_ALREADY_MERGED`, `PR_METADATA_FETCH_FAILED`, `PR_METADATA_INVALID`, `PR_ADOPTION_POLICY_CONFLICT`.
+- `src/awf/service/workspaces.py` — `WorkspaceService.cancel_workspace`/`stop_workspace`/`destroy_workspace`/`remonitor_workspace`/`request_validate_workspace` accept `idempotency_key` but **not** `expected_version`; this is the structural reason MCP cannot enforce `If-Match` today and is correctly tracked by `TODO§P1-if-match-parity` (out of scope here).
+
+Existing parity test surface (read-only references, **not** edited):
+
+- `tests/unit/mcp/_parity_utils.py` — markdown-table parser shared across tests.
+- `tests/unit/mcp/test_mcp_parity_matrix_crossref.py` — verifies REST endpoints / MCP tool names / CLI commands / error codes / schema names referenced in the parity matrix exist in source.
+- `tests/unit/mcp/test_mcp_client_parity_docs.py` — verifies parity matrix structure (columns, status vocabulary, `MCP implemented` rows have a real MCP tool, partial/missing rows have `TODO§` backlog reference).
+- `tests/unit/mcp/test_mcp_operator_surfaces.py` (2197) — exhaustive REST↔MCP parity for read-only operator surfaces; covers some control responses and idempotency. Treated as the existing baseline; new contract tests deliberately do not duplicate its body but cite its patterns.
+- `tests/unit/api/test_workspace_controls_idempotency.py` (1860) — REST-only Idempotency-Key/If-Match coverage for all control endpoints.
+- `tests/unit/cli/test_cli.py` — Typer CliRunner + mocked `httpx.request` pattern for CLI assertions.
+- `tests/unit/api/test_pr_monitor_adoption.py` — REST adopt-pr happy/auth/error paths.
+- `tests/unit/mcp/test_mcp_server.py` — MCP server-level argument-contract checks.
+
+Drift hypotheses to confirm via failing tests first:
+
+1. **MCP control errors drop `detail`.** Hitting `awf_cancel_workspace` / `awf_remonitor_workspace` with a stale `If-Match`-equivalent (which today is impossible to send via MCP, but `VERSION_CONFLICT` can still surface from underlying code if the service re-introduces version checks; for the *general* contract, the envelope mismatch shows up for `WorkspaceRemonitorStateError` whose `detail = {"status": ..., "eligible_statuses": ...}`). Compare `result.structuredContent.get("detail")` (MCP) vs `response.json()["detail"]["detail"]` (REST). If MCP returns `None` while REST returns a populated dict, the contract test fails. Fix: pass `detail=exc.detail` from `_tool_error` (single-line change in `src/awf/mcp/server.py`).
+2. **Adopt-pr error envelope shape differs from controls.** REST adopt-pr returns flat `{error_code, message, detail}`; REST controls return nested `{detail: {error_code, message, detail}}`. This is internal REST drift and is intentional under the `JSONResponse(ErrorResponse(...).model_dump())` pattern. Contract test will use a `_unwrap_error_envelope(payload)` adapter that accepts both shapes and verifies `ErrorResponse.model_validate(...)` succeeds either way. **No source fix.**
+3. **CLI `awf workspace remonitor` requires `--idempotency-key`.** Already true in source; tests assert it.
+4. **CLI commands without `--api-token` propagate REST 401s.** Existing CLI tests show `result.exit_code == 1`; new contract test asserts the rendered stderr JSON carries the canonical `{detail: {error_code: "UNAUTHORIZED", ...}}` envelope.
+5. **MCP idempotency replay across remonitor / validate.** Already proven for `awf_remonitor_workspace` in `test_mcp_operator_surfaces.py` lines 2055-2097. New contract test extends to `awf_cancel_workspace`, `awf_stop_workspace`, `awf_destroy_workspace`, and `awf_request_workspace_validation` if not already covered by service-level tests. If REST + MCP idempotency semantics diverge for any of these tools, the contract test fails — likely no source fix needed because all tools route through `WorkspaceControlService` which centralises replay.
+6. **Parity-matrix-driven If-Match contract.** New parity-table-driven test asserts: every row whose Schema column mentions `VERSION_CONFLICT` AND whose Status is `MCP implemented` must have an `expected_version` argument on its MCP tool. Today, such rows are tagged `MCP partial` with backlog `TODO§P1-if-match-parity`, so the assertion passes vacuously while preventing future drift. If a future PR flips a row to `MCP implemented` without adding `expected_version`, the test catches it.
+7. **`awf workspace adopt-pr` request shape.** CLI's body builder transforms `--repo` into `repo_url` vs `repo_slug` based on whether the value contains `github.com`. New contract test asserts the generated CLI body validates against `PullRequestMonitorAdoptionRequest` for representative inputs.
+
+## Intended Files To Touch
+
+| File | Status | Purpose |
+| --- | --- | --- |
+| `tests/unit/contract/__init__.py` | NEW | Mark package. |
+| `tests/unit/contract/conftest.py` | NEW | Shared fixtures: `contract_stack` (REST AsyncClient + MCP server + Typer CliRunner + DB session factory + auth headers); seed helpers; `_unwrap_error_envelope` adapter; `_invoke_cli_against_mocked_rest` helper. |
+| `tests/unit/contract/test_request_payload_alignment.py` | NEW | Per capability: build CLI body via Typer + mocked httpx, build MCP-side request via tool invocation, validate both through canonical `awf.api.schemas` Pydantic model, assert deep equality against a REST-side reference body. Capabilities: workspace create v1 + v2, adopt-pr (slug/url/idempotent), remonitor (with idempotency key + if-match), retry. |
+| `tests/unit/contract/test_response_payload_alignment.py` | NEW | Seed deterministic state per capability, fetch via REST AsyncClient and via MCP tool, validate both through the canonical response model, assert equality. Capabilities: get workspace, list workspaces, list operations, list events, list overview, list merge queue, get workspace runtime, get_service_health/readiness, control responses (`WorkspaceControlResponse`, `OperationResponse`). |
+| `tests/unit/contract/test_reason_code_alignment.py` | NEW | Trigger each canonical reason code (`NOT_FOUND`, `WORKSPACE_ACTIVE`, `IDEMPOTENCY_CONFLICT`, `VERSION_CONFLICT`, `WORKSPACE_STATE_NOT_REMONITORABLE`, `WORKSPACE_STATE_NOT_VALIDATABLE`, `WORKSPACE_PR_URL_REQUIRED`, `MERGE_CANDIDATE_NOT_FOUND`, `WORKSPACE_REBASE_CONFLICT`, `PR_NOT_FOUND`, `PR_ALREADY_CLOSED`, `PR_ALREADY_MERGED`, `PR_ADOPTION_INPUT_REQUIRED`, `INVALID_GITHUB_REPO`, `PR_ADOPTION_POLICY_CONFLICT`, `UNAUTHORIZED`, `API_TOKEN_NOT_CONFIGURED`) on REST and (where the MCP tool exists for that capability) on MCP, then assert `_unwrap_error_envelope(rest_body)["error_code"] == mcp_error_payload["error_code"]` and that both validate as `ErrorResponse`. Single tabulated test using `pytest.mark.parametrize`. |
+| `tests/unit/contract/test_idempotency_concurrency_auth_alignment.py` | NEW | Three grouped contract sections backed by parametrized cases: (a) Idempotency-Key replay/conflict identical across REST and MCP for cancel/stop/destroy/remonitor/validate; (b) `If-Match` REST↔CLI parity (REST returns VERSION_CONFLICT with detail; CLI propagates 409 to non-zero exit; MCP "partial" rows in the parity matrix must reference `TODO§P1-if-match-parity` — vacuous-true assertion for current state, becomes load-bearing if a row flips to `MCP implemented`); (c) auth-failure parity: REST 401 `UNAUTHORIZED`, REST 503 `API_TOKEN_NOT_CONFIGURED` when `AWF_API_TOKEN` unset, CLI propagates JSON to stderr and exits 1, MCP transport-trust note encoded as a contract on the documented security boundary. |
+| `src/awf/mcp/server.py` | CONDITIONAL EDIT | Pass `detail=exc.detail` in `_tool_error(exc)` only if the response-envelope contract test fails. Single-line change to align `_tool_error` with the existing `_workspace_error_result` helper in the same file. Includes a focused MCP-side unit test for the helper to keep coverage tight. |
+| `TODO/pre-gke-industrial-readiness.md` | EDIT | Mark the contract-tests checkbox `[x]` and add an evidence sentence (test paths, focused validation result). No other rows touched. |
+
+## Tests To Write First (TDD Order)
+
+Write each test as failing or vacuously-true-but-pinned-to-contract before any source
+edit. The order minimizes wasted work — start with the parity-matrix-driven assertions
+that don't require seed data, then add the seeded REST+MCP contract suites, then
+the smallest-safe-surface-drift verifier.
+
+Phase 1 — fixture and adapters (no assertions yet):
+
+1. `tests/unit/contract/conftest.py` — implement `contract_stack` fixture wrapping
+   AsyncClient + MCP server + CliRunner + DB factory, plus `_unwrap_error_envelope`,
+   `_invoke_cli`, `_seed_monitoring_workspace`, `_seed_destroyed_workspace`,
+   `_seed_active_workspace` helpers. Add a smoke test (`test_contract_stack_smoke`)
+   that walks REST `/healthz` + MCP `awf_get_service_health` + CLI `awf service status`
+   to prove the fixture boots all three surfaces.
+
+Phase 2 — request-payload contract:
+
+2. `test_request_payload_alignment.py::test_workspace_create_v2_cli_body_validates_against_rest_schema` — invoke CLI with representative args, capture mocked `httpx.request` body, assert `WorkspaceCreateV2Request.model_validate(body)` succeeds and matches a hand-built REST body.
+3. `test_request_payload_alignment.py::test_workspace_create_v2_mcp_args_validate_against_rest_schema` — invoke MCP `awf_create_workspace_v2`, intercept the request constructed by the tool (via a service spy), assert `WorkspaceCreateV2Request.model_validate(...)` matches the same canonical body.
+4. `test_request_payload_alignment.py::test_adopt_pr_request_shape_aligned` — parametrized over `repo_slug+pr_number`, `pr_url`, mixed; capture CLI body + MCP-side request + REST request, validate all through `PullRequestMonitorAdoptionRequest`, assert they normalize to the same canonical model instance.
+5. `test_request_payload_alignment.py::test_remonitor_request_aligned_with_idempotency_and_if_match` — REST POST with both headers, CLI invocation captures both headers, MCP `awf_remonitor_workspace` accepts `idempotency_key` (and the test asserts `expected_version` is currently absent on MCP — pinning the documented partial state).
+
+Phase 3 — response-payload contract:
+
+6. `test_response_payload_alignment.py::test_get_workspace_rest_and_mcp_payloads_match` — seed one workspace, fetch via REST `/v1/workspaces/{id}` and via MCP `awf_get_workspace`, assert `WorkspaceResponse.model_validate(rest) == WorkspaceResponse.model_validate(mcp)`.
+7. `test_response_payload_alignment.py::test_list_workspaces_rest_and_mcp_payloads_match` — seed three workspaces, fetch both surfaces, assert ordered structural equality.
+8. `test_response_payload_alignment.py::test_list_operations_rest_and_mcp_payloads_match` — seed several operations, fetch both, validate as `OperationListResponse`.
+9. `test_response_payload_alignment.py::test_list_workspace_events_rest_and_mcp_payloads_match` — seed events, fetch both, validate as `WorkspaceEventListResponse`.
+10. `test_response_payload_alignment.py::test_workspace_overview_rest_and_mcp_payloads_match` — same pattern, validate as `WorkspaceOverviewListResponse`.
+11. `test_response_payload_alignment.py::test_merge_queue_rest_and_mcp_payloads_match` — same pattern, validate as `MergeQueueListResponse`.
+12. `test_response_payload_alignment.py::test_workspace_runtime_rest_and_mcp_payloads_match` — seed one workspace, fetch both surfaces with a stub runtime inspector, validate as `WorkspaceRuntimeResponse`.
+13. `test_response_payload_alignment.py::test_workspace_control_response_rest_and_mcp_payloads_match` — execute a remonitor on a `monitoring_pr` workspace via REST and via MCP (separate seeds to avoid state interference), validate both as `WorkspaceControlResponse`, assert structural equivalence.
+
+Phase 4 — reason-code + structured-error contract:
+
+14. `test_reason_code_alignment.py::test_each_control_reason_code_matches_across_rest_and_mcp` — parametrized over `(reason_code, seed_factory, rest_call, mcp_call)`, seed the prerequisite state, hit REST + MCP, assert `error_code` matches, assert `_unwrap_error_envelope(...)` validates as `ErrorResponse` on both sides.
+15. `test_reason_code_alignment.py::test_mcp_control_error_payload_carries_same_detail_as_rest` — focused on `WORKSPACE_STATE_NOT_REMONITORABLE` (which has a populated `detail = {"status", "eligible_statuses"}`). Asserts MCP `result.structuredContent["detail"]` equals REST `response.json()["detail"]["detail"]`. **Expected to fail today** — the `_tool_error` helper in `src/awf/mcp/server.py:1127` does not pass `detail` through. Smallest-safe fix: pass `detail=exc.detail`.
+16. `test_reason_code_alignment.py::test_adopt_pr_terminal_error_codes_match_across_rest_and_mcp` — parametrized over `PR_ALREADY_MERGED`, `PR_ALREADY_CLOSED`, `PR_NOT_FOUND`. Existing `tests/unit/mcp/test_mcp_server.py::test_adopt_pull_request_monitor_tool_returns_terminal_pr_error_result` covers MCP side; the new test pins REST↔MCP equivalence in one place.
+17. `test_reason_code_alignment.py::test_unauthorized_error_envelope_structure` — REST without auth on a protected endpoint returns `{detail: {error_code: "UNAUTHORIZED", ...}}`; CLI invoked against a mocked 401 prints the same JSON to stderr and exits 1; MCP — since the contract for MCP is in-process trust — the test pins this by asserting MCP tools never call `require_api_token` (verified by inspecting `mcp/server.py` for absence of an auth dep) and that no MCP error code currently equals `UNAUTHORIZED`.
+
+Phase 5 — idempotency / concurrency / auth grouped contract:
+
+18. `test_idempotency_concurrency_auth_alignment.py::test_idempotency_replay_returns_same_operation_on_rest_and_mcp` — parametrized over the four control surfaces with MCP tools (`cancel`, `stop`, `destroy` (as a soft-destroy on a non-active workspace), `remonitor`, `validate`). Send the same `Idempotency-Key` twice via REST and twice via MCP, assert each surface returns the same `operation_id` on the replay and the database has only one Operation row per surface.
+19. `test_idempotency_concurrency_auth_alignment.py::test_idempotency_conflict_when_payload_changes` — REST same key + different payload returns 409 `IDEMPOTENCY_CONFLICT`; MCP same `idempotency_key` + different `reason` argument returns the same code via `_tool_error`.
+20. `test_idempotency_concurrency_auth_alignment.py::test_if_match_version_conflict_on_rest_and_cli` — REST POST to `/cancel` with mismatched `If-Match` returns 409 `VERSION_CONFLICT` with `expected_version`/`actual_version` in detail. CLI `awf workspace remonitor --if-match N` with mocked 409 propagates the JSON to stderr and exits 1.
+21. `test_idempotency_concurrency_auth_alignment.py::test_mcp_if_match_partial_status_pinned_to_backlog_slice` — parses the parity matrix; for each row whose Schema column mentions `VERSION_CONFLICT` and whose Status is `MCP partial`, asserts the Backlog Slice references `TODO§P1-if-match-parity`. For each row whose Status is `MCP implemented` AND Schema mentions `VERSION_CONFLICT`, asserts the underlying MCP tool's argument schema includes `expected_version`. (Today the second clause is vacuously true. Tomorrow when If-Match parity lands, it becomes load-bearing.)
+22. `test_idempotency_concurrency_auth_alignment.py::test_rest_unauthenticated_returns_uniform_envelope` — parametrized over all REST endpoints listed in the parity matrix as `require_api_token`. Hit each without an auth header; assert 401 + `error_code == "UNAUTHORIZED"` (or 503 + `API_TOKEN_NOT_CONFIGURED` when the test boots without `AWF_API_TOKEN` configured).
+23. `test_idempotency_concurrency_auth_alignment.py::test_cli_propagates_rest_unauthenticated_error_to_stderr_with_nonzero_exit` — for representative CLI commands that take `--api-token` (`workspace retry`, `workspace remonitor`, `workspace adopt-pr`, `locks list`), invoke with mocked 401 REST response; assert exit code 1 and stderr contains `"UNAUTHORIZED"`.
+
+Phase 6 — smallest-safe-surface fix verification (only if Phase 4 #15 fails):
+
+24. `tests/unit/mcp/test_mcp_server.py` (additive only — coordination warning is advisory, but to be safe we add the focused unit test inside the new contract test file instead): `test_tool_error_helper_keeps_workspace_control_error_detail` — direct unit test on `_tool_error(WorkspaceRemonitorStateError(...))` asserting the resulting `structuredContent["detail"]` equals the input exception's detail. Drives the one-line change in `src/awf/mcp/server.py`.
+
+## Implementation Details Per New File
+
+### `tests/unit/contract/conftest.py`
+
+Fixtures and helpers:
+
+- `contract_stack` (async fixture): boots `engine` (reusing the project-level
+  `engine` fixture), constructs a `WorkspaceService(factory)`, builds an MCP server
+  via `build_mcp_server(service=...)`, builds a FastAPI app via `create_app(use_lifespan=False)`,
+  attaches the session factory, sets `AWF_API_TOKEN=secret` via monkeypatch, returns a
+  dataclass `ContractStack(rest_client, mcp, factory, settings, auth_headers, cli_runner)`.
+- `_unwrap_error_envelope(payload: dict) -> dict`: returns the inner `{error_code, message, detail}` dict whether the input is `{detail: {...}}` (HTTPException flow) or already flat (JSONResponse flow). Validates via `ErrorResponse.model_validate(...)` and returns the dump.
+- `_invoke_cli(runner, args, *, response_status=200, response_payload=None, response_text=""", env=None)`: thin wrapper around `_runner.invoke(app, args)` that patches `awf.cli.main.httpx.request` to return a configured `MagicMock(spec=httpx.Response)` and captures the call. Returns `(result, captured_request)` where `captured_request` is `(method, url, kwargs)`.
+- `_seed_monitoring_workspace(factory, *, with_pr_url=True)`: wraps the existing seed pattern from `tests/unit/api/test_workspace_controls_idempotency.py::_seed_monitoring_workspace`. Reimplemented locally rather than imported to avoid cross-test-package coupling; the seed does the same `provisioning → ready → running → validating → pushing → monitoring_pr` walk.
+- `_seed_active_workspace(factory)`: returns a `running` workspace that triggers `WorkspaceNotFoundError` / `WORKSPACE_ACTIVE` as needed.
+- `_seed_completed_workspace(factory)`: drives the workspace to a terminal state for `WORKSPACE_STATE_NOT_REMONITORABLE` triggers.
+- `_call_mcp(mcp, name, args)` and `_call_mcp_result(mcp, name, args)`: thin helpers, lifted in spirit from `tests/unit/mcp/test_mcp_operator_surfaces.py::_call`/`_call_result` (re-implemented locally).
+
+Smoke test:
+
+```python
+@pytest.mark.unit
+async def test_contract_stack_smoke(contract_stack: ContractStack) -> None:
+    rest_health = (await contract_stack.rest_client.get("/healthz")).json()
+    mcp_health = await _call_mcp(contract_stack.mcp, "awf_get_service_health", {})
+    assert rest_health["status"] == mcp_health["status"]
+```
+
+### `tests/unit/contract/test_request_payload_alignment.py`
+
+Pattern per capability:
+
+```python
+@pytest.mark.unit
+async def test_workspace_create_v2_request_aligned(contract_stack: ContractStack) -> None:
+    canonical = WorkspaceCreateV2Request(
+        repo=WorkspaceV2Repo(url="git@github.com:x/y.git"),
+        task=WorkspaceV2Task(
+            title="t", prompt="p", agent="codex",
+            auto_merge=True, initial_review_grace_period_seconds=None,
+        ),
+        workspace=WorkspaceV2Workspace(profile_ref="generic", profile=None),
+        validation=WorkspaceV2Validation(commands=["pytest -q"], requested_tier=1),
+        resources=WorkspaceV2Resources(),
+        preflight=WorkspaceLaunchPreflight(),
+    )
+
+    cli_result, cli_request = _invoke_cli(
+        contract_stack.cli_runner,
+        ["workspace", "create", "--repo", "git@github.com:x/y.git",
+         "--title", "t", "--prompt", "p", "--test", "pytest -q"],
+        response_payload={"workspace_id": "ws_x"},
+        response_status=202,
+    )
+    cli_body = cli_request.kwargs["json"]
+    assert WorkspaceCreateV2Request.model_validate(cli_body) == canonical
+
+    # MCP equivalent — Field defaults differ for env_profile etc., so we use the v1 tool
+    # for create v1 contract, and a separate test for create v2 sends v2-shaped args via REST direct.
+```
+
+For adopt-pr specifically, parametrized cases:
+
+| Case | CLI args | MCP args | REST body |
+| --- | --- | --- | --- |
+| repo slug + pr number | `--repo dimileeh/aira-web --pr 277` | `{"repo_slug": "dimileeh/aira-web", "pr_number": 277}` | `{"repo_slug": "dimileeh/aira-web", "pr_number": 277}` |
+| pr_url | `--pr-url https://github.com/dimileeh/aira-web/pull/277` | `{"pr_url": "..."}` | `{"pr_url": "..."}` |
+| github URL repo | `--repo https://github.com/dimileeh/aira-web --pr 277` | n/a (MCP requires slug) | `{"repo_url": "https://github.com/dimileeh/aira-web", "pr_number": 277}` |
+
+Each row asserts `PullRequestMonitorAdoptionRequest.model_validate(...)` succeeds and the
+canonicalized result is identical for the rows that share an underlying intent.
+
+### `tests/unit/contract/test_response_payload_alignment.py`
+
+Reuses the seed helpers from `conftest.py`, calls REST + MCP for each capability, and
+asserts:
+
+```python
+rest_payload = (await client.get(f"/v1/workspaces/{ws_id}", headers=auth)).json()
+mcp_payload = await _call_mcp(mcp, "awf_get_workspace", {"workspace_id": ws_id})
+assert WorkspaceResponse.model_validate(rest_payload) == WorkspaceResponse.model_validate(mcp_payload)
+```
+
+For control responses, each surface gets its own seed to avoid state interference:
+
+```python
+rest_ws = await _seed_monitoring_workspace(factory)
+rest_response = (await client.post(
+    f"/v1/workspaces/{rest_ws}/remonitor",
+    headers={**auth, "Idempotency-Key": "rest-1"},
+    json={"reason": "rest contract"},
+)).json()
+
+mcp_ws = await _seed_monitoring_workspace(factory)
+mcp_response = await _call_mcp(mcp, "awf_remonitor_workspace",
+    {"workspace_id": mcp_ws, "reason": "mcp contract", "idempotency_key": "mcp-1"})
+
+WorkspaceControlResponse.model_validate(rest_response)
+WorkspaceControlResponse.model_validate(mcp_response)
+assert rest_response["status"] == mcp_response["status"]
+assert rest_response["operation_status"] == mcp_response["operation_status"]
+# operation_id differs (different workspaces); status fields must match
+```
+
+### `tests/unit/contract/test_reason_code_alignment.py`
+
+Single parametrized table:
+
+```python
+@pytest.mark.parametrize(
+    "case",
+    [
+        ReasonCase(
+            error_code="WORKSPACE_STATE_NOT_REMONITORABLE",
+            seed=lambda f: _seed_completed_workspace(f),
+            rest=lambda c, w, h: c.post(f"/v1/workspaces/{w}/remonitor",
+                headers={**h, "Idempotency-Key": "k"}, json={}),
+            mcp=lambda m, w: _call_mcp_result(m, "awf_remonitor_workspace",
+                {"workspace_id": w, "idempotency_key": "k"}),
+            expects_detail_keys={"status", "eligible_statuses"},
+        ),
+        ...
+    ],
+)
+async def test_each_control_reason_code_matches_across_rest_and_mcp(case): ...
+```
+
+The `expects_detail_keys` field drives the smallest-safe-surface-fix assertion: if a
+reason has a populated `detail`, both REST and MCP must surface it.
+
+### `tests/unit/contract/test_idempotency_concurrency_auth_alignment.py`
+
+Three section classes:
+
+- `class TestIdempotencyContract` — replay/conflict parity per control.
+- `class TestIfMatchContract` — REST + CLI parity, plus the parity-matrix-driven MCP-implies-`expected_version` assertion.
+- `class TestAuthFailureContract` — REST 401/503 + CLI 401 propagation + MCP transport-trust pin.
+
+For the parity-matrix-driven If-Match assertion, reuse `tests/unit/mcp/_parity_utils.py::_parity_rows` (read-only import of the existing helper module — no edit). Walk rows, for each row with Status `MCP implemented` and Schema mentioning `VERSION_CONFLICT`, introspect the matching MCP tool's argument list (via `mcp._tool_manager._tools` or equivalent), assert `expected_version` is one of the parameters.
+
+### Conditional fix in `src/awf/mcp/server.py`
+
+If test #15 fails as predicted:
+
+```python
+def _tool_error(exc: WorkspaceControlError) -> CallToolResult:
+    error = ErrorResponse(error_code=exc.error_code, message=exc.message, detail=exc.detail)
+    return _tool_result(error.model_dump(mode="json"), is_error=True)
+```
+
+This single-line change aligns `_tool_error` with the existing `_workspace_error_result`
+helper (lines 1148-1154) which already passes `detail=exc.detail`. No behavioural change
+to non-control tools.
+
+The change is covered both by the new contract test #15 and by an additive focused unit
+test in the same `test_reason_code_alignment.py` file (kept inside `tests/unit/contract/`
+to avoid touching `tests/unit/mcp/` which is owned by parallel workspaces).
+
+## Validation Commands
+
+Iterative loop (run as tests are added):
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/contract -q -x`
+- `uv run --python 3.12 --extra dev pytest tests/unit/contract tests/unit/api/test_workspace_controls_idempotency.py tests/unit/api/test_pr_monitor_adoption.py tests/unit/mcp/test_mcp_operator_surfaces.py tests/unit/mcp/test_mcp_server.py tests/unit/mcp/test_mcp_parity_matrix_crossref.py tests/unit/mcp/test_mcp_client_parity_docs.py tests/unit/cli/test_cli.py -q`
+
+Touched-file gate (run before commit):
+
+- `uv run ruff check src/awf tests/unit/contract tests/unit/mcp tests/unit/api tests/unit/cli`
+- `uv run mypy src/awf`
+- `uv run --python 3.12 --extra dev pytest tests/unit/contract tests/unit/mcp tests/unit/api tests/unit/cli tests/unit/service tests/unit/control tests/unit/runtime -q`
+
+Coverage gate (final):
+
+- `uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing` — must report `>= 99.00%` (the `fail_under = 99` gate in `pyproject.toml`). The conditional one-line MCP edit is fully covered by the new contract test plus the focused helper test; the new test files exercise REST routes and MCP tools that are already covered, adding negligible new uncovered surface (`src/awf/cli/main.py` is omitted from coverage at line 194 of `pyproject.toml`).
+
+Static guardrails:
+
+- AWF profile validation phases run automatically: `uv sync --extra dev`, ruff/mypy on
+  CLI, focused CLI test slice, fake-test guardrail
+  (`tests/unit/control/test_test_quality_guardrails_self.py`).
+
+## Risks, Assumptions, And Coordination
+
+**Risks**
+
+- `R1` — Coordination overlap with `ws_1f89a8c10b1d497d9c912ccb` (MCP safe operator action tools). That workspace likely adds `expected_version` to MCP control tools and may add `awf_refresh_workspace`/`awf_rebase_workspace`. Mitigation: contract tests pin the parity matrix Status, so when that workspace flips a row from `MCP partial` → `MCP implemented`, our `expected_version` assertion becomes load-bearing exactly as intended. We do **not** add MCP arguments ourselves.
+- `R2` — Coordination overlap with `ws_e7365dffc3a243a2b8f7e775` (CLI command coverage). That workspace adds CLI commands for currently-`CLI absent` rows. Mitigation: our CLI-side contract tests target only commands that exist today (`workspace create`, `workspace adopt-pr`, `workspace remonitor`, `workspace retry`, `locks list`); we do not assert presence of commands that are still absent.
+- `R3` — The `_tool_error` fix changes the wire shape MCP tools return for control errors (adds `detail` where it was previously `null`). Risk of breaking downstream consumers. Mitigation: `_workspace_error_result` already returns `detail` for non-control tools, so consumers must already tolerate populated `detail`; the change makes the envelope strictly more informative without removing fields.
+- `R4` — Touching `tests/unit/api/`, `tests/unit/cli/`, or `tests/unit/mcp/` tests directly would clash with the advisory overlap warnings. Mitigation: all new tests live under `tests/unit/contract/`; existing tests in those paths are read-only references.
+- `R5` — Pinning the parity matrix could lock the doc shape in unintended ways. Mitigation: we **import** the existing `tests/unit/mcp/_parity_utils.py` rather than duplicating it; the matrix shape is already governed by `test_mcp_client_parity_docs.py` and `test_mcp_parity_matrix_crossref.py` so our tests only consume rows.
+- `R6` — Long suite runtime if many seeded workspaces are created. Mitigation: seed once per parametrized case and rely on per-test `engine` fixture isolation; aim to keep new contract tests under ~3 seconds total.
+
+**Assumptions**
+
+- `A1` — The existing project `engine` fixture (`tests/conftest.py:107`) is the right entry point for an isolated PostgreSQL schema; the contract suite layers REST + MCP on top of the same engine.
+- `A2` — `awf.api.schemas` Pydantic models are the canonical schema source of truth (per `docs/MCP_CLIENT_PARITY.md` "REST is the canonical AWF control-plane API and schema source of truth").
+- `A3` — `WorkspaceService` is the shared façade for both REST and MCP control flows, so any divergence MUST be in the surface adapter (route handler vs MCP tool wrapper) rather than in business logic. This focuses the contract assertion on adapter correctness.
+- `A4` — The test `test_remonitor_workspace_with_idempotency_key_replays_on_duplicate` in `test_mcp_operator_surfaces.py` already covers replay for `awf_remonitor_workspace`; our new tests extend coverage to other MCP control tools without duplicating that case.
+- `A5` — `src/awf/cli/main.py` remains omitted from coverage (`pyproject.toml:194`); CLI behavioural assertions still run via `CliRunner` but do not contribute to the 99% threshold.
+
+**Coordination**
+
+- Read-only imports of `tests/unit/mcp/_parity_utils.py`. No edits.
+- No edits to `tests/unit/mcp/test_mcp_operator_surfaces.py`, `tests/unit/mcp/test_mcp_server.py`, `tests/unit/mcp/test_mcp_parity_matrix_crossref.py`, `tests/unit/mcp/test_mcp_client_parity_docs.py`.
+- No edits to `tests/unit/api/test_workspace_controls_idempotency.py`, `tests/unit/api/test_pr_monitor_adoption.py`, `tests/unit/api/test_workspaces.py`, `tests/unit/api/test_controls.py`.
+- No edits to `tests/unit/cli/test_cli.py`.
+- No edits to `docs/MCP_CLIENT_PARITY.md`.
+- No edits to `src/awf/api/`, `src/awf/cli/`, or `src/awf/service/`.
+- `src/awf/mcp/server.py` may receive a one-line `_tool_error` fix conditioned on a
+  failing contract test; otherwise untouched.
+- `TODO/pre-gke-industrial-readiness.md` receives only the single checkbox + evidence
+  edit for our slice's row; the Active/Completed Slices ledger and other slice rows
+  are not touched.
+
+## Non-Goals (restated explicit list)
+
+1. New MCP tools (refresh, rebase, retry already-existing-but-MCP-missing, artifact content download).
+2. New CLI commands for the `CLI absent` rows.
+3. `expected_version` / `If-Match` parameters on MCP control tools.
+4. Refactoring REST error envelope shape (HTTPException vs JSONResponse).
+5. Restructuring or rewording the parity matrix.
+6. Adding any new public API endpoint, MCP tool, or CLI subcommand.
+7. Any change to coverage thresholds, validation policy, or release scorecard.
+
+## TODO Update Plan
+
+After tests pass, the following one-line change in `TODO/pre-gke-industrial-readiness.md`:
+
+```diff
+-- [ ] Add contract tests proving REST API, CLI, and MCP stay aligned: request
++- [x] Add contract tests proving REST API, CLI, and MCP stay aligned: request
+   payloads, response payloads, reason codes, idempotency keys, `If-Match` /
+   workspace-version concurrency, auth failures, and structured error semantics
+-  must not drift across the three clients.
++  must not drift across the three clients. Evidence: `tests/unit/contract/`
++  package with shared `contract_stack` fixture covers request payloads, response
++  payloads, the canonical reason-code set, Idempotency-Key replay and conflict
++  parity, REST/CLI If-Match propagation, parity-matrix-driven `MCP implemented`
++  expected_version pin, and REST 401/503 + CLI exit-code auth failure parity.
++  Aligned MCP control error envelope to carry `detail` payload (single-line
++  `_tool_error` fix in `src/awf/mcp/server.py`). Validation: focused
++  `tests/unit/contract` plus touched-area `tests/unit/{api,cli,mcp,service,
++  control,runtime}` suites pass and coverage stays >=99%.
+```
+
+The Active Slices row for `ws_797d2f7d48a748a0b3566d21` will be moved to Completed
+Slices once AWF observes the merged PR; that move is performed by the post-merge
+reconciliation flow, not by this plan.

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -1125,7 +1125,7 @@ def build_mcp_server(
 
 
 def _tool_error(exc: WorkspaceControlError) -> CallToolResult:
-    error = ErrorResponse(error_code=exc.error_code, message=exc.message)
+    error = ErrorResponse(error_code=exc.error_code, message=exc.message, detail=exc.detail)
     return _tool_result(error.model_dump(mode="json"), is_error=True)
 
 

--- a/tests/unit/contract/__init__.py
+++ b/tests/unit/contract/__init__.py
@@ -1,0 +1,1 @@
+"""Contract tests proving REST, CLI, and MCP clients stay aligned."""

--- a/tests/unit/contract/conftest.py
+++ b/tests/unit/contract/conftest.py
@@ -1,0 +1,326 @@
+"""Shared fixtures and helpers for the AWF REST/CLI/MCP contract suite.
+
+The contract suite asserts that the three supported client surfaces -- REST
+(canonical), CLI, and MCP -- agree on request payloads, response payloads,
+reason codes, idempotency keys, ``If-Match`` / workspace-version concurrency,
+auth failures, and the structured error envelope. Tests live in this package
+under ``tests/unit/contract`` so the existing per-surface suites in
+``tests/unit/api``, ``tests/unit/cli``, and ``tests/unit/mcp`` keep their
+ownership boundaries intact.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+from httpx import ASGITransport, AsyncClient
+from mcp.types import CallToolResult
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+from typer.testing import CliRunner
+
+from awf.api.app import configure_database, create_app
+from awf.api.schemas import ErrorResponse
+from awf.cli.main import app as cli_app
+from awf.common.config import Settings, get_settings
+from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.repositories import (
+    MergeCandidateRepository,
+    OperationRepository,
+    TaskAttemptRepository,
+    TaskRepository,
+    WorkspaceRepository,
+)
+from awf.db.session import make_session_factory
+from awf.mcp.server import WorkspaceService, build_mcp_server
+from awf.service.disk import DiskCheck
+
+
+@dataclass
+class ContractStack:
+    """Bundle of REST, MCP, and CLI handles plus a shared session factory.
+
+    All three surfaces are wired against the same per-test PostgreSQL schema and
+    the same ``AWF_API_TOKEN`` value so the contract suite can call them
+    interchangeably and compare the resulting payloads.
+    """
+
+    rest_client: AsyncClient
+    mcp: Any
+    factory: async_sessionmaker[AsyncSession]
+    settings: Settings
+    auth_headers: dict[str, str]
+    cli_runner: CliRunner
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> AsyncIterator[None]:
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+def _ok_disk_check(settings: Settings) -> DiskCheck:
+    threshold = settings.min_free_disk_bytes
+    free = threshold + 1
+    return DiskCheck(
+        path=settings.work_dir,
+        checked_path=settings.work_dir,
+        total_bytes=free,
+        used_bytes=0,
+        free_bytes=free,
+        percent_free=100.0,
+        threshold_bytes=threshold,
+        ok=True,
+        status="ok",
+        reason="SUFFICIENT_DISK",
+    )
+
+
+@pytest.fixture
+async def contract_stack(
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> AsyncIterator[ContractStack]:
+    work_dir = tmp_path / "awf-state"
+    monkeypatch.setenv("AWF_API_TOKEN", "secret")
+    monkeypatch.setenv("AWF_WORK_DIR", str(work_dir))
+    monkeypatch.setenv("AWF_MIN_FREE_DISK_BYTES", "700")
+    get_settings.cache_clear()
+
+    factory = make_session_factory(engine)
+    settings = Settings(
+        _env_file=None,
+        api_token="secret",
+        work_dir=str(work_dir),
+        min_free_disk_bytes=700,
+    )
+    app = create_app(use_lifespan=False)
+    configure_database(app, factory)
+    app.dependency_overrides[get_settings] = lambda: settings
+    app.state.workspace_admission_disk_check = _ok_disk_check
+
+    mcp = build_mcp_server(service=WorkspaceService(factory, settings=settings))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        yield ContractStack(
+            rest_client=client,
+            mcp=mcp,
+            factory=factory,
+            settings=settings,
+            auth_headers={"Authorization": "Bearer secret"},
+            cli_runner=CliRunner(),
+        )
+
+
+def unwrap_error_envelope(payload: dict[str, Any]) -> dict[str, Any]:
+    """Normalize REST/MCP/CLI error envelopes to the canonical ``ErrorResponse`` shape.
+
+    REST surfaces use two envelope flavors: ``HTTPException`` raises produce
+    ``{"detail": {"error_code": ..., "message": ..., "detail": ...}}`` while
+    routes that return ``JSONResponse(ErrorResponse(...).model_dump())`` produce
+    a flat ``{"error_code": ..., "message": ..., "detail": ...}``. MCP tool
+    errors return the flat shape directly. This helper accepts either input,
+    validates the inner dict against ``ErrorResponse`` to confirm the contract,
+    and returns its dump so callers compare a single canonical structure.
+    """
+
+    if "error_code" in payload:
+        inner = payload
+    elif "detail" in payload and isinstance(payload["detail"], dict):
+        inner = payload["detail"]
+    else:  # pragma: no cover - defensive: unrecognised envelope shapes flunk loud
+        raise AssertionError(f"unrecognised error envelope: {payload!r}")
+    return ErrorResponse.model_validate(inner).model_dump(mode="json")
+
+
+async def call_mcp_structured(mcp: Any, name: str, args: dict[str, Any]) -> Any:
+    """Invoke an MCP tool and return its ``structuredContent`` payload."""
+
+    result = await mcp.call_tool(name, args)
+    if isinstance(result, CallToolResult):
+        return result.structuredContent
+    _, payload = result
+    if isinstance(payload, dict) and list(payload.keys()) == ["result"]:
+        return payload["result"]
+    return payload
+
+
+async def call_mcp_result(mcp: Any, name: str, args: dict[str, Any]) -> CallToolResult:
+    """Invoke an MCP tool and return the raw ``CallToolResult`` for error cases."""
+
+    result = await mcp.call_tool(name, args)
+    assert isinstance(result, CallToolResult)
+    return result
+
+
+def invoke_cli(
+    runner: CliRunner,
+    args: list[str],
+    *,
+    response_status: int = 200,
+    response_payload: object | None = None,
+    response_text: str = "",
+    env: dict[str, str] | None = None,
+) -> tuple[Any, MagicMock]:
+    """Invoke the AWF Typer CLI with ``httpx.request`` patched to a stub response.
+
+    The contract suite uses this helper to assert the *outbound* HTTP request
+    the CLI generates, not real backend behavior. Returns the Typer ``Result``
+    and the captured ``httpx.request`` mock so callers can inspect call args.
+    """
+
+    response = MagicMock(spec=httpx.Response)
+    response.status_code = response_status
+    if response_payload is not None:
+        response.content = json.dumps(response_payload).encode("utf-8")
+        response.text = json.dumps(response_payload)
+        response.json.return_value = response_payload
+    elif response_text:
+        response.content = response_text.encode("utf-8")
+        response.text = response_text
+        response.json.side_effect = ValueError("not json")
+    else:
+        response.content = b""
+        response.text = ""
+        response.json.return_value = None
+
+    with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+        result = runner.invoke(cli_app, args, env=env)
+    return result, mock
+
+
+async def seed_monitoring_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    title: str = "Contract monitoring workspace",
+    final_status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
+    with_pr_url: bool = True,
+    with_open_candidate: bool = False,
+) -> str:
+    """Seed a workspace walked through the canonical lifecycle.
+
+    Mirrors the pattern in ``tests/unit/api/test_workspace_controls_idempotency``
+    but is reimplemented locally so the contract suite owns a single seed shape
+    and does not import test-private helpers from a sibling package.
+    """
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/contract.git",
+            branch_base="main",
+            task_title=title,
+            task_prompt=f"Implement {title}.",
+            agent="codex",
+            test_commands=["pytest -q"],
+        )
+        task = await TaskRepository(session).create_or_get(
+            repo_url=workspace.repo_url,
+            base_branch=workspace.branch_base,
+            title=workspace.task_title,
+            prompt=workspace.task_prompt,
+            external_id=workspace.task_external_id,
+            idempotency_key=None,
+            task_class=workspace.task_class,
+            owned_paths=list(workspace.owned_paths),
+        )
+        attempt = await TaskAttemptRepository(session).create_for_workspace(
+            task=task,
+            workspace=workspace,
+        )
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="SEED")
+        workspace.branch_name = f"awf/{workspace.id}"
+        workspace.remote_push_branch = workspace.branch_name
+        workspace.base_commit = "a" * 40
+        workspace.compose_project_name = f"awf_{workspace.id}"
+        workspace.compose_file_path = f"/tmp/awf/{workspace.id}/compose.yml"
+        await repo.transition(workspace, to=WorkspaceStatus.ready, reason_code="SEED")
+        if final_status == WorkspaceStatus.ready:
+            await session.commit()
+            return workspace.id
+        await repo.transition(workspace, to=WorkspaceStatus.running, reason_code="SEED")
+        await repo.transition(workspace, to=WorkspaceStatus.validating, reason_code="SEED")
+        await repo.transition(workspace, to=WorkspaceStatus.pushing, reason_code="SEED")
+        if with_pr_url:
+            workspace.pr_url = "https://github.com/example/contract/pull/42"
+            workspace.pr_number = 42
+            workspace.monitor_last_commit_sha = "b" * 40
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.monitoring_pr,
+            reason_code="SEED",
+        )
+        if final_status in {
+            WorkspaceStatus.completed,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+        }:
+            await repo.transition(workspace, to=final_status, reason_code="SEED")
+        elif final_status != WorkspaceStatus.monitoring_pr:
+            raise AssertionError(f"unsupported seed status {final_status}")
+
+        if with_open_candidate:
+            if not workspace.pr_url:
+                raise AssertionError("open candidate seed requires a PR URL")
+            await MergeCandidateRepository(session).create_or_update_open_for_attempt(
+                task=task,
+                attempt=attempt,
+                workspace=workspace,
+                head_sha=workspace.monitor_last_commit_sha,
+                base_sha=workspace.base_commit,
+            )
+
+        await session.commit()
+        return workspace.id
+
+
+async def seed_requested_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    title: str = "Contract requested workspace",
+) -> str:
+    """Seed a freshly-requested workspace (initial state, version=1)."""
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/contract.git",
+            branch_base="main",
+            task_title=title,
+            task_prompt=f"Implement {title}.",
+            agent="codex",
+            test_commands=["pytest -q"],
+        )
+        await session.commit()
+        return workspace.id
+
+
+async def seed_workspace_operation(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    workspace_id: str,
+    operation_type: OperationType = OperationType.cancel,
+    status: OperationStatus = OperationStatus.succeeded,
+) -> str:
+    """Seed one operation row attached to ``workspace_id`` and return its id."""
+
+    async with factory() as session:
+        operation = await OperationRepository(session).create(
+            workspace_id=workspace_id,
+            operation_type=operation_type,
+            status=status,
+            payload={"source": "contract_seed"},
+        )
+        await session.commit()
+        return operation.id
+
+
+def now_utc() -> datetime:
+    return datetime.now(UTC)

--- a/tests/unit/contract/test_contract_stack_smoke.py
+++ b/tests/unit/contract/test_contract_stack_smoke.py
@@ -1,0 +1,32 @@
+"""Smoke test that proves the shared contract_stack fixture wires all surfaces."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.unit.contract.conftest import (
+    ContractStack,
+    call_mcp_structured,
+    invoke_cli,
+)
+
+
+@pytest.mark.unit
+async def test_contract_stack_smoke(contract_stack: ContractStack) -> None:
+    rest_health = (await contract_stack.rest_client.get("/healthz")).json()
+    mcp_health = await call_mcp_structured(contract_stack.mcp, "awf_get_service_health", {})
+
+    assert rest_health["status"] == mcp_health["status"]
+    assert rest_health["service"] == mcp_health["service"]
+
+    cli_result, request_mock = invoke_cli(
+        contract_stack.cli_runner,
+        ["workspace", "list"],
+        response_status=200,
+        response_payload=[],
+    )
+    assert cli_result.exit_code == 0
+    assert request_mock.called
+    method, url = request_mock.call_args.args[0], request_mock.call_args.args[1]
+    assert method == "GET"
+    assert url.endswith("/v1/workspaces")

--- a/tests/unit/contract/test_idempotency_concurrency_auth_alignment.py
+++ b/tests/unit/contract/test_idempotency_concurrency_auth_alignment.py
@@ -1,0 +1,347 @@
+"""Contract: idempotency, ``If-Match`` concurrency, and auth-failure parity.
+
+Three sections:
+
+* ``TestIdempotencyContract`` -- replaying the same ``Idempotency-Key`` returns
+  the same operation_id on REST and on the MCP control tools that already
+  expose the key. A different payload under the same key returns
+  ``IDEMPOTENCY_CONFLICT`` from both surfaces.
+* ``TestIfMatchContract`` -- REST/CLI propagate ``If-Match`` and surface
+  ``VERSION_CONFLICT`` consistently. The parity-matrix-driven assertion pins
+  the documented ``MCP partial`` state for ``If-Match``: rows whose Schema
+  mentions ``VERSION_CONFLICT`` and Status is ``MCP partial`` must reference
+  the ``TODO§P1-if-match-parity`` backlog slice; rows that flip to
+  ``MCP implemented`` must add an ``expected_version`` parameter to the MCP
+  tool. The second clause is vacuously true today and becomes load-bearing
+  the moment the parity gap is closed.
+* ``TestAuthFailureContract`` -- REST 401 ``UNAUTHORIZED`` propagates to the
+  CLI as a non-zero exit with the canonical envelope on stderr. REST 503
+  ``API_TOKEN_NOT_CONFIGURED`` works the same way. MCP tools never construct
+  these codes, per the documented in-process trust boundary.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from awf.api.schemas import ErrorResponse
+
+from tests.unit.contract.conftest import (
+    ContractStack,
+    call_mcp_structured,
+    invoke_cli,
+    seed_monitoring_workspace,
+    unwrap_error_envelope,
+)
+from tests.unit.mcp._parity_utils import _parity_rows, _strip_backticks
+
+
+@pytest.mark.unit
+class TestIdempotencyContract:
+    async def test_remonitor_idempotency_replay_aligned_across_rest_and_mcp(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        rest_workspace = await seed_monitoring_workspace(
+            contract_stack.factory, title="Remon idem REST"
+        )
+        mcp_workspace = await seed_monitoring_workspace(
+            contract_stack.factory, title="Remon idem MCP"
+        )
+
+        rest_first = await contract_stack.rest_client.post(
+            f"/v1/workspaces/{rest_workspace}/remonitor",
+            headers={
+                **contract_stack.auth_headers,
+                "Idempotency-Key": "remon-replay-rest",
+            },
+            json={"reason": "replay"},
+        )
+        rest_second = await contract_stack.rest_client.post(
+            f"/v1/workspaces/{rest_workspace}/remonitor",
+            headers={
+                **contract_stack.auth_headers,
+                "Idempotency-Key": "remon-replay-rest",
+            },
+            json={"reason": "replay"},
+        )
+        assert rest_first.status_code == 200
+        assert rest_second.status_code == 200
+        assert rest_first.json()["operation_id"] == rest_second.json()["operation_id"]
+
+        mcp_first = await call_mcp_structured(
+            contract_stack.mcp,
+            "awf_remonitor_workspace",
+            {
+                "workspace_id": mcp_workspace,
+                "reason": "replay",
+                "idempotency_key": "remon-replay-mcp",
+            },
+        )
+        mcp_second = await call_mcp_structured(
+            contract_stack.mcp,
+            "awf_remonitor_workspace",
+            {
+                "workspace_id": mcp_workspace,
+                "reason": "replay",
+                "idempotency_key": "remon-replay-mcp",
+            },
+        )
+        assert isinstance(mcp_first, dict)
+        assert isinstance(mcp_second, dict)
+        assert mcp_first["operation_id"] == mcp_second["operation_id"]
+
+    async def test_remonitor_idempotency_conflict_aligned_across_rest_and_mcp(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        rest_workspace = await seed_monitoring_workspace(
+            contract_stack.factory, title="Remon conflict REST"
+        )
+        mcp_workspace = await seed_monitoring_workspace(
+            contract_stack.factory, title="Remon conflict MCP"
+        )
+
+        await contract_stack.rest_client.post(
+            f"/v1/workspaces/{rest_workspace}/remonitor",
+            headers={
+                **contract_stack.auth_headers,
+                "Idempotency-Key": "remon-conflict-rest",
+            },
+            json={"reason": "first"},
+        )
+        rest_conflict = await contract_stack.rest_client.post(
+            f"/v1/workspaces/{rest_workspace}/remonitor",
+            headers={
+                **contract_stack.auth_headers,
+                "Idempotency-Key": "remon-conflict-rest",
+            },
+            json={"reason": "different"},
+        )
+        assert rest_conflict.status_code == 409
+        rest_envelope = unwrap_error_envelope(rest_conflict.json())
+        assert rest_envelope["error_code"] == "IDEMPOTENCY_CONFLICT"
+
+        await call_mcp_structured(
+            contract_stack.mcp,
+            "awf_remonitor_workspace",
+            {
+                "workspace_id": mcp_workspace,
+                "reason": "first",
+                "idempotency_key": "remon-conflict-mcp",
+            },
+        )
+        from tests.unit.contract.conftest import call_mcp_result
+
+        mcp_conflict = await call_mcp_result(
+            contract_stack.mcp,
+            "awf_remonitor_workspace",
+            {
+                "workspace_id": mcp_workspace,
+                "reason": "different",
+                "idempotency_key": "remon-conflict-mcp",
+            },
+        )
+        assert mcp_conflict.isError is True
+        mcp_envelope = unwrap_error_envelope(mcp_conflict.structuredContent)
+        assert mcp_envelope["error_code"] == "IDEMPOTENCY_CONFLICT"
+        assert ErrorResponse.model_validate(mcp_envelope).error_code == ErrorResponse.model_validate(
+            rest_envelope
+        ).error_code
+
+
+@pytest.mark.unit
+class TestIfMatchContract:
+    async def test_rest_if_match_stale_returns_canonical_version_conflict(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        workspace_id = await seed_monitoring_workspace(contract_stack.factory)
+
+        response = await contract_stack.rest_client.post(
+            f"/v1/workspaces/{workspace_id}/remonitor",
+            headers={
+                **contract_stack.auth_headers,
+                "Idempotency-Key": "remon-stale-version",
+                "If-Match": "0",
+            },
+            json={"reason": "stale"},
+        )
+        assert response.status_code == 409
+        envelope = unwrap_error_envelope(response.json())
+        assert envelope["error_code"] == "VERSION_CONFLICT"
+        assert envelope["detail"] == {
+            "expected_version": 0,
+            "actual_version": 7,
+        }
+
+    def test_cli_remonitor_propagates_409_version_conflict_to_stderr(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        rest_envelope = ErrorResponse(
+            error_code="VERSION_CONFLICT",
+            message="Workspace version does not match If-Match.",
+            detail={"expected_version": 1, "actual_version": 7},
+        ).model_dump(mode="json")
+        rest_body = {"detail": rest_envelope}
+
+        cli_result, _request_mock = invoke_cli(
+            contract_stack.cli_runner,
+            [
+                "workspace",
+                "remonitor",
+                "ws_x",
+                "--idempotency-key",
+                "remon-cli",
+                "--if-match",
+                "1",
+                "--api-token",
+                "secret",
+            ],
+            response_status=409,
+            response_payload=rest_body,
+        )
+        assert cli_result.exit_code == 1
+        stderr_payload = json.loads(cli_result.stderr or cli_result.stdout)
+        assert (
+            unwrap_error_envelope(stderr_payload)["error_code"] == "VERSION_CONFLICT"
+        )
+
+    def test_parity_matrix_pins_mcp_if_match_partial_state(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        rows = _parity_rows()
+        rows_with_version_conflict = [
+            row
+            for row in rows
+            if "VERSION_CONFLICT" in _strip_backticks(row.get("Schema / Error-Code Contract", ""))
+        ]
+        assert rows_with_version_conflict, (
+            "Parity matrix must list at least one row with VERSION_CONFLICT in its "
+            "schema column for the contract to be meaningful."
+        )
+
+        partial_rows = [r for r in rows_with_version_conflict if "partial" in r["Status"].lower()]
+        for row in partial_rows:
+            backlog = _strip_backticks(row.get("Backlog Slice", ""))
+            assert "TODO§P1-if-match-parity" in backlog, (
+                f"Row {row.get('Capability', '?')!r} marks VERSION_CONFLICT as MCP partial "
+                "but does not reference TODO§P1-if-match-parity."
+            )
+
+        # Load-bearing the moment the parity gap closes: every row whose Status
+        # is "MCP implemented" AND whose schema mentions VERSION_CONFLICT must
+        # have an `expected_version` argument on the MCP tool. Today the
+        # iteration is vacuous; tomorrow it pins the contract.
+        implemented_rows = [
+            r
+            for r in rows_with_version_conflict
+            if "MCP implemented" in r["Status"]
+        ]
+        for row in implemented_rows:
+            tool_cell = _strip_backticks(row.get("MCP tool name", ""))
+            for tool_name in [name.strip() for name in tool_cell.split(",") if name.strip()]:
+                if not tool_name.startswith("awf_"):
+                    continue
+                tool = contract_stack.mcp._tool_manager._tools.get(tool_name)
+                assert tool is not None, (
+                    f"Parity matrix references missing MCP tool {tool_name!r}"
+                )
+                assert "expected_version" in tool.parameters["properties"], (
+                    f"Tool {tool_name!r} is marked MCP implemented for VERSION_CONFLICT "
+                    "but does not expose an expected_version argument; either add it "
+                    "or change the parity matrix Status."
+                )
+
+
+@pytest.mark.unit
+class TestAuthFailureContract:
+    async def test_rest_unauthorized_returns_canonical_envelope(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        response = await contract_stack.rest_client.post(
+            "/v1/workspaces/ws_irrelevant/cancel",
+            json={"reason": "no auth"},
+            headers={"Idempotency-Key": "cancel-no-auth"},
+        )
+        assert response.status_code == 401
+        envelope = unwrap_error_envelope(response.json())
+        assert envelope["error_code"] == "UNAUTHORIZED"
+        assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+    async def test_rest_returns_503_when_api_token_not_configured(
+        self,
+        contract_stack: ContractStack,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from awf.common.config import get_settings
+
+        monkeypatch.delenv("AWF_API_TOKEN", raising=False)
+        get_settings.cache_clear()
+        contract_stack.rest_client._transport.app.dependency_overrides.clear()  # type: ignore[attr-defined]
+
+        try:
+            response = await contract_stack.rest_client.post(
+                "/v1/workspaces/ws_irrelevant/cancel",
+                json={"reason": "no token"},
+                headers={"Idempotency-Key": "cancel-no-token"},
+            )
+        finally:
+            get_settings.cache_clear()
+
+        assert response.status_code == 503
+        envelope = unwrap_error_envelope(response.json())
+        assert envelope["error_code"] == "API_TOKEN_NOT_CONFIGURED"
+
+    @pytest.mark.parametrize(
+        "cli_args",
+        [
+            [
+                "workspace",
+                "remonitor",
+                "ws_x",
+                "--idempotency-key",
+                "remon",
+            ],
+            ["workspace", "retry", "ws_x"],
+            [
+                "workspace",
+                "adopt-pr",
+                "--repo",
+                "owner/x",
+                "--pr",
+                "1",
+            ],
+            ["locks", "list"],
+        ],
+    )
+    def test_cli_propagates_rest_401_with_nonzero_exit(
+        self,
+        contract_stack: ContractStack,
+        cli_args: list[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.delenv("AWF_API_TOKEN", raising=False)
+
+        rest_body: dict[str, Any] = {
+            "detail": ErrorResponse(
+                error_code="UNAUTHORIZED",
+                message="Invalid AWF API token.",
+            ).model_dump(mode="json")
+        }
+
+        cli_result, _request_mock = invoke_cli(
+            contract_stack.cli_runner,
+            cli_args,
+            response_status=401,
+            response_payload=rest_body,
+        )
+        assert cli_result.exit_code == 1
+        text = cli_result.stderr or cli_result.stdout
+        assert "UNAUTHORIZED" in text

--- a/tests/unit/contract/test_reason_code_alignment.py
+++ b/tests/unit/contract/test_reason_code_alignment.py
@@ -1,0 +1,287 @@
+"""Contract: REST and MCP must surface canonical reason codes uniformly.
+
+For each reason code reachable from a controllable seed, both REST (canonical)
+and the MCP tool (where one exists for that capability) must:
+
+1. carry the same ``error_code`` string;
+2. validate as ``ErrorResponse`` after ``unwrap_error_envelope``;
+3. preserve the ``detail`` payload when one is populated by the underlying
+   ``WorkspaceControlError`` -- this is the contract the MCP control tool path
+   currently breaks (the ``_tool_error`` helper in ``src/awf/mcp/server.py``
+   drops ``detail``), so the smallest-safe surface fix lives in this slice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from awf.api.schemas import ErrorResponse
+from awf.db.enums import WorkspaceStatus
+from awf.mcp import server as mcp_server
+from awf.service.controls import (
+    WorkspaceRemonitorStateError,
+)
+
+from tests.unit.contract.conftest import (
+    ContractStack,
+    call_mcp_result,
+    seed_monitoring_workspace,
+    seed_requested_workspace,
+    unwrap_error_envelope,
+)
+
+
+@pytest.mark.unit
+async def test_remonitor_workspace_not_found_error_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    rest = await contract_stack.rest_client.post(
+        "/v1/workspaces/ws_missing/remonitor",
+        headers={**contract_stack.auth_headers, "Idempotency-Key": "remon-missing"},
+        json={"reason": "missing"},
+    )
+    mcp = await call_mcp_result(
+        contract_stack.mcp,
+        "awf_remonitor_workspace",
+        {
+            "workspace_id": "ws_missing",
+            "reason": "missing",
+            "idempotency_key": "remon-missing",
+        },
+    )
+
+    assert rest.status_code == 404
+    rest_envelope = unwrap_error_envelope(rest.json())
+    assert mcp.isError is True
+    assert isinstance(mcp.structuredContent, dict)
+    mcp_envelope = unwrap_error_envelope(mcp.structuredContent)
+    assert rest_envelope["error_code"] == mcp_envelope["error_code"] == "NOT_FOUND"
+
+
+@pytest.mark.unit
+async def test_remonitor_workspace_state_error_keeps_detail_on_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    """Pin the smallest-safe-surface fix: MCP must carry ``detail`` like REST.
+
+    REST returns ``{"detail": {"error_code": "WORKSPACE_STATE_NOT_REMONITORABLE",
+    "message": ..., "detail": {"status": ..., "eligible_statuses": [...]}}}``.
+    MCP must surface the same ``detail`` payload through ``_tool_error``;
+    historically it dropped the field, which is the precise bug this contract
+    test pins.
+    """
+
+    completed_id = await seed_monitoring_workspace(
+        contract_stack.factory, final_status=WorkspaceStatus.completed
+    )
+
+    rest = await contract_stack.rest_client.post(
+        f"/v1/workspaces/{completed_id}/remonitor",
+        headers={
+            **contract_stack.auth_headers,
+            "Idempotency-Key": "remon-state-rest",
+        },
+        json={"reason": "state error"},
+    )
+    mcp = await call_mcp_result(
+        contract_stack.mcp,
+        "awf_remonitor_workspace",
+        {
+            "workspace_id": completed_id,
+            "reason": "state error",
+            "idempotency_key": "remon-state-mcp",
+        },
+    )
+
+    assert rest.status_code == 409
+    rest_envelope = unwrap_error_envelope(rest.json())
+    assert rest_envelope["error_code"] == "WORKSPACE_STATE_NOT_REMONITORABLE"
+    rest_detail = rest_envelope["detail"]
+    assert rest_detail is not None
+    assert rest_detail["status"] == WorkspaceStatus.completed.value
+    assert WorkspaceStatus.monitoring_pr.value in rest_detail["eligible_statuses"]
+
+    assert mcp.isError is True
+    assert isinstance(mcp.structuredContent, dict)
+    mcp_envelope = unwrap_error_envelope(mcp.structuredContent)
+    assert mcp_envelope["error_code"] == "WORKSPACE_STATE_NOT_REMONITORABLE"
+    assert mcp_envelope["detail"] is not None, (
+        "MCP must surface the same `detail` payload as REST for control errors. "
+        "If this assertion fails, align `_tool_error` in src/awf/mcp/server.py "
+        "with `_workspace_error_result` (pass `detail=exc.detail`)."
+    )
+    assert mcp_envelope["detail"] == rest_detail
+
+
+@pytest.mark.unit
+async def test_remonitor_missing_pr_url_error_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(
+        contract_stack.factory, with_pr_url=False
+    )
+
+    rest = await contract_stack.rest_client.post(
+        f"/v1/workspaces/{workspace_id}/remonitor",
+        headers={
+            **contract_stack.auth_headers,
+            "Idempotency-Key": "remon-pr-rest",
+        },
+        json={"reason": "no pr"},
+    )
+    mcp = await call_mcp_result(
+        contract_stack.mcp,
+        "awf_remonitor_workspace",
+        {
+            "workspace_id": workspace_id,
+            "reason": "no pr",
+            "idempotency_key": "remon-pr-mcp",
+        },
+    )
+
+    assert rest.status_code == 400
+    rest_envelope = unwrap_error_envelope(rest.json())
+    assert rest_envelope["error_code"] == "WORKSPACE_PR_URL_REQUIRED"
+    assert rest_envelope["detail"] is not None
+    assert rest_envelope["detail"]["status"] == WorkspaceStatus.monitoring_pr.value
+
+    assert mcp.isError is True
+    assert isinstance(mcp.structuredContent, dict)
+    mcp_envelope = unwrap_error_envelope(mcp.structuredContent)
+    assert mcp_envelope["error_code"] == "WORKSPACE_PR_URL_REQUIRED"
+    assert mcp_envelope["detail"] == rest_envelope["detail"]
+
+
+@pytest.mark.unit
+async def test_request_validation_state_error_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_requested_workspace(
+        contract_stack.factory, title="Validate state error"
+    )
+
+    rest = await contract_stack.rest_client.post(
+        f"/v1/workspaces/{workspace_id}/validate",
+        headers={
+            **contract_stack.auth_headers,
+            "Idempotency-Key": "validate-state-rest",
+        },
+        json={"reason": "state"},
+    )
+    mcp = await call_mcp_result(
+        contract_stack.mcp,
+        "awf_request_workspace_validation",
+        {
+            "workspace_id": workspace_id,
+            "reason": "state",
+            "idempotency_key": "validate-state-mcp",
+        },
+    )
+
+    assert rest.status_code == 409
+    rest_envelope = unwrap_error_envelope(rest.json())
+    assert rest_envelope["error_code"] == "WORKSPACE_STATE_NOT_VALIDATABLE"
+    assert rest_envelope["detail"] is not None
+    assert rest_envelope["detail"]["status"] == WorkspaceStatus.requested.value
+
+    assert mcp.isError is True
+    assert isinstance(mcp.structuredContent, dict)
+    mcp_envelope = unwrap_error_envelope(mcp.structuredContent)
+    assert mcp_envelope["error_code"] == "WORKSPACE_STATE_NOT_VALIDATABLE"
+    assert mcp_envelope["detail"] == rest_envelope["detail"]
+
+
+@pytest.mark.unit
+async def test_adopt_pr_input_required_error_uses_uniform_envelope(
+    contract_stack: ContractStack,
+) -> None:
+    rest = await contract_stack.rest_client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=contract_stack.auth_headers,
+        json={},
+    )
+    mcp = await call_mcp_result(
+        contract_stack.mcp,
+        "awf_adopt_pull_request_monitor",
+        {},
+    )
+
+    assert rest.status_code == 422
+    rest_envelope = unwrap_error_envelope(rest.json())
+    assert rest_envelope["error_code"] == "PR_ADOPTION_INPUT_REQUIRED"
+
+    assert mcp.isError is True
+    assert isinstance(mcp.structuredContent, dict)
+    mcp_envelope = unwrap_error_envelope(mcp.structuredContent)
+    assert mcp_envelope["error_code"] == "PR_ADOPTION_INPUT_REQUIRED"
+    assert ErrorResponse.model_validate(mcp_envelope) == ErrorResponse.model_validate(
+        rest_envelope
+    )
+
+
+@pytest.mark.unit
+async def test_unauthorized_rest_envelope_validates_as_error_response(
+    contract_stack: ContractStack,
+) -> None:
+    """REST 401 must use the canonical ``UNAUTHORIZED`` envelope.
+
+    The MCP transport-trust contract is in-process (per parity-matrix security
+    note), so MCP tools have no equivalent ``UNAUTHORIZED`` code; this is
+    documented and pinned by ``test_mcp_tools_do_not_expose_unauthorized_code``.
+
+    Hits a route that is known to enforce ``require_api_token`` at the router
+    level (workspace controls). Some other parity-matrix-listed routes do not
+    yet enforce the token at the route level; those gaps are tracked
+    separately and not part of the structured-error contract.
+    """
+
+    response = await contract_stack.rest_client.post(
+        "/v1/workspaces/ws_irrelevant/remonitor",
+        json={"reason": "missing auth"},
+        headers={"Idempotency-Key": "remon-no-auth"},
+    )
+    assert response.status_code == 401
+    envelope = unwrap_error_envelope(response.json())
+    assert envelope["error_code"] == "UNAUTHORIZED"
+    assert response.headers.get("WWW-Authenticate") == "Bearer"
+
+
+@pytest.mark.unit
+def test_mcp_tools_do_not_expose_unauthorized_code() -> None:
+    """MCP tool wrappers never construct an ``UNAUTHORIZED`` error envelope.
+
+    The MCP transport sits inside the trusted process. Any ``UNAUTHORIZED``
+    string in MCP server source would imply a token-check that contradicts
+    the documented security boundary.
+    """
+
+    import inspect
+
+    source = inspect.getsource(mcp_server)
+    assert "UNAUTHORIZED" not in source
+
+
+@pytest.mark.unit
+def test_tool_error_helper_carries_detail_payload() -> None:
+    """The ``_tool_error`` helper must propagate ``WorkspaceControlError.detail``.
+
+    This is the unit-level guard for the contract pinned by
+    ``test_remonitor_workspace_state_error_keeps_detail_on_rest_and_mcp``: any
+    future regression that drops ``detail`` from the helper fails this test
+    even before the integration assertion runs.
+    """
+
+    fake_workspace = type("FakeWorkspace", (), {"status": WorkspaceStatus.completed.value})()
+    exc = WorkspaceRemonitorStateError(fake_workspace)  # type: ignore[arg-type]
+
+    result = mcp_server._tool_error(exc)
+    assert result.isError is True
+    assert isinstance(result.structuredContent, dict)
+    payload: dict[str, Any] = result.structuredContent
+    assert payload["error_code"] == "WORKSPACE_STATE_NOT_REMONITORABLE"
+    assert payload["detail"] == exc.detail, (
+        "_tool_error must keep `detail=exc.detail` so MCP and REST surface "
+        "the same structured envelope for WorkspaceControlError instances."
+    )

--- a/tests/unit/contract/test_request_payload_alignment.py
+++ b/tests/unit/contract/test_request_payload_alignment.py
@@ -1,0 +1,286 @@
+"""Contract: REST canonical schemas validate the request bodies CLI and MCP build.
+
+REST is the canonical schema source of truth for AWF. The CLI is a JSON-first
+HTTP client; the MCP control tools build the same canonical request models
+internally before delegating to the shared ``WorkspaceService``. These tests
+prove the CLI body and the MCP-built body for each capability validate against
+the same Pydantic model and normalize to the same canonical instance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.api.schemas import (
+    PullRequestMonitorAdoptionRequest,
+    WorkspaceCreateV2Request,
+)
+
+from tests.unit.contract.conftest import ContractStack, invoke_cli
+
+
+@pytest.mark.unit
+class TestWorkspaceCreateV2RequestContract:
+    """``POST /v2/workspaces`` body must match what the CLI emits and MCP builds."""
+
+    def test_cli_body_validates_against_canonical_schema(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        cli_result, request_mock = invoke_cli(
+            contract_stack.cli_runner,
+            [
+                "workspace",
+                "create",
+                "--repo",
+                "git@github.com:example/contract.git",
+                "--title",
+                "Contract create",
+                "--prompt",
+                "Implement the contract.",
+                "--test",
+                "pytest -q",
+                "--test",
+                "ruff check .",
+            ],
+            response_status=202,
+            response_payload={
+                "workspace_id": "ws_create",
+                "status": "requested",
+                "version": 1,
+                "status_url": "/v1/workspaces/ws_create",
+                "events_url": "/v1/workspaces/ws_create/events",
+                "accepted_at": "2026-01-01T00:00:00Z",
+            },
+        )
+        assert cli_result.exit_code == 0
+        body = request_mock.call_args.kwargs["json"]
+
+        validated = WorkspaceCreateV2Request.model_validate(body)
+        assert validated.repo.url == "git@github.com:example/contract.git"
+        assert validated.task.title == "Contract create"
+        assert validated.validation.commands == ["pytest -q", "ruff check ."]
+
+    async def test_mcp_built_body_validates_against_canonical_schema(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        captured: dict[str, WorkspaceCreateV2Request] = {}
+
+        class _CreatedStub:
+            def model_dump(self, *, mode: str = "json") -> dict[str, str]:
+                return {"workspace_id": "ws_create_mcp"}
+
+        async def spy_create_v2(req: WorkspaceCreateV2Request) -> _CreatedStub:
+            captured["req"] = req
+            return _CreatedStub()
+
+        from awf.mcp.server import WorkspaceService, build_mcp_server
+
+        service = WorkspaceService(contract_stack.factory, settings=contract_stack.settings)
+        service.create_v2 = spy_create_v2  # type: ignore[method-assign]
+        mcp = build_mcp_server(service=service)
+
+        from tests.unit.contract.conftest import call_mcp_structured
+
+        await call_mcp_structured(
+            mcp,
+            "awf_create_workspace_v2",
+            {
+                "repo_url": "git@github.com:example/contract.git",
+                "task_title": "Contract create",
+                "task_prompt": "Implement the contract.",
+                "validation_commands": ["pytest -q", "ruff check ."],
+            },
+        )
+        assert "req" in captured
+        body = captured["req"].model_dump(mode="json")
+        validated = WorkspaceCreateV2Request.model_validate(body)
+        assert validated.repo.url == "git@github.com:example/contract.git"
+        assert validated.task.title == "Contract create"
+        assert validated.validation.commands == ["pytest -q", "ruff check ."]
+
+
+@pytest.mark.unit
+class TestAdoptPullRequestMonitorRequestContract:
+    """Existing PR adoption body shape must agree across REST, CLI, and MCP."""
+
+    @pytest.mark.parametrize(
+        ("cli_args", "expected_repo_slug", "expected_repo_url", "expected_pr_url"),
+        [
+            (
+                ["--repo", "dimileeh/aira-web", "--pr", "277"],
+                "dimileeh/aira-web",
+                None,
+                None,
+            ),
+            (
+                [
+                    "--repo",
+                    "https://github.com/dimileeh/aira-web",
+                    "--pr",
+                    "277",
+                ],
+                None,
+                "https://github.com/dimileeh/aira-web",
+                None,
+            ),
+            (
+                [
+                    "--pr-url",
+                    "https://github.com/dimileeh/aira-web/pull/277",
+                ],
+                None,
+                None,
+                "https://github.com/dimileeh/aira-web/pull/277",
+            ),
+        ],
+    )
+    def test_cli_body_normalizes_repo_input_into_canonical_schema(
+        self,
+        contract_stack: ContractStack,
+        cli_args: list[str],
+        expected_repo_slug: str | None,
+        expected_repo_url: str | None,
+        expected_pr_url: str | None,
+    ) -> None:
+        cli_result, request_mock = invoke_cli(
+            contract_stack.cli_runner,
+            ["workspace", "adopt-pr", *cli_args],
+            response_status=202,
+            response_payload={
+                "workspace_id": "ws_adopt",
+                "status": "requested",
+                "version": 1,
+                "task_id": None,
+                "attempt_id": None,
+                "candidate_id": None,
+                "repo_slug": "dimileeh/aira-web",
+                "repo_url": "https://github.com/dimileeh/aira-web",
+                "pr_number": 277,
+                "pr_url": "https://github.com/dimileeh/aira-web/pull/277",
+                "head_ref": "feature/x",
+                "base_ref": "development",
+                "auto_merge": True,
+                "monitor_policy": {},
+                "attached_existing": False,
+                "validation_provenance": {"freshness_status": "unavailable"},
+                "status_url": "/v1/workspaces/ws_adopt",
+                "events_url": "/v1/workspaces/ws_adopt/events",
+                "logs_url": "/v1/workspaces/ws_adopt/logs",
+            },
+        )
+        assert cli_result.exit_code == 0
+        body = request_mock.call_args.kwargs["json"]
+
+        validated = PullRequestMonitorAdoptionRequest.model_validate(body)
+        assert validated.repo_slug == expected_repo_slug
+        assert validated.repo_url == expected_repo_url
+        assert validated.pr_url == expected_pr_url
+
+    async def test_mcp_built_body_validates_against_canonical_schema(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        captured: dict[str, PullRequestMonitorAdoptionRequest] = {}
+
+        async def spy_adopt(req: PullRequestMonitorAdoptionRequest):
+            captured["req"] = req
+            from awf.api.schemas import PullRequestMonitorAdoptionResponse
+
+            return PullRequestMonitorAdoptionResponse(
+                workspace_id="ws_adopt",
+                status="requested",
+                version=1,
+                repo_slug="dimileeh/aira-web",
+                repo_url="https://github.com/dimileeh/aira-web",
+                pr_number=277,
+                pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                head_ref="feature/x",
+                base_ref="development",
+                auto_merge=True,
+                attached_existing=False,
+                status_url="/v1/workspaces/ws_adopt",
+                events_url="/v1/workspaces/ws_adopt/events",
+                logs_url="/v1/workspaces/ws_adopt/logs",
+            )
+
+        from awf.mcp.server import WorkspaceService, build_mcp_server
+
+        service = WorkspaceService(contract_stack.factory, settings=contract_stack.settings)
+        service.adopt_pull_request_monitor = spy_adopt  # type: ignore[method-assign]
+        mcp = build_mcp_server(service=service)
+
+        from tests.unit.contract.conftest import call_mcp_structured
+
+        await call_mcp_structured(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+        )
+        assert captured["req"].repo_slug == "dimileeh/aira-web"
+        assert captured["req"].pr_number == 277
+        assert captured["req"].pr_url is None
+
+        validated = PullRequestMonitorAdoptionRequest.model_validate(
+            captured["req"].model_dump(mode="json")
+        )
+        assert validated == captured["req"]
+
+
+@pytest.mark.unit
+class TestRemonitorRequestContract:
+    """Remonitor must surface ``Idempotency-Key`` and ``If-Match`` consistently."""
+
+    def test_cli_forwards_idempotency_key_and_if_match_headers(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        cli_result, request_mock = invoke_cli(
+            contract_stack.cli_runner,
+            [
+                "workspace",
+                "remonitor",
+                "ws_remon",
+                "--idempotency-key",
+                "remon-key-1",
+                "--if-match",
+                "7",
+                "--api-token",
+                "secret",
+                "--reason",
+                "operator recovery",
+            ],
+            response_status=200,
+            response_payload={
+                "workspace_id": "ws_remon",
+                "operation_id": "op_remon",
+                "operation_status": "succeeded",
+                "status": "monitoring_pr",
+                "message": "ok",
+            },
+        )
+        assert cli_result.exit_code == 0
+        kwargs = request_mock.call_args.kwargs
+        assert kwargs["headers"]["Idempotency-Key"] == "remon-key-1"
+        assert kwargs["headers"]["If-Match"] == "7"
+        assert kwargs["headers"]["Authorization"] == "Bearer secret"
+        assert kwargs["json"] == {"reason": "operator recovery"}
+
+    def test_mcp_remonitor_tool_arguments_pin_partial_if_match_state(
+        self,
+        contract_stack: ContractStack,
+    ) -> None:
+        """Document the current ``MCP partial`` state for the parity matrix.
+
+        ``awf_remonitor_workspace`` accepts ``idempotency_key`` but does not
+        yet accept ``expected_version`` -- this is owned by the
+        ``TODO§P1-if-match-parity`` slice. Pin both facts so a future change
+        that flips the matrix row to ``MCP implemented`` without adding the
+        arg fails this contract test.
+        """
+
+        tool = contract_stack.mcp._tool_manager._tools["awf_remonitor_workspace"]
+        properties = tool.parameters["properties"]
+        assert "idempotency_key" in properties
+        assert "expected_version" not in properties

--- a/tests/unit/contract/test_response_payload_alignment.py
+++ b/tests/unit/contract/test_response_payload_alignment.py
@@ -1,0 +1,268 @@
+"""Contract: REST and MCP must return identical structures for read surfaces.
+
+For each capability we seed deterministic state, fetch via REST and via the
+MCP tool, validate both through the canonical Pydantic response model, and
+assert deep structural equality. ``WorkspaceService`` is the shared façade,
+so divergence here flags a route/tool adapter, not a data-model bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.api.routes.health import HealthResponse
+from awf.api.schemas import (
+    MergeQueueListResponse,
+    OperationListResponse,
+    OperationResponse,
+    WorkspaceEventListResponse,
+    WorkspaceLockListResponse,
+    WorkspaceOverviewListResponse,
+    WorkspaceResponse,
+)
+
+from tests.unit.contract.conftest import (
+    ContractStack,
+    call_mcp_structured,
+    seed_monitoring_workspace,
+    seed_requested_workspace,
+    seed_workspace_operation,
+)
+
+
+@pytest.mark.unit
+async def test_get_workspace_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(contract_stack.factory)
+
+    rest_payload = (
+        await contract_stack.rest_client.get(f"/v1/workspaces/{workspace_id}")
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_get_workspace",
+        {"workspace_id": workspace_id},
+    )
+
+    assert isinstance(mcp_payload, dict)
+    rest_validated = WorkspaceResponse.model_validate(rest_payload)
+    mcp_validated = WorkspaceResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_list_workspaces_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    await seed_requested_workspace(contract_stack.factory, title="contract-list-1")
+    await seed_requested_workspace(contract_stack.factory, title="contract-list-2")
+    await seed_requested_workspace(contract_stack.factory, title="contract-list-3")
+
+    rest_payload = (await contract_stack.rest_client.get("/v1/workspaces")).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_workspaces",
+        {"limit": 50},
+    )
+
+    assert isinstance(rest_payload, list)
+    assert isinstance(mcp_payload, list)
+    assert len(rest_payload) == len(mcp_payload) == 3
+    rest_validated = [WorkspaceResponse.model_validate(item) for item in rest_payload]
+    mcp_validated = [WorkspaceResponse.model_validate(item) for item in mcp_payload]
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_list_workspace_overview_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    await seed_requested_workspace(contract_stack.factory, title="contract-overview-1")
+    await seed_requested_workspace(contract_stack.factory, title="contract-overview-2")
+
+    rest_payload = (
+        await contract_stack.rest_client.get("/v1/workspaces/overview")
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_workspace_overview",
+        {"limit": 50},
+    )
+
+    assert isinstance(rest_payload, dict)
+    assert isinstance(mcp_payload, dict)
+    rest_validated = WorkspaceOverviewListResponse.model_validate(rest_payload)
+    mcp_validated = WorkspaceOverviewListResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_list_workspace_events_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(contract_stack.factory)
+
+    rest_payload = (
+        await contract_stack.rest_client.get(f"/v1/workspaces/{workspace_id}/events")
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_workspace_events",
+        {"workspace_id": workspace_id},
+    )
+
+    assert isinstance(mcp_payload, list)
+    rest_validated = WorkspaceEventListResponse.model_validate(rest_payload)
+    # MCP exposes events as a bare list; REST wraps it in the canonical envelope.
+    # Wrap MCP into the envelope before comparing to the REST shape.
+    mcp_envelope = WorkspaceEventListResponse.model_validate(
+        {"items": mcp_payload, "limit": 50, "cursor": None}
+    )
+    assert {item.id for item in rest_validated.items} == {
+        item.id for item in mcp_envelope.items
+    }
+    assert rest_validated.items == mcp_envelope.items
+
+
+@pytest.mark.unit
+async def test_list_workspace_operations_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(contract_stack.factory)
+
+    rest_payload = (
+        await contract_stack.rest_client.get(f"/v1/workspaces/{workspace_id}/operations")
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_workspace_operations",
+        {"workspace_id": workspace_id, "limit": 50},
+    )
+
+    assert isinstance(mcp_payload, list)
+    rest_validated = OperationListResponse.model_validate(rest_payload)
+    mcp_envelope = OperationListResponse.model_validate(
+        {"items": mcp_payload, "limit": 50, "cursor": None}
+    )
+    assert rest_validated.items == mcp_envelope.items
+
+
+@pytest.mark.unit
+async def test_list_operations_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    await seed_monitoring_workspace(contract_stack.factory)
+    await seed_monitoring_workspace(
+        contract_stack.factory, title="Operations parity 2"
+    )
+
+    rest_payload = (
+        await contract_stack.rest_client.get(
+            "/v1/operations",
+            headers=contract_stack.auth_headers,
+        )
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_operations",
+        {"limit": 50},
+    )
+
+    assert isinstance(rest_payload, dict)
+    assert isinstance(mcp_payload, dict)
+    rest_validated = OperationListResponse.model_validate(rest_payload)
+    mcp_validated = OperationListResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_get_operation_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(contract_stack.factory)
+    operation_id = await seed_workspace_operation(
+        contract_stack.factory, workspace_id=workspace_id
+    )
+
+    rest_payload = (
+        await contract_stack.rest_client.get(
+            f"/v1/operations/{operation_id}",
+            headers=contract_stack.auth_headers,
+        )
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_get_operation",
+        {"operation_id": operation_id},
+    )
+
+    assert isinstance(rest_payload, dict)
+    assert isinstance(mcp_payload, dict)
+    rest_validated = OperationResponse.model_validate(rest_payload)
+    mcp_validated = OperationResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_merge_queue_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    await seed_monitoring_workspace(contract_stack.factory, with_open_candidate=True)
+
+    rest_payload = (
+        await contract_stack.rest_client.get(
+            "/v1/merge-queue",
+            headers=contract_stack.auth_headers,
+        )
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_merge_queue",
+        {"limit": 50},
+    )
+
+    assert isinstance(rest_payload, dict)
+    assert isinstance(mcp_payload, dict)
+    rest_validated = MergeQueueListResponse.model_validate(rest_payload)
+    mcp_validated = MergeQueueListResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_locks_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    await seed_monitoring_workspace(contract_stack.factory)
+
+    rest_payload = (
+        await contract_stack.rest_client.get(
+            "/v1/locks",
+            headers=contract_stack.auth_headers,
+        )
+    ).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp,
+        "awf_list_locks",
+        {"limit": 50},
+    )
+
+    assert isinstance(rest_payload, dict)
+    assert isinstance(mcp_payload, dict)
+    rest_validated = WorkspaceLockListResponse.model_validate(rest_payload)
+    mcp_validated = WorkspaceLockListResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated
+
+
+@pytest.mark.unit
+async def test_service_health_payload_aligned_across_rest_and_mcp(
+    contract_stack: ContractStack,
+) -> None:
+    rest_payload = (await contract_stack.rest_client.get("/healthz")).json()
+    mcp_payload = await call_mcp_structured(
+        contract_stack.mcp, "awf_get_service_health", {}
+    )
+
+    rest_validated = HealthResponse.model_validate(rest_payload)
+    mcp_validated = HealthResponse.model_validate(mcp_payload)
+    assert rest_validated == mcp_validated


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_797d2f7d48a748a0b3566d21` (agent: `claude_code`, model: `claude-opus-4-7`, effort: `xhigh`).


### Task
Implement the P1 backlog slice "Contract tests proving REST API, CLI, and MCP stay aligned" from TODO/pre-gke-industrial-readiness.md.

Read TODO/pre-gke-industrial-readiness.md, README.md, docs/awf_prd_v2.2.md, docs/MCP_CLIENT_PARITY.md, and the relevant implementation/tests before changing code.

Acceptance target:
Add contract tests proving REST API, CLI, and MCP stay aligned for request payloads, response payloads, reason codes, idempotency keys, If-Match/workspace-version concurrency, auth failures, and structured error semantics. Prefer reusable fixtures/schema snapshots over brittle string tests. If implementation gaps are found, fix the smallest safe surface drift needed to make the contract true.

AWF dogfood requirements:
- Use strict TDD: write or update failing tests first for missing behavior, then implement the smallest green change.
- No fake tests, empty assertions, broad behavior-skipping monkeypatches, or lowering coverage/profile/quality gates.
- Preserve or improve the repository's 99% coverage target. Run focused validation for touched code and broaden when risk warrants it.
- Keep AWF generic and project-local; do not add Aira-specific assumptions to core.
- Keep changes tightly scoped to this slice. Do not remove or rewrite Active/Completed Slices ledger rows for other workspaces.
- Update TODO/pre-gke-industrial-readiness.md only with implementation-backed status/evidence for this slice.
- Commit your changes and let AWF create and monitor the PR with auto_merge=true.

---
Validation: 5 profile command(s) passed inside the workspace container.
