### PR TITLE
PR adoption terminal idempotency hardening

### DIFF
--- a/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
+++ b/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
@@ -146,7 +146,7 @@ uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
 
 ## Assumptions
 
-- A live adoption workspace means it is still capable of entering or running PR monitor work; terminal rows cannot satisfy an adoption replay.
+- A live adoption workspace means it is still capable of entering or running PR monitor work; terminal rows (`completed`, `failed`, `cancelled`, `destroyed`, and raw string `superseded`) cannot satisfy an adoption replay. `destroying` rows are treated as live.
 - The PR metadata fetcher remains the authority for whether the target PR is open, closed, or merged.
 - CLI parity is satisfied by preserving the REST endpoint contract because the CLI does not implement local adoption decisions.
 - Existing old terminal rows should remain as immutable audit history; this slice should not manually clear stale idempotency claims.

--- a/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
+++ b/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
@@ -79,8 +79,8 @@ Fix PR monitor adoption so the deterministic repo/PR adoption key only reattache
 ## Implementation Approach
 
 1. Define adoption liveness vocabulary in `src/awf/service/pr_monitor_adoption.py`.
-   - Live adoption statuses should be the statuses that can still progress into or run PR monitoring: `requested`, `provisioning`, `ready`, `running`, `validating`, `pushing`, and `monitoring_pr`.
-   - Terminal/non-attach statuses should include at least `completed`, `failed`, `cancelled`, `destroying`, `destroyed`, and raw string `superseded`. The tests required by this slice will cover `destroyed`, `cancelled`, `failed`, and `superseded`.
+   - Live adoption statuses should be the statuses that can still progress into or run PR monitoring: `requested`, `provisioning`, `ready`, `running`, `validating`, `pushing`, `monitoring_pr`, and `destroying`.
+   - Terminal/non-attach statuses should include at least `completed`, `failed`, `cancelled`, `destroyed`, and raw string `superseded`. The tests required by this slice will cover `destroyed`, `cancelled`, `failed`, and `superseded`.
 
 2. Keep the deterministic repo/PR key as the logical adoption key.
    - Continue using `pr_adoption_idempotency_key(repo_slug, pr_number)` for the advisory lock and for the first-generation workspace when available.
@@ -93,7 +93,7 @@ Fix PR monitor adoption so the deterministic repo/PR adoption key only reattache
 
 4. Create a fresh generation when only terminal history exists.
    - Fetch current PR metadata after proving no live monitor exists, preserving current closed/merged rejection behavior.
-   - Choose a unique per-workspace idempotency key. If the logical key is unused, use it; otherwise generate a deterministic generation key such as `<logical-key>:g<N>` under the advisory lock and check for uniqueness before insert.
+   - Choose a unique per-workspace idempotency key. Once terminal adoption history exists, allocate a deterministic generation key such as `<logical-key>:g<N>` under the advisory lock and check for uniqueness before insert.
    - Pass the per-workspace key to `WorkspaceRepository.create()` and the `adopt_pr` operation, while recording the logical repo/PR key in the adoption policy/event payload.
 
 5. Preserve audit and lineage.
@@ -146,7 +146,7 @@ uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
 
 ## Assumptions
 
-- A live adoption workspace means it is still capable of entering or running PR monitor work; terminal and destroying rows cannot satisfy an adoption replay.
+- A live adoption workspace means it is still capable of entering or running PR monitor work; terminal rows cannot satisfy an adoption replay.
 - The PR metadata fetcher remains the authority for whether the target PR is open, closed, or merged.
 - CLI parity is satisfied by preserving the REST endpoint contract because the CLI does not implement local adoption decisions.
 - Existing old terminal rows should remain as immutable audit history; this slice should not manually clear stale idempotency claims.

--- a/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
+++ b/docs/awf-plans/ws_e5b86a598da842e0aaf50d1f.md
@@ -1,0 +1,161 @@
+# Implementation Plan: Harden PR monitor adoption after terminal prior workspace
+
+## Goal
+
+Fix PR monitor adoption so the deterministic repo/PR adoption key only reattaches to a live adoption workspace that can still monitor the PR. If the only matching adoption history is terminal, AWF must create a fresh monitor workspace, keep the old audit history intact, avoid the unique `workspaces.idempotency_key` conflict, and keep REST, CLI, and MCP behavior structured and consistent.
+
+## Current Behavior Observed
+
+- `PullRequestMonitorAdoptionService.adopt()` normalizes repo/PR, computes `pr_adoption_idempotency_key(repo_slug, pr_number)`, takes the advisory lock for that key, then calls `WorkspaceRepository.get_by_idempotency_key()`.
+- Any existing workspace with that key is returned as `attached_existing=True` after policy comparison, regardless of workspace status.
+- `Workspace.idempotency_key` is globally unique, so a destroyed/cancelled/failed/superseded prior adoption row owning the deterministic key prevents a new row from using that same key.
+- REST (`POST /v1/workspaces/adopt-pr`), CLI (`awf workspace adopt-pr`), and MCP (`awf_adopt_pull_request_monitor`) already share the service path, so the main fix should stay centralized in the service/repository layer.
+
+## Intended Files And Modules To Touch
+
+- `tests/unit/service/test_pr_monitor_adoption.py`
+  - Add failing regression coverage for terminal prior adoption rows with statuses `destroyed`, `cancelled`, `failed`, and raw string `superseded`.
+  - Add or replace race coverage with real concurrent adoption calls using separate PostgreSQL sessions, not a monkeypatch that bypasses the lock/lookup behavior.
+  - Tighten active reattach and active policy conflict assertions so terminal-history behavior does not weaken the existing active monitor contract.
+
+- `tests/unit/api/test_pr_monitor_adoption.py`
+  - Add REST coverage for a representative terminal prior adoption row, proving the endpoint returns `202` with a fresh workspace and `attached_existing=false`.
+  - Add or extend REST coverage for an active policy mismatch returning structured `PR_ADOPTION_POLICY_CONFLICT`.
+
+- `tests/unit/mcp/test_mcp_server.py` or `tests/unit/mcp/test_mcp_operator_surfaces.py`
+  - Add MCP-visible coverage for the same service behavior: terminal prior adoption creates a fresh monitor response, active policy conflict returns an MCP error result with `PR_ADOPTION_POLICY_CONFLICT`.
+
+- `tests/unit/cli/test_cli.py`
+  - No CLI behavior change is expected because the CLI delegates to REST. Touch only if response/error handling changes are needed; otherwise keep existing request-shape coverage as the CLI parity proof.
+
+- `src/awf/service/pr_monitor_adoption.py`
+  - Centralize live-vs-terminal adoption selection.
+  - Keep the logical repo/PR adoption key separate from the per-workspace unique idempotency key when terminal history already owns the logical key.
+  - Add lineage/audit payload fields for fresh adoption after terminal history.
+
+- `src/awf/db/repositories.py`
+  - Add focused repository helper(s) only if needed, likely on `WorkspaceRepository`, to list PR adoption history by deterministic adoption identity and to find live adoption rows under the existing advisory lock.
+
+- `src/awf/api/routes/workspaces.py`, `src/awf/api/schemas.py`, `src/awf/service/workspaces.py`, `src/awf/mcp/server.py`
+  - No planned contract changes. Touch only if tests reveal an error-mapping or schema gap. REST/MCP should continue to expose the existing `PullRequestMonitorAdoptionResponse` and `PRMonitorAdoptionError` structure.
+
+- `TODO/pre-gke-industrial-readiness.md`
+  - Update only after implementation and validation, with concrete evidence for this slice.
+
+## Tests To Write First
+
+1. Service: terminal prior rows do not attach
+   - Seed an adopted PR workspace with the deterministic repo/PR workspace idempotency key and status parameterized over `destroyed`, `cancelled`, `failed`, and `superseded`.
+   - Call `PullRequestMonitorAdoptionService.adopt()` for the same open PR.
+   - Assert the response has `attached_existing is False`, a different `workspace_id`, `status == requested`, and the old terminal workspace remains unchanged.
+   - Assert there are exactly two adoption workspaces for that repo/PR and only one live monitor candidate.
+   - Assert the fresh workspace avoids the old unique key conflict by using a unique workspace idempotency key when the terminal row still owns the logical key.
+   - Assert audit/lineage context records the prior terminal workspace id/status, either in `task_policy.pr_adoption` lineage metadata and/or the `adopt_pr` operation/event payload.
+
+2. Service: active reattach still works
+   - Seed or create a live adoption workspace, preferably `monitoring_pr` plus one pre-monitor state such as `requested` if practical.
+   - Replay adoption with the same monitor policy.
+   - Assert `attached_existing is True`, no new workspace/attempt/operation is created, and metadata fetch is not repeated when the live row already satisfies the request.
+
+3. Service: active policy conflicts still win
+   - Seed a live adoption workspace and replay with a changed active monitor policy, such as `auto_merge` or `initial_review_grace_period_seconds`.
+   - Assert `PRMonitorAdoptionError.error_code == "PR_ADOPTION_POLICY_CONFLICT"` and the error detail still names the live workspace.
+   - Also cover the contrast case where a terminal prior row with a different monitor policy does not block a fresh adoption.
+
+4. Service: concurrent adoption race creates at most one live monitor
+   - Use real concurrent `asyncio.gather()` calls with separate sessions and commits against the PostgreSQL fixture.
+   - Cover the terminal-history race: a destroyed prior row owns the deterministic key, then two adoption requests race for the same open PR.
+   - Assert both responses refer to the same fresh live workspace after one winner creates it, one loser reattaches, and total live adoption count is one.
+   - Avoid monkeypatching `acquire_idempotency_key_lock()` or skipping the lookup/insert behavior under test.
+
+5. REST: terminal history and policy conflict stay structured
+   - Seed a representative destroyed prior adoption row, call `POST /v1/workspaces/adopt-pr`, assert `202`, fresh `workspace_id`, `attached_existing=false`, and no stale destroyed id returned.
+   - Seed a live adoption policy mismatch, call the endpoint, assert `409` with `error_code == "PR_ADOPTION_POLICY_CONFLICT"`.
+
+6. MCP: visible behavior matches REST/service
+   - Through `awf_adopt_pull_request_monitor`, assert terminal prior adoption returns a normal structured success payload for the fresh workspace.
+   - Assert active policy conflict returns `CallToolResult.isError is True` with structured `PR_ADOPTION_POLICY_CONFLICT`.
+
+## Implementation Approach
+
+1. Define adoption liveness vocabulary in `src/awf/service/pr_monitor_adoption.py`.
+   - Live adoption statuses should be the statuses that can still progress into or run PR monitoring: `requested`, `provisioning`, `ready`, `running`, `validating`, `pushing`, and `monitoring_pr`.
+   - Terminal/non-attach statuses should include at least `completed`, `failed`, `cancelled`, `destroying`, `destroyed`, and raw string `superseded`. The tests required by this slice will cover `destroyed`, `cancelled`, `failed`, and `superseded`.
+
+2. Keep the deterministic repo/PR key as the logical adoption key.
+   - Continue using `pr_adoption_idempotency_key(repo_slug, pr_number)` for the advisory lock and for the first-generation workspace when available.
+   - Do not clear or mutate the old terminal workspace idempotency key.
+
+3. Add a live adoption lookup under the advisory lock.
+   - After taking the logical key lock, list matching adoption workspaces for the normalized repo/PR. Prefer the deterministic task external id (`_adoption_external_id(repo_slug, pr_number)`) plus `task_kind == sync_feature_pr`; include a JSON-policy fallback only if needed for older adoption rows.
+   - Select a live matching workspace first. If one exists, run the existing `_raise_if_policy_conflicts()` check and return `_response(..., attached_existing=True)`.
+   - Treat matching terminal workspaces as history only. They must never be returned as `attached_existing=True`.
+
+4. Create a fresh generation when only terminal history exists.
+   - Fetch current PR metadata after proving no live monitor exists, preserving current closed/merged rejection behavior.
+   - Choose a unique per-workspace idempotency key. If the logical key is unused, use it; otherwise generate a deterministic generation key such as `<logical-key>:g<N>` under the advisory lock and check for uniqueness before insert.
+   - Pass the per-workspace key to `WorkspaceRepository.create()` and the `adopt_pr` operation, while recording the logical repo/PR key in the adoption policy/event payload.
+
+5. Preserve audit and lineage.
+   - Add lineage metadata for fresh generations after terminal history, including previous terminal workspace id, status, task id, attempt id when available, and the logical adoption key.
+   - Keep old terminal rows unchanged.
+   - Reuse the existing task/attempt lineage when the old task scope is compatible. If a terminal history task scope would conflict with a changed terminal policy, prefer creating a new task/attempt with explicit lineage metadata over blocking the fresh adoption solely because a terminal row has old policy.
+
+6. Keep active policy conflict behavior unchanged.
+   - `_raise_if_policy_conflicts()` should only run against the selected live workspace.
+   - Terminal history can influence lineage, not admission conflict.
+
+7. Keep REST, CLI, and MCP contracts stable.
+   - The service fix should flow through REST, CLI, and MCP without new public fields.
+   - Preserve existing `PullRequestMonitorAdoptionResponse` fields, `attached_existing`, and structured error codes.
+
+8. Update the backlog only after green validation.
+   - Mark the TODO slice complete with evidence naming the service/API/MCP tests, race coverage, and validation commands that passed.
+
+## Validation Commands
+
+Focused first:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_pr_monitor_adoption.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/api/test_pr_monitor_adoption.py tests/unit/mcp/test_mcp_server.py tests/unit/cli/test_cli.py -q
+```
+
+Broader Python/control-plane validation for the touched surface:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest tests/unit -q
+python scripts/generate_openapi.py --check
+```
+
+Coverage gate if the touched surface or review risk justifies it:
+
+```bash
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+```
+
+## Risks
+
+- `superseded` is currently used as a raw status string in some areas, not a `WorkspaceStatus` enum member. The liveness helper must compare raw strings safely and must not construct `WorkspaceStatus("superseded")`.
+- If terminal history keeps the logical workspace idempotency key, fresh generations must use unique workspace idempotency keys while still serializing on the logical key. Otherwise the original unique constraint incident will recur.
+- Real concurrent tests can be timing-sensitive. They should rely on PostgreSQL advisory locks and committed transactions, not sleeps or monkeypatched lock behavior.
+- Task external id uniqueness can conflict if a terminal prior adoption was created with a different task scope. The implementation should preserve lineage without letting old terminal policy block fresh adoption.
+- Querying adoption history by JSON policy may be database-specific. Prefer existing deterministic workspace fields where possible and keep any JSON fallback minimal and covered.
+
+## Assumptions
+
+- A live adoption workspace means it is still capable of entering or running PR monitor work; terminal and destroying rows cannot satisfy an adoption replay.
+- The PR metadata fetcher remains the authority for whether the target PR is open, closed, or merged.
+- CLI parity is satisfied by preserving the REST endpoint contract because the CLI does not implement local adoption decisions.
+- Existing old terminal rows should remain as immutable audit history; this slice should not manually clear stale idempotency claims.
+
+## Explicit Non-Goals
+
+- Do not switch branches, push, rebase, or merge; AWF owns branch and PR handling.
+- Do not rewrite unrelated backlog items or unrelated active ledger rows.
+- Do not change remonitor state rules, PR monitor runtime loops, merge policy, GC policy, or provider recovery behavior.
+- Do not add a schema migration unless the tests prove the unique-key problem cannot be solved within the existing model.
+- Do not retire or redesign the CLI/MCP adoption surface; keep this as a hardening change to the existing adoption contract.
+- Do not lower validation, coverage, or profile gates.

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -169,7 +169,6 @@ class _MonitorRunnerProto(Protocol):
 
 
 _log = get_logger(__name__)
-_monotonic = time.monotonic
 
 
 def _monotonic() -> float:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -169,6 +169,7 @@ class _MonitorRunnerProto(Protocol):
 
 
 _log = get_logger(__name__)
+_monotonic = time.monotonic
 
 
 def _monotonic() -> float:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -82,6 +82,7 @@ from awf.db.models import (
     WorkspaceLogStream,
     WorkspaceSecretLease,
 )
+from awf.db.utils import escape_like_pattern as _escape_like_pattern
 from awf.runtime.merge_eligibility import DOCS_TASK_SCOPE_VIOLATION_STALE_REASON
 from awf.service.scheduler import scheduler_order_key, scheduler_score_from_workspace
 
@@ -3755,10 +3756,6 @@ def _owned_path_conflict_advisory_lock_key(*, repo_url: str, branch_base: str) -
     if unsigned >= 1 << 63:
         return unsigned - (1 << 64)
     return unsigned
-
-
-def _escape_like_pattern(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _operation_idempotency_advisory_lock_key(key: str) -> int:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -2674,6 +2674,21 @@ class WorkspaceRepository:
         )
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
+    async def list_idempotency_key_family(self, logical_key: str) -> builtins.list[str]:
+        generation_pattern = f"{_escape_like_pattern(logical_key)}:g%"
+        stmt = (
+            select(Workspace.idempotency_key)
+            .where(
+                or_(
+                    Workspace.idempotency_key == logical_key,
+                    Workspace.idempotency_key.like(generation_pattern, escape="\\"),
+                )
+            )
+            .order_by(Workspace.idempotency_key.asc())
+        )
+        keys = (await self._session.execute(stmt)).scalars().all()
+        return [key for key in keys if key is not None]
+
     async def list_pr_adoption_history(
         self,
         *,
@@ -3738,6 +3753,10 @@ def _owned_path_conflict_advisory_lock_key(*, repo_url: str, branch_base: str) -
     if unsigned >= 1 << 63:
         return unsigned - (1 << 64)
     return unsigned
+
+
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _operation_idempotency_advisory_lock_key(key: str) -> int:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -2686,6 +2686,7 @@ class WorkspaceRepository:
         """List workspaces that represent adoption history for one repo/PR."""
         stmt = (
             select(Workspace)
+            .options(selectinload(Workspace.task_attempt))
             .where(
                 or_(
                     Workspace.task_external_id == task_external_id,

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -2674,6 +2674,44 @@ class WorkspaceRepository:
         )
         return (await self._session.execute(stmt)).scalar_one_or_none()
 
+    async def list_pr_adoption_history(
+        self,
+        *,
+        task_external_id: str,
+        idempotency_key: str,
+        task_kind: str,
+        repo_slug: str,
+        pr_number: int,
+    ) -> builtins.list[Workspace]:
+        """List workspaces that represent adoption history for one repo/PR."""
+        stmt = (
+            select(Workspace)
+            .where(
+                or_(
+                    Workspace.task_external_id == task_external_id,
+                    Workspace.idempotency_key == idempotency_key,
+                    and_(
+                        Workspace.task_kind == task_kind,
+                        Workspace.pr_number == pr_number,
+                    ),
+                )
+            )
+            .order_by(Workspace.created_at.asc(), Workspace.id.asc())
+        )
+        candidates = list((await self._session.execute(stmt)).scalars())
+        return [
+            workspace
+            for workspace in candidates
+            if _matches_pr_adoption_identity(
+                workspace,
+                task_external_id=task_external_id,
+                idempotency_key=idempotency_key,
+                task_kind=task_kind,
+                repo_slug=repo_slug,
+                pr_number=pr_number,
+            )
+        ]
+
     async def acquire_idempotency_key_lock(self, key: str) -> None:
         """Serialize workspace idempotency decisions with a PostgreSQL advisory lock."""
         lock_key = _workspace_idempotency_advisory_lock_key(key)
@@ -3397,6 +3435,45 @@ class WorkspaceRepository:
         workspace.events.extend(created)
         await self._session.flush()
         return created
+
+
+def _matches_pr_adoption_identity(
+    workspace: Workspace,
+    *,
+    task_external_id: str,
+    idempotency_key: str,
+    task_kind: str,
+    repo_slug: str,
+    pr_number: int,
+) -> bool:
+    if workspace.task_kind == task_kind and workspace.task_external_id == task_external_id:
+        return True
+
+    adoption = _workspace_pr_adoption_policy(workspace)
+    if not adoption:
+        return False
+    if workspace.task_kind != task_kind and workspace.idempotency_key != idempotency_key:
+        return False
+
+    adoption_repo = adoption.get("repo_slug")
+    adoption_pr_number = adoption.get("pr_number")
+    if not isinstance(adoption_pr_number, str | int):
+        return False
+    try:
+        normalized_pr_number = int(adoption_pr_number)
+    except (TypeError, ValueError):
+        return False
+    return (
+        isinstance(adoption_repo, str)
+        and adoption_repo.lower() == repo_slug.lower()
+        and normalized_pr_number == pr_number
+    )
+
+
+def _workspace_pr_adoption_policy(workspace: Workspace) -> Mapping[str, Any]:
+    policy = workspace.task_policy
+    adoption = policy.get("pr_adoption") if isinstance(policy, dict) else None
+    return adoption if isinstance(adoption, Mapping) else {}
 
 
 def _candidate_terminal_close_reason(status: WorkspaceStatus) -> str:

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -2699,6 +2699,7 @@ class WorkspaceRepository:
         pr_number: int,
     ) -> builtins.list[Workspace]:
         """List workspaces that represent adoption history for one repo/PR."""
+        adoption_repo_slug = Workspace.task_policy["pr_adoption"]["repo_slug"].as_string()
         stmt = (
             select(Workspace)
             .options(selectinload(Workspace.task_attempt))
@@ -2709,6 +2710,7 @@ class WorkspaceRepository:
                     and_(
                         Workspace.task_kind == task_kind,
                         Workspace.pr_number == pr_number,
+                        func.lower(adoption_repo_slug) == repo_slug.lower(),
                     ),
                 )
             )

--- a/src/awf/db/utils.py
+++ b/src/awf/db/utils.py
@@ -1,0 +1,9 @@
+"""Small SQL helper utilities shared by database-facing code."""
+
+from __future__ import annotations
+
+
+def escape_like_pattern(value: str) -> str:
+    """Escape wildcard characters for SQL LIKE patterns using a backslash escape."""
+
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -6,6 +6,7 @@ import hashlib
 from collections.abc import Awaitable, Callable, Mapping
 from typing import Any
 
+from sqlalchemy import inspect, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.schemas import (
@@ -24,7 +25,7 @@ from awf.common.github_client import (
 )
 from awf.common.logging import get_logger
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
-from awf.db.models import MergeCandidate, Task, Workspace
+from awf.db.models import MergeCandidate, Task, TaskAttempt, Workspace
 from awf.db.repositories import (
     MergeCandidateRepository,
     OperationRepository,
@@ -548,12 +549,26 @@ async def _terminal_adoption_lineage(
     session: AsyncSession,
     workspaces: list[Workspace],
 ) -> list[dict[str, str | None]]:
-    attempt_repo = TaskAttemptRepository(session)
+    terminal_workspaces = [
+        workspace for workspace in workspaces if not _is_live_adoption_status(workspace.status)
+    ]
+    attempts_by_workspace_id: dict[str, TaskAttempt | None] = {}
+    unloaded_workspace_ids: list[str] = []
+    for workspace in terminal_workspaces:
+        if "task_attempt" in inspect(workspace).unloaded:
+            unloaded_workspace_ids.append(workspace.id)
+        else:
+            attempts_by_workspace_id[workspace.id] = workspace.task_attempt
+    if unloaded_workspace_ids:
+        stmt = select(TaskAttempt).where(TaskAttempt.workspace_id.in_(unloaded_workspace_ids))
+        attempts = (await session.execute(stmt)).scalars()
+        attempts_by_workspace_id.update(
+            {attempt.workspace_id: attempt for attempt in attempts}
+        )
+
     lineage: list[dict[str, str | None]] = []
-    for workspace in workspaces:
-        if _is_live_adoption_status(workspace.status):
-            continue
-        attempt = await attempt_repo.get_by_workspace_id(workspace.id)
+    for workspace in terminal_workspaces:
+        attempt = attempts_by_workspace_id.get(workspace.id)
         lineage.append(
             {
                 "workspace_id": workspace.id,

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -355,18 +355,23 @@ class PullRequestMonitorAdoptionService:
         except TaskExternalIdConflictError:
             if not previous_terminal_adoptions:
                 raise
+            task_generation_idempotency_key = await _next_adoption_task_idempotency_key(
+                self._session,
+                logical_idempotency_key=logical_idempotency_key,
+                task_external_id=workspace.task_external_id or _adoption_external_id(
+                    repo_slug=repo.slug(),
+                    pr_number=metadata.number,
+                ),
+            )
             workspace.task_external_id = _adoption_generation_external_id(
                 repo_slug=repo.slug(),
                 pr_number=metadata.number,
                 logical_idempotency_key=logical_idempotency_key,
-                workspace_idempotency_key=idempotency_key,
+                workspace_idempotency_key=task_generation_idempotency_key,
             )
             task = await _create_or_get_task(
                 external_id=workspace.task_external_id,
-                task_idempotency_key=_adoption_generation_idempotency_key(
-                    logical_idempotency_key=logical_idempotency_key,
-                    workspace_idempotency_key=idempotency_key,
-                ),
+                task_idempotency_key=task_generation_idempotency_key,
             )
         attempt = await TaskAttemptRepository(self._session).create_for_workspace(
             task=task,
@@ -587,6 +592,68 @@ async def _task_idempotency_key_family(
     )
     keys = (await session.execute(stmt)).scalars().all()
     return [key for key in keys if key is not None]
+
+
+async def _task_external_id_family_idempotency_keys(
+    session: AsyncSession,
+    *,
+    logical_idempotency_key: str,
+    task_external_id: str,
+) -> list[str]:
+    generation_pattern = f"{_escape_like_pattern(task_external_id)}:g%"
+    stmt = (
+        select(Task.external_id)
+        .where(
+            or_(
+                Task.external_id == task_external_id,
+                Task.external_id.like(generation_pattern, escape="\\"),
+            )
+        )
+        .order_by(Task.external_id.asc())
+    )
+    external_ids = (await session.execute(stmt)).scalars().all()
+    reserved_keys: list[str] = []
+    generation_prefix = f"{task_external_id}:"
+    for external_id in external_ids:
+        if external_id == task_external_id:
+            reserved_keys.append(logical_idempotency_key)
+            continue
+        if external_id is None or not external_id.startswith(generation_prefix):
+            continue
+        generation = external_id[len(generation_prefix) :]
+        if _is_adoption_generation_suffix(generation):
+            reserved_keys.append(f"{logical_idempotency_key}:{generation}")
+    return list(dict.fromkeys(reserved_keys))
+
+
+async def _next_adoption_task_idempotency_key(
+    session: AsyncSession,
+    *,
+    logical_idempotency_key: str,
+    task_external_id: str,
+) -> str:
+    existing_keys = set(
+        await _task_idempotency_key_family(
+            session,
+            logical_idempotency_key=logical_idempotency_key,
+        )
+    )
+    existing_keys.update(
+        await _task_external_id_family_idempotency_keys(
+            session,
+            logical_idempotency_key=logical_idempotency_key,
+            task_external_id=task_external_id,
+        )
+    )
+    for generation in range(1, 1000):
+        candidate = f"{logical_idempotency_key}:g{generation}"
+        if candidate not in existing_keys:
+            return candidate
+    raise RuntimeError("Could not allocate a fresh PR adoption task idempotency key.")
+
+
+def _is_adoption_generation_suffix(value: str) -> bool:
+    return value.startswith("g") and value[1:].isdigit()
 
 
 async def _terminal_adoption_lineage(

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -36,7 +36,6 @@ from awf.db.repositories import (
     TaskRepository,
     ValidationRunRepository,
     WorkspaceRepository,
-    _escape_like_pattern,
 )
 from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.validation_observability import validation_freshness_summary
@@ -938,6 +937,10 @@ def _raise_if_existing_workspace_is_not_requested_adoption(
             "existing_pr_adoption_pr_number": existing_pr_number,
         },
     )
+
+
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _raise_if_policy_conflicts(

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -36,6 +36,7 @@ from awf.db.repositories import (
     TaskRepository,
     ValidationRunRepository,
     WorkspaceRepository,
+    _escape_like_pattern,
 )
 from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.validation_observability import validation_freshness_summary
@@ -56,7 +57,6 @@ _LIVE_ADOPTION_STATUSES = frozenset(
         WorkspaceStatus.validating.value,
         WorkspaceStatus.pushing.value,
         WorkspaceStatus.monitoring_pr.value,
-        WorkspaceStatus.destroying.value,
     }
 )
 # Keep the public adoption error-code contract present in service source so
@@ -548,10 +548,16 @@ async def _next_adoption_workspace_idempotency_key(
     workspace_repo: WorkspaceRepository,
     *,
     logical_idempotency_key: str,
+    known_workspace_keys: Iterable[str] | None = None,
     reserved_idempotency_keys: Iterable[str] = (),
     require_generation: bool = False,
 ) -> str:
-    existing_keys = set(await workspace_repo.list_idempotency_key_family(logical_idempotency_key))
+    if known_workspace_keys is None:
+        existing_keys = set(
+            await workspace_repo.list_idempotency_key_family(logical_idempotency_key)
+        )
+    else:
+        existing_keys = set(known_workspace_keys)
     existing_keys.update(reserved_idempotency_keys)
     if not existing_keys and not require_generation:
         return logical_idempotency_key
@@ -805,10 +811,6 @@ def _adoption_generation_suffix(
     if workspace_idempotency_key.startswith(prefix):
         return workspace_idempotency_key[len(prefix) :]
     return "g1"
-
-
-def _escape_like_pattern(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: RepoRef) -> str:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -56,7 +56,6 @@ _LIVE_ADOPTION_STATUSES = frozenset(
         WorkspaceStatus.validating.value,
         WorkspaceStatus.pushing.value,
         WorkspaceStatus.monitoring_pr.value,
-        WorkspaceStatus.destroying.value,
     }
 )
 # Keep the public adoption error-code contract present in service source so

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -45,6 +45,17 @@ PR_ADOPTION_SUPERSEDED_REASON = "PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE"
 PR_ADOPTION_ADMITTED_REASON = "PR_ADOPTION_ADMITTED"
 PR_ADOPTION_OPERATION_ACTION = "adopt_pr_monitor"
 PR_ADOPTION_TASK_KIND = "sync_feature_pr"
+_LIVE_ADOPTION_STATUSES = frozenset(
+    {
+        WorkspaceStatus.requested.value,
+        WorkspaceStatus.provisioning.value,
+        WorkspaceStatus.ready.value,
+        WorkspaceStatus.running.value,
+        WorkspaceStatus.validating.value,
+        WorkspaceStatus.pushing.value,
+        WorkspaceStatus.monitoring_pr.value,
+    }
+)
 # Keep the public adoption error-code contract present in service source so
 # docs parity tests can cross-reference the matrix against implementation.
 _PR_ADOPTION_ERROR_CODE_CONTRACT = (
@@ -115,10 +126,23 @@ class PullRequestMonitorAdoptionService:
             repo_slug=repo.slug(),
             pr_number=pr_number,
         )
+        task_external_id = _adoption_external_id(repo_slug=repo.slug(), pr_number=pr_number)
         workspace_repo = WorkspaceRepository(self._session)
         await workspace_repo.acquire_idempotency_key_lock(idempotency_key)
         # Re-read under the transaction lock so a concurrent adopter that won
         # the race attaches here instead of surfacing the unique constraint.
+        adoption_history = await workspace_repo.list_pr_adoption_history(
+            task_external_id=task_external_id,
+            idempotency_key=idempotency_key,
+            task_kind=PR_ADOPTION_TASK_KIND,
+            repo_slug=repo.slug(),
+            pr_number=pr_number,
+        )
+        live_adoption = _select_live_adoption_workspace(adoption_history)
+        if live_adoption is not None:
+            _raise_if_policy_conflicts(live_adoption, request, repo=repo)
+            return await self._response(live_adoption, attached_existing=True)
+
         existing = await workspace_repo.get_by_idempotency_key(idempotency_key)
         if existing is not None:
             _raise_if_existing_workspace_is_not_requested_adoption(
@@ -130,29 +154,30 @@ class PullRequestMonitorAdoptionService:
                 _raise_if_policy_conflicts(existing, request, repo=repo)
                 return await self._response(existing, attached_existing=True)
 
-            metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
+        metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
+        previous_terminal_adoptions = await _terminal_adoption_lineage(
+            self._session,
+            adoption_history,
+        )
+        superseded_adoption: dict[str, Any] | None = None
+        superseded_workspace: Workspace | None = None
+        if existing is not None:
             superseded_adoption = await self._supersede_previous_adoption(
                 workspace=existing,
                 idempotency_key=idempotency_key,
                 repo=repo,
                 pr_number=pr_number,
             )
-            workspace = await self._create_adoption_workspace(
-                request=request,
-                repo=repo,
-                metadata=metadata,
-                idempotency_key=idempotency_key,
-                superseded_adoption=superseded_adoption,
-                superseded_workspace=existing,
-            )
-            return await self._response(workspace, attached_existing=False)
-
-        metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
+            superseded_workspace = existing
         workspace = await self._create_adoption_workspace(
             request=request,
             repo=repo,
             metadata=metadata,
             idempotency_key=idempotency_key,
+            logical_idempotency_key=idempotency_key,
+            previous_terminal_adoptions=previous_terminal_adoptions,
+            superseded_adoption=superseded_adoption,
+            superseded_workspace=superseded_workspace,
         )
         return await self._response(workspace, attached_existing=False)
 
@@ -245,6 +270,8 @@ class PullRequestMonitorAdoptionService:
         repo: RepoRef,
         metadata: PullRequestAdoptionMetadata,
         idempotency_key: str,
+        logical_idempotency_key: str,
+        previous_terminal_adoptions: list[dict[str, str | None]],
         superseded_adoption: dict[str, Any] | None = None,
         superseded_workspace: Workspace | None = None,
     ) -> Workspace:
@@ -255,6 +282,10 @@ class PullRequestMonitorAdoptionService:
             metadata=metadata,
             request=request,
             repo_url=repo_url,
+            lineage=_adoption_lineage_payload(
+                logical_idempotency_key=logical_idempotency_key,
+                previous_terminal_adoptions=previous_terminal_adoptions,
+            ),
         )
         operator_reason = _redacted_optional_text(request.reason)
         workspace_repo = WorkspaceRepository(self._session)
@@ -353,6 +384,9 @@ class PullRequestMonitorAdoptionService:
             "pr_url": metadata.url,
             "auto_merge": request.auto_merge,
             "reason": operator_reason,
+            "logical_idempotency_key": logical_idempotency_key,
+            "workspace_idempotency_key": idempotency_key,
+            "previous_terminal_adoptions": previous_terminal_adoptions,
         }
         if superseded_payload is not None:
             operation_payload["superseded_adoption"] = superseded_payload
@@ -376,6 +410,9 @@ class PullRequestMonitorAdoptionService:
             "base_sha": metadata.base_sha,
             "auto_merge": request.auto_merge,
             "reason": operator_reason,
+            "logical_idempotency_key": logical_idempotency_key,
+            "workspace_idempotency_key": idempotency_key,
+            "previous_terminal_adoptions": previous_terminal_adoptions,
         }
         if superseded_payload is not None:
             event_payload["superseded_adoption"] = superseded_payload
@@ -460,6 +497,68 @@ async def _default_metadata_fetcher(
         repo=repo,
         pr_number=pr_number,
     )
+
+
+def _select_live_adoption_workspace(workspaces: list[Workspace]) -> Workspace | None:
+    live_workspaces = [
+        workspace for workspace in workspaces if _is_live_adoption_status(workspace.status)
+    ]
+    if not live_workspaces:
+        return None
+    return max(live_workspaces, key=lambda workspace: (workspace.created_at, workspace.id))
+
+
+def _is_live_adoption_status(status: str) -> bool:
+    return status in _LIVE_ADOPTION_STATUSES
+
+
+async def _next_adoption_workspace_idempotency_key(
+    workspace_repo: WorkspaceRepository,
+    *,
+    logical_idempotency_key: str,
+) -> str:
+    if await workspace_repo.get_by_idempotency_key(logical_idempotency_key) is None:
+        return logical_idempotency_key
+
+    for generation in range(1, 1000):
+        candidate = f"{logical_idempotency_key}:g{generation}"
+        if await workspace_repo.get_by_idempotency_key(candidate) is None:
+            return candidate
+    raise RuntimeError("Could not allocate a fresh PR adoption workspace idempotency key.")
+
+
+async def _terminal_adoption_lineage(
+    session: AsyncSession,
+    workspaces: list[Workspace],
+) -> list[dict[str, str | None]]:
+    attempt_repo = TaskAttemptRepository(session)
+    lineage: list[dict[str, str | None]] = []
+    for workspace in workspaces:
+        if _is_live_adoption_status(workspace.status):
+            continue
+        attempt = await attempt_repo.get_by_workspace_id(workspace.id)
+        lineage.append(
+            {
+                "workspace_id": workspace.id,
+                "status": workspace.status,
+                "task_id": attempt.task_id if attempt is not None else None,
+                "attempt_id": attempt.id if attempt is not None else None,
+            }
+        )
+    return lineage
+
+
+def _adoption_lineage_payload(
+    *,
+    logical_idempotency_key: str,
+    previous_terminal_adoptions: list[dict[str, str | None]],
+) -> dict[str, object] | None:
+    if not previous_terminal_adoptions:
+        return None
+    return {
+        "logical_idempotency_key": logical_idempotency_key,
+        "previous_terminal_adoptions": previous_terminal_adoptions,
+    }
 
 
 def pr_adoption_idempotency_key(*, repo_slug: str, pr_number: int) -> str:
@@ -547,8 +646,9 @@ def _adoption_task_policy(
     metadata: PullRequestAdoptionMetadata,
     request: PullRequestMonitorAdoptionRequest,
     repo_url: str,
+    lineage: dict[str, object] | None = None,
 ) -> dict[str, Any]:
-    return {
+    policy: dict[str, Any] = {
         "task_kind": PR_ADOPTION_TASK_KIND,
         "pr_adoption": {
             "repo_slug": repo.slug(),
@@ -568,6 +668,9 @@ def _adoption_task_policy(
             "source": "existing_github_pr",
         },
     }
+    if lineage is not None:
+        policy["pr_adoption"]["lineage"] = lineage
+    return policy
 
 
 def _adoption_task_prompt(
@@ -605,6 +708,8 @@ def _github_repo_url_like(repo_url: str, repo_slug: str) -> str:
 
 
 def _adoption_workspace_is_resumable(workspace: Workspace) -> bool:
+    if workspace.status == "superseded":
+        return False
     try:
         status = WorkspaceStatus(workspace.status)
     except ValueError:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -330,20 +330,27 @@ class PullRequestMonitorAdoptionService:
 
         task_repo = TaskRepository(self._session)
 
-        async def _create_or_get_task(*, external_id: str | None) -> Task:
+        async def _create_or_get_task(
+            *,
+            external_id: str | None,
+            task_idempotency_key: str | None,
+        ) -> Task:
             return await task_repo.create_or_get(
                 repo_url=workspace.repo_url,
                 base_branch=workspace.branch_base,
                 title=workspace.task_title,
                 prompt=workspace.task_prompt,
                 external_id=external_id,
-                idempotency_key=idempotency_key,
+                idempotency_key=task_idempotency_key,
                 task_class=workspace.task_class,
                 owned_paths=list(workspace.owned_paths),
             )
 
         try:
-            task = await _create_or_get_task(external_id=workspace.task_external_id)
+            task = await _create_or_get_task(
+                external_id=workspace.task_external_id,
+                task_idempotency_key=idempotency_key,
+            )
         except TaskExternalIdConflictError:
             if not previous_terminal_adoptions:
                 raise
@@ -353,7 +360,13 @@ class PullRequestMonitorAdoptionService:
                 logical_idempotency_key=logical_idempotency_key,
                 workspace_idempotency_key=idempotency_key,
             )
-            task = await _create_or_get_task(external_id=workspace.task_external_id)
+            task = await _create_or_get_task(
+                external_id=workspace.task_external_id,
+                task_idempotency_key=_adoption_generation_idempotency_key(
+                    logical_idempotency_key=logical_idempotency_key,
+                    workspace_idempotency_key=idempotency_key,
+                ),
+            )
         attempt = await TaskAttemptRepository(self._session).create_for_workspace(
             task=task,
             workspace=workspace,
@@ -740,12 +753,34 @@ def _adoption_generation_external_id(
     workspace_idempotency_key: str,
 ) -> str:
     base_external_id = _adoption_external_id(repo_slug=repo_slug, pr_number=pr_number)
+    generation = _adoption_generation_suffix(
+        logical_idempotency_key=logical_idempotency_key,
+        workspace_idempotency_key=workspace_idempotency_key,
+    )
+    return f"{base_external_id}:{generation}"
+
+
+def _adoption_generation_idempotency_key(
+    *,
+    logical_idempotency_key: str,
+    workspace_idempotency_key: str,
+) -> str:
+    generation = _adoption_generation_suffix(
+        logical_idempotency_key=logical_idempotency_key,
+        workspace_idempotency_key=workspace_idempotency_key,
+    )
+    return f"{logical_idempotency_key}:{generation}"
+
+
+def _adoption_generation_suffix(
+    *,
+    logical_idempotency_key: str,
+    workspace_idempotency_key: str,
+) -> str:
     prefix = f"{logical_idempotency_key}:"
     if workspace_idempotency_key.startswith(prefix):
-        generation = workspace_idempotency_key[len(prefix) :]
-    else:
-        generation = "g1"
-    return f"{base_external_id}:{generation}"
+        return workspace_idempotency_key[len(prefix) :]
+    return "g1"
 
 
 def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: RepoRef) -> str:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -24,13 +24,14 @@ from awf.common.github_client import (
 )
 from awf.common.logging import get_logger
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
-from awf.db.models import MergeCandidate, Workspace
+from awf.db.models import MergeCandidate, Task, Workspace
 from awf.db.repositories import (
     MergeCandidateRepository,
     OperationRepository,
     QueueDecisionRepository,
     ResourceReservationRepository,
     TaskAttemptRepository,
+    TaskExternalIdConflictError,
     TaskRepository,
     ValidationRunRepository,
     WorkspaceRepository,
@@ -326,16 +327,32 @@ class PullRequestMonitorAdoptionService:
             else None
         )
 
-        task = await TaskRepository(self._session).create_or_get(
-            repo_url=workspace.repo_url,
-            base_branch=workspace.branch_base,
-            title=workspace.task_title,
-            prompt=workspace.task_prompt,
-            external_id=workspace.task_external_id,
-            idempotency_key=idempotency_key,
-            task_class=workspace.task_class,
-            owned_paths=list(workspace.owned_paths),
-        )
+        task_repo = TaskRepository(self._session)
+
+        async def _create_or_get_task(*, external_id: str | None) -> Task:
+            return await task_repo.create_or_get(
+                repo_url=workspace.repo_url,
+                base_branch=workspace.branch_base,
+                title=workspace.task_title,
+                prompt=workspace.task_prompt,
+                external_id=external_id,
+                idempotency_key=idempotency_key,
+                task_class=workspace.task_class,
+                owned_paths=list(workspace.owned_paths),
+            )
+
+        try:
+            task = await _create_or_get_task(external_id=workspace.task_external_id)
+        except TaskExternalIdConflictError:
+            if not previous_terminal_adoptions:
+                raise
+            workspace.task_external_id = _adoption_generation_external_id(
+                repo_slug=repo.slug(),
+                pr_number=metadata.number,
+                logical_idempotency_key=logical_idempotency_key,
+                workspace_idempotency_key=idempotency_key,
+            )
+            task = await _create_or_get_task(external_id=workspace.task_external_id)
         attempt = await TaskAttemptRepository(self._session).create_for_workspace(
             task=task,
             workspace=workspace,
@@ -697,6 +714,22 @@ def _superseded_adoption_idempotency_key(*, idempotency_key: str, workspace_id: 
 
 def _superseded_adoption_external_id(*, external_id: str, workspace_id: str) -> str:
     return f"{external_id}:superseded:{workspace_id}"
+
+
+def _adoption_generation_external_id(
+    *,
+    repo_slug: str,
+    pr_number: int,
+    logical_idempotency_key: str,
+    workspace_idempotency_key: str,
+) -> str:
+    base_external_id = _adoption_external_id(repo_slug=repo_slug, pr_number=pr_number)
+    prefix = f"{logical_idempotency_key}:"
+    if workspace_idempotency_key.startswith(prefix):
+        generation = workspace_idempotency_key[len(prefix) :]
+    else:
+        generation = "g1"
+    return f"{base_external_id}:{generation}"
 
 
 def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: RepoRef) -> str:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -347,6 +347,27 @@ class PullRequestMonitorAdoptionService:
                 owned_paths=list(workspace.owned_paths),
             )
 
+        async def _create_generated_task() -> Task:
+            task_external_id = workspace.task_external_id or _adoption_external_id(
+                repo_slug=repo.slug(),
+                pr_number=metadata.number,
+            )
+            task_generation_idempotency_key = await _next_adoption_task_idempotency_key(
+                self._session,
+                logical_idempotency_key=logical_idempotency_key,
+                task_external_id=task_external_id,
+            )
+            workspace.task_external_id = _adoption_generation_external_id(
+                repo_slug=repo.slug(),
+                pr_number=metadata.number,
+                logical_idempotency_key=logical_idempotency_key,
+                workspace_idempotency_key=task_generation_idempotency_key,
+            )
+            return await _create_or_get_task(
+                external_id=workspace.task_external_id,
+                task_idempotency_key=task_generation_idempotency_key,
+            )
+
         try:
             task = await _create_or_get_task(
                 external_id=workspace.task_external_id,
@@ -355,24 +376,14 @@ class PullRequestMonitorAdoptionService:
         except TaskExternalIdConflictError:
             if not previous_terminal_adoptions:
                 raise
-            task_generation_idempotency_key = await _next_adoption_task_idempotency_key(
-                self._session,
-                logical_idempotency_key=logical_idempotency_key,
-                task_external_id=workspace.task_external_id or _adoption_external_id(
-                    repo_slug=repo.slug(),
-                    pr_number=metadata.number,
-                ),
-            )
-            workspace.task_external_id = _adoption_generation_external_id(
-                repo_slug=repo.slug(),
-                pr_number=metadata.number,
-                logical_idempotency_key=logical_idempotency_key,
-                workspace_idempotency_key=task_generation_idempotency_key,
-            )
-            task = await _create_or_get_task(
-                external_id=workspace.task_external_id,
-                task_idempotency_key=task_generation_idempotency_key,
-            )
+            task = await _create_generated_task()
+        else:
+            if (
+                previous_terminal_adoptions
+                and task.idempotency_key == logical_idempotency_key
+                and await _task_has_existing_attempt(self._session, task.id)
+            ):
+                task = await _create_generated_task()
         attempt = await TaskAttemptRepository(self._session).create_for_workspace(
             task=task,
             workspace=workspace,
@@ -651,6 +662,11 @@ async def _next_adoption_task_idempotency_key(
         if candidate not in existing_keys:
             return candidate
     raise RuntimeError("Could not allocate a fresh PR adoption task idempotency key.")
+
+
+async def _task_has_existing_attempt(session: AsyncSession, task_id: str) -> bool:
+    stmt = select(TaskAttempt.id).where(TaskAttempt.task_id == task_id).limit(1)
+    return (await session.execute(stmt)).scalar_one_or_none() is not None
 
 
 def _is_adoption_generation_suffix(value: str) -> bool:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -858,18 +858,6 @@ def _adoption_generation_external_id(
     return f"{base_external_id}:{generation}"
 
 
-def _adoption_generation_idempotency_key(
-    *,
-    logical_idempotency_key: str,
-    workspace_idempotency_key: str,
-) -> str:
-    generation = _adoption_generation_suffix(
-        logical_idempotency_key=logical_idempotency_key,
-        workspace_idempotency_key=workspace_idempotency_key,
-    )
-    return f"{logical_idempotency_key}:{generation}"
-
-
 def _adoption_generation_suffix(
     *,
     logical_idempotency_key: str,

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import hashlib
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import Any
 
-from sqlalchemy import inspect, select
+from sqlalchemy import inspect, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.schemas import (
@@ -547,9 +547,12 @@ async def _next_adoption_workspace_idempotency_key(
     workspace_repo: WorkspaceRepository,
     *,
     logical_idempotency_key: str,
+    reserved_idempotency_keys: Iterable[str] = (),
+    require_generation: bool = False,
 ) -> str:
     existing_keys = set(await workspace_repo.list_idempotency_key_family(logical_idempotency_key))
-    if logical_idempotency_key not in existing_keys:
+    existing_keys.update(reserved_idempotency_keys)
+    if not existing_keys and not require_generation:
         return logical_idempotency_key
 
     for generation in range(1, 1000):
@@ -557,6 +560,26 @@ async def _next_adoption_workspace_idempotency_key(
         if candidate not in existing_keys:
             return candidate
     raise RuntimeError("Could not allocate a fresh PR adoption workspace idempotency key.")
+
+
+async def _task_idempotency_key_family(
+    session: AsyncSession,
+    *,
+    logical_idempotency_key: str,
+) -> list[str]:
+    generation_pattern = f"{_escape_like_pattern(logical_idempotency_key)}:g%"
+    stmt = (
+        select(Task.idempotency_key)
+        .where(
+            or_(
+                Task.idempotency_key == logical_idempotency_key,
+                Task.idempotency_key.like(generation_pattern, escape="\\"),
+            )
+        )
+        .order_by(Task.idempotency_key.asc())
+    )
+    keys = (await session.execute(stmt)).scalars().all()
+    return [key for key in keys if key is not None]
 
 
 async def _terminal_adoption_lineage(
@@ -781,6 +804,10 @@ def _adoption_generation_suffix(
     if workspace_idempotency_key.startswith(prefix):
         return workspace_idempotency_key[len(prefix) :]
     return "g1"
+
+
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: RepoRef) -> str:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -56,6 +56,7 @@ _LIVE_ADOPTION_STATUSES = frozenset(
         WorkspaceStatus.validating.value,
         WorkspaceStatus.pushing.value,
         WorkspaceStatus.monitoring_pr.value,
+        WorkspaceStatus.destroying.value,
     }
 )
 # Keep the public adoption error-code contract present in service source so

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -557,14 +557,16 @@ async def _next_adoption_workspace_idempotency_key(
     reserved_idempotency_keys: Iterable[str] = (),
     require_generation: bool = False,
 ) -> str:
-    existing_keys = set(
+    workspace_keys = set(
         await workspace_repo.list_idempotency_key_family(logical_idempotency_key)
     )
     if known_workspace_keys is not None:
-        existing_keys.update(known_workspace_keys)
-    existing_keys.update(reserved_idempotency_keys)
-    if not existing_keys and not require_generation:
+        workspace_keys.update(known_workspace_keys)
+    if not require_generation and not workspace_keys:
         return logical_idempotency_key
+
+    existing_keys = set(workspace_keys)
+    existing_keys.update(reserved_idempotency_keys)
 
     for generation in range(1, 1000):
         candidate = f"{logical_idempotency_key}:g{generation}"

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -535,12 +535,13 @@ async def _next_adoption_workspace_idempotency_key(
     *,
     logical_idempotency_key: str,
 ) -> str:
-    if await workspace_repo.get_by_idempotency_key(logical_idempotency_key) is None:
+    existing_keys = set(await workspace_repo.list_idempotency_key_family(logical_idempotency_key))
+    if logical_idempotency_key not in existing_keys:
         return logical_idempotency_key
 
     for generation in range(1, 1000):
         candidate = f"{logical_idempotency_key}:g{generation}"
-        if await workspace_repo.get_by_idempotency_key(candidate) is None:
+        if candidate not in existing_keys:
             return candidate
     raise RuntimeError("Could not allocate a fresh PR adoption workspace idempotency key.")
 

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -37,6 +37,7 @@ from awf.db.repositories import (
     ValidationRunRepository,
     WorkspaceRepository,
 )
+from awf.db.utils import escape_like_pattern as _escape_like_pattern
 from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.validation_observability import validation_freshness_summary
 
@@ -936,10 +937,6 @@ def _raise_if_existing_workspace_is_not_requested_adoption(
             "existing_pr_adoption_pr_number": existing_pr_number,
         },
     )
-
-
-def _escape_like_pattern(value: str) -> str:
-    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
 def _raise_if_policy_conflicts(

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -556,12 +556,11 @@ async def _next_adoption_workspace_idempotency_key(
     reserved_idempotency_keys: Iterable[str] = (),
     require_generation: bool = False,
 ) -> str:
-    if known_workspace_keys is None:
-        existing_keys = set(
-            await workspace_repo.list_idempotency_key_family(logical_idempotency_key)
-        )
-    else:
-        existing_keys = set(known_workspace_keys)
+    existing_keys = set(
+        await workspace_repo.list_idempotency_key_family(logical_idempotency_key)
+    )
+    if known_workspace_keys is not None:
+        existing_keys.update(known_workspace_keys)
     existing_keys.update(reserved_idempotency_keys)
     if not existing_keys and not require_generation:
         return logical_idempotency_key

--- a/tests/integration/test_alembic_postgres.py
+++ b/tests/integration/test_alembic_postgres.py
@@ -95,9 +95,7 @@ def _quote_identifier(value: str) -> str:
 
 
 def _asyncpg_url(url: URL) -> str:
-    query = dict(url.query)
-    query.pop("awf_search_path", None)
-    query.pop("awf_null_pool", None)
+    query = {key: value for key, value in url.query.items() if not key.startswith("awf_")}
     return url.set(drivername="postgresql", query=query).render_as_string(hide_password=False)
 
 

--- a/tests/postgres.py
+++ b/tests/postgres.py
@@ -134,6 +134,19 @@ def _query_value(value: object | None) -> str | None:
     return None if value is None else str(value)
 
 
+def _schema_identifier_from_search_path(value: object | None) -> str | None:
+    search_path = _query_value(value)
+    if search_path is None:
+        return None
+    if search_path.startswith('"') and search_path.endswith('"'):
+        schema = search_path[1:-1].replace('""', '"')
+    else:
+        schema = search_path
+    if schema != "public" and _POSTGRES_TEST_SCHEMA_RE.fullmatch(schema) is None:
+        raise RuntimeError("PostgreSQL test search path must target an AWF test schema.")
+    return _quote_identifier(schema)
+
+
 async def _with_postgres_connection_retry[T](operation: Callable[[], Awaitable[T]]) -> T:
     for attempt in range(_SCHEMA_ENGINE_CONNECT_ATTEMPTS):
         try:
@@ -311,14 +324,18 @@ async def _create_metadata_engine(schema_database_url: str) -> AsyncEngine:
         engine = _make_test_engine(schema_database_url)
         try:
             async with engine.begin() as conn:
-                search_path = _query_value(
+                schema_identifier = _schema_identifier_from_search_path(
                     make_url(schema_database_url).query.get("awf_search_path")
                 )
-                if search_path is not None:
-                    await conn.execute(
-                        text("SELECT set_config('search_path', :search_path, false)"),
-                        {"search_path": search_path},
-                    )
+                if schema_identifier is not None:
+                    await conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {schema_identifier}"))
+                    await conn.execute(text(f"SET search_path TO {schema_identifier}"))
+                    selected_schema = await conn.scalar(text("SELECT current_schema()"))
+                    if selected_schema is None:
+                        raise RuntimeError(
+                            f"PostgreSQL test metadata search_path did not select "
+                            f"{schema_identifier}."
+                        )
                 await conn.run_sync(Base.metadata.create_all)
         except Exception as exc:
             await _dispose_engine(engine)
@@ -461,14 +478,14 @@ async def create_postgres_test_engine() -> AsyncEngine:
         async with _postgres_schema_ddl_lock(admin_engine) as admin_conn:
             await _create_schema(admin_conn, quoted_schema)
             schema_created = True
-        engine = await _create_metadata_engine(
-            _test_schema_url(
-                database_url,
-                quoted_schema,
-                null_pool=True,
-                connect_retries=True,
+            engine = await _create_metadata_engine(
+                _test_schema_url(
+                    database_url,
+                    quoted_schema,
+                    null_pool=True,
+                    connect_retries=True,
+                )
             )
-        )
     except Exception:
         await _dispose_engine(engine)
         if schema_created:
@@ -498,15 +515,15 @@ async def postgres_test_url() -> AsyncIterator[str]:
         async with _postgres_schema_ddl_lock(admin_engine) as admin_conn:
             await _create_schema(admin_conn, quoted_schema)
             schema_created = True
-        schema_database_url = _test_schema_url(
-            database_url,
-            quoted_schema,
-            null_pool=True,
-            connect_retries=True,
-        )
-        engine = await _create_metadata_engine(schema_database_url)
-        await _dispose_engine(engine)
-        engine = None
+            schema_database_url = _test_schema_url(
+                database_url,
+                quoted_schema,
+                null_pool=True,
+                connect_retries=True,
+            )
+            engine = await _create_metadata_engine(schema_database_url)
+            await _dispose_engine(engine)
+            engine = None
         yield schema_database_url
     finally:
         await _dispose_engine(engine)
@@ -535,16 +552,16 @@ def postgres_test_url_sync() -> Iterator[str]:
             async with _postgres_schema_ddl_lock(admin_engine) as admin_conn:
                 await _create_schema(admin_conn, quoted_schema)
                 schema_created = True
-            schema_database_url = _test_schema_url(
-                database_url,
-                quoted_schema,
-                null_pool=True,
-                connect_retries=True,
-            )
-            engine = await _create_metadata_engine(schema_database_url)
-            await _dispose_engine(engine)
-            engine = None
-            return schema_database_url
+                schema_database_url = _test_schema_url(
+                    database_url,
+                    quoted_schema,
+                    null_pool=True,
+                    connect_retries=True,
+                )
+                engine = await _create_metadata_engine(schema_database_url)
+                await _dispose_engine(engine)
+                engine = None
+                return schema_database_url
         except Exception:
             await _dispose_engine(engine)
             if schema_created:

--- a/tests/postgres.py
+++ b/tests/postgres.py
@@ -128,6 +128,12 @@ def _make_test_engine(url: str) -> AsyncEngine:
     return make_engine(url, connect_args={"timeout": _TEST_CONNECT_TIMEOUT_SECONDS})
 
 
+def _query_value(value: object | None) -> str | None:
+    if isinstance(value, tuple):
+        value = value[0] if value else None
+    return None if value is None else str(value)
+
+
 async def _with_postgres_connection_retry[T](operation: Callable[[], Awaitable[T]]) -> T:
     for attempt in range(_SCHEMA_ENGINE_CONNECT_ATTEMPTS):
         try:
@@ -305,6 +311,14 @@ async def _create_metadata_engine(schema_database_url: str) -> AsyncEngine:
         engine = _make_test_engine(schema_database_url)
         try:
             async with engine.begin() as conn:
+                search_path = _query_value(
+                    make_url(schema_database_url).query.get("awf_search_path")
+                )
+                if search_path is not None:
+                    await conn.execute(
+                        text("SELECT set_config('search_path', :search_path, false)"),
+                        {"search_path": search_path},
+                    )
                 await conn.run_sync(Base.metadata.create_all)
         except Exception as exc:
             await _dispose_engine(engine)

--- a/tests/unit/api/test_pr_monitor_adoption.py
+++ b/tests/unit/api/test_pr_monitor_adoption.py
@@ -260,6 +260,85 @@ async def test_adopt_pr_supersedes_cancelled_previous_adoption(
 
 
 @pytest.mark.unit
+async def test_adopt_pr_ignores_destroyed_prior_adoption_and_creates_fresh_monitor(
+    adoption_client: tuple[AsyncClient, _MetadataFetcher],
+    engine: AsyncEngine,
+) -> None:
+    client, fetcher = adoption_client
+    headers = {"Authorization": "Bearer secret"}
+
+    first = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+    )
+    assert first.status_code == 202
+    old_workspace_id = first.json()["workspace_id"]
+    session_factory = make_session_factory(engine)
+    async with session_factory() as session:
+        workspace = await WorkspaceRepository(session).get(old_workspace_id)
+        assert workspace is not None
+        workspace.status = WorkspaceStatus.destroyed.value
+        await session.commit()
+
+    second = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+    )
+
+    assert second.status_code == 202
+    body = second.json()
+    assert body["attached_existing"] is False
+    assert body["workspace_id"] != old_workspace_id
+    assert body["status"] == "requested"
+    assert fetcher.calls == [("dimileeh/aira-web", 277), ("dimileeh/aira-web", 277)]
+
+    async with session_factory() as session:
+        rows = list((await session.execute(select(Workspace))).scalars())
+    assert len(rows) == 2
+    assert sorted(workspace.status for workspace in rows) == ["destroyed", "requested"]
+
+
+@pytest.mark.unit
+async def test_adopt_pr_active_policy_mismatch_returns_structured_conflict(
+    adoption_client: tuple[AsyncClient, _MetadataFetcher],
+) -> None:
+    client, _fetcher = adoption_client
+    headers = {"Authorization": "Bearer secret"}
+
+    first = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "auto_merge": False,
+        },
+    )
+    assert first.status_code == 202
+
+    conflict = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "auto_merge": True,
+        },
+    )
+
+    assert conflict.status_code == 409
+    body = conflict.json()
+    assert body["error_code"] == "PR_ADOPTION_POLICY_CONFLICT"
+    assert body["detail"] == {
+        "workspace_id": first.json()["workspace_id"],
+        "existing_auto_merge": False,
+        "requested_auto_merge": True,
+    }
+
+
+@pytest.mark.unit
 async def test_adopt_pr_returns_structured_terminal_pr_error(
     engine: AsyncEngine,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/db/test_postgres_helpers.py
+++ b/tests/unit/db/test_postgres_helpers.py
@@ -21,8 +21,19 @@ class _FakeConnection:
         return None
 
     async def execute(self, _statement: Any, params: dict[str, object] | None = None) -> None:
+        statement = str(_statement)
+        if statement.startswith("CREATE SCHEMA IF NOT EXISTS "):
+            self._events.append(
+                f"ensure_schema:{statement.removeprefix('CREATE SCHEMA IF NOT EXISTS ')}"
+            )
+        if statement.startswith("SET search_path TO "):
+            self._events.append(f"set_search_path:{statement.removeprefix('SET search_path TO ')}")
         if params and "search_path" in params:
             self._events.append(f"set_search_path:{params['search_path']}")
+
+    async def scalar(self, _statement: Any) -> str:
+        self._events.append("verify_schema")
+        return "awf_test_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
     async def run_sync(self, fn: Any) -> None:
         fn(self)
@@ -146,7 +157,9 @@ async def test_postgres_test_engine_serializes_schema_create_and_drop(
         "lock:admin",
         "create:admin",
         "unlock:admin",
+        'ensure_schema:"awf_test_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
         'set_search_path:"awf_test_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
+        "verify_schema",
         "create_all",
         "yield:schema",
         "dispose:schema",

--- a/tests/unit/db/test_postgres_helpers.py
+++ b/tests/unit/db/test_postgres_helpers.py
@@ -11,11 +11,18 @@ import tests.postgres as postgres
 
 
 class _FakeConnection:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
     async def __aenter__(self) -> _FakeConnection:
         return self
 
     async def __aexit__(self, *exc_info: object) -> None:
         return None
+
+    async def execute(self, _statement: Any, params: dict[str, object] | None = None) -> None:
+        if params and "search_path" in params:
+            self._events.append(f"set_search_path:{params['search_path']}")
 
     async def run_sync(self, fn: Any) -> None:
         fn(self)
@@ -27,7 +34,7 @@ class _FakeEngine:
         self._events = events
 
     def begin(self) -> _FakeConnection:
-        return _FakeConnection()
+        return _FakeConnection(self._events)
 
     async def dispose(self) -> None:
         self._events.append(f"dispose:{self.name}")
@@ -121,6 +128,11 @@ async def test_postgres_test_engine_serializes_schema_create_and_drop(
         events.append("create_all")
 
     monkeypatch.setattr(postgres, "postgres_test_database_url", lambda: "postgresql+asyncpg://u:p@h/db")
+    monkeypatch.setattr(
+        postgres,
+        "_new_postgres_test_schema",
+        lambda: "awf_test_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
     monkeypatch.setattr(postgres, "make_engine", fake_make_engine)
     monkeypatch.setattr(postgres, "_postgres_schema_ddl_lock", fake_lock, raising=False)
     monkeypatch.setattr(postgres, "_create_schema", fake_create_schema)
@@ -134,6 +146,7 @@ async def test_postgres_test_engine_serializes_schema_create_and_drop(
         "lock:admin",
         "create:admin",
         "unlock:admin",
+        'set_search_path:"awf_test_0123456789abcdef_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"',
         "create_all",
         "yield:schema",
         "dispose:schema",

--- a/tests/unit/db/test_utils.py
+++ b/tests/unit/db/test_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import pytest
+
+from awf.db.utils import escape_like_pattern
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("plain", "plain"),
+        ("adopt_%:key", "adopt\\_\\%:key"),
+        ("path\\with\\slashes", "path\\\\with\\\\slashes"),
+        ("mixed\\_%", "mixed\\\\\\_\\%"),
+    ],
+)
+def test_escape_like_pattern_escapes_like_wildcards(value: str, expected: str) -> None:
+    assert escape_like_pattern(value) == expected

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -1005,6 +1005,64 @@ class TestIdempotency:
         ]
 
 
+class TestPrAdoptionHistory:
+    @pytest.mark.unit
+    async def test_pr_number_fallback_is_scoped_to_adoption_repo_policy(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        target = await repo.create(
+            repo_url="https://github.com/dimileeh/aira-web.git",
+            branch_base="development",
+            task_title="adopt target",
+            task_prompt="monitor target PR",
+            agent="codex",
+            test_commands=[],
+            task_external_id="adopt-target-external",
+            idempotency_key="adopt-target-key",
+            task_kind="sync_feature_pr",
+            task_policy={"pr_adoption": {"repo_slug": "DIMILEEH/AIRA-WEB", "pr_number": 277}},
+        )
+        target.pr_number = 277
+        unrelated = await repo.create(
+            repo_url="https://github.com/example/other.git",
+            branch_base="development",
+            task_title="adopt unrelated",
+            task_prompt="monitor unrelated PR",
+            agent="codex",
+            test_commands=[],
+            task_external_id="adopt-other-external",
+            idempotency_key="adopt-other-key",
+            task_kind="sync_feature_pr",
+            task_policy={"pr_adoption": {"repo_slug": "example/other", "pr_number": 277}},
+        )
+        unrelated.pr_number = 277
+        await session.commit()
+        session.expunge_all()
+
+        loaded_workspace_ids: list[str] = []
+
+        def capture_workspace_load(workspace: Workspace, _context: object) -> None:
+            loaded_workspace_ids.append(workspace.id)
+
+        event.listen(Workspace, "load", capture_workspace_load)
+        try:
+            history = await WorkspaceRepository(session).list_pr_adoption_history(
+                task_external_id="adopt-target-external",
+                idempotency_key="adopt-target-key",
+                task_kind="sync_feature_pr",
+                repo_slug="dimileeh/aira-web",
+                pr_number=277,
+            )
+        finally:
+            event.remove(Workspace, "load", capture_workspace_load)
+
+        assert [workspace.id for workspace in history] == [target.id]
+        assert target.id in loaded_workspace_ids
+        assert unrelated.id not in loaded_workspace_ids
+
+
 class TestExists:
     @pytest.mark.unit
     async def test_returns_boolean_existence(self, session: AsyncSession) -> None:

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -969,6 +969,41 @@ class TestIdempotency:
         repo = WorkspaceRepository(session)
         assert await repo.get_by_idempotency_key("never-used") is None
 
+    @pytest.mark.unit
+    async def test_list_idempotency_key_family_returns_exact_and_generation_keys(
+        self,
+        session: AsyncSession,
+    ) -> None:
+        repo = WorkspaceRepository(session)
+        logical_key = "adopt_%:key"
+        for index, idempotency_key in enumerate(
+            [
+                logical_key,
+                f"{logical_key}:g1",
+                f"{logical_key}:g2",
+                f"{logical_key}:retry",
+                "adoptX%:key:g1",
+                "adopt_%:other:g1",
+            ],
+            start=1,
+        ):
+            await repo.create(
+                repo_url="git@github.com:example/a.git",
+                branch_base="development",
+                task_title=f"t {index}",
+                task_prompt="p",
+                agent="codex",
+                test_commands=[],
+                idempotency_key=idempotency_key,
+            )
+        await session.commit()
+
+        assert await repo.list_idempotency_key_family(logical_key) == [
+            logical_key,
+            f"{logical_key}:g1",
+            f"{logical_key}:g2",
+        ]
+
 
 class TestExists:
     @pytest.mark.unit

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -410,6 +410,121 @@ class TestToolRegistration:
         assert payload["auto_merge"] is False
 
     @pytest.mark.unit
+    async def test_adopt_pull_request_monitor_tool_ignores_destroyed_prior_adoption(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async def _fetcher(
+            *,
+            repo: RepoRef,
+            pr_number: int,
+        ) -> PullRequestAdoptionMetadata:
+            assert repo.slug() == "dimileeh/aira-web"
+            assert pr_number == 277
+            return PullRequestAdoptionMetadata(
+                number=277,
+                head_ref="feature/ready",
+                head_repo_slug="dimileeh/aira-web",
+                base_ref="development",
+                head_sha="h" * 40,
+                base_sha="b" * 40,
+                state="OPEN",
+                is_draft=False,
+                closed=False,
+                merged=False,
+                author="octocat",
+                url="https://github.com/dimileeh/aira-web/pull/277",
+                title="feature: ready",
+            )
+
+        mcp = build_mcp_server(
+            service=WorkspaceService(factory, pr_adoption_metadata_fetcher=_fetcher)
+        )
+        first = await _call(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+        )
+        assert isinstance(first, dict)
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).get(str(first["workspace_id"]))
+            assert workspace is not None
+            workspace.status = WorkspaceStatus.destroyed.value
+            await session.commit()
+
+        second = await _call(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+        )
+
+        assert isinstance(second, dict)
+        assert second["attached_existing"] is False
+        assert second["workspace_id"] != first["workspace_id"]
+        assert second["status"] == "requested"
+
+    @pytest.mark.unit
+    async def test_adopt_pull_request_monitor_tool_returns_policy_conflict_error_result(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async def _fetcher(
+            *,
+            repo: RepoRef,
+            pr_number: int,
+        ) -> PullRequestAdoptionMetadata:
+            assert repo.slug() == "dimileeh/aira-web"
+            assert pr_number == 277
+            return PullRequestAdoptionMetadata(
+                number=277,
+                head_ref="feature/ready",
+                head_repo_slug="dimileeh/aira-web",
+                base_ref="development",
+                head_sha="h" * 40,
+                base_sha="b" * 40,
+                state="OPEN",
+                is_draft=False,
+                closed=False,
+                merged=False,
+                author="octocat",
+                url="https://github.com/dimileeh/aira-web/pull/277",
+                title="feature: ready",
+            )
+
+        mcp = build_mcp_server(
+            service=WorkspaceService(factory, pr_adoption_metadata_fetcher=_fetcher)
+        )
+        first = await _call(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {
+                "repo_slug": "dimileeh/aira-web",
+                "pr_number": 277,
+                "auto_merge": False,
+            },
+        )
+        assert isinstance(first, dict)
+
+        result = await mcp.call_tool(
+            "awf_adopt_pull_request_monitor",
+            {
+                "repo_slug": "dimileeh/aira-web",
+                "pr_number": 277,
+                "auto_merge": True,
+            },
+        )
+
+        assert isinstance(result, CallToolResult)
+        assert result.isError is True
+        assert result.structuredContent is not None
+        assert result.structuredContent["error_code"] == "PR_ADOPTION_POLICY_CONFLICT"
+        assert result.structuredContent["detail"] == {
+            "workspace_id": first["workspace_id"],
+            "existing_auto_merge": False,
+            "requested_auto_merge": True,
+        }
+
+    @pytest.mark.unit
     async def test_adopt_pull_request_monitor_tool_returns_terminal_pr_error_result(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -2360,6 +2360,27 @@ class TestPullRequestMonitorAdoptionService:
         assert repo.calls == ["pr-adopt:logical"]
 
     @pytest.mark.unit
+    async def test_adoption_workspace_idempotency_key_ignores_task_reservations_without_generation(
+        self,
+    ) -> None:
+        class _WorkspaceRepo:
+            async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
+                assert logical_key == "pr-adopt:logical"
+                return []
+
+        key = await adoption_module._next_adoption_workspace_idempotency_key(
+            _WorkspaceRepo(),  # type: ignore[arg-type]
+            logical_idempotency_key="pr-adopt:logical",
+            reserved_idempotency_keys=[
+                "pr-adopt:logical",
+                "pr-adopt:logical:g1",
+            ],
+            require_generation=False,
+        )
+
+        assert key == "pr-adopt:logical"
+
+    @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:
         class _ExhaustedWorkspaceRepo:
             async def list_idempotency_key_family(self, logical_key: str) -> list[str]:

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -27,7 +27,12 @@ from awf.db.models import (
     Workspace,
     WorkspaceEvent,
 )
-from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
+from awf.db.repositories import (
+    TaskAttemptRepository,
+    TaskExternalIdConflictError,
+    TaskRepository,
+    WorkspaceRepository,
+)
 from awf.db.session import make_session_factory
 from awf.service import pr_monitor_adoption as adoption_module
 from awf.service.pr_monitor_adoption import (
@@ -2052,7 +2057,10 @@ class TestPullRequestMonitorAdoptionService:
     @pytest.mark.parametrize(
         ("reason_code", "status_code"),
         [
+            ("PR_NOT_FOUND", 404),
             ("PR_ALREADY_CLOSED", 409),
+            ("PR_ALREADY_MERGED", 409),
+            ("INVALID_GITHUB_REPO", 422),
             ("PR_ADOPTION_INPUT_REQUIRED", 422),
             ("PR_METADATA_FETCH_FAILED", 502),
             ("PR_METADATA_INVALID", 502),
@@ -2076,6 +2084,41 @@ class TestPullRequestMonitorAdoptionService:
     @pytest.mark.unit
     def test_inline_profile_name_handles_missing_profile(self) -> None:
         assert adoption_module._inline_profile_name(None) is None
+
+    @pytest.mark.unit
+    def test_redacted_optional_text_preserves_only_present_text(self) -> None:
+        assert adoption_module._redacted_optional_text(None) is None
+        assert adoption_module._redacted_optional_text("") is None
+        assert adoption_module._redacted_optional_text("operator note") == "operator note"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (True, None),
+            (17, 17),
+            (" 42 ", 42),
+            ("not-a-number", None),
+            ("", None),
+            (["277"], None),
+        ],
+    )
+    def test_optional_int_parses_only_scalar_integers(
+        self,
+        value: object,
+        expected: int | None,
+    ) -> None:
+        assert adoption_module._optional_int(value) == expected
+
+    @pytest.mark.unit
+    def test_adoption_generation_suffix_defaults_for_non_family_key(self) -> None:
+        assert (
+            adoption_module._adoption_generation_suffix(
+                logical_idempotency_key="pr-adopt:logical",
+                workspace_idempotency_key="other-family-key",
+            )
+            == "g1"
+        )
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -2320,6 +2363,231 @@ class TestPullRequestMonitorAdoptionService:
             },
         ]
         assert task_attempt_selects == []
+
+    @pytest.mark.unit
+    async def test_terminal_lineage_loads_unloaded_task_attempts_in_bulk(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert workspace is not None
+            workspace.status = WorkspaceStatus.destroyed.value
+            await session.flush()
+            session.expire(workspace, ["task_attempt"])
+
+            lineage = await adoption_module._terminal_adoption_lineage(session, [workspace])
+
+        assert lineage == [
+            {
+                "workspace_id": first.workspace_id,
+                "status": WorkspaceStatus.destroyed.value,
+                "task_id": first.task_id,
+                "attempt_id": first.attempt_id,
+            }
+        ]
+
+    @pytest.mark.unit
+    async def test_supersede_previous_adoption_without_attempt_updates_workspace_only(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        logical_key = _canonical_key()
+        adoption_external_id = adoption_module._adoption_external_id(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:dimileeh/aira-web.git",
+                branch_base="development",
+                task_title="detached adoption",
+                task_prompt="recover detached adoption",
+                task_external_id=adoption_external_id,
+                agent="codex",
+                test_commands=[],
+                idempotency_key=logical_key,
+                task_kind=adoption_module.PR_ADOPTION_TASK_KIND,
+            )
+            workspace.status = WorkspaceStatus.destroyed.value
+
+            payload = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            )._supersede_previous_adoption(
+                workspace=workspace,
+                idempotency_key=logical_key,
+                repo=RepoRef(owner="dimileeh", name="aira-web"),
+                pr_number=277,
+            )
+            await session.commit()
+
+        assert payload["previous_workspace_id"] == workspace.id
+        assert payload["previous_idempotency_key"] == logical_key
+
+        async with factory() as session:
+            superseded = await WorkspaceRepository(session).get(workspace.id)
+            assert superseded is not None
+            assert superseded.idempotency_key is not None
+            assert superseded.idempotency_key.startswith(f"{logical_key}:superseded:")
+            assert superseded.task_external_id == adoption_module._superseded_adoption_external_id(
+                external_id=adoption_external_id,
+                workspace_id=workspace.id,
+            )
+            assert await _count(session, TaskAttempt) == 0
+
+    @pytest.mark.unit
+    async def test_create_adoption_workspace_reraises_unexpected_task_conflict(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _raise_task_conflict(
+            _repo: TaskRepository,
+            **kwargs: object,
+        ) -> Task:
+            raise TaskExternalIdConflictError(str(kwargs["external_id"]))
+
+        monkeypatch.setattr(TaskRepository, "create_or_get", _raise_task_conflict)
+
+        metadata = _metadata()
+        logical_key = _canonical_key()
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(metadata),
+            )
+            with pytest.raises(TaskExternalIdConflictError):
+                await service._create_adoption_workspace(
+                    request=PullRequestMonitorAdoptionRequest(
+                        repo_slug="dimileeh/aira-web",
+                        pr_number=277,
+                    ),
+                    repo=RepoRef(owner="dimileeh", name="aira-web"),
+                    metadata=metadata,
+                    idempotency_key=logical_key,
+                    logical_idempotency_key=logical_key,
+                    previous_terminal_adoptions=[],
+                )
+
+    @pytest.mark.unit
+    async def test_task_external_id_family_filters_generated_adoption_ids(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        logical_key = "pr-adopt:github:dimileeh/aira-web:277"
+        task_external_id = "pr-adopt:github:dimileeh/aira-web:277"
+        async with factory() as session:
+            session.add_all(
+                [
+                    Task(
+                        id="task-family-base",
+                        external_id=task_external_id,
+                        idempotency_key=logical_key,
+                        repo_url="git@github.com:dimileeh/aira-web.git",
+                        base_branch="development",
+                        title="base",
+                        prompt="base prompt",
+                        owned_paths=[],
+                    ),
+                    Task(
+                        id="task-family-g2",
+                        external_id=f"{task_external_id}:g2",
+                        idempotency_key=None,
+                        repo_url="git@github.com:dimileeh/aira-web.git",
+                        base_branch="development",
+                        title="generated",
+                        prompt="generated prompt",
+                        owned_paths=[],
+                    ),
+                    Task(
+                        id="task-family-invalid",
+                        external_id=f"{task_external_id}:garbage",
+                        idempotency_key=None,
+                        repo_url="git@github.com:dimileeh/aira-web.git",
+                        base_branch="development",
+                        title="invalid generation",
+                        prompt="invalid prompt",
+                        owned_paths=[],
+                    ),
+                    Task(
+                        id="task-family-other",
+                        external_id="pr-adopt:github:dimileeh/other:277:g9",
+                        idempotency_key=None,
+                        repo_url="git@github.com:dimileeh/other.git",
+                        base_branch="development",
+                        title="other",
+                        prompt="other prompt",
+                        owned_paths=[],
+                    ),
+                    Task(
+                        id="task-family-null",
+                        external_id=None,
+                        idempotency_key="unrelated-null",
+                        repo_url="git@github.com:dimileeh/aira-web.git",
+                        base_branch="development",
+                        title="null",
+                        prompt="null prompt",
+                        owned_paths=[],
+                    ),
+                ]
+            )
+            await session.flush()
+
+            reserved = await adoption_module._task_external_id_family_idempotency_keys(
+                session,
+                logical_idempotency_key=logical_key,
+                task_external_id=task_external_id,
+            )
+
+        assert reserved == [logical_key, f"{logical_key}:g2"]
+
+    @pytest.mark.unit
+    async def test_adoption_task_idempotency_key_exhaustion_is_explicit(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        async def _reserved_task_keys(
+            _session: AsyncSession,
+            *,
+            logical_idempotency_key: str,
+        ) -> list[str]:
+            return [
+                logical_idempotency_key,
+                *(f"{logical_idempotency_key}:g{generation}" for generation in range(1, 1000)),
+            ]
+
+        async def _reserved_external_keys(
+            _session: AsyncSession,
+            *,
+            logical_idempotency_key: str,
+            task_external_id: str,
+        ) -> list[str]:
+            del logical_idempotency_key, task_external_id
+            return []
+
+        monkeypatch.setattr(adoption_module, "_task_idempotency_key_family", _reserved_task_keys)
+        monkeypatch.setattr(
+            adoption_module,
+            "_task_external_id_family_idempotency_keys",
+            _reserved_external_keys,
+        )
+
+        with pytest.raises(RuntimeError, match="fresh PR adoption task idempotency key"):
+            await adoption_module._next_adoption_task_idempotency_key(
+                None,  # type: ignore[arg-type]
+                logical_idempotency_key="pr-adopt:exhausted",
+                task_external_id="pr-adopt:external",
+            )
 
     @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_merges_known_keys_with_family(

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -44,7 +44,6 @@ _LIVE_ADOPTION_STATUSES = {
     WorkspaceStatus.validating.value,
     WorkspaceStatus.pushing.value,
     WorkspaceStatus.monitoring_pr.value,
-    WorkspaceStatus.destroying.value,
 }
 
 
@@ -562,7 +561,6 @@ class TestPullRequestMonitorAdoptionService:
         [
             WorkspaceStatus.requested.value,
             WorkspaceStatus.monitoring_pr.value,
-            WorkspaceStatus.destroying.value,
         ],
     )
     async def test_replay_attaches_to_live_adoption_without_refetching_metadata(
@@ -606,6 +604,7 @@ class TestPullRequestMonitorAdoptionService:
     @pytest.mark.parametrize(
         "terminal_status",
         [
+            WorkspaceStatus.destroying.value,
             WorkspaceStatus.destroyed.value,
             WorkspaceStatus.cancelled.value,
             WorkspaceStatus.failed.value,

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -44,6 +44,7 @@ _LIVE_ADOPTION_STATUSES = {
     WorkspaceStatus.validating.value,
     WorkspaceStatus.pushing.value,
     WorkspaceStatus.monitoring_pr.value,
+    WorkspaceStatus.destroying.value,
 }
 
 
@@ -561,6 +562,7 @@ class TestPullRequestMonitorAdoptionService:
         [
             WorkspaceStatus.requested.value,
             WorkspaceStatus.monitoring_pr.value,
+            WorkspaceStatus.destroying.value,
         ],
     )
     async def test_replay_attaches_to_live_adoption_without_refetching_metadata(
@@ -604,7 +606,6 @@ class TestPullRequestMonitorAdoptionService:
     @pytest.mark.parametrize(
         "terminal_status",
         [
-            WorkspaceStatus.destroying.value,
             WorkspaceStatus.destroyed.value,
             WorkspaceStatus.cancelled.value,
             WorkspaceStatus.failed.value,

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -7,7 +7,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 import pytest
-from sqlalchemy import func, select
+from sqlalchemy import event, func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.schemas import PullRequestMonitorAdoptionRequest
@@ -2021,6 +2021,102 @@ class TestPullRequestMonitorAdoptionService:
                 "attempt_id": first.attempt_id,
             }
         ]
+
+    @pytest.mark.unit
+    async def test_terminal_lineage_uses_adoption_history_attempts_without_extra_reads(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            )
+            first = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            first_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert first_workspace is not None
+            first_workspace.status = WorkspaceStatus.destroyed.value
+            second = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            second_workspace = await WorkspaceRepository(session).get(second.workspace_id)
+            assert second_workspace is not None
+            second_workspace.status = WorkspaceStatus.destroyed.value
+            await session.flush()
+
+            repo_slug = "dimileeh/aira-web"
+            pr_number = 277
+            history = await WorkspaceRepository(session).list_pr_adoption_history(
+                task_external_id=adoption_module._adoption_external_id(
+                    repo_slug=repo_slug,
+                    pr_number=pr_number,
+                ),
+                idempotency_key=adoption_module.pr_adoption_idempotency_key(
+                    repo_slug=repo_slug,
+                    pr_number=pr_number,
+                ),
+                task_kind=adoption_module.PR_ADOPTION_TASK_KIND,
+                repo_slug=repo_slug,
+                pr_number=pr_number,
+            )
+
+            task_attempt_selects: list[str] = []
+
+            def _capture_task_attempt_selects(
+                _conn: object,
+                _cursor: object,
+                statement: str,
+                _parameters: object,
+                _context: object,
+                _executemany: bool,
+            ) -> None:
+                normalized = statement.upper()
+                if not normalized.lstrip().startswith("SELECT"):
+                    return
+                if "FROM TASK_ATTEMPTS" in normalized:
+                    task_attempt_selects.append(statement)
+
+            engine = factory.kw["bind"]
+            event.listen(
+                engine.sync_engine,
+                "before_cursor_execute",
+                _capture_task_attempt_selects,
+            )
+            try:
+                lineage = await adoption_module._terminal_adoption_lineage(
+                    session,
+                    history,
+                )
+            finally:
+                event.remove(
+                    engine.sync_engine,
+                    "before_cursor_execute",
+                    _capture_task_attempt_selects,
+                )
+
+        assert lineage == [
+            {
+                "workspace_id": first.workspace_id,
+                "status": WorkspaceStatus.destroyed.value,
+                "task_id": first.task_id,
+                "attempt_id": first.attempt_id,
+            },
+            {
+                "workspace_id": second.workspace_id,
+                "status": WorkspaceStatus.destroyed.value,
+                "task_id": second.task_id,
+                "attempt_id": second.attempt_id,
+            },
+        ]
+        assert task_attempt_selects == []
 
     @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -874,6 +874,88 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task.title == "feature: retitled"
 
     @pytest.mark.unit
+    async def test_terminal_prior_reserves_generated_task_external_id_without_task_key(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        logical_key = adoption_module.pr_adoption_idempotency_key(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+        logical_task_external_id = adoption_module._adoption_external_id(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: ready")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            first_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            first_task = await session.get(Task, first.task_id)
+            assert first_workspace is not None
+            assert first_task is not None
+            first_workspace.status = WorkspaceStatus.destroyed.value
+            first_workspace.idempotency_key = None
+            first_task.idempotency_key = logical_key
+            await session.commit()
+
+        async with factory() as session:
+            second = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: retitled")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            second_workspace = await WorkspaceRepository(session).get(second.workspace_id)
+            second_task = await session.get(Task, second.task_id)
+            assert second_workspace is not None
+            assert second_task is not None
+            assert second_workspace.idempotency_key == logical_key
+            assert second_task.external_id == f"{logical_task_external_id}:g1"
+            second_workspace.status = WorkspaceStatus.destroyed.value
+            second_workspace.idempotency_key = None
+            second_task.idempotency_key = None
+            await session.commit()
+
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: retitled again")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.task_id not in {first.task_id, second.task_id}
+
+        async with factory() as session:
+            assert await _count(session, Task) == 3
+            fresh_workspace = await WorkspaceRepository(session).get(result.workspace_id)
+            fresh_task = await session.get(Task, result.task_id)
+
+            assert fresh_workspace is not None
+            assert fresh_task is not None
+            assert fresh_workspace.idempotency_key == logical_key
+            assert fresh_workspace.task_external_id == f"{logical_task_external_id}:g2"
+            assert fresh_task.external_id == fresh_workspace.task_external_id
+            assert fresh_task.idempotency_key == f"{logical_key}:g2"
+            assert fresh_task.title == "feature: retitled again"
+
+    @pytest.mark.unit
     async def test_terminal_prior_reuses_canonical_key_from_loaded_adoption_history(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -805,6 +805,74 @@ class TestPullRequestMonitorAdoptionService:
             ]
 
     @pytest.mark.unit
+    async def test_terminal_prior_with_stale_task_idempotency_uses_task_generation_key(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        logical_key = adoption_module.pr_adoption_idempotency_key(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+        logical_task_external_id = adoption_module._adoption_external_id(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: ready")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            old_task = await session.get(Task, first.task_id)
+            assert old_workspace is not None
+            assert old_task is not None
+            assert old_workspace.idempotency_key == logical_key
+            assert old_task.idempotency_key == logical_key
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            old_workspace.idempotency_key = None
+            await session.commit()
+
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: retitled")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.workspace_id != first.workspace_id
+        assert result.task_id != first.task_id
+
+        async with factory() as session:
+            assert await _count(session, Task) == 2
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            old_task = await session.get(Task, first.task_id)
+            fresh_workspace = await WorkspaceRepository(session).get(result.workspace_id)
+            fresh_task = await session.get(Task, result.task_id)
+
+            assert old_workspace is not None
+            assert old_task is not None
+            assert fresh_workspace is not None
+            assert fresh_task is not None
+            assert old_workspace.idempotency_key is None
+            assert old_task.idempotency_key == logical_key
+            assert fresh_workspace.task_external_id == f"{logical_task_external_id}:g1"
+            assert fresh_task.external_id == fresh_workspace.task_external_id
+            assert fresh_task.idempotency_key == f"{logical_key}:g1"
+            assert fresh_task.title == "feature: retitled"
+
+    @pytest.mark.unit
     async def test_concurrent_terminal_history_adoptions_create_one_live_monitor(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -834,8 +834,14 @@ class TestPullRequestMonitorAdoptionService:
             assert old_task is not None
             assert old_workspace.idempotency_key == logical_key
             assert old_task.idempotency_key == logical_key
+            superseded_external_id = adoption_module._superseded_adoption_external_id(
+                external_id=logical_task_external_id,
+                workspace_id=first.workspace_id,
+            )
             old_workspace.status = WorkspaceStatus.destroyed.value
             old_workspace.idempotency_key = None
+            old_workspace.task_external_id = superseded_external_id
+            old_task.external_id = superseded_external_id
             await session.commit()
 
         async with factory() as session:
@@ -867,6 +873,10 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task is not None
             assert old_workspace.idempotency_key is None
             assert old_task.idempotency_key == logical_key
+            assert old_task.external_id == adoption_module._superseded_adoption_external_id(
+                external_id=logical_task_external_id,
+                workspace_id=first.workspace_id,
+            )
             assert fresh_workspace.idempotency_key == logical_key
             assert fresh_workspace.task_external_id == f"{logical_task_external_id}:g1"
             assert fresh_task.external_id == fresh_workspace.task_external_id

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -562,7 +562,6 @@ class TestPullRequestMonitorAdoptionService:
         [
             WorkspaceStatus.requested.value,
             WorkspaceStatus.monitoring_pr.value,
-            WorkspaceStatus.destroying.value,
         ],
     )
     async def test_replay_attaches_to_live_adoption_without_refetching_metadata(
@@ -873,6 +872,65 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task.external_id == fresh_workspace.task_external_id
             assert fresh_task.idempotency_key == f"{logical_key}:g1"
             assert fresh_task.title == "feature: retitled"
+
+    @pytest.mark.unit
+    async def test_terminal_prior_reuses_canonical_key_from_loaded_adoption_history(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        logical_key = adoption_module.pr_adoption_idempotency_key(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            await session.commit()
+
+        async def _unexpected_family_lookup(
+            _self: WorkspaceRepository,
+            _logical_key: str,
+        ) -> list[str]:
+            raise AssertionError("adoption history should provide workspace idempotency keys")
+
+        monkeypatch.setattr(
+            WorkspaceRepository,
+            "list_idempotency_key_family",
+            _unexpected_family_lookup,
+        )
+
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.workspace_id != first.workspace_id
+
+        async with factory() as session:
+            fresh_workspace = await WorkspaceRepository(session).get(result.workspace_id)
+
+        assert fresh_workspace is not None
+        assert fresh_workspace.idempotency_key == logical_key
 
     @pytest.mark.unit
     async def test_concurrent_terminal_history_adoptions_create_one_live_monitor(
@@ -2190,22 +2248,12 @@ class TestPullRequestMonitorAdoptionService:
         assert task_attempt_selects == []
 
     @pytest.mark.unit
-    async def test_adoption_workspace_idempotency_key_prefetches_generation_family(
+    async def test_adoption_workspace_idempotency_key_uses_known_workspace_keys(
         self,
     ) -> None:
         class _WorkspaceRepo:
-            def __init__(self) -> None:
-                self.list_calls: list[str] = []
-
             async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
-                self.list_calls.append(logical_key)
-                return [
-                    logical_key,
-                    f"{logical_key}:g1",
-                    f"{logical_key}:g3",
-                    f"{logical_key}:g1000",
-                    f"{logical_key}:gignored",
-                ]
+                raise AssertionError(f"unexpected generation family lookup for {logical_key}")
 
             async def get_by_idempotency_key(self, key: str) -> object | None:
                 raise AssertionError(f"unexpected per-key lookup for {key}")
@@ -2215,19 +2263,29 @@ class TestPullRequestMonitorAdoptionService:
         key = await adoption_module._next_adoption_workspace_idempotency_key(
             repo,  # type: ignore[arg-type]
             logical_idempotency_key="pr-adopt:logical",
+            known_workspace_keys=[
+                "pr-adopt:logical",
+                "pr-adopt:logical:g1",
+                "pr-adopt:logical:g3",
+                "pr-adopt:logical:g1000",
+                "pr-adopt:logical:gignored",
+            ],
         )
 
         assert key == "pr-adopt:logical:g2"
-        assert repo.list_calls == ["pr-adopt:logical"]
 
     @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:
         class _ExhaustedWorkspaceRepo:
             async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
-                return [logical_key, *(f"{logical_key}:g{generation}" for generation in range(1, 1000))]
+                raise AssertionError(f"unexpected generation family lookup for {logical_key}")
 
         with pytest.raises(RuntimeError, match="fresh PR adoption workspace idempotency key"):
             await adoption_module._next_adoption_workspace_idempotency_key(
                 _ExhaustedWorkspaceRepo(),  # type: ignore[arg-type]
                 logical_idempotency_key="pr-adopt:exhausted",
+                known_workspace_keys=[
+                    "pr-adopt:exhausted",
+                    *(f"pr-adopt:exhausted:g{generation}" for generation in range(1, 1000)),
+                ],
             )

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -735,6 +735,75 @@ class TestPullRequestMonitorAdoptionService:
         assert result.auto_merge is True
 
     @pytest.mark.unit
+    async def test_terminal_prior_task_scope_change_supersedes_old_task_slot(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        logical_task_external_id = adoption_module._adoption_external_id(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: ready")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            await session.commit()
+
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(title="feature: retitled")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.workspace_id != first.workspace_id
+        assert result.task_id != first.task_id
+        assert result.attempt_id != first.attempt_id
+
+        async with factory() as session:
+            assert await _count(session, Task) == 2
+            old_task = await session.get(Task, first.task_id)
+            fresh_task = await session.get(Task, result.task_id)
+            fresh_workspace = await WorkspaceRepository(session).get(result.workspace_id)
+
+            assert old_task is not None
+            assert fresh_task is not None
+            assert fresh_workspace is not None
+            assert old_task.external_id == adoption_module._superseded_adoption_external_id(
+                external_id=logical_task_external_id,
+                workspace_id=first.workspace_id,
+            )
+            assert old_task.title == "feature: ready"
+            assert fresh_task.external_id == logical_task_external_id
+            assert fresh_task.title == "feature: retitled"
+            assert fresh_workspace.task_external_id == fresh_task.external_id
+            assert fresh_workspace.task_policy["pr_adoption"]["lineage"][
+                "previous_terminal_adoptions"
+            ] == [
+                {
+                    "workspace_id": first.workspace_id,
+                    "status": WorkspaceStatus.destroyed.value,
+                    "task_id": first.task_id,
+                    "attempt_id": first.attempt_id,
+                }
+            ]
+
+    @pytest.mark.unit
     async def test_concurrent_terminal_history_adoptions_create_one_live_monitor(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -867,6 +867,7 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task is not None
             assert old_workspace.idempotency_key is None
             assert old_task.idempotency_key == logical_key
+            assert fresh_workspace.idempotency_key == logical_key
             assert fresh_workspace.task_external_id == f"{logical_task_external_id}:g1"
             assert fresh_task.external_id == fresh_workspace.task_external_id
             assert fresh_task.idempotency_key == f"{logical_key}:g1"

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -16,6 +16,7 @@ from awf.common.github_client import (
     PullRequestMetadataError,
     RepoRef,
 )
+from awf.db import repositories as repository_module
 from awf.db.enums import OperationType, WorkspaceStatus
 from awf.db.models import (
     Operation,
@@ -34,6 +35,16 @@ from awf.service.pr_monitor_adoption import (
     PullRequestMonitorAdoptionService,
 )
 from tests.postgres import postgres_test_engine
+
+_LIVE_ADOPTION_STATUSES = {
+    WorkspaceStatus.requested.value,
+    WorkspaceStatus.provisioning.value,
+    WorkspaceStatus.ready.value,
+    WorkspaceStatus.running.value,
+    WorkspaceStatus.validating.value,
+    WorkspaceStatus.pushing.value,
+    WorkspaceStatus.monitoring_pr.value,
+}
 
 
 @pytest.fixture
@@ -126,6 +137,29 @@ def _canonical_key() -> str:
     return adoption_module.pr_adoption_idempotency_key(
         repo_slug="dimileeh/aira-web",
         pr_number=277,
+    )
+
+
+async def _adoption_workspaces(
+    session: AsyncSession,
+    *,
+    repo_slug: str = "dimileeh/aira-web",
+    pr_number: int = 277,
+) -> list[Workspace]:
+    task_external_id = adoption_module._adoption_external_id(
+        repo_slug=repo_slug,
+        pr_number=pr_number,
+    )
+    idempotency_key = adoption_module.pr_adoption_idempotency_key(
+        repo_slug=repo_slug,
+        pr_number=pr_number,
+    )
+    return await WorkspaceRepository(session).list_pr_adoption_history(
+        task_external_id=task_external_id,
+        idempotency_key=idempotency_key,
+        task_kind=adoption_module.PR_ADOPTION_TASK_KIND,
+        repo_slug=repo_slug,
+        pr_number=pr_number,
     )
 
 
@@ -522,6 +556,240 @@ class TestPullRequestMonitorAdoptionService:
             assert await _count(session, TaskAttempt) == 0
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "live_status",
+        [
+            WorkspaceStatus.requested.value,
+            WorkspaceStatus.monitoring_pr.value,
+        ],
+    )
+    async def test_replay_attaches_to_live_adoption_without_refetching_metadata(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        live_status: str,
+    ) -> None:
+        metadata = _metadata()
+        fetcher = _MetadataFetcher(metadata)
+
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(session, metadata_fetcher=fetcher)
+            first = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert workspace is not None
+            workspace.status = live_status
+
+            result = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is True
+        assert result.workspace_id == first.workspace_id
+        assert result.status == WorkspaceStatus(live_status)
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            assert await _count(session, Workspace) == 1
+            assert await _count(session, TaskAttempt) == 1
+            assert await _count(session, Operation) == 1
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "terminal_status",
+        [
+            WorkspaceStatus.destroyed.value,
+            WorkspaceStatus.cancelled.value,
+            WorkspaceStatus.failed.value,
+            "superseded",
+        ],
+    )
+    async def test_terminal_prior_adoption_creates_fresh_monitor_workspace(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        terminal_status: str,
+    ) -> None:
+        metadata = _metadata()
+        logical_key = adoption_module.pr_adoption_idempotency_key(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+        )
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(metadata),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            assert old_workspace.idempotency_key == logical_key
+            old_workspace.status = terminal_status
+            await session.commit()
+
+        fetcher = _MetadataFetcher(metadata)
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.workspace_id != first.workspace_id
+        assert result.status == WorkspaceStatus.requested
+        assert result.task_id != first.task_id
+        assert result.attempt_id != first.attempt_id
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            workspaces = await _adoption_workspaces(session)
+            assert len(workspaces) == 2
+            old = next(workspace for workspace in workspaces if workspace.id == first.workspace_id)
+            fresh = next(workspace for workspace in workspaces if workspace.id == result.workspace_id)
+            live_workspaces = [
+                workspace for workspace in workspaces if workspace.status in _LIVE_ADOPTION_STATUSES
+            ]
+            assert [workspace.id for workspace in live_workspaces] == [result.workspace_id]
+            assert old.status == terminal_status
+            assert old.idempotency_key is not None
+            assert old.idempotency_key.startswith(f"{logical_key}:superseded:")
+            assert fresh.status == WorkspaceStatus.requested.value
+            assert fresh.idempotency_key == logical_key
+            lineage = fresh.task_policy["pr_adoption"]["lineage"]
+            assert lineage["logical_idempotency_key"] == logical_key
+            assert lineage["previous_terminal_adoptions"] == [
+                {
+                    "workspace_id": first.workspace_id,
+                    "status": terminal_status,
+                    "task_id": first.task_id,
+                    "attempt_id": first.attempt_id,
+                }
+            ]
+            adoption_event = next(
+                event
+                for event in fresh.events
+                if event.event_type == "workspace.pr_monitor_adoption_requested"
+            )
+            assert adoption_event.payload["logical_idempotency_key"] == logical_key
+            assert adoption_event.payload["workspace_idempotency_key"] == fresh.idempotency_key
+            assert adoption_event.payload["previous_terminal_adoptions"] == [
+                {
+                    "workspace_id": first.workspace_id,
+                    "status": terminal_status,
+                    "task_id": first.task_id,
+                    "attempt_id": first.attempt_id,
+                }
+            ]
+
+    @pytest.mark.unit
+    async def test_terminal_prior_policy_mismatch_does_not_block_fresh_adoption(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=False,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            await session.commit()
+
+        async with factory() as session:
+            result = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=True,
+                )
+            )
+            await session.commit()
+
+        assert result.attached_existing is False
+        assert result.workspace_id != first.workspace_id
+        assert result.auto_merge is True
+
+    @pytest.mark.unit
+    async def test_concurrent_terminal_history_adoptions_create_one_live_monitor(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            await session.commit()
+
+        fetcher = _MetadataFetcher(_metadata())
+
+        async def _adopt_once() -> Any:
+            async with factory() as session:
+                result = await PullRequestMonitorAdoptionService(
+                    session,
+                    metadata_fetcher=fetcher,
+                ).adopt(
+                    PullRequestMonitorAdoptionRequest(
+                        repo_slug="dimileeh/aira-web",
+                        pr_number=277,
+                    )
+                )
+                await session.commit()
+                return result
+
+        first_result, second_result = await asyncio.gather(_adopt_once(), _adopt_once())
+
+        assert {first_result.workspace_id, second_result.workspace_id} != {first.workspace_id}
+        assert first_result.workspace_id == second_result.workspace_id
+        assert sorted(
+            [first_result.attached_existing, second_result.attached_existing],
+        ) == [False, True]
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            workspaces = await _adoption_workspaces(session)
+            live_workspaces = [
+                workspace for workspace in workspaces if workspace.status in _LIVE_ADOPTION_STATUSES
+            ]
+            assert len(workspaces) == 2
+            assert [workspace.id for workspace in live_workspaces] == [
+                first_result.workspace_id
+            ]
+
+    @pytest.mark.unit
     async def test_replay_with_changed_monitor_policy_conflicts(
         self,
         factory: async_sessionmaker[AsyncSession],
@@ -547,6 +815,11 @@ class TestPullRequestMonitorAdoptionService:
                 )
 
         assert excinfo.value.error_code == "PR_ADOPTION_POLICY_CONFLICT"
+        assert excinfo.value.detail == {
+            "workspace_id": excinfo.value.detail["workspace_id"],
+            "existing_auto_merge": False,
+            "requested_auto_merge": True,
+        }
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
@@ -1361,6 +1634,32 @@ class TestPullRequestMonitorAdoptionService:
         assert fetcher.calls == []
 
     @pytest.mark.unit
+    async def test_pr_url_rejects_unparseable_secondary_repo_identity_before_metadata_fetch(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        fetcher = _MetadataFetcher(_metadata())
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(session, metadata_fetcher=fetcher)
+            with pytest.raises(PRMonitorAdoptionError) as excinfo:
+                await service.adopt(
+                    PullRequestMonitorAdoptionRequest(
+                        pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                        repo_url="https://example.com/not/github",
+                    )
+                )
+
+            assert await _count(session, Workspace) == 0
+
+        assert excinfo.value.error_code == "INVALID_GITHUB_REPO"
+        assert excinfo.value.status_code == 422
+        assert excinfo.value.detail == {
+            "repo": "https://example.com/not/github",
+            "field": "repo_url",
+        }
+        assert fetcher.calls == []
+
+    @pytest.mark.unit
     async def test_invalid_repo_identity_raises_structured_input_error(
         self,
         factory: async_sessionmaker[AsyncSession],
@@ -1501,3 +1800,167 @@ class TestPullRequestMonitorAdoptionService:
         }
 
         assert {"PR_METADATA_FETCH_FAILED", "PR_METADATA_INVALID"} <= contract_codes
+
+    @pytest.mark.unit
+    def test_inline_profile_name_handles_missing_profile(self) -> None:
+        assert adoption_module._inline_profile_name(None) is None
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("workspace", "expected"),
+        [
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id="pr-adopt-external",
+                    idempotency_key=None,
+                    task_policy={},
+                ),
+                True,
+            ),
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id=None,
+                    idempotency_key="logical-key",
+                    task_policy={
+                        "pr_adoption": {
+                            "repo_slug": "DIMILEEH/AIRA-WEB",
+                            "pr_number": "277",
+                        }
+                    },
+                ),
+                True,
+            ),
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id=None,
+                    idempotency_key="logical-key",
+                    task_policy={},
+                ),
+                False,
+            ),
+            (
+                Workspace(
+                    task_kind="feature_branch_pr",
+                    task_external_id=None,
+                    idempotency_key="other-key",
+                    task_policy={
+                        "pr_adoption": {
+                            "repo_slug": "dimileeh/aira-web",
+                            "pr_number": 277,
+                        }
+                    },
+                ),
+                False,
+            ),
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id=None,
+                    idempotency_key="logical-key",
+                    task_policy={
+                        "pr_adoption": {
+                            "repo_slug": "dimileeh/aira-web",
+                            "pr_number": ["277"],
+                        }
+                    },
+                ),
+                False,
+            ),
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id=None,
+                    idempotency_key="logical-key",
+                    task_policy={
+                        "pr_adoption": {
+                            "repo_slug": "dimileeh/aira-web",
+                            "pr_number": "not-a-number",
+                        }
+                    },
+                ),
+                False,
+            ),
+            (
+                Workspace(
+                    task_kind="sync_feature_pr",
+                    task_external_id=None,
+                    idempotency_key="logical-key",
+                    task_policy={"pr_adoption": "legacy-bad-payload"},
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_pr_adoption_history_identity_matches_external_id_and_policy_fallback(
+        self,
+        workspace: Workspace,
+        expected: bool,
+    ) -> None:
+        assert (
+            repository_module._matches_pr_adoption_identity(
+                workspace,
+                task_external_id="pr-adopt-external",
+                idempotency_key="logical-key",
+                task_kind="sync_feature_pr",
+                repo_slug="dimileeh/aira-web",
+                pr_number=277,
+            )
+            is expected
+        )
+
+    @pytest.mark.unit
+    async def test_terminal_lineage_skips_live_adoption_candidates(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            )
+            first = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert old_workspace is not None
+            old_workspace.status = WorkspaceStatus.destroyed.value
+            fresh = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                )
+            )
+            fresh_workspace = await WorkspaceRepository(session).get(fresh.workspace_id)
+            assert fresh_workspace is not None
+
+            lineage = await adoption_module._terminal_adoption_lineage(
+                session,
+                [old_workspace, fresh_workspace],
+            )
+
+        assert lineage == [
+            {
+                "workspace_id": first.workspace_id,
+                "status": WorkspaceStatus.destroyed.value,
+                "task_id": first.task_id,
+                "attempt_id": first.attempt_id,
+            }
+        ]
+
+    @pytest.mark.unit
+    async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:
+        class _ExhaustedWorkspaceRepo:
+            async def get_by_idempotency_key(self, key: str) -> object:
+                return object()
+
+        with pytest.raises(RuntimeError, match="fresh PR adoption workspace idempotency key"):
+            await adoption_module._next_adoption_workspace_idempotency_key(
+                _ExhaustedWorkspaceRepo(),  # type: ignore[arg-type]
+                logical_idempotency_key="pr-adopt:exhausted",
+            )

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -956,10 +956,9 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task.title == "feature: retitled again"
 
     @pytest.mark.unit
-    async def test_terminal_prior_reuses_canonical_key_from_loaded_adoption_history(
+    async def test_terminal_prior_reuses_canonical_key_despite_unrelated_generated_key(
         self,
         factory: async_sessionmaker[AsyncSession],
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         logical_key = adoption_module.pr_adoption_idempotency_key(
             repo_slug="dimileeh/aira-web",
@@ -979,19 +978,17 @@ class TestPullRequestMonitorAdoptionService:
             old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
             assert old_workspace is not None
             old_workspace.status = WorkspaceStatus.destroyed.value
+            await WorkspaceRepository(session).create(
+                repo_url="git@github.com:dimileeh/unrelated.git",
+                branch_base="main",
+                task_title="unrelated stale adoption key",
+                task_prompt="stale key collision fixture",
+                task_external_id="unrelated-stale-adoption-key",
+                agent="codex",
+                test_commands=[],
+                idempotency_key=f"{logical_key}:g1",
+            )
             await session.commit()
-
-        async def _unexpected_family_lookup(
-            _self: WorkspaceRepository,
-            _logical_key: str,
-        ) -> list[str]:
-            raise AssertionError("adoption history should provide workspace idempotency keys")
-
-        monkeypatch.setattr(
-            WorkspaceRepository,
-            "list_idempotency_key_family",
-            _unexpected_family_lookup,
-        )
 
         async with factory() as session:
             result = await PullRequestMonitorAdoptionService(
@@ -2330,12 +2327,21 @@ class TestPullRequestMonitorAdoptionService:
         assert task_attempt_selects == []
 
     @pytest.mark.unit
-    async def test_adoption_workspace_idempotency_key_uses_known_workspace_keys(
+    async def test_adoption_workspace_idempotency_key_merges_known_keys_with_family(
         self,
     ) -> None:
         class _WorkspaceRepo:
+            calls: list[str]
+
+            def __init__(self) -> None:
+                self.calls = []
+
             async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
-                raise AssertionError(f"unexpected generation family lookup for {logical_key}")
+                self.calls.append(logical_key)
+                return [
+                    "pr-adopt:logical:g2",
+                    "pr-adopt:logical:g1000",
+                ]
 
             async def get_by_idempotency_key(self, key: str) -> object | None:
                 raise AssertionError(f"unexpected per-key lookup for {key}")
@@ -2352,15 +2358,18 @@ class TestPullRequestMonitorAdoptionService:
                 "pr-adopt:logical:g1000",
                 "pr-adopt:logical:gignored",
             ],
+            reserved_idempotency_keys=["pr-adopt:logical:g4"],
         )
 
-        assert key == "pr-adopt:logical:g2"
+        assert key == "pr-adopt:logical:g5"
+        assert repo.calls == ["pr-adopt:logical"]
 
     @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:
         class _ExhaustedWorkspaceRepo:
             async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
-                raise AssertionError(f"unexpected generation family lookup for {logical_key}")
+                assert logical_key == "pr-adopt:exhausted"
+                return []
 
         with pytest.raises(RuntimeError, match="fresh PR adoption workspace idempotency key"):
             await adoption_module._next_adoption_workspace_idempotency_key(

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -44,6 +44,7 @@ _LIVE_ADOPTION_STATUSES = {
     WorkspaceStatus.validating.value,
     WorkspaceStatus.pushing.value,
     WorkspaceStatus.monitoring_pr.value,
+    WorkspaceStatus.destroying.value,
 }
 
 
@@ -561,6 +562,7 @@ class TestPullRequestMonitorAdoptionService:
         [
             WorkspaceStatus.requested.value,
             WorkspaceStatus.monitoring_pr.value,
+            WorkspaceStatus.destroying.value,
         ],
     )
     async def test_replay_attaches_to_live_adoption_without_refetching_metadata(

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -2119,10 +2119,41 @@ class TestPullRequestMonitorAdoptionService:
         assert task_attempt_selects == []
 
     @pytest.mark.unit
+    async def test_adoption_workspace_idempotency_key_prefetches_generation_family(
+        self,
+    ) -> None:
+        class _WorkspaceRepo:
+            def __init__(self) -> None:
+                self.list_calls: list[str] = []
+
+            async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
+                self.list_calls.append(logical_key)
+                return [
+                    logical_key,
+                    f"{logical_key}:g1",
+                    f"{logical_key}:g3",
+                    f"{logical_key}:g1000",
+                    f"{logical_key}:gignored",
+                ]
+
+            async def get_by_idempotency_key(self, key: str) -> object | None:
+                raise AssertionError(f"unexpected per-key lookup for {key}")
+
+        repo = _WorkspaceRepo()
+
+        key = await adoption_module._next_adoption_workspace_idempotency_key(
+            repo,  # type: ignore[arg-type]
+            logical_idempotency_key="pr-adopt:logical",
+        )
+
+        assert key == "pr-adopt:logical:g2"
+        assert repo.list_calls == ["pr-adopt:logical"]
+
+    @pytest.mark.unit
     async def test_adoption_workspace_idempotency_key_exhaustion_is_explicit(self) -> None:
         class _ExhaustedWorkspaceRepo:
-            async def get_by_idempotency_key(self, key: str) -> object:
-                return object()
+            async def list_idempotency_key_family(self, logical_key: str) -> list[str]:
+                return [logical_key, *(f"{logical_key}:g{generation}" for generation in range(1, 1000))]
 
         with pytest.raises(RuntimeError, match="fresh PR adoption workspace idempotency key"):
             await adoption_module._next_adoption_workspace_idempotency_key(

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -31,21 +31,11 @@ from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.service import pr_monitor_adoption as adoption_module
 from awf.service.pr_monitor_adoption import (
+    _LIVE_ADOPTION_STATUSES,
     PRMonitorAdoptionError,
     PullRequestMonitorAdoptionService,
 )
 from tests.postgres import postgres_test_engine
-
-_LIVE_ADOPTION_STATUSES = {
-    WorkspaceStatus.requested.value,
-    WorkspaceStatus.provisioning.value,
-    WorkspaceStatus.ready.value,
-    WorkspaceStatus.running.value,
-    WorkspaceStatus.validating.value,
-    WorkspaceStatus.pushing.value,
-    WorkspaceStatus.monitoring_pr.value,
-    WorkspaceStatus.destroying.value,
-}
 
 
 @pytest.fixture

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -785,6 +785,7 @@ class TestPullRequestMonitorAdoptionService:
             assert old_task is not None
             assert fresh_task is not None
             assert fresh_workspace is not None
+            workspaces = await _adoption_workspaces(session)
             assert old_task.external_id == adoption_module._superseded_adoption_external_id(
                 external_id=logical_task_external_id,
                 workspace_id=first.workspace_id,
@@ -793,6 +794,10 @@ class TestPullRequestMonitorAdoptionService:
             assert fresh_task.external_id == logical_task_external_id
             assert fresh_task.title == "feature: retitled"
             assert fresh_workspace.task_external_id == fresh_task.external_id
+            assert [workspace.id for workspace in workspaces] == [
+                first.workspace_id,
+                result.workspace_id,
+            ]
             assert fresh_workspace.task_policy["pr_adoption"]["lineage"][
                 "previous_terminal_adoptions"
             ] == [

--- a/tests/unit/test_postgres_only_edges.py
+++ b/tests/unit/test_postgres_only_edges.py
@@ -385,7 +385,7 @@ async def test_postgres_context_helpers_lock_ddl_and_drop_after_metadata_dispose
             assert isinstance(yielded, str)
             assert schema_engine.disposed is True
 
-    metadata_lock_depth = 0
+    metadata_lock_depth = 0 if helper_name == "postgres_test_engine" else 1
     assert admin_engine.dispose_count == 1
     assert schema_engine.dispose_count == 1
     assert ("metadata", False, metadata_lock_depth) in events


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e5b86a598da842e0aaf50d1f` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Implement the P1 backlog slice "Harden PR monitor adoption when a previous repo/PR adoption workspace is terminal" from TODO/pre-gke-industrial-readiness.md.

Context and incident:
- An operator tried to adopt PR #206 after its previous AWF adoption workspace had been destroyed.
- AWF used the deterministic repo/PR adoption idempotency key and returned the old destroyed workspace as a successful attached_existing response.
- remonitor correctly rejected that destroyed workspace, so the operator had to manually clear the stale idempotency claim to create a new monitor.

Required behavior:
- Adoption must attach only to live adoption workspaces that can still monitor the PR.
- Terminal adoption rows such as destroyed, cancelled, failed, and superseded must not satisfy the deterministic repo/PR idempotency key as a successful monitor attachment.
- For an open PR with only terminal adoption history, AWF must create a fresh monitor workspace while preserving audit/lineage context and avoiding unique idempotency conflicts.
- Active monitor policy mismatches must still return PR_ADOPTION_POLICY_CONFLICT.
- Concurrent adoption attempts must create at most one live monitor.
- REST, CLI, and MCP-visible behavior must remain consistent and structured.

Engineering requirements:
- Use strict TDD: write failing regression tests first, then implement the smallest correct fix.
- No fake tests, empty assertions, monkeypatches that skip the behavior under test, or lowered validation/coverage/profile gates.
- Add focused unit coverage for destroyed, cancelled, failed, and superseded prior adoption rows; active idempotent reattach; active policy conflict; and concurrent adoption race behavior.
- Preserve 99%+ coverage and run focused validation first, then the broader Python/control-plane validation required by the touched surface.
- Keep changes scoped to the adoption service/API/CLI/MCP contract as needed; do not rewrite unrelated backlog or active ledger rows.
- Update TODO/pre-gke-industrial-readiness.md only with implementation-backed evidence for this slice.
- Commit changes and let AWF create and monitor the PR with auto_merge=true.

---
Validation: 5 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced PR monitor adoption to intelligently reattach to existing live monitoring workspaces when available, improving idempotency and adoption tracking.
  * Implemented fresh workspace creation when only historical adoption records exist, eliminating conflicts.

* **Bug Fixes**
  * Added validation for conflicting auto-merge policies with clear error responses (HTTP 409) when adoption policies mismatch.

* **Tests**
  * Expanded test coverage for adoption replay scenarios, terminal states, and concurrent adoption edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->