### PR TITLE
Adopt or preserve active executions after worker restart

### DIFF
--- a/docs/awf-plans/ws_13dd6ba7165141c285bd771e.md
+++ b/docs/awf-plans/ws_13dd6ba7165141c285bd771e.md
@@ -1,0 +1,155 @@
+# P1 Restart Recovery Plan: Preserve Live Agent Executions
+
+## Objective
+
+Make control-worker restart recovery stop treating healthy live agent runtimes as stale just because the new worker has an empty in-memory `_execution_tasks` map. For this slice, full reattachment to an already-running agent/validation/push process is not assumed safe because the original `WorkspaceExecutor.execute()` coroutine and subprocess handles are gone after process restart. The safe behavior will be to preserve the live runtime, worktree, logs, and diff, record a durable recovery decision, and leave the workspace recoverable for explicit operator retry/recovery without calling runtime cleanup.
+
+## Current Code Context
+
+- `src/awf/control/worker.py` currently lists active execution statuses (`running`, `validating`, `pushing`) as stale-active candidates when the execution claim is missing or expired and the workspace is not in `_execution_tasks`.
+- A live stack with a running `agent` service currently records `workspace.stale_active_execution_detected` on one scan and can call `_cleanup_and_fail_stale_active_execution()` on a later scan. That is the dangerous path to replace for healthy live agent runtimes.
+- `src/awf/service/workspace_runtime_health.py` can already classify missing/stopped/exited runtimes, but a healthy running agent returns no finding. The worker needs a separate restart-recovery decision for this case because the runtime is healthy but no longer owned by an in-process worker task.
+- Orphan reporting in `src/awf/service/orphan_resources.py` classifies resources for active workspace statuses as expected. Preserved active executions should stay out of ordinary orphan cleanup candidates.
+
+## Intended Files And Modules To Touch
+
+- `tests/unit/control/test_worker.py`
+  - Add strict TDD regressions for fresh-worker restart recovery of live `running`, `validating`, and `pushing` workspaces.
+  - Replace/update the existing stale live-stack expectation that currently fails the workspace after the second scan.
+  - Add multi-workspace coverage proving five healthy active workspaces are preserved and no runtime cleanup is invoked.
+  - Add no-container/truly orphaned, expired-claim, active-claim, cleanup-failure, and node-filter coverage around the same worker scan path.
+
+- `tests/unit/control/test_worker_coverage_edges.py`
+  - Add helper/payload edge coverage if new small helpers are introduced for preservation payloads, claim classification, or runtime-snapshot decisions.
+
+- `src/awf/control/worker.py`
+  - Add a distinct recovery decision for active execution candidates with a live running `agent` service and stale/missing execution ownership.
+  - Record a durable preservation event instead of `workspace.stale_active_execution_detected` for healthy live runtimes.
+  - Create a running or succeeded operation, likely `OperationType.refresh` unless a small enum extension is justified, with payload fields that make the decision auditable: source, owner, requested_action, reason_code, workspace status, previous claim, runtime snapshot, compose project/file, and preservation decision.
+  - Clear expired execution claims only as part of the preservation decision, or take a new short-lived worker claim if the implementation chooses durable ownership of the preserved state. Do not start a duplicate executor task.
+  - Keep `_cleanup_and_fail_stale_active_execution()` for truly stranded/no-container/exited-agent paths only, and add a guard so it never runs for a workspace that already has a preservation event for the same active status/runtime identity.
+
+- `src/awf/service/workspace_runtime_health.py`
+  - Extend runtime health vocabulary if needed with a preserved/recoverable decision for live executions that were preserved after worker restart.
+  - Add summary/count helpers only if metrics or runtime-health checks need to distinguish preserved live runtimes from stranded/fail candidates.
+
+- `src/awf/api/schemas.py`
+  - Update `WorkspaceRuntimeHealthResponse` literals if a new decision/status such as `preserve_runtime` or `preserved` is exposed through workspace detail/runtime endpoints.
+
+- `src/awf/service/workspaces.py`
+  - Surface the persisted preservation event in `WorkspaceResponse.runtime_health` and/or `subphase` so status/detail responses explain that the active runtime was preserved for operator recovery.
+
+- `src/awf/service/orphan_resources.py`
+  - Touch only if tests show preserved active workspaces are reported as cleanup candidates. The preferred outcome is no change: active statuses remain expected resources, while missing/terminal resources remain cleanup candidates.
+
+- `tests/unit/service/test_workspace_runtime_health.py`, `tests/unit/service/test_workspaces.py`, and `tests/unit/api/test_runtime.py`
+  - Add/update tests for any new runtime-health response vocabulary and persisted event rendering.
+
+- `TODO/pre-gke-industrial-readiness.md`
+  - Implementation phase only: update the backlog item after the code and validation evidence exist. Do not touch it during planning.
+
+## Tests To Write First
+
+1. `test_restart_recovery_preserves_live_running_agent_runtime_without_cleanup`
+   - Seed an active `running` workspace with stale or missing execution claim and a Docker snapshot containing a running healthy `agent` service.
+   - Run a fresh `ControlWorker` with empty `_execution_tasks`.
+   - Assert the workspace remains `running`, runtime cleaner has no calls, no `workspace.stale_active_execution_detected` event is written, and a new preservation event/operation records the runtime snapshot and previous claim state.
+
+2. `test_restart_recovery_preserves_live_validating_and_pushing_runtimes`
+   - Parametrize over `validating` and `pushing` with the same healthy agent snapshot.
+   - Assert no duplicate `execute()` dispatch, no cleanup, no failure transition, and preservation evidence includes the original active status.
+
+3. `test_restart_recovery_preserves_five_live_workspaces_after_worker_restart`
+   - Seed five active workspaces across `running`, `validating`, and `pushing`, all with healthy running `agent` containers and stale/missing claims.
+   - Run a new worker with `max_concurrent_executions=0` and empty task map.
+   - Assert all five remain active, all five have one preservation event/operation, inspector was called for each compose project, and cleaner was never called.
+
+4. `test_restart_recovery_skips_unexpired_execution_claim`
+   - Keep or extend existing coverage proving a workspace with an active future execution claim is not inspected, not preserved by the new worker, and not cleaned up.
+
+5. `test_restart_recovery_preserves_expired_claim_with_live_container`
+   - Seed an expired `execution_claimed_by` and healthy live agent snapshot.
+   - Assert expired claim handling is explicit in the preservation payload, and the workspace is not failed or cleaned.
+
+6. `test_restart_recovery_no_container_remains_cleanup_or_recovery_candidate`
+   - Seed active `running`/`validating`/`pushing` workspaces with compose metadata but no containers.
+   - Assert current stranded behavior still applies: retry-policy rows record recoverable stranding, non-retry rows can fail/preserve evidence without live-runtime preservation, and no false live-preserved event is created.
+
+7. `test_restart_recovery_exited_or_missing_agent_is_not_live_preserved`
+   - Cover missing-agent and exited-agent snapshots to ensure they remain runtime-stranding/failure or retry-policy candidates, not healthy live preservation.
+
+8. `test_cleanup_failure_path_does_not_target_preserved_live_runtime`
+   - Seed a workspace that already has the preservation event and a healthy live agent snapshot.
+   - Run another scan and assert `_cleanup_and_fail_stale_active_execution()` is not reached. Keep existing cleanup-failure coverage for genuinely stale/stranded cleanup paths.
+
+9. `test_workspace_detail_and_runtime_endpoint_surface_preserved_runtime_decision`
+   - After a preservation event, assert `WorkspaceService.get()` and, if vocabulary changes, `/runtime` response show a clear reason code/decision and runtime services without reporting the workspace as an ordinary orphan or failed stranding.
+
+10. `test_orphan_summary_keeps_preserved_active_resources_expected`
+    - Build an orphan summary with a preserved active workspace and live containers/worktree.
+    - Assert resources remain `expected`, not `terminal` or `missing`, and cleanup readiness is not blocked by the preserved active runtime alone.
+
+## Implementation Outline
+
+1. Add the worker red tests first and confirm the existing implementation records stale-active events and/or invokes cleanup for healthy live runtimes.
+2. Introduce worker-level constants such as `ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART` and `workspace.active_execution_preserved_after_restart`.
+3. Add a small helper that identifies a healthy live agent runtime from `RuntimeSnapshot`: `stack_state == "running"` and an `agent` service with `state == "running"`. Treat missing/exited agent and no-container snapshots as stranded, not preserved.
+4. In `_recover_stale_active_execution()`, after runtime inspection and stranded classification, branch healthy live agent snapshots to a new `_record_preserved_active_execution_after_restart()` path before any stale-active event/cleanup logic.
+5. In the preservation recorder, re-read the row in the same transaction and require: same workspace status, active execution status, stale/missing execution claim at the current cutoff, and no prior preservation event for the same recovery reason/status. Then record the event and operation, set a clear `subphase` such as `runtime_preserved_after_restart`, and clear only expired/missing execution claims if tests establish that this improves operator clarity without implying duplicate execution ownership.
+6. Keep the active workspace status unchanged for this slice. This avoids schema churn and keeps orphan cleanup from treating live resources as terminal or missing. The recoverable/preserved state is surfaced through event, operation, subphase, and runtime-health response.
+7. Update existing stale-active cleanup checks so a preserved live runtime is idempotent across repeated scans and never escalates to `compose down` merely because a previous scan recorded recovery evidence.
+8. Extend `WorkspaceRuntimeHealthResponse` and `_workspace_runtime_health_from_events()` only as far as needed to render the persisted preservation event. If adding a new status would force broad API churn, expose it as `status="ok"`, `reason_code="ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"`, and a new decision literal `preserve_runtime`.
+9. Keep truly orphaned/no-container cases on the existing runtime-stranding path, preserving retry-policy/remonitor behavior and cleanup-failure evidence.
+10. After implementation and validation, update `TODO/pre-gke-industrial-readiness.md` with the exact test and validation evidence, then commit locally. AWF will handle push and PR creation.
+
+## Validation Commands
+
+Focused worker/runtime surface first:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_worker.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_worker_coverage_edges.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_workspace_runtime_health.py tests/unit/service/test_workspaces.py tests/unit/service/test_orphan_resources.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/api/test_runtime.py -q
+```
+
+Repository-required validation:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest tests/unit -q
+python scripts/generate_openapi.py --check
+```
+
+Coverage/profile validation if the implementation touches shared runtime health, API schema, or worker recovery broadly:
+
+```bash
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+```
+
+## Risks
+
+- Full live adoption is risky because the restarted worker cannot recover the original Python coroutine, subprocess handles, or exact executor phase continuation. Preserving the runtime is safer and matches the acceptance fallback.
+- Keeping the workspace in `running`/`validating`/`pushing` while marking `subphase=runtime_preserved_after_restart` is pragmatic but may need a future first-class status if operators need queue semantics beyond explicit retry/recovery.
+- Expired claim handling must not create a false owner that implies AWF is still driving the agent process. Payload wording and optional claim clearing must distinguish preserved evidence from duplicate execution ownership.
+- Existing tests expect live stale-active stacks to fail on a later scan. Those tests must be deliberately updated, not deleted, so they assert the new no-cleanup invariant.
+- Runtime-health API literals are strict. Adding a new status/decision will require coordinated schema and API test updates.
+- The advisory overlap is on `TODO/pre-gke-industrial-readiness.md`, not the likely implementation files. The backlog file should only be updated after implementation-backed evidence exists.
+
+## Assumptions
+
+- A running `agent` service in a running compose stack is the minimum safe signal for live execution preservation.
+- AWF cannot safely infer that validation or push completed after the worker restart unless the normal executor/monitor path persisted that state before the crash.
+- Active statuses should continue to make Docker containers/worktrees expected resources in orphan reporting.
+- Existing `WorkspaceEvent` and `Operation` tables are sufficient for auditability; no migration is expected for this slice.
+- Operator recovery can use existing retry/remonitor/control surfaces once the preserved state is visible. A new explicit adopt/resume API is out of scope unless tests prove existing surfaces cannot represent recovery.
+
+## Explicit Non-Goals
+
+- No branch switching, pushing, rebasing, force-pushing, or PR creation by the agent.
+- No implementation work during this planning phase.
+- No Docker lifecycle cleanup for healthy live agent runtimes as part of restart recovery.
+- No attempt to attach to an already-running CLI subprocess or continue validation/push from an unknown in-memory phase.
+- No broad scheduler, state-machine, or migration refactor unless the red tests prove the event/subphase/runtime-health approach cannot satisfy the contract.
+- No console UI changes in this slice beyond existing API/status fields surfacing the new event-derived state.

--- a/openapi.json
+++ b/openapi.json
@@ -9799,7 +9799,8 @@
               "none",
               "fail_workspace",
               "remonitor_workspace",
-              "defer_retry_policy"
+              "defer_retry_policy",
+              "preserve_runtime"
             ],
             "title": "Decision",
             "type": "string"

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -471,6 +471,7 @@ class WorkspaceRuntimeHealthResponse(BaseModel):
         "fail_workspace",
         "remonitor_workspace",
         "defer_retry_policy",
+        "preserve_runtime",
     ]
     message: str
     services: list[dict[str, str]] = Field(default_factory=list)

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -92,6 +92,9 @@ _ACTIVE_EXECUTION_PRESERVED_SUBPHASE = "runtime_preserved_after_restart"
 _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE = (
     "STALE_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
+_ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_CLEARED_REASON_CODE = (
+    "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+)
 _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
     "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
@@ -678,10 +681,7 @@ class ControlWorker:
                             WorkspaceStatus.ready.value,
                         ]
                     ),
-                    and_(
-                        Workspace.status.in_(active_execution_values),
-                        _stale_execution_claim_filter(claim_cutoff),
-                    ),
+                    Workspace.status.in_(active_execution_values),
                     and_(
                         Workspace.status == WorkspaceStatus.monitoring_pr.value,
                         _stale_monitor_claim_filter(claim_cutoff),
@@ -860,8 +860,6 @@ class ControlWorker:
             ws = await repo.get_for_update(candidate.workspace_id)
             if ws is None or ws.status != candidate.status.value:
                 return
-            if not _execution_claim_is_stale(ws, now):
-                return
             if await self._has_operator_refresh_after_latest_preservation_for_workspace(
                 session,
                 ws,
@@ -886,7 +884,7 @@ class ControlWorker:
                 ws,
                 claim_cutoff=now,
             )
-            if claim_cleanup["action"] == "cleared_stale":
+            if claim_cleanup["action"] in {"cleared_stale", "cleared_unexpired"}:
                 ws.execution_claimed_by = None
                 ws.execution_claim_expires_at = None
             ws.subphase = _ACTIVE_EXECUTION_PRESERVED_SUBPHASE
@@ -1959,7 +1957,11 @@ def _active_execution_preservation_claim_cleanup_payload(
         return payload
 
     if not _execution_claim_is_stale(workspace, claim_cutoff):
-        raise ValueError("active execution preservation cleanup requires a stale execution claim")
+        return {
+            **payload,
+            "action": "cleared_unexpired",
+            "reason_code": _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_CLEARED_REASON_CODE,
+        }
 
     return {
         **payload,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -925,6 +925,7 @@ class ControlWorker:
                 ws,
                 candidate.status,
                 include_operator_refresh=False,
+                include_execution_claim_expiry=False,
             )
             latest_refresh = await self._latest_operator_refresh_requested_at(
                 session,
@@ -1040,9 +1041,10 @@ class ControlWorker:
         status: WorkspaceStatus,
         *,
         include_operator_refresh: bool = True,
+        include_execution_claim_expiry: bool = True,
     ) -> datetime | None:
         floors: list[datetime] = []
-        if workspace.execution_claim_expires_at is not None:
+        if include_execution_claim_expiry and workspace.execution_claim_expires_at is not None:
             floors.append(_utc_datetime(workspace.execution_claim_expires_at))
 
         stmt = (

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -54,6 +54,8 @@ from awf.service.scheduler import (
 )
 from awf.service.secret_leases import SecretLeaseService
 from awf.service.workspace_runtime_health import (
+    ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+    ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
     RUNTIME_STRANDED_EVENT_TYPE,
     RuntimeWorkspace,
     WorkspaceRuntimeFinding,
@@ -84,6 +86,18 @@ _STALE_ACTIVE_EXECUTION_CLEANUP_FAILED_EVENT_TYPE = (
     "workspace.stale_active_execution_cleanup_failed"
 )
 _STALE_ACTIVE_EXECUTION_CLEANUP_FAILED_REASON_CODE = "STALE_ACTIVE_EXECUTION_CLEANUP_FAILED"
+_ACTIVE_EXECUTION_PRESERVED_SOURCE = "worker_restart"
+_ACTIVE_EXECUTION_PRESERVED_OWNER = "control_worker"
+_ACTIVE_EXECUTION_PRESERVED_SUBPHASE = "runtime_preserved_after_restart"
+_ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE = (
+    "STALE_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+)
+_ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
+    "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
+)
+_ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_REASON_CODE = (
+    "UNEXPIRED_EXECUTION_CLAIM_PRESERVED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+)
 _MONITOR_RECOVERY_REASON_CODE = "MONITOR_RECOVERY_AFTER_RESTART"
 _MONITOR_RECOVERY_EVENT_TYPE = "workspace.monitor_recovery_started"
 _MONITOR_RECOVERY_SOURCE = "worker_restart"
@@ -752,6 +766,9 @@ class ControlWorker:
         if finding is not None and finding.decision == "defer_retry_policy":
             await self._record_recoverable_runtime_stranding(candidate, snapshot, finding)
             return
+        if candidate.status in _ACTIVE_EXECUTION_STATUSES and _has_running_agent_runtime(snapshot):
+            await self._record_preserved_active_execution_after_restart(candidate, snapshot)
+            return
         if candidate.compose_project_name and snapshot.stack_state == "running":
             if not await self._record_stale_active_execution_detected(
                 candidate,
@@ -814,6 +831,90 @@ class ControlWorker:
         )
         return (await session.execute(stmt)).scalar_one_or_none() is not None
 
+    async def _record_preserved_active_execution_after_restart(
+        self,
+        candidate: _ActiveExecutionCandidate,
+        snapshot: RuntimeSnapshot,
+    ) -> None:
+        now = datetime.now(UTC)
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            if ws is None or ws.status != candidate.status.value:
+                return
+            if not _execution_claim_is_stale(ws, now):
+                return
+            if await self._has_preserved_active_execution_event(
+                session,
+                candidate.workspace_id,
+            ):
+                return
+
+            previous_claim = _workspace_claim_snapshot(ws)
+            claim_cleanup = _active_execution_preservation_claim_cleanup_payload(
+                ws,
+                claim_cutoff=now,
+            )
+            if claim_cleanup["action"] == "cleared_stale":
+                ws.execution_claimed_by = None
+                ws.execution_claim_expires_at = None
+            ws.subphase = _ACTIVE_EXECUTION_PRESERVED_SUBPHASE
+            ws.version += 1
+            payload = _active_execution_preservation_payload(
+                candidate,
+                snapshot,
+                worker_id=self._worker_id,
+                previous_claim=previous_claim,
+                claim_cleanup=claim_cleanup,
+            )
+            operation = await OperationRepository(session).create(
+                workspace_id=candidate.workspace_id,
+                operation_type=OperationType.refresh,
+                status=OperationStatus.running,
+                payload=payload,
+            )
+            payload_with_operation = {**payload, "operation_id": operation.id}
+            operation.payload = payload_with_operation
+            await OperationRepository(session).finish(
+                operation,
+                status=OperationStatus.succeeded,
+                result={
+                    "decision": "preserve_runtime",
+                    "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+                },
+            )
+            await repo.add_event(
+                ws,
+                event_type=ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+                reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+                payload=payload_with_operation,
+            )
+            await session.commit()
+
+        _log.warning(
+            ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+            workspace_id=candidate.workspace_id,
+            status=candidate.status.value,
+            compose_project_name=candidate.compose_project_name,
+            reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+        )
+
+    async def _has_preserved_active_execution_event(
+        self,
+        session: AsyncSession,
+        workspace_id: str,
+    ) -> bool:
+        stmt = (
+            select(WorkspaceEvent.id)
+            .where(
+                WorkspaceEvent.workspace_id == workspace_id,
+                WorkspaceEvent.event_type == ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+                WorkspaceEvent.reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+            )
+            .limit(1)
+        )
+        return (await session.execute(stmt)).scalar_one_or_none() is not None
+
     async def _cleanup_and_fail_stale_active_execution(
         self,
         candidate: _ActiveExecutionCandidate,
@@ -865,6 +966,11 @@ class ControlWorker:
             if ws is None or ws.status != candidate.status.value:
                 return False
             if not _execution_claim_is_stale(ws, datetime.now(UTC)):
+                return False
+            if await self._has_preserved_active_execution_event(
+                session,
+                candidate.workspace_id,
+            ):
                 return False
             return await self._has_stale_active_execution_event(
                 session,
@@ -1621,12 +1727,51 @@ def _runtime_workspace(candidate: _ActiveExecutionCandidate) -> RuntimeWorkspace
     )
 
 
+def _has_running_agent_runtime(snapshot: RuntimeSnapshot) -> bool:
+    if snapshot.stack_state != "running":
+        return False
+    return any(
+        service.name.lower() == "agent" and service.state.lower() == "running"
+        for service in snapshot.services
+    )
+
+
 def _workspace_claim_snapshot(workspace: Workspace) -> dict[str, str | None]:
     return {
         "monitor_claimed_by": workspace.monitor_claimed_by,
         "monitor_claim_expires_at": _json_datetime(workspace.monitor_claim_expires_at),
         "execution_claimed_by": workspace.execution_claimed_by,
         "execution_claim_expires_at": _json_datetime(workspace.execution_claim_expires_at),
+    }
+
+
+def _active_execution_preservation_claim_cleanup_payload(
+    workspace: Workspace,
+    *,
+    claim_cutoff: datetime,
+) -> dict[str, str | None]:
+    previous_claimed_by = workspace.execution_claimed_by
+    previous_expires_at = _json_datetime(workspace.execution_claim_expires_at)
+    payload = {
+        "action": "none",
+        "reason_code": _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE,
+        "previous_claimed_by": previous_claimed_by,
+        "previous_expires_at": previous_expires_at,
+    }
+    if previous_claimed_by is None and workspace.execution_claim_expires_at is None:
+        return payload
+
+    if _execution_claim_is_stale(workspace, claim_cutoff):
+        return {
+            **payload,
+            "action": "cleared_stale",
+            "reason_code": _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE,
+        }
+
+    return {
+        **payload,
+        "action": "preserved_unexpired",
+        "reason_code": _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_REASON_CODE,
     }
 
 
@@ -1748,6 +1893,36 @@ def _runtime_snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:
             }
             for service in snapshot.services
         ],
+    }
+
+
+def _active_execution_preservation_payload(
+    candidate: _ActiveExecutionCandidate,
+    snapshot: RuntimeSnapshot,
+    *,
+    worker_id: str,
+    previous_claim: dict[str, str | None],
+    claim_cleanup: dict[str, str | None],
+) -> dict[str, Any]:
+    return {
+        "owner": _ACTIVE_EXECUTION_PRESERVED_OWNER,
+        "source": _ACTIVE_EXECUTION_PRESERVED_SOURCE,
+        "requested_action": OperationType.refresh.value,
+        "reason": (
+            "Worker restart found a persisted active execution with a live running "
+            "agent runtime. AWF preserved the runtime for explicit operator recovery "
+            "instead of starting a duplicate execution or stopping the compose stack."
+        ),
+        "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+        "decision": "preserve_runtime",
+        "workspace_status": candidate.status.value,
+        "subphase": _ACTIVE_EXECUTION_PRESERVED_SUBPHASE,
+        "compose_project_name": candidate.compose_project_name,
+        "compose_file_path": candidate.compose_file_path,
+        "worker_id": worker_id,
+        "previous_claim": previous_claim,
+        "claim_cleanup": claim_cleanup,
+        "runtime": _runtime_snapshot_payload(snapshot),
     }
 
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1901,15 +1901,17 @@ def _active_execution_preservation_payload(
     previous_claim: dict[str, str | None],
     claim_cleanup: dict[str, str | None],
 ) -> dict[str, Any]:
+    message = (
+        "Worker restart found a persisted active execution with a live running "
+        "agent runtime. AWF preserved the runtime for explicit operator recovery "
+        "instead of starting a duplicate execution or stopping the compose stack."
+    )
     return {
         "owner": _ACTIVE_EXECUTION_PRESERVED_OWNER,
         "source": _ACTIVE_EXECUTION_PRESERVED_SOURCE,
         "requested_action": OperationType.refresh.value,
-        "reason": (
-            "Worker restart found a persisted active execution with a live running "
-            "agent runtime. AWF preserved the runtime for explicit operator recovery "
-            "instead of starting a duplicate execution or stopping the compose stack."
-        ),
+        "reason": message,
+        "message": message,
         "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
         "decision": "preserve_runtime",
         "workspace_status": candidate.status.value,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -94,8 +94,8 @@ _ACTIVE_EXECUTION_PRESERVED_SUBPHASE = "runtime_preserved_after_restart"
 _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE = (
     "STALE_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
-_ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_CLEARED_REASON_CODE = (
-    "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+_ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_PRESERVED_REASON_CODE = (
+    "UNEXPIRED_EXECUTION_CLAIM_PRESERVED_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
 _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
     "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
@@ -681,7 +681,10 @@ class ControlWorker:
                             WorkspaceStatus.ready.value,
                         ]
                     ),
-                    Workspace.status.in_(active_execution_values),
+                    and_(
+                        Workspace.status.in_(active_execution_values),
+                        _stale_execution_claim_filter(claim_cutoff),
+                    ),
                     and_(
                         Workspace.status == WorkspaceStatus.monitoring_pr.value,
                         _stale_monitor_claim_filter(claim_cutoff),
@@ -860,6 +863,8 @@ class ControlWorker:
             ws = await repo.get_for_update(candidate.workspace_id)
             if ws is None or ws.status != candidate.status.value:
                 return
+            if not _execution_claim_is_stale(ws, now):
+                return
             if await self._has_operator_refresh_after_latest_preservation_for_workspace(
                 session,
                 ws,
@@ -884,7 +889,7 @@ class ControlWorker:
                 ws,
                 claim_cutoff=now,
             )
-            if claim_cleanup["action"] in {"cleared_stale", "cleared_unexpired"}:
+            if claim_cleanup["action"] == "cleared_stale":
                 ws.execution_claimed_by = None
                 ws.execution_claim_expires_at = None
             ws.subphase = _ACTIVE_EXECUTION_PRESERVED_SUBPHASE
@@ -1959,8 +1964,8 @@ def _active_execution_preservation_claim_cleanup_payload(
     if not _execution_claim_is_stale(workspace, claim_cutoff):
         return {
             **payload,
-            "action": "cleared_unexpired",
-            "reason_code": _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_CLEARED_REASON_CODE,
+            "action": "preserved_unexpired",
+            "reason_code": _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_PRESERVED_REASON_CODE,
         }
 
     return {

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -849,6 +849,12 @@ class ControlWorker:
                 return
             if not _execution_claim_is_stale(ws, now):
                 return
+            if await self._has_operator_refresh_after_latest_preservation_for_workspace(
+                session,
+                ws,
+                candidate.status,
+            ):
+                return
             event_floor = await self._active_execution_preservation_event_floor(
                 session,
                 ws,
@@ -920,29 +926,41 @@ class ControlWorker:
             ws = await repo.get(candidate.workspace_id)
             if ws is None or ws.status != candidate.status.value:
                 return False
-            event_floor = await self._active_execution_preservation_event_floor(
+            return await self._has_operator_refresh_after_latest_preservation_for_workspace(
                 session,
                 ws,
                 candidate.status,
-                include_operator_refresh=False,
-                include_execution_claim_expiry=False,
             )
-            latest_refresh = await self._latest_operator_refresh_requested_at(
-                session,
-                candidate.workspace_id,
-                event_floor=event_floor,
-            )
-            if latest_refresh is None:
-                return False
-            latest_preservation = await self._latest_preserved_active_execution_at(
-                session,
-                candidate.workspace_id,
-                candidate.status,
-                event_floor=event_floor,
-            )
-            if latest_preservation is None:
-                return True
-            return _utc_datetime(latest_refresh) >= _utc_datetime(latest_preservation)
+
+    async def _has_operator_refresh_after_latest_preservation_for_workspace(
+        self,
+        session: AsyncSession,
+        workspace: Workspace,
+        status: WorkspaceStatus,
+    ) -> bool:
+        event_floor = await self._active_execution_preservation_event_floor(
+            session,
+            workspace,
+            status,
+            include_operator_refresh=False,
+            include_execution_claim_expiry=False,
+        )
+        latest_refresh = await self._latest_operator_refresh_requested_at(
+            session,
+            workspace.id,
+            event_floor=event_floor,
+        )
+        if latest_refresh is None:
+            return False
+        latest_preservation = await self._latest_preserved_active_execution_at(
+            session,
+            workspace.id,
+            status,
+            event_floor=event_floor,
+        )
+        if latest_preservation is None:
+            return True
+        return _utc_datetime(latest_refresh) >= _utc_datetime(latest_preservation)
 
     async def _has_current_preserved_active_execution(
         self,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -916,19 +916,19 @@ class ControlWorker:
         candidate: _ActiveExecutionCandidate,
     ) -> bool:
         async with self._session_factory() as session:
-            latest_preservation = await self._latest_preserved_active_execution_at(
-                session,
-                candidate.workspace_id,
-                candidate.status,
-            )
-            if latest_preservation is None:
-                return False
             latest_refresh = await self._latest_operator_refresh_requested_at(
                 session,
                 candidate.workspace_id,
             )
             if latest_refresh is None:
                 return False
+            latest_preservation = await self._latest_preserved_active_execution_at(
+                session,
+                candidate.workspace_id,
+                candidate.status,
+            )
+            if latest_preservation is None:
+                return True
             return _utc_datetime(latest_refresh) >= _utc_datetime(latest_preservation)
 
     async def _has_current_preserved_active_execution(

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -972,7 +972,7 @@ class ControlWorker:
             event_floor=event_floor,
         )
         if latest_preservation is None:
-            return True
+            return False
         return _utc_datetime(latest_refresh) >= _utc_datetime(latest_preservation)
 
     async def _has_current_preserved_active_execution(

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -916,9 +916,20 @@ class ControlWorker:
         candidate: _ActiveExecutionCandidate,
     ) -> bool:
         async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            if ws is None or ws.status != candidate.status.value:
+                return False
+            event_floor = await self._active_execution_preservation_event_floor(
+                session,
+                ws,
+                candidate.status,
+                include_operator_refresh=False,
+            )
             latest_refresh = await self._latest_operator_refresh_requested_at(
                 session,
                 candidate.workspace_id,
+                event_floor=event_floor,
             )
             if latest_refresh is None:
                 return False
@@ -926,6 +937,7 @@ class ControlWorker:
                 session,
                 candidate.workspace_id,
                 candidate.status,
+                event_floor=event_floor,
             )
             if latest_preservation is None:
                 return True
@@ -982,6 +994,8 @@ class ControlWorker:
         session: AsyncSession,
         workspace_id: str,
         status: WorkspaceStatus,
+        *,
+        event_floor: datetime | None = None,
     ) -> datetime | None:
         stmt = (
             select(WorkspaceEvent.occurred_at)
@@ -994,12 +1008,16 @@ class ControlWorker:
             .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
             .limit(1)
         )
+        if event_floor is not None:
+            stmt = stmt.where(WorkspaceEvent.occurred_at >= event_floor)
         return (await session.execute(stmt)).scalar_one_or_none()
 
     async def _latest_operator_refresh_requested_at(
         self,
         session: AsyncSession,
         workspace_id: str,
+        *,
+        event_floor: datetime | None = None,
     ) -> datetime | None:
         stmt = (
             select(WorkspaceEvent.occurred_at)
@@ -1011,6 +1029,8 @@ class ControlWorker:
             .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
             .limit(1)
         )
+        if event_floor is not None:
+            stmt = stmt.where(WorkspaceEvent.occurred_at >= event_floor)
         return (await session.execute(stmt)).scalar_one_or_none()
 
     async def _active_execution_preservation_event_floor(
@@ -1018,6 +1038,8 @@ class ControlWorker:
         session: AsyncSession,
         workspace: Workspace,
         status: WorkspaceStatus,
+        *,
+        include_operator_refresh: bool = True,
     ) -> datetime | None:
         floors: list[datetime] = []
         if workspace.execution_claim_expires_at is not None:
@@ -1039,12 +1061,13 @@ class ControlWorker:
 
         # An operator refresh is an explicit recovery request for preserved runtime.
         # Preservation evidence older than that request must not keep scans skipped.
-        refresh_requested_at = await self._latest_operator_refresh_requested_at(
-            session,
-            workspace.id,
-        )
-        if refresh_requested_at is not None:
-            floors.append(_utc_datetime(refresh_requested_at))
+        if include_operator_refresh:
+            refresh_requested_at = await self._latest_operator_refresh_requested_at(
+                session,
+                workspace.id,
+            )
+            if refresh_requested_at is not None:
+                floors.append(_utc_datetime(refresh_requested_at))
 
         return max(floors) if floors else None
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -841,10 +841,16 @@ class ControlWorker:
                 return
             if not _execution_claim_is_stale(ws, now):
                 return
+            event_floor = await self._active_execution_preservation_event_floor(
+                session,
+                ws,
+                candidate.status,
+            )
             if await self._has_preserved_active_execution_event(
                 session,
                 candidate.workspace_id,
                 candidate.status,
+                event_floor=event_floor,
             ):
                 return
 
@@ -902,6 +908,8 @@ class ControlWorker:
         session: AsyncSession,
         workspace_id: str,
         status: WorkspaceStatus,
+        *,
+        event_floor: datetime | None = None,
     ) -> bool:
         stmt = (
             select(WorkspaceEvent.id)
@@ -913,7 +921,35 @@ class ControlWorker:
             )
             .limit(1)
         )
+        if event_floor is not None:
+            stmt = stmt.where(WorkspaceEvent.occurred_at >= event_floor)
         return (await session.execute(stmt)).scalar_one_or_none() is not None
+
+    async def _active_execution_preservation_event_floor(
+        self,
+        session: AsyncSession,
+        workspace: Workspace,
+        status: WorkspaceStatus,
+    ) -> datetime | None:
+        floors: list[datetime] = []
+        if workspace.execution_claim_expires_at is not None:
+            floors.append(_utc_datetime(workspace.execution_claim_expires_at))
+
+        stmt = (
+            select(WorkspaceEvent.occurred_at)
+            .where(
+                WorkspaceEvent.workspace_id == workspace.id,
+                WorkspaceEvent.event_type == "workspace.state_changed",
+                WorkspaceEvent.new_state == status.value,
+            )
+            .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
+            .limit(1)
+        )
+        status_started_at = (await session.execute(stmt)).scalar_one_or_none()
+        if status_started_at is not None:
+            floors.append(_utc_datetime(status_started_at))
+
+        return max(floors) if floors else None
 
     async def _cleanup_and_fail_stale_active_execution(
         self,
@@ -967,10 +1003,16 @@ class ControlWorker:
                 return False
             if not _execution_claim_is_stale(ws, datetime.now(UTC)):
                 return False
+            event_floor = await self._active_execution_preservation_event_floor(
+                session,
+                ws,
+                candidate.status,
+            )
             if await self._has_preserved_active_execution_event(
                 session,
                 candidate.workspace_id,
                 candidate.status,
+                event_floor=event_floor,
             ):
                 return False
             return await self._has_stale_active_execution_event(
@@ -1871,6 +1913,12 @@ def _json_datetime(value: datetime | None) -> str | None:
     if value.tzinfo is None:
         value = value.replace(tzinfo=UTC)
     return value.isoformat()
+
+
+def _utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _runtime_snapshot_payload(snapshot: RuntimeSnapshot) -> dict[str, Any]:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1079,7 +1079,9 @@ class ControlWorker:
     ) -> datetime | None:
         floors: list[datetime] = []
         if include_execution_claim_expiry and workspace.execution_claim_expires_at is not None:
-            floors.append(_utc_datetime(workspace.execution_claim_expires_at))
+            claim_floor = _utc_datetime(workspace.execution_claim_expires_at)
+            if claim_floor <= datetime.now(UTC):
+                floors.append(claim_floor)
 
         stmt = (
             select(WorkspaceEvent.occurred_at)

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -95,6 +95,8 @@ _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE = (
 _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
     "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
+_OPERATOR_REFRESH_EVENT_TYPE = "workspace.refresh_requested"
+_OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 _MONITOR_RECOVERY_REASON_CODE = "MONITOR_RECOVERY_AFTER_RESTART"
 _MONITOR_RECOVERY_EVENT_TYPE = "workspace.monitor_recovery_started"
 _MONITOR_RECOVERY_SOURCE = "worker_restart"
@@ -974,6 +976,22 @@ class ControlWorker:
         status_started_at = (await session.execute(stmt)).scalar_one_or_none()
         if status_started_at is not None:
             floors.append(_utc_datetime(status_started_at))
+
+        # An operator refresh is an explicit recovery request for preserved runtime.
+        # Preservation evidence older than that request must not keep scans skipped.
+        stmt = (
+            select(WorkspaceEvent.occurred_at)
+            .where(
+                WorkspaceEvent.workspace_id == workspace.id,
+                WorkspaceEvent.event_type == _OPERATOR_REFRESH_EVENT_TYPE,
+                WorkspaceEvent.reason_code == _OPERATOR_REFRESH_REASON_CODE,
+            )
+            .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
+            .limit(1)
+        )
+        refresh_requested_at = (await session.execute(stmt)).scalar_one_or_none()
+        if refresh_requested_at is not None:
+            floors.append(_utc_datetime(refresh_requested_at))
 
         return max(floors) if floors else None
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -767,7 +767,11 @@ class ControlWorker:
         if finding is not None and finding.decision == "defer_retry_policy":
             await self._record_recoverable_runtime_stranding(candidate, snapshot, finding)
             return
-        if candidate.status in _ACTIVE_EXECUTION_STATUSES and _has_running_agent_runtime(snapshot):
+        if (
+            candidate.status in _ACTIVE_EXECUTION_STATUSES
+            and _has_running_agent_runtime(snapshot)
+            and not await self._has_operator_refresh_after_latest_preservation(candidate)
+        ):
             await self._record_preserved_active_execution_after_restart(candidate, snapshot)
             return
         if candidate.compose_project_name and snapshot.stack_state == "running":
@@ -907,6 +911,26 @@ class ControlWorker:
             reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
         )
 
+    async def _has_operator_refresh_after_latest_preservation(
+        self,
+        candidate: _ActiveExecutionCandidate,
+    ) -> bool:
+        async with self._session_factory() as session:
+            latest_preservation = await self._latest_preserved_active_execution_at(
+                session,
+                candidate.workspace_id,
+                candidate.status,
+            )
+            if latest_preservation is None:
+                return False
+            latest_refresh = await self._latest_operator_refresh_requested_at(
+                session,
+                candidate.workspace_id,
+            )
+            if latest_refresh is None:
+                return False
+            return _utc_datetime(latest_refresh) >= _utc_datetime(latest_preservation)
+
     async def _has_current_preserved_active_execution(
         self,
         candidate: _ActiveExecutionCandidate,
@@ -953,6 +977,42 @@ class ControlWorker:
             stmt = stmt.where(WorkspaceEvent.occurred_at >= event_floor)
         return (await session.execute(stmt)).scalar_one_or_none() is not None
 
+    async def _latest_preserved_active_execution_at(
+        self,
+        session: AsyncSession,
+        workspace_id: str,
+        status: WorkspaceStatus,
+    ) -> datetime | None:
+        stmt = (
+            select(WorkspaceEvent.occurred_at)
+            .where(
+                WorkspaceEvent.workspace_id == workspace_id,
+                WorkspaceEvent.event_type == ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+                WorkspaceEvent.reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+                WorkspaceEvent.payload["workspace_status"].as_string() == status.value,
+            )
+            .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
+            .limit(1)
+        )
+        return (await session.execute(stmt)).scalar_one_or_none()
+
+    async def _latest_operator_refresh_requested_at(
+        self,
+        session: AsyncSession,
+        workspace_id: str,
+    ) -> datetime | None:
+        stmt = (
+            select(WorkspaceEvent.occurred_at)
+            .where(
+                WorkspaceEvent.workspace_id == workspace_id,
+                WorkspaceEvent.event_type == _OPERATOR_REFRESH_EVENT_TYPE,
+                WorkspaceEvent.reason_code == _OPERATOR_REFRESH_REASON_CODE,
+            )
+            .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
+            .limit(1)
+        )
+        return (await session.execute(stmt)).scalar_one_or_none()
+
     async def _active_execution_preservation_event_floor(
         self,
         session: AsyncSession,
@@ -979,17 +1039,10 @@ class ControlWorker:
 
         # An operator refresh is an explicit recovery request for preserved runtime.
         # Preservation evidence older than that request must not keep scans skipped.
-        stmt = (
-            select(WorkspaceEvent.occurred_at)
-            .where(
-                WorkspaceEvent.workspace_id == workspace.id,
-                WorkspaceEvent.event_type == _OPERATOR_REFRESH_EVENT_TYPE,
-                WorkspaceEvent.reason_code == _OPERATOR_REFRESH_REASON_CODE,
-            )
-            .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
-            .limit(1)
+        refresh_requested_at = await self._latest_operator_refresh_requested_at(
+            session,
+            workspace.id,
         )
-        refresh_requested_at = (await session.execute(stmt)).scalar_one_or_none()
         if refresh_requested_at is not None:
             floors.append(_utc_datetime(refresh_requested_at))
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -800,7 +800,16 @@ class ControlWorker:
                 return False
             if not _execution_claim_is_stale(ws, datetime.now(UTC)):
                 return False
-            if await self._has_stale_active_execution_event(session, candidate.workspace_id):
+            event_floor = await self._active_execution_preservation_event_floor(
+                session,
+                ws,
+                candidate.status,
+            )
+            if await self._has_stale_active_execution_event(
+                session,
+                candidate.workspace_id,
+                event_floor=event_floor,
+            ):
                 return False
 
             await repo.add_event(
@@ -824,6 +833,8 @@ class ControlWorker:
         self,
         session: AsyncSession,
         workspace_id: str,
+        *,
+        event_floor: datetime | None = None,
     ) -> bool:
         stmt = (
             select(WorkspaceEvent.id)
@@ -834,6 +845,8 @@ class ControlWorker:
             )
             .limit(1)
         )
+        if event_floor is not None:
+            stmt = stmt.where(WorkspaceEvent.occurred_at >= event_floor)
         return (await session.execute(stmt)).scalar_one_or_none() is not None
 
     async def _record_preserved_active_execution_after_restart(
@@ -1158,6 +1171,7 @@ class ControlWorker:
             return await self._has_stale_active_execution_event(
                 session,
                 candidate.workspace_id,
+                event_floor=event_floor,
             )
 
     async def _record_stale_active_execution_cleanup_failed(

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -847,6 +847,7 @@ class ControlWorker:
             if await self._has_preserved_active_execution_event(
                 session,
                 candidate.workspace_id,
+                candidate.status,
             ):
                 return
 
@@ -903,6 +904,7 @@ class ControlWorker:
         self,
         session: AsyncSession,
         workspace_id: str,
+        status: WorkspaceStatus,
     ) -> bool:
         stmt = (
             select(WorkspaceEvent.id)
@@ -910,6 +912,7 @@ class ControlWorker:
                 WorkspaceEvent.workspace_id == workspace_id,
                 WorkspaceEvent.event_type == ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
                 WorkspaceEvent.reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+                WorkspaceEvent.payload["workspace_status"].as_string() == status.value,
             )
             .limit(1)
         )
@@ -970,6 +973,7 @@ class ControlWorker:
             if await self._has_preserved_active_execution_event(
                 session,
                 candidate.workspace_id,
+                candidate.status,
             ):
                 return False
             return await self._has_stale_active_execution_event(

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -56,6 +56,8 @@ from awf.service.secret_leases import SecretLeaseService
 from awf.service.workspace_runtime_health import (
     ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
     ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+    OPERATOR_REFRESH_EVENT_TYPE,
+    OPERATOR_REFRESH_REASON_CODE,
     RUNTIME_STRANDED_EVENT_TYPE,
     RuntimeWorkspace,
     WorkspaceRuntimeFinding,
@@ -98,8 +100,6 @@ _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_CLEARED_REASON_CODE = (
 _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
     "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
-_OPERATOR_REFRESH_EVENT_TYPE = "workspace.refresh_requested"
-_OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 _MONITOR_RECOVERY_REASON_CODE = "MONITOR_RECOVERY_AFTER_RESTART"
 _MONITOR_RECOVERY_EVENT_TYPE = "workspace.monitor_recovery_started"
 _MONITOR_RECOVERY_SOURCE = "worker_restart"
@@ -1053,8 +1053,8 @@ class ControlWorker:
             select(WorkspaceEvent.occurred_at)
             .where(
                 WorkspaceEvent.workspace_id == workspace_id,
-                WorkspaceEvent.event_type == _OPERATOR_REFRESH_EVENT_TYPE,
-                WorkspaceEvent.reason_code == _OPERATOR_REFRESH_REASON_CODE,
+                WorkspaceEvent.event_type == OPERATOR_REFRESH_EVENT_TYPE,
+                WorkspaceEvent.reason_code == OPERATOR_REFRESH_REASON_CODE,
             )
             .order_by(WorkspaceEvent.occurred_at.desc(), WorkspaceEvent.id.desc())
             .limit(1)

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -839,7 +839,7 @@ class ControlWorker:
         now = datetime.now(UTC)
         async with self._session_factory() as session:
             repo = WorkspaceRepository(session)
-            ws = await repo.get(candidate.workspace_id)
+            ws = await repo.get_for_update(candidate.workspace_id)
             if ws is None or ws.status != candidate.status.value:
                 return
             if not _execution_claim_is_stale(ws, now):

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -712,6 +712,8 @@ class ControlWorker:
         self,
         candidate: _ActiveExecutionCandidate,
     ) -> None:
+        if await self._has_current_preserved_active_execution(candidate):
+            return
         try:
             snapshot = await self._runtime_inspector.inspect(candidate.compose_project_name)
         except Exception as exc:  # pragma: no cover - defensive around Docker tooling
@@ -902,6 +904,30 @@ class ControlWorker:
             compose_project_name=candidate.compose_project_name,
             reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
         )
+
+    async def _has_current_preserved_active_execution(
+        self,
+        candidate: _ActiveExecutionCandidate,
+    ) -> bool:
+        if candidate.status not in _ACTIVE_EXECUTION_STATUSES:
+            return False
+
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            if ws is None or ws.status != candidate.status.value:
+                return False
+            event_floor = await self._active_execution_preservation_event_floor(
+                session,
+                ws,
+                candidate.status,
+            )
+            return await self._has_preserved_active_execution_event(
+                session,
+                candidate.workspace_id,
+                candidate.status,
+                event_floor=event_floor,
+            )
 
     async def _has_preserved_active_execution_event(
         self,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -95,9 +95,6 @@ _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE = (
 _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE = (
     "NO_EXECUTION_CLAIM_DURING_ACTIVE_EXECUTION_PRESERVATION"
 )
-_ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_REASON_CODE = (
-    "UNEXPIRED_EXECUTION_CLAIM_PRESERVED_DURING_ACTIVE_EXECUTION_PRESERVATION"
-)
 _MONITOR_RECOVERY_REASON_CODE = "MONITOR_RECOVERY_AFTER_RESTART"
 _MONITOR_RECOVERY_EVENT_TYPE = "workspace.monitor_recovery_started"
 _MONITOR_RECOVERY_SOURCE = "worker_restart"
@@ -1765,17 +1762,13 @@ def _active_execution_preservation_claim_cleanup_payload(
     if previous_claimed_by is None and workspace.execution_claim_expires_at is None:
         return payload
 
-    if _execution_claim_is_stale(workspace, claim_cutoff):
-        return {
-            **payload,
-            "action": "cleared_stale",
-            "reason_code": _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE,
-        }
+    if not _execution_claim_is_stale(workspace, claim_cutoff):
+        raise ValueError("active execution preservation cleanup requires a stale execution claim")
 
     return {
         **payload,
-        "action": "preserved_unexpired",
-        "reason_code": _ACTIVE_EXECUTION_PRESERVED_UNEXPIRED_CLAIM_REASON_CODE,
+        "action": "cleared_stale",
+        "reason_code": _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE,
     }
 
 

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -39,6 +39,10 @@ from awf.service.secret_leases import (
     SecretLeaseService,
     secret_lease_revocation_summary,
 )
+from awf.service.workspace_runtime_health import (
+    OPERATOR_REFRESH_EVENT_TYPE,
+    OPERATOR_REFRESH_REASON_CODE,
+)
 
 ProjectStopper = Callable[[str | None], Awaitable[None]]
 CleanupResultLike = WorkspaceCleanupResult | Sequence[str] | Mapping[str, object]
@@ -71,7 +75,6 @@ _OPERATOR_API_SOURCE = "operator_api"
 _OPERATOR_CANCEL_REASON_CODE = "OPERATOR_CANCEL"
 _OPERATOR_STOP_REASON_CODE = "OPERATOR_STOP"
 _OPERATOR_REMONITOR_REASON_CODE = "OPERATOR_REMONITOR"
-_OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 _OPERATOR_VALIDATE_REASON_CODE = "OPERATOR_VALIDATE"
 _OPERATOR_REBASE_REASON_CODE = "OPERATOR_REBASE"
 _OPERATOR_DESTROY_REASON_CODE = "OPERATOR_DESTROY"
@@ -618,7 +621,7 @@ class WorkspaceControlService:
         operations = OperationRepository(self._session)
         payload = _operator_operation_payload(
             reason=reason,
-            reason_code=_OPERATOR_REFRESH_REASON_CODE,
+            reason_code=OPERATOR_REFRESH_REASON_CODE,
             requested_action=OperationType.refresh.value,
         )
         operation_payload = _operation_payload(payload, expected_version=expected_version)
@@ -653,8 +656,8 @@ class WorkspaceControlService:
         )
         await repo.add_event(
             workspace,
-            event_type="workspace.refresh_requested",
-            reason_code=_OPERATOR_REFRESH_REASON_CODE,
+            event_type=OPERATOR_REFRESH_EVENT_TYPE,
+            reason_code=OPERATOR_REFRESH_REASON_CODE,
             payload=_event_payload(
                 {
                     "source": _OPERATOR_API_SOURCE,

--- a/src/awf/service/workspace_runtime_health.py
+++ b/src/awf/service/workspace_runtime_health.py
@@ -19,16 +19,20 @@ RuntimeHealthReasonCode = Literal[
     "AGENT_CONTAINER_MISSING",
     "AGENT_CONTAINER_EXITED",
     "RUNTIME_INSPECTION_UNAVAILABLE",
+    "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART",
 ]
 RuntimeHealthDecision = Literal[
     "none",
     "fail_workspace",
     "remonitor_workspace",
     "defer_retry_policy",
+    "preserve_runtime",
 ]
 RuntimeHealthStatus = Literal["ok", "stranded", "unavailable"]
 
 RUNTIME_STRANDED_EVENT_TYPE = "workspace.runtime_stranded_detected"
+ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
+ACTIVE_EXECUTION_PRESERVED_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
 
 ACTIVE_RUNTIME_HEALTH_STATUSES = frozenset(
     {

--- a/src/awf/service/workspace_runtime_health.py
+++ b/src/awf/service/workspace_runtime_health.py
@@ -31,6 +31,8 @@ RuntimeHealthDecision = Literal[
 RuntimeHealthStatus = Literal["ok", "stranded", "unavailable"]
 
 RUNTIME_STRANDED_EVENT_TYPE = "workspace.runtime_stranded_detected"
+OPERATOR_REFRESH_EVENT_TYPE = "workspace.refresh_requested"
+OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
 ACTIVE_EXECUTION_PRESERVED_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1881,6 +1881,12 @@ def _workspace_runtime_health_from_matching_events(
         if reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE:
             if workspace.status not in ACTIVE_RUNTIME_HEALTH_STATUSES:
                 return None
+            event_workspace_status = payload.get("workspace_status")
+            if (
+                not isinstance(event_workspace_status, str)
+                or event_workspace_status != workspace.status
+            ):
+                return None
             status = "ok"
         return WorkspaceRuntimeHealthResponse(
             status=cast(Any, status),

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -157,6 +157,8 @@ OWNED_PATH_OVERLAP_PAYLOAD_FIELDS = (
     "existing_path",
     "requested_path",
 )
+_OPERATOR_REFRESH_EVENT_TYPE = "workspace.refresh_requested"
+_OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 PROVIDER_READINESS_PREFLIGHT_EVENT_TYPE = "workspace.provider_readiness_preflight"
 PROVIDER_READINESS_READY_REASON = "PROVIDER_READINESS_READY"
 PROVIDER_READINESS_OVERRIDE_REASON = "PROVIDER_READINESS_OVERRIDE_USED"
@@ -1918,6 +1920,13 @@ def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
         and event.event_type == "workspace.state_changed"
         and event.new_state == status
     ]
+    floors.extend(
+        _utc_datetime(event.occurred_at)
+        for event in workspace.events
+        if isinstance(event.occurred_at, datetime)
+        and event.event_type == _OPERATOR_REFRESH_EVENT_TYPE
+        and event.reason_code == _OPERATOR_REFRESH_REASON_CODE
+    )
     return max(floors) if floors else None
 
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -7,6 +7,7 @@ import builtins
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol, cast
 from urllib.parse import SplitResult, urlsplit, urlunsplit
@@ -1864,8 +1865,18 @@ def _workspace_runtime_health_from_matching_events(
     *,
     event_types: frozenset[str],
 ) -> WorkspaceRuntimeHealthResponse | None:
+    preserved_event_floor = (
+        _active_runtime_health_event_floor(workspace)
+        if ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE in event_types
+        else None
+    )
     for event in reversed(workspace.events):
         if event.event_type not in event_types:
+            continue
+        if (
+            event.event_type == ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE
+            and _event_occurred_before_floor(event.occurred_at, preserved_event_floor)
+        ):
             continue
         payload = event.payload or {}
         reason_code = payload.get("reason_code") or event.reason_code
@@ -1896,6 +1907,35 @@ def _workspace_runtime_health_from_matching_events(
             services=_runtime_health_event_services(payload),
         )
     return None
+
+
+def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
+    status = str(workspace.status)
+    floors = [
+        _utc_datetime(event.occurred_at)
+        for event in workspace.events
+        if isinstance(event.occurred_at, datetime)
+        and event.event_type == "workspace.state_changed"
+        and event.new_state == status
+    ]
+    return max(floors) if floors else None
+
+
+def _event_occurred_before_floor(
+    occurred_at: datetime | None,
+    floor: datetime | None,
+) -> bool:
+    return (
+        isinstance(occurred_at, datetime)
+        and floor is not None
+        and _utc_datetime(occurred_at) < floor
+    )
+
+
+def _utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
 
 
 def _runtime_health_event_services(payload: Mapping[str, Any]) -> list[dict[str, str]]:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1932,7 +1932,7 @@ def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
         occurred_at = _utc_datetime(event.occurred_at)
         if status_started_at is None or occurred_at >= status_started_at:
             floors.append(occurred_at)
-    claim_expires_at = workspace.execution_claim_expires_at
+    claim_expires_at = getattr(workspace, "execution_claim_expires_at", None)
     if claim_expires_at is not None:
         claim_floor = _utc_datetime(claim_expires_at)
         if claim_floor <= datetime.now(UTC):
@@ -2116,19 +2116,6 @@ def _dind_mode_from_profile_snapshot(profile: Mapping[str, Any] | None) -> str:
     if isinstance(docker, Mapping) and docker.get("mode") == "dind":
         return "dind"
     return "none"
-
-
-def _resource_reservation_row_summary(reservation: Any) -> dict[str, Any]:
-    return {
-        "node_id": reservation.node_id,
-        "steady_cpu": reservation.steady_cpu,
-        "steady_memory_gb": reservation.steady_memory_gb,
-        "peak_cpu": reservation.peak_cpu,
-        "peak_memory_gb": reservation.peak_memory_gb,
-        "disk_mb": reservation.disk_mb,
-        "dind_slots": reservation.dind_slots,
-        "phase": reservation.phase,
-    }
 
 
 def _parse_memory_gb(value: str | None) -> float | None:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -137,6 +137,8 @@ from awf.service.workspace_runtime_health import (
     ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
     ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
     ACTIVE_RUNTIME_HEALTH_STATUSES,
+    OPERATOR_REFRESH_EVENT_TYPE,
+    OPERATOR_REFRESH_REASON_CODE,
     RUNTIME_STRANDED_EVENT_TYPE,
     classify_runtime_snapshot,
     runtime_workspace_from_workspace,
@@ -157,8 +159,6 @@ OWNED_PATH_OVERLAP_PAYLOAD_FIELDS = (
     "existing_path",
     "requested_path",
 )
-_OPERATOR_REFRESH_EVENT_TYPE = "workspace.refresh_requested"
-_OPERATOR_REFRESH_REASON_CODE = "OPERATOR_REFRESH"
 PROVIDER_READINESS_PREFLIGHT_EVENT_TYPE = "workspace.provider_readiness_preflight"
 PROVIDER_READINESS_READY_REASON = "PROVIDER_READINESS_READY"
 PROVIDER_READINESS_OVERRIDE_REASON = "PROVIDER_READINESS_OVERRIDE_USED"
@@ -1924,8 +1924,8 @@ def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
         _utc_datetime(event.occurred_at)
         for event in workspace.events
         if isinstance(event.occurred_at, datetime)
-        and event.event_type == _OPERATOR_REFRESH_EVENT_TYPE
-        and event.reason_code == _OPERATOR_REFRESH_REASON_CODE
+        and event.event_type == OPERATOR_REFRESH_EVENT_TYPE
+        and event.reason_code == OPERATOR_REFRESH_REASON_CODE
     )
     return max(floors) if floors else None
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1927,7 +1927,6 @@ def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
             not isinstance(event.occurred_at, datetime)
             or event.event_type != OPERATOR_REFRESH_EVENT_TYPE
             or event.reason_code != OPERATOR_REFRESH_REASON_CODE
-            or event.new_state != status
         ):
             continue
         occurred_at = _utc_datetime(event.occurred_at)

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -642,14 +642,14 @@ class WorkspaceService:
             compose_project_name = workspace.compose_project_name
             runtime_workspace = runtime_workspace_from_workspace(workspace)
             app_endpoints = _workspace_app_endpoint_responses(workspace)
-            persisted_runtime_health = _workspace_runtime_health_from_events(workspace)
+            preserved_runtime_health = _workspace_preserved_runtime_health_from_events(workspace)
 
         snapshot = await self._runtime_inspector.inspect(compose_project_name)
         finding = classify_runtime_snapshot(runtime_workspace, snapshot)
         runtime_health = (
             WorkspaceRuntimeHealthResponse(**finding.to_response_dict())
             if finding is not None
-            else persisted_runtime_health
+            else preserved_runtime_health
         )
         return WorkspaceRuntimeResponse(
             workspace_id=workspace_id,
@@ -1839,11 +1839,33 @@ def _approved_planning_scope_fallback_model(
 def _workspace_runtime_health_from_events(
     workspace: Workspace,
 ) -> WorkspaceRuntimeHealthResponse | None:
+    return _workspace_runtime_health_from_matching_events(
+        workspace,
+        event_types=frozenset(
+            {
+                RUNTIME_STRANDED_EVENT_TYPE,
+                ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+            }
+        ),
+    )
+
+
+def _workspace_preserved_runtime_health_from_events(
+    workspace: Workspace,
+) -> WorkspaceRuntimeHealthResponse | None:
+    return _workspace_runtime_health_from_matching_events(
+        workspace,
+        event_types=frozenset({ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE}),
+    )
+
+
+def _workspace_runtime_health_from_matching_events(
+    workspace: Workspace,
+    *,
+    event_types: frozenset[str],
+) -> WorkspaceRuntimeHealthResponse | None:
     for event in reversed(workspace.events):
-        if event.event_type not in {
-            RUNTIME_STRANDED_EVENT_TYPE,
-            ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
-        }:
+        if event.event_type not in event_types:
             continue
         payload = event.payload or {}
         reason_code = payload.get("reason_code") or event.reason_code

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1893,13 +1893,13 @@ def _workspace_runtime_health_from_matching_events(
             status = "unavailable"
         if reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE:
             if workspace.status not in ACTIVE_RUNTIME_HEALTH_STATUSES:
-                return None
+                continue
             event_workspace_status = payload.get("workspace_status")
             if (
                 not isinstance(event_workspace_status, str)
                 or event_workspace_status != workspace.status
             ):
-                return None
+                continue
             status = "ok"
         return WorkspaceRuntimeHealthResponse(
             status=cast(Any, status),

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -133,6 +133,8 @@ from awf.service.workspace_observability import (
     workspace_pricing_metadata,
 )
 from awf.service.workspace_runtime_health import (
+    ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+    ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
     RUNTIME_STRANDED_EVENT_TYPE,
     classify_runtime_snapshot,
     runtime_workspace_from_workspace,
@@ -639,9 +641,15 @@ class WorkspaceService:
             compose_project_name = workspace.compose_project_name
             runtime_workspace = runtime_workspace_from_workspace(workspace)
             app_endpoints = _workspace_app_endpoint_responses(workspace)
+            persisted_runtime_health = _workspace_runtime_health_from_events(workspace)
 
         snapshot = await self._runtime_inspector.inspect(compose_project_name)
         finding = classify_runtime_snapshot(runtime_workspace, snapshot)
+        runtime_health = (
+            WorkspaceRuntimeHealthResponse(**finding.to_response_dict())
+            if finding is not None
+            else persisted_runtime_health
+        )
         return WorkspaceRuntimeResponse(
             workspace_id=workspace_id,
             compose_project_name=compose_project_name,
@@ -662,11 +670,7 @@ class WorkspaceService:
             logs_available=True,
             control_available=True,
             reason=snapshot.reason,
-            runtime_health=(
-                WorkspaceRuntimeHealthResponse(**finding.to_response_dict())
-                if finding is not None
-                else None
-            ),
+            runtime_health=runtime_health,
             app_endpoints=app_endpoints,
         )
 
@@ -1835,7 +1839,10 @@ def _workspace_runtime_health_from_events(
     workspace: Workspace,
 ) -> WorkspaceRuntimeHealthResponse | None:
     for event in reversed(workspace.events):
-        if event.event_type != RUNTIME_STRANDED_EVENT_TYPE:
+        if event.event_type not in {
+            RUNTIME_STRANDED_EVENT_TYPE,
+            ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+        }:
             continue
         payload = event.payload or {}
         reason_code = payload.get("reason_code") or event.reason_code
@@ -1845,8 +1852,13 @@ def _workspace_runtime_health_from_events(
             return None
         if not isinstance(message, str):
             message = reason_code
+        status = "stranded"
+        if reason_code == "RUNTIME_INSPECTION_UNAVAILABLE":
+            status = "unavailable"
+        if reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE:
+            status = "ok"
         return WorkspaceRuntimeHealthResponse(
-            status="unavailable" if reason_code == "RUNTIME_INSPECTION_UNAVAILABLE" else "stranded",
+            status=cast(Any, status),
             reason_code=reason_code,
             decision=cast(Any, decision),
             message=message,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1913,20 +1913,31 @@ def _workspace_runtime_health_from_matching_events(
 
 def _active_runtime_health_event_floor(workspace: Workspace) -> datetime | None:
     status = str(workspace.status)
-    floors = [
+    status_floors = [
         _utc_datetime(event.occurred_at)
         for event in workspace.events
         if isinstance(event.occurred_at, datetime)
         and event.event_type == "workspace.state_changed"
         and event.new_state == status
     ]
-    floors.extend(
-        _utc_datetime(event.occurred_at)
-        for event in workspace.events
-        if isinstance(event.occurred_at, datetime)
-        and event.event_type == OPERATOR_REFRESH_EVENT_TYPE
-        and event.reason_code == OPERATOR_REFRESH_REASON_CODE
-    )
+    status_started_at = max(status_floors) if status_floors else None
+    floors = [status_started_at] if status_started_at is not None else []
+    for event in workspace.events:
+        if (
+            not isinstance(event.occurred_at, datetime)
+            or event.event_type != OPERATOR_REFRESH_EVENT_TYPE
+            or event.reason_code != OPERATOR_REFRESH_REASON_CODE
+            or event.new_state != status
+        ):
+            continue
+        occurred_at = _utc_datetime(event.occurred_at)
+        if status_started_at is None or occurred_at >= status_started_at:
+            floors.append(occurred_at)
+    claim_expires_at = workspace.execution_claim_expires_at
+    if claim_expires_at is not None:
+        claim_floor = _utc_datetime(claim_expires_at)
+        if claim_floor <= datetime.now(UTC):
+            floors.append(claim_floor)
     return max(floors) if floors else None
 
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -135,6 +135,7 @@ from awf.service.workspace_observability import (
 from awf.service.workspace_runtime_health import (
     ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
     ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+    ACTIVE_RUNTIME_HEALTH_STATUSES,
     RUNTIME_STRANDED_EVENT_TYPE,
     classify_runtime_snapshot,
     runtime_workspace_from_workspace,
@@ -1856,6 +1857,8 @@ def _workspace_runtime_health_from_events(
         if reason_code == "RUNTIME_INSPECTION_UNAVAILABLE":
             status = "unavailable"
         if reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE:
+            if workspace.status not in ACTIVE_RUNTIME_HEALTH_STATUSES:
+                return None
             status = "ok"
         return WorkspaceRuntimeHealthResponse(
             status=cast(Any, status),

--- a/tests/integration/test_alembic_postgres.py
+++ b/tests/integration/test_alembic_postgres.py
@@ -90,30 +90,33 @@ def test_postgres_database_url_reads_repo_dotenv_database_url(
     )
 
 
-def _asyncpg_url(url: URL) -> str:
-    return url.set(drivername="postgresql").render_as_string(hide_password=False)
-
-
 def _quote_identifier(value: str) -> str:
     return '"' + value.replace('"', '""') + '"'
 
 
+def _asyncpg_url(url: URL) -> str:
+    query = dict(url.query)
+    query.pop("awf_search_path", None)
+    query.pop("awf_null_pool", None)
+    return url.set(drivername="postgresql", query=query).render_as_string(hide_password=False)
+
+
 def _schema_database_url(url: URL, schema_name: str) -> URL:
     query = dict(url.query)
-    query["awf_search_path"] = schema_name
+    query["awf_search_path"] = _quote_identifier(schema_name)
     return url.set(query=query)
 
 
-async def _create_schema(database_url: URL, schema_name: str) -> None:
-    conn = await asyncpg.connect(dsn=_asyncpg_url(database_url))
+async def _create_schema(url: URL, schema_name: str) -> None:
+    conn = await asyncpg.connect(dsn=_asyncpg_url(url))
     try:
         await conn.execute(f"CREATE SCHEMA {_quote_identifier(schema_name)}")
     finally:
         await conn.close()
 
 
-async def _drop_schema(database_url: URL, schema_name: str) -> None:
-    conn = await asyncpg.connect(dsn=_asyncpg_url(database_url))
+async def _drop_schema(url: URL, schema_name: str) -> None:
+    conn = await asyncpg.connect(dsn=_asyncpg_url(url))
     try:
         await conn.execute(f"DROP SCHEMA IF EXISTS {_quote_identifier(schema_name)} CASCADE")
     finally:

--- a/tests/unit/api/test_runtime.py
+++ b/tests/unit/api/test_runtime.py
@@ -13,9 +13,10 @@ from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
-
-PRESERVED_EXECUTION_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
-PRESERVED_EXECUTION_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
+from awf.service.workspace_runtime_health import (
+    ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+    ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+)
 
 
 class _RuntimeInspector:
@@ -151,10 +152,10 @@ async def test_runtime_endpoint_surfaces_preserved_live_runtime_health(
         assert workspace is not None
         await WorkspaceRepository(session).add_event(
             workspace,
-            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
-            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            event_type=ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+            reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
             payload={
-                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
                 "decision": "preserve_runtime",
                 "workspace_status": WorkspaceStatus.running.value,
                 "message": "Live agent runtime was preserved after worker restart.",
@@ -190,7 +191,7 @@ async def test_runtime_endpoint_surfaces_preserved_live_runtime_health(
     assert response.status_code == 200
     assert response.json()["runtime_health"] == {
         "status": "ok",
-        "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+        "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
         "decision": "preserve_runtime",
         "message": "Live agent runtime was preserved after worker restart.",
         "services": [{"name": "agent", "state": "running", "container_id": "agent"}],

--- a/tests/unit/api/test_runtime.py
+++ b/tests/unit/api/test_runtime.py
@@ -156,6 +156,7 @@ async def test_runtime_endpoint_surfaces_preserved_live_runtime_health(
             payload={
                 "reason_code": PRESERVED_EXECUTION_REASON_CODE,
                 "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
                 "message": "Live agent runtime was preserved after worker restart.",
                 "runtime": {
                     "services": [

--- a/tests/unit/api/test_runtime.py
+++ b/tests/unit/api/test_runtime.py
@@ -12,7 +12,10 @@ from awf.api.app import configure_database, create_app
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
-from awf.runtime.inspection import RuntimeSnapshot
+from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
+
+PRESERVED_EXECUTION_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
+PRESERVED_EXECUTION_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
 
 
 class _RuntimeInspector:
@@ -133,6 +136,64 @@ async def test_runtime_endpoint_serializes_app_endpoint_metadata(
             },
         }
     ]
+
+
+@pytest.mark.unit
+async def test_runtime_endpoint_surfaces_preserved_live_runtime_health(
+    runtime_app_and_client: tuple[object, AsyncClient],
+    engine: AsyncEngine,
+) -> None:
+    app, client = runtime_app_and_client
+    workspace_id = await _running_workspace(engine)
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        await WorkspaceRepository(session).add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent",
+                        }
+                    ]
+                },
+            },
+        )
+        await session.commit()
+
+    app.state.workspace_runtime_inspector = _RuntimeInspector(
+        RuntimeSnapshot(
+            stack_state="running",
+            services=[
+                RuntimeService(
+                    name="agent",
+                    container_id="agent",
+                    image="awf-agent:latest",
+                    state="running",
+                )
+            ],
+        )
+    )
+
+    response = await client.get(f"/v1/workspaces/{workspace_id}/runtime")
+
+    assert response.status_code == 200
+    assert response.json()["runtime_health"] == {
+        "status": "ok",
+        "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+        "decision": "preserve_runtime",
+        "message": "Live agent runtime was preserved after worker restart.",
+        "services": [{"name": "agent", "state": "running", "container_id": "agent"}],
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -5254,7 +5254,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             worker._execution_tasks.pop(workspace_id, None)
 
     @pytest.mark.unit
-    async def test_stale_active_execution_scan_defers_unexpired_exited_claim_failure(
+    async def test_stale_active_execution_scan_skips_unexpired_exited_claim_failure(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -5319,10 +5319,10 @@ class TestRunOnceStaleActiveExecutionRecovery:
             )
         assert preserved_events == []
         assert stranded_events == []
-        assert inspector.calls == ["awf_claimed_running"]
+        assert inspector.calls == []
 
     @pytest.mark.unit
-    async def test_restart_recovery_preserves_live_runtime_before_unexpired_claim_expires(
+    async def test_restart_recovery_defers_live_runtime_until_unexpired_claim_expires(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -5363,18 +5363,43 @@ class TestRunOnceStaleActiveExecutionRecovery:
         )
 
         assert await worker.run_once() == 0
-        inspector._snapshots[compose_project] = RuntimeSnapshot(  # noqa: SLF001
-            stack_state="stopped",
-            services=[
-                RuntimeService(
-                    name="agent",
-                    container_id="agent-unexpired",
-                    image="awf-agent:latest",
-                    state="exited",
-                    status="Exited (0) 1 minute ago",
-                )
-            ],
-        )
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stranded_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.running.value
+        assert ws.subphase != PRESERVED_EXECUTION_SUBPHASE
+        assert ws.execution_claimed_by == "previous-worker"
+        assert ws.execution_claim_expires_at is not None
+        assert ws.execution_claim_expires_at.replace(tzinfo=UTC) == claim_expires_at
+        assert ws.failure_reason is None
+        assert ws.failure_message is None
+        assert preserved_events == []
+        assert stranded_events == []
+        assert stale_events == []
+        assert inspector.calls == []
+        assert cleaner.calls == []
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            expired_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            ws.execution_claim_expires_at = expired_claim_expires_at
+            await s.commit()
+
         assert await worker.run_once() == 0
 
         async with session_factory() as s:
@@ -5402,14 +5427,93 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert len(preserved_events) == 1
         assert preserved_events[0].payload is not None
         assert preserved_events[0].payload["claim_cleanup"] == {
-            "action": "cleared_unexpired",
+            "action": "cleared_stale",
             "reason_code": (
-                "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+                "STALE_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
             ),
             "previous_claimed_by": "previous-worker",
-            "previous_expires_at": claim_expires_at.isoformat(),
+            "previous_expires_at": expired_claim_expires_at.isoformat(),
         }
         assert stranded_events == []
+        assert stale_events == []
+        assert inspector.calls == [compose_project]
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_restart_recovery_preservation_rechecks_refreshed_execution_claim(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_refreshed_live_claim_runtime"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "refreshed-live-claim-runtime",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+            node_id="node-a",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "maybe-dead-worker"
+            ws.execution_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await s.commit()
+
+        refreshed_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+
+        class _RefreshingLiveRuntimeInspector:
+            def __init__(self) -> None:
+                self.calls: list[str | None] = []
+
+            async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
+                self.calls.append(compose_project_name)
+                async with session_factory() as s:
+                    ws = await WorkspaceRepository(s).get(workspace_id)
+                    assert ws is not None
+                    ws.execution_claimed_by = "live-worker"
+                    ws.execution_claim_expires_at = refreshed_expires_at
+                    await s.commit()
+                return _live_agent_snapshot(container_id="agent-refreshed-live")
+
+        inspector = _RefreshingLiveRuntimeInspector()
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.running.value
+        assert ws.subphase != PRESERVED_EXECUTION_SUBPHASE
+        assert ws.execution_claimed_by == "live-worker"
+        assert ws.execution_claim_expires_at is not None
+        assert ws.execution_claim_expires_at.replace(tzinfo=UTC) == refreshed_expires_at
+        assert ws.failure_reason is None
+        assert preserved_events == []
         assert stale_events == []
         assert inspector.calls == [compose_project]
         assert cleaner.calls == []

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3688,6 +3688,70 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == [compose_project]
 
     @pytest.mark.unit
+    async def test_preservation_idempotency_keeps_current_event_with_unexpired_claim(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_fresh_claim"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-fresh-claim",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+        )
+        now = datetime.now(UTC)
+        status_started_at = now - timedelta(minutes=5)
+        preserved_at = now - timedelta(minutes=1)
+        claim_expires_at = now + timedelta(minutes=5)
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            state_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.state_changed",
+            )
+            running_started = next(
+                event
+                for event in state_events
+                if event.new_state == WorkspaceStatus.running.value
+            )
+            running_started.occurred_at = status_started_at
+            preserved = await repo.add_event(
+                ws,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                reason_code=PRESERVED_EXECUTION_REASON_CODE,
+                payload={
+                    "workspace_status": WorkspaceStatus.running.value,
+                    "decision": "preserve_runtime",
+                },
+            )
+            preserved.occurred_at = preserved_at
+            ws.execution_claimed_by = "live-worker"
+            ws.execution_claim_expires_at = claim_expires_at
+            await s.commit()
+
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=_RecordingRuntimeInspector({compose_project: _live_agent_snapshot()}),
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker._has_current_preserved_active_execution(  # noqa: SLF001
+            _ActiveExecutionCandidate(
+                workspace_id=workspace_id,
+                status=WorkspaceStatus.running,
+                repo_url=str(origin_repo),
+                compose_project_name=compose_project,
+            )
+        )
+
+    @pytest.mark.unit
     async def test_operator_refresh_from_old_cycle_does_not_block_fresh_preservation(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3689,6 +3689,92 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == [compose_project]
 
     @pytest.mark.unit
+    async def test_operator_refresh_from_old_cycle_does_not_block_fresh_preservation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_after_old_refresh"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-after-old-refresh",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+        )
+        old_preservation_time = datetime.now(UTC) - timedelta(days=1)
+        old_refresh_time = old_preservation_time + timedelta(minutes=5)
+        new_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            old_preserved = await repo.add_event(
+                ws,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                reason_code=PRESERVED_EXECUTION_REASON_CODE,
+                payload={
+                    "workspace_status": WorkspaceStatus.running.value,
+                    "decision": "preserve_runtime",
+                },
+            )
+            old_preserved.occurred_at = old_preservation_time
+            old_refresh = await repo.add_event(
+                ws,
+                event_type="workspace.refresh_requested",
+                reason_code="OPERATOR_REFRESH",
+                payload={"reason": "operator recovery"},
+            )
+            old_refresh.occurred_at = old_refresh_time
+            await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="TEST_ADVANCE")
+            await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="TEST_ADVANCE")
+            await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="TEST_REQUEUE")
+            await repo.transition(ws, to=WorkspaceStatus.running, reason_code="TEST_REEXECUTE")
+            ws.execution_claimed_by = "fresh-dead-worker"
+            ws.execution_claim_expires_at = new_claim_expires_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-fresh-after-refresh")}
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert ws.execution_claimed_by is None
+        assert ws.execution_claim_expires_at is None
+        assert len(preserved_events) == 2
+        assert preserved_events[0].occurred_at > old_refresh_time
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["workspace_status"] == WorkspaceStatus.running.value
+        assert stale_events == []
+        assert len(operations) == 1
+        assert operations[0].payload["runtime"]["services"][0]["container_id"] == (
+            "agent-fresh-after-refresh"
+        )
+        assert inspector.calls == [compose_project]
+
+    @pytest.mark.unit
     async def test_restart_recovery_serializes_concurrent_preservation_recording(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4680,6 +4680,95 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == [compose_project, compose_project]
 
     @pytest.mark.unit
+    async def test_operator_refresh_before_stale_lease_expiry_prevents_late_preservation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_refresh_before_lease_expiry"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "refresh-before-lease-expiry",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        now = datetime.now(UTC)
+        status_started_at = now - timedelta(minutes=10)
+        refresh_requested_at = now - timedelta(minutes=2)
+        lease_expires_at = now - timedelta(minutes=1)
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "old-worker"
+            ws.execution_claim_expires_at = lease_expires_at
+            state_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.state_changed",
+            )
+            pushing_started = next(
+                event
+                for event in state_events
+                if event.new_state == WorkspaceStatus.pushing.value
+            )
+            pushing_started.occurred_at = status_started_at
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-before-lease-expiry",
+            )
+            refresh_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.refresh_requested",
+            )
+            assert refresh_events
+            refresh_events[0].occurred_at = refresh_requested_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-refresh-before-expiry")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.pushing.value
+        assert preserved_events == []
+        assert len(stale_events) == 1
+        assert stale_events[0].reason_code == "STALE_ACTIVE_EXECUTION"
+        assert cleaner.calls == []
+        assert inspector.calls == [compose_project]
+
+    @pytest.mark.unit
     async def test_operator_refresh_of_live_preserved_runtime_does_not_represerve(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4439,6 +4439,86 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert cleaner.calls == []
 
     @pytest.mark.unit
+    async def test_operator_refresh_unblocks_preserved_runtime_recovery_scan(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserved_refresh_exited"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserved-refresh-exited",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-preserved-refresh")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-preserved-runtime",
+            )
+            await s.commit()
+
+        inspector._snapshots[compose_project] = RuntimeSnapshot(  # noqa: SLF001
+            stack_state="stopped",
+            services=[
+                RuntimeService(
+                    name="agent",
+                    container_id="agent-preserved-refresh",
+                    image="awf-agent:latest",
+                    state="exited",
+                    status="Exited (0) 1 minute ago",
+                )
+            ],
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stranded_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == FailureReason.infrastructure_failure.value
+        assert len(preserved_events) == 1
+        assert len(stranded_events) == 1
+        assert stranded_events[0].reason_code == "AGENT_CONTAINER_EXITED"
+        assert inspector.calls == [compose_project, compose_project]
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
     async def test_stale_active_execution_scan_is_throttled_between_intervals(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -9,7 +9,6 @@ concurrency, so end-to-end is the most useful test.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import subprocess
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
@@ -3797,9 +3796,11 @@ class TestRunOnceStaleActiveExecutionRecovery:
             compose_project_name=compose_project,
         )
         snapshot = _live_agent_snapshot(container_id="agent-race")
-        first_checked = asyncio.Event()
+        both_started = asyncio.Event()
+        first_selected = asyncio.Event()
+        allow_first_recording = asyncio.Event()
         second_checked = asyncio.Event()
-        both_selected = asyncio.Event()
+        started_count = 0
         call_count = 0
         selected_count = 0
         count_lock = asyncio.Lock()
@@ -3817,16 +3818,8 @@ class TestRunOnceStaleActiveExecutionRecovery:
             async with count_lock:
                 call_count += 1
                 call_number = call_count
-                if call_number == 1:
-                    first_checked.set()
-                elif call_number == 2:
+                if call_number == 2:
                     second_checked.set()
-
-            if call_number == 1:
-                with contextlib.suppress(TimeoutError):
-                    await asyncio.wait_for(second_checked.wait(), timeout=0.2)
-            else:
-                await first_checked.wait()
 
             has_event = await original_has_event(
                 self,
@@ -3837,11 +3830,10 @@ class TestRunOnceStaleActiveExecutionRecovery:
             )
             async with count_lock:
                 selected_count += 1
-                if selected_count == 2:
-                    both_selected.set()
-            if not has_event:
-                with contextlib.suppress(TimeoutError):
-                    await asyncio.wait_for(both_selected.wait(), timeout=0.2)
+            if call_number == 1:
+                first_selected.set()
+                assert not has_event
+                await asyncio.wait_for(allow_first_recording.wait(), timeout=1.0)
             return has_event
 
         monkeypatch.setattr(
@@ -3865,15 +3857,35 @@ class TestRunOnceStaleActiveExecutionRecovery:
             for _ in range(2)
         ]
 
-        await asyncio.gather(
-            *(
-                worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
-                    candidate,
-                    snapshot,
-                )
-                for worker in workers
+        async def _record_started(worker: ControlWorker) -> None:
+            nonlocal started_count
+            async with count_lock:
+                started_count += 1
+                if started_count == len(workers):
+                    both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=1.0)
+            await worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
+                candidate,
+                snapshot,
             )
-        )
+
+        tasks = [asyncio.create_task(_record_started(worker)) for worker in workers]
+        try:
+            await asyncio.wait_for(first_selected.wait(), timeout=1.0)
+            with pytest.raises(TimeoutError):
+                await asyncio.wait_for(second_checked.wait(), timeout=0.2)
+            allow_first_recording.set()
+            await asyncio.gather(*tasks)
+        finally:
+            allow_first_recording.set()
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+        assert started_count == 2
+        assert call_count == 2
+        assert selected_count == 2
 
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4909,6 +4909,114 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == [compose_project, compose_project, compose_project]
 
     @pytest.mark.unit
+    async def test_operator_refresh_ignores_stale_cleanup_evidence_before_refresh(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserved_refresh_stale_floor"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserved-refresh-stale-floor",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        now = datetime.now(UTC)
+        status_started_at = now - timedelta(minutes=10)
+        old_preservation_at = now - timedelta(minutes=9)
+        old_stale_at = now - timedelta(minutes=8)
+        refresh_requested_at = now - timedelta(minutes=1)
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            state_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.state_changed",
+            )
+            pushing_started = next(
+                event
+                for event in state_events
+                if event.new_state == WorkspaceStatus.pushing.value
+            )
+            pushing_started.occurred_at = status_started_at
+            preserved = await repo.add_event(
+                ws,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                reason_code=PRESERVED_EXECUTION_REASON_CODE,
+                payload={
+                    "workspace_status": WorkspaceStatus.pushing.value,
+                    "decision": "preserve_runtime",
+                },
+            )
+            preserved.occurred_at = old_preservation_at
+            stale = await repo.add_event(
+                ws,
+                event_type="workspace.stale_active_execution_detected",
+                reason_code="STALE_ACTIVE_EXECUTION",
+                payload={
+                    "compose_project_name": compose_project,
+                    "workspace_status": WorkspaceStatus.pushing.value,
+                    "runtime": {"stack_state": "running"},
+                },
+            )
+            stale.occurred_at = old_stale_at
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-stale-floor",
+            )
+            refresh_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.refresh_requested",
+            )
+            assert refresh_events
+            refresh_events[0].occurred_at = refresh_requested_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-refresh-stale-floor")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        fresh_stale_events = [
+            event for event in stale_events if event.occurred_at >= refresh_requested_at
+        ]
+        assert ws.status == WorkspaceStatus.pushing.value
+        assert ws.failure_reason is None
+        assert len(stale_events) == 2
+        assert len(fresh_stale_events) == 1
+        assert cleaner.calls == []
+        assert inspector.calls == [compose_project]
+
+    @pytest.mark.unit
     async def test_stale_active_execution_scan_is_throttled_between_intervals(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -5556,6 +5664,74 @@ async def test_stale_active_execution_check_preserves_unexpired_execution_claim(
         assert ws is not None
         ws.execution_claimed_by = "live-worker"
         ws.execution_claim_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        await session.commit()
+
+    assert not await worker._stale_active_execution_can_fail(  # noqa: SLF001
+        _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.running,
+            compose_project_name=f"awf_{workspace_id}",
+            repo_url=str(origin_repo),
+        )
+    )
+
+
+@pytest.mark.unit
+async def test_stale_active_execution_check_ignores_stale_event_before_refresh(
+    worker: ControlWorker,
+    session_factory: async_sessionmaker[AsyncSession],
+    origin_repo: Path,
+) -> None:
+    workspace_id = await _create_active_execution(
+        session_factory,
+        origin_repo,
+        "stale-event-before-refresh",
+        WorkspaceStatus.running,
+    )
+    now = datetime.now(UTC)
+    status_started_at = now - timedelta(minutes=10)
+    old_stale_at = now - timedelta(minutes=8)
+    refresh_requested_at = now - timedelta(minutes=1)
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        state_events = await WorkspaceEventRepository(session).list(
+            workspace_id=workspace_id,
+            event_type="workspace.state_changed",
+        )
+        running_started = next(
+            event
+            for event in state_events
+            if event.new_state == WorkspaceStatus.running.value
+        )
+        running_started.occurred_at = status_started_at
+        stale = await repo.add_event(
+            ws,
+            event_type="workspace.stale_active_execution_detected",
+            reason_code="STALE_ACTIVE_EXECUTION",
+            payload={
+                "compose_project_name": f"awf_{workspace_id}",
+                "workspace_status": WorkspaceStatus.running.value,
+                "runtime": {"stack_state": "running"},
+            },
+        )
+        stale.occurred_at = old_stale_at
+        await WorkspaceControlService(
+            session,
+            project_stopper=_noop_project_stop,
+            cleaner_factory=_unexpected_cleaner_factory,
+        ).request_refresh_workspace(
+            workspace_id,
+            reason="operator recovery",
+            idempotency_key="refresh-before-stale-check",
+        )
+        refresh_events = await WorkspaceEventRepository(session).list(
+            workspace_id=workspace_id,
+            event_type="workspace.refresh_requested",
+        )
+        assert refresh_events
+        refresh_events[0].occurred_at = refresh_requested_at
         await session.commit()
 
     assert not await worker._stale_active_execution_can_fail(  # noqa: SLF001

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -5178,7 +5178,9 @@ class TestRunOnceStaleActiveExecutionRecovery:
         )
 
         assert await worker.run_once() == 0
+        assert worker._next_stale_active_execution_scan_at == 1_060.0  # noqa: SLF001
         assert await worker.run_once() == 0
+        assert worker._next_stale_active_execution_scan_at == 1_060.0  # noqa: SLF001
         assert inspector.calls == ["awf_throttled_running"]
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)
@@ -5188,6 +5190,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
         current_time = 1_060.0
 
         assert await worker.run_once() == 0
+        assert worker._next_stale_active_execution_scan_at == 1_120.0  # noqa: SLF001
         assert inspector.calls == ["awf_throttled_running"]
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3612,6 +3612,83 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == [compose_project, compose_project]
 
     @pytest.mark.unit
+    async def test_restart_recovery_preservation_idempotency_is_scoped_to_fresh_execution(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_fresh_execution"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-fresh-execution",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+        )
+        old_event_time = datetime.now(UTC) - timedelta(days=1)
+        new_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            old_event = await repo.add_event(
+                ws,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                reason_code=PRESERVED_EXECUTION_REASON_CODE,
+                payload={
+                    "workspace_status": WorkspaceStatus.running.value,
+                    "decision": "preserve_runtime",
+                },
+            )
+            old_event.occurred_at = old_event_time
+            await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="TEST_ADVANCE")
+            await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="TEST_ADVANCE")
+            await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="TEST_REQUEUE")
+            await repo.transition(ws, to=WorkspaceStatus.running, reason_code="TEST_REEXECUTE")
+            ws.execution_claimed_by = "fresh-dead-worker"
+            ws.execution_claim_expires_at = new_claim_expires_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-fresh")}
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert ws.execution_claimed_by is None
+        assert ws.execution_claim_expires_at is None
+        assert len(preserved_events) == 2
+        latest_preserved = preserved_events[0]
+        assert latest_preserved.occurred_at > old_event_time
+        assert latest_preserved.payload is not None
+        assert latest_preserved.payload["previous_claim"]["execution_claimed_by"] == (
+            "fresh-dead-worker"
+        )
+        assert latest_preserved.payload["previous_claim"]["execution_claim_expires_at"] == (
+            new_claim_expires_at.isoformat()
+        )
+        assert len(operations) == 1
+        assert operations[0].payload["runtime"]["services"][0]["container_id"] == "agent-fresh"
+        assert inspector.calls == [compose_project]
+
+    @pytest.mark.unit
     async def test_restart_recovery_serializes_concurrent_preservation_recording(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -3647,6 +3724,8 @@ class TestRunOnceStaleActiveExecutionRecovery:
             session: AsyncSession,
             workspace_id: str,
             status: WorkspaceStatus,
+            *,
+            event_floor: datetime | None = None,
         ) -> bool:
             nonlocal call_count, selected_count
             async with count_lock:
@@ -3663,7 +3742,13 @@ class TestRunOnceStaleActiveExecutionRecovery:
             else:
                 await first_checked.wait()
 
-            has_event = await original_has_event(self, session, workspace_id, status)
+            has_event = await original_has_event(
+                self,
+                session,
+                workspace_id,
+                status,
+                event_floor=event_floor,
+            )
             async with count_lock:
                 selected_count += 1
                 if selected_count == 2:

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3532,6 +3532,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
         preserved = preserved_events[0]
         assert preserved.reason_code == PRESERVED_EXECUTION_REASON_CODE
         assert preserved.payload is not None
+        assert preserved.payload["message"].startswith("Worker restart found")
         assert preserved.payload["decision"] == "preserve_runtime"
         assert preserved.payload["requested_action"] == OperationType.refresh.value
         assert preserved.payload["workspace_status"] == WorkspaceStatus.running.value

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4519,6 +4519,81 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert cleaner.calls == []
 
     @pytest.mark.unit
+    async def test_operator_refresh_before_first_preservation_prevents_late_preservation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_refresh_before_preservation"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "refresh-before-preservation",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        async with session_factory() as s:
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-before-preservation",
+            )
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-refresh-before-preserve")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == FailureReason.infrastructure_failure.value
+        assert preserved_events == []
+        assert len(stale_events) == 1
+        assert cleaner.calls == [
+            {
+                "workspace_id": workspace_id,
+                "repo_url": str(origin_repo),
+                "compose_project_name": compose_project,
+                "compose_file_path": Path(f"/tmp/awf/{workspace_id}/compose.yml"),
+                "worktree_host_path": None,
+                "remove_volumes": True,
+                "remove_worktree": False,
+            }
+        ]
+        assert inspector.calls == [compose_project, compose_project]
+
+    @pytest.mark.unit
     async def test_operator_refresh_of_live_preserved_runtime_does_not_represerve(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -9,6 +9,7 @@ concurrency, so end-to-end is the most useful test.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import subprocess
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
@@ -3549,6 +3550,113 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert inspector.calls == ["awf_preserve_live_running"]
         assert executor.calls == []
         assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_restart_recovery_serializes_concurrent_preservation_recording(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        compose_project = "awf_preserve_race"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-live-race",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+            node_id="node-a",
+        )
+        candidate = _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.running,
+            repo_url=str(origin_repo),
+            compose_project_name=compose_project,
+        )
+        snapshot = _live_agent_snapshot(container_id="agent-race")
+        first_checked = asyncio.Event()
+        second_checked = asyncio.Event()
+        both_selected = asyncio.Event()
+        call_count = 0
+        selected_count = 0
+        count_lock = asyncio.Lock()
+        original_has_event = ControlWorker._has_preserved_active_execution_event
+
+        async def _racing_has_preserved_event(
+            self: ControlWorker,
+            session: AsyncSession,
+            workspace_id: str,
+        ) -> bool:
+            nonlocal call_count, selected_count
+            async with count_lock:
+                call_count += 1
+                call_number = call_count
+                if call_number == 1:
+                    first_checked.set()
+                elif call_number == 2:
+                    second_checked.set()
+
+            if call_number == 1:
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(second_checked.wait(), timeout=0.2)
+            else:
+                await first_checked.wait()
+
+            has_event = await original_has_event(self, session, workspace_id)
+            async with count_lock:
+                selected_count += 1
+                if selected_count == 2:
+                    both_selected.set()
+            if not has_event:
+                with contextlib.suppress(TimeoutError):
+                    await asyncio.wait_for(both_selected.wait(), timeout=0.2)
+            return has_event
+
+        monkeypatch.setattr(
+            ControlWorker,
+            "_has_preserved_active_execution_event",
+            _racing_has_preserved_event,
+        )
+        workers = [
+            ControlWorker(
+                session_factory=session_factory,
+                provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+                executor=_RecordingExecutor(),
+                runtime_inspector=_RecordingRuntimeInspector({compose_project: snapshot}),
+                runtime_cleaner=_RecordingRuntimeCleaner(),
+                config=WorkerConfig(
+                    poll_interval_seconds=0.01,
+                    max_concurrent_executions=0,
+                    node_id="node-a",
+                ),
+            )
+            for _ in range(2)
+        ]
+
+        await asyncio.gather(
+            *(
+                worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
+                    candidate,
+                    snapshot,
+                )
+                for worker in workers
+            )
+        )
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert ws is not None
+        assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+        assert len(preserved_events) == 1
+        assert len(operations) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["operation_id"] == operations[0].id
 
     @pytest.mark.unit
     @pytest.mark.parametrize("status", [WorkspaceStatus.validating, WorkspaceStatus.pushing])

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3891,7 +3891,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert preserved_events[0].payload["operation_id"] == operations[0].id
 
     @pytest.mark.unit
-    async def test_preservation_recording_rechecks_operator_refresh_under_lock(
+    async def test_preservation_recording_rechecks_operator_refresh_after_preservation_under_lock(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -3911,7 +3911,34 @@ class TestRunOnceStaleActiveExecutionRecovery:
             compose_project_name=compose_project,
         )
         snapshot = _live_agent_snapshot(container_id="agent-refresh-race")
+        now = datetime.now(UTC)
+        status_started_at = now - timedelta(minutes=3)
+        preserved_at = now - timedelta(minutes=2)
+        refresh_requested_at = now - timedelta(minutes=1)
         async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            state_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.state_changed",
+            )
+            pushing_started = next(
+                event
+                for event in state_events
+                if event.new_state == WorkspaceStatus.pushing.value
+            )
+            pushing_started.occurred_at = status_started_at
+            preserved = await repo.add_event(
+                ws,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                reason_code=PRESERVED_EXECUTION_REASON_CODE,
+                payload={
+                    "workspace_status": WorkspaceStatus.pushing.value,
+                    "decision": "preserve_runtime",
+                },
+            )
+            preserved.occurred_at = preserved_at
             await WorkspaceControlService(
                 s,
                 project_stopper=_noop_project_stop,
@@ -3921,6 +3948,12 @@ class TestRunOnceStaleActiveExecutionRecovery:
                 reason="operator recovery",
                 idempotency_key="refresh-before-locked-preservation",
             )
+            refresh_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.refresh_requested",
+            )
+            assert refresh_events
+            refresh_events[0].occurred_at = refresh_requested_at
             await s.commit()
 
         worker = ControlWorker(
@@ -3950,8 +3983,82 @@ class TestRunOnceStaleActiveExecutionRecovery:
 
         assert ws is not None
         assert ws.subphase is None
-        assert preserved_events == []
+        assert len(preserved_events) == 1
         assert [operation.type for operation in operations] == [OperationType.refresh.value]
+
+    @pytest.mark.unit
+    async def test_preservation_recording_allows_operator_refresh_before_first_preservation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_pre_refresh_race"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-pre-refresh-race",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        candidate = _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.pushing,
+            repo_url=str(origin_repo),
+            compose_project_name=compose_project,
+        )
+        snapshot = _live_agent_snapshot(container_id="agent-pre-refresh-race")
+        async with session_factory() as s:
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-before-first-locked-preservation",
+            )
+            await s.commit()
+
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=_RecordingRuntimeInspector({compose_project: snapshot}),
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+            ),
+        )
+
+        await worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
+            candidate,
+            snapshot,
+        )
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert ws is not None
+        assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+        assert len(preserved_events) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["runtime"]["services"][0]["container_id"] == (
+            "agent-pre-refresh-race"
+        )
+        assert len(
+            [
+                operation
+                for operation in operations
+                if operation.result is not None
+                and operation.result.get("reason_code") == PRESERVED_EXECUTION_REASON_CODE
+            ]
+        ) == 1
 
     @pytest.mark.unit
     @pytest.mark.parametrize("status", [WorkspaceStatus.validating, WorkspaceStatus.pushing])
@@ -4668,7 +4775,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert cleaner.calls == []
 
     @pytest.mark.unit
-    async def test_operator_refresh_before_first_preservation_prevents_late_preservation(
+    async def test_operator_refresh_before_first_preservation_preserves_live_runtime(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -4711,7 +4818,6 @@ class TestRunOnceStaleActiveExecutionRecovery:
         )
 
         assert await worker.run_once() == 0
-        assert await worker.run_once() == 0
 
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)
@@ -4725,25 +4831,17 @@ class TestRunOnceStaleActiveExecutionRecovery:
                 event_type="workspace.stale_active_execution_detected",
             )
 
-        assert ws.status == WorkspaceStatus.failed.value
-        assert ws.failure_reason == FailureReason.infrastructure_failure.value
-        assert preserved_events == []
-        assert len(stale_events) == 1
-        assert cleaner.calls == [
-            {
-                "workspace_id": workspace_id,
-                "repo_url": str(origin_repo),
-                "compose_project_name": compose_project,
-                "compose_file_path": Path(f"/tmp/awf/{workspace_id}/compose.yml"),
-                "worktree_host_path": None,
-                "remove_volumes": True,
-                "remove_worktree": False,
-            }
-        ]
-        assert inspector.calls == [compose_project, compose_project]
+        assert ws.status == WorkspaceStatus.pushing.value
+        assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+        assert ws.failure_reason is None
+        assert ws.failure_message is None
+        assert len(preserved_events) == 1
+        assert stale_events == []
+        assert cleaner.calls == []
+        assert inspector.calls == [compose_project]
 
     @pytest.mark.unit
-    async def test_operator_refresh_before_stale_lease_expiry_prevents_late_preservation(
+    async def test_operator_refresh_before_stale_lease_expiry_allows_first_preservation(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -4825,9 +4923,15 @@ class TestRunOnceStaleActiveExecutionRecovery:
             )
 
         assert ws.status == WorkspaceStatus.pushing.value
-        assert preserved_events == []
-        assert len(stale_events) == 1
-        assert stale_events[0].reason_code == "STALE_ACTIVE_EXECUTION"
+        assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+        assert ws.failure_reason is None
+        assert ws.failure_message is None
+        assert len(preserved_events) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["runtime"]["services"][0]["container_id"] == (
+            "agent-refresh-before-expiry"
+        )
+        assert stale_events == []
         assert cleaner.calls == []
         assert inspector.calls == [compose_project]
 

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -56,6 +56,10 @@ from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.workspace_runtime_health import WorkspaceRuntimeFinding
 from tests.postgres import postgres_test_engine
 
+PRESERVED_EXECUTION_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
+PRESERVED_EXECUTION_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
+PRESERVED_EXECUTION_SUBPHASE = "runtime_preserved_after_restart"
+
 
 def _git(args: list[str], cwd: Path) -> None:
     subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
@@ -442,6 +446,22 @@ class _RecordingRuntimeCleaner:
             }
         )
         return self.result
+
+
+def _live_agent_snapshot(*, container_id: str = "agent") -> RuntimeSnapshot:
+    return RuntimeSnapshot(
+        stack_state="running",
+        services=[
+            RuntimeService(
+                name="agent",
+                container_id=container_id,
+                image="awf-agent:latest",
+                state="running",
+                status="Up 2 minutes",
+                health="healthy",
+            )
+        ],
+    )
 
 
 class _HealthyRuntimeInspector:
@@ -3459,6 +3479,313 @@ class TestRunOnceStaleActiveExecutionRecovery:
             assert not any(event.reason_code == "STALE_ACTIVE_EXECUTION" for event in events)
 
     @pytest.mark.unit
+    async def test_restart_recovery_preserves_live_running_agent_runtime_without_cleanup(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-live-running",
+            WorkspaceStatus.running,
+            compose_project_name="awf_preserve_live_running",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {"awf_preserve_live_running": _live_agent_snapshot(container_id="agent-running")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.running.value
+            assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+            assert ws.execution_claimed_by is None
+            assert ws.execution_claim_expires_at is None
+            assert ws.failure_reason is None
+            assert ws.failure_message is None
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert stale_events == []
+        assert len(preserved_events) == 1
+        preserved = preserved_events[0]
+        assert preserved.reason_code == PRESERVED_EXECUTION_REASON_CODE
+        assert preserved.payload is not None
+        assert preserved.payload["decision"] == "preserve_runtime"
+        assert preserved.payload["requested_action"] == OperationType.refresh.value
+        assert preserved.payload["workspace_status"] == WorkspaceStatus.running.value
+        assert preserved.payload["previous_claim"] == {
+            "monitor_claimed_by": None,
+            "monitor_claim_expires_at": None,
+            "execution_claimed_by": None,
+            "execution_claim_expires_at": None,
+        }
+        assert preserved.payload["runtime"]["services"][0]["container_id"] == "agent-running"
+        assert len(operations) == 1
+        operation = operations[0]
+        assert operation.type == OperationType.refresh.value
+        assert operation.status == OperationStatus.succeeded.value
+        assert operation.payload == {**preserved.payload, "operation_id": operation.id}
+        assert inspector.calls == ["awf_preserve_live_running"]
+        assert executor.calls == []
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("status", [WorkspaceStatus.validating, WorkspaceStatus.pushing])
+    async def test_restart_recovery_preserves_live_validating_and_pushing_runtimes(
+        self,
+        status: WorkspaceStatus,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = f"awf_preserve_live_{status.value}"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            f"preserve-live-{status.value}",
+            status,
+            compose_project_name=compose_project,
+        )
+        inspector = _RecordingRuntimeInspector({compose_project: _live_agent_snapshot()})
+        cleaner = _RecordingRuntimeCleaner()
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == status.value
+            assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+            assert ws.failure_reason is None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert len(preserved_events) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["workspace_status"] == status.value
+        assert preserved_events[0].payload["decision"] == "preserve_runtime"
+        assert stale_events == []
+        assert executor.calls == []
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_restart_recovery_preserves_five_live_workspaces_after_worker_restart(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        statuses = [
+            WorkspaceStatus.running,
+            WorkspaceStatus.validating,
+            WorkspaceStatus.pushing,
+            WorkspaceStatus.running,
+            WorkspaceStatus.pushing,
+        ]
+        workspace_ids: list[str] = []
+        snapshots: dict[str | None, RuntimeSnapshot] = {}
+        for index, status in enumerate(statuses):
+            compose_project = f"awf_preserve_five_{index}"
+            workspace_ids.append(
+                await _create_active_execution(
+                    session_factory,
+                    origin_repo,
+                    f"preserve-five-{index}",
+                    status,
+                    compose_project_name=compose_project,
+                    node_id="node-a",
+                )
+            )
+            snapshots[compose_project] = _live_agent_snapshot(container_id=f"agent-{index}")
+
+        inspector = _RecordingRuntimeInspector(snapshots)
+        cleaner = _RecordingRuntimeCleaner()
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            for workspace_id, status in zip(workspace_ids, statuses, strict=True):
+                ws = await WorkspaceRepository(s).get(workspace_id)
+                assert ws is not None
+                assert ws.status == status.value
+                assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+                assert ws.failure_reason is None
+                preserved_events = await WorkspaceEventRepository(s).list(
+                    workspace_id=workspace_id,
+                    event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+                )
+                stale_events = await WorkspaceEventRepository(s).list(
+                    workspace_id=workspace_id,
+                    event_type="workspace.stale_active_execution_detected",
+                )
+                operations = await OperationRepository(s).list_for_workspace(workspace_id)
+                assert len(preserved_events) == 1
+                assert stale_events == []
+                assert len(operations) == 1
+                assert operations[0].status == OperationStatus.succeeded.value
+
+        assert set(inspector.calls) == set(snapshots)
+        assert len(inspector.calls) == 5
+        assert executor.calls == []
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_restart_recovery_preserves_expired_claim_with_live_container(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        expired_at = datetime.now(UTC) - timedelta(seconds=1)
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-expired-claim",
+            WorkspaceStatus.running,
+            compose_project_name="awf_preserve_expired_claim",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "dead-worker"
+            ws.execution_claim_expires_at = expired_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {"awf_preserve_expired_claim": _live_agent_snapshot()}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=0),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.running.value
+            assert ws.execution_claimed_by is None
+            assert ws.execution_claim_expires_at is None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+        assert len(preserved_events) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["claim_cleanup"] == {
+            "action": "cleared_stale",
+            "reason_code": "STALE_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION",
+            "previous_claimed_by": "dead-worker",
+            "previous_expires_at": expired_at.isoformat(),
+        }
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_cleanup_failure_path_does_not_target_preserved_live_runtime(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserved-live-idempotent",
+            WorkspaceStatus.pushing,
+            compose_project_name="awf_preserved_live_idempotent",
+        )
+        inspector = _RecordingRuntimeInspector(
+            {"awf_preserved_live_idempotent": _live_agent_snapshot()}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.pushing.value
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            cleanup_failed_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_cleanup_failed",
+            )
+        assert len(preserved_events) == 1
+        assert cleanup_failed_events == []
+        assert inspector.calls == [
+            "awf_preserved_live_idempotent",
+            "awf_preserved_live_idempotent",
+        ]
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
     async def test_stale_active_execution_failure_marks_workspace_failed(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -3700,7 +4027,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             assert not any(event.reason_code == "STRANDED_WORKSPACE" for event in events)
 
     @pytest.mark.unit
-    async def test_stale_running_stack_is_evented_then_failed_on_next_scan(
+    async def test_live_running_stack_is_preserved_and_not_failed_on_next_scan(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -3749,57 +4076,42 @@ class TestRunOnceStaleActiveExecutionRecovery:
             ws = await WorkspaceRepository(s).get(workspace_id)
             assert ws is not None
             assert ws.status == WorkspaceStatus.pushing.value
+            assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
             assert ws.failure_reason is None
-            events = await WorkspaceEventRepository(s).list(
+            stale_events = await WorkspaceEventRepository(s).list(
                 workspace_id=workspace_id,
                 event_type="workspace.stale_active_execution_detected",
             )
-            assert len(events) == 1
-            assert events[0].reason_code == "STALE_ACTIVE_EXECUTION"
-            assert events[0].payload == {
-                "compose_project_name": "awf_pushing_running",
-                "workspace_status": "pushing",
-                "runtime": {
-                    "stack_state": "running",
-                    "reason": None,
-                    "services": [
-                        {
-                            "name": "agent",
-                            "container_id": "abc123",
-                            "image": "awf-agent:latest",
-                            "state": "running",
-                            "status": "Up 2 minutes",
-                            "health": "healthy",
-                            "ports": [],
-                            "started_at": None,
-                        }
-                    ],
-                },
-            }
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+            assert stale_events == []
+            assert len(preserved_events) == 1
+            assert preserved_events[0].reason_code == PRESERVED_EXECUTION_REASON_CODE
+            assert preserved_events[0].payload is not None
+            assert preserved_events[0].payload["runtime"]["services"][0]["container_id"] == "abc123"
+            assert len(operations) == 1
+            assert operations[0].type == OperationType.refresh.value
+            assert operations[0].status == OperationStatus.succeeded.value
 
         assert await worker.run_once() == 0
 
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)
             assert ws is not None
-            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.status == WorkspaceStatus.pushing.value
             assert ws.execution_claimed_by is None
             assert ws.execution_claim_expires_at is None
-            assert ws.failure_reason == "infrastructure_failure"
-            assert ws.failure_message is not None
-            assert "active execution was lost" in ws.failure_message
+            assert ws.failure_reason is None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            assert len(preserved_events) == 1
         assert inspector.calls == ["awf_pushing_running", "awf_pushing_running"]
-        assert cleaner.calls == [
-            {
-                "workspace_id": workspace_id,
-                "repo_url": str(origin_repo),
-                "compose_project_name": "awf_pushing_running",
-                "compose_file_path": Path(f"/tmp/awf/{workspace_id}/compose.yml"),
-                "worktree_host_path": None,
-                "remove_volumes": True,
-                "remove_worktree": False,
-            }
-        ]
+        assert cleaner.calls == []
 
     @pytest.mark.unit
     async def test_stale_active_execution_scan_is_throttled_between_intervals(
@@ -3861,7 +4173,15 @@ class TestRunOnceStaleActiveExecutionRecovery:
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)
             assert ws is not None
-            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.status == WorkspaceStatus.pushing.value
+            assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+            assert ws.failure_reason is None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            assert len(preserved_events) == 1
+        assert cleaner.calls == []
 
     @pytest.mark.unit
     async def test_current_in_memory_execution_task_is_not_touched(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -5239,7 +5239,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             worker._execution_tasks.pop(workspace_id, None)
 
     @pytest.mark.unit
-    async def test_stale_active_execution_scan_skips_unexpired_execution_claim(
+    async def test_stale_active_execution_scan_defers_unexpired_exited_claim_failure(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
@@ -5259,7 +5259,22 @@ class TestRunOnceStaleActiveExecutionRecovery:
             ws.execution_claim_expires_at = datetime.now(UTC) + timedelta(minutes=5)
             await s.commit()
 
-        inspector = _RecordingRuntimeInspector({})
+        inspector = _RecordingRuntimeInspector(
+            {
+                "awf_claimed_running": RuntimeSnapshot(
+                    stack_state="stopped",
+                    services=[
+                        RuntimeService(
+                            name="agent",
+                            container_id="agent-claimed",
+                            image="awf-agent:latest",
+                            state="exited",
+                            status="Exited (0) 1 minute ago",
+                        )
+                    ],
+                )
+            }
+        )
         worker = ControlWorker(
             session_factory=session_factory,
             provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
@@ -5279,7 +5294,110 @@ class TestRunOnceStaleActiveExecutionRecovery:
             assert ws is not None
             assert ws.status == WorkspaceStatus.running.value
             assert ws.failure_reason is None
-        assert inspector.calls == []
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stranded_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+        assert preserved_events == []
+        assert stranded_events == []
+        assert inspector.calls == ["awf_claimed_running"]
+
+    @pytest.mark.unit
+    async def test_restart_recovery_preserves_live_runtime_before_unexpired_claim_expires(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_unexpired_claim_live_runtime"
+        claim_expires_at = datetime.now(UTC) + timedelta(minutes=5)
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "unexpired-claim-live-runtime",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+            node_id="node-a",
+        )
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            ws.execution_claimed_by = "previous-worker"
+            ws.execution_claim_expires_at = claim_expires_at
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-unexpired")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+                node_id="node-a",
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        inspector._snapshots[compose_project] = RuntimeSnapshot(  # noqa: SLF001
+            stack_state="stopped",
+            services=[
+                RuntimeService(
+                    name="agent",
+                    container_id="agent-unexpired",
+                    image="awf-agent:latest",
+                    state="exited",
+                    status="Exited (0) 1 minute ago",
+                )
+            ],
+        )
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stranded_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.running.value
+        assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+        assert ws.execution_claimed_by is None
+        assert ws.execution_claim_expires_at is None
+        assert ws.failure_reason is None
+        assert ws.failure_message is None
+        assert len(preserved_events) == 1
+        assert preserved_events[0].payload is not None
+        assert preserved_events[0].payload["claim_cleanup"] == {
+            "action": "cleared_unexpired",
+            "reason_code": (
+                "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION"
+            ),
+            "previous_claimed_by": "previous-worker",
+            "previous_expires_at": claim_expires_at.isoformat(),
+        }
+        assert stranded_events == []
+        assert stale_events == []
+        assert inspector.calls == [compose_project]
+        assert cleaner.calls == []
 
     @pytest.mark.unit
     async def test_stale_active_execution_scan_recovers_expired_execution_claim(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3891,6 +3891,69 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert preserved_events[0].payload["operation_id"] == operations[0].id
 
     @pytest.mark.unit
+    async def test_preservation_recording_rechecks_operator_refresh_under_lock(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_refresh_race"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-refresh-race",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        candidate = _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.pushing,
+            repo_url=str(origin_repo),
+            compose_project_name=compose_project,
+        )
+        snapshot = _live_agent_snapshot(container_id="agent-refresh-race")
+        async with session_factory() as s:
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-before-locked-preservation",
+            )
+            await s.commit()
+
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=_RecordingRuntimeInspector({compose_project: snapshot}),
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+            ),
+        )
+
+        await worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
+            candidate,
+            snapshot,
+        )
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert ws is not None
+        assert ws.subphase is None
+        assert preserved_events == []
+        assert [operation.type for operation in operations] == [OperationType.refresh.value]
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("status", [WorkspaceStatus.validating, WorkspaceStatus.pushing])
     async def test_restart_recovery_preserves_live_validating_and_pushing_runtimes(
         self,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4519,6 +4519,83 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert cleaner.calls == []
 
     @pytest.mark.unit
+    async def test_operator_refresh_of_live_preserved_runtime_does_not_represerve(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserved_refresh_live"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserved-refresh-live",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-preserved-refresh-live")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            await WorkspaceControlService(
+                s,
+                project_stopper=_noop_project_stop,
+                cleaner_factory=_unexpected_cleaner_factory,
+            ).request_refresh_workspace(
+                workspace_id,
+                reason="operator recovery",
+                idempotency_key="refresh-preserved-live-runtime",
+            )
+            await s.commit()
+
+        assert await worker.run_once() == 0
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == FailureReason.infrastructure_failure.value
+        assert len(preserved_events) == 1
+        assert len(stale_events) == 1
+        assert cleaner.calls == [
+            {
+                "workspace_id": workspace_id,
+                "repo_url": str(origin_repo),
+                "compose_project_name": compose_project,
+                "compose_file_path": Path(f"/tmp/awf/{workspace_id}/compose.yml"),
+                "worktree_host_path": None,
+                "remove_volumes": True,
+                "remove_worktree": False,
+            }
+        ]
+        assert inspector.calls == [compose_project, compose_project, compose_project]
+
+    @pytest.mark.unit
     async def test_stale_active_execution_scan_is_throttled_between_intervals(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -3552,6 +3552,65 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert cleaner.calls == []
 
     @pytest.mark.unit
+    async def test_restart_recovery_records_preservation_once_per_active_phase(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserve_phase_change"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserve-phase-change",
+            WorkspaceStatus.running,
+            compose_project_name=compose_project,
+        )
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-phase")}
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=_RecordingRuntimeCleaner(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            await repo.transition(ws, to=WorkspaceStatus.validating, reason_code="TEST_ADVANCE")
+            await s.commit()
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            operations = await OperationRepository(s).list_for_workspace(workspace_id)
+
+        assert len(preserved_events) == 2
+        assert {event.payload["workspace_status"] for event in preserved_events} == {
+            WorkspaceStatus.running.value,
+            WorkspaceStatus.validating.value,
+        }
+        assert len(operations) == 2
+        assert {operation.payload["workspace_status"] for operation in operations} == {
+            WorkspaceStatus.running.value,
+            WorkspaceStatus.validating.value,
+        }
+        assert inspector.calls == [compose_project, compose_project]
+
+    @pytest.mark.unit
     async def test_restart_recovery_serializes_concurrent_preservation_recording(
         self,
         session_factory: async_sessionmaker[AsyncSession],
@@ -3586,6 +3645,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             self: ControlWorker,
             session: AsyncSession,
             workspace_id: str,
+            status: WorkspaceStatus,
         ) -> bool:
             nonlocal call_count, selected_count
             async with count_lock:
@@ -3602,7 +3662,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             else:
                 await first_checked.wait()
 
-            has_event = await original_has_event(self, session, workspace_id)
+            has_event = await original_has_event(self, session, workspace_id, status)
             async with count_lock:
                 selected_count += 1
                 if selected_count == 2:

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -4033,10 +4033,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
             )
         assert len(preserved_events) == 1
         assert cleanup_failed_events == []
-        assert inspector.calls == [
-            "awf_preserved_live_idempotent",
-            "awf_preserved_live_idempotent",
-        ]
+        assert inspector.calls == ["awf_preserved_live_idempotent"]
         assert cleaner.calls == []
 
     @pytest.mark.unit
@@ -4364,7 +4361,81 @@ class TestRunOnceStaleActiveExecutionRecovery:
                 event_type=PRESERVED_EXECUTION_EVENT_TYPE,
             )
             assert len(preserved_events) == 1
-        assert inspector.calls == ["awf_pushing_running", "awf_pushing_running"]
+        assert inspector.calls == ["awf_pushing_running"]
+        assert cleaner.calls == []
+
+    @pytest.mark.unit
+    async def test_preserved_runtime_exit_before_operator_recovery_is_not_failed_by_scan(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        compose_project = "awf_preserved_then_exited"
+        workspace_id = await _create_active_execution(
+            session_factory,
+            origin_repo,
+            "preserved-then-exited",
+            WorkspaceStatus.pushing,
+            compose_project_name=compose_project,
+        )
+        inspector = _RecordingRuntimeInspector(
+            {compose_project: _live_agent_snapshot(container_id="agent-preserved")}
+        )
+        cleaner = _RecordingRuntimeCleaner()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            runtime_cleaner=cleaner,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                stale_active_execution_scan_interval_seconds=0.0,
+            ),
+        )
+
+        assert await worker.run_once() == 0
+
+        inspector._snapshots[compose_project] = RuntimeSnapshot(  # noqa: SLF001
+            stack_state="stopped",
+            services=[
+                RuntimeService(
+                    name="agent",
+                    container_id="agent-preserved",
+                    image="awf-agent:latest",
+                    state="exited",
+                    status="Exited (0) 1 minute ago",
+                )
+            ],
+        )
+
+        assert await worker.run_once() == 0
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.pushing.value
+            assert ws.subphase == PRESERVED_EXECUTION_SUBPHASE
+            assert ws.failure_reason is None
+            assert ws.failure_message is None
+            preserved_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            )
+            stranded_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+            stale_events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.stale_active_execution_detected",
+            )
+
+        assert len(preserved_events) == 1
+        assert stranded_events == []
+        assert stale_events == []
+        assert inspector.calls == [compose_project]
         assert cleaner.calls == []
 
     @pytest.mark.unit
@@ -4423,7 +4494,7 @@ class TestRunOnceStaleActiveExecutionRecovery:
         current_time = 1_060.0
 
         assert await worker.run_once() == 0
-        assert inspector.calls == ["awf_throttled_running", "awf_throttled_running"]
+        assert inspector.calls == ["awf_throttled_running"]
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).get(workspace_id)
             assert ws is not None

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -558,7 +558,7 @@ def test_execution_claim_is_stale_handles_missing_and_naive_datetimes() -> None:
 
 
 @pytest.mark.unit
-def test_active_execution_preservation_claim_cleanup_clears_unexpired_claim() -> None:
+def test_active_execution_preservation_claim_cleanup_preserves_unexpired_claim() -> None:
     cutoff = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
     workspace = SimpleNamespace(
         execution_claimed_by="live-worker",
@@ -569,8 +569,8 @@ def test_active_execution_preservation_claim_cleanup_clears_unexpired_claim() ->
         workspace,
         claim_cutoff=cutoff,
     ) == {
-        "action": "cleared_unexpired",
-        "reason_code": "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION",
+        "action": "preserved_unexpired",
+        "reason_code": "UNEXPIRED_EXECUTION_CLAIM_PRESERVED_DURING_ACTIVE_EXECUTION_PRESERVATION",
         "previous_claimed_by": "live-worker",
         "previous_expires_at": "2026-04-27T12:05:00+00:00",
     }

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.control.worker import (
     ControlWorker,
     WorkerConfig,
+    _active_execution_preservation_claim_cleanup_payload,
     _ActiveExecutionCandidate,
     _execution_claim_is_stale,
     _json_datetime,
@@ -554,6 +555,21 @@ def test_execution_claim_is_stale_handles_missing_and_naive_datetimes() -> None:
         ),
         cutoff,
     )
+
+
+@pytest.mark.unit
+def test_active_execution_preservation_claim_cleanup_rejects_unexpired_claim() -> None:
+    cutoff = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    workspace = SimpleNamespace(
+        execution_claimed_by="live-worker",
+        execution_claim_expires_at=cutoff + timedelta(minutes=5),
+    )
+
+    with pytest.raises(ValueError, match="requires a stale execution claim"):
+        _active_execution_preservation_claim_cleanup_payload(
+            workspace,
+            claim_cutoff=cutoff,
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -558,18 +558,22 @@ def test_execution_claim_is_stale_handles_missing_and_naive_datetimes() -> None:
 
 
 @pytest.mark.unit
-def test_active_execution_preservation_claim_cleanup_rejects_unexpired_claim() -> None:
+def test_active_execution_preservation_claim_cleanup_clears_unexpired_claim() -> None:
     cutoff = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
     workspace = SimpleNamespace(
         execution_claimed_by="live-worker",
         execution_claim_expires_at=cutoff + timedelta(minutes=5),
     )
 
-    with pytest.raises(ValueError, match="requires a stale execution claim"):
-        _active_execution_preservation_claim_cleanup_payload(
-            workspace,
-            claim_cutoff=cutoff,
-        )
+    assert _active_execution_preservation_claim_cleanup_payload(
+        workspace,
+        claim_cutoff=cutoff,
+    ) == {
+        "action": "cleared_unexpired",
+        "reason_code": "UNEXPIRED_EXECUTION_CLAIM_CLEARED_DURING_ACTIVE_EXECUTION_PRESERVATION",
+        "previous_claimed_by": "live-worker",
+        "previous_expires_at": "2026-04-27T12:05:00+00:00",
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -18,19 +18,22 @@ from awf.control.worker import (
     _active_execution_preservation_claim_cleanup_payload,
     _ActiveExecutionCandidate,
     _execution_claim_is_stale,
+    _has_running_agent_runtime,
     _json_datetime,
     _monitor_claim_is_stale,
     _stale_active_execution_failure_message,
+    _utc_datetime,
 )
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
 from awf.db.repositories import (
     OperationRepository,
     SecretLeaseIssue,
     SecretLeaseRepository,
+    WorkspaceEventRepository,
     WorkspaceRepository,
 )
 from awf.db.session import make_session_factory
-from awf.runtime.inspection import RuntimeSnapshot
+from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
 from tests.postgres import postgres_test_engine
 
 
@@ -670,3 +673,123 @@ def test_stale_active_execution_failure_message_includes_runtime_reason() -> Non
         RuntimeSnapshot(stack_state="stopped", services=[]),
     )
     assert "compose runtime state is stopped." in no_reason_message
+
+
+@pytest.mark.unit
+def test_runtime_snapshot_requires_running_stack_before_agent_detection() -> None:
+    assert not _has_running_agent_runtime(
+        RuntimeSnapshot(
+            stack_state="stopped",
+            services=[
+                RuntimeService(
+                    name="agent",
+                    container_id="agent-1",
+                    image="awf-agent-runtime",
+                    state="running",
+                )
+            ],
+        )
+    )
+
+
+@pytest.mark.unit
+def test_worker_utc_datetime_normalizes_naive_values() -> None:
+    assert _utc_datetime(datetime(2026, 4, 27, 12, 0)) == datetime(
+        2026,
+        4,
+        27,
+        12,
+        0,
+        tzinfo=UTC,
+    )
+
+
+@pytest.mark.unit
+async def test_wait_for_execution_tasks_removes_completed_tasks(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+    worker._execution_tasks["ws_done"] = asyncio.create_task(asyncio.sleep(0))  # noqa: SLF001
+
+    await worker.wait_for_execution_tasks()
+
+    assert worker._execution_tasks == {}  # noqa: SLF001
+
+
+@pytest.mark.unit
+async def test_execution_and_monitor_claim_helpers_skip_already_running_task(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+    task = asyncio.create_task(asyncio.sleep(30))
+    worker._execution_tasks["ws_busy"] = task  # noqa: SLF001
+
+    try:
+        assert worker._dispatchable_execution_ids(  # noqa: SLF001
+            ["ws_busy", "ws_next"],
+            limit=2,
+        ) == ["ws_next"]
+        assert await worker._claim_monitoring_pr_ids(["ws_busy"], limit=1) == []  # noqa: SLF001
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+
+@pytest.mark.unit
+async def test_stale_active_execution_without_runtime_cleaner_records_cleanup_failure(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _seed_status(
+        factory,
+        WorkspaceStatus.running,
+        title="stale active execution without cleaner",
+    )
+    worker = _worker(factory)
+    candidate = _ActiveExecutionCandidate(
+        workspace_id=workspace_id,
+        status=WorkspaceStatus.running,
+        compose_project_name=f"awf_{workspace_id}",
+        repo_url="git@example.com:repo/app.git",
+    )
+    snapshot = RuntimeSnapshot(stack_state="running", reason="control worker restarted")
+    assert await worker._record_stale_active_execution_detected(candidate, snapshot)  # noqa: SLF001
+
+    await worker._cleanup_and_fail_stale_active_execution(candidate, snapshot)  # noqa: SLF001
+
+    async with factory() as session:
+        events = await WorkspaceEventRepository(session).list(
+            workspace_id=workspace_id,
+            event_type="workspace.stale_active_execution_cleanup_failed",
+        )
+
+    assert len(events) == 1
+    assert events[0].reason_code == "STALE_ACTIVE_EXECUTION_CLEANUP_FAILED"
+    assert events[0].payload["message"] == "runtime cleanup is not configured"
+
+
+@pytest.mark.unit
+async def test_fail_stale_active_execution_skips_status_mismatch(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _seed_status(
+        factory,
+        WorkspaceStatus.running,
+        title="stale active execution status mismatch",
+    )
+    worker = _worker(factory)
+
+    await worker._fail_stale_active_execution(  # noqa: SLF001
+        _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.validating,
+            compose_project_name=f"awf_{workspace_id}",
+        ),
+        RuntimeSnapshot(stack_state="running", reason="worker restarted"),
+    )
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.running.value

--- a/tests/unit/service/test_workspace_response.py
+++ b/tests/unit/service/test_workspace_response.py
@@ -25,6 +25,11 @@ from awf.service.validation_observability import (
     latest_merge_candidate,
     validation_freshness_summary,
 )
+from awf.service.workspace_runtime_health import (
+    ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+    ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+    RUNTIME_STRANDED_EVENT_TYPE,
+)
 from awf.service.workspaces import workspace_failure_details_payload, workspace_response
 
 
@@ -1584,3 +1589,149 @@ def test_workspace_response_provider_recovery_state_none_when_absent() -> None:
     response = workspace_response(workspace)  # type: ignore[arg-type]
 
     assert response.provider_recovery_state is None
+
+
+def _workspace_response_fixture(
+    *,
+    workspace_id: str,
+    status: str,
+    events: list[SimpleNamespace],
+    execution_claim_expires_at: datetime | None = None,
+) -> SimpleNamespace:
+    now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+    return SimpleNamespace(
+        id=workspace_id,
+        status=status,
+        version=1,
+        repo_url="git@github.com:example/project.git",
+        branch_base="main",
+        branch_name=f"awf/{workspace_id}",
+        base_commit="abc123",
+        task_title="Runtime health projection",
+        task_prompt="Exercise runtime health projection.",
+        task_external_id=None,
+        task_class=None,
+        owned_paths=[],
+        task_policy={},
+        auto_merge=True,
+        initial_review_grace_period_seconds=None,
+        agent="codex",
+        env_profile=None,
+        profile_ref=None,
+        requested_profile=None,
+        resolved_profile=None,
+        test_commands=[],
+        requires_database=False,
+        node_id=None,
+        compose_project_name=None,
+        compose_file_path=None,
+        pr_url=None,
+        failure_reason=None,
+        failure_message=None,
+        active_policy_findings=[],
+        operations=[],
+        secret_leases=[],
+        events=events,
+        execution_claim_expires_at=execution_claim_expires_at,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+@pytest.mark.unit
+def test_workspace_response_projects_runtime_inspection_unavailable_health() -> None:
+    workspace = _workspace_response_fixture(
+        workspace_id="ws-runtime-unavailable",
+        status=WorkspaceStatus.ready.value,
+        events=[
+            SimpleNamespace(
+                event_type=RUNTIME_STRANDED_EVENT_TYPE,
+                reason_code="RUNTIME_INSPECTION_UNAVAILABLE",
+                old_state=None,
+                new_state=None,
+                payload={
+                    "reason_code": "RUNTIME_INSPECTION_UNAVAILABLE",
+                    "decision": "none",
+                    "message": "Docker runtime inspection is unavailable.",
+                },
+                occurred_at=datetime(2026, 4, 27, 12, 5, tzinfo=UTC),
+            )
+        ],
+    )
+
+    response = workspace_response(workspace)  # type: ignore[arg-type]
+
+    assert response.runtime_health is not None
+    assert response.runtime_health.status == "unavailable"
+    assert response.runtime_health.reason_code == "RUNTIME_INSPECTION_UNAVAILABLE"
+    assert response.runtime_health.message == "Docker runtime inspection is unavailable."
+
+
+@pytest.mark.unit
+def test_workspace_response_ignores_preserved_runtime_health_before_current_status_floor() -> None:
+    status_started_at = datetime(2026, 4, 27, 12, 0)
+    stale_preservation = SimpleNamespace(
+        event_type=ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+        reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+        old_state=None,
+        new_state=None,
+        payload={
+            "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+            "decision": "preserve_runtime",
+            "message": "Old runtime preservation belongs to the previous status.",
+            "workspace_status": WorkspaceStatus.running.value,
+        },
+        occurred_at=status_started_at - timedelta(minutes=1),
+    )
+    current_preservation = SimpleNamespace(
+        event_type=ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+        reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+        old_state=None,
+        new_state=None,
+        payload={
+            "reason_code": ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+            "decision": "preserve_runtime",
+            "message": "Runtime is still owned by the active agent.",
+            "workspace_status": WorkspaceStatus.running.value,
+            "runtime": {
+                "services": [
+                    {
+                        "name": "agent",
+                        "state": "running",
+                        "container_id": "container-123",
+                    }
+                ]
+            },
+        },
+        occurred_at=status_started_at + timedelta(minutes=1),
+    )
+    workspace = _workspace_response_fixture(
+        workspace_id="ws-runtime-preserved",
+        status=WorkspaceStatus.running.value,
+        events=[
+            current_preservation,
+            SimpleNamespace(
+                event_type="workspace.state_changed",
+                reason_code="EXECUTION_STARTED",
+                old_state=WorkspaceStatus.ready.value,
+                new_state=WorkspaceStatus.running.value,
+                payload=None,
+                occurred_at=status_started_at,
+            ),
+            stale_preservation,
+        ],
+    )
+
+    response = workspace_response(workspace)  # type: ignore[arg-type]
+
+    assert response.runtime_health is not None
+    assert response.runtime_health.status == "ok"
+    assert response.runtime_health.reason_code == ACTIVE_EXECUTION_PRESERVED_REASON_CODE
+    assert response.runtime_health.message == "Runtime is still owned by the active agent."
+    assert response.runtime_health.services == [
+        {
+            "name": "agent",
+            "state": "running",
+            "container_id": "container-123",
+        }
+    ]

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -66,7 +66,9 @@ async def _workspace_with_runtime_health_event(
     session_factory: async_sessionmaker[AsyncSession],
     *,
     payload: dict[str, object],
+    event_type: str = RUNTIME_STRANDED_EVENT_TYPE,
     reason_code: str = "STRANDED_WORKSPACE",
+    status: WorkspaceStatus = WorkspaceStatus.failed,
 ) -> str:
     async with session_factory() as session:
         repo = WorkspaceRepository(session)
@@ -78,11 +80,12 @@ async def _workspace_with_runtime_health_event(
             agent="codex",
             test_commands=[],
         )
-        workspace.status = WorkspaceStatus.failed.value
-        workspace.failure_reason = "infrastructure_failure"
+        workspace.status = status.value
+        if status == WorkspaceStatus.failed:
+            workspace.failure_reason = "infrastructure_failure"
         await repo.add_event(
             workspace,
-            event_type=RUNTIME_STRANDED_EVENT_TYPE,
+            event_type=event_type,
             reason_code=reason_code,
             payload=payload,
         )
@@ -351,6 +354,37 @@ async def test_workspace_detail_exposes_persisted_preserved_runtime_health(
 
 
 @pytest.mark.unit
+async def test_workspace_detail_ignores_persisted_preserved_runtime_health_after_cancel(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _workspace_with_runtime_health_event(
+        session_factory,
+        status=WorkspaceStatus.cancelled,
+        event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+        reason_code=PRESERVED_EXECUTION_REASON_CODE,
+        payload={
+            "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+            "decision": "preserve_runtime",
+            "message": "Live agent runtime was preserved after worker restart.",
+            "runtime": {
+                "services": [
+                    {
+                        "name": "agent",
+                        "state": "running",
+                        "container_id": "agent",
+                    }
+                ]
+            },
+        },
+    )
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is None
+
+
+@pytest.mark.unit
 async def test_runtime_detail_uses_preserved_health_when_live_snapshot_is_healthy(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -415,6 +449,54 @@ async def test_runtime_detail_uses_preserved_health_when_live_snapshot_is_health
     assert runtime.runtime_health.status == "ok"
     assert runtime.runtime_health.reason_code == PRESERVED_EXECUTION_REASON_CODE
     assert runtime.runtime_health.decision == "preserve_runtime"
+
+
+@pytest.mark.unit
+async def test_runtime_detail_ignores_preserved_health_for_stopped_terminal_workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _workspace(
+        session_factory,
+        status=WorkspaceStatus.cancelled,
+        compose_project_name="awf_cancelled_preserved_runtime",
+    )
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent",
+                        }
+                    ]
+                },
+            },
+        )
+        await session.commit()
+
+    inspector = _RuntimeInspector(
+        {"awf_cancelled_preserved_runtime": RuntimeSnapshot(stack_state="stopped")}
+    )
+
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert runtime is not None
+    assert runtime.stack_state == "stopped"
+    assert runtime.runtime_health is None
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -326,6 +326,7 @@ async def test_workspace_detail_exposes_persisted_preserved_runtime_health(
             payload={
                 "reason_code": PRESERVED_EXECUTION_REASON_CODE,
                 "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
                 "message": "Live agent runtime was preserved after worker restart.",
                 "runtime": {
                     "services": [
@@ -354,6 +355,38 @@ async def test_workspace_detail_exposes_persisted_preserved_runtime_health(
 
 
 @pytest.mark.unit
+async def test_workspace_detail_ignores_preserved_health_from_prior_active_status(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _workspace_with_runtime_health_event(
+        session_factory,
+        status=WorkspaceStatus.validating,
+        event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+        reason_code=PRESERVED_EXECUTION_REASON_CODE,
+        payload={
+            "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+            "decision": "preserve_runtime",
+            "workspace_status": WorkspaceStatus.running.value,
+            "message": "Live agent runtime was preserved after worker restart.",
+            "runtime": {
+                "services": [
+                    {
+                        "name": "agent",
+                        "state": "running",
+                        "container_id": "agent",
+                    }
+                ]
+            },
+        },
+    )
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is None
+
+
+@pytest.mark.unit
 async def test_workspace_detail_ignores_persisted_preserved_runtime_health_after_cancel(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:
@@ -365,6 +398,7 @@ async def test_workspace_detail_ignores_persisted_preserved_runtime_health_after
         payload={
             "reason_code": PRESERVED_EXECUTION_REASON_CODE,
             "decision": "preserve_runtime",
+            "workspace_status": WorkspaceStatus.running.value,
             "message": "Live agent runtime was preserved after worker restart.",
             "runtime": {
                 "services": [
@@ -408,6 +442,7 @@ async def test_runtime_detail_uses_preserved_health_when_live_snapshot_is_health
             payload={
                 "reason_code": PRESERVED_EXECUTION_REASON_CODE,
                 "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.pushing.value,
                 "message": "Live agent runtime was preserved after worker restart.",
                 "runtime": {
                     "services": [
@@ -535,6 +570,7 @@ async def test_runtime_detail_ignores_preserved_health_for_stopped_terminal_work
             payload={
                 "reason_code": PRESERVED_EXECUTION_REASON_CODE,
                 "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
                 "message": "Live agent runtime was preserved after worker restart.",
                 "runtime": {
                     "services": [

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -17,6 +17,8 @@ from awf.service.workspaces import WorkspaceService
 
 PRESERVED_EXECUTION_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
 PRESERVED_EXECUTION_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
+REFRESH_REQUESTED_EVENT_TYPE = "workspace.refresh_requested"
+REFRESH_REQUESTED_REASON_CODE = "OPERATOR_REFRESH"
 
 
 @pytest.fixture
@@ -468,6 +470,82 @@ async def test_preserved_runtime_health_is_scoped_to_current_status_cycle(
             )
         }
     )
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is None
+    assert runtime is not None
+    assert runtime.runtime_health is None
+
+
+@pytest.mark.unit
+async def test_preserved_runtime_health_is_floored_by_operator_refresh(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime refresh floor",
+            task_prompt="do not show preservation superseded by refresh",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.pushing.value
+        workspace.compose_project_name = "awf_preserved_runtime_refresh_floor"
+        workspace.compose_file_path = f"/tmp/{workspace.id}/compose.yml"
+        base = datetime.now(UTC)
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.pushing.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent-preserved",
+                        }
+                    ]
+                },
+            },
+        )
+        preserved.occurred_at = base
+        refresh = await repo.add_event(
+            workspace,
+            event_type=REFRESH_REQUESTED_EVENT_TYPE,
+            reason_code=REFRESH_REQUESTED_REASON_CODE,
+        )
+        refresh.occurred_at = base + timedelta(seconds=1)
+        await session.commit()
+        workspace_id = workspace.id
+
+    inspector = _RuntimeInspector(
+        {
+            "awf_preserved_runtime_refresh_floor": RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="agent-current",
+                        image="awf-agent:latest",
+                        state="running",
+                    )
+                ],
+            )
+        }
+    )
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
     runtime = await WorkspaceService(
         session_factory,
         runtime_inspector=inspector,

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -389,6 +389,57 @@ async def test_workspace_detail_ignores_preserved_health_from_prior_active_statu
 
 
 @pytest.mark.unit
+async def test_workspace_detail_falls_back_to_stranded_health_after_mismatched_preserved_event(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="persisted mismatched preserved runtime",
+            task_prompt="show earlier stranded runtime finding",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.validating.value
+        base = datetime.now(UTC)
+        stranded = await repo.add_event(
+            workspace,
+            event_type=RUNTIME_STRANDED_EVENT_TYPE,
+            reason_code="AGENT_CONTAINER_EXITED",
+            payload={
+                "reason_code": "AGENT_CONTAINER_EXITED",
+                "decision": "fail_workspace",
+                "message": "Workspace agent container is not running.",
+            },
+        )
+        stranded.occurred_at = base
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+            },
+        )
+        preserved.occurred_at = base + timedelta(seconds=1)
+        await session.commit()
+        workspace_id = workspace.id
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is not None
+    assert detail.runtime_health.status == "stranded"
+    assert detail.runtime_health.reason_code == "AGENT_CONTAINER_EXITED"
+    assert detail.runtime_health.decision == "fail_workspace"
+
+
+@pytest.mark.unit
 async def test_preserved_runtime_health_is_scoped_to_current_status_cycle(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -609,6 +609,174 @@ async def test_preserved_runtime_health_is_floored_by_operator_refresh(
 
 
 @pytest.mark.unit
+async def test_preserved_runtime_health_is_floored_by_past_execution_claim_expiry(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime claim floor",
+            task_prompt="do not show preservation from replaced execution claim",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.running.value
+        workspace.compose_project_name = "awf_preserved_runtime_claim_floor"
+        workspace.compose_file_path = f"/tmp/{workspace.id}/compose.yml"
+        base = datetime.now(UTC) - timedelta(minutes=10)
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent-preserved",
+                        }
+                    ]
+                },
+            },
+        )
+        preserved.occurred_at = base
+        workspace.execution_claim_expires_at = base + timedelta(seconds=1)
+        await session.commit()
+        workspace_id = workspace.id
+
+    inspector = _RuntimeInspector(
+        {
+            "awf_preserved_runtime_claim_floor": RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="agent-current",
+                        image="awf-agent:latest",
+                        state="running",
+                    )
+                ],
+            )
+        }
+    )
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is None
+    assert runtime is not None
+    assert runtime.runtime_health is None
+
+
+@pytest.mark.unit
+async def test_preserved_runtime_health_keeps_current_event_with_unexpired_execution_claim(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime fresh claim",
+            task_prompt="show preservation owned by active execution claim",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.validating.value
+        base = datetime.now(UTC)
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.validating.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+            },
+        )
+        preserved.occurred_at = base
+        workspace.execution_claim_expires_at = base + timedelta(minutes=5)
+        await session.commit()
+        workspace_id = workspace.id
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is not None
+    assert detail.runtime_health.status == "ok"
+    assert detail.runtime_health.reason_code == PRESERVED_EXECUTION_REASON_CODE
+    assert detail.runtime_health.decision == "preserve_runtime"
+
+
+@pytest.mark.unit
+async def test_preserved_runtime_health_ignores_operator_refresh_from_prior_status(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime status-scoped refresh",
+            task_prompt="do not let another status refresh hide preservation",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.running.value
+        base = datetime.now(UTC)
+        running = await repo.add_event(
+            workspace,
+            event_type="workspace.state_changed",
+            reason_code="WORKSPACE_RUNNING",
+        )
+        running.old_state = WorkspaceStatus.ready.value
+        running.new_state = WorkspaceStatus.running.value
+        running.occurred_at = base
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+            },
+        )
+        preserved.occurred_at = base + timedelta(seconds=1)
+        refresh = await repo.add_event(
+            workspace,
+            event_type=REFRESH_REQUESTED_EVENT_TYPE,
+            reason_code=REFRESH_REQUESTED_REASON_CODE,
+        )
+        refresh.old_state = WorkspaceStatus.validating.value
+        refresh.new_state = WorkspaceStatus.validating.value
+        refresh.occurred_at = base + timedelta(seconds=2)
+        await session.commit()
+        workspace_id = workspace.id
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is not None
+    assert detail.runtime_health.status == "ok"
+    assert detail.runtime_health.reason_code == PRESERVED_EXECUTION_REASON_CODE
+    assert detail.runtime_health.decision == "preserve_runtime"
+
+
+@pytest.mark.unit
 async def test_workspace_detail_ignores_persisted_preserved_runtime_health_after_cancel(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -15,6 +15,9 @@ from awf.runtime.inspection import RuntimeService, RuntimeSnapshot
 from awf.service.workspace_runtime_health import RUNTIME_STRANDED_EVENT_TYPE
 from awf.service.workspaces import WorkspaceService
 
+PRESERVED_EXECUTION_EVENT_TYPE = "workspace.active_execution_preserved_after_restart"
+PRESERVED_EXECUTION_REASON_CODE = "ACTIVE_EXECUTION_PRESERVED_AFTER_RESTART"
+
 
 @pytest.fixture
 async def session_factory(
@@ -296,6 +299,122 @@ async def test_workspace_detail_exposes_persisted_runtime_health(
     assert detail.runtime_health.services == [
         {"name": "agent", "state": "exited", "container_id": "agent"}
     ]
+
+
+@pytest.mark.unit
+async def test_workspace_detail_exposes_persisted_preserved_runtime_health(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="persisted preserved runtime",
+            task_prompt="show preserved runtime finding",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.running.value
+        await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent",
+                        }
+                    ]
+                },
+            },
+        )
+        await session.commit()
+        workspace_id = workspace.id
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is not None
+    assert detail.runtime_health.status == "ok"
+    assert detail.runtime_health.reason_code == PRESERVED_EXECUTION_REASON_CODE
+    assert detail.runtime_health.decision == "preserve_runtime"
+    assert detail.runtime_health.services == [
+        {"name": "agent", "state": "running", "container_id": "agent"}
+    ]
+
+
+@pytest.mark.unit
+async def test_runtime_detail_uses_preserved_health_when_live_snapshot_is_healthy(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime endpoint",
+            task_prompt="show preserved runtime in runtime endpoint",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.pushing.value
+        workspace.compose_project_name = "awf_preserved_runtime_endpoint"
+        workspace.compose_file_path = f"/tmp/{workspace.id}/compose.yml"
+        await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent",
+                        }
+                    ]
+                },
+            },
+        )
+        await session.commit()
+        workspace_id = workspace.id
+
+    inspector = _RuntimeInspector(
+        {
+            "awf_preserved_runtime_endpoint": RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="agent",
+                        image="awf-agent:latest",
+                        state="running",
+                    )
+                ],
+            )
+        }
+    )
+
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert runtime is not None
+    assert runtime.runtime_health is not None
+    assert runtime.runtime_health.status == "ok"
+    assert runtime.runtime_health.reason_code == PRESERVED_EXECUTION_REASON_CODE
+    assert runtime.runtime_health.decision == "preserve_runtime"
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -452,6 +452,70 @@ async def test_runtime_detail_uses_preserved_health_when_live_snapshot_is_health
 
 
 @pytest.mark.unit
+async def test_runtime_detail_ignores_stale_stranded_health_when_live_snapshot_is_healthy(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="recovered runtime endpoint",
+            task_prompt="do not show stale stranded findings",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.running.value
+        workspace.compose_project_name = "awf_recovered_runtime_endpoint"
+        workspace.compose_file_path = f"/tmp/{workspace.id}/compose.yml"
+        await repo.add_event(
+            workspace,
+            event_type=RUNTIME_STRANDED_EVENT_TYPE,
+            reason_code="AGENT_CONTAINER_EXITED",
+            payload={
+                "reason_code": "AGENT_CONTAINER_EXITED",
+                "decision": "fail_workspace",
+                "message": "Workspace agent container is not running.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "exited",
+                            "container_id": "agent-old",
+                        }
+                    ]
+                },
+            },
+        )
+        await session.commit()
+        workspace_id = workspace.id
+
+    inspector = _RuntimeInspector(
+        {
+            "awf_recovered_runtime_endpoint": RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="agent-running",
+                        image="awf-agent:latest",
+                        state="running",
+                    )
+                ],
+            )
+        }
+    )
+
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert runtime is not None
+    assert runtime.runtime_health is None
+
+
+@pytest.mark.unit
 async def test_runtime_detail_ignores_preserved_health_for_stopped_terminal_workspace(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -734,15 +734,20 @@ async def test_preserved_runtime_health_ignores_operator_refresh_from_prior_stat
             agent="codex",
             test_commands=[],
         )
-        workspace.status = WorkspaceStatus.running.value
+        workspace.status = WorkspaceStatus.ready.value
         base = datetime.now(UTC)
-        running = await repo.add_event(
+        refresh = await repo.add_event(
             workspace,
-            event_type="workspace.state_changed",
+            event_type=REFRESH_REQUESTED_EVENT_TYPE,
+            reason_code=REFRESH_REQUESTED_REASON_CODE,
+        )
+        refresh.occurred_at = base + timedelta(seconds=2)
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.running,
             reason_code="WORKSPACE_RUNNING",
         )
-        running.old_state = WorkspaceStatus.ready.value
-        running.new_state = WorkspaceStatus.running.value
+        running = workspace.events[-1]
         running.occurred_at = base
         preserved = await repo.add_event(
             workspace,
@@ -756,14 +761,6 @@ async def test_preserved_runtime_health_ignores_operator_refresh_from_prior_stat
             },
         )
         preserved.occurred_at = base + timedelta(seconds=1)
-        refresh = await repo.add_event(
-            workspace,
-            event_type=REFRESH_REQUESTED_EVENT_TYPE,
-            reason_code=REFRESH_REQUESTED_REASON_CODE,
-        )
-        refresh.old_state = WorkspaceStatus.validating.value
-        refresh.new_state = WorkspaceStatus.validating.value
-        refresh.occurred_at = base + timedelta(seconds=2)
         await session.commit()
         workspace_id = workspace.id
 

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
@@ -384,6 +384,99 @@ async def test_workspace_detail_ignores_preserved_health_from_prior_active_statu
 
     assert detail is not None
     assert detail.runtime_health is None
+
+
+@pytest.mark.unit
+async def test_preserved_runtime_health_is_scoped_to_current_status_cycle(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/runtime.git",
+            branch_base="main",
+            task_title="preserved runtime cycle floor",
+            task_prompt="do not show previous-cycle preserved runtime",
+            agent="codex",
+            test_commands=[],
+        )
+        workspace.status = WorkspaceStatus.running.value
+        workspace.compose_project_name = "awf_preserved_runtime_cycle_floor"
+        workspace.compose_file_path = f"/tmp/{workspace.id}/compose.yml"
+        base = datetime.now(UTC)
+        prior_running = await repo.add_event(
+            workspace,
+            event_type="workspace.state_changed",
+            reason_code="WORKSPACE_RUNNING",
+        )
+        prior_running.old_state = WorkspaceStatus.ready.value
+        prior_running.new_state = WorkspaceStatus.running.value
+        prior_running.occurred_at = base
+        preserved = await repo.add_event(
+            workspace,
+            event_type=PRESERVED_EXECUTION_EVENT_TYPE,
+            reason_code=PRESERVED_EXECUTION_REASON_CODE,
+            payload={
+                "reason_code": PRESERVED_EXECUTION_REASON_CODE,
+                "decision": "preserve_runtime",
+                "workspace_status": WorkspaceStatus.running.value,
+                "message": "Live agent runtime was preserved after worker restart.",
+                "runtime": {
+                    "services": [
+                        {
+                            "name": "agent",
+                            "state": "running",
+                            "container_id": "agent-old",
+                        }
+                    ]
+                },
+            },
+        )
+        preserved.occurred_at = base + timedelta(seconds=1)
+        completed = await repo.add_event(
+            workspace,
+            event_type="workspace.state_changed",
+            reason_code="WORKSPACE_COMPLETED",
+        )
+        completed.old_state = WorkspaceStatus.running.value
+        completed.new_state = WorkspaceStatus.completed.value
+        completed.occurred_at = base + timedelta(seconds=2)
+        current_running = await repo.add_event(
+            workspace,
+            event_type="workspace.state_changed",
+            reason_code="WORKSPACE_RUNNING",
+        )
+        current_running.old_state = WorkspaceStatus.ready.value
+        current_running.new_state = WorkspaceStatus.running.value
+        current_running.occurred_at = base + timedelta(seconds=3)
+        await session.commit()
+        workspace_id = workspace.id
+
+    detail = await WorkspaceService(session_factory).get(workspace_id)
+    inspector = _RuntimeInspector(
+        {
+            "awf_preserved_runtime_cycle_floor": RuntimeSnapshot(
+                stack_state="running",
+                services=[
+                    RuntimeService(
+                        name="agent",
+                        container_id="agent-current",
+                        image="awf-agent:latest",
+                        state="running",
+                    )
+                ],
+            )
+        }
+    )
+    runtime = await WorkspaceService(
+        session_factory,
+        runtime_inspector=inspector,
+    ).get_runtime(workspace_id)
+
+    assert detail is not None
+    assert detail.runtime_health is None
+    assert runtime is not None
+    assert runtime.runtime_health is None
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspaces.py
+++ b/tests/unit/service/test_workspaces.py
@@ -577,6 +577,7 @@ async def test_preserved_runtime_health_is_floored_by_operator_refresh(
             reason_code=REFRESH_REQUESTED_REASON_CODE,
         )
         refresh.occurred_at = base + timedelta(seconds=1)
+        refresh.new_state = None
         await session.commit()
         workspace_id = workspace.id
 
@@ -741,7 +742,7 @@ async def test_preserved_runtime_health_ignores_operator_refresh_from_prior_stat
             event_type=REFRESH_REQUESTED_EVENT_TYPE,
             reason_code=REFRESH_REQUESTED_REASON_CODE,
         )
-        refresh.occurred_at = base + timedelta(seconds=2)
+        refresh.occurred_at = base - timedelta(seconds=1)
         await repo.transition(
             workspace,
             to=WorkspaceStatus.running,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_13dd6ba7165141c285bd771e` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Implement the P1 backlog slice "Adopt or safely preserve running agent executions after worker restart" from TODO/pre-gke-industrial-readiness.md.

Problem to solve:
When the control-plane worker restarts, it loses its in-memory execution task map. If persisted workspaces are still running/validating/pushing and Docker still has live agent runtime containers, AWF must not classify those containers as stale-active and tear them down simply because the new worker does not own the original asyncio task.

Required behavior:
- Restart recovery must distinguish truly orphaned stale-active resources from live agent/validation/push executions whose durable DB state still says active.
- If AWF can safely reattach/adopt the running execution, it should take durable ownership and continue log/runtime observation without duplicate execution.
- If full reattachment is not yet safe, AWF must transition to a clear recoverable/preserved state that keeps the container, worktree, logs, and implementation diff for explicit retry/operator recovery.
- AWF must not automatically `compose down` live healthy agent runtimes during restart recovery.
- Events, operations, status, runtime health, and cleanup/orphan reporting must make the recovery/preservation decision auditable.
- Regression coverage must prove a worker restart during active work cannot kill multiple healthy workspaces merely because the new worker has an empty in-memory task map.

Testing requirements:
- Use strict TDD: add failing tests first.
- Cover running, validating, and pushing workspaces with live containers.
- Cover no-container / truly orphaned cases that should remain cleanup/recovery candidates.
- Cover expired claims, active claims, cleanup failure, and at least a multi-workspace restart scenario with five active workspaces.
- No fake tests, empty assertions, or monkeypatches that bypass the behavior under test.

Validation:
Run focused tests for the worker/runtime/orphan touched surface, then ruff, mypy, and the broader Python suite/coverage required by the repo profile. Preserve 99%+ coverage. Update the backlog only with implementation-backed evidence, commit changes, and let AWF create and monitor the PR with auto_merge=true.

---
Validation: 5 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Worker restart now preserves healthy live agent executions instead of treating them as stale, improving recovery behavior during restart events.
  * Added new runtime health decision states to API responses for better visibility into execution preservation.

* **Bug Fixes**
  * Improved restart recovery logic to correctly detect and retain active running executions.

* **Tests**
  * Expanded test coverage for restart recovery and execution preservation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->