### PR TITLE
Allow fresh adoption after terminal PR monitor

### DIFF
--- a/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.conformance.json
+++ b/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.conformance.json
@@ -1,5 +1,5 @@
 {
   "status": "satisfied",
-  "summary": "The committed PR adoption implementation matches the saved plan: terminal previous adoption rows are superseded while remaining auditable, active/resumable rows still attach idempotently with policy conflict checks, task identity supersession prevents stale task reuse, audit events record the supersession, and PostgreSQL-backed service/API regressions cover the required behavior. The missing validation evidence has now been run and recorded in docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.validation.txt, including focused PR adoption service/API tests, touched-file ruff, mypy src/awf, and the full 99% coverage gate.",
+  "summary": "The current PR adoption implementation matches the saved plan: terminal previous adoption rows are superseded while remaining auditable, active/resumable rows still attach idempotently with policy conflict checks, task identity supersession prevents stale task reuse, audit events record the supersession, and PostgreSQL-backed service/API regressions cover the required behavior. Existing validation evidence in docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.validation.txt records focused PR adoption service/API tests, touched-file ruff, mypy src/awf, and the full 99% coverage gate passing.",
   "gaps": []
 }

--- a/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.conformance.json
+++ b/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.conformance.json
@@ -1,0 +1,5 @@
+{
+  "status": "satisfied",
+  "summary": "The committed PR adoption implementation matches the saved plan: terminal previous adoption rows are superseded while remaining auditable, active/resumable rows still attach idempotently with policy conflict checks, task identity supersession prevents stale task reuse, audit events record the supersession, and PostgreSQL-backed service/API regressions cover the required behavior. The missing validation evidence has now been run and recorded in docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.validation.txt, including focused PR adoption service/API tests, touched-file ruff, mypy src/awf, and the full 99% coverage gate.",
+  "gaps": []
+}

--- a/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.md
+++ b/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.md
@@ -1,0 +1,151 @@
+# Plan: PR Monitor Adoption Idempotency Supersession
+
+## Current Understanding
+
+`PullRequestMonitorAdoptionService.adopt()` normalizes the requested repo/PR, builds the deterministic adoption idempotency key, takes the PostgreSQL advisory transaction lock for that key, then returns any workspace currently holding `Workspace.idempotency_key == key`. That preserves retry/idempotent behavior for active monitors, but it also makes terminal adoption workspaces (`cancelled`, `failed`, `destroyed`, and likely other callback-terminal states) permanently block a fresh monitor for the same still-open PR.
+
+The fix should keep the advisory-lock serialization as the concurrency boundary, classify the existing adoption workspace before attaching, and supersede only non-resumable previous adoption identity inside the same transaction before creating the fresh workspace.
+
+## Intended Files / Modules To Touch
+
+- `src/awf/service/pr_monitor_adoption.py`
+  - Add explicit resumability classification for existing adoption workspaces.
+  - Keep attach behavior for active/resumable rows.
+  - For non-resumable terminal rows, fetch current PR metadata, validate the requested policy normally for the new workspace, supersede the previous row's canonical adoption idempotency key, then create the fresh workspace with the canonical repo/PR key.
+  - Add event/log/audit metadata for supersession: previous workspace id, previous status, previous adoption key, replacement workspace id, repo/PR identity, and reason code.
+  - Include supersession metadata in the new adoption operation/requested event payload.
+  - If the previous adoption-created task owns the same deterministic task idempotency/external identity and would block current metadata/base/title, supersede that task identity in the same transaction while keeping the old task and attempt rows auditable.
+- `tests/unit/service/test_pr_monitor_adoption.py`
+  - Add PostgreSQL-backed regression tests for terminal-row supersession, idempotent replay, concurrency, audit trail, and current-metadata response behavior.
+- `tests/unit/api/test_pr_monitor_adoption.py`
+  - Add a narrow REST contract regression proving a terminal previous adoption returns a fresh workspace with `attached_existing=false` and current PR metadata.
+
+No schema/migration work is intended. No OpenAPI schema changes are expected unless implementation unexpectedly changes response shape, which it should not.
+
+## Tests To Write First
+
+All new tests will use the existing PostgreSQL-backed fixtures (`postgres_test_engine` / `engine`) and will not introduce SQLite or fake database coverage.
+
+1. `test_cancelled_existing_adoption_is_superseded_by_fresh_workspace`
+   - Arrange an adopted workspace for `dimileeh/aira-web#277`, transition it to `cancelled`, then adopt the still-open PR again with newer metadata.
+   - Expect a different workspace id, `attached_existing=false`, two workspace rows remain, and the new workspace owns the canonical adoption idempotency key.
+   - Expect the old workspace idempotency key no longer equals the canonical key.
+
+2. Parametrized extension for `failed` and `destroyed`
+   - Use legal state transitions where practical (`requested -> failed`; `requested -> cancelled -> destroying -> destroyed`).
+   - Expect the same fresh-workspace behavior as `cancelled`.
+
+3. `test_active_existing_adoption_still_attaches`
+   - Keep the existing active row in `requested` or `monitoring_pr`.
+   - Re-adopt with matching policy.
+   - Expect `attached_existing=true`, same workspace id, no second workspace, and no metadata fetch on replay.
+
+4. `test_active_existing_adoption_policy_conflicts_are_preserved`
+   - Re-adopt an active row with changed `agent`, `profile_ref`, inline profile, `auto_merge`, or review grace.
+   - Expect the existing `PR_ADOPTION_POLICY_CONFLICT` behavior.
+   - Confirm terminal rows do not run this active-row conflict path before fresh adoption.
+
+5. `test_terminal_policy_difference_does_not_block_fresh_adoption`
+   - Old terminal row uses stale agent/profile/runtime metadata.
+   - New request uses current requested policy and current PR metadata.
+   - Expect a fresh workspace created from the new request, with no stale old profile/runtime metadata in the response or new row.
+
+6. `test_superseded_terminal_row_remains_auditable`
+   - After supersession, reload old and new workspaces.
+   - Assert old row, task attempt, operations, and events remain present.
+   - Assert an event such as `workspace.pr_monitor_adoption_superseded` has reason code `PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE` and payload with previous status/idempotency key plus replacement workspace id.
+   - Assert the new adoption operation/requested event payload includes the same supersession summary.
+
+7. `test_replay_after_supersession_attaches_new_active_workspace`
+   - After a terminal old row is superseded and a fresh workspace exists, adopt the same repo/PR again.
+   - Expect the replay attaches to the fresh active workspace and does not create a third workspace.
+
+8. `test_concurrent_terminal_supersession_converges_on_one_fresh_workspace`
+   - Use two independent PostgreSQL sessions and `asyncio.gather()` with the existing advisory lock path.
+   - Start from one terminal old adoption row holding the canonical key.
+   - Both adopters request the same still-open PR.
+   - Expect one caller creates the fresh workspace (`attached_existing=false`), the other attaches to that fresh workspace (`attached_existing=true`), and only one active non-terminal monitor row owns the canonical key.
+
+9. `test_fresh_response_uses_current_pr_metadata_not_stale_previous_policy`
+   - Old terminal row has stale `head_ref`, `head_sha`, `base_ref`, `base_sha`, `repo_url`, and profile/runtime snapshot.
+   - Metadata fetcher returns current values.
+   - Expect response and new `task_policy.pr_adoption` to reflect current metadata only.
+
+10. REST contract test in `tests/unit/api/test_pr_monitor_adoption.py`
+    - Create a terminal prior adoption through the service or repository, then POST `/v1/workspaces/adopt-pr`.
+    - Expect HTTP 202, `attached_existing=false`, fresh workspace id, current metadata fields, and no stale previous profile/runtime leakage.
+
+## Implementation Approach
+
+1. Add helper predicates/constants in `pr_monitor_adoption.py`:
+   - `_NON_RESUMABLE_ADOPTION_STATUSES`, at minimum `failed`, `cancelled`, `destroying`, and `destroyed`; consider `completed` non-resumable because it cannot continue monitoring if the PR is still open.
+   - `_adoption_workspace_is_resumable(workspace)` to keep this generic and avoid tying the decision to GitHub-specific fields.
+
+2. Change `adopt()` under the existing advisory transaction lock:
+   - If no existing workspace owns the canonical key, keep current create path.
+   - If an existing workspace owns the key and is resumable, keep current behavior: policy conflict check, then `attached_existing=true` response.
+   - If an existing workspace owns the key and is non-resumable, do not attach. Fetch current PR metadata first so closed/merged PRs are still rejected normally.
+   - Supersede the old workspace's `idempotency_key` before creating the fresh workspace, using a bounded unique key like `<canonical>:superseded:<workspace_id>`.
+   - Supersede the previous adoption task's deterministic identity only when it exactly matches the canonical adoption idempotency/external id, so stale task metadata cannot block a fresh task while unrelated task history is untouched.
+   - Flush after superseding old identity and before inserting the fresh workspace, so PostgreSQL uniqueness constraints are satisfied inside the same transaction.
+
+3. Extend `_create_adoption_workspace()` to accept optional supersession context:
+   - Add the supersession summary to the `Operation.payload` for `adopt_pr`.
+   - Add the same summary to the new workspace's `workspace.pr_monitor_adoption_requested` event payload.
+   - After the new workspace exists, add an event on the old workspace recording the supersession and replacement workspace id.
+   - Emit a structured log line with repo/PR, previous workspace id/status, replacement workspace id, and reason code. Do not log tokens or operator secret-like fields.
+
+4. Keep policy conflict handling scoped:
+   - Active/resumable existing rows still run `_raise_if_policy_conflicts()` before attach.
+   - Terminal/non-resumable rows do not conflict against old policy; the new request is validated through normal request schema, metadata fetch, and workspace creation paths.
+
+5. Preserve generic SCM posture:
+   - Keep existing GitHub metadata parsing/fetching unchanged.
+   - Name helpers around repository/pull-request adoption identity rather than GitHub-specific lifecycle assumptions.
+   - Do not encode provider-specific terminal rules beyond AWF workspace status semantics.
+
+## Validation Commands
+
+Focused first:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_pr_monitor_adoption.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/api/test_pr_monitor_adoption.py -q
+```
+
+Lint/type checks for touched code:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf/service/pr_monitor_adoption.py tests/unit/service/test_pr_monitor_adoption.py tests/unit/api/test_pr_monitor_adoption.py
+uv run --python 3.12 --extra dev mypy src/awf
+```
+
+Broader required gate:
+
+```bash
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+```
+
+Optional if response schemas or route declarations change unexpectedly:
+
+```bash
+python scripts/generate_openapi.py --check
+```
+
+## Risks / Assumptions
+
+- Assumption: AWF workspace statuses are the correct resumability signal for adoption idempotency. Active statuses attach; callback-terminal/non-resumable statuses are superseded for still-open PRs.
+- Assumption: PostgreSQL advisory transaction locks are already the intended serialization primitive, so the fix should reuse `WorkspaceRepository.acquire_idempotency_key_lock()` rather than introduce another lock table or unique index.
+- Assumption: `destroying` should be treated as non-resumable because it cannot safely continue monitoring, even though it is an in-progress cleanup status.
+- Risk: `TaskRepository.create_or_get()` also uses deterministic adoption identity. The implementation must avoid stale/terminal task identity causing either uniqueness conflicts or stale metadata reuse.
+- Risk: Treating `completed` as non-resumable may change behavior for re-adopting PRs whose previous monitor finished successfully. This should be covered deliberately if included; if too broad, keep the first implementation to `cancelled`, `failed`, `destroying`, and `destroyed` only.
+- Risk: Concurrent test timing can be flaky if it relies only on sleeps. Use advisory-lock behavior and committing per adopter session rather than time-based assertions.
+- Risk: Event payloads must remain redacted and compact; operator-provided reason text should continue to pass through existing redaction.
+
+## Explicit Non-Goals
+
+- Do not change PR monitor runner behavior, merge policy, review grace timing, comment handling, or stale detection semantics outside adoption idempotency.
+- Do not delete old workspaces, tasks, task attempts, operations, events, logs, or artifacts.
+- Do not add migrations or new database tables/columns unless an unexpected schema limitation makes the scoped fix impossible.
+- Do not change CLI arguments, REST request/response fields, or OpenAPI schema.
+- Do not introduce SQLite-only tests, fake database assumptions, or broad refactors of repository/task lifecycle code.

--- a/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.validation.txt
+++ b/docs/awf-plans/ws_6bdf949938c14ad3b4a1d58e.validation.txt
@@ -1,0 +1,31 @@
+Validation evidence for ws_6bdf949938c14ad3b4a1d58e
+(PR Monitor Adoption Idempotency Supersession)
+
+Commands run on 2026-05-07:
+
+1. uv run --python 3.12 --extra dev pytest tests/unit/service/test_pr_monitor_adoption.py -q
+   - Result: 39 passed in 63.34s.
+   - Evidence: PostgreSQL-backed service regressions covered terminal adoption
+     supersession, active-row replay, policy conflict preservation, audit
+     metadata, task identity supersession, and concurrent replay convergence.
+
+2. uv run --python 3.12 --extra dev pytest tests/unit/api/test_pr_monitor_adoption.py -q
+   - Result: 5 passed in 8.91s.
+   - Evidence: REST adoption contract covered cancelled previous adoption
+     returning a fresh workspace with attached_existing=false and current PR
+     metadata.
+
+3. uv run --python 3.12 --extra dev ruff check src/awf/service/pr_monitor_adoption.py tests/unit/service/test_pr_monitor_adoption.py tests/unit/api/test_pr_monitor_adoption.py
+   - Result: All checks passed.
+
+4. uv run --python 3.12 --extra dev mypy src/awf
+   - Result: Success: no issues found in 147 source files.
+
+5. uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+   - Result: 4838 passed, 7 skipped, 1 warning in 2641.08s (0:44:01).
+   - Coverage: Required test coverage of 99.0% reached. Total coverage: 99.00%.
+   - Skips: Docker/Compose-dependent integration tests skipped because the
+     Docker daemon or Compose plugin was not available in this workspace.
+
+Gap closed: the focused PR adoption tests, touched-file ruff check, full mypy
+check, and full pytest coverage gate were run and recorded for this workspace.

--- a/openapi.json
+++ b/openapi.json
@@ -4027,7 +4027,15 @@
             "type": "string"
           },
           "status": {
-            "$ref": "#/components/schemas/WorkspaceStatus"
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WorkspaceStatus"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "title": "Status"
           },
           "status_url": {
             "title": "Status Url",

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -278,7 +278,7 @@ class PullRequestMonitorAdoptionResponse(BaseModel):
     """Response for the supported existing-PR adoption flow."""
 
     workspace_id: str
-    status: WorkspaceStatus
+    status: WorkspaceStatus | str
     version: int
     task_id: str | None = None
     attempt_id: str | None = None

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -22,6 +22,7 @@ from awf.common.github_client import (
     fetch_pull_request_adoption_metadata,
     parse_github_pull_request_url,
 )
+from awf.common.logging import get_logger
 from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import MergeCandidate, Workspace
 from awf.db.repositories import (
@@ -38,20 +39,12 @@ from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.validation_observability import validation_freshness_summary
 
 PR_ADOPTION_REQUESTED_EVENT_TYPE = "workspace.pr_monitor_adoption_requested"
+PR_ADOPTION_SUPERSEDED_EVENT_TYPE = "workspace.pr_monitor_adoption_superseded"
 PR_ADOPTION_REQUESTED_REASON = "PR_MONITOR_ADOPTION_REQUESTED"
+PR_ADOPTION_SUPERSEDED_REASON = "PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE"
 PR_ADOPTION_ADMITTED_REASON = "PR_ADOPTION_ADMITTED"
 PR_ADOPTION_OPERATION_ACTION = "adopt_pr_monitor"
 PR_ADOPTION_TASK_KIND = "sync_feature_pr"
-PR_ADOPTION_SUPERSEDED_EVENT_TYPE = "workspace.pr_monitor_adoption_superseded"
-PR_ADOPTION_SUPERSEDED_REASON = "PR_MONITOR_ADOPTION_SUPERSEDED"
-_FRESH_ADOPTION_ALLOWED_STATUSES = frozenset(
-    {
-        WorkspaceStatus.cancelled.value,
-        WorkspaceStatus.completed.value,
-        WorkspaceStatus.destroyed.value,
-        WorkspaceStatus.failed.value,
-    }
-)
 # Keep the public adoption error-code contract present in service source so
 # docs parity tests can cross-reference the matrix against implementation.
 _PR_ADOPTION_ERROR_CODE_CONTRACT = (
@@ -64,6 +57,16 @@ _PR_ADOPTION_ERROR_CODE_CONTRACT = (
     {"error_code": "PR_METADATA_INVALID"},
     {"error_code": "PR_ADOPTION_POLICY_CONFLICT"},
 )
+_NON_RESUMABLE_ADOPTION_STATUSES = frozenset(
+    {
+        WorkspaceStatus.completed,
+        WorkspaceStatus.failed,
+        WorkspaceStatus.cancelled,
+        WorkspaceStatus.destroying,
+        WorkspaceStatus.destroyed,
+    }
+)
+_log = get_logger(__name__)
 
 MetadataFetcher = Callable[
     [RepoRef, int],
@@ -117,32 +120,78 @@ class PullRequestMonitorAdoptionService:
         # Re-read under the transaction lock so a concurrent adopter that won
         # the race attaches here instead of surfacing the unique constraint.
         existing = await workspace_repo.get_by_idempotency_key(idempotency_key)
-        fresh_task_identity = False
         if existing is not None:
-            if not _allows_fresh_adoption(existing):
+            if _adoption_workspace_is_resumable(existing):
                 _raise_if_policy_conflicts(existing, request, repo=repo)
                 return await self._response(existing, attached_existing=True)
 
-            fresh_task_identity = True
             metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
-            await self._archive_terminal_adoption_key(
-                workspace_repo=workspace_repo,
+            superseded_adoption = await self._supersede_previous_adoption(
                 workspace=existing,
                 idempotency_key=idempotency_key,
                 repo=repo,
                 pr_number=pr_number,
             )
-        else:
-            metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
+            workspace = await self._create_adoption_workspace(
+                request=request,
+                repo=repo,
+                metadata=metadata,
+                idempotency_key=idempotency_key,
+                superseded_adoption=superseded_adoption,
+                superseded_workspace=existing,
+            )
+            return await self._response(workspace, attached_existing=False)
 
+        metadata = await self._fetch_metadata(repo=repo, pr_number=pr_number)
         workspace = await self._create_adoption_workspace(
             request=request,
             repo=repo,
             metadata=metadata,
             idempotency_key=idempotency_key,
-            fresh_task_identity=fresh_task_identity,
         )
         return await self._response(workspace, attached_existing=False)
+
+    async def _supersede_previous_adoption(
+        self,
+        *,
+        workspace: Workspace,
+        idempotency_key: str,
+        repo: RepoRef,
+        pr_number: int,
+    ) -> dict[str, Any]:
+        previous_idempotency_key = workspace.idempotency_key
+        superseded_idempotency_key = _superseded_adoption_idempotency_key(
+            idempotency_key=idempotency_key,
+            workspace_id=workspace.id,
+        )
+        workspace.idempotency_key = superseded_idempotency_key
+
+        attempt = await TaskAttemptRepository(self._session).get_by_workspace_id(workspace.id)
+        if attempt is not None:
+            task = await TaskRepository(self._session).get(attempt.task_id)
+            if task is not None:
+                if task.idempotency_key == idempotency_key:
+                    task.idempotency_key = superseded_idempotency_key
+                adoption_external_id = _adoption_external_id(
+                    repo_slug=repo.slug(),
+                    pr_number=pr_number,
+                )
+                if task.external_id == adoption_external_id:
+                    task.external_id = _superseded_adoption_external_id(
+                        external_id=adoption_external_id,
+                        workspace_id=workspace.id,
+                    )
+
+        await self._session.flush()
+        return {
+            "reason_code": PR_ADOPTION_SUPERSEDED_REASON,
+            "repo_slug": repo.slug(),
+            "pr_number": pr_number,
+            "previous_workspace_id": workspace.id,
+            "previous_status": workspace.status,
+            "previous_idempotency_key": previous_idempotency_key,
+            "superseded_idempotency_key": superseded_idempotency_key,
+        }
 
     async def _fetch_metadata(
         self,
@@ -181,35 +230,6 @@ class PullRequestMonitorAdoptionService:
             )
         return metadata
 
-    async def _archive_terminal_adoption_key(
-        self,
-        *,
-        workspace_repo: WorkspaceRepository,
-        workspace: Workspace,
-        idempotency_key: str,
-        repo: RepoRef,
-        pr_number: int,
-    ) -> None:
-        previous_key = workspace.idempotency_key
-        workspace.idempotency_key = _archived_adoption_idempotency_key(
-            idempotency_key=idempotency_key,
-            workspace_id=workspace.id,
-        )
-        await workspace_repo.add_event(
-            workspace,
-            event_type=PR_ADOPTION_SUPERSEDED_EVENT_TYPE,
-            reason_code=PR_ADOPTION_SUPERSEDED_REASON,
-            payload={
-                "repo_slug": repo.slug(),
-                "pr_number": pr_number,
-                "previous_workspace_id": workspace.id,
-                "previous_status": workspace.status,
-                "previous_idempotency_key": previous_key,
-                "new_idempotency_key": workspace.idempotency_key,
-            },
-        )
-        await self._session.flush()
-
     async def _create_adoption_workspace(
         self,
         *,
@@ -217,7 +237,8 @@ class PullRequestMonitorAdoptionService:
         repo: RepoRef,
         metadata: PullRequestAdoptionMetadata,
         idempotency_key: str,
-        fresh_task_identity: bool = False,
+        superseded_adoption: dict[str, Any] | None = None,
+        superseded_workspace: Workspace | None = None,
     ) -> Workspace:
         requested_profile = _requested_inline_profile_policy(request)
         repo_url = _adoption_repo_url(request=request, repo=repo)
@@ -257,16 +278,14 @@ class PullRequestMonitorAdoptionService:
         workspace.pr_number = metadata.number
         workspace.base_commit = metadata.base_sha
         workspace.monitor_last_commit_sha = metadata.head_sha
-        task_idempotency_key = idempotency_key
-        if fresh_task_identity and workspace.task_external_id is not None:
-            workspace.task_external_id = _fresh_adoption_task_external_id(
-                external_id=workspace.task_external_id,
-                workspace_id=workspace.id,
-            )
-            task_idempotency_key = _fresh_adoption_task_idempotency_key(
-                idempotency_key=idempotency_key,
-                workspace_id=workspace.id,
-            )
+        superseded_payload = (
+            {
+                **superseded_adoption,
+                "replacement_workspace_id": workspace.id,
+            }
+            if superseded_adoption is not None
+            else None
+        )
 
         task = await TaskRepository(self._session).create_or_get(
             repo_url=workspace.repo_url,
@@ -274,7 +293,7 @@ class PullRequestMonitorAdoptionService:
             title=workspace.task_title,
             prompt=workspace.task_prompt,
             external_id=workspace.task_external_id,
-            idempotency_key=task_idempotency_key,
+            idempotency_key=idempotency_key,
             task_class=workspace.task_class,
             owned_paths=list(workspace.owned_paths),
         )
@@ -319,39 +338,56 @@ class PullRequestMonitorAdoptionService:
             overlap_risk_summary={"count": 0, "overlaps": []},
             score_summary=scheduler_score.score_summary,
         )
+        operation_payload: dict[str, Any] = {
+            "action": PR_ADOPTION_OPERATION_ACTION,
+            "repo_slug": repo.slug(),
+            "pr_number": metadata.number,
+            "pr_url": metadata.url,
+            "auto_merge": request.auto_merge,
+            "reason": operator_reason,
+        }
+        if superseded_payload is not None:
+            operation_payload["superseded_adoption"] = superseded_payload
         operation = await OperationRepository(self._session).create(
             workspace_id=workspace.id,
             operation_type=OperationType.adopt_pr,
             status=OperationStatus.succeeded,
             idempotency_key=idempotency_key,
-            payload={
-                "action": PR_ADOPTION_OPERATION_ACTION,
-                "repo_slug": repo.slug(),
-                "pr_number": metadata.number,
-                "pr_url": metadata.url,
-                "auto_merge": request.auto_merge,
-                "reason": operator_reason,
-            },
+            payload=operation_payload,
         )
+        event_payload: dict[str, Any] = {
+            "operation_id": operation.id,
+            "repo_slug": repo.slug(),
+            "pr_number": metadata.number,
+            "pr_url": metadata.url,
+            "head_ref": metadata.head_ref,
+            "head_repo_slug": metadata.head_repo_slug,
+            "head_repo_url": _github_repo_url_like(repo_url, metadata.head_repo_slug),
+            "base_ref": metadata.base_ref,
+            "head_sha": metadata.head_sha,
+            "base_sha": metadata.base_sha,
+            "auto_merge": request.auto_merge,
+            "reason": operator_reason,
+        }
+        if superseded_payload is not None:
+            event_payload["superseded_adoption"] = superseded_payload
         await workspace_repo.add_event(
             workspace,
             event_type=PR_ADOPTION_REQUESTED_EVENT_TYPE,
             reason_code=PR_ADOPTION_REQUESTED_REASON,
-            payload={
-                "operation_id": operation.id,
-                "repo_slug": repo.slug(),
-                "pr_number": metadata.number,
-                "pr_url": metadata.url,
-                "head_ref": metadata.head_ref,
-                "head_repo_slug": metadata.head_repo_slug,
-                "head_repo_url": _github_repo_url_like(repo_url, metadata.head_repo_slug),
-                "base_ref": metadata.base_ref,
-                "head_sha": metadata.head_sha,
-                "base_sha": metadata.base_sha,
-                "auto_merge": request.auto_merge,
-                "reason": operator_reason,
-            },
+            payload=event_payload,
         )
+        if superseded_workspace is not None and superseded_payload is not None:
+            await workspace_repo.add_event(
+                superseded_workspace,
+                event_type=PR_ADOPTION_SUPERSEDED_EVENT_TYPE,
+                reason_code=PR_ADOPTION_SUPERSEDED_REASON,
+                payload=superseded_payload,
+            )
+            _log.info(
+                "pr_monitor_adoption.superseded_terminal_workspace",
+                **superseded_payload,
+            )
         await self._session.flush()
         return workspace
 
@@ -421,14 +457,6 @@ async def _default_metadata_fetcher(
 def pr_adoption_idempotency_key(*, repo_slug: str, pr_number: int) -> str:
     digest = hashlib.sha256(f"{repo_slug.lower()}#{pr_number}".encode()).hexdigest()
     return f"pr-adopt:{digest[:48]}"
-
-
-def _allows_fresh_adoption(workspace: Workspace) -> bool:
-    return workspace.status in _FRESH_ADOPTION_ALLOWED_STATUSES
-
-
-def _archived_adoption_idempotency_key(*, idempotency_key: str, workspace_id: str) -> str:
-    return f"{idempotency_key}:terminal:{workspace_id}"
 
 
 def _normalize_request_identity(
@@ -552,12 +580,12 @@ def _adoption_external_id(*, repo_slug: str, pr_number: int) -> str:
     return f"pr-adopt-{digest[:40]}"
 
 
-def _fresh_adoption_task_external_id(*, external_id: str, workspace_id: str) -> str:
-    return f"{external_id}:{workspace_id}"
+def _superseded_adoption_idempotency_key(*, idempotency_key: str, workspace_id: str) -> str:
+    return f"{idempotency_key}:superseded:{workspace_id}"
 
 
-def _fresh_adoption_task_idempotency_key(*, idempotency_key: str, workspace_id: str) -> str:
-    return f"{idempotency_key}:task:{workspace_id}"
+def _superseded_adoption_external_id(*, external_id: str, workspace_id: str) -> str:
+    return f"{external_id}:superseded:{workspace_id}"
 
 
 def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: RepoRef) -> str:
@@ -566,6 +594,14 @@ def _adoption_repo_url(*, request: PullRequestMonitorAdoptionRequest, repo: Repo
 
 def _github_repo_url_like(repo_url: str, repo_slug: str) -> str:
     return RepoRef.from_url(repo_slug).clone_url_like(repo_url)
+
+
+def _adoption_workspace_is_resumable(workspace: Workspace) -> bool:
+    try:
+        status = WorkspaceStatus(workspace.status)
+    except ValueError:
+        return False
+    return status not in _NON_RESUMABLE_ADOPTION_STATUSES
 
 
 def _raise_if_policy_conflicts(

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -599,7 +599,9 @@ def _adoption_workspace_is_resumable(workspace: Workspace) -> bool:
     try:
         status = WorkspaceStatus(workspace.status)
     except ValueError:
-        return False
+        # Unknown statuses may be active states introduced before this code
+        # was updated; attach rather than superseding the canonical key.
+        return True
     return status not in _NON_RESUMABLE_ADOPTION_STATUSES
 
 

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -59,7 +59,6 @@ _PR_ADOPTION_ERROR_CODE_CONTRACT = (
 )
 _NON_RESUMABLE_ADOPTION_STATUSES = frozenset(
     {
-        WorkspaceStatus.completed,
         WorkspaceStatus.failed,
         WorkspaceStatus.cancelled,
         WorkspaceStatus.destroying,

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -418,7 +418,7 @@ class PullRequestMonitorAdoptionService:
         pr_url = str(adoption.get("pr_url") or workspace.pr_url or "")
         return PullRequestMonitorAdoptionResponse(
             workspace_id=workspace.id,
-            status=WorkspaceStatus(workspace.status),
+            status=_workspace_status_for_response(workspace.status),
             version=workspace.version,
             task_id=attempt.task_id if attempt is not None else None,
             attempt_id=attempt.id if attempt is not None else None,
@@ -612,6 +612,13 @@ def _adoption_workspace_is_resumable(workspace: Workspace) -> bool:
         # was updated; attach rather than superseding the canonical key.
         return True
     return status not in _NON_RESUMABLE_ADOPTION_STATUSES
+
+
+def _workspace_status_for_response(status: str) -> WorkspaceStatus | str:
+    try:
+        return WorkspaceStatus(status)
+    except ValueError:
+        return status
 
 
 def _raise_if_existing_workspace_is_not_requested_adoption(

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -59,6 +59,7 @@ _PR_ADOPTION_ERROR_CODE_CONTRACT = (
 )
 _NON_RESUMABLE_ADOPTION_STATUSES = frozenset(
     {
+        WorkspaceStatus.completed,
         WorkspaceStatus.failed,
         WorkspaceStatus.cancelled,
         WorkspaceStatus.destroying,

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -169,6 +169,16 @@ class PullRequestMonitorAdoptionService:
             workspace_id=workspace.id,
         )
         workspace.idempotency_key = superseded_idempotency_key
+        adoption_external_id = _adoption_external_id(
+            repo_slug=repo.slug(),
+            pr_number=pr_number,
+        )
+        superseded_external_id = _superseded_adoption_external_id(
+            external_id=adoption_external_id,
+            workspace_id=workspace.id,
+        )
+        if workspace.task_external_id == adoption_external_id:
+            workspace.task_external_id = superseded_external_id
 
         attempt = await TaskAttemptRepository(self._session).get_by_workspace_id(workspace.id)
         if attempt is not None:
@@ -176,15 +186,8 @@ class PullRequestMonitorAdoptionService:
             if task is not None:
                 if task.idempotency_key == idempotency_key:
                     task.idempotency_key = superseded_idempotency_key
-                adoption_external_id = _adoption_external_id(
-                    repo_slug=repo.slug(),
-                    pr_number=pr_number,
-                )
                 if task.external_id == adoption_external_id:
-                    task.external_id = _superseded_adoption_external_id(
-                        external_id=adoption_external_id,
-                        workspace_id=workspace.id,
-                    )
+                    task.external_id = superseded_external_id
 
         await self._session.flush()
         return {

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -120,6 +120,11 @@ class PullRequestMonitorAdoptionService:
         # the race attaches here instead of surfacing the unique constraint.
         existing = await workspace_repo.get_by_idempotency_key(idempotency_key)
         if existing is not None:
+            _raise_if_existing_workspace_is_not_requested_adoption(
+                existing,
+                repo=repo,
+                pr_number=pr_number,
+            )
             if _adoption_workspace_is_resumable(existing):
                 _raise_if_policy_conflicts(existing, request, repo=repo)
                 return await self._response(existing, attached_existing=True)
@@ -605,6 +610,39 @@ def _adoption_workspace_is_resumable(workspace: Workspace) -> bool:
     return status not in _NON_RESUMABLE_ADOPTION_STATUSES
 
 
+def _raise_if_existing_workspace_is_not_requested_adoption(
+    workspace: Workspace,
+    *,
+    repo: RepoRef,
+    pr_number: int,
+) -> None:
+    adoption = _adoption_policy(workspace)
+    existing_repo_slug = _optional_str(adoption.get("repo_slug"))
+    existing_pr_number = _optional_int(adoption.get("pr_number"))
+    if (
+        existing_repo_slug is not None
+        and existing_repo_slug.lower() == repo.slug().lower()
+        and existing_pr_number == pr_number
+    ):
+        return
+
+    raise PRMonitorAdoptionError(
+        error_code="PR_ADOPTION_POLICY_CONFLICT",
+        message=(
+            "Canonical PR adoption idempotency key is already owned by a workspace "
+            "for a different or missing PR adoption identity."
+        ),
+        detail={
+            "workspace_id": workspace.id,
+            "repo_slug": repo.slug(),
+            "pr_number": pr_number,
+            "existing_task_kind": workspace.task_kind,
+            "existing_pr_adoption_repo_slug": existing_repo_slug,
+            "existing_pr_adoption_pr_number": existing_pr_number,
+        },
+    )
+
+
 def _raise_if_policy_conflicts(
     workspace: Workspace,
     request: PullRequestMonitorAdoptionRequest,
@@ -705,6 +743,19 @@ def _adoption_policy(workspace: Workspace) -> Mapping[str, Any]:
 
 def _optional_str(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip():
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
 
 
 def _redacted_optional_text(value: str | None) -> str | None:

--- a/tests/unit/api/test_pr_monitor_adoption.py
+++ b/tests/unit/api/test_pr_monitor_adoption.py
@@ -141,6 +141,7 @@ async def test_adopt_pr_accepts_repo_slug_and_pr_number(
 @pytest.mark.unit
 async def test_adopt_pr_accepts_full_pr_url_idempotently(
     adoption_client: tuple[AsyncClient, _MetadataFetcher],
+    engine: AsyncEngine,
 ) -> None:
     client, fetcher = adoption_client
     headers = {"Authorization": "Bearer secret"}
@@ -160,6 +161,29 @@ async def test_adopt_pr_accepts_full_pr_url_idempotently(
     assert second.status_code == 202
     assert second.json()["attached_existing"] is True
     assert second.json()["workspace_id"] == first.json()["workspace_id"]
+    assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+    session_factory = make_session_factory(engine)
+    unknown_status = "monitoring_review_repair"
+    async with session_factory() as session:
+        workspace = (
+            await session.execute(
+                select(Workspace).where(Workspace.id == first.json()["workspace_id"])
+            )
+        ).scalar_one()
+        workspace.status = unknown_status
+        await session.commit()
+
+    third = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={"pr_url": "https://github.com/dimileeh/aira-web/pull/277"},
+    )
+
+    assert third.status_code == 202
+    assert third.json()["attached_existing"] is True
+    assert third.json()["workspace_id"] == first.json()["workspace_id"]
+    assert third.json()["status"] == unknown_status
     assert fetcher.calls == [("dimileeh/aira-web", 277)]
 
 

--- a/tests/unit/api/test_pr_monitor_adoption.py
+++ b/tests/unit/api/test_pr_monitor_adoption.py
@@ -15,6 +15,7 @@ from awf.common.config import Settings, get_settings
 from awf.common.github_client import PullRequestAdoptionMetadata, RepoRef
 from awf.db.enums import WorkspaceStatus
 from awf.db.models import Workspace
+from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.service.pr_monitor_adoption import pr_adoption_idempotency_key
 
@@ -30,14 +31,18 @@ def _metadata(
     *,
     state: str = "OPEN",
     number: int = 277,
+    head_ref: str = "feature/ready",
+    base_ref: str = "development",
+    head_sha: str = "h" * 40,
+    base_sha: str = "b" * 40,
 ) -> PullRequestAdoptionMetadata:
     return PullRequestAdoptionMetadata(
         number=number,
-        head_ref="feature/ready",
+        head_ref=head_ref,
         head_repo_slug="dimileeh/aira-web",
-        base_ref="development",
-        head_sha="h" * 40,
-        base_sha="b" * 40,
+        base_ref=base_ref,
+        head_sha=head_sha,
+        base_sha=base_sha,
         state=state,
         is_draft=False,
         closed=state == "CLOSED",
@@ -156,6 +161,78 @@ async def test_adopt_pr_accepts_full_pr_url_idempotently(
     assert second.json()["attached_existing"] is True
     assert second.json()["workspace_id"] == first.json()["workspace_id"]
     assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+
+@pytest.mark.unit
+async def test_adopt_pr_supersedes_cancelled_previous_adoption(
+    adoption_client: tuple[AsyncClient, _MetadataFetcher],
+    engine: AsyncEngine,
+) -> None:
+    client, fetcher = adoption_client
+    headers = {"Authorization": "Bearer secret"}
+    session_factory = make_session_factory(engine)
+    fetcher.metadata = _metadata(
+        head_ref="feature/stale",
+        base_ref="development-old",
+        head_sha="a" * 40,
+        base_sha="1" * 40,
+    )
+    first = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "auto_merge": False,
+        },
+    )
+    assert first.status_code == 202
+    first_body = first.json()
+
+    async with session_factory() as session:
+        repo = WorkspaceRepository(session)
+        previous = await repo.get(first_body["workspace_id"])
+        assert previous is not None
+        await repo.transition(previous, to=WorkspaceStatus.cancelled, reason_code="TEST_CANCEL")
+        await session.commit()
+
+    fetcher.metadata = _metadata(
+        head_ref="feature/current",
+        base_ref="development",
+        head_sha="c" * 40,
+        base_sha="2" * 40,
+    )
+    second = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers=headers,
+        json={
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "auto_merge": True,
+        },
+    )
+
+    assert second.status_code == 202
+    body = second.json()
+    assert body["attached_existing"] is False
+    assert body["workspace_id"] != first_body["workspace_id"]
+    assert body["head_ref"] == "feature/current"
+    assert body["base_ref"] == "development"
+    assert body["head_sha"] == "c" * 40
+    assert body["base_sha"] == "2" * 40
+    assert body["auto_merge"] is True
+
+    canonical_key = pr_adoption_idempotency_key(repo_slug="dimileeh/aira-web", pr_number=277)
+    async with session_factory() as session:
+        workspaces = list((await session.execute(select(Workspace))).scalars())
+    assert len(workspaces) == 2
+    previous = next(workspace for workspace in workspaces if workspace.id == first_body["workspace_id"])
+    fresh = next(workspace for workspace in workspaces if workspace.id == body["workspace_id"])
+    assert previous.status == WorkspaceStatus.cancelled.value
+    assert previous.idempotency_key != canonical_key
+    assert fresh.idempotency_key == canonical_key
+    assert previous.task_policy["pr_adoption"]["head_ref"] == "feature/stale"
+    assert fresh.task_policy["pr_adoption"]["head_ref"] == "feature/current"
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_pr_monitor_adoption.py
+++ b/tests/unit/api/test_pr_monitor_adoption.py
@@ -265,9 +265,11 @@ async def test_adopt_pr_returns_structured_terminal_pr_error(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("terminal_status", [WorkspaceStatus.failed, WorkspaceStatus.completed])
 async def test_terminal_existing_adoption_fetch_error_preserves_idempotency_key(
     adoption_client: tuple[AsyncClient, _MetadataFetcher],
     engine: AsyncEngine,
+    terminal_status: WorkspaceStatus,
 ) -> None:
     client, fetcher = adoption_client
     headers = {"Authorization": "Bearer secret"}
@@ -289,7 +291,7 @@ async def test_terminal_existing_adoption_fetch_error_preserves_idempotency_key(
         workspace = (
             await session.execute(select(Workspace).where(Workspace.id == workspace_id))
         ).scalar_one()
-        workspace.status = WorkspaceStatus.failed.value
+        workspace.status = terminal_status.value
         assert workspace.idempotency_key == idempotency_key
         await session.commit()
 

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -331,7 +331,6 @@ class TestPullRequestMonitorAdoptionService:
         "terminal_status",
         [
             WorkspaceStatus.cancelled,
-            WorkspaceStatus.completed,
             WorkspaceStatus.destroyed,
             WorkspaceStatus.failed,
         ],
@@ -371,12 +370,10 @@ class TestPullRequestMonitorAdoptionService:
             assert second_workspace is not None
             assert first_workspace.idempotency_key != original_key
             assert first_workspace.idempotency_key is not None
-            assert first_workspace.idempotency_key.startswith(f"{original_key}:terminal:")
+            assert first_workspace.idempotency_key.startswith(f"{original_key}:superseded:")
             assert second_workspace.idempotency_key == original_key
             assert original_external_id is not None
-            assert second_workspace.task_external_id != original_external_id
-            assert second_workspace.task_external_id is not None
-            assert second_workspace.task_external_id.startswith(f"{original_external_id}:")
+            assert second_workspace.task_external_id == original_external_id
             assert await _count(session, Workspace) == 2
             assert await _count(session, Task) == 2
             assert await _count(session, TaskAttempt) == 2
@@ -416,12 +413,15 @@ class TestPullRequestMonitorAdoptionService:
             assert second_workspace is not None
             assert original_key is not None
             assert original_external_id is not None
-            assert first_workspace.idempotency_key.startswith(f"{original_key}:terminal:")
+            assert first_workspace.idempotency_key is not None
+            assert first_workspace.idempotency_key.startswith(f"{original_key}:superseded:")
             assert second_workspace.idempotency_key == original_key
             assert second_workspace.task_title == "feature: revised title"
-            assert second_workspace.task_external_id != original_external_id
-            assert second_workspace.task_external_id is not None
-            assert second_workspace.task_external_id.startswith(f"{original_external_id}:")
+            assert second_workspace.task_external_id == original_external_id
+            superseded_external_id = adoption_module._superseded_adoption_external_id(
+                external_id=original_external_id,
+                workspace_id=first.workspace_id,
+            )
             tasks = list((await session.execute(select(Task))).scalars())
             assert len(tasks) == 2
             assert {task.title for task in tasks} == {
@@ -429,12 +429,12 @@ class TestPullRequestMonitorAdoptionService:
                 "feature: revised title",
             }
             assert {task.external_id for task in tasks} == {
-                original_external_id,
+                superseded_external_id,
                 second_workspace.task_external_id,
             }
             assert {task.idempotency_key for task in tasks} == {
+                first_workspace.idempotency_key,
                 original_key,
-                f"{original_key}:task:{second.workspace_id}",
             }
 
     @pytest.mark.unit

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -23,8 +24,9 @@ from awf.db.models import (
     Task,
     TaskAttempt,
     Workspace,
+    WorkspaceEvent,
 )
-from awf.db.repositories import WorkspaceRepository
+from awf.db.repositories import TaskAttemptRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.service import pr_monitor_adoption as adoption_module
 from awf.service.pr_monitor_adoption import (
@@ -84,6 +86,40 @@ class _MetadataFetcher:
 
 async def _count(session: AsyncSession, model: type[Any]) -> int:
     return int((await session.execute(select(func.count()).select_from(model))).scalar_one())
+
+
+async def _transition_adoption(
+    session: AsyncSession,
+    workspace_id: str,
+    status: WorkspaceStatus,
+) -> None:
+    repo = WorkspaceRepository(session)
+    workspace = await repo.get(workspace_id)
+    assert workspace is not None
+    if status == WorkspaceStatus.cancelled:
+        await repo.transition(workspace, to=WorkspaceStatus.cancelled, reason_code="TEST_CANCEL")
+        return
+    if status == WorkspaceStatus.failed:
+        await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        return
+    if status in {WorkspaceStatus.destroying, WorkspaceStatus.destroyed}:
+        await repo.transition(workspace, to=WorkspaceStatus.cancelled, reason_code="TEST_CANCEL")
+        await repo.transition(workspace, to=WorkspaceStatus.destroying, reason_code="TEST_DESTROY")
+        if status == WorkspaceStatus.destroyed:
+            await repo.transition(
+                workspace,
+                to=WorkspaceStatus.destroyed,
+                reason_code="TEST_DESTROYED",
+            )
+        return
+    raise AssertionError(f"Unsupported terminal test status: {status.value}")
+
+
+def _canonical_key() -> str:
+    return adoption_module.pr_adoption_idempotency_key(
+        repo_slug="dimileeh/aira-web",
+        pr_number=277,
+    )
 
 
 class TestPullRequestMonitorAdoptionService:
@@ -503,6 +539,367 @@ class TestPullRequestMonitorAdoptionService:
                 )
 
         assert excinfo.value.error_code == "PR_ADOPTION_POLICY_CONFLICT"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "terminal_status",
+        [
+            WorkspaceStatus.cancelled,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.destroyed,
+        ],
+    )
+    async def test_terminal_existing_adoption_is_superseded_by_fresh_workspace(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        terminal_status: WorkspaceStatus,
+    ) -> None:
+        canonical_key = _canonical_key()
+        old_metadata = _metadata(
+            head_ref="feature/stale",
+            base_ref="development-old",
+            head_sha="a" * 40,
+            base_sha="1" * 40,
+        )
+        current_metadata = _metadata(
+            head_ref="feature/current",
+            base_ref="development",
+            head_sha="c" * 40,
+            base_sha="2" * 40,
+        )
+        old_fetcher = _MetadataFetcher(old_metadata)
+        current_fetcher = _MetadataFetcher(current_metadata)
+
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=old_fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=False,
+                )
+            )
+            await _transition_adoption(session, first.workspace_id, terminal_status)
+            await session.commit()
+
+        async with factory() as session:
+            fresh = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=current_fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=True,
+                )
+            )
+            await session.commit()
+
+        assert fresh.attached_existing is False
+        assert fresh.workspace_id != first.workspace_id
+        assert fresh.status == WorkspaceStatus.requested
+        assert fresh.head_ref == "feature/current"
+        assert fresh.base_ref == "development"
+        assert fresh.head_sha == "c" * 40
+        assert fresh.base_sha == "2" * 40
+        assert fresh.auto_merge is True
+        assert current_fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            workspaces = list(
+                (
+                    await session.execute(
+                        select(Workspace).order_by(Workspace.created_at.asc(), Workspace.id.asc())
+                    )
+                ).scalars()
+            )
+            assert len(workspaces) == 2
+            old = next(workspace for workspace in workspaces if workspace.id == first.workspace_id)
+            new = next(workspace for workspace in workspaces if workspace.id == fresh.workspace_id)
+            assert old.status == terminal_status.value
+            assert old.idempotency_key != canonical_key
+            assert old.idempotency_key is not None
+            assert old.idempotency_key.startswith(f"{canonical_key}:superseded:")
+            assert new.idempotency_key == canonical_key
+            assert new.task_policy["pr_adoption"]["head_ref"] == "feature/current"
+            assert old.task_policy["pr_adoption"]["head_ref"] == "feature/stale"
+
+    @pytest.mark.unit
+    async def test_active_existing_adoption_still_attaches_without_metadata_fetch(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        fetcher = _MetadataFetcher(_metadata())
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(session, metadata_fetcher=fetcher)
+            first = await service.adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=False,
+                )
+            )
+            replay_fetcher = _MetadataFetcher(_metadata(head_ref="feature/should-not-fetch"))
+            replay = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=replay_fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                    auto_merge=False,
+                )
+            )
+            await session.commit()
+
+        assert replay.attached_existing is True
+        assert replay.workspace_id == first.workspace_id
+        assert replay_fetcher.calls == []
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            assert await _count(session, Workspace) == 1
+
+    @pytest.mark.unit
+    async def test_terminal_policy_difference_does_not_block_fresh_adoption(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        canonical_key = _canonical_key()
+        async with factory() as session:
+            stale = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/stale")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    agent="codex",
+                    profile_ref="auto",
+                    auto_merge=False,
+                    initial_review_grace_period_seconds=7,
+                )
+            )
+            await _transition_adoption(session, stale.workspace_id, WorkspaceStatus.cancelled)
+            await session.commit()
+
+        async with factory() as session:
+            fresh = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(
+                    _metadata(head_ref="feature/current", head_sha="d" * 40)
+                ),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    agent="claude_code",
+                    profile_ref="python",
+                    auto_merge=True,
+                    initial_review_grace_period_seconds=13,
+                )
+            )
+            await session.commit()
+
+        assert fresh.attached_existing is False
+        assert fresh.workspace_id != stale.workspace_id
+        assert fresh.head_ref == "feature/current"
+        assert fresh.auto_merge is True
+        assert fresh.monitor_policy == {
+            "auto_merge": True,
+            "initial_review_grace_period_seconds": 13.0,
+        }
+
+        async with factory() as session:
+            old = await WorkspaceRepository(session).get(stale.workspace_id)
+            new = await WorkspaceRepository(session).get(fresh.workspace_id)
+            assert old is not None
+            assert new is not None
+            assert old.idempotency_key != canonical_key
+            assert new.idempotency_key == canonical_key
+            assert old.agent == "codex"
+            assert old.profile_ref == "auto"
+            assert old.auto_merge is False
+            assert old.initial_review_grace_period_seconds == 7
+            assert new.agent == "claude_code"
+            assert new.profile_ref == "python"
+            assert new.auto_merge is True
+            assert new.initial_review_grace_period_seconds == 13
+            assert new.task_policy["pr_adoption"]["head_ref"] == "feature/current"
+            assert new.task_policy["pr_adoption"]["head_sha"] == "d" * 40
+
+    @pytest.mark.unit
+    async def test_superseded_terminal_row_remains_auditable(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        canonical_key = _canonical_key()
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/stale")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            await _transition_adoption(session, first.workspace_id, WorkspaceStatus.cancelled)
+            await session.commit()
+
+        async with factory() as session:
+            fresh = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/current")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            await session.commit()
+
+        async with factory() as session:
+            old_workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            new_workspace = await WorkspaceRepository(session).get(fresh.workspace_id)
+            assert old_workspace is not None
+            assert new_workspace is not None
+
+            old_attempt = await TaskAttemptRepository(session).get_by_workspace_id(
+                first.workspace_id
+            )
+            new_attempt = await TaskAttemptRepository(session).get_by_workspace_id(
+                fresh.workspace_id
+            )
+            assert old_attempt is not None
+            assert new_attempt is not None
+            assert old_attempt.id != new_attempt.id
+
+            operations = list(
+                (
+                    await session.execute(
+                        select(Operation).order_by(Operation.created_at.asc(), Operation.id.asc())
+                    )
+                ).scalars()
+            )
+            assert len(operations) == 2
+
+            old_events = list(
+                (
+                    await session.execute(
+                        select(WorkspaceEvent)
+                        .where(WorkspaceEvent.workspace_id == first.workspace_id)
+                        .order_by(WorkspaceEvent.occurred_at.asc(), WorkspaceEvent.id.asc())
+                    )
+                ).scalars()
+            )
+            superseded_event = next(
+                event
+                for event in old_events
+                if event.event_type == "workspace.pr_monitor_adoption_superseded"
+            )
+            assert superseded_event.reason_code == "PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE"
+            assert superseded_event.payload == {
+                "reason_code": "PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE",
+                "repo_slug": "dimileeh/aira-web",
+                "pr_number": 277,
+                "previous_workspace_id": first.workspace_id,
+                "previous_status": WorkspaceStatus.cancelled.value,
+                "previous_idempotency_key": canonical_key,
+                "superseded_idempotency_key": old_workspace.idempotency_key,
+                "replacement_workspace_id": fresh.workspace_id,
+            }
+
+            new_operation = next(operation for operation in operations if operation.workspace_id == fresh.workspace_id)
+            assert new_operation.payload is not None
+            assert new_operation.payload["superseded_adoption"] == superseded_event.payload
+
+            new_requested_event = next(
+                event
+                for event in new_workspace.events
+                if event.event_type == "workspace.pr_monitor_adoption_requested"
+            )
+            assert new_requested_event.payload is not None
+            assert new_requested_event.payload["superseded_adoption"] == superseded_event.payload
+
+    @pytest.mark.unit
+    async def test_replay_after_supersession_attaches_new_active_workspace(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/stale")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            await _transition_adoption(session, first.workspace_id, WorkspaceStatus.cancelled)
+            await session.commit()
+
+        async with factory() as session:
+            service = PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/current")),
+            )
+            fresh = await service.adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            replay = await service.adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            await session.commit()
+
+        assert fresh.attached_existing is False
+        assert replay.attached_existing is True
+        assert replay.workspace_id == fresh.workspace_id
+
+        async with factory() as session:
+            assert await _count(session, Workspace) == 2
+
+    @pytest.mark.unit
+    async def test_concurrent_terminal_supersession_converges_on_one_fresh_workspace(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/stale")),
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(repo_slug="dimileeh/aira-web", pr_number=277)
+            )
+            await _transition_adoption(session, first.workspace_id, WorkspaceStatus.cancelled)
+            await session.commit()
+
+        async def _adopt_once() -> tuple[str, bool]:
+            async with factory() as session:
+                result = await PullRequestMonitorAdoptionService(
+                    session,
+                    metadata_fetcher=_MetadataFetcher(_metadata(head_ref="feature/current")),
+                ).adopt(
+                    PullRequestMonitorAdoptionRequest(
+                        repo_slug="dimileeh/aira-web",
+                        pr_number=277,
+                    )
+                )
+                await session.commit()
+                return result.workspace_id, result.attached_existing
+
+        results = await asyncio.gather(_adopt_once(), _adopt_once())
+
+        workspace_ids = {workspace_id for workspace_id, _attached in results}
+        attached_flags = sorted(attached for _workspace_id, attached in results)
+        assert len(workspace_ids) == 1
+        assert attached_flags == [False, True]
+
+        async with factory() as session:
+            canonical_key = _canonical_key()
+            active_workspaces = list(
+                (
+                    await session.execute(
+                        select(Workspace).where(Workspace.idempotency_key == canonical_key)
+                    )
+                ).scalars()
+            )
+            assert len(active_workspaces) == 1
+            assert active_workspaces[0].id in workspace_ids
+            assert await _count(session, Workspace) == 2
 
     @pytest.mark.unit
     async def test_replay_with_changed_explicit_repo_url_conflicts(

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -553,6 +553,7 @@ class TestPullRequestMonitorAdoptionService:
         [
             WorkspaceStatus.cancelled,
             WorkspaceStatus.failed,
+            WorkspaceStatus.destroying,
             WorkspaceStatus.destroyed,
         ],
     )

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -687,6 +687,48 @@ class TestPullRequestMonitorAdoptionService:
         assert adoption_module._adoption_workspace_is_resumable(workspace) is True
 
     @pytest.mark.unit
+    async def test_unknown_existing_adoption_status_attaches_with_raw_status(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        fetcher = _MetadataFetcher(_metadata())
+        unknown_status = "monitoring_review_repair"
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=False,
+                )
+            )
+            workspace = await WorkspaceRepository(session).get(first.workspace_id)
+            assert workspace is not None
+            workspace.status = unknown_status
+            await session.commit()
+
+        async with factory() as session:
+            replay_fetcher = _MetadataFetcher(_metadata(head_ref="feature/should-not-fetch"))
+            replay = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=replay_fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                    auto_merge=False,
+                )
+            )
+            await session.commit()
+
+        assert replay.attached_existing is True
+        assert replay.workspace_id == first.workspace_id
+        assert replay.status == unknown_status
+        assert replay_fetcher.calls == []
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+    @pytest.mark.unit
     async def test_completed_existing_adoption_refetches_and_rejects_merged_pr(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -102,6 +102,13 @@ async def _transition_adoption(
     if status == WorkspaceStatus.failed:
         await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
         return
+    if status == WorkspaceStatus.completed:
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST_PROVISION")
+        await repo.transition(workspace, to=WorkspaceStatus.ready, reason_code="TEST_READY")
+        await repo.transition(workspace, to=WorkspaceStatus.running, reason_code="TEST_RUN")
+        await repo.transition(workspace, to=WorkspaceStatus.validating, reason_code="TEST_VALIDATE")
+        await repo.transition(workspace, to=WorkspaceStatus.completed, reason_code="TEST_COMPLETE")
+        return
     if status in {WorkspaceStatus.destroying, WorkspaceStatus.destroyed}:
         await repo.transition(workspace, to=WorkspaceStatus.cancelled, reason_code="TEST_CANCEL")
         await repo.transition(workspace, to=WorkspaceStatus.destroying, reason_code="TEST_DESTROY")
@@ -655,6 +662,48 @@ class TestPullRequestMonitorAdoptionService:
 
         assert replay.attached_existing is True
         assert replay.workspace_id == first.workspace_id
+        assert replay_fetcher.calls == []
+        assert fetcher.calls == [("dimileeh/aira-web", 277)]
+
+        async with factory() as session:
+            assert await _count(session, Workspace) == 1
+
+    @pytest.mark.unit
+    async def test_completed_existing_adoption_still_attaches_without_metadata_fetch(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        fetcher = _MetadataFetcher(_metadata())
+        async with factory() as session:
+            first = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    repo_slug="dimileeh/aira-web",
+                    pr_number=277,
+                    auto_merge=False,
+                )
+            )
+            await _transition_adoption(session, first.workspace_id, WorkspaceStatus.completed)
+            await session.commit()
+
+        async with factory() as session:
+            replay_fetcher = _MetadataFetcher(_metadata(head_ref="feature/should-not-fetch"))
+            replay = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=replay_fetcher,
+            ).adopt(
+                PullRequestMonitorAdoptionRequest(
+                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                    auto_merge=False,
+                )
+            )
+            await session.commit()
+
+        assert replay.attached_existing is True
+        assert replay.workspace_id == first.workspace_id
+        assert replay.status == WorkspaceStatus.completed
         assert replay_fetcher.calls == []
         assert fetcher.calls == [("dimileeh/aira-web", 277)]
 

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -669,6 +669,12 @@ class TestPullRequestMonitorAdoptionService:
             assert await _count(session, Workspace) == 1
 
     @pytest.mark.unit
+    def test_unknown_existing_adoption_status_is_treated_as_resumable(self) -> None:
+        workspace = Workspace(status="monitoring_review_repair")
+
+        assert adoption_module._adoption_workspace_is_resumable(workspace) is True
+
+    @pytest.mark.unit
     async def test_completed_existing_adoption_still_attaches_without_metadata_fetch(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -331,6 +331,7 @@ class TestPullRequestMonitorAdoptionService:
         "terminal_status",
         [
             WorkspaceStatus.cancelled,
+            WorkspaceStatus.completed,
             WorkspaceStatus.destroyed,
             WorkspaceStatus.failed,
         ],
@@ -686,7 +687,7 @@ class TestPullRequestMonitorAdoptionService:
         assert adoption_module._adoption_workspace_is_resumable(workspace) is True
 
     @pytest.mark.unit
-    async def test_completed_existing_adoption_still_attaches_without_metadata_fetch(
+    async def test_completed_existing_adoption_refetches_and_rejects_merged_pr(
         self,
         factory: async_sessionmaker[AsyncSession],
     ) -> None:
@@ -706,22 +707,21 @@ class TestPullRequestMonitorAdoptionService:
             await session.commit()
 
         async with factory() as session:
-            replay_fetcher = _MetadataFetcher(_metadata(head_ref="feature/should-not-fetch"))
-            replay = await PullRequestMonitorAdoptionService(
-                session,
-                metadata_fetcher=replay_fetcher,
-            ).adopt(
-                PullRequestMonitorAdoptionRequest(
-                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
-                    auto_merge=False,
+            replay_fetcher = _MetadataFetcher(_metadata(state="MERGED"))
+            with pytest.raises(PRMonitorAdoptionError) as excinfo:
+                await PullRequestMonitorAdoptionService(
+                    session,
+                    metadata_fetcher=replay_fetcher,
+                ).adopt(
+                    PullRequestMonitorAdoptionRequest(
+                        pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                        auto_merge=False,
+                    )
                 )
-            )
             await session.commit()
 
-        assert replay.attached_existing is True
-        assert replay.workspace_id == first.workspace_id
-        assert replay.status == WorkspaceStatus.completed
-        assert replay_fetcher.calls == []
+        assert excinfo.value.error_code == "PR_ALREADY_MERGED"
+        assert replay_fetcher.calls == [("dimileeh/aira-web", 277)]
         assert fetcher.calls == [("dimileeh/aira-web", 277)]
 
         async with factory() as session:

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -786,6 +786,63 @@ class TestPullRequestMonitorAdoptionService:
             assert new.task_policy["pr_adoption"]["head_sha"] == "d" * 40
 
     @pytest.mark.unit
+    async def test_terminal_non_adoption_key_conflicts_without_superseding(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        canonical_key = _canonical_key()
+        fetcher = _MetadataFetcher(_metadata(head_ref="feature/current"))
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="https://github.com/dimileeh/aira-web.git",
+                branch_base="development",
+                task_title="ordinary workspace",
+                task_prompt="This is not a PR adoption.",
+                agent="codex",
+                test_commands=[],
+                idempotency_key=canonical_key,
+                task_policy={},
+                profile_ref="auto",
+            )
+            workspace_id = workspace.id
+            await _transition_adoption(session, workspace_id, WorkspaceStatus.cancelled)
+            await session.commit()
+
+        async with factory() as session:
+            with pytest.raises(PRMonitorAdoptionError) as excinfo:
+                await PullRequestMonitorAdoptionService(
+                    session,
+                    metadata_fetcher=fetcher,
+                ).adopt(
+                    PullRequestMonitorAdoptionRequest(
+                        repo_slug="dimileeh/aira-web",
+                        pr_number=277,
+                    )
+                )
+
+        assert excinfo.value.error_code == "PR_ADOPTION_POLICY_CONFLICT"
+        assert excinfo.value.detail == {
+            "workspace_id": workspace_id,
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "existing_task_kind": "feature_branch_pr",
+            "existing_pr_adoption_repo_slug": None,
+            "existing_pr_adoption_pr_number": None,
+        }
+        assert fetcher.calls == []
+
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).get(workspace_id)
+            assert workspace is not None
+            assert workspace.idempotency_key == canonical_key
+            assert workspace.task_policy == {}
+            assert await _count(session, Workspace) == 1
+            assert not any(
+                event.event_type == "workspace.pr_monitor_adoption_superseded"
+                for event in workspace.events
+            )
+
+    @pytest.mark.unit
     async def test_superseded_terminal_row_remains_auditable(
         self,
         factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/service/test_pr_monitor_adoption.py
+++ b/tests/unit/service/test_pr_monitor_adoption.py
@@ -626,11 +626,21 @@ class TestPullRequestMonitorAdoptionService:
             assert len(workspaces) == 2
             old = next(workspace for workspace in workspaces if workspace.id == first.workspace_id)
             new = next(workspace for workspace in workspaces if workspace.id == fresh.workspace_id)
+            canonical_external_id = adoption_module._adoption_external_id(
+                repo_slug="dimileeh/aira-web",
+                pr_number=277,
+            )
+            superseded_external_id = adoption_module._superseded_adoption_external_id(
+                external_id=canonical_external_id,
+                workspace_id=old.id,
+            )
             assert old.status == terminal_status.value
             assert old.idempotency_key != canonical_key
             assert old.idempotency_key is not None
             assert old.idempotency_key.startswith(f"{canonical_key}:superseded:")
+            assert old.task_external_id == superseded_external_id
             assert new.idempotency_key == canonical_key
+            assert new.task_external_id == canonical_external_id
             assert new.task_policy["pr_adoption"]["head_ref"] == "feature/current"
             assert old.task_policy["pr_adoption"]["head_ref"] == "feature/stale"
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_6bdf949938c14ad3b4a1d58e` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Fix AWF PR-monitor adoption idempotency so cancelled or stale adoption rows do not block a clean fresh adoption of the same open PR.

Observed production/dogfood bug:
- We adopted several existing PRs into AWF PR monitoring.
- Those monitor workspaces had to be stopped/cancelled because they were rendered from stale PR-head profile data before the branch picked up the per-workspace Postgres sidecar config.
- After stopping them, running `awf workspace adopt-pr --repo dimileeh/aira-agent-workspace-fabric --pr <n> ...` returned the cancelled workspace with `attached_existing=true` instead of creating a fresh monitor workspace.
- Root cause appears to be `PullRequestMonitorAdoptionService.adopt()` using a deterministic repo+PR idempotency key and treating any existing row with that key as attachable, regardless of terminal/stale status.

Required behavior:
1. If an existing adoption workspace for the same repo+PR is active or otherwise safely resumable, keep current idempotent behavior and attach to it.
2. If the existing adoption workspace is terminal and cannot continue monitoring, especially `cancelled`, `failed`, or `destroyed`, adoption must create a fresh workspace for the still-open PR instead of returning the terminal row.
3. The old terminal row must remain auditable. Do not delete history. If needed, clear/supersede only the old row's adoption idempotency key inside the same transaction so the new workspace can claim the canonical repo+PR adoption key.
4. Avoid duplicate active monitors. Concurrent adoption requests for the same repo+PR must still serialize and converge on one active new workspace.
5. Preserve policy conflict handling for agent/profile/auto_merge conflicts against active/resumable rows. Terminal rows should not prevent fresh adoption, but the new request should still validate policy normally.
6. Add clear events/logging/audit metadata showing a fresh adoption superseded a terminal previous adoption, including previous workspace id/status and reason code.
7. Keep behavior generic to SCM identity where possible; the current implementation is GitHub-only, but do not hard-code assumptions that make future GitLab/Bitbucket adoption harder.

Testing requirements:
- Strict TDD: add failing regression tests first, then implement.
- Cover cancelled previous adoption row -> fresh workspace is created with `attached_existing=false`.
- Cover failed/destroyed previous adoption rows similarly if the state machine/data model supports them.
- Cover active monitoring previous adoption row -> existing behavior remains `attached_existing=true`.
- Cover concurrent/idempotent replay behavior does not create duplicate active monitors.
- Cover old terminal row remains present and auditable, with its idempotency key no longer blocking the fresh adoption key.
- Cover response fields for the fresh workspace use current PR metadata/head/base and do not leak stale previous workspace profile/runtime metadata.
- Use real PostgreSQL-backed tests only. No SQLite or fake database assumptions.

Validation:
- Run focused tests for PR adoption first.
- Run ruff and mypy for touched code.
- Run the full coverage gate and preserve the repo's 99% coverage requirement.

Do not modify unrelated backlog items or PR monitor flow behavior beyond this adoption-idempotency bug.

---
Validation: 5 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PR adoption idempotency when previous adoptions are in terminal states (cancelled, failed, destroyed). The system now creates a fresh adoption with updated PR metadata instead of blocking.
  * Improved concurrent adoption request handling to ensure convergence with a single active workspace.

* **Documentation**
  * Added comprehensive documentation for PR adoption supersession behavior and validation evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->