### PR TITLE
P0: add AWF-owned conformance to validation handoff

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -37,6 +37,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service gc`
 **Docs Link:** [docs/REASON_CATALOG.md#completed_workspace_without_pr](#completed_workspace_without_pr)
 
+### CONFORMANCE_REQUIRES_AWF_VALIDATION
+**Problem:** Plan conformance found no deterministic implementation gap, but AWF-owned validation evidence is missing, stale, or insufficient.
+**Likely Cause:** The agent completed the implementation before AWF ran or persisted the required profile validation gates.
+**Operator Fix:** Let AWF run validation and rerun conformance against the persisted validation provenance and log stream references.
+**Related Command:** `awf workspace show <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#conformance_requires_awf_validation](#conformance_requires_awf_validation)
+
 ### DISK_USAGE_UNAVAILABLE
 **Problem:** Free disk could not be inspected for the AWF work directory.
 **Likely Cause:** Permission denied or path does not exist.

--- a/docs/awf-plans/ws_c76512d8b0514eff9a3c8a38.md
+++ b/docs/awf-plans/ws_c76512d8b0514eff9a3c8a38.md
@@ -1,0 +1,201 @@
+# Plan: AWF-owned Conformance-to-Validation Handoff
+
+## Goal
+
+Fix the regression where a workspace can fail with `PLAN_CONFORMANCE_UNSATISFIED`
+when the implementation appears complete and the only remaining conformance gap
+is missing or stale AWF-owned validation evidence.
+
+The intended behavior is:
+
+1. Conformance reports deterministic implementation/API/plan gaps as normal agent
+   iteration work.
+2. Conformance reports validation-evidence-only gaps with the explicit reason code
+   `CONFORMANCE_REQUIRES_AWF_VALIDATION`.
+3. The executor treats that reason as an AWF control-plane handoff: commit/capture
+   agent work, transition to validation, run the configured profile gates, persist
+   validation run provenance and log stream references, then run a conformance-only
+   compare again against that evidence.
+4. Validation failures remain owned by the existing validation recovery/fix cycle.
+5. PR-monitor recovery paths keep skipping planning and feature implementation, but
+   can run the same post-validation conformance-only evidence check when a recovery
+   payload or existing conformance report indicates this handoff reason.
+
+## Intended Files And Modules To Touch
+
+- `src/awf/runtime/planning.py`
+  - Add `CONFORMANCE_REQUIRES_AWF_VALIDATION`.
+  - Update the conformance prompt to document the optional `reason_code` field and
+    the strict meaning of the new reason code.
+  - Add a conservative classifier, likely `conformance_requires_awf_validation(report)`,
+    that returns true only for validation-evidence-only reports.
+  - Keep invalid JSON, mixed gaps, and ordinary deterministic gaps on the existing
+    `needs_iteration` path.
+
+- `src/awf/control/executor.py`
+  - Add a small typed result for planning/conformance handoff, for example
+    `_PlanningValidationHandoff`, instead of collapsing all `needs_iteration`
+    reports into agent iterations or final `PLAN_CONFORMANCE_UNSATISFIED`.
+  - Teach `_run_agent_task_with_optional_planning()` to return that handoff when
+    the new classifier matches.
+  - Preserve the existing post-agent commit and validation-run creation path so
+    validation provenance remains durable in `ValidationRun` rows and log stream
+    refs.
+  - After a successful validation run for a handoff, run a conformance-only compare
+    with validation evidence in the prompt. Continue only if it reports satisfied.
+  - If validation fails, use the existing validation fix-cycle and rerun the
+    post-validation conformance check only after validation recovers.
+  - If the post-validation conformance check reports a deterministic implementation
+    gap, invoke a bounded agent iteration path rather than hiding it as validation
+    evidence.
+  - Keep validate-only/rebase-only PR-monitor recovery from running planning or
+    feature implementation; add only the conformance-only evidence check when the
+    recovery context indicates `CONFORMANCE_REQUIRES_AWF_VALIDATION`.
+
+- `src/awf/runtime/monitor_prompts.py` or `src/awf/runtime/pr_monitor_runner.py`
+  - Touch only if needed to carry a conformance handoff marker through PR-monitor
+    recovery operation payloads. The default monitor recovery path should remain
+    unchanged when no conformance handoff is present.
+
+- `src/awf/service/validation_provenance.py` or `src/awf/api/validation_runs.py`
+  - Touch only if the conformance evidence prompt needs a small reusable formatter
+    for persisted validation run summaries. Prefer existing validation-run fields
+    and `log_stream_refs`; avoid schema changes unless tests prove a gap.
+
+- `docs/REASON_CATALOG.md`
+  - Add operator-facing documentation for `CONFORMANCE_REQUIRES_AWF_VALIDATION` if
+    this repository treats new public reason codes as catalog entries.
+
+- Tests listed below.
+
+## Tests To Write First
+
+1. Runtime planning classifier tests in `tests/unit/runtime/test_planning.py`.
+   - Parse a conformance report with `status=needs_iteration`,
+     `reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION`, and gaps limited to missing
+     or stale validation evidence; assert the classifier returns true.
+   - Parse a mixed report containing both validation evidence and a real API/plan
+     gap; assert the classifier returns false.
+   - Assert the conformance prompt names the new reason code and says it is only
+     for AWF-owned validation evidence.
+
+2. Normal feature workspace handoff success in `tests/unit/control/test_executor.py`.
+   - Arrange a planned workspace whose first conformance report says implementation
+     is complete except for AWF validation evidence using
+     `CONFORMANCE_REQUIRES_AWF_VALIDATION`.
+   - Assert the executor does not run another execution prompt before validation.
+   - Assert it transitions `running -> validating`, creates/finishes a validation
+     run with command/log refs, reruns conformance after validation, and completes
+     when the second conformance report is satisfied.
+   - Assert a workspace event or failure detail uses
+     `CONFORMANCE_REQUIRES_AWF_VALIDATION` for the handoff, not
+     `PLAN_CONFORMANCE_UNSATISFIED`.
+
+3. Validation failure recovery in `tests/unit/control/test_executor.py` or
+   `tests/unit/control/test_executor_validation_fix_cycle.py`.
+   - Arrange the same handoff, then make the first validation command fail.
+   - Assert the existing validation fix prompt runs, the fix commit path is used if
+     the agent changes files, validation reruns, and only then conformance reruns.
+   - Assert exhausted validation still fails as validation failure with the
+     validation reason code, not as plan conformance failure.
+
+4. Real plan gap stays agent-owned in `tests/unit/control/test_executor.py`.
+   - Arrange conformance with a deterministic gap such as `wire API endpoint` or
+     `add implementation`, without the new reason code or with a mixed gap set.
+   - Assert the executor runs the next execution iteration and does not transition
+     to validation first.
+   - Keep the existing exhausted path as `PLAN_CONFORMANCE_UNSATISFIED`.
+
+5. PR-monitor recovery coverage in `tests/unit/control/test_executor_monitor_recovery.py`.
+   - Seed a validate-only recovery workspace with a planning profile and a
+     conformance-handoff marker/report.
+   - Assert recovery still skips planning and feature execution prompts.
+   - Assert validation runs, persisted validation evidence is included in the
+     conformance-only rerun, and clean conformance lets recovery finish.
+   - Add the negative case where ordinary validate-only recovery without a handoff
+     still makes zero adapter calls on a clean validation pass.
+
+6. Provenance/evidence tests if a formatter is added.
+   - Assert the post-validation conformance prompt includes bounded, secret-safe
+     validation facts: validation run id, status, reason code, command phases,
+     stream ids/log refs, coverage metadata, and retry count where available.
+   - Assert failed command output is represented by existing log refs/tails without
+     leaking raw secrets.
+
+## Implementation Sequence
+
+1. Add failing planning classifier/prompt tests.
+2. Implement only the new reason code, prompt text, and classifier in
+   `runtime/planning.py`; run the planning tests to confirm they turn green.
+3. Add failing normal executor handoff success and real-gap tests.
+4. Introduce `_PlanningValidationHandoff` and adjust
+   `_run_agent_task_with_optional_planning()` to return it only when the classifier
+   accepts the report.
+5. Add an executor helper for post-validation conformance reruns. It should reuse
+   the existing adapter, compose context, plan/report paths, and conformance prompt,
+   with an added validation-evidence section.
+6. Wire the helper after successful validation runs before push/PR creation.
+7. Add validation-failure recovery tests, then wire handoff state through the
+   existing validation fix cycle so conformance reruns only after a successful
+   validation result.
+8. Add PR-monitor recovery tests and, only if needed, carry a handoff marker in the
+   validate/rebase recovery operation payload without changing normal monitor
+   recovery behavior.
+9. Add reason catalog/docs updates if the new reason code is externally visible.
+10. Run focused tests after each small implementation step, then run the broader
+    validation commands below.
+
+## Validation Commands
+
+Focused TDD commands first:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_planning.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_executor.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_executor_validation_fix_cycle.py -q
+uv run --python 3.12 --extra dev pytest tests/unit/control/test_executor_monitor_recovery.py -q
+```
+
+Broader validation before handoff:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest tests/unit -q
+uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
+python scripts/generate_openapi.py --check
+```
+
+Run OpenAPI only if API schemas or generated API docs are touched; otherwise note
+that it was not required. The coverage gate must remain at or above the repo's
+99% target, or the PR must explain the measured gap and why this slice still moves
+coverage closer.
+
+## Risks And Assumptions
+
+- The conformance classifier must be conservative. It should require the explicit
+  `CONFORMANCE_REQUIRES_AWF_VALIDATION` reason code and reject mixed or ambiguous
+  gaps so real implementation work still goes back to the agent.
+- Rerunning conformance after validation must be read-only except for the JSON
+  conformance report path. Scope checks should continue to catch file writes during
+  conformance.
+- Validation evidence must come from AWF-owned validation runs/log refs, not from
+  agent-claimed command output. The prompt evidence should be bounded and redacted.
+- The validation fix cycle already runs an agent while the workspace is in
+  `validating`; reuse that pattern rather than expanding the state machine unless
+  tests show a hard transition limitation.
+- Existing validation coverage evidence reuse should remain intact. Do not add
+  broad validation parallelism or xdist behavior in this slice.
+- PR-monitor recovery must not regress the current guarantee that validate-only
+  recovery does not rerun planning or feature implementation.
+
+## Explicit Non-goals
+
+- Do not change DB connection retry policy.
+- Do not change terminal runtime cleanup policy.
+- Do not implement broad validation parallelism or xdist deterministic coverage.
+- Do not weaken `PLAN_CONFORMANCE_UNSATISFIED` for deterministic plan/API/code gaps.
+- Do not add a new database migration unless existing validation-run metadata and
+  operation payloads cannot represent the required provenance.
+- Do not push, rebase, force-push, switch branches, or create PRs manually during
+  implementation; AWF owns that workflow.

--- a/migrations/versions/c5d6e7f8a9b0_validation_run_coverage.py
+++ b/migrations/versions/c5d6e7f8a9b0_validation_run_coverage.py
@@ -1,0 +1,28 @@
+"""Add dedicated validation run coverage payload.
+
+Revision ID: c5d6e7f8a9b0
+Revises: b3c4d5e6f7a8
+Create Date: 2026-05-08
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "c5d6e7f8a9b0"
+down_revision: str | Sequence[str] | None = "b3c4d5e6f7a8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("validation_runs") as batch:
+        batch.add_column(sa.Column("coverage", sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("validation_runs") as batch:
+        batch.drop_column("coverage")

--- a/migrations/versions/c5d6e7f8a9b0_validation_run_coverage.py
+++ b/migrations/versions/c5d6e7f8a9b0_validation_run_coverage.py
@@ -19,10 +19,8 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    with op.batch_alter_table("validation_runs") as batch:
-        batch.add_column(sa.Column("coverage", sa.JSON(), nullable=True))
+    op.add_column("validation_runs", sa.Column("coverage", sa.JSON(), nullable=True))
 
 
 def downgrade() -> None:
-    with op.batch_alter_table("validation_runs") as batch:
-        batch.drop_column("coverage")
+    op.drop_column("validation_runs", "coverage")

--- a/src/awf/api/validation_runs.py
+++ b/src/awf/api/validation_runs.py
@@ -13,6 +13,7 @@ from awf.api.schemas import (
     ValidationTier,
 )
 from awf.db.models import ValidationRun
+from awf.db.validation_runs import validation_run_coverage_payload
 
 
 def validation_run_summary(
@@ -131,7 +132,7 @@ def validation_identity_fields(run: ValidationRun) -> dict[str, Any]:
 
 
 def validation_coverage_fields(run: ValidationRun) -> dict[str, Any]:
-    coverage = _json_dict(_json_dict(run.log_stream_refs).get("coverage"))
+    coverage = validation_run_coverage_payload(run)
     gaps = coverage.get("gaps")
     if not isinstance(gaps, list):
         gaps = []

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -84,6 +84,7 @@ from awf.db.repositories import (
     WorkspaceRepository,
     sync_candidate_readiness,
 )
+from awf.db.validation_runs import validation_run_coverage_payload
 from awf.node.compose_manager import ComposeManager, ComposeOperationError
 from awf.node.git_manager import mirror_path_for_worktree, repair_agent_writable_worktree
 from awf.profiles.models import WorkspaceProfile
@@ -3541,8 +3542,8 @@ class WorkspaceExecutor:
                     now=datetime.now(UTC),
                 )
             if reusable is not None:
-                metadata = (reusable.log_stream_refs or {}).get("coverage")
-                if isinstance(metadata, Mapping):
+                metadata = validation_run_coverage_payload(reusable)
+                if metadata:
                     return _CoverageEvidenceResult(
                         coverage=_coverage_result_from_metadata(metadata),
                         evidence_status="reused",
@@ -3717,6 +3718,8 @@ class WorkspaceExecutor:
                 }
             else:
                 log_stream_refs = dict(run.log_stream_refs or {})
+                log_stream_refs.pop("coverage", None)
+                coverage = validation_run_coverage_payload(run)
                 payload = {
                     "validation_run_id": run.id,
                     "status": run.status,
@@ -3725,7 +3728,7 @@ class WorkspaceExecutor:
                     "retry_count": run.retry_count,
                     "commands": list(run.commands or [])[:20],
                     "log_stream_refs": log_stream_refs,
-                    "coverage": log_stream_refs.get("coverage"),
+                    "coverage": coverage,
                     "command_set_hash": run.command_set_hash,
                     "base_commit": run.base_commit,
                     "base_sha": run.base_sha,
@@ -3739,10 +3742,12 @@ class WorkspaceExecutor:
                     "environment_identity_digest": run.environment_identity_digest,
                 }
         safe_payload = redact_audit_value(payload)
+        serialized_payload = json.dumps(safe_payload, sort_keys=True, default=str)
+        safe_serialized_payload = redact_audit_text(serialized_payload, limit=20000)
         return (
             "AWF persisted validation run evidence:\n"
             "```json\n"
-            f"{json.dumps(safe_payload, sort_keys=True, default=str)}\n"
+            f"{safe_serialized_payload}\n"
             "```"
         )
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3737,13 +3737,12 @@ class WorkspaceExecutor:
         handoff: _PlanningValidationHandoff,
         validation_run_id: str,
     ) -> _PlanningRunFailure | None:
+        # Post-validation conformance is strictly report-only, regardless of
+        # ordinary planning unexplained-deviation policy.
+        del profile
         evidence = await self._validation_run_evidence_for_conformance(validation_run_id)
         before_compare = await self._changed_paths(worktree_path)
-        before_compare_head = (
-            await self._git_rev_parse_head(worktree_path)
-            if profile.planning.fail_on_unexplained_deviation
-            else None
-        )
+        before_compare_head = await self._git_rev_parse_head(worktree_path)
         # A stale handoff report may still be present at this path; prefer
         # stdout unless the conformance rerun actually refreshed the file.
         report_path = worktree_path / handoff.report_path
@@ -3764,24 +3763,23 @@ class WorkspaceExecutor:
             workspace_id=workspace.id,
         )
         after_compare = await self._changed_paths(worktree_path)
-        if profile.planning.fail_on_unexplained_deviation:
-            committed_compare = (
-                await self._committed_paths_since(worktree_path, before_compare_head)
-                if before_compare_head is not None
-                else set()
+        committed_compare = (
+            await self._committed_paths_since(worktree_path, before_compare_head)
+            if before_compare_head is not None
+            else set()
+        )
+        compare_paths = after_compare | committed_compare
+        extra = sorted(compare_paths - before_compare - {handoff.report_path})
+        if extra:
+            return _build_planning_scope_failure(
+                scope_phase="conformance",
+                required_paths=(handoff.report_path,),
+                offending_paths=extra,
+                summary=(
+                    "post-validation conformance phase changed files outside "
+                    f"`{handoff.report_path}`"
+                ),
             )
-            compare_paths = after_compare | committed_compare
-            extra = sorted(compare_paths - before_compare - {handoff.report_path})
-            if extra:
-                return _build_planning_scope_failure(
-                    scope_phase="conformance",
-                    required_paths=(handoff.report_path,),
-                    offending_paths=extra,
-                    summary=(
-                        "post-validation conformance phase changed files outside "
-                        f"`{handoff.report_path}`"
-                    ),
-                )
 
         report_text = _read_text_if_present(report_path)
         report_from_fresh_file = (

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -582,6 +582,7 @@ def _recovery_conformance_reason_code(
     conformance: Mapping[str, Any],
 ) -> str | None:
     for value in (
+        conformance.get("report_reason_code"),
         conformance.get("reason_code"),
         recovery_payload.get("conformance_reason_code"),
         recovery_payload.get("conformance_handoff_reason_code"),

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2041,10 +2041,25 @@ class WorkspaceExecutor:
         last_failure_message: str | None = None
         successful_validation_run_id: str | None = None
         successful_validation_workspace_head_sha: str | None = None
+        validation_fix_passes_used = 0
         post_validation_conformance_fix_attempts = 0
-        for pass_number in range(max_fix_passes + 1):
-            # pass_number == 0 is the initial run (already-committed agent
-            # work). 1..N are fix attempts driven by the retry prompt.
+        post_validation_conformance_fix_pass_budget = (
+            max(
+                0,
+                planning_validation_handoff.max_iterations
+                - planning_validation_handoff.iteration
+                - 1,
+            )
+            if planning_validation_handoff is not None and recovery is None
+            else 0
+        )
+        max_validation_attempts = (
+            max_fix_passes + post_validation_conformance_fix_pass_budget + 1
+        )
+        for pass_number in range(max_validation_attempts):
+            # This loop covers the initial validation plus any validation or
+            # post-validation conformance fix prompts. The per-category
+            # counters below enforce their separate budgets.
             if not await self._recheck_status(
                 workspace_id,
                 expected=WorkspaceStatus.validating,
@@ -2368,7 +2383,6 @@ class WorkspaceExecutor:
                         # conformance miss would only rerun validation.
                         if (
                             recovery is not None
-                            or pass_number >= max_fix_passes
                             or remaining_conformance_iterations <= 0
                         ):
                             await self._finish_pending_validate_operations(
@@ -2394,8 +2408,9 @@ class WorkspaceExecutor:
                             "executor.post_validation_conformance_needs_fix_pass",
                             workspace_id=workspace_id,
                             validation_run_id=validation_run_id,
-                            fix_pass=pass_number,
-                            max_fix_passes=max_fix_passes,
+                            fix_pass=post_validation_conformance_fix_attempts + 1,
+                            max_fix_passes=post_validation_conformance_fix_pass_budget,
+                            validation_fix_passes_used=validation_fix_passes_used,
                             remaining_conformance_iterations=remaining_conformance_iterations,
                             reason_code=(
                                 conformance_failure.reason_code
@@ -2430,28 +2445,46 @@ class WorkspaceExecutor:
                         reason_code="VALIDATION_OK",
                         coverage=validation_coverage,
                     )
-                    if pass_number > 0:
+                    if validation_fix_passes_used or post_validation_conformance_fix_attempts:
                         _log.info(
                             "executor.validation_recovered",
                             workspace_id=workspace_id,
-                            fix_passes_used=pass_number,
+                            fix_passes_used=validation_fix_passes_used,
+                            post_validation_conformance_fix_attempts=(
+                                post_validation_conformance_fix_attempts
+                            ),
                         )
                     break
 
             first_fail = val_result.first_failure
+            is_post_validation_conformance_fix_pass = (
+                first_fail is not None
+                and first_fail.phase == "conformance"
+                and first_fail.command == "post-validation plan conformance"
+            )
             _log.info(
                 "executor.validation_failed",
                 workspace_id=workspace_id,
                 failed_command=first_fail.command if first_fail else None,
                 fix_pass=pass_number,
                 max_fix_passes=max_fix_passes,
+                validation_fix_passes_used=validation_fix_passes_used,
+                post_validation_conformance_fix_attempts=(
+                    post_validation_conformance_fix_attempts
+                ),
             )
             last_failure_message = _validation_failure_message(
                 val_result,
                 baseline_coverage=baseline_coverage,
             )
 
-            if pass_number >= max_fix_passes or first_fail is None:
+            if (
+                first_fail is None
+                or (
+                    not is_post_validation_conformance_fix_pass
+                    and validation_fix_passes_used >= max_fix_passes
+                )
+            ):
                 # Exhausted our budget (or no failure details to anchor a
                 # fix prompt on) — mark failed and let the operator triage.
                 # If a post-validation conformance fix already consumed a
@@ -2488,13 +2521,21 @@ class WorkspaceExecutor:
 
             # Fire a fix pass: re-invoke the coding CLI with the failure
             # context, then re-commit whatever it changed.
+            if is_post_validation_conformance_fix_pass:
+                fix_pass_number = max(1, post_validation_conformance_fix_attempts)
+                fix_pass_total_passes = max(1, post_validation_conformance_fix_pass_budget)
+                fix_pass_kind = "post-validation conformance"
+            else:
+                fix_pass_number = validation_fix_passes_used + 1
+                fix_pass_total_passes = max_fix_passes
+                fix_pass_kind = "validation"
             fix_context = ValidationFixContext(
                 failed_command=first_fail.command,
                 returncode=first_fail.returncode,
                 stdout_tail=read_output_tail(first_fail.stdout_path),
                 stderr_tail=read_output_tail(first_fail.stderr_path),
-                pass_number=pass_number + 1,
-                total_passes=max_fix_passes,
+                pass_number=fix_pass_number,
+                total_passes=fix_pass_total_passes,
                 test_commands=test_commands_tuple,
                 reason_code=_validation_run_reason_code(val_result),
                 coverage_percent=val_result.coverage.percent if val_result.coverage else None,
@@ -2519,8 +2560,9 @@ class WorkspaceExecutor:
             _log.info(
                 "executor.fix_pass_start",
                 workspace_id=workspace_id,
-                pass_number=pass_number + 1,
-                max_fix_passes=max_fix_passes,
+                pass_number=fix_pass_number,
+                max_fix_passes=fix_pass_total_passes,
+                fix_pass_kind=fix_pass_kind,
                 failed_command=first_fail.command,
             )
             if not await self._recheck_status(
@@ -2557,7 +2599,8 @@ class WorkspaceExecutor:
                 _log.error(
                     "executor.fix_pass_cleanup_failed",
                     workspace_id=workspace_id,
-                    pass_number=pass_number + 1,
+                    pass_number=fix_pass_number,
+                    fix_pass_kind=fix_pass_kind,
                     source=exc.source,
                     label=exc.label,
                     invocation_id=exc.invocation_id,
@@ -2600,10 +2643,14 @@ class WorkspaceExecutor:
                 _log.warning(
                     "executor.fix_pass_agent_nonzero_exit",
                     workspace_id=workspace_id,
-                    pass_number=pass_number + 1,
+                    pass_number=fix_pass_number,
+                    fix_pass_kind=fix_pass_kind,
                     returncode=exc.result.returncode,
                     reason_code=exc.reason_code,
                 )
+
+            if not is_post_validation_conformance_fix_pass:
+                validation_fix_passes_used += 1
 
             if not await self._recheck_status(
                 workspace_id,
@@ -2732,10 +2779,10 @@ class WorkspaceExecutor:
                     requested_tier=validation_tier,
                 ):
                     return
-                commit_msg = f"awf: fix pass {pass_number + 1} for {ws.task_title}"[:72]
+                commit_msg = f"awf: fix pass {fix_pass_number} for {ws.task_title}"[:72]
                 commit_body = (
-                    f"AWF validation fix pass {pass_number + 1} of "
-                    f"{max_fix_passes} for workspace {workspace_id} "
+                    f"AWF {fix_pass_kind} fix pass {fix_pass_number} of "
+                    f"{fix_pass_total_passes} for workspace {workspace_id} "
                     f"(agent: {ws.agent}). Failed command: "
                     f"{first_fail.command}."
                 )

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2271,6 +2271,16 @@ class WorkspaceExecutor:
                                     + post_validation_conformance_fix_attempts
                                 ),
                             )
+                        if recovery is not None:
+                            _log.info(
+                                "executor.post_validation_conformance_recovery_single_attempt",
+                                workspace_id=workspace_id,
+                                validation_run_id=validation_run_id,
+                                recovery_mode=recovery.get("recovery_mode"),
+                                source=recovery.get("source"),
+                                max_fix_passes=post_validation_conformance_fix_pass_budget,
+                                will_retry=False,
+                            )
                         conformance_failure = await self._run_post_validation_conformance_check(
                             adapter=adapter,
                             workspace=ws,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import inspect
+import json
 import re
 import shlex
 import time
@@ -39,7 +40,7 @@ from awf.adapters.base import (
     get_adapter,
 )
 from awf.adapters.defaults import DEFAULT_AGENT_DEFAULTS, defaults_with_model_overrides
-from awf.common.audit import redact_audit_text
+from awf.common.audit import redact_audit_text, redact_audit_value
 from awf.common.command_evidence import append_command_evidence
 from awf.common.commands import AsyncCommandRunner, CommandResult
 from awf.common.compose_exec import (
@@ -95,12 +96,14 @@ from awf.runtime.logs import LogStore
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     AGENT_STALLED_IN_CONFORMANCE,
+    CONFORMANCE_REQUIRES_AWF_VALIDATION,
     PLAN_CONFORMANCE_UNSATISFIED,
     ConformanceIterationRecord,
     ConformanceStallEvidence,
     ConformanceStallKind,
     ConformanceStallPolicy,
     PlanConformanceReport,
+    PlanConformanceStatus,
     build_agent_task_prompt,
     build_conformance_failure_evidence,
     build_conformance_prompt,
@@ -109,6 +112,7 @@ from awf.runtime.planning import (
     build_planning_prompt,
     changed_paths_from_porcelain,
     classify_conformance_stall,
+    conformance_requires_awf_validation,
     parse_conformance_report,
     render_workspace_path,
 )
@@ -233,6 +237,15 @@ class _PlanningRunFailure:
     message: str
     reason_code: str | None = None
     details: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class _PlanningValidationHandoff:
+    report: PlanConformanceReport
+    plan_path: Path
+    report_path: Path
+    iteration: int
+    max_iterations: int
 
 
 @dataclass(frozen=True)
@@ -454,6 +467,90 @@ def _is_validate_only_recovery_payload(payload: object) -> bool:
         payload.get("source") in _VALIDATE_ONLY_RECOVERY_SOURCES
         and payload.get("recovery_mode") in _VALIDATE_ONLY_RECOVERY_MODES
     )
+
+
+def _planning_validation_handoff_from_recovery_payload(
+    *,
+    workspace_id: str,
+    profile: WorkspaceProfile,
+    recovery_payload: Mapping[str, Any],
+) -> _PlanningValidationHandoff | None:
+    conformance_payload = recovery_payload.get("conformance")
+    conformance = conformance_payload if isinstance(conformance_payload, Mapping) else {}
+    reason_code = _recovery_conformance_reason_code(recovery_payload, conformance)
+    if reason_code != CONFORMANCE_REQUIRES_AWF_VALIDATION:
+        return None
+    try:
+        plan_path = render_workspace_path(
+            _recovery_conformance_path(
+                conformance,
+                key="plan_path",
+                fallback=profile.planning.plan_path,
+            ),
+            workspace_id=workspace_id,
+        )
+        report_path = render_workspace_path(
+            _recovery_conformance_path(
+                conformance,
+                key="report_path",
+                fallback=profile.planning.conformance_report_path,
+            ),
+            workspace_id=workspace_id,
+        )
+    except ValueError:
+        return None
+    gaps = _recovery_conformance_gaps(conformance)
+    summary_value = conformance.get("summary")
+    summary = (
+        summary_value.strip()
+        if isinstance(summary_value, str) and summary_value.strip()
+        else "Conformance requires AWF-owned validation evidence."
+    )
+    return _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary=summary,
+            gaps=gaps or ("AWF-owned validation evidence is missing or stale.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=plan_path,
+        report_path=report_path,
+        iteration=0,
+        max_iterations=profile.planning.max_iterations,
+    )
+
+
+def _recovery_conformance_reason_code(
+    recovery_payload: Mapping[str, Any],
+    conformance: Mapping[str, Any],
+) -> str | None:
+    for value in (
+        conformance.get("reason_code"),
+        recovery_payload.get("conformance_reason_code"),
+        recovery_payload.get("conformance_handoff_reason_code"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip().upper().replace("-", "_")
+    return None
+
+
+def _recovery_conformance_path(
+    conformance: Mapping[str, Any],
+    *,
+    key: str,
+    fallback: str,
+) -> str:
+    value = conformance.get(key)
+    return value if isinstance(value, str) and value.strip() else fallback
+
+
+def _recovery_conformance_gaps(conformance: Mapping[str, Any]) -> tuple[str, ...]:
+    value = conformance.get("gaps")
+    if isinstance(value, list):
+        return tuple(str(item).strip() for item in value if str(item).strip())
+    if isinstance(value, str) and value.strip():
+        return (value.strip(),)
+    return ()
 
 
 def _validate_only_recovery_needs_existing_pr_push(
@@ -1164,6 +1261,7 @@ class WorkspaceExecutor:
         agent_exit_note: str | None = None
         agent_run_reason_code: str | None = None
         agent_run_details: Mapping[str, Any] | None = None
+        planning_validation_handoff: _PlanningValidationHandoff | None = None
         expected_branch = ws.branch_name or f"awf/{workspace_id}"
         adapter: AgentAdapter | None = None
         defaults: AgentDefaults | None = None
@@ -1249,7 +1347,13 @@ class WorkspaceExecutor:
                     model=default_model,
                     command_evidence=agent_command_evidence,
                 )
-                if planning_failure is not None:
+                if isinstance(planning_failure, _PlanningValidationHandoff):
+                    planning_validation_handoff = planning_failure
+                    await self._record_planning_validation_handoff_event(
+                        workspace_id=workspace_id,
+                        handoff=planning_failure,
+                    )
+                elif planning_failure is not None:
                     failure_message = (
                         planning_failure
                         if isinstance(planning_failure, str)
@@ -1286,6 +1390,11 @@ class WorkspaceExecutor:
                     source=recovery.get("source"),
                     recovery_mode=recovery.get("recovery_mode"),
                     reason=recovery.get("reason"),
+                )
+                planning_validation_handoff = _planning_validation_handoff_from_recovery_payload(
+                    workspace_id=workspace_id,
+                    profile=profile,
+                    recovery_payload=recovery,
                 )
         except ComposeExecCleanupError as exc:
             _log.error(
@@ -2031,6 +2140,41 @@ class WorkspaceExecutor:
                 coverage_evidence_source_run_id=coverage_evidence.source_run_id,
             )
             if val_result.all_passed:
+                if planning_validation_handoff is not None:
+                    conformance_failure = await self._run_post_validation_conformance_check(
+                        adapter=adapter,
+                        workspace=ws,
+                        profile=profile,
+                        compose_project=compose_project,
+                        compose_file=compose_file,
+                        worktree_path=worktree_path,
+                        model=default_model,
+                        handoff=planning_validation_handoff,
+                        validation_run_id=validation_run_id,
+                    )
+                    if conformance_failure is not None:
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=conformance_failure.reason_code
+                            or PLAN_CONFORMANCE_UNSATISFIED,
+                            coverage=_validation_run_coverage_metadata(
+                                val_result,
+                                baseline_coverage=baseline_coverage,
+                            ),
+                            error_message=conformance_failure.message,
+                        )
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.agent_failure,
+                            message=conformance_failure.message[:2000],
+                            reason_code=conformance_failure.reason_code,
+                            details=conformance_failure.details,
+                        )
+                        return
                 successful_validation_run_id = validation_run_id
                 successful_validation_workspace_head_sha = validation_workspace_head_sha
                 await self._finish_pending_validate_operations(
@@ -3380,6 +3524,169 @@ class WorkspaceExecutor:
             return None
         return max(1, int(reservation.steady_cpu))
 
+    async def _record_planning_validation_handoff_event(
+        self,
+        *,
+        workspace_id: str,
+        handoff: _PlanningValidationHandoff,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            workspace = await repo.get(workspace_id)
+            if workspace is None:
+                return
+            await repo.add_event(
+                workspace,
+                event_type="workspace.planning_conformance_requires_awf_validation",
+                reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                payload={
+                    "summary": handoff.report.summary,
+                    "gaps": list(handoff.report.gaps),
+                    "report_reason_code": handoff.report.reason_code,
+                    "plan_path": handoff.plan_path.as_posix(),
+                    "report_path": handoff.report_path.as_posix(),
+                    "iteration": handoff.iteration,
+                    "max_iterations": handoff.max_iterations,
+                },
+            )
+            await session.commit()
+
+    async def _run_post_validation_conformance_check(
+        self,
+        *,
+        adapter: AgentAdapter,
+        workspace: Workspace,
+        profile: WorkspaceProfile,
+        compose_project: str,
+        compose_file: Path,
+        worktree_path: Path,
+        model: str | None,
+        handoff: _PlanningValidationHandoff,
+        validation_run_id: str,
+    ) -> _PlanningRunFailure | None:
+        evidence = await self._validation_run_evidence_for_conformance(validation_run_id)
+        before_compare = await self._changed_paths(worktree_path)
+        await self._update_subphase(workspace.id, "conformance")
+        compare_result = await adapter.run(
+            compose_project=compose_project,
+            compose_file=compose_file,
+            prompt=build_conformance_prompt(
+                task_prompt=workspace.task_prompt,
+                plan_path=handoff.plan_path,
+                report_path=handoff.report_path,
+                iteration=handoff.iteration + 1,
+                validation_evidence=evidence,
+            ),
+            model=model,
+            workspace_id=workspace.id,
+        )
+        after_compare = await self._changed_paths(worktree_path)
+        if profile.planning.fail_on_unexplained_deviation:
+            extra = sorted(after_compare - before_compare - {handoff.report_path})
+            if extra:
+                return _build_planning_scope_failure(
+                    scope_phase="conformance",
+                    required_paths=(handoff.report_path,),
+                    offending_paths=extra,
+                    summary=(
+                        "post-validation conformance phase changed files outside "
+                        f"`{handoff.report_path}`"
+                    ),
+                )
+
+        report_text = _read_text_if_present(worktree_path / handoff.report_path)
+        report = parse_conformance_report(report_text or compare_result.stdout)
+        if report.satisfied:
+            await self._record_post_validation_conformance_event(
+                workspace_id=workspace.id,
+                handoff=handoff,
+                report=report,
+                validation_run_id=validation_run_id,
+            )
+            return None
+
+        gap_text = "; ".join(report.gaps) or report.summary
+        return _PlanningRunFailure(
+            message=f"post-validation plan conformance was not satisfied: {gap_text}",
+            reason_code=PLAN_CONFORMANCE_UNSATISFIED,
+            details={
+                "conformance": build_conformance_failure_evidence(
+                    report=report,
+                    iterations_used=1,
+                    max_iterations=handoff.max_iterations,
+                    plan_path=handoff.plan_path,
+                    report_path=handoff.report_path,
+                ),
+                "validation_run_id": validation_run_id,
+            },
+        )
+
+    async def _record_post_validation_conformance_event(
+        self,
+        *,
+        workspace_id: str,
+        handoff: _PlanningValidationHandoff,
+        report: PlanConformanceReport,
+        validation_run_id: str,
+    ) -> None:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            workspace = await repo.get(workspace_id)
+            if workspace is None:
+                return
+            await repo.add_event(
+                workspace,
+                event_type="workspace.post_validation_conformance_satisfied",
+                reason_code=report.reason_code,
+                payload={
+                    "summary": report.summary,
+                    "plan_path": handoff.plan_path.as_posix(),
+                    "report_path": handoff.report_path.as_posix(),
+                    "validation_run_id": validation_run_id,
+                },
+            )
+            await session.commit()
+
+    async def _validation_run_evidence_for_conformance(self, validation_run_id: str) -> str:
+        async with self._session_factory() as session:
+            run = await ValidationRunRepository(session).get(validation_run_id)
+            if run is None:
+                payload: dict[str, Any] = {
+                    "validation_run_id": validation_run_id,
+                    "status": "missing",
+                    "reason_code": "VALIDATION_RUN_NOT_FOUND",
+                }
+            else:
+                log_stream_refs = dict(run.log_stream_refs or {})
+                payload = {
+                    "validation_run_id": run.id,
+                    "status": run.status,
+                    "reason_code": run.reason_code,
+                    "tier": run.tier,
+                    "retry_count": run.retry_count,
+                    "commands": list(run.commands or [])[:20],
+                    "log_stream_refs": log_stream_refs,
+                    "coverage": log_stream_refs.get("coverage"),
+                    "command_set_hash": run.command_set_hash,
+                    "base_commit": run.base_commit,
+                    "base_sha": run.base_sha,
+                    "workspace_head_sha": run.workspace_head_sha,
+                    "target_branch": run.target_branch,
+                    "target_head_sha": run.target_head_sha,
+                    "profile_name": run.profile_name,
+                    "profile_version": run.profile_version,
+                    "profile_source": run.profile_source,
+                    "resolved_profile_digest": run.resolved_profile_digest,
+                    "environment_identity_digest": run.environment_identity_digest,
+                }
+        safe_payload = redact_audit_value(payload)
+        return (
+            "AWF persisted validation run evidence:\n"
+            "```json\n"
+            f"{json.dumps(safe_payload, sort_keys=True, default=str)}\n"
+            "```"
+        )
+
     async def _run_agent_task_with_optional_planning(
         self,
         *,
@@ -3391,7 +3698,7 @@ class WorkspaceExecutor:
         worktree_path: Path,
         model: str | None,
         command_evidence: list[str] | None = None,
-    ) -> str | _PlanningRunFailure | None:
+    ) -> str | _PlanningRunFailure | _PlanningValidationHandoff | None:
         planning = profile.planning
         coordination_warnings = coordination_warnings_from_task_policy(
             getattr(workspace, "task_policy", None)
@@ -3664,6 +3971,23 @@ class WorkspaceExecutor:
                     summary=report.summary,
                 )
                 return None
+
+            if report is not None and conformance_requires_awf_validation(report):
+                _log.info(
+                    "executor.planning_conformance_requires_awf_validation",
+                    workspace_id=workspace.id,
+                    iteration=iteration,
+                    max_iterations=planning.max_iterations,
+                    gaps=list(report.gaps),
+                    reason_code=report.reason_code,
+                )
+                return _PlanningValidationHandoff(
+                    report=report,
+                    plan_path=plan_path,
+                    report_path=report_path,
+                    iteration=iteration,
+                    max_iterations=planning.max_iterations,
+                )
 
             stall = classify_conformance_stall(
                 history=iteration_history,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2209,8 +2209,8 @@ class WorkspaceExecutor:
             if val_result.all_passed:
                 conformance_failure: _PlanningRunFailure | None = None
                 if planning_validation_handoff is not None:
+                    conformance_handoff = planning_validation_handoff
                     try:
-                        conformance_handoff = planning_validation_handoff
                         if post_validation_conformance_fix_attempts:
                             conformance_handoff = replace(
                                 planning_validation_handoff,
@@ -2356,9 +2356,18 @@ class WorkspaceExecutor:
                         )
                         return
                     if conformance_failure is not None:
+                        remaining_conformance_iterations = max(
+                            0,
+                            conformance_handoff.max_iterations
+                            - (conformance_handoff.iteration + 1),
+                        )
                         # Recovery skips feature execution; retrying this
                         # conformance miss would only rerun validation.
-                        if recovery is not None or pass_number >= max_fix_passes:
+                        if (
+                            recovery is not None
+                            or pass_number >= max_fix_passes
+                            or remaining_conformance_iterations <= 0
+                        ):
                             await self._finish_pending_validate_operations(
                                 workspace_id=workspace_id,
                                 status=OperationStatus.failed,
@@ -2384,6 +2393,7 @@ class WorkspaceExecutor:
                             validation_run_id=validation_run_id,
                             fix_pass=pass_number,
                             max_fix_passes=max_fix_passes,
+                            remaining_conformance_iterations=remaining_conformance_iterations,
                             reason_code=(
                                 conformance_failure.reason_code
                                 or PLAN_CONFORMANCE_UNSATISFIED
@@ -3881,7 +3891,7 @@ class WorkspaceExecutor:
             details={
                 "conformance": build_conformance_failure_evidence(
                     report=report,
-                    iterations_used=1,
+                    iterations_used=handoff.iteration + 2,
                     max_iterations=handoff.max_iterations,
                     plan_path=handoff.plan_path,
                     report_path=handoff.report_path,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3863,9 +3863,11 @@ class WorkspaceExecutor:
         report_from_fresh_file = (
             report_text is not None and _digest_text(report_text) != before_report_digest
         )
-        if not report_from_fresh_file and compare_result.stdout:
+        if not report_from_fresh_file:
+            report_text = None
+        if report_text is None and compare_result.stdout:
             report_text = compare_result.stdout
-        report = parse_conformance_report(report_text or compare_result.stdout)
+        report = parse_conformance_report(report_text or "")
         if report.satisfied:
             if not report_from_fresh_file:
                 self._write_satisfied_post_validation_conformance_report(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3680,6 +3680,18 @@ class WorkspaceExecutor:
         report_text = _read_text_if_present(worktree_path / handoff.report_path)
         report = parse_conformance_report(report_text or compare_result.stdout)
         if report.satisfied:
+            if report_text is None:
+                self._write_satisfied_post_validation_conformance_report(
+                    worktree_path=worktree_path,
+                    report_path=handoff.report_path,
+                    report=report,
+                )
+            await self._commit_post_validation_conformance_report(
+                workspace_id=workspace.id,
+                worktree_path=worktree_path,
+                report_path=handoff.report_path,
+                validation_run_id=validation_run_id,
+            )
             await self._record_post_validation_conformance_event(
                 workspace_id=workspace.id,
                 handoff=handoff,
@@ -3703,6 +3715,102 @@ class WorkspaceExecutor:
                 "validation_run_id": validation_run_id,
             },
         )
+
+    @staticmethod
+    def _write_satisfied_post_validation_conformance_report(
+        *,
+        worktree_path: Path,
+        report_path: Path,
+        report: PlanConformanceReport,
+    ) -> None:
+        path = worktree_path / report_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "status": report.status.value,
+                    "summary": report.summary,
+                    "reason_code": report.reason_code,
+                    "gaps": list(report.gaps),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+    async def _commit_post_validation_conformance_report(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        report_path: Path,
+        validation_run_id: str,
+    ) -> bool:
+        report_path_text = report_path.as_posix()
+        git_base = [
+            "git",
+            *git_safe_directory_config_args(worktree_path),
+            "-C",
+            str(worktree_path),
+        ]
+        add_result = await self._runner.run([*git_base, "add", "--", report_path_text])
+        await self._repair_agent_git_ownership(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            reason="post_validation_conformance_report_git_add",
+        )
+        if not add_result.ok:
+            raise RuntimeError(
+                "post-validation conformance report git add failed "
+                f"(exit={add_result.returncode}): {add_result.stderr}"
+            )
+
+        cached = await self._runner.run(
+            [*git_base, "diff", "--cached", "--name-only", "--", report_path_text]
+        )
+        if not cached.ok:
+            raise RuntimeError(
+                "post-validation conformance report staged diff failed "
+                f"(exit={cached.returncode}): {cached.stderr}"
+            )
+        staged_paths = _git_name_lines(cached.stdout) if cached.stdout.strip() else []
+        if report_path_text not in staged_paths:
+            _log.info(
+                "executor.post_validation_conformance_report_no_commit_needed",
+                workspace_id=workspace_id,
+                report_path=report_path_text,
+                validation_run_id=validation_run_id,
+            )
+            return False
+
+        commit_result = await self._runner.run(
+            [
+                *git_base,
+                *git_identity_config_args(),
+                "commit",
+                "-m",
+                "awf: post-validation conformance report",
+                "-m",
+                (
+                    "Persist satisfied post-validation conformance report "
+                    f"for validation run {validation_run_id}."
+                ),
+                "--",
+                report_path_text,
+            ],
+        )
+        await self._repair_agent_git_ownership(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            reason="post_validation_conformance_report_git_commit",
+        )
+        if not commit_result.ok:
+            raise RuntimeError(
+                "post-validation conformance report commit failed "
+                f"(exit={commit_result.returncode}): {commit_result.stderr}"
+            )
+        return True
 
     async def _record_post_validation_conformance_event(
         self,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3649,6 +3649,11 @@ class WorkspaceExecutor:
     ) -> _PlanningRunFailure | None:
         evidence = await self._validation_run_evidence_for_conformance(validation_run_id)
         before_compare = await self._changed_paths(worktree_path)
+        before_compare_head = (
+            await self._git_rev_parse_head(worktree_path)
+            if profile.planning.fail_on_unexplained_deviation
+            else None
+        )
         await self._update_subphase(workspace.id, "conformance")
         compare_result = await adapter.run(
             compose_project=compose_project,
@@ -3665,7 +3670,13 @@ class WorkspaceExecutor:
         )
         after_compare = await self._changed_paths(worktree_path)
         if profile.planning.fail_on_unexplained_deviation:
-            extra = sorted(after_compare - before_compare - {handoff.report_path})
+            committed_compare = (
+                await self._committed_paths_since(worktree_path, before_compare_head)
+                if before_compare_head is not None
+                else set()
+            )
+            compare_paths = after_compare | committed_compare
+            extra = sorted(compare_paths - before_compare - {handoff.report_path})
             if extra:
                 return _build_planning_scope_failure(
                     scope_phase="conformance",

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -610,23 +610,31 @@ def _recovery_conformance_gaps(conformance: Mapping[str, Any]) -> tuple[str, ...
     return ()
 
 
-def _validate_only_recovery_needs_existing_pr_push(
+def _recovery_needs_existing_pr_push(
     recovery_payload: Mapping[str, Any],
     *,
     validated_workspace_head_sha: str | None,
     rebase_recovery_result: _RebaseRecoveryResult | None,
 ) -> bool:
     """Return true when recovery produced local commits that are not on the PR yet."""
-    if recovery_payload.get("recovery_mode") != "validate_only":
-        return False
-    if rebase_recovery_result is not None:
-        return False
     if not validated_workspace_head_sha:
         return False
-    source_head_sha = recovery_payload.get("source_head_sha")
-    if not isinstance(source_head_sha, str) or not source_head_sha.strip():
+    validated_head = validated_workspace_head_sha.strip()
+    if not validated_head:
         return False
-    return validated_workspace_head_sha != source_head_sha.strip()
+    recovery_mode = recovery_payload.get("recovery_mode")
+    if recovery_mode == "validate_only":
+        if rebase_recovery_result is not None:
+            return False
+        source_head_sha = recovery_payload.get("source_head_sha")
+        if not isinstance(source_head_sha, str) or not source_head_sha.strip():
+            return False
+        return validated_head != source_head_sha.strip()
+    if recovery_mode == "rebase_only":
+        if rebase_recovery_result is None:
+            return False
+        return validated_head != rebase_recovery_result.head_sha
+    return False
 
 
 def _is_callback_terminal_status(status: str) -> bool:
@@ -2732,11 +2740,12 @@ class WorkspaceExecutor:
         # ── Recovery skip-push guard ───────────────────────────────────────
         # Recovery for a workspace that already has an open PR must NOT
         # re-create the PR. Clean validate-only recovery does not push; if a
-        # fix pass created a new validated local commit, update the existing PR
-        # branch before handing back to the monitor. Rebase-only recovery
-        # already pushed the rebased branch above.
+        # fix pass or handoff report created a new validated local commit,
+        # update the existing PR branch before handing back to the monitor.
+        # Rebase-only recovery already pushed the rebased branch above, but
+        # later validation work can still advance local HEAD.
         if recovery is not None and ws.pr_url:
-            recovery_requires_pr_update = _validate_only_recovery_needs_existing_pr_push(
+            recovery_requires_pr_update = _recovery_needs_existing_pr_push(
                 recovery,
                 validated_workspace_head_sha=successful_validation_workspace_head_sha,
                 rebase_recovery_result=rebase_recovery_result,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2150,6 +2150,7 @@ class WorkspaceExecutor:
                 coverage_evidence_source_run_id=coverage_evidence.source_run_id,
             )
             if val_result.all_passed:
+                conformance_failure: _PlanningRunFailure | None = None
                 if planning_validation_handoff is not None:
                     try:
                         conformance_failure = await self._run_post_validation_conformance_check(
@@ -2223,43 +2224,60 @@ class WorkspaceExecutor:
                         )
                         return
                     if conformance_failure is not None:
-                        await self._finish_pending_validate_operations(
+                        if pass_number >= max_fix_passes:
+                            await self._finish_pending_validate_operations(
+                                workspace_id=workspace_id,
+                                status=OperationStatus.failed,
+                                validation_run_id=validation_run_id,
+                                requested_tier=validation_tier,
+                                reason_code=conformance_failure.reason_code
+                                or PLAN_CONFORMANCE_UNSATISFIED,
+                                coverage=validation_coverage,
+                                error_message=conformance_failure.message,
+                            )
+                            await self._mark_failed(
+                                workspace_id=workspace_id,
+                                from_status=WorkspaceStatus.validating,
+                                failure_reason=FailureReason.agent_failure,
+                                message=conformance_failure.message[:2000],
+                                reason_code=conformance_failure.reason_code,
+                                details=conformance_failure.details,
+                            )
+                            return
+                        _log.info(
+                            "executor.post_validation_conformance_needs_fix_pass",
                             workspace_id=workspace_id,
-                            status=OperationStatus.failed,
                             validation_run_id=validation_run_id,
-                            requested_tier=validation_tier,
-                            reason_code=conformance_failure.reason_code
-                            or PLAN_CONFORMANCE_UNSATISFIED,
-                            coverage=validation_coverage,
-                            error_message=conformance_failure.message,
+                            fix_pass=pass_number,
+                            max_fix_passes=max_fix_passes,
+                            reason_code=(
+                                conformance_failure.reason_code
+                                or PLAN_CONFORMANCE_UNSATISFIED
+                            ),
                         )
-                        await self._mark_failed(
+                        val_result = _post_validation_conformance_fix_result(
+                            failure=conformance_failure,
                             workspace_id=workspace_id,
-                            from_status=WorkspaceStatus.validating,
-                            failure_reason=FailureReason.agent_failure,
-                            message=conformance_failure.message[:2000],
-                            reason_code=conformance_failure.reason_code,
-                            details=conformance_failure.details,
+                            artifacts_root=self._config.compose_projects_root,
                         )
-                        # This return keeps successful_validation_* assignments unreachable.
-                        return
-                successful_validation_run_id = validation_run_id
-                successful_validation_workspace_head_sha = validation_workspace_head_sha
-                await self._finish_pending_validate_operations(
-                    workspace_id=workspace_id,
-                    status=OperationStatus.succeeded,
-                    validation_run_id=validation_run_id,
-                    requested_tier=validation_tier,
-                    reason_code="VALIDATION_OK",
-                    coverage=validation_coverage,
-                )
-                if pass_number > 0:
-                    _log.info(
-                        "executor.validation_recovered",
+                if conformance_failure is None:
+                    successful_validation_run_id = validation_run_id
+                    successful_validation_workspace_head_sha = validation_workspace_head_sha
+                    await self._finish_pending_validate_operations(
                         workspace_id=workspace_id,
-                        fix_passes_used=pass_number,
+                        status=OperationStatus.succeeded,
+                        validation_run_id=validation_run_id,
+                        requested_tier=validation_tier,
+                        reason_code="VALIDATION_OK",
+                        coverage=validation_coverage,
                     )
-                break
+                    if pass_number > 0:
+                        _log.info(
+                            "executor.validation_recovered",
+                            workspace_id=workspace_id,
+                            fix_passes_used=pass_number,
+                        )
+                    break
 
             first_fail = val_result.first_failure
             _log.info(
@@ -6238,6 +6256,54 @@ def _validation_failure_message(
             details += f"; logs: {log_hint}"
         return details
     return f"validation failed: {first_fail.command}" if first_fail else "validation failed"
+
+
+def _post_validation_conformance_fix_result(
+    *,
+    failure: _PlanningRunFailure,
+    workspace_id: str,
+    artifacts_root: Path,
+) -> ValidationResult:
+    artifacts_dir = artifacts_root / workspace_id / "post_validation_conformance"
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = artifacts_dir / "post_validation_conformance.stdout"
+    stderr_path = artifacts_dir / "post_validation_conformance.stderr"
+    stdout_path.write_text(_post_validation_conformance_failure_text(failure), encoding="utf-8")
+    stderr_path.write_text("", encoding="utf-8")
+    return ValidationResult(
+        commands=[
+            ValidationCommandResult(
+                command="post-validation plan conformance",
+                returncode=1,
+                duration_seconds=0.0,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                phase="conformance",
+                reason_code=failure.reason_code or PLAN_CONFORMANCE_UNSATISFIED,
+                policy_failed=True,
+            )
+        ]
+    )
+
+
+def _post_validation_conformance_failure_text(failure: _PlanningRunFailure) -> str:
+    lines = [failure.message]
+    details = failure.details or {}
+    conformance = details.get("conformance")
+    if isinstance(conformance, Mapping):
+        summary = conformance.get("summary")
+        if isinstance(summary, str) and summary.strip():
+            lines.append(f"Summary: {summary.strip()}")
+        report_reason = conformance.get("report_reason_code")
+        if isinstance(report_reason, str) and report_reason.strip():
+            lines.append(f"Report reason code: {report_reason.strip()}")
+        gaps = conformance.get("gaps")
+        if isinstance(gaps, list):
+            gap_lines = [str(gap).strip() for gap in gaps if str(gap).strip()]
+            if gap_lines:
+                lines.append("Remaining conformance gaps:")
+                lines.extend(f"- {gap}" for gap in gap_lines)
+    return "\n".join(lines)
 
 
 def _post_validation_conformance_agent_failure_message(exc: AgentRunError) -> str:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2062,8 +2062,7 @@ class WorkspaceExecutor:
             max(
                 0,
                 planning_validation_handoff.max_iterations
-                - planning_validation_handoff.iteration
-                - 1,
+                - planning_validation_handoff.iteration,
             )
             if planning_validation_handoff is not None and recovery is None
             else 0
@@ -2432,7 +2431,7 @@ class WorkspaceExecutor:
                         remaining_conformance_iterations = max(
                             0,
                             conformance_handoff.max_iterations
-                            - (conformance_handoff.iteration + 1),
+                            - conformance_handoff.iteration,
                         )
                         # Recovery skips feature execution; retrying this
                         # conformance miss would only rerun validation.

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -193,6 +193,7 @@ GIT_OBJECT_MISSING_RECOVERED_REASON_CODE = "GIT_OBJECT_MISSING_RECOVERED"
 POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE = (
     "POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED"
 )
+POST_VALIDATION_CONFORMANCE_FAILED_REASON_CODE = "POST_VALIDATION_CONFORMANCE_FAILED"
 _PR_MONITOR_ADOPTED_EVENT = "workspace.pr_monitor_adopted"
 _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"
 _PR_ADOPTION_SKIP_AGENT_REASON_CODE = "PR_ADOPTION_SKIP_AGENT"
@@ -2282,6 +2283,34 @@ class WorkspaceExecutor:
                             message=message,
                             reason_code=reason_code,
                             details=failure_details,
+                        )
+                        return
+                    except Exception as exc:
+                        reason_code = POST_VALIDATION_CONFORMANCE_FAILED_REASON_CODE
+                        message = (
+                            f"post-validation conformance check failed: {exc!r}"
+                        )[:2000]
+                        _log.exception(
+                            "executor.post_validation_conformance_unexpected_failed",
+                            workspace_id=workspace_id,
+                            validation_run_id=validation_run_id,
+                            reason_code=reason_code,
+                        )
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=reason_code,
+                            coverage=validation_coverage,
+                            error_message=message,
+                        )
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.infrastructure_failure,
+                            message=message,
+                            reason_code=reason_code,
                         )
                         return
                     if conformance_failure is not None:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -251,16 +251,36 @@ class _RebaseRecoveryResult:
 
 
 class _PostValidationConformanceReportGitError(RuntimeError):
-    def __init__(self, *, operation: str, result: CommandResult) -> None:
+    def __init__(
+        self,
+        *,
+        operation: str,
+        result: CommandResult,
+        cleanup_operation: str | None = None,
+        cleanup_result: CommandResult | None = None,
+    ) -> None:
         output = (result.stderr or result.stdout or "").strip()
         message = (
             f"post-validation conformance report git {operation} failed "
             f"(exit={result.returncode}): {output}"
         )
+        if cleanup_operation is not None and cleanup_result is not None:
+            cleanup_output = (cleanup_result.stderr or cleanup_result.stdout or "").strip()
+            message = (
+                f"{message}; cleanup git {cleanup_operation} failed "
+                f"(exit={cleanup_result.returncode}): {cleanup_output}"
+            )
         super().__init__(message)
         self.operation = operation
         self.returncode = result.returncode
         self.command_reason_code = result.reason_code
+        self.cleanup_operation = cleanup_operation
+        self.cleanup_returncode = (
+            cleanup_result.returncode if cleanup_result is not None else None
+        )
+        self.cleanup_command_reason_code = (
+            cleanup_result.reason_code if cleanup_result is not None else None
+        )
 
 
 class _PostValidationConformanceReportWriteError(RuntimeError):
@@ -2350,6 +2370,14 @@ class WorkspaceExecutor:
                         }
                         if exc.command_reason_code is not None:
                             failure_details["command_reason_code"] = exc.command_reason_code
+                        if exc.cleanup_operation is not None:
+                            failure_details["cleanup_operation"] = exc.cleanup_operation
+                            failure_details["cleanup_returncode"] = exc.cleanup_returncode
+                            failure_details["report_left_staged"] = True
+                        if exc.cleanup_command_reason_code is not None:
+                            failure_details["cleanup_command_reason_code"] = (
+                                exc.cleanup_command_reason_code
+                            )
                         await self._mark_failed(
                             workspace_id=workspace_id,
                             from_status=WorkspaceStatus.validating,
@@ -4093,6 +4121,8 @@ class WorkspaceExecutor:
             raise _PostValidationConformanceReportGitError(
                 operation="diff",
                 result=cached,
+                cleanup_operation="reset" if not reset_result.ok else None,
+                cleanup_result=reset_result if not reset_result.ok else None,
             )
         staged_paths = _git_name_lines(cached.stdout) if cached.stdout.strip() else []
         if report_path_text not in staged_paths:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2422,6 +2422,7 @@ class WorkspaceExecutor:
                             failure=conformance_failure,
                             workspace_id=workspace_id,
                             artifacts_root=self._config.compose_projects_root,
+                            attempt=post_validation_conformance_fix_attempts,
                         )
                 if conformance_failure is None:
                     successful_validation_run_id = validation_run_id
@@ -5955,13 +5956,13 @@ def _validation_evidence_floor_payload(
     floor_payload = {
         key: _validation_evidence_floor_value(payload[key])
         for key in _VALIDATION_EVIDENCE_CORE_KEYS
-        if key in payload
+        if key in payload and key != "coverage"
     }
+    if "coverage" in payload:
+        floor_payload["coverage"] = _validation_evidence_size_summary(payload["coverage"])
     floor_payload["evidence_truncated"] = True
     floor_payload["truncation_reason"] = "validation_evidence_json_limit"
     floor_payload["oversized_serialized_length"] = oversized_serialized_length
-    if "coverage" in payload:
-        floor_payload["coverage"] = _validation_evidence_size_summary(payload["coverage"])
     floor_payload["commands"] = _validation_evidence_size_summary(payload.get("commands"))
     floor_payload["log_stream_refs"] = _validation_evidence_size_summary(
         payload.get("log_stream_refs")
@@ -6768,11 +6769,22 @@ def _post_validation_conformance_fix_result(
     failure: _PlanningRunFailure,
     workspace_id: str,
     artifacts_root: Path,
+    attempt: int | None = None,
 ) -> ValidationResult:
     artifacts_dir = artifacts_root / workspace_id / "post_validation_conformance"
     artifacts_dir.mkdir(parents=True, exist_ok=True)
-    stdout_path = artifacts_dir / "post_validation_conformance.stdout"
-    stderr_path = artifacts_dir / "post_validation_conformance.stderr"
+    attempt_value: object = attempt
+    if attempt_value is None and failure.details:
+        attempt_value = failure.details.get("attempt")
+    suffix = (
+        f".{attempt_value}"
+        if isinstance(attempt_value, int)
+        and not isinstance(attempt_value, bool)
+        and attempt_value > 0
+        else ""
+    )
+    stdout_path = artifacts_dir / f"post_validation_conformance{suffix}.stdout"
+    stderr_path = artifacts_dir / f"post_validation_conformance{suffix}.stderr"
     stdout_path.write_text(_post_validation_conformance_failure_text(failure), encoding="utf-8")
     stderr_path.write_text("", encoding="utf-8")
     return ValidationResult(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3654,6 +3654,11 @@ class WorkspaceExecutor:
             if profile.planning.fail_on_unexplained_deviation
             else None
         )
+        # A stale handoff report may still be present at this path; prefer
+        # stdout unless the conformance rerun actually refreshed the file.
+        report_path = worktree_path / handoff.report_path
+        before_report_text = _read_text_if_present(report_path)
+        before_report_digest = _digest_text(before_report_text) if before_report_text else None
         await self._update_subphase(workspace.id, "conformance")
         compare_result = await adapter.run(
             compose_project=compose_project,
@@ -3688,10 +3693,15 @@ class WorkspaceExecutor:
                     ),
                 )
 
-        report_text = _read_text_if_present(worktree_path / handoff.report_path)
+        report_text = _read_text_if_present(report_path)
+        report_from_fresh_file = (
+            report_text is not None and _digest_text(report_text) != before_report_digest
+        )
+        if not report_from_fresh_file and compare_result.stdout:
+            report_text = compare_result.stdout
         report = parse_conformance_report(report_text or compare_result.stdout)
         if report.satisfied:
-            if report_text is None:
+            if not report_from_fresh_file:
                 self._write_satisfied_post_validation_conformance_report(
                     worktree_path=worktree_path,
                     report_path=handoff.report_path,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2353,6 +2353,17 @@ class WorkspaceExecutor:
                 if conformance_failure is None:
                     successful_validation_run_id = validation_run_id
                     successful_validation_workspace_head_sha = validation_workspace_head_sha
+                    if (
+                        recovery is not None
+                        and ws.pr_url
+                        and planning_validation_handoff is not None
+                    ):
+                        post_conformance_head_sha = await self._capture_workspace_head_sha(
+                            workspace_id=workspace_id,
+                            worktree_path=worktree_path,
+                        )
+                        if post_conformance_head_sha:
+                            successful_validation_workspace_head_sha = post_conformance_head_sha
                     await self._finish_pending_validate_operations(
                         workspace_id=workspace_id,
                         status=OperationStatus.succeeded,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -190,6 +190,9 @@ _PR_CREATE_FAILED_REASON_CODE = "PR_CREATE_FAILED"
 GIT_AGENT_WRITABILITY_FAILED_REASON_CODE = "GIT_AGENT_WRITABILITY_FAILED"
 GIT_OBJECT_MISSING_REASON_CODE = "GIT_OBJECT_MISSING"
 GIT_OBJECT_MISSING_RECOVERED_REASON_CODE = "GIT_OBJECT_MISSING_RECOVERED"
+POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE = (
+    "POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED"
+)
 _PR_MONITOR_ADOPTED_EVENT = "workspace.pr_monitor_adopted"
 _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"
 _PR_ADOPTION_SKIP_AGENT_REASON_CODE = "PR_ADOPTION_SKIP_AGENT"
@@ -217,6 +220,19 @@ _REBASE_RECOVERY_OPERATION_IDENTITY_KEYS = (
 class _RebaseRecoveryResult:
     base_sha: str
     head_sha: str
+
+
+class _PostValidationConformanceReportGitError(RuntimeError):
+    def __init__(self, *, operation: str, result: CommandResult) -> None:
+        output = (result.stderr or result.stdout or "").strip()
+        message = (
+            f"post-validation conformance report git {operation} failed "
+            f"(exit={result.returncode}): {output}"
+        )
+        super().__init__(message)
+        self.operation = operation
+        self.returncode = result.returncode
+        self.command_reason_code = result.reason_code
 
 
 @dataclass(frozen=True)
@@ -2223,6 +2239,44 @@ class WorkspaceExecutor:
                             ),
                         )
                         return
+                    except _PostValidationConformanceReportGitError as exc:
+                        reason_code = POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE
+                        message = str(exc)
+                        _log.error(
+                            "executor.post_validation_conformance_report_git_failed",
+                            workspace_id=workspace_id,
+                            validation_run_id=validation_run_id,
+                            operation=exc.operation,
+                            returncode=exc.returncode,
+                            command_reason_code=exc.command_reason_code,
+                            reason_code=reason_code,
+                        )
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=reason_code,
+                            coverage=validation_coverage,
+                            error_message=message,
+                        )
+                        failure_details: dict[str, Any] = {
+                            "validation_run_id": validation_run_id,
+                            "report_path": planning_validation_handoff.report_path.as_posix(),
+                            "operation": exc.operation,
+                            "returncode": exc.returncode,
+                        }
+                        if exc.command_reason_code is not None:
+                            failure_details["command_reason_code"] = exc.command_reason_code
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.infrastructure_failure,
+                            message=message,
+                            reason_code=reason_code,
+                            details=failure_details,
+                        )
+                        return
                     if conformance_failure is not None:
                         if pass_number >= max_fix_passes:
                             await self._finish_pending_validate_operations(
@@ -3782,18 +3836,18 @@ class WorkspaceExecutor:
             reason="post_validation_conformance_report_git_add",
         )
         if not add_result.ok:
-            raise RuntimeError(
-                "post-validation conformance report git add failed "
-                f"(exit={add_result.returncode}): {add_result.stderr}"
+            raise _PostValidationConformanceReportGitError(
+                operation="add",
+                result=add_result,
             )
 
         cached = await self._runner.run(
             [*git_base, "diff", "--cached", "--name-only", "--", report_path_text]
         )
         if not cached.ok:
-            raise RuntimeError(
-                "post-validation conformance report staged diff failed "
-                f"(exit={cached.returncode}): {cached.stderr}"
+            raise _PostValidationConformanceReportGitError(
+                operation="diff",
+                result=cached,
             )
         staged_paths = _git_name_lines(cached.stdout) if cached.stdout.strip() else []
         if report_path_text not in staged_paths:
@@ -3827,9 +3881,9 @@ class WorkspaceExecutor:
             reason="post_validation_conformance_report_git_commit",
         )
         if not commit_result.ok:
-            raise RuntimeError(
-                "post-validation conformance report commit failed "
-                f"(exit={commit_result.returncode}): {commit_result.stderr}"
+            raise _PostValidationConformanceReportGitError(
+                operation="commit",
+                result=commit_result,
             )
         return True
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -507,6 +507,12 @@ def _planning_validation_handoff_from_recovery_payload(
         if isinstance(summary_value, str) and summary_value.strip()
         else "Conformance requires AWF-owned validation evidence."
     )
+    iteration = _int_or_none(conformance.get("iteration"))
+    if iteration is None:
+        iteration = _int_or_none(recovery_payload.get("iteration"))
+    max_iterations = _int_or_none(conformance.get("max_iterations"))
+    if max_iterations is None:
+        max_iterations = _int_or_none(recovery_payload.get("max_iterations"))
     return _PlanningValidationHandoff(
         report=PlanConformanceReport(
             status=PlanConformanceStatus.needs_iteration,
@@ -516,8 +522,10 @@ def _planning_validation_handoff_from_recovery_payload(
         ),
         plan_path=plan_path,
         report_path=report_path,
-        iteration=0,
-        max_iterations=profile.planning.max_iterations,
+        iteration=iteration if iteration is not None else 0,
+        max_iterations=(
+            max_iterations if max_iterations is not None else profile.planning.max_iterations
+        ),
     )
 
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2038,6 +2038,7 @@ class WorkspaceExecutor:
         last_failure_message: str | None = None
         successful_validation_run_id: str | None = None
         successful_validation_workspace_head_sha: str | None = None
+        post_validation_conformance_fix_attempts = 0
         for pass_number in range(max_fix_passes + 1):
             # pass_number == 0 is the initial run (already-committed agent
             # work). 1..N are fix attempts driven by the retry prompt.
@@ -2209,6 +2210,15 @@ class WorkspaceExecutor:
                 conformance_failure: _PlanningRunFailure | None = None
                 if planning_validation_handoff is not None:
                     try:
+                        conformance_handoff = planning_validation_handoff
+                        if post_validation_conformance_fix_attempts:
+                            conformance_handoff = replace(
+                                planning_validation_handoff,
+                                iteration=(
+                                    planning_validation_handoff.iteration
+                                    + post_validation_conformance_fix_attempts
+                                ),
+                            )
                         conformance_failure = await self._run_post_validation_conformance_check(
                             adapter=adapter,
                             workspace=ws,
@@ -2217,7 +2227,7 @@ class WorkspaceExecutor:
                             compose_file=compose_file,
                             worktree_path=worktree_path,
                             model=default_model,
-                            handoff=planning_validation_handoff,
+                            handoff=conformance_handoff,
                             validation_run_id=validation_run_id,
                         )
                     except ComposeExecCleanupError as exc:
@@ -2379,6 +2389,7 @@ class WorkspaceExecutor:
                                 or PLAN_CONFORMANCE_UNSATISFIED
                             ),
                         )
+                        post_validation_conformance_fix_attempts += 1
                         val_result = _post_validation_conformance_fix_result(
                             failure=conformance_failure,
                             workspace_id=workspace_id,
@@ -2430,6 +2441,9 @@ class WorkspaceExecutor:
             if pass_number >= max_fix_passes or first_fail is None:
                 # Exhausted our budget (or no failure details to anchor a
                 # fix prompt on) — mark failed and let the operator triage.
+                # If a post-validation conformance fix already consumed a
+                # prior successful run, this terminal path intentionally
+                # reports coverage from the fresh failing validation result.
                 await self._finish_pending_validate_operations(
                     workspace_id=workspace_id,
                     status=OperationStatus.failed,
@@ -3787,6 +3801,9 @@ class WorkspaceExecutor:
         # ordinary planning unexplained-deviation policy.
         del profile
         evidence = await self._validation_run_evidence_for_conformance(validation_run_id)
+        # Snapshot before the adapter run and before any AWF-synthesized
+        # satisfied report write below; this scope check only polices changes
+        # made during the report-only conformance command.
         before_compare = await self._changed_paths(worktree_path)
         before_compare_head = await self._git_rev_parse_head(worktree_path)
         # A stale handoff report may still be present at this path; prefer

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -193,6 +193,9 @@ GIT_OBJECT_MISSING_RECOVERED_REASON_CODE = "GIT_OBJECT_MISSING_RECOVERED"
 POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE = (
     "POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED"
 )
+POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE = (
+    "POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED"
+)
 POST_VALIDATION_CONFORMANCE_FAILED_REASON_CODE = "POST_VALIDATION_CONFORMANCE_FAILED"
 _PR_MONITOR_ADOPTED_EVENT = "workspace.pr_monitor_adopted"
 _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"
@@ -258,6 +261,18 @@ class _PostValidationConformanceReportGitError(RuntimeError):
         self.operation = operation
         self.returncode = result.returncode
         self.command_reason_code = result.reason_code
+
+
+class _PostValidationConformanceReportWriteError(RuntimeError):
+    def __init__(self, *, report_path: Path, error: OSError) -> None:
+        message = (
+            "post-validation conformance report write failed for "
+            f"{report_path.as_posix()}: {error}"
+        )
+        super().__init__(message)
+        self.report_path = report_path
+        self.error_type = type(error).__name__
+        self.errno = error.errno
 
 
 @dataclass(frozen=True)
@@ -2345,6 +2360,46 @@ class WorkspaceExecutor:
                             details=failure_details,
                         )
                         return
+                    except _PostValidationConformanceReportWriteError as exc:
+                        reason_code = (
+                            POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE
+                        )
+                        message = str(exc)
+                        _log.error(
+                            "executor.post_validation_conformance_report_write_failed",
+                            workspace_id=workspace_id,
+                            validation_run_id=validation_run_id,
+                            report_path=exc.report_path.as_posix(),
+                            error_type=exc.error_type,
+                            errno=exc.errno,
+                            reason_code=reason_code,
+                        )
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=reason_code,
+                            coverage=validation_coverage,
+                            error_message=message,
+                        )
+                        write_failure_details: dict[str, Any] = {
+                            "validation_run_id": validation_run_id,
+                            "report_path": exc.report_path.as_posix(),
+                            "operation": "write",
+                            "error_type": exc.error_type,
+                        }
+                        if exc.errno is not None:
+                            write_failure_details["errno"] = exc.errno
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.infrastructure_failure,
+                            message=message,
+                            reason_code=reason_code,
+                            details=write_failure_details,
+                        )
+                        return
                     except Exception as exc:
                         reason_code = POST_VALIDATION_CONFORMANCE_FAILED_REASON_CODE
                         message = (
@@ -3929,11 +3984,17 @@ class WorkspaceExecutor:
         report = parse_conformance_report(report_text or "")
         if report.satisfied:
             if not report_from_fresh_file:
-                self._write_satisfied_post_validation_conformance_report(
-                    worktree_path=worktree_path,
-                    report_path=handoff.report_path,
-                    report=report,
-                )
+                try:
+                    self._write_satisfied_post_validation_conformance_report(
+                        worktree_path=worktree_path,
+                        report_path=handoff.report_path,
+                        report=report,
+                    )
+                except OSError as exc:
+                    raise _PostValidationConformanceReportWriteError(
+                        report_path=handoff.report_path,
+                        error=exc,
+                    ) from exc
             await self._commit_post_validation_conformance_report(
                 workspace_id=workspace.id,
                 worktree_path=worktree_path,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2235,6 +2235,7 @@ class WorkspaceExecutor:
                             reason_code=conformance_failure.reason_code,
                             details=conformance_failure.details,
                         )
+                        # This return keeps successful_validation_* assignments unreachable.
                         return
                 successful_validation_run_id = validation_run_id
                 successful_validation_workspace_head_sha = validation_workspace_head_sha

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3819,6 +3819,13 @@ class WorkspaceExecutor:
         # made during the report-only conformance command.
         before_compare = await self._changed_paths(worktree_path)
         before_compare_head = await self._git_rev_parse_head(worktree_path)
+        allowed_paths = {handoff.report_path}
+        # Path-set subtraction misses edits to already-dirty paths, so keep a
+        # content snapshot for every pre-dirty non-report path.
+        before_dirty_digests = {
+            path: self._digest_dirty_content(worktree_path, {path})
+            for path in before_compare - allowed_paths
+        }
         # A stale handoff report may still be present at this path; prefer
         # stdout unless the conformance rerun actually refreshed the file.
         report_path = worktree_path / handoff.report_path
@@ -3844,10 +3851,14 @@ class WorkspaceExecutor:
             if before_compare_head is not None
             else set()
         )
-        allowed_paths = {handoff.report_path}
+        edited_pre_dirty_extra = {
+            path
+            for path, digest in before_dirty_digests.items()
+            if self._digest_dirty_content(worktree_path, {path}) != digest
+        }
         dirty_extra = after_compare - before_compare - allowed_paths
         committed_extra = committed_compare - allowed_paths
-        extra = sorted(dirty_extra | committed_extra)
+        extra = sorted(dirty_extra | committed_extra | edited_pre_dirty_extra)
         if extra:
             return _build_planning_scope_failure(
                 scope_phase="conformance",

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3970,6 +3970,18 @@ class WorkspaceExecutor:
             [*git_base, "diff", "--cached", "--name-only", "--", report_path_text]
         )
         if not cached.ok:
+            reset_result = await self._runner.run(
+                [*git_base, "reset", "-q", "--", report_path_text]
+            )
+            if not reset_result.ok:
+                _log.warning(
+                    "executor.post_validation_conformance_report_unstage_failed",
+                    workspace_id=workspace_id,
+                    report_path=report_path_text,
+                    triggering_operation="diff",
+                    returncode=reset_result.returncode,
+                    command_reason_code=reset_result.reason_code,
+                )
             raise _PostValidationConformanceReportGitError(
                 operation="diff",
                 result=cached,
@@ -5855,9 +5867,10 @@ def _validation_evidence_json(payload: dict[str, Any]) -> str:
     if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
         return serialized
 
+    oversized_serialized_length = len(json.dumps(safe_payload, default=str))
     floor_payload = _validation_evidence_floor_payload(
         safe_payload,
-        oversized_serialized_length=len(serialized),
+        oversized_serialized_length=oversized_serialized_length,
     )
     serialized = _serialize_validation_evidence_payload(floor_payload)
     if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
@@ -5867,7 +5880,7 @@ def _validation_evidence_json(payload: dict[str, Any]) -> str:
         {
             "evidence_truncated": True,
             "truncation_reason": "validation_evidence_json_limit",
-            "oversized_serialized_length": len(serialized),
+            "oversized_serialized_length": oversized_serialized_length,
         }
     )
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3781,8 +3781,10 @@ class WorkspaceExecutor:
             if before_compare_head is not None
             else set()
         )
-        compare_paths = after_compare | committed_compare
-        extra = sorted(compare_paths - before_compare - {handoff.report_path})
+        allowed_paths = {handoff.report_path}
+        dirty_extra = after_compare - before_compare - allowed_paths
+        committed_extra = committed_compare - allowed_paths
+        extra = sorted(dirty_extra | committed_extra)
         if extra:
             return _build_planning_scope_failure(
                 scope_phase="conformance",

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -4048,7 +4048,7 @@ class WorkspaceExecutor:
                     "tier": run.tier,
                     "retry_count": run.retry_count,
                     "command_set_hash": run.command_set_hash,
-                    "commands": list(run.commands or [])[:20],
+                    "commands": list(run.commands or []),
                     "log_stream_refs": log_stream_refs,
                     "profile_name": run.profile_name,
                     "profile_version": run.profile_version,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -200,6 +200,30 @@ _PR_ADOPTION_SKIP_AGENT_REASON_CODE = "PR_ADOPTION_SKIP_AGENT"
 _PR_ADOPTION_METADATA_MISSING_REASON_CODE = "PR_ADOPTION_METADATA_MISSING"
 _PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE = "PR_ADOPTION_MONITOR_UNAVAILABLE"
 _EXCEPTION_TRACEBACK_LIMIT = 4000
+_VALIDATION_EVIDENCE_JSON_LIMIT = 20000
+_VALIDATION_EVIDENCE_COVERAGE_PRIORITY_KEYS = (
+    "status",
+    "reason_code",
+    "percent",
+    "minimum_percent",
+    "enforce",
+    "provider",
+)
+_VALIDATION_EVIDENCE_RETAINED_KEY_COUNT = 5
+_VALIDATION_EVIDENCE_CORE_KEYS = (
+    "validation_run_id",
+    "status",
+    "reason_code",
+    "coverage",
+    "workspace_head_sha",
+    "target_branch",
+    "target_head_sha",
+    "base_commit",
+    "base_sha",
+    "tier",
+    "retry_count",
+    "command_set_hash",
+)
 
 _RECOVERY_ACTIVE_OPERATION_STATUSES = {
     OperationStatus.pending.value,
@@ -3979,28 +4003,27 @@ class WorkspaceExecutor:
                     "validation_run_id": run.id,
                     "status": run.status,
                     "reason_code": run.reason_code,
-                    "tier": run.tier,
-                    "retry_count": run.retry_count,
-                    "commands": list(run.commands or [])[:20],
-                    "log_stream_refs": log_stream_refs,
                     "coverage": coverage,
-                    "command_set_hash": run.command_set_hash,
-                    "base_commit": run.base_commit,
-                    "base_sha": run.base_sha,
                     "workspace_head_sha": run.workspace_head_sha,
                     "target_branch": run.target_branch,
                     "target_head_sha": run.target_head_sha,
+                    "base_commit": run.base_commit,
+                    "base_sha": run.base_sha,
+                    "tier": run.tier,
+                    "retry_count": run.retry_count,
+                    "command_set_hash": run.command_set_hash,
+                    "commands": list(run.commands or [])[:20],
+                    "log_stream_refs": log_stream_refs,
                     "profile_name": run.profile_name,
                     "profile_version": run.profile_version,
                     "profile_source": run.profile_source,
                     "resolved_profile_digest": run.resolved_profile_digest,
                     "environment_identity_digest": run.environment_identity_digest,
                 }
-        # Preserve the complete evidence shape for conformance, then redact both
-        # structured secret values and inline tokens in the serialized payload.
-        safe_payload = redact_audit_value(payload)
-        serialized_payload = json.dumps(safe_payload, sort_keys=True, default=str)
-        safe_serialized_payload = redact_audit_text(serialized_payload, limit=20000)
+        # Preserve the complete evidence shape when it fits. If it does not,
+        # compact bulky fields as JSON values so the fenced evidence stays
+        # parseable while retaining the validation result fields first.
+        safe_serialized_payload = _validation_evidence_json(payload)
         return (
             "AWF persisted validation run evidence:\n"
             "```json\n"
@@ -5735,6 +5758,90 @@ class WorkspaceExecutor:
                 workspace_head_sha=workspace_head_sha,
             )
             await session.commit()
+
+
+def _validation_evidence_json(payload: dict[str, Any]) -> str:
+    safe_payload = cast(dict[str, Any], redact_audit_value(payload))
+    serialized = _serialize_validation_evidence_payload(safe_payload)
+    if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
+        return serialized
+
+    compact_payload = dict(safe_payload)
+    compact_payload["evidence_truncated"] = True
+    compact_payload["commands"] = _validation_evidence_size_summary(
+        safe_payload.get("commands")
+    )
+    compact_payload["log_stream_refs"] = _validation_evidence_size_summary(
+        safe_payload.get("log_stream_refs")
+    )
+    serialized = _serialize_validation_evidence_payload(compact_payload)
+    if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
+        return serialized
+
+    compact_payload["coverage"] = _validation_evidence_coverage_summary(
+        safe_payload.get("coverage")
+    )
+    serialized = _serialize_validation_evidence_payload(compact_payload)
+    if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
+        return serialized
+
+    minimal_payload = {
+        key: compact_payload.get(key)
+        for key in _VALIDATION_EVIDENCE_CORE_KEYS
+        if key in compact_payload
+    }
+    minimal_payload["evidence_truncated"] = True
+    minimal_payload["commands"] = _validation_evidence_size_summary(
+        safe_payload.get("commands")
+    )
+    minimal_payload["log_stream_refs"] = _validation_evidence_size_summary(
+        safe_payload.get("log_stream_refs")
+    )
+    return _serialize_validation_evidence_payload(minimal_payload)
+
+
+def _serialize_validation_evidence_payload(payload: Mapping[str, Any]) -> str:
+    serialized = json.dumps(payload, default=str)
+    return redact_audit_text(serialized, limit=len(serialized) + 4096)
+
+
+def _validation_evidence_coverage_summary(value: object) -> object:
+    if not isinstance(value, Mapping):
+        return _validation_evidence_size_summary(value)
+    summary = _validation_evidence_size_summary(value)
+    for key in _VALIDATION_EVIDENCE_COVERAGE_PRIORITY_KEYS:
+        if key in value:
+            summary[key] = value[key]
+    return summary
+
+
+def _validation_evidence_size_summary(value: object) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        retained_keys = [
+            str(key) for key in list(value)[:_VALIDATION_EVIDENCE_RETAINED_KEY_COUNT]
+        ]
+        return {
+            "truncated": True,
+            "original_type": "mapping",
+            "original_entry_count": len(value),
+            "retained_keys": retained_keys,
+        }
+    if isinstance(value, list):
+        return {
+            "truncated": True,
+            "original_type": "list",
+            "original_length": len(value),
+        }
+    if isinstance(value, str):
+        return {
+            "truncated": True,
+            "original_type": "string",
+            "original_length": len(value),
+        }
+    return {
+        "truncated": True,
+        "original_type": type(value).__name__,
+    }
 
 
 _PR_NUMBER_RE = re.compile(r"/pull/(\d+)(?:/|$)")

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3981,6 +3981,8 @@ class WorkspaceExecutor:
                     "resolved_profile_digest": run.resolved_profile_digest,
                     "environment_identity_digest": run.environment_identity_digest,
                 }
+        # Preserve the complete evidence shape for conformance, then redact both
+        # structured secret values and inline tokens in the serialized payload.
         safe_payload = redact_audit_value(payload)
         serialized_payload = json.dumps(safe_payload, sort_keys=True, default=str)
         safe_serialized_payload = redact_audit_text(serialized_payload, limit=20000)

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2314,7 +2314,9 @@ class WorkspaceExecutor:
                         )
                         return
                     if conformance_failure is not None:
-                        if pass_number >= max_fix_passes:
+                        # Recovery skips feature execution; retrying this
+                        # conformance miss would only rerun validation.
+                        if recovery is not None or pass_number >= max_fix_passes:
                             await self._finish_pending_validate_operations(
                                 workspace_id=workspace_id,
                                 status=OperationStatus.failed,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -515,7 +515,14 @@ def _planning_validation_handoff_from_recovery_payload(
             workspace_id=workspace_id,
         )
     except ValueError:
-        return None
+        plan_path = render_workspace_path(
+            profile.planning.plan_path,
+            workspace_id=workspace_id,
+        )
+        report_path = render_workspace_path(
+            profile.planning.conformance_report_path,
+            workspace_id=workspace_id,
+        )
     gaps = _recovery_conformance_gaps(conformance)
     summary_value = conformance.get("summary")
     summary = (

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2314,7 +2314,7 @@ class WorkspaceExecutor:
                         )
                         failure_details: dict[str, Any] = {
                             "validation_run_id": validation_run_id,
-                            "report_path": planning_validation_handoff.report_path.as_posix(),
+                            "report_path": conformance_handoff.report_path.as_posix(),
                             "operation": exc.operation,
                             "returncode": exc.returncode,
                         }
@@ -5860,7 +5860,7 @@ def _validation_evidence_json(payload: dict[str, Any]) -> str:
 
 def _serialize_validation_evidence_payload(payload: Mapping[str, Any]) -> str:
     serialized = json.dumps(payload, default=str)
-    return redact_audit_text(serialized, limit=len(serialized) + 4096)
+    return redact_audit_text(serialized, limit=_VALIDATION_EVIDENCE_JSON_LIMIT)
 
 
 def _validation_evidence_coverage_summary(value: object) -> object:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2126,25 +2126,22 @@ class WorkspaceExecutor:
                 val_result,
                 baseline_coverage=baseline_coverage,
             )
+            validation_coverage = _validation_run_coverage_metadata(
+                val_result,
+                baseline_coverage=baseline_coverage,
+            )
             await self._finish_validation_run(
                 validation_run_id,
                 status="succeeded" if val_result.all_passed else "failed",
                 reason_code=_validation_run_reason_code(val_result),
                 retry_count=val_result.total_retries,
-                coverage=_validation_run_coverage_metadata(
-                    val_result,
-                    baseline_coverage=baseline_coverage,
-                ),
+                coverage=validation_coverage,
                 command_retries=[c.retry_count for c in val_result.commands],
                 coverage_evidence_status=coverage_evidence.evidence_status,
                 coverage_evidence_reason_code=coverage_evidence.reason_code,
                 coverage_evidence_source_run_id=coverage_evidence.source_run_id,
             )
             if val_result.all_passed:
-                validation_coverage = _validation_run_coverage_metadata(
-                    val_result,
-                    baseline_coverage=baseline_coverage,
-                )
                 if planning_validation_handoff is not None:
                     try:
                         conformance_failure = await self._run_post_validation_conformance_check(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3928,12 +3928,12 @@ class WorkspaceExecutor:
             "-C",
             str(worktree_path),
         ]
-        add_result = await self._runner.run([*git_base, "add", "--", report_path_text])
         await self._repair_agent_git_ownership(
             workspace_id=workspace_id,
             worktree_path=worktree_path,
             reason="post_validation_conformance_report_git_add",
         )
+        add_result = await self._runner.run([*git_base, "add", "--", report_path_text])
         if not add_result.ok:
             raise _PostValidationConformanceReportGitError(
                 operation="add",
@@ -5823,7 +5823,25 @@ def _validation_evidence_json(payload: dict[str, Any]) -> str:
     minimal_payload["log_stream_refs"] = _validation_evidence_size_summary(
         safe_payload.get("log_stream_refs")
     )
-    return _serialize_validation_evidence_payload(minimal_payload)
+    serialized = _serialize_validation_evidence_payload(minimal_payload)
+    if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
+        return serialized
+
+    floor_payload = _validation_evidence_floor_payload(
+        safe_payload,
+        oversized_serialized_length=len(serialized),
+    )
+    serialized = _serialize_validation_evidence_payload(floor_payload)
+    if len(serialized) <= _VALIDATION_EVIDENCE_JSON_LIMIT:
+        return serialized
+
+    return _serialize_validation_evidence_payload(
+        {
+            "evidence_truncated": True,
+            "truncation_reason": "validation_evidence_json_limit",
+            "oversized_serialized_length": len(serialized),
+        }
+    )
 
 
 def _serialize_validation_evidence_payload(payload: Mapping[str, Any]) -> str:
@@ -5839,6 +5857,38 @@ def _validation_evidence_coverage_summary(value: object) -> object:
         if key in value:
             summary[key] = value[key]
     return summary
+
+
+def _validation_evidence_floor_payload(
+    payload: Mapping[str, Any],
+    *,
+    oversized_serialized_length: int,
+) -> dict[str, Any]:
+    floor_payload = {
+        key: _validation_evidence_floor_value(payload[key])
+        for key in _VALIDATION_EVIDENCE_CORE_KEYS
+        if key in payload
+    }
+    floor_payload["evidence_truncated"] = True
+    floor_payload["truncation_reason"] = "validation_evidence_json_limit"
+    floor_payload["oversized_serialized_length"] = oversized_serialized_length
+    if "coverage" in payload:
+        floor_payload["coverage"] = _validation_evidence_size_summary(payload["coverage"])
+    floor_payload["commands"] = _validation_evidence_size_summary(payload.get("commands"))
+    floor_payload["log_stream_refs"] = _validation_evidence_size_summary(
+        payload.get("log_stream_refs")
+    )
+    return floor_payload
+
+
+def _validation_evidence_floor_value(value: object) -> object:
+    if isinstance(value, str):
+        if len(value) <= 512:
+            return value
+        return _validation_evidence_size_summary(value)
+    if isinstance(value, int | float | bool) or value is None:
+        return value
+    return _validation_evidence_size_summary(value)
 
 
 def _validation_evidence_size_summary(value: object) -> dict[str, Any]:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -633,6 +633,8 @@ def _recovery_needs_existing_pr_push(
     if recovery_mode == "rebase_only":
         if rebase_recovery_result is None:
             return False
+        # Push only when AWF-owned work, such as validation fixes or a
+        # conformance report commit, advanced HEAD past the pushed rebase commit.
         return validated_head != rebase_recovery_result.head_sha
     return False
 
@@ -4048,6 +4050,8 @@ class WorkspaceExecutor:
                     "tier": run.tier,
                     "retry_count": run.retry_count,
                     "command_set_hash": run.command_set_hash,
+                    # Command records are metadata-only; stdout/stderr stay in log refs.
+                    # If that changes, update evidence compaction before passing them through.
                     "commands": list(run.commands or []),
                     "log_stream_refs": log_stream_refs,
                     "profile_name": run.profile_name,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2140,18 +2140,82 @@ class WorkspaceExecutor:
                 coverage_evidence_source_run_id=coverage_evidence.source_run_id,
             )
             if val_result.all_passed:
+                validation_coverage = _validation_run_coverage_metadata(
+                    val_result,
+                    baseline_coverage=baseline_coverage,
+                )
                 if planning_validation_handoff is not None:
-                    conformance_failure = await self._run_post_validation_conformance_check(
-                        adapter=adapter,
-                        workspace=ws,
-                        profile=profile,
-                        compose_project=compose_project,
-                        compose_file=compose_file,
-                        worktree_path=worktree_path,
-                        model=default_model,
-                        handoff=planning_validation_handoff,
-                        validation_run_id=validation_run_id,
-                    )
+                    try:
+                        conformance_failure = await self._run_post_validation_conformance_check(
+                            adapter=adapter,
+                            workspace=ws,
+                            profile=profile,
+                            compose_project=compose_project,
+                            compose_file=compose_file,
+                            worktree_path=worktree_path,
+                            model=default_model,
+                            handoff=planning_validation_handoff,
+                            validation_run_id=validation_run_id,
+                        )
+                    except ComposeExecCleanupError as exc:
+                        message = cleanup_failure_message(exc)
+                        _log.error(
+                            "executor.post_validation_conformance_cleanup_failed",
+                            workspace_id=workspace_id,
+                            validation_run_id=validation_run_id,
+                            source=exc.source,
+                            label=exc.label,
+                            invocation_id=exc.invocation_id,
+                            reason_code=exc.reason_code,
+                        )
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=EXEC_PROCESS_CLEANUP_FAILED,
+                            coverage=validation_coverage,
+                            error_message=message,
+                        )
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.infrastructure_failure,
+                            message=message,
+                            reason_code=EXEC_PROCESS_CLEANUP_FAILED,
+                        )
+                        return
+                    except AgentRunError as exc:
+                        reason_code = exc.reason_code or "AGENT_CLI_FAILED"
+                        message = _post_validation_conformance_agent_failure_message(exc)
+                        _log.warning(
+                            "executor.post_validation_conformance_agent_failed",
+                            workspace_id=workspace_id,
+                            validation_run_id=validation_run_id,
+                            returncode=exc.result.returncode,
+                            reason_code=reason_code,
+                        )
+                        await self._finish_pending_validate_operations(
+                            workspace_id=workspace_id,
+                            status=OperationStatus.failed,
+                            validation_run_id=validation_run_id,
+                            requested_tier=validation_tier,
+                            reason_code=reason_code,
+                            coverage=validation_coverage,
+                            error_message=message,
+                        )
+                        await self._mark_failed(
+                            workspace_id=workspace_id,
+                            from_status=WorkspaceStatus.validating,
+                            failure_reason=FailureReason.agent_failure,
+                            message=message,
+                            reason_code=reason_code,
+                            details=_post_validation_conformance_agent_failure_details(
+                                exc,
+                                validation_run_id=validation_run_id,
+                            ),
+                        )
+                        return
                     if conformance_failure is not None:
                         await self._finish_pending_validate_operations(
                             workspace_id=workspace_id,
@@ -2160,10 +2224,7 @@ class WorkspaceExecutor:
                             requested_tier=validation_tier,
                             reason_code=conformance_failure.reason_code
                             or PLAN_CONFORMANCE_UNSATISFIED,
-                            coverage=_validation_run_coverage_metadata(
-                                val_result,
-                                baseline_coverage=baseline_coverage,
-                            ),
+                            coverage=validation_coverage,
                             error_message=conformance_failure.message,
                         )
                         await self._mark_failed(
@@ -2183,10 +2244,7 @@ class WorkspaceExecutor:
                     validation_run_id=validation_run_id,
                     requested_tier=validation_tier,
                     reason_code="VALIDATION_OK",
-                    coverage=_validation_run_coverage_metadata(
-                        val_result,
-                        baseline_coverage=baseline_coverage,
-                    ),
+                    coverage=validation_coverage,
                 )
                 if pass_number > 0:
                     _log.info(
@@ -6169,6 +6227,42 @@ def _validation_failure_message(
             details += f"; logs: {log_hint}"
         return details
     return f"validation failed: {first_fail.command}" if first_fail else "validation failed"
+
+
+def _post_validation_conformance_agent_failure_message(exc: AgentRunError) -> str:
+    reason_code = exc.reason_code or "AGENT_CLI_FAILED"
+    output = (exc.result.stderr.strip() or exc.result.stdout.strip() or "<no output>")
+    safe_output = redact_audit_text(output, limit=1000)
+    return (
+        "post-validation conformance agent failed "
+        f"({reason_code}, exit {exc.result.returncode}): {safe_output}"
+    )[:2000]
+
+
+def _post_validation_conformance_agent_failure_details(
+    exc: AgentRunError,
+    *,
+    validation_run_id: str,
+) -> dict[str, Any]:
+    reason_code = exc.reason_code or "AGENT_CLI_FAILED"
+    conformance: dict[str, Any] = {
+        "phase": "post_validation",
+        "reason_code": reason_code,
+        "returncode": exc.result.returncode,
+    }
+    stdout = redact_audit_text(exc.result.stdout.strip(), limit=1000)
+    stderr = redact_audit_text(exc.result.stderr.strip(), limit=1000)
+    if stdout:
+        conformance["stdout"] = stdout
+    if stderr:
+        conformance["stderr"] = stderr
+    details: dict[str, Any] = {
+        "conformance": conformance,
+        "validation_run_id": validation_run_id,
+    }
+    if exc.details:
+        details["agent"] = redact_audit_value(exc.details)
+    return details
 
 
 def _git_name_lines(output: str) -> list[str]:

--- a/src/awf/control/validation_fix_cycle.py
+++ b/src/awf/control/validation_fix_cycle.py
@@ -55,9 +55,9 @@ class ValidationFixContext:
     """1-indexed — "this is attempt 1 of N". Never 0."""
 
     total_passes: int
-    """The configured ``max_validation_fix_passes``. The coding CLI
-    sees both counters so it can pace itself (conservative on attempt
-    1, more aggressive near the cap)."""
+    """The retry budget for this failure category. The coding CLI sees
+    both counters so it can pace itself (conservative on attempt 1,
+    more aggressive near the cap)."""
 
     test_commands: tuple[str, ...]
     """All validation commands that will run on the NEXT pass —

--- a/src/awf/control/validation_fix_cycle.py
+++ b/src/awf/control/validation_fix_cycle.py
@@ -132,13 +132,16 @@ def build_fix_prompt(context: ValidationFixContext) -> str:
     stdout_block = context.stdout_tail.rstrip() or "(empty)"
     stderr_block = context.stderr_tail.rstrip() or "(empty)"
     test_cmds_block = "\n".join(f"  - {cmd}" for cmd in context.test_commands)
-    coverage_below_threshold = (
+    provider_fail_under = context.reason_code == "COVERAGE_FAIL_UNDER_NOT_REACHED"
+    numeric_coverage_below_threshold = (
         context.coverage_percent is not None
         and context.coverage_minimum_percent is not None
         and context.coverage_percent < context.coverage_minimum_percent
     )
+    coverage_below_threshold = provider_fail_under or numeric_coverage_below_threshold
     coverage_meets_threshold = (
-        context.coverage_percent is not None
+        not provider_fail_under
+        and context.coverage_percent is not None
         and context.coverage_minimum_percent is not None
         and context.coverage_percent >= context.coverage_minimum_percent
     )
@@ -150,7 +153,15 @@ def build_fix_prompt(context: ValidationFixContext) -> str:
         "`pytest.ini`, or CI workflow files unless the task explicitly "
         "asked you to change those policies.",
     ]
-    if coverage_below_threshold:
+    if provider_fail_under:
+        policy_lines.append(
+            "  - Coverage provider reported fail-under was not reached; add "
+            "meaningful tests for the relevant code paths after fixing any named "
+            "failing tests. If the threshold is already unreachable on the "
+            "unchanged base branch, preserve the threshold and make the smallest "
+            "honest coverage improvement you can."
+        )
+    elif numeric_coverage_below_threshold:
         policy_lines.append(
             "  - Coverage is below the configured threshold; add meaningful "
             "tests for the relevant code paths after fixing any named failing "
@@ -184,9 +195,11 @@ def build_fix_prompt(context: ValidationFixContext) -> str:
         coverage_lines.append(
             f"Pre-agent base-branch coverage: {context.baseline_coverage_percent:.2f}%"
         )
-    if coverage_meets_threshold:
+    if provider_fail_under:
+        coverage_lines.append("Coverage provider reported fail-under was not reached")
+    elif coverage_meets_threshold:
         coverage_lines.append("Coverage already meets the configured threshold")
-    elif coverage_below_threshold and failing_values:
+    if coverage_below_threshold and failing_values:
         coverage_lines.append("Fix the failing pytest tests first, then revisit coverage")
     coverage_block = ""
     if coverage_lines:

--- a/src/awf/db/models.py
+++ b/src/awf/db/models.py
@@ -772,6 +772,7 @@ class ValidationRun(Base):
     log_stream_refs: Mapped[dict[str, Any]] = mapped_column(
         JSON, nullable=False, default=dict, server_default=text("'{}'")
     )
+    coverage: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/src/awf/db/repositories.py
+++ b/src/awf/db/repositories.py
@@ -83,6 +83,7 @@ from awf.db.models import (
     WorkspaceSecretLease,
 )
 from awf.db.utils import escape_like_pattern as _escape_like_pattern
+from awf.db.validation_runs import validation_run_coverage_payload
 from awf.runtime.merge_eligibility import DOCS_TASK_SCOPE_VIOLATION_STALE_REASON
 from awf.service.scheduler import scheduler_order_key, scheduler_score_from_workspace
 
@@ -1520,8 +1521,10 @@ class ValidationRunRepository:
         run.retry_count = retry_count
         run.finished_at = finished_at or datetime.now(UTC)
         if coverage is not None:
+            coverage_payload = dict(coverage)
+            run.coverage = coverage_payload
             log_stream_refs = dict(run.log_stream_refs or {})
-            log_stream_refs["coverage"] = dict(coverage)
+            log_stream_refs["coverage"] = coverage_payload
             run.log_stream_refs = log_stream_refs
         if command_retries is not None:
             updated_commands = list(run.commands)
@@ -1594,10 +1597,9 @@ class ValidationRunRepository:
         )
         rows = (await self._session.execute(stmt)).scalars().all()
         for row in rows:
-            coverage = (row.log_stream_refs or {}).get("coverage")
+            coverage = validation_run_coverage_payload(row)
             if (
-                isinstance(coverage, Mapping)
-                and coverage.get("status") in {
+                coverage.get("status") in {
                     "passed",
                     "not_configured",
                 }

--- a/src/awf/db/validation_runs.py
+++ b/src/awf/db/validation_runs.py
@@ -1,0 +1,29 @@
+"""Validation run payload helpers shared across persistence and API surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def validation_run_coverage_payload(run: object) -> dict[str, Any]:
+    """Return structured coverage metadata, preferring the dedicated column.
+
+    Older rows stored coverage under ``log_stream_refs.coverage``. Keep that as
+    a read fallback so durable provenance remains readable across migrations.
+    """
+
+    coverage = getattr(run, "coverage", None)
+    if isinstance(coverage, Mapping):
+        return _json_dict(coverage)
+
+    log_stream_refs = getattr(run, "log_stream_refs", None)
+    if isinstance(log_stream_refs, Mapping):
+        return _json_dict(log_stream_refs.get("coverage"))
+    return {}
+
+
+def _json_dict(value: object) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return {str(k): v for k, v in value.items()}
+    return {}

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -570,6 +570,7 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "api",
         "endpoint",
         "implement",
+        "implementation",
         "wire",
         "function",
         "class",

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -618,7 +618,8 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     # around test/test(s) remain validation evidence.
     for match in re.finditer(r"(?<![a-z0-9_])tests?(?![a-z0-9_])", text):
         if re.match(
-            r"[\s-]+(?:coverage|(?:suites?|runners?|runs?|reports?)[\s-]+coverage)\b",
+            r"[\s-]+(?:coverage|(?:suites?|runners?|runs?|reports?)[\s-]+"
+            r"(?:coverage|evidence|provenance|logs?))\b",
             text[match.end() :],
         ):
             continue

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -349,7 +349,8 @@ def conformance_requires_awf_validation(report: PlanConformanceReport) -> bool:
 
     if report.status != PlanConformanceStatus.needs_iteration:
         return False
-    if report.reason_code != CONFORMANCE_REQUIRES_AWF_VALIDATION:
+    normalized_reason = report.reason_code.strip().upper().replace("-", "_")
+    if normalized_reason != CONFORMANCE_REQUIRES_AWF_VALIDATION:
         return False
     if not report.gaps:
         return False

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 PLAN_CONFORMANCE_UNSATISFIED = "PLAN_CONFORMANCE_UNSATISFIED"
 PLAN_CONFORMANCE_REPORTED = "PLAN_CONFORMANCE_REPORTED"
+CONFORMANCE_REQUIRES_AWF_VALIDATION = "CONFORMANCE_REQUIRES_AWF_VALIDATION"
 AGENT_PLAN_PHASE_SCOPE_VIOLATION = "AGENT_PLAN_PHASE_SCOPE_VIOLATION"
 AGENT_STALLED_IN_CONFORMANCE = "AGENT_STALLED_IN_CONFORMANCE"
 AGENT_IDLE_TIMEOUT_REASON_CODE = "AGENT_IDLE_TIMEOUT"
@@ -285,7 +286,13 @@ def build_conformance_prompt(
     plan_path: Path,
     report_path: Path,
     iteration: int,
+    validation_evidence: str | None = None,
 ) -> str:
+    validation_evidence_section = (
+        f"### Validation evidence\n{validation_evidence.strip()}\n\n"
+        if validation_evidence and validation_evidence.strip()
+        else ""
+    )
     return (
         "## Conformance phase\n\n"
         f"Compare the current workspace implementation against `{plan_path.as_posix()}`.\n"
@@ -296,10 +303,16 @@ def build_conformance_prompt(
         "logs, validation summaries, git diff, and artifacts instead. If validation "
         "evidence is missing, stale, or insufficient, report `needs_iteration` with "
         "a specific gap asking AWF to run the missing validation under the validation "
-        "phase.\n\n"
+        "phase. Set `reason_code` to `CONFORMANCE_REQUIRES_AWF_VALIDATION` only when "
+        "every remaining gap is missing, stale, or insufficient AWF-owned validation "
+        "evidence. Do not use it for implementation, API, plan, or documentation gaps.\n\n"
+        f"{validation_evidence_section}"
         f"Write a JSON object to `{report_path.as_posix()}` and also print the same JSON object "
         "as your final response. The object must have this shape:\n\n"
-        '```json\n{"status":"satisfied|needs_iteration","summary":"...","gaps":["..."]}\n```\n\n'
+        "```json\n"
+        '{"status":"satisfied|needs_iteration","summary":"...",'
+        '"gaps":["..."],"reason_code":"optional reason code"}\n'
+        "```\n\n"
         "Use `satisfied` only when the implementation fully achieves the saved plan. "
         "Use `needs_iteration` when any planned behavior, test, validation, or documented "
         "non-goal handling is missing. Keep gaps actionable and specific.\n\n"
@@ -328,6 +341,18 @@ def build_conformance_failure_evidence(
         "plan_path": plan_path.as_posix(),
         "report_path": report_path.as_posix(),
     }
+
+
+def conformance_requires_awf_validation(report: PlanConformanceReport) -> bool:
+    """Return true only for explicit validation-evidence-only conformance gaps."""
+
+    if report.status != PlanConformanceStatus.needs_iteration:
+        return False
+    if report.reason_code != CONFORMANCE_REQUIRES_AWF_VALIDATION:
+        return False
+    if not report.gaps:
+        return False
+    return all(_is_awf_validation_evidence_gap(gap) for gap in report.gaps)
 
 
 def classify_conformance_stall(
@@ -461,6 +486,45 @@ def classify_conformance_stall(
         )
 
     return None
+
+
+def _is_awf_validation_evidence_gap(gap: str) -> bool:
+    text = gap.strip().lower()
+    if "validation" not in text:
+        return False
+    evidence_markers = (
+        "evidence",
+        "provenance",
+        "missing",
+        "stale",
+        "insufficient",
+        "absent",
+        "unavailable",
+        "not available",
+        "not found",
+        "not run",
+        "has not run",
+        "run validation",
+        "validation run",
+        "profile gate",
+        "profile gates",
+    )
+    if not any(marker in text for marker in evidence_markers):
+        return False
+    deterministic_markers = (
+        "api",
+        "endpoint",
+        "implement",
+        "wire",
+        "code",
+        "function",
+        "class",
+        "schema",
+        "migration",
+        "document",
+        "docs",
+    )
+    return not any(marker in text for marker in deterministic_markers)
 
 
 def build_conformance_stall_failure_evidence(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -491,11 +491,15 @@ def classify_conformance_stall(
 
 def _is_awf_validation_evidence_gap(gap: str) -> bool:
     text = gap.strip().lower()
-    if "validation" not in text:
-        return False
+
+    def has_marker(marker: str) -> bool:
+        return re.search(rf"(?<![a-z0-9_]){re.escape(marker)}(?![a-z0-9_])", text) is not None
+
     evidence_markers = (
         "evidence",
         "provenance",
+        "log",
+        "logs",
         "missing",
         "stale",
         "insufficient",
@@ -510,7 +514,20 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "profile gate",
         "profile gates",
     )
-    if not any(marker in text for marker in evidence_markers):
+    if not any(has_marker(marker) for marker in evidence_markers):
+        return False
+    validation_subject_markers = (
+        "validation",
+        "coverage",
+        "profile",
+        "profile gate",
+        "profile gates",
+        "evidence",
+        "provenance",
+        "log",
+        "logs",
+    )
+    if not any(has_marker(marker) for marker in validation_subject_markers):
         return False
     deterministic_markers = (
         "api",
@@ -524,18 +541,35 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     )
     if any(marker in text for marker in deterministic_markers):
         return False
-    documentation_work_patterns = (
+    deterministic_gap_patterns = (
         r"(?:^|[.;:]\s*|(?<![a-z0-9_])please\s+)document(?![a-z0-9_])"
         r"\s+(?:the\s+)?",
         r"(?<![a-z0-9_])(?:must|should|need|needs|required)\s+"
         r"(?:to\s+)?document(?![a-z0-9_])",
         r"(?<![a-z0-9_])(?:add|create|update|write|revise)\s+"
-        r"(?:the\s+)?(?:docs|documentation|document|guide|readme)(?![a-z0-9_])",
-        r"(?<![a-z0-9_])(?:docs|documentation|document|guide|readme)(?![a-z0-9_])"
+        r"(?:the\s+)?(?:docs|documentation|document|doc|guide|readme)(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:docs|documentation|document|doc|guide|readme)(?![a-z0-9_])"
         r"\s+(?:gap|gaps|task|tasks|todo|todos|update|updates|change|changes|"
         r"need|needs|must|should|required|missing|absent|stale|outdated)",
+        r"(?<![a-z0-9_])(?:add|create|update|write|revise)\s+"
+        r"(?:the\s+)?(?:saved\s+)?plan(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:saved\s+)?plan(?![a-z0-9_])"
+        r"\s+(?:gap|gaps|task|tasks|todo|todos|update|updates|change|changes|"
+        r"need|needs|must|should|required|missing|absent|stale|outdated|lacks?)",
+        r"(?<![a-z0-9_])(?:from|in|inside|within)\s+(?:the\s+)?"
+        r"(?:saved\s+)?plan(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:from|in|inside|within)\s+(?:the\s+)?"
+        r"(?:docs|documentation|document|doc|guide|readme)(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:saved\s+)?plan(?![a-z0-9_])"
+        r"[^.;:]*\b(?:evidence|coverage|profile gate|log|logs)\b[^.;:]*"
+        r"\b(?:missing|absent|stale|outdated|insufficient|unavailable|not available|"
+        r"not found|not run|has not run)\b",
+        r"(?<![a-z0-9_])(?:docs|documentation|document|doc|guide|readme)"
+        r"(?![a-z0-9_])[^.;:]*\b(?:evidence|coverage|profile gate|log|logs)\b[^.;:]*"
+        r"\b(?:missing|absent|stale|outdated|insufficient|unavailable|not available|"
+        r"not found|not run|has not run)\b",
     )
-    if any(re.search(pattern, text) for pattern in documentation_work_patterns):
+    if any(re.search(pattern, text) for pattern in deterministic_gap_patterns):
         return False
     for match in re.finditer(r"(?<![a-z0-9_])code(?![a-z0-9_])", text):
         if re.match(r"[\s-]+coverage\b", text[match.end() :]):

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -577,6 +577,12 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         if re.match(r"[\s-]+coverage\b", text[match.end() :]):
             continue
         return False
+    # Test work is deterministic agent work; only "test coverage" remains
+    # validation evidence.
+    for match in re.finditer(r"(?<![a-z0-9_])tests?(?![a-z0-9_])", text):
+        if re.match(r"[\s-]+coverage\b", text[match.end() :]):
+            continue
+        return False
     return True
 
 

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -10,6 +10,7 @@ needed from that report.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -516,7 +517,6 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "endpoint",
         "implement",
         "wire",
-        "code",
         "function",
         "class",
         "schema",
@@ -524,7 +524,13 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "document",
         "docs",
     )
-    return not any(marker in text for marker in deterministic_markers)
+    if any(marker in text for marker in deterministic_markers):
+        return False
+    for match in re.finditer(r"(?<![a-z0-9_])code(?![a-z0-9_])", text):
+        if re.match(r"[\s-]+coverage\b", text[match.end() :]):
+            continue
+        return False
+    return True
 
 
 def build_conformance_stall_failure_evidence(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -529,6 +529,10 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     )
     if not any(has_marker(marker) for marker in validation_subject_markers):
         return False
+    # Migration implementation gaps stay agent-owned; migration-gate evidence
+    # gaps are AWF-owned because the profile gate must produce that evidence.
+    if has_marker("migration") and not _has_migration_validation_evidence_context(text):
+        return False
     deterministic_markers = (
         "api",
         "endpoint",
@@ -537,7 +541,6 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "function",
         "class",
         "schema",
-        "migration",
     )
     if any(has_marker(marker) for marker in deterministic_markers):
         return False
@@ -584,6 +587,16 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
             continue
         return False
     return True
+
+
+def _has_migration_validation_evidence_context(text: str) -> bool:
+    patterns = (
+        r"(?<![a-z0-9_])migration\s+validation\s+"
+        r"(?:evidence|provenance|logs?|runs?)(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:(?:alembic(?:[/ -]profile)?|profile)\s+)?"
+        r"migration\s+(?:profile\s+)?gates?(?![a-z0-9_])",
+    )
+    return any(re.search(pattern, text) for pattern in patterns)
 
 
 def build_conformance_stall_failure_evidence(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -610,10 +610,13 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         if re.match(r"[\s-]+coverage\b", text[match.end() :]):
             continue
         return False
-    # Test work is deterministic agent work; only "test coverage" remains
-    # validation evidence.
+    # Test work is deterministic agent work; only coverage artifact phrases
+    # around test/test(s) remain validation evidence.
     for match in re.finditer(r"(?<![a-z0-9_])tests?(?![a-z0-9_])", text):
-        if re.match(r"[\s-]+coverage\b", text[match.end() :]):
+        if re.match(
+            r"[\s-]+(?:coverage|(?:suites?|runners?|runs?|reports?)[\s-]+coverage)\b",
+            text[match.end() :],
+        ):
             continue
         return False
     return True

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -496,6 +496,31 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     def has_marker(marker: str) -> bool:
         return re.search(rf"(?<![a-z0-9_]){re.escape(marker)}(?![a-z0-9_])", text) is not None
 
+    named_validation_command_handoff = (
+        re.search(r"(?<![a-z0-9_])(?:re-?run|run)(?![a-z0-9_])", text) is not None
+        and any(
+            has_marker(marker)
+            for marker in (
+                "awf",
+                "validation",
+                "validation phase",
+                "profile gate",
+                "profile gates",
+            )
+        )
+        and any(
+            has_marker(marker)
+            for marker in (
+                "pytest",
+                "ruff",
+                "mypy",
+                "coverage",
+                "npm",
+                "lint",
+                "build",
+            )
+        )
+    )
     evidence_markers = (
         "evidence",
         "provenance",
@@ -515,7 +540,9 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "profile gate",
         "profile gates",
     )
-    if not any(has_marker(marker) for marker in evidence_markers):
+    if not named_validation_command_handoff and not any(
+        has_marker(marker) for marker in evidence_markers
+    ):
         return False
     validation_subject_markers = (
         "validation",
@@ -528,7 +555,9 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "log",
         "logs",
     )
-    if not any(has_marker(marker) for marker in validation_subject_markers):
+    if not named_validation_command_handoff and not any(
+        has_marker(marker) for marker in validation_subject_markers
+    ):
         return False
     # Migration implementation gaps stay agent-owned; migration-gate evidence
     # gaps are AWF-owned because the profile gate must produce that evidence.

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -571,6 +571,8 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     )
     if any(re.search(pattern, text) for pattern in deterministic_gap_patterns):
         return False
+    # Mixed mentions remain agent-owned: only "code coverage" is AWF-validation
+    # evidence, while any other standalone "code" use is a deterministic gap.
     for match in re.finditer(r"(?<![a-z0-9_])code(?![a-z0-9_])", text):
         if re.match(r"[\s-]+coverage\b", text[match.end() :]):
             continue

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -615,9 +615,15 @@ def build_conformance_stall_recovery_prompt(
         "git add, and git commit. Use existing validation evidence from logs, validation "
         "summaries, git diff, and artifacts. If validation evidence is missing, stale, "
         "or insufficient, report `needs_iteration` with a specific gap asking AWF to "
-        "run the missing validation under the validation phase.\n\n"
+        "run the missing validation under the validation phase. Set `reason_code` to "
+        "`CONFORMANCE_REQUIRES_AWF_VALIDATION` only when every remaining gap is missing, "
+        "stale, or insufficient AWF-owned validation evidence. Do not use it for "
+        "implementation, API, plan, or documentation gaps.\n\n"
         "The object must have this shape:\n\n"
-        '```json\n{"status":"satisfied|needs_iteration","summary":"...","gaps":["..."]}\n```\n\n'
+        "```json\n"
+        '{"status":"satisfied|needs_iteration","summary":"...",'
+        '"gaps":["..."],"reason_code":"optional reason code"}\n'
+        "```\n\n"
         f"### Prior gaps (advisory)\n{gap_lines}\n\n"
         f"### Original task\n{task_prompt}\n"
     )

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -561,7 +561,10 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         return False
     # Migration implementation gaps stay agent-owned; migration-gate evidence
     # gaps are AWF-owned because the profile gate must produce that evidence.
-    if has_marker("migration") and not _has_migration_validation_evidence_context(text):
+    migration_validation_evidence_gap = (
+        has_marker("migration") and _has_migration_validation_evidence_context(text)
+    )
+    if has_marker("migration") and not migration_validation_evidence_gap:
         return False
     deterministic_markers = (
         "api",
@@ -570,9 +573,10 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "wire",
         "function",
         "class",
-        "schema",
     )
     if any(has_marker(marker) for marker in deterministic_markers):
+        return False
+    if has_marker("schema") and not migration_validation_evidence_gap:
         return False
     deterministic_gap_patterns = (
         r"(?:^|[.;:]\s*|(?<![a-z0-9_])please\s+)document(?![a-z0-9_])"

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -619,8 +619,8 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     # around test/test(s) remain validation evidence.
     for match in re.finditer(r"(?<![a-z0-9_])tests?(?![a-z0-9_])", text):
         if re.match(
-            r"[\s-]+(?:coverage|evidence|provenance|logs?|"
-            r"(?:suites?|runners?|runs?|reports?)[\s-]+"
+            r"[\s\-,:]+(?:coverage|evidence|provenance|logs?|"
+            r"(?:suites?|runners?|runs?|reports?)[\s\-,:]+"
             r"(?:coverage|evidence|provenance|logs?))\b",
             text[match.end() :],
         ):

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -539,7 +539,7 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "schema",
         "migration",
     )
-    if any(marker in text for marker in deterministic_markers):
+    if any(has_marker(marker) for marker in deterministic_markers):
         return False
     deterministic_gap_patterns = (
         r"(?:^|[.;:]\s*|(?<![a-z0-9_])please\s+)document(?![a-z0-9_])"

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -521,10 +521,21 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
         "class",
         "schema",
         "migration",
-        "document",
-        "docs",
     )
     if any(marker in text for marker in deterministic_markers):
+        return False
+    documentation_work_patterns = (
+        r"(?:^|[.;:]\s*|(?<![a-z0-9_])please\s+)document(?![a-z0-9_])"
+        r"\s+(?:the\s+)?",
+        r"(?<![a-z0-9_])(?:must|should|need|needs|required)\s+"
+        r"(?:to\s+)?document(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:add|create|update|write|revise)\s+"
+        r"(?:the\s+)?(?:docs|documentation|document|guide|readme)(?![a-z0-9_])",
+        r"(?<![a-z0-9_])(?:docs|documentation|document|guide|readme)(?![a-z0-9_])"
+        r"\s+(?:gap|gaps|task|tasks|todo|todos|update|updates|change|changes|"
+        r"need|needs|must|should|required|missing|absent|stale|outdated)",
+    )
+    if any(re.search(pattern, text) for pattern in documentation_work_patterns):
         return False
     for match in re.finditer(r"(?<![a-z0-9_])code(?![a-z0-9_])", text):
         if re.match(r"[\s-]+coverage\b", text[match.end() :]):

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -619,7 +619,8 @@ def _is_awf_validation_evidence_gap(gap: str) -> bool:
     # around test/test(s) remain validation evidence.
     for match in re.finditer(r"(?<![a-z0-9_])tests?(?![a-z0-9_])", text):
         if re.match(
-            r"[\s-]+(?:coverage|(?:suites?|runners?|runs?|reports?)[\s-]+"
+            r"[\s-]+(?:coverage|evidence|provenance|logs?|"
+            r"(?:suites?|runners?|runs?|reports?)[\s-]+"
             r"(?:coverage|evidence|provenance|logs?))\b",
             text[match.end() :],
         ):

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -265,6 +265,9 @@ _TERMINAL_WORKSPACE_STATUSES = {
     WorkspaceStatus.destroyed.value,
 }
 _PLANNING_VALIDATION_HANDOFF_EVENT = "workspace.planning_conformance_requires_awf_validation"
+_POST_VALIDATION_CONFORMANCE_SATISFIED_EVENT = (
+    "workspace.post_validation_conformance_satisfied"
+)
 
 
 def _normalize_conformance_handoff_reason_code(value: object) -> str | None:
@@ -277,7 +280,10 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
     """Return conformance handoff context for monitor-dispatched validation recovery."""
     events = getattr(workspace, "events", None) or []
     for event in reversed(events):
-        if getattr(event, "event_type", None) != _PLANNING_VALIDATION_HANDOFF_EVENT:
+        event_type = getattr(event, "event_type", None)
+        if event_type == _POST_VALIDATION_CONFORMANCE_SATISFIED_EVENT:
+            return None
+        if event_type != _PLANNING_VALIDATION_HANDOFF_EVENT:
             continue
         raw_payload = getattr(event, "payload", None)
         payload = raw_payload if isinstance(raw_payload, Mapping) else {}

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -73,6 +73,7 @@ from awf.runtime.monitor_prompts import (
     ready_to_merge_comment,
     sync_base_conflict_prompt,
 )
+from awf.runtime.planning import CONFORMANCE_REQUIRES_AWF_VALIDATION
 from awf.runtime.pr_monitor import (
     Abort,
     AbortReason,
@@ -263,6 +264,39 @@ _TERMINAL_WORKSPACE_STATUSES = {
     WorkspaceStatus.cancelled.value,
     WorkspaceStatus.destroyed.value,
 }
+_PLANNING_VALIDATION_HANDOFF_EVENT = "workspace.planning_conformance_requires_awf_validation"
+
+
+def _normalize_conformance_handoff_reason_code(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip().upper().replace("-", "_")
+
+
+def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any] | None:
+    """Return conformance handoff context for monitor-dispatched validation recovery."""
+    events = getattr(workspace, "events", None) or []
+    for event in reversed(events):
+        if getattr(event, "event_type", None) != _PLANNING_VALIDATION_HANDOFF_EVENT:
+            continue
+        raw_payload = getattr(event, "payload", None)
+        payload = raw_payload if isinstance(raw_payload, Mapping) else {}
+        reason_code = (
+            _normalize_conformance_handoff_reason_code(payload.get("report_reason_code"))
+            or _normalize_conformance_handoff_reason_code(payload.get("reason_code"))
+            or _normalize_conformance_handoff_reason_code(getattr(event, "reason_code", None))
+        )
+        if reason_code != CONFORMANCE_REQUIRES_AWF_VALIDATION:
+            continue
+        conformance: dict[str, Any] = {
+            "reason_code": reason_code,
+            "report_reason_code": reason_code,
+        }
+        for key in ("summary", "gaps", "plan_path", "report_path", "iteration", "max_iterations"):
+            if key in payload:
+                conformance[key] = payload[key]
+        return {"conformance": conformance}
+    return None
 
 
 class BaseFetchError(Exception):
@@ -2945,6 +2979,7 @@ class PullRequestMonitorRunner:
                     log_stream_refs=(
                         {"monitor": monitor_log.stream_id} if monitor_log is not None else None
                     ),
+                    extra=_monitor_recovery_conformance_payload(_ws),
                 )
                 operation_repo = OperationRepository(s)
                 idempotency_key = await retryable_monitor_operation_idempotency_key(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -282,7 +282,7 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
     for event in reversed(events):
         event_type = getattr(event, "event_type", None)
         if event_type == _POST_VALIDATION_CONFORMANCE_SATISFIED_EVENT:
-            return None
+            continue
         if event_type != _PLANNING_VALIDATION_HANDOFF_EVENT:
             continue
         raw_payload = getattr(event, "payload", None)

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -282,7 +282,7 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
     for event in reversed(events):
         event_type = getattr(event, "event_type", None)
         if event_type == _POST_VALIDATION_CONFORMANCE_SATISFIED_EVENT:
-            continue
+            return None
         if event_type != _PLANNING_VALIDATION_HANDOFF_EVENT:
             continue
         raw_payload = getattr(event, "payload", None)

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -63,6 +63,10 @@ _COVERAGE_SUMMARY_RE = re.compile(
 _COVERAGE_FAIL_UNDER_RE = re.compile(
     r"(?i)^\s*FAIL\b.*\bcoverage\b.*\bnot reached\b.*$"
 )
+_COVERAGE_FAIL_UNDER_PERCENT_RE = re.compile(
+    r"(?i)^\s*FAIL\b.*\bnot reached\b.*\btotal\s+coverage:\s*"
+    r"(?P<percent>\d+(?:\.\d+)?)%\s*$"
+)
 _COVERAGE_FILE_LINE_RE = re.compile(
     r"^(?P<file>\S.*?)\s+(?P<stmts>\d+)\s+(?P<miss>\d+)\s+(?P<cover>\d+)%\s*(?P<missing>.*?)\s*$"
 )
@@ -1447,10 +1451,15 @@ def _runs_pytest_under_coverage(token_names: list[str]) -> bool:
 
 def _parse_python_coverage_percent_from_files(paths: list[Path]) -> float | None:
     total_percent: float | None = None
+    fail_under_percent: float | None = None
     summary_percent: float | None = None
     for path in paths:
         with path.open("r", encoding="utf-8", errors="replace") as stream:
             for line in stream:
+                fail_under_match = _COVERAGE_FAIL_UNDER_PERCENT_RE.search(line)
+                if fail_under_match:
+                    fail_under_percent = float(fail_under_match.group("percent"))
+                    continue
                 total_match = _COVERAGE_TOTAL_RE.search(line)
                 if total_match:
                     total_percent = float(total_match.group("percent"))
@@ -1459,6 +1468,8 @@ def _parse_python_coverage_percent_from_files(paths: list[Path]) -> float | None
                 if summary_match:
                     summary_percent = float(summary_match.group("percent"))
 
+    if fail_under_percent is not None:
+        return fail_under_percent
     return total_percent if total_percent is not None else summary_percent
 
 

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -64,8 +64,7 @@ _COVERAGE_FAIL_UNDER_RE = re.compile(
     r"(?i)^\s*FAIL\b.*\bcoverage\b.*\bnot reached\b.*$"
 )
 _COVERAGE_FAIL_UNDER_PERCENT_RE = re.compile(
-    r"(?i)^\s*FAIL\b.*\bnot reached\b.*\btotal\s+coverage:\s*"
-    r"(?P<percent>\d+(?:\.\d+)?)%\s*$"
+    r"(?i)\btotal\s+coverage:\s*(?P<percent>\d+(?:\.\d+)?)%"
 )
 _COVERAGE_FILE_LINE_RE = re.compile(
     r"^(?P<file>\S.*?)\s+(?P<stmts>\d+)\s+(?P<miss>\d+)\s+(?P<cover>\d+)%\s*(?P<missing>.*?)\s*$"
@@ -1455,11 +1454,30 @@ def _parse_python_coverage_percent_from_files(paths: list[Path]) -> float | None
     summary_percent: float | None = None
     for path in paths:
         with path.open("r", encoding="utf-8", errors="replace") as stream:
+            pending_fail_under_lines = 0
+            recent_total_coverage_percent: float | None = None
+            recent_total_coverage_lines = 0
             for line in stream:
+                fail_under_line = _COVERAGE_FAIL_UNDER_RE.match(line) is not None
                 fail_under_match = _COVERAGE_FAIL_UNDER_PERCENT_RE.search(line)
-                if fail_under_match:
+                if fail_under_line and fail_under_match:
                     fail_under_percent = float(fail_under_match.group("percent"))
                     continue
+                if fail_under_line:
+                    if recent_total_coverage_percent is not None:
+                        fail_under_percent = recent_total_coverage_percent
+                    else:
+                        pending_fail_under_lines = 2
+                    continue
+                if pending_fail_under_lines > 0:
+                    if fail_under_match:
+                        fail_under_percent = float(fail_under_match.group("percent"))
+                        pending_fail_under_lines = 0
+                        continue
+                    pending_fail_under_lines -= 1
+                if fail_under_match:
+                    recent_total_coverage_percent = float(fail_under_match.group("percent"))
+                    recent_total_coverage_lines = 2
                 total_match = _COVERAGE_TOTAL_RE.search(line)
                 if total_match:
                     total_percent = float(total_match.group("percent"))
@@ -1467,6 +1485,10 @@ def _parse_python_coverage_percent_from_files(paths: list[Path]) -> float | None
                 summary_match = _COVERAGE_SUMMARY_RE.search(line)
                 if summary_match:
                     summary_percent = float(summary_match.group("percent"))
+                if not fail_under_match and recent_total_coverage_lines > 0:
+                    recent_total_coverage_lines -= 1
+                    if recent_total_coverage_lines == 0:
+                        recent_total_coverage_percent = None
 
     if fail_under_percent is not None:
         return fail_under_percent

--- a/tests/unit/api/test_metrics.py
+++ b/tests/unit/api/test_metrics.py
@@ -10,9 +10,11 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 from starlette.requests import Request
 
+from awf.api.routes import metrics as metrics_route
 from awf.common.config import get_settings
 from awf.db.enums import FailureReason, WorkspaceStatus
 from awf.db.session import make_session_factory
+from awf.service.resource_capacity import LocalCapacityLimits
 from tests.unit.helpers import create_workspace, zero_status_counts
 
 
@@ -40,6 +42,38 @@ async def test_workspace_summary_returns_zero_counts_for_empty_db(
     assert body["stuck_count"] == 0
     assert body["actionable_reason_count"] == 0
     assert body["unactionable_reason_count"] == 0
+
+
+@pytest.mark.unit
+async def test_resource_saturation_local_capacity_accepts_async_provider() -> None:
+    async def _provider(_settings: object) -> LocalCapacityLimits:
+        return LocalCapacityLimits(cpu_cores=12, memory_gb=48, source="test")
+
+    request = SimpleNamespace(
+        app=SimpleNamespace(state=SimpleNamespace(local_capacity_detector=_provider))
+    )
+
+    result = await metrics_route._resource_saturation_local_capacity(  # noqa: SLF001
+        request,  # type: ignore[arg-type]
+        get_settings(),
+    )
+
+    assert result == LocalCapacityLimits(cpu_cores=12, memory_gb=48, source="test")
+
+
+@pytest.mark.unit
+async def test_resource_saturation_local_capacity_skips_detection_when_configured() -> None:
+    settings = get_settings().model_copy(
+        update={"local_capacity_cpu_cores": 8, "local_capacity_memory_gb": 32}
+    )
+    request = SimpleNamespace(app=SimpleNamespace(state=SimpleNamespace()))
+
+    result = await metrics_route._resource_saturation_local_capacity(  # noqa: SLF001
+        request,  # type: ignore[arg-type]
+        settings,
+    )
+
+    assert result == LocalCapacityLimits()
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_metrics_capacity.py
+++ b/tests/unit/api/test_metrics_capacity.py
@@ -13,6 +13,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncEngine
 
 from awf.api.app import configure_database, create_app
+from awf.api.routes import metrics as metrics_route
 from awf.common.config import Settings, get_settings
 from awf.db.enums import WorkspaceStatus
 from awf.db.repositories import (
@@ -220,6 +221,24 @@ async def test_resource_saturation_endpoint_uses_detected_docker_capacity_when_u
         "available_after_next_default": 0.0,
         "reason_code": None,
     }
+
+
+@pytest.mark.unit
+async def test_resource_saturation_endpoint_tolerates_egress_count_failure(
+    metrics_app_and_client: tuple[Any, AsyncClient],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _app, client = metrics_app_and_client
+
+    async def _raise_egress_counts(_session: object) -> dict[str, int]:
+        raise RuntimeError("egress query failed")
+
+    monkeypatch.setattr(metrics_route, "_egress_posture_counts", _raise_egress_counts)
+
+    response = await client.get("/v1/metrics/resources/saturation")
+
+    assert response.status_code == 200
+    assert response.json()["egress_posture_counts"] == {}
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_operations_listing.py
+++ b/tests/unit/api/test_operations_listing.py
@@ -1,3 +1,5 @@
+import base64
+import json
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
@@ -9,6 +11,7 @@ from awf.api.schemas import OperationResponse
 from awf.db.enums import OperationStatus, OperationType
 from awf.db.repositories import OperationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.bounded_list import InvalidBoundedListCursorError
 from awf.service.operations import build_operation_list_response, decode_operation_list_cursor
 from awf.service.workspaces import OperationRowsPage
 
@@ -46,6 +49,17 @@ def test_operation_list_response_uses_keyset_cursor_from_last_returned_row() -> 
     assert decoded is not None
     assert decoded.created_at == operation.created_at
     assert decoded.operation_id == operation.id
+
+
+@pytest.mark.unit
+def test_decode_operation_list_cursor_rejects_empty_operation_id() -> None:
+    payload = {"c": datetime(2026, 1, 1, tzinfo=UTC).isoformat(), "i": ""}
+    cursor = base64.urlsafe_b64encode(
+        json.dumps(payload, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+
+    with pytest.raises(InvalidBoundedListCursorError):
+        decode_operation_list_cursor(cursor)
 
 
 @pytest.fixture
@@ -348,6 +362,22 @@ async def test_list_operations_invalid_cursor_returns_structured_400(
     client: AsyncClient,
 ) -> None:
     response = await client.get("/v1/operations?cursor=not-a-cursor")
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == {
+        "error_code": "INVALID_CURSOR",
+        "message": "Invalid operation list cursor.",
+    }
+
+
+@pytest.mark.unit
+async def test_list_workspace_operations_invalid_cursor_returns_structured_400(
+    client: AsyncClient,
+    sample_data,
+) -> None:
+    ws1, _ws2 = sample_data
+
+    response = await client.get(f"/v1/workspaces/{ws1.id}/operations?cursor=not-a-cursor")
 
     assert response.status_code == 400
     assert response.json()["detail"] == {

--- a/tests/unit/api/test_validation_coverage_gaps.py
+++ b/tests/unit/api/test_validation_coverage_gaps.py
@@ -71,6 +71,32 @@ def test_validation_coverage_fields_extracts_gaps() -> None:
 
 
 @pytest.mark.unit
+def test_validation_coverage_fields_prefers_coverage_column_over_log_refs() -> None:
+    run = _run(
+        coverage={
+            "percent": 99.4,
+            "minimum_percent": 99.0,
+            "status": "passed",
+            "reason_code": "COVERAGE_OK",
+        },
+        log_stream_refs={
+            "coverage": {
+                "percent": 72.0,
+                "minimum_percent": 99.0,
+                "status": "failed",
+                "reason_code": "COVERAGE_BELOW_THRESHOLD",
+            }
+        },
+    )
+
+    fields = validation_coverage_fields(run)
+
+    assert fields["coverage_percent"] == 99.4
+    assert fields["coverage_status"] == "passed"
+    assert fields["coverage_reason_code"] == "COVERAGE_OK"
+
+
+@pytest.mark.unit
 def test_validation_coverage_fields_handles_missing_gaps() -> None:
     run = _run(
         log_stream_refs={

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -39,6 +39,10 @@ from awf.runtime.planning import (
     PLAN_CONFORMANCE_UNSATISFIED,
 )
 from awf.runtime.pr_creator import PullRequestCreator
+from awf.runtime.pr_monitor_operations import (
+    build_monitor_operation_payload,
+    monitor_operation_idempotency_key,
+)
 from awf.runtime.validation import (
     ValidationCommandResult,
     ValidationCoverageResult,
@@ -139,17 +143,38 @@ async def _insert_validate_handoff_recovery_operation(
     workspace_id: str,
     operation_id: str,
 ) -> None:
-    payload = {
-        "source": "pr_monitor",
-        "recovery_mode": "validate_only",
-        "reason": "planning_conformance_requires_awf_validation",
-        "conformance": {
-            "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
-            "summary": "AWF validation evidence is required before conformance can pass.",
-            "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
-        },
-    }
     async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        pr_number = 225
+        source_head_sha = "deadbeef01"
+        remote_branch = workspace.branch_name or f"awf/{workspace_id}"
+        reason = "planning_conformance_requires_awf_validation"
+        workspace.pr_number = pr_number
+        workspace.pr_url = f"https://github.com/dimileeh/aira-agent/pull/{pr_number}"
+        workspace.monitor_last_commit_sha = source_head_sha
+        workspace.remote_push_branch = remote_branch
+        payload = build_monitor_operation_payload(
+            workspace=workspace,
+            action="validate_only",
+            requested_action="validate",
+            reason=reason,
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+            pr_number=pr_number,
+            source_head_sha=source_head_sha,
+            source_base_sha=workspace.base_commit,
+            target_branch=workspace.branch_base,
+            remote_branch=remote_branch,
+            recovery_mode="validate_only",
+            stale_reason=reason,
+            extra={
+                "conformance": {
+                    "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                    "summary": "AWF validation evidence is required before conformance can pass.",
+                    "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+                },
+            },
+        )
         await session.execute(
             text(
                 """
@@ -159,6 +184,7 @@ async def _insert_validate_handoff_recovery_operation(
                     type,
                     status,
                     payload,
+                    idempotency_key,
                     created_at
                 )
                 VALUES (
@@ -167,6 +193,7 @@ async def _insert_validate_handoff_recovery_operation(
                     'validate',
                     'pending',
                     CAST(:payload AS JSON),
+                    :idempotency_key,
                     :created_at
                 )
                 """
@@ -175,6 +202,14 @@ async def _insert_validate_handoff_recovery_operation(
                 "operation_id": operation_id,
                 "workspace_id": workspace_id,
                 "payload": json.dumps(payload),
+                "idempotency_key": monitor_operation_idempotency_key(
+                    workspace_id=workspace_id,
+                    action="validate_only",
+                    pr_number=pr_number,
+                    reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                    source_head_sha=source_head_sha,
+                    source_base_sha=workspace.base_commit,
+                ),
                 "created_at": datetime.now(UTC),
             },
         )

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -22,6 +22,7 @@ from awf.common.commands import COMMAND_IDLE_TIMEOUT_REASON, FakeCommandRunner
 from awf.common.compose_exec import EXEC_PROCESS_CLEANUP_FAILED
 from awf.control.executor import (
     POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE,
+    POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE,
     ExecutorConfig,
     WorkspaceExecutor,
     _apply_baseline_coverage_ratchet,
@@ -1441,6 +1442,139 @@ class TestHappyPath:
             == POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE
         )
         assert result["validation_run_id"]
+
+    @pytest.mark.unit
+    async def test_planning_validation_handoff_report_write_failure_finishes_validate_operation(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        operation_id = "op_pv_report_write_failed"
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id=operation_id,
+        )
+
+        def fail_write(**_: object) -> None:
+            raise OSError("disk full")
+
+        executor._write_satisfied_post_validation_conformance_report = fail_write  # type: ignore[method-assign]
+
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance after status
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            run = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, reason_code
+                            FROM validation_runs
+                            WHERE workspace_id = :workspace_id
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, error_message, result, finished_at
+                            FROM operations
+                            WHERE id = :operation_id
+                            """
+                        ),
+                        {"operation_id": operation_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            event = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT reason_code, payload
+                            FROM workspace_events
+                            WHERE workspace_id = :workspace_id
+                              AND event_type = 'workspace.state_changed'
+                              AND new_state = 'failed'
+                            ORDER BY occurred_at DESC
+                            LIMIT 1
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "infrastructure_failure"
+        assert "post-validation conformance report write failed" in (
+            ws.failure_message or ""
+        )
+        assert "disk full" in (ws.failure_message or "")
+        assert run == {"status": "succeeded", "reason_code": "VALIDATION_OK"}
+        assert operation["status"] == "failed"
+        assert (
+            operation["error_code"]
+            == POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE
+        )
+        assert operation["finished_at"] is not None
+        assert "disk full" in operation["error_message"]
+        result = _json_value(operation["result"])
+        assert (
+            result["reason_code"]
+            == POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE
+        )
+        assert result["validation_run_id"]
+        assert event["reason_code"] == POST_VALIDATION_CONFORMANCE_REPORT_WRITE_FAILED_REASON_CODE
+        event_payload = _json_value(event["payload"])
+        assert event_payload["details"]["operation"] == "write"
+        assert event_payload["details"]["error_type"] == "OSError"
+        assert event_payload["details"]["report_path"] == report_path
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_unexpected_post_validation_error_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -18,7 +18,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.adapters import registry as _registry  # noqa: F401 - populates adapter registry
 from awf.adapters.base import AgentAdapter
-from awf.common.commands import FakeCommandRunner
+from awf.common.commands import COMMAND_IDLE_TIMEOUT_REASON, FakeCommandRunner
+from awf.common.compose_exec import EXEC_PROCESS_CLEANUP_FAILED
 from awf.control.executor import (
     ExecutorConfig,
     WorkspaceExecutor,
@@ -118,6 +119,54 @@ def _created_pr_body(fake: FakeCommandRunner) -> str:
 
 def _json_value(value: object) -> object:
     return json.loads(value) if isinstance(value, str) else value
+
+
+async def _insert_validate_handoff_recovery_operation(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    workspace_id: str,
+    operation_id: str,
+) -> None:
+    payload = {
+        "source": "pr_monitor",
+        "recovery_mode": "validate_only",
+        "reason": "planning_conformance_requires_awf_validation",
+        "conformance": {
+            "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+            "summary": "AWF validation evidence is required before conformance can pass.",
+            "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+        },
+    }
+    async with factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO operations (
+                    id,
+                    workspace_id,
+                    type,
+                    status,
+                    payload,
+                    created_at
+                )
+                VALUES (
+                    :operation_id,
+                    :workspace_id,
+                    'validate',
+                    'pending',
+                    CAST(:payload AS JSON),
+                    :created_at
+                )
+                """
+            ),
+            {
+                "operation_id": operation_id,
+                "workspace_id": workspace_id,
+                "payload": json.dumps(payload),
+                "created_at": datetime.now(UTC),
+            },
+        )
+        await session.commit()
 
 
 class TestCoverageBaselineRatchet:
@@ -719,6 +768,171 @@ class TestHappyPath:
             if event.reason_code == CONFORMANCE_REQUIRES_AWF_VALIDATION
         ]
         assert handoff_events
+
+    @pytest.mark.unit
+    async def test_planning_validation_handoff_agent_failure_finishes_validate_operation(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id="op_validate_handoff_agent_failed",
+        )
+
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=1, stderr="conformance runner failed")
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            run = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, reason_code
+                            FROM validation_runs
+                            WHERE workspace_id = :workspace_id
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, error_message, result, finished_at
+                            FROM operations
+                            WHERE id = 'op_validate_handoff_agent_failed'
+                            """
+                        )
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "agent_failure"
+        assert "post-validation conformance agent failed" in (ws.failure_message or "")
+        assert run == {"status": "succeeded", "reason_code": "VALIDATION_OK"}
+        assert operation["status"] == "failed"
+        assert operation["error_code"] == "AGENT_CLI_FAILED"
+        assert operation["finished_at"] is not None
+        assert "post-validation conformance agent failed" in operation["error_message"]
+        result = _json_value(operation["result"])
+        assert result["reason_code"] == "AGENT_CLI_FAILED"
+        assert result["validation_run_id"]
+
+    @pytest.mark.unit
+    async def test_planning_validation_handoff_cleanup_failure_finishes_validate_operation(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id="op_validate_handoff_cleanup_failed",
+        )
+
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(
+            returncode=124,
+            stderr="idle timeout exceeded",
+            reason_code=COMMAND_IDLE_TIMEOUT_REASON,
+        )
+        fake.queue_result(returncode=1, stderr="cleanup still saw tagged processes")
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            run = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, reason_code
+                            FROM validation_runs
+                            WHERE workspace_id = :workspace_id
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, error_message, result, finished_at
+                            FROM operations
+                            WHERE id = 'op_validate_handoff_cleanup_failed'
+                            """
+                        )
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "infrastructure_failure"
+        assert EXEC_PROCESS_CLEANUP_FAILED in (ws.failure_message or "")
+        assert run == {"status": "succeeded", "reason_code": "VALIDATION_OK"}
+        assert operation["status"] == "failed"
+        assert operation["error_code"] == EXEC_PROCESS_CLEANUP_FAILED
+        assert operation["finished_at"] is not None
+        assert EXEC_PROCESS_CLEANUP_FAILED in operation["error_message"]
+        result = _json_value(operation["result"])
+        assert result["reason_code"] == EXEC_PROCESS_CLEANUP_FAILED
+        assert result["validation_run_id"]
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_uses_validation_fix_cycle_before_rerun(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -21,6 +21,7 @@ from awf.adapters.base import AgentAdapter
 from awf.common.commands import COMMAND_IDLE_TIMEOUT_REASON, FakeCommandRunner
 from awf.common.compose_exec import EXEC_PROCESS_CLEANUP_FAILED
 from awf.control.executor import (
+    POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE,
     ExecutorConfig,
     WorkspaceExecutor,
     _apply_baseline_coverage_ratchet,
@@ -1228,6 +1229,122 @@ class TestHappyPath:
         assert EXEC_PROCESS_CLEANUP_FAILED in operation["error_message"]
         result = _json_value(operation["result"])
         assert result["reason_code"] == EXEC_PROCESS_CLEANUP_FAILED
+        assert result["validation_run_id"]
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "failing_git_operation",
+        ["add", "diff", "commit"],
+    )
+    async def test_planning_validation_handoff_report_commit_failure_finishes_validate_operation(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        failing_git_operation: str,
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        operation_id = f"op_pv_{failing_git_operation}_failed"
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id=operation_id,
+        )
+
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+        failure_message = f"{failing_git_operation} failed"
+
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        if failing_git_operation == "add":
+            fake.queue_result(returncode=1, stderr=failure_message)
+        elif failing_git_operation == "diff":
+            fake.queue_result(returncode=0)  # git add report
+            fake.queue_result(returncode=1, stderr=failure_message)
+        else:
+            fake.queue_result(returncode=0)  # git add report
+            fake.queue_result(returncode=0, stdout=f"{report_path}\n")  # cached report diff
+            fake.queue_result(returncode=1, stderr=failure_message)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            run = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, reason_code
+                            FROM validation_runs
+                            WHERE workspace_id = :workspace_id
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, error_message, result, finished_at
+                            FROM operations
+                            WHERE id = :operation_id
+                        """
+                        ),
+                        {"operation_id": operation_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "infrastructure_failure"
+        assert "post-validation conformance report" in (ws.failure_message or "")
+        assert failure_message in (ws.failure_message or "")
+        assert run == {"status": "succeeded", "reason_code": "VALIDATION_OK"}
+        assert operation["status"] == "failed"
+        assert (
+            operation["error_code"]
+            == POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE
+        )
+        assert operation["finished_at"] is not None
+        assert failure_message in operation["error_message"]
+        result = _json_value(operation["result"])
+        assert (
+            result["reason_code"]
+            == POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE
+        )
         assert result["validation_run_id"]
 
     @pytest.mark.unit

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -881,6 +881,65 @@ class TestHappyPath:
         assert "[redacted]" in evidence
 
     @pytest.mark.unit
+    async def test_validation_handoff_evidence_keeps_large_payload_json_valid(
+        self,
+        executor: WorkspaceExecutor,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+
+        async with factory() as session:
+            repo = ValidationRunRepository(session)
+            run = await repo.start(
+                workspace_id=ws_id,
+                attempt_id=None,
+                tier=1,
+                commands=[
+                    {
+                        "phase": "validate",
+                        "command": f"pytest tests/unit/test_{idx}.py " + ("x" * 1500),
+                    }
+                    for idx in range(25)
+                ],
+                base_commit="base",
+                workspace_head_sha="workspace-head",
+                target_branch="main",
+                target_head_sha="target",
+                log_stream_refs={
+                    f"stream_{idx:02d}": {
+                        "stdout": f"validation.{idx:02d}.stdout",
+                        "stderr": "stderr-" + ("y" * 1500),
+                    }
+                    for idx in range(40)
+                },
+            )
+            await repo.finish(
+                run.id,
+                status="succeeded",
+                reason_code="VALIDATION_OK",
+                coverage={
+                    "status": "passed",
+                    "reason_code": "COVERAGE_OK",
+                    "percent": 99.4,
+                },
+            )
+            validation_run_id = run.id
+            await session.commit()
+
+        evidence = await executor._validation_run_evidence_for_conformance(validation_run_id)
+        json_text = evidence.split("```json\n", 1)[1].split("\n```", 1)[0]
+        payload = json.loads(json_text)
+        keys = list(payload)
+
+        assert len(json_text) <= 20000
+        assert keys.index("coverage") < keys.index("commands")
+        assert keys.index("workspace_head_sha") < keys.index("commands")
+        assert payload["status"] == "succeeded"
+        assert payload["reason_code"] == "VALIDATION_OK"
+        assert payload["coverage"]["reason_code"] == "COVERAGE_OK"
+        assert payload["workspace_head_sha"] == "workspace-head"
+
+    @pytest.mark.unit
     async def test_planning_validation_handoff_agent_failure_finishes_validate_operation(
         self,
         executor: WorkspaceExecutor,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1330,7 +1330,7 @@ class TestHappyPath:
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "failing_git_operation",
-        ["add", "diff", "commit"],
+        ["add", "diff", "diff_reset", "commit"],
     )
     async def test_planning_validation_handoff_report_commit_failure_finishes_validate_operation(
         self,
@@ -1378,9 +1378,15 @@ class TestHappyPath:
         fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
         if failing_git_operation == "add":
             fake.queue_result(returncode=1, stderr=failure_message)
-        elif failing_git_operation == "diff":
+        elif failing_git_operation in {"diff", "diff_reset"}:
             fake.queue_result(returncode=0)  # git add report
             fake.queue_result(returncode=1, stderr=failure_message)
+            if failing_git_operation == "diff_reset":
+                fake.queue_result(
+                    returncode=129,
+                    stderr="reset failed",
+                    reason_code="GIT_RESET_FAILED",
+                )
         else:
             fake.queue_result(returncode=0)  # git add report
             fake.queue_result(returncode=0, stdout=f"{report_path}\n")  # cached report diff
@@ -1422,6 +1428,15 @@ class TestHappyPath:
                 .mappings()
                 .one()
             )
+            failure_event = next(
+                event
+                for event in await WorkspaceEventRepository(s).list(
+                    workspace_id=ws_id,
+                    event_type="workspace.state_changed",
+                    limit=10,
+                )
+                if event.new_state == WorkspaceStatus.failed.value
+            )
 
         assert ws is not None
         assert ws.status == WorkspaceStatus.failed.value
@@ -1442,6 +1457,21 @@ class TestHappyPath:
             == POST_VALIDATION_CONFORMANCE_REPORT_GIT_FAILED_REASON_CODE
         )
         assert result["validation_run_id"]
+        failure_payload = _json_value(failure_event.payload)
+        expected_operation = (
+            "diff" if failing_git_operation == "diff_reset" else failing_git_operation
+        )
+        assert failure_payload["details"]["operation"] == expected_operation
+        if failing_git_operation == "diff_reset":
+            assert failure_payload["details"]["cleanup_operation"] == "reset"
+            assert failure_payload["details"]["cleanup_returncode"] == 129
+            assert (
+                failure_payload["details"]["cleanup_command_reason_code"]
+                == "GIT_RESET_FAILED"
+            )
+            assert failure_payload["details"]["report_left_staged"] is True
+        else:
+            assert "cleanup_operation" not in failure_payload["details"]
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_report_write_failure_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1193,6 +1193,22 @@ class TestHappyPath:
                 .mappings()
                 .one()
             )
+            extra_validate_recovery_ops = (
+                await s.execute(
+                    text(
+                        """
+                        SELECT COUNT(*)
+                        FROM operations
+                        WHERE workspace_id = :workspace_id
+                          AND type = 'validate'
+                          AND status IN ('pending', 'running')
+                          AND id <> :operation_id
+                          AND idempotency_key LIKE 'pr_monitor:validate_only:%'
+                        """
+                    ),
+                    {"workspace_id": ws_id, "operation_id": operation_id},
+                )
+            ).scalar_one()
 
         assert ws is not None
         assert ws.status == WorkspaceStatus.failed.value
@@ -1222,6 +1238,7 @@ class TestHappyPath:
         result = _json_value(operation["result"])
         assert result["reason_code"] == PLAN_CONFORMANCE_UNSATISFIED
         assert result["requested_tier"] == 1
+        assert extra_validate_recovery_ops == 0
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_cleanup_failure_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1021,7 +1021,7 @@ class TestHappyPath:
         assert result["validation_run_id"]
 
     @pytest.mark.unit
-    async def test_post_validation_conformance_gap_runs_fix_pass_before_terminal_failure(
+    async def test_post_validation_conformance_gap_stops_at_preserved_handoff_budget(
         self,
         executor: WorkspaceExecutor,
         fake: FakeCommandRunner,
@@ -1194,7 +1194,7 @@ class TestHappyPath:
             for prompt in post_validation_conformance_prompts
             for line in prompt.splitlines()
             if line.startswith("Iteration: ")
-        ] == ["Iteration: 1", "Iteration: 2", "Iteration: 3"]
+        ] == ["Iteration: 1", "Iteration: 2"]
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             runs = (
@@ -1228,17 +1228,17 @@ class TestHappyPath:
             )
 
         assert ws is not None
-        assert ws.status == WorkspaceStatus.completed.value
-        assert [run["status"] for run in runs] == ["succeeded", "succeeded", "succeeded"]
-        assert [run["reason_code"] for run in runs] == [
-            "VALIDATION_OK",
-            "VALIDATION_OK",
-            "VALIDATION_OK",
-        ]
-        assert operation["status"] == "succeeded"
-        assert operation["error_code"] is None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "agent_failure"
+        assert "Document the API endpoint required by the saved plan." in (
+            ws.failure_message or ""
+        )
+        assert [run["status"] for run in runs] == ["succeeded", "succeeded"]
+        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK", "VALIDATION_OK"]
+        assert operation["status"] == "failed"
+        assert operation["error_code"] == PLAN_CONFORMANCE_UNSATISFIED
         assert operation["finished_at"] is not None
-        assert _json_value(operation["result"])["reason_code"] == "VALIDATION_OK"
+        assert _json_value(operation["result"])["reason_code"] == PLAN_CONFORMANCE_UNSATISFIED
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_cleanup_failure_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -8,7 +8,7 @@ since each call is distinguishable by its argv.
 from __future__ import annotations
 
 import json
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
@@ -143,6 +143,9 @@ async def _insert_validate_handoff_recovery_operation(
     *,
     workspace_id: str,
     operation_id: str,
+    requested_tier: int | None = None,
+    conformance_overrides: Mapping[str, object] | None = None,
+    created_at: datetime | None = None,
 ) -> None:
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
@@ -155,6 +158,13 @@ async def _insert_validate_handoff_recovery_operation(
         workspace.pr_url = f"https://github.com/dimileeh/aira-agent/pull/{pr_number}"
         workspace.monitor_last_commit_sha = source_head_sha
         workspace.remote_push_branch = remote_branch
+        conformance_payload: dict[str, object] = {
+            "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+            "summary": "AWF validation evidence is required before conformance can pass.",
+            "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+        }
+        if conformance_overrides:
+            conformance_payload.update(conformance_overrides)
         payload = build_monitor_operation_payload(
             workspace=workspace,
             action="validate_only",
@@ -168,14 +178,10 @@ async def _insert_validate_handoff_recovery_operation(
             remote_branch=remote_branch,
             recovery_mode="validate_only",
             stale_reason=reason,
-            extra={
-                "conformance": {
-                    "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
-                    "summary": "AWF validation evidence is required before conformance can pass.",
-                    "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
-                },
-            },
+            extra={"conformance": conformance_payload},
         )
+        if requested_tier is not None:
+            payload["requested_tier"] = requested_tier
         await session.execute(
             text(
                 """
@@ -211,7 +217,7 @@ async def _insert_validate_handoff_recovery_operation(
                     source_head_sha=source_head_sha,
                     source_base_sha=workspace.base_commit,
                 ),
-                "created_at": datetime.now(UTC),
+                "created_at": created_at or datetime.now(UTC),
             },
         )
         await session.commit()
@@ -1107,90 +1113,22 @@ class TestHappyPath:
             },
         )
         operation_id = "op_post_validation_conformance_gap"
-        async with factory() as session:
-            await session.execute(
-                text(
-                    """
-                    INSERT INTO operations (
-                        id,
-                        workspace_id,
-                        type,
-                        status,
-                        payload,
-                        created_at
-                    )
-                    VALUES (
-                        :operation_id,
-                        :workspace_id,
-                        'validate',
-                        'pending',
-                        CAST(:payload AS JSON),
-                        :created_at
-                    )
-                    """
-                ),
-                {
-                    "operation_id": operation_id,
-                    "workspace_id": ws_id,
-                    "payload": json.dumps({"requested_tier": 1}),
-                    "created_at": datetime.now(UTC),
-                },
-            )
-            await session.commit()
-        handoff_report = json.dumps(
-            {
-                "status": "needs_iteration",
-                "summary": "Only AWF validation evidence is missing.",
-                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
-                "gaps": ["AWF-owned validation evidence is missing for pytest."],
-            }
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id=operation_id,
+            requested_tier=1,
+            conformance_overrides={"iteration": 1, "max_iterations": 2},
         )
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
         post_validation_gap_report = json.dumps(
-            {
-                "status": "needs_iteration",
-                "summary": "Validation passed, but the API is still incomplete.",
-                "gaps": ["Wire the API endpoint required by the saved plan."],
-            }
-        )
-        second_post_validation_gap_report = json.dumps(
             {
                 "status": "needs_iteration",
                 "summary": "Validation passed, but the API docs are still incomplete.",
                 "gaps": ["Document the API endpoint required by the saved plan."],
             }
         )
-        satisfied_report = json.dumps(
-            {
-                "status": "satisfied",
-                "summary": "implementation and validation evidence satisfy the plan",
-                "gaps": [],
-            }
-        )
 
-        fake.queue_result(returncode=0, stdout="")  # before planning
-        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
-        fake.queue_result(returncode=0, stdout="plan written")  # planning
-        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
-        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
-        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD pre-loop
-        fake.queue_result(returncode=0, stdout="implemented")  # initial execute
-        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
-        fake.queue_result(returncode=0, stdout=handoff_report)
-        fake.queue_result(
-            returncode=0,
-            stdout=(
-                f"?? docs/awf-plans/{ws_id}.md\n"
-                f"?? docs/awf-plans/{ws_id}.conformance.json\n"
-                " M src/x.py\n"
-            ),
-        )
-        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD post-iter
-        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
-        fake.queue_result(returncode=0)  # git add
-        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
-        fake.queue_result(returncode=0)  # git commit
-        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
-        fake.queue_result(returncode=0)  # merge-base --is-ancestor
         _queue_validation_head(fake)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
@@ -1198,43 +1136,9 @@ class TestHappyPath:
         fake.queue_result(returncode=0, stdout=post_validation_gap_report)
         fake.queue_result(
             returncode=0,
-            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+            stdout=f"?? {report_path}\n",
         )
         fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
-        fake.queue_result(returncode=0, stdout="fixed post-validation gap")  # fix pass
-        fake.queue_result(returncode=0)  # fix git add
-        fake.queue_result(returncode=0, stdout="src/api.py\n")  # fix cached diff
-        fake.queue_result(returncode=0)  # fix commit
-        _queue_validation_head(fake, head="b" * 40)
-        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
-        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
-        fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
-        fake.queue_result(returncode=0, stdout=second_post_validation_gap_report)
-        fake.queue_result(
-            returncode=0,
-            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
-        )
-        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
-        fake.queue_result(returncode=0, stdout="fixed second post-validation gap")
-        fake.queue_result(returncode=0)  # second fix git add
-        fake.queue_result(returncode=0, stdout="docs/api.md\n")  # second fix cached diff
-        fake.queue_result(returncode=0)  # second fix commit
-        _queue_validation_head(fake, head="c" * 40)
-        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers again
-        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
-        fake.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # conformance scope HEAD
-        fake.queue_result(returncode=0, stdout=satisfied_report)
-        fake.queue_result(
-            returncode=0,
-            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
-        )
-        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
-        _queue_post_validation_conformance_report_commit(
-            fake, f"docs/awf-plans/{ws_id}.conformance.json"
-        )
-        _queue_pre_push_diagnostics(fake)
-        fake.queue_result(returncode=0)  # git push
-        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
 
         await executor.execute(ws_id)
 
@@ -1243,24 +1147,20 @@ class TestHappyPath:
             for call in fake.calls
             if call.args[:2] == ["docker", "compose"] and "codex" in call.args
         ]
-        fix_prompt = next(
-            prompt
-            for prompt in adapter_prompts
-            if "post-validation plan conformance" in prompt
-        )
         post_validation_conformance_prompts = [
             prompt
             for prompt in adapter_prompts
             if "Conformance phase" in prompt and "### Validation evidence" in prompt
         ]
 
-        assert "Wire the API endpoint required by the saved plan." in fix_prompt
+        assert len(adapter_prompts) == 1
+        assert post_validation_conformance_prompts == adapter_prompts
         assert [
             line
             for prompt in post_validation_conformance_prompts
             for line in prompt.splitlines()
             if line.startswith("Iteration: ")
-        ] == ["Iteration: 1", "Iteration: 2"]
+        ] == ["Iteration: 2"]
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             runs = (
@@ -1281,7 +1181,8 @@ class TestHappyPath:
                     await s.execute(
                         text(
                             """
-                            SELECT status, error_code, result, finished_at
+                            SELECT status, error_code, result, finished_at, payload,
+                                   idempotency_key
                             FROM operations
                             WHERE id = :operation_id
                             """
@@ -1299,12 +1200,28 @@ class TestHappyPath:
         assert "Document the API endpoint required by the saved plan." in (
             ws.failure_message or ""
         )
-        assert [run["status"] for run in runs] == ["succeeded", "succeeded"]
-        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK", "VALIDATION_OK"]
+        assert [run["status"] for run in runs] == ["succeeded"]
+        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK"]
         assert operation["status"] == "failed"
         assert operation["error_code"] == PLAN_CONFORMANCE_UNSATISFIED
         assert operation["finished_at"] is not None
-        assert _json_value(operation["result"])["reason_code"] == PLAN_CONFORMANCE_UNSATISFIED
+        payload = _json_value(operation["payload"])
+        assert payload["owner"] == "pr_monitor"
+        assert payload["source"] == "pr_monitor"
+        assert payload["action"] == "validate_only"
+        assert payload["requested_action"] == "validate"
+        assert payload["requested_tier"] == 1
+        assert payload["source_head_sha"] == "deadbeef01"
+        assert payload["source_base_sha"] == "a" * 40
+        assert payload["target_branch"] == "development"
+        assert payload["remote_branch"] == f"awf/{ws_id}"
+        assert payload["recovery_mode"] == "validate_only"
+        assert payload["conformance"]["iteration"] == 1
+        assert payload["conformance"]["max_iterations"] == 2
+        assert operation["idempotency_key"].startswith("pr_monitor:validate_only:")
+        result = _json_value(operation["result"])
+        assert result["reason_code"] == PLAN_CONFORMANCE_UNSATISFIED
+        assert result["requested_tier"] == 1
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_cleanup_failure_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -743,14 +743,10 @@ class TestHappyPath:
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
         fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
-        fake.queue_result(
-            returncode=0,
-            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
-        )
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
         fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
-        _queue_post_validation_conformance_report_commit(
-            fake, f"docs/awf-plans/{ws_id}.conformance.json"
-        )
+        _queue_post_validation_conformance_report_commit(fake, report_path)
         _queue_pre_push_diagnostics(fake)
         fake.queue_result(returncode=0)  # git push
         fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
@@ -785,6 +781,14 @@ class TestHappyPath:
         assert "Validation evidence" in prompts[-1]
         assert "VALIDATION_OK" in prompts[-1]
         assert "validation.01_validate.stdout" in prompts[-1]
+        git_calls = [call.args for call in fake.calls if call.args and call.args[0] == "git"]
+        assert any(call[-3:] == ["add", "--", report_path] for call in git_calls)
+        assert any(
+            "commit" in call
+            and "awf: post-validation conformance report" in call
+            and call[-1] == report_path
+            for call in git_calls
+        )
 
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1677,6 +1677,158 @@ class TestHappyPath:
         assert [run["reason_code"] for run in runs] == ["COMMAND_FAILED", "VALIDATION_OK"]
 
     @pytest.mark.unit
+    async def test_post_validation_conformance_fix_does_not_consume_validation_fix_budget(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=fake,
+            compose=ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE),
+            validation=ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts"),
+            pr_creator=PullRequestCreator(fake),
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "work" / "worktrees",
+                compose_projects_root=tmp_path / "work" / "compose",
+                default_models={AgentRuntime.codex: "gpt-5"},
+                max_validation_fix_passes=1,
+            ),
+        )
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 3,
+                    "enforce_plan_only_changes": True,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        handoff_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Only AWF validation evidence is missing.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        )
+        post_validation_gap_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Validation passed, but the implementation still misses the plan.",
+                "gaps": ["Add the saved API behavior required by the plan."],
+            }
+        )
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # changed paths before planning
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # execution adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=handoff_report)  # conformance handoff
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                f"?? docs/awf-plans/{ws_id}.md\n"
+                f"?? {report_path}\n"
+                " M src/x.py\n"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD post-iter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        _queue_validation_head(fake, head="b" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=post_validation_gap_report)
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        fake.queue_result(returncode=0, stdout="implemented conformance fix")  # fix adapter
+        fake.queue_result(returncode=0)  # fix git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # fix cached diff
+        fake.queue_result(returncode=0)  # fix commit
+        _queue_validation_head(fake, head="c" * 40)
+        fake.queue_result(returncode=1, stderr="pytest: failed after conformance fix")
+        fake.queue_result(returncode=0, stdout="fixed pytest")  # validation fix adapter
+        fake.queue_result(returncode=0)  # validation fix git add
+        fake.queue_result(returncode=0, stdout="tests/test_x.py\n")  # validation fix diff
+        fake.queue_result(returncode=0)  # validation fix commit
+        _queue_validation_head(fake, head="d" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'d' * 40}\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        _queue_post_validation_conformance_report_commit(fake, report_path)
+        _queue_pre_push_diagnostics(fake, head="d" * 40)
+        fake.queue_result(returncode=0)  # git push
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompts = [
+            call.args[-1]
+            for call in fake.calls
+            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
+        ]
+        fix_prompts = [
+            prompt
+            for prompt in adapter_prompts
+            if "Validation failed after your previous pass" in prompt
+        ]
+
+        assert len(fix_prompts) == 2
+        assert "post-validation plan conformance" in fix_prompts[0]
+        assert "pytest -q" in fix_prompts[1]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            runs = (
+                (
+                    await s.execute(
+                        text(
+                            "SELECT status, reason_code FROM validation_runs "
+                            "WHERE workspace_id = :workspace_id ORDER BY started_at"
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        assert [run["status"] for run in runs] == ["succeeded", "failed", "succeeded"]
+        assert [run["reason_code"] for run in runs] == [
+            "VALIDATION_OK",
+            "COMMAND_FAILED",
+            "VALIDATION_OK",
+        ]
+
+    @pytest.mark.unit
     async def test_planning_profile_iterates_when_conformance_reports_gaps(
         self,
         executor: WorkspaceExecutor,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1086,6 +1086,13 @@ class TestHappyPath:
                 "gaps": ["Wire the API endpoint required by the saved plan."],
             }
         )
+        second_post_validation_gap_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Validation passed, but the API docs are still incomplete.",
+                "gaps": ["Document the API endpoint required by the saved plan."],
+            }
+        )
         satisfied_report = json.dumps(
             {
                 "status": "satisfied",
@@ -1136,6 +1143,20 @@ class TestHappyPath:
         fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
         fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=second_post_validation_gap_report)
+        fake.queue_result(
+            returncode=0,
+            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        fake.queue_result(returncode=0, stdout="fixed second post-validation gap")
+        fake.queue_result(returncode=0)  # second fix git add
+        fake.queue_result(returncode=0, stdout="docs/api.md\n")  # second fix cached diff
+        fake.queue_result(returncode=0)  # second fix commit
+        _queue_validation_head(fake, head="c" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers again
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=satisfied_report)
         fake.queue_result(
             returncode=0,
@@ -1161,8 +1182,19 @@ class TestHappyPath:
             for prompt in adapter_prompts
             if "post-validation plan conformance" in prompt
         )
+        post_validation_conformance_prompts = [
+            prompt
+            for prompt in adapter_prompts
+            if "Conformance phase" in prompt and "### Validation evidence" in prompt
+        ]
 
         assert "Wire the API endpoint required by the saved plan." in fix_prompt
+        assert [
+            line
+            for prompt in post_validation_conformance_prompts
+            for line in prompt.splitlines()
+            if line.startswith("Iteration: ")
+        ] == ["Iteration: 1", "Iteration: 2", "Iteration: 3"]
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             runs = (
@@ -1197,8 +1229,12 @@ class TestHappyPath:
 
         assert ws is not None
         assert ws.status == WorkspaceStatus.completed.value
-        assert [run["status"] for run in runs] == ["succeeded", "succeeded"]
-        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK", "VALIDATION_OK"]
+        assert [run["status"] for run in runs] == ["succeeded", "succeeded", "succeeded"]
+        assert [run["reason_code"] for run in runs] == [
+            "VALIDATION_OK",
+            "VALIDATION_OK",
+            "VALIDATION_OK",
+        ]
         assert operation["status"] == "succeeded"
         assert operation["error_code"] is None
         assert operation["finished_at"] is not None

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -912,6 +912,183 @@ class TestHappyPath:
         assert result["validation_run_id"]
 
     @pytest.mark.unit
+    async def test_post_validation_conformance_gap_runs_fix_pass_before_terminal_failure(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        operation_id = "op_post_validation_conformance_gap"
+        async with factory() as session:
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO operations (
+                        id,
+                        workspace_id,
+                        type,
+                        status,
+                        payload,
+                        created_at
+                    )
+                    VALUES (
+                        :operation_id,
+                        :workspace_id,
+                        'validate',
+                        'pending',
+                        CAST(:payload AS JSON),
+                        :created_at
+                    )
+                    """
+                ),
+                {
+                    "operation_id": operation_id,
+                    "workspace_id": ws_id,
+                    "payload": json.dumps({"requested_tier": 1}),
+                    "created_at": datetime.now(UTC),
+                },
+            )
+            await session.commit()
+        handoff_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Only AWF validation evidence is missing.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        )
+        post_validation_gap_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Validation passed, but the API is still incomplete.",
+                "gaps": ["Wire the API endpoint required by the saved plan."],
+            }
+        )
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # before planning
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # initial execute
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=handoff_report)
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                f"?? docs/awf-plans/{ws_id}.md\n"
+                f"?? docs/awf-plans/{ws_id}.conformance.json\n"
+                " M src/x.py\n"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD post-iter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=post_validation_gap_report)
+        fake.queue_result(
+            returncode=0,
+            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        fake.queue_result(returncode=0, stdout="fixed post-validation gap")  # fix pass
+        fake.queue_result(returncode=0)  # fix git add
+        fake.queue_result(returncode=0, stdout="src/api.py\n")  # fix cached diff
+        fake.queue_result(returncode=0)  # fix commit
+        _queue_validation_head(fake, head="b" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=satisfied_report)
+        fake.queue_result(
+            returncode=0,
+            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        _queue_pre_push_diagnostics(fake)
+        fake.queue_result(returncode=0)  # git push
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompts = [
+            call.args[-1]
+            for call in fake.calls
+            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
+        ]
+        fix_prompt = next(
+            prompt
+            for prompt in adapter_prompts
+            if "post-validation plan conformance" in prompt
+        )
+
+        assert "Wire the API endpoint required by the saved plan." in fix_prompt
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            runs = (
+                (
+                    await s.execute(
+                        text(
+                            "SELECT status, reason_code FROM validation_runs "
+                            "WHERE workspace_id = :workspace_id ORDER BY started_at"
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, result, finished_at
+                            FROM operations
+                            WHERE id = :operation_id
+                            """
+                        ),
+                        {"operation_id": operation_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        assert [run["status"] for run in runs] == ["succeeded", "succeeded"]
+        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK", "VALIDATION_OK"]
+        assert operation["status"] == "succeeded"
+        assert operation["error_code"] is None
+        assert operation["finished_at"] is not None
+        assert _json_value(operation["result"])["reason_code"] == "VALIDATION_OK"
+
+    @pytest.mark.unit
     async def test_planning_validation_handoff_cleanup_failure_finishes_validate_operation(
         self,
         executor: WorkspaceExecutor,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1649,8 +1649,12 @@ class TestHappyPath:
         post_validation_conformance_index = max(
             index for index, prompt in enumerate(adapter_prompts) if "Conformance phase" in prompt
         )
+        post_validation_prompt = adapter_prompts[post_validation_conformance_index]
 
         assert fix_prompt_index < post_validation_conformance_index
+        assert "### Validation evidence" in post_validation_prompt
+        assert "VALIDATION_OK" in post_validation_prompt
+        assert "COMMAND_FAILED" not in post_validation_prompt
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
             runs = (

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1721,6 +1721,11 @@ class TestHappyPath:
 
         assert len(adapter_prompts) == 5
         assert iteration_prompt_index < validation_call_index
+        async with factory() as s:
+            events = await WorkspaceEventRepository(s).list(workspace_id=ws_id, limit=100)
+        assert not any(
+            event.reason_code == CONFORMANCE_REQUIRES_AWF_VALIDATION for event in events
+        )
 
     @pytest.mark.unit
     async def test_planning_profile_failure_records_conformance_evidence_and_salvage(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -116,6 +116,14 @@ def _queue_validation_head(fake: FakeCommandRunner, head: str = "deadbeef01") ->
     fake.queue_result(returncode=0, stdout=f"{head}\n")  # pre-validation rev-parse HEAD
 
 
+def _queue_post_validation_conformance_report_commit(
+    fake: FakeCommandRunner, report_path: str
+) -> None:
+    fake.queue_result(returncode=0)  # git add report
+    fake.queue_result(returncode=0, stdout=f"{report_path}\n")  # cached report diff
+    fake.queue_result(returncode=0)  # commit refreshed report
+
+
 def _created_pr_body(fake: FakeCommandRunner) -> str:
     create_call = next(call.args for call in fake.calls if call.args[:3] == ["gh", "pr", "create"])
     return create_call[create_call.index("--body") + 1]
@@ -702,6 +710,9 @@ class TestHappyPath:
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        _queue_post_validation_conformance_report_commit(
+            fake, f"docs/awf-plans/{ws_id}.conformance.json"
+        )
         _queue_pre_push_diagnostics(fake)
         fake.queue_result(returncode=0)  # git push
         fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
@@ -1029,6 +1040,9 @@ class TestHappyPath:
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        _queue_post_validation_conformance_report_commit(
+            fake, f"docs/awf-plans/{ws_id}.conformance.json"
+        )
         _queue_pre_push_diagnostics(fake)
         fake.queue_result(returncode=0)  # git push
         fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
@@ -1254,6 +1268,9 @@ class TestHappyPath:
         fake.queue_result(
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        _queue_post_validation_conformance_report_commit(
+            fake, f"docs/awf-plans/{ws_id}.conformance.json"
         )
         _queue_pre_push_diagnostics(fake)
         fake.queue_result(returncode=0)

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -705,11 +705,13 @@ class TestHappyPath:
         _queue_validation_head(fake)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
         fake.queue_result(
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
         _queue_post_validation_conformance_report_commit(
             fake, f"docs/awf-plans/{ws_id}.conformance.json"
         )
@@ -871,6 +873,7 @@ class TestHappyPath:
         _queue_validation_head(fake)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
         fake.queue_result(returncode=1, stderr="conformance runner failed")
 
         await executor.execute(ws_id)
@@ -1023,11 +1026,13 @@ class TestHappyPath:
         _queue_validation_head(fake)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=post_validation_gap_report)
         fake.queue_result(
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
         fake.queue_result(returncode=0, stdout="fixed post-validation gap")  # fix pass
         fake.queue_result(returncode=0)  # fix git add
         fake.queue_result(returncode=0, stdout="src/api.py\n")  # fix cached diff
@@ -1035,11 +1040,13 @@ class TestHappyPath:
         _queue_validation_head(fake, head="b" * 40)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=satisfied_report)
         fake.queue_result(
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
         _queue_post_validation_conformance_report_commit(
             fake, f"docs/awf-plans/{ws_id}.conformance.json"
         )
@@ -1131,6 +1138,7 @@ class TestHappyPath:
         _queue_validation_head(fake)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
         fake.queue_result(
             returncode=124,
             stderr="idle timeout exceeded",
@@ -1264,11 +1272,13 @@ class TestHappyPath:
         _queue_validation_head(fake, head="b" * 40)
         fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
         fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
         fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
         fake.queue_result(
             returncode=0,
             stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
         )
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
         _queue_post_validation_conformance_report_commit(
             fake, f"docs/awf-plans/{ws_id}.conformance.json"
         )

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -26,7 +26,11 @@ from awf.control.executor import (
     _apply_baseline_coverage_ratchet,
 )
 from awf.db.enums import AgentRuntime, WorkspaceStatus
-from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.repositories import (
+    ValidationRunRepository,
+    WorkspaceEventRepository,
+    WorkspaceRepository,
+)
 from awf.db.session import make_session_factory
 from awf.node.compose_manager import ComposeManager
 from awf.runtime.planning import (
@@ -768,6 +772,64 @@ class TestHappyPath:
             if event.reason_code == CONFORMANCE_REQUIRES_AWF_VALIDATION
         ]
         assert handoff_events
+
+    @pytest.mark.unit
+    async def test_validation_handoff_evidence_prefers_coverage_column_and_redacts(
+        self,
+        executor: WorkspaceExecutor,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+
+        async with factory() as session:
+            repo = ValidationRunRepository(session)
+            run = await repo.start(
+                workspace_id=ws_id,
+                attempt_id=None,
+                tier=1,
+                commands=[
+                    {
+                        "phase": "validate",
+                        "command": "GITHUB_TOKEN=ghp_secretvalue123 pytest -q",
+                    }
+                ],
+                base_commit="base",
+                target_branch="main",
+                target_head_sha="target",
+                log_stream_refs={
+                    "coverage": {
+                        "status": "failed",
+                        "reason_code": "COVERAGE_BELOW_THRESHOLD",
+                        "percent": 72.0,
+                    }
+                },
+            )
+            await repo.finish(
+                run.id,
+                status="succeeded",
+                reason_code="VALIDATION_OK",
+                coverage={
+                    "status": "passed",
+                    "reason_code": "COVERAGE_OK",
+                    "percent": 99.4,
+                },
+            )
+            run.log_stream_refs = {
+                "coverage": {
+                    "status": "failed",
+                    "reason_code": "COVERAGE_BELOW_THRESHOLD",
+                    "percent": 72.0,
+                }
+            }
+            await session.commit()
+            validation_run_id = run.id
+
+        evidence = await executor._validation_run_evidence_for_conformance(validation_run_id)
+
+        assert "COVERAGE_OK" in evidence
+        assert "COVERAGE_BELOW_THRESHOLD" not in evidence
+        assert "ghp_secretvalue123" not in evidence
+        assert "[redacted]" in evidence
 
     @pytest.mark.unit
     async def test_planning_validation_handoff_agent_failure_finishes_validate_operation(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1811,6 +1811,152 @@ class TestHappyPath:
         assert [run["reason_code"] for run in runs] == ["COMMAND_FAILED", "VALIDATION_OK"]
 
     @pytest.mark.unit
+    async def test_planning_validation_handoff_keeps_remaining_conformance_fix_iteration(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=fake,
+            compose=ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE),
+            validation=ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts"),
+            pr_creator=PullRequestCreator(fake),
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "work" / "worktrees",
+                compose_projects_root=tmp_path / "work" / "compose",
+                default_models={AgentRuntime.codex: "gpt-5"},
+                max_validation_fix_passes=0,
+            ),
+        )
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned",
+                "planning": {"required": True, "max_iterations": 1},
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        handoff_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Only AWF validation evidence is missing.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        )
+        post_validation_gap_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Validation passed, but the implementation still misses behavior.",
+                "gaps": ["Add the behavior required by the saved plan."],
+            }
+        )
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # changed paths before planning
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # execution adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=handoff_report)  # conformance handoff
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                f"?? docs/awf-plans/{ws_id}.md\n"
+                f"?? {report_path}\n"
+                " M src/x.py\n"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD post-iter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        _queue_validation_head(fake, head="b" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'b' * 40}\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=post_validation_gap_report)
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        fake.queue_result(returncode=0, stdout="implemented missing behavior")  # fix adapter
+        fake.queue_result(returncode=0)  # fix git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # fix cached diff
+        fake.queue_result(returncode=0)  # fix commit
+        _queue_validation_head(fake, head="c" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=satisfied_report)
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        _queue_post_validation_conformance_report_commit(fake, report_path)
+        _queue_pre_push_diagnostics(fake, head="c" * 40)
+        fake.queue_result(returncode=0)  # git push
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompts = [
+            call.args[-1]
+            for call in fake.calls
+            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
+        ]
+        fix_prompts = [
+            prompt
+            for prompt in adapter_prompts
+            if "Validation failed after your previous pass" in prompt
+        ]
+        post_validation_conformance_prompts = [
+            prompt
+            for prompt in adapter_prompts
+            if "Conformance phase" in prompt and "### Validation evidence" in prompt
+        ]
+
+        assert len(fix_prompts) == 1
+        assert "post-validation plan conformance" in fix_prompts[0]
+        assert [
+            line
+            for prompt in post_validation_conformance_prompts
+            for line in prompt.splitlines()
+            if line.startswith("Iteration: ")
+        ] == ["Iteration: 1", "Iteration: 2"]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            runs = (
+                (
+                    await s.execute(
+                        text(
+                            "SELECT status, reason_code FROM validation_runs "
+                            "WHERE workspace_id = :workspace_id ORDER BY started_at"
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        assert [run["status"] for run in runs] == ["succeeded", "succeeded"]
+        assert [run["reason_code"] for run in runs] == ["VALIDATION_OK", "VALIDATION_OK"]
+
+    @pytest.mark.unit
     async def test_post_validation_conformance_fix_does_not_consume_validation_fix_budget(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -30,6 +30,7 @@ from awf.db.session import make_session_factory
 from awf.node.compose_manager import ComposeManager
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
+    CONFORMANCE_REQUIRES_AWF_VALIDATION,
     PLAN_CONFORMANCE_UNSATISFIED,
 )
 from awf.runtime.pr_creator import PullRequestCreator
@@ -583,6 +584,267 @@ class TestHappyPath:
             assert ws.last_activity_at is not None
 
     @pytest.mark.unit
+    async def test_planning_validation_handoff_runs_validation_then_conformance_only_check(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                    "enforce_plan_only_changes": True,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+
+        handoff_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Implementation appears complete; AWF validation evidence is missing.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+            }
+        )
+        satisfied_report = json.dumps(
+            {"status": "satisfied", "summary": "implementation and validation satisfy plan", "gaps": []}
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # changed paths before planning
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # execution adapter
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=handoff_report)  # conformance handoff
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                f"?? docs/awf-plans/{ws_id}.md\n"
+                f"?? docs/awf-plans/{ws_id}.conformance.json\n"
+                " M src/x.py\n"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="base_commit_sha\n")  # rev-parse HEAD post-iter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(
+            returncode=0,
+            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        _queue_pre_push_diagnostics(fake)
+        fake.queue_result(returncode=0)  # git push
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompt_calls = [
+            (index, call.args[-1])
+            for index, call in enumerate(fake.calls)
+            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
+        ]
+        prompts = [prompt for _, prompt in adapter_prompt_calls]
+        validation_call_index = next(
+            index
+            for index, call in enumerate(fake.calls)
+            if "pytest -q" in call.args[-1] and "codex" not in call.args
+        )
+        conformance_call_indexes = [
+            index for index, prompt in adapter_prompt_calls if "Conformance phase" in prompt
+        ]
+        phase_names = []
+        for prompt in prompts:
+            if "## Planning phase" in prompt:
+                phase_names.append("planning")
+            elif "## Execution phase" in prompt:
+                phase_names.append("execution")
+            elif "## Conformance phase" in prompt:
+                phase_names.append("conformance")
+
+        assert phase_names == ["planning", "execution", "conformance", "conformance"]
+        assert conformance_call_indexes[-1] > validation_call_index
+        assert "Validation evidence" in prompts[-1]
+        assert "VALIDATION_OK" in prompts[-1]
+        assert "validation.01_validate.stdout" in prompts[-1]
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            events = await WorkspaceEventRepository(s).list(workspace_id=ws_id, limit=20)
+            runs = (
+                (
+                    await s.execute(
+                        text(
+                            "SELECT status, reason_code, log_stream_refs "
+                            "FROM validation_runs WHERE workspace_id = :workspace_id"
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert ws.status == WorkspaceStatus.completed.value
+        assert runs[0]["status"] == "succeeded"
+        assert runs[0]["reason_code"] == "VALIDATION_OK"
+        assert _json_value(runs[0]["log_stream_refs"]) == {
+            "commands": [
+                {
+                    "stdout": "validation.01_validate.stdout",
+                    "stderr": "validation.01_validate.stderr",
+                }
+            ]
+        }
+        handoff_events = [
+            event
+            for event in events
+            if event.reason_code == CONFORMANCE_REQUIRES_AWF_VALIDATION
+        ]
+        assert handoff_events
+
+    @pytest.mark.unit
+    async def test_planning_validation_handoff_uses_validation_fix_cycle_before_rerun(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=fake,
+            compose=ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE),
+            validation=ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts"),
+            pr_creator=PullRequestCreator(fake),
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "work" / "worktrees",
+                compose_projects_root=tmp_path / "work" / "compose",
+                default_models={AgentRuntime.codex: "gpt-5"},
+                max_validation_fix_passes=1,
+            ),
+        )
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned",
+                "planning": {"required": True, "max_iterations": 1},
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        handoff_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Only AWF validation evidence is missing.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        )
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # before planning
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # initial execute
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=handoff_report)
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                f"?? docs/awf-plans/{ws_id}.md\n"
+                f"?? docs/awf-plans/{ws_id}.conformance.json\n"
+                " M src/x.py\n"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD post-iter
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+        fake.queue_result(returncode=0)  # git add
+        fake.queue_result(returncode=0, stdout="src/x.py\n")  # cached diff
+        fake.queue_result(returncode=0)  # git commit
+        fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=1, stderr="pytest: failed")  # validation fails
+        fake.queue_result(returncode=0, stdout="fixed tests")  # validation fix adapter
+        fake.queue_result(returncode=0)  # fix git add
+        fake.queue_result(returncode=0, stdout="tests/test_x.py\n")  # fix cached diff
+        fake.queue_result(returncode=0)  # fix commit
+        _queue_validation_head(fake, head="b" * 40)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation recovers
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(
+            returncode=0,
+            stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        )
+        _queue_pre_push_diagnostics(fake)
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompts = [
+            call.args[-1]
+            for call in fake.calls
+            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
+        ]
+        fix_prompt_index = next(
+            index
+            for index, prompt in enumerate(adapter_prompts)
+            if "Validation failed after your previous pass" in prompt
+        )
+        post_validation_conformance_index = max(
+            index for index, prompt in enumerate(adapter_prompts) if "Conformance phase" in prompt
+        )
+
+        assert fix_prompt_index < post_validation_conformance_index
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            runs = (
+                (
+                    await s.execute(
+                        text(
+                            "SELECT status, reason_code FROM validation_runs "
+                            "WHERE workspace_id = :workspace_id ORDER BY started_at"
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        assert [run["status"] for run in runs] == ["failed", "succeeded"]
+        assert [run["reason_code"] for run in runs] == ["COMMAND_FAILED", "VALIDATION_OK"]
+
+    @pytest.mark.unit
     async def test_planning_profile_iterates_when_conformance_reports_gaps(
         self,
         executor: WorkspaceExecutor,
@@ -644,6 +906,88 @@ class TestHappyPath:
         ]
         assert len(adapter_prompts) == 5
         assert "Iteration 1" in adapter_prompts[3]
+
+    @pytest.mark.unit
+    async def test_planning_mixed_validation_and_api_gap_stays_agent_owned(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned",
+                "planning": {
+                    "required": True,
+                    "max_iterations": 1,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        mixed_report = json.dumps(
+            {
+                "status": "needs_iteration",
+                "summary": "Validation evidence is missing and a real API gap remains.",
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": [
+                    "AWF-owned validation evidence is missing.",
+                    "Wire the API endpoint required by the plan.",
+                ],
+            }
+        )
+
+        fake.queue_result(returncode=0, stdout="")  # before planning
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD baseline
+        fake.queue_result(returncode=0, stdout="plan written")  # planning
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n")
+        fake.queue_result(returncode=0, stdout="")  # committed_paths_since
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD pre-loop
+        fake.queue_result(returncode=0, stdout="implemented")  # initial execute
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout=mixed_report)
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD iter 0 post
+        fake.queue_result(returncode=0, stdout="fixed api")  # iteration execute
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(
+            returncode=0,
+            stdout='{"status":"satisfied","summary":"done","gaps":[]}',
+        )
+        fake.queue_result(returncode=0, stdout=f"?? docs/awf-plans/{ws_id}.md\n M src/x.py\n")
+        fake.queue_result(returncode=0, stdout="sha1\n")  # rev-parse HEAD iter 1 post
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="src/x.py\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")
+        _queue_pre_push_diagnostics(fake)
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="https://github.com/a/b/pull/1")
+
+        await executor.execute(ws_id)
+
+        adapter_prompts = [
+            call.args[-1]
+            for call in fake.calls
+            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
+        ]
+        validation_call_index = next(
+            index
+            for index, call in enumerate(fake.calls)
+            if "pytest -q" in call.args[-1] and "codex" not in call.args
+        )
+        iteration_prompt_index = next(
+            index
+            for index, call in enumerate(fake.calls)
+            if "## Execution phase" in call.args[-1] and "Iteration 1" in call.args[-1]
+        )
+
+        assert len(adapter_prompts) == 5
+        assert iteration_prompt_index < validation_call_index
 
     @pytest.mark.unit
     async def test_planning_profile_failure_records_conformance_evidence_and_salvage(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -1348,6 +1348,107 @@ class TestHappyPath:
         assert result["validation_run_id"]
 
     @pytest.mark.unit
+    async def test_planning_validation_handoff_unexpected_post_validation_error_finishes_validate_operation(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(
+            factory,
+            resolved_profile={
+                "name": "planned-recovery",
+                "planning": {
+                    "required": True,
+                    "plan_path": "docs/awf-plans/{workspace_id}.md",
+                    "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+                    "max_iterations": 2,
+                },
+                "phases": {"validate": ["pytest -q"]},
+            },
+        )
+        operation_id = "op_pv_unexpected_failed"
+        await _insert_validate_handoff_recovery_operation(
+            factory,
+            workspace_id=ws_id,
+            operation_id=operation_id,
+        )
+
+        async def fail_record_event(**_: object) -> None:
+            raise RuntimeError("event persistence exploded")
+
+        executor._record_post_validation_conformance_event = fail_record_event  # type: ignore[method-assign]
+
+        report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+        satisfied_report = json.dumps(
+            {
+                "status": "satisfied",
+                "summary": "implementation and validation evidence satisfy the plan",
+                "gaps": [],
+            }
+        )
+
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0, stdout="tests ok")  # validation
+        fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+        fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
+        fake.queue_result(returncode=0, stdout=satisfied_report)  # conformance-only rerun
+        fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+        fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+        _queue_post_validation_conformance_report_commit(fake, report_path)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            run = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, reason_code
+                            FROM validation_runs
+                            WHERE workspace_id = :workspace_id
+                            """
+                        ),
+                        {"workspace_id": ws_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+            operation = (
+                (
+                    await s.execute(
+                        text(
+                            """
+                            SELECT status, error_code, error_message, result, finished_at
+                            FROM operations
+                            WHERE id = :operation_id
+                            """
+                        ),
+                        {"operation_id": operation_id},
+                    )
+                )
+                .mappings()
+                .one()
+            )
+
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert ws.failure_reason == "infrastructure_failure"
+        assert "post-validation conformance check failed" in (ws.failure_message or "")
+        assert "event persistence exploded" in (ws.failure_message or "")
+        assert run == {"status": "succeeded", "reason_code": "VALIDATION_OK"}
+        assert operation["status"] == "failed"
+        assert operation["error_code"] == "POST_VALIDATION_CONFORMANCE_FAILED"
+        assert operation["finished_at"] is not None
+        assert "event persistence exploded" in operation["error_message"]
+        result = _json_value(operation["result"])
+        assert result["reason_code"] == "POST_VALIDATION_CONFORMANCE_FAILED"
+        assert result["validation_run_id"]
+
+    @pytest.mark.unit
     async def test_planning_validation_handoff_uses_validation_fix_cycle_before_rerun(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -885,6 +885,68 @@ class TestHappyPath:
         assert "[redacted]" in evidence
 
     @pytest.mark.unit
+    async def test_validation_handoff_evidence_keeps_late_coverage_command_provenance(
+        self,
+        executor: WorkspaceExecutor,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+        commands = [
+            {"phase": "validate", "command": f"pytest tests/unit/test_{idx}.py -q"}
+            for idx in range(24)
+        ]
+        commands.append(
+            {
+                "phase": "coverage",
+                "command": "pytest --cov=awf --cov-report=term",
+            }
+        )
+
+        async with factory() as session:
+            repo = ValidationRunRepository(session)
+            run = await repo.start(
+                workspace_id=ws_id,
+                attempt_id=None,
+                tier=1,
+                commands=commands,
+                base_commit="base",
+                target_branch="main",
+                target_head_sha="target",
+                log_stream_refs={},
+            )
+            await repo.finish(
+                run.id,
+                status="succeeded",
+                reason_code="VALIDATION_OK",
+                coverage={
+                    "status": "passed",
+                    "reason_code": "COVERAGE_OK",
+                    "percent": 99.4,
+                },
+                coverage_evidence_status="reused",
+                coverage_evidence_reason_code="COVERAGE_EVIDENCE_REUSED",
+            )
+            validation_run_id = run.id
+            await session.commit()
+
+        evidence = await executor._validation_run_evidence_for_conformance(validation_run_id)
+        json_text = evidence.split("```json\n", 1)[1].split("\n```", 1)[0]
+        payload = json.loads(json_text)
+        coverage_commands = [
+            command for command in payload["commands"] if command.get("phase") == "coverage"
+        ]
+
+        assert len(payload["commands"]) == 25
+        assert coverage_commands == [
+            {
+                "phase": "coverage",
+                "command": "pytest --cov=awf --cov-report=term",
+                "evidence_status": "reused",
+                "evidence_reason_code": "COVERAGE_EVIDENCE_REUSED",
+            }
+        ]
+
+    @pytest.mark.unit
     async def test_validation_handoff_evidence_keeps_large_payload_json_valid(
         self,
         executor: WorkspaceExecutor,

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -361,6 +361,35 @@ async def test_post_validation_report_repairs_git_ownership_before_add(
 
 
 @pytest.mark.unit
+async def test_post_validation_report_unstages_report_when_cached_diff_fails(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    runner.queue_result(returncode=0)  # git add report
+    runner.queue_result(returncode=128, stderr="fatal: index.lock exists")
+    runner.queue_result(returncode=0)  # git reset report
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    with pytest.raises(executor_mod._PostValidationConformanceReportGitError) as exc_info:
+        await executor._commit_post_validation_conformance_report(
+            workspace_id="ws_post",
+            worktree_path=tmp_path / "worktree",
+            report_path=report_path,
+            validation_run_id="validation-run-1",
+        )
+
+    assert exc_info.value.operation == "diff"
+    assert runner.calls[-1].args[-4:] == [
+        "reset",
+        "-q",
+        "--",
+        report_path.as_posix(),
+    ]
+
+
+@pytest.mark.unit
 def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
     oversized_percent = {f"pkg_{index}": "x" * 1000 for index in range(100)}
     payload = {
@@ -389,6 +418,10 @@ def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
     assert decoded["evidence_truncated"] is True
     assert decoded["coverage"]["truncated"] is True
     assert "percent" not in decoded["coverage"]
+    assert decoded["oversized_serialized_length"] == len(
+        json.dumps(executor_mod.redact_audit_value(payload), default=str)
+    )
+    assert decoded["oversized_serialized_length"] > len(evidence)
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -477,6 +477,74 @@ async def test_post_validation_conformance_rejects_committed_implementation_path
     executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
 
 
+@pytest.mark.unit
+async def test_post_validation_conformance_rejects_committed_paths_when_deviation_guard_disabled(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="")  # clean status after conformance
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._git_rev_parse_head = AsyncMock(return_value="validated-head")  # type: ignore[method-assign]
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("src/unvalidated.py")}
+    )
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planned",
+            "planning": {
+                "required": True,
+                "fail_on_unexplained_deviation": False,
+            },
+        }
+    )
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(
+            '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.reason_code == AGENT_PLAN_PHASE_SCOPE_VIOLATION
+    assert failure.details is not None
+    assert failure.details["planning_scope"]["offending_paths"] == ["src/unvalidated.py"]
+    executor._git_rev_parse_head.assert_awaited_once_with(  # type: ignore[attr-defined]
+        tmp_path / "worktree"
+    )
+    executor._committed_paths_since.assert_awaited_once_with(  # type: ignore[attr-defined]
+        tmp_path / "worktree",
+        "validated-head",
+    )
+    executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
+
+
 def _coordination_task_policy() -> dict[str, object]:
     return {
         "coordination": {

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -256,7 +256,9 @@ async def test_satisfied_post_validation_conformance_report_is_committed(
         encoding="utf-8",
     )
     runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="validated-head\n")
     runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="")  # committed paths since validated HEAD
     runner.queue_result(returncode=0)  # git add report
     runner.queue_result(returncode=0, stdout=f"{report_path.as_posix()}\n")
     runner.queue_result(returncode=0)  # git commit report
@@ -311,6 +313,67 @@ async def test_satisfied_post_validation_conformance_report_is_committed(
     assert add_index < commit_index
     assert event_markers == [("record", len(runner.calls))]
     assert commit_index < event_markers[0][1]
+
+
+@pytest.mark.unit
+async def test_post_validation_conformance_rejects_committed_implementation_paths(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="")  # clean status after conformance
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._git_rev_parse_head = AsyncMock(return_value="validated-head")  # type: ignore[method-assign]
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("src/unvalidated.py")}
+    )
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(
+            '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.reason_code == AGENT_PLAN_PHASE_SCOPE_VIOLATION
+    assert failure.message.startswith(
+        "post-validation conformance phase changed files outside "
+        "`docs/awf-plans/ws_post.conformance.json`"
+    )
+    assert failure.details is not None
+    assert failure.details["planning_scope"]["offending_paths"] == ["src/unvalidated.py"]
+    executor._committed_paths_since.assert_awaited_once_with(  # type: ignore[attr-defined]
+        tmp_path / "worktree",
+        "validated-head",
+    )
+    executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 def _coordination_task_policy() -> dict[str, object]:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -425,6 +425,42 @@ def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
 
 
 @pytest.mark.unit
+def test_validation_evidence_floor_payload_special_cases_coverage_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coverage = {
+        "status": "failed",
+        "reason_code": "COVERAGE_BELOW_THRESHOLD",
+        "percent": {f"pkg_{index}": "x" * 1000 for index in range(10)},
+    }
+    payload = {
+        "validation_run_id": "validation-run-1",
+        "status": "failed",
+        "coverage": coverage,
+    }
+    floor_values: list[object] = []
+    original_floor_value = executor_mod._validation_evidence_floor_value
+
+    def record_floor_value(value: object) -> object:
+        floor_values.append(value)
+        return original_floor_value(value)
+
+    monkeypatch.setattr(
+        executor_mod,
+        "_validation_evidence_floor_value",
+        record_floor_value,
+    )
+
+    floor_payload = executor_mod._validation_evidence_floor_payload(
+        payload,
+        oversized_serialized_length=123456,
+    )
+
+    assert coverage not in floor_values
+    assert floor_payload["coverage"] == executor_mod._validation_evidence_size_summary(coverage)
+
+
+@pytest.mark.unit
 def test_validation_evidence_serializer_uses_evidence_limit_for_redaction_expansion() -> None:
     payload = {"output": " ".join(["SECRET=a"] * 2166)}
     raw_length = len(json.dumps(payload, default=str))
@@ -437,6 +473,42 @@ def test_validation_evidence_serializer_uses_evidence_limit_for_redaction_expans
     assert "[redacted]" in evidence
     assert "SECRET=a" not in evidence
     assert evidence.endswith("...[truncated]")
+
+
+@pytest.mark.unit
+def test_post_validation_conformance_fix_result_preserves_attempt_artifacts(
+    tmp_path: Path,
+) -> None:
+    first = executor_mod._post_validation_conformance_fix_result(
+        failure=executor_mod._PlanningRunFailure(
+            message="first conformance gap",
+            reason_code=PLAN_CONFORMANCE_UNSATISFIED,
+        ),
+        workspace_id="ws_post",
+        artifacts_root=tmp_path,
+        attempt=1,
+    )
+    second = executor_mod._post_validation_conformance_fix_result(
+        failure=executor_mod._PlanningRunFailure(
+            message="second conformance gap",
+            reason_code=PLAN_CONFORMANCE_UNSATISFIED,
+        ),
+        workspace_id="ws_post",
+        artifacts_root=tmp_path,
+        attempt=2,
+    )
+
+    first_command = first.commands[0]
+    second_command = second.commands[0]
+    assert first_command.stdout_path.name == "post_validation_conformance.1.stdout"
+    assert first_command.stderr_path.name == "post_validation_conformance.1.stderr"
+    assert second_command.stdout_path.name == "post_validation_conformance.2.stdout"
+    assert second_command.stderr_path.name == "post_validation_conformance.2.stderr"
+    assert first_command.stdout_path.read_text(encoding="utf-8") == "first conformance gap"
+    assert second_command.stdout_path.read_text(encoding="utf-8") == "second conformance gap"
+    assert not (
+        tmp_path / "ws_post" / "post_validation_conformance" / "post_validation_conformance.stdout"
+    ).exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -1199,82 +1199,85 @@ async def test_final_coverage_gate_caps_parallel_workers_to_active_reservation(
     tmp_path: Path,
 ) -> None:
     engine = await create_postgres_test_engine()
-    factory = make_session_factory(engine)
-    profile = WorkspaceProfile.model_validate(
-        {
-            "name": "final-gate-parallel",
-            "validation": {
-                "strategy": {"final_gate": "coverage"},
-                "coverage": {
-                    "minimum_percent": 99,
-                    "command": "pytest --cov=awf",
-                    "parallel_workers": 20,
+    try:
+        factory = make_session_factory(engine)
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "final-gate-parallel",
+                "validation": {
+                    "strategy": {"final_gate": "coverage"},
+                    "coverage": {
+                        "minimum_percent": 99,
+                        "command": "pytest --cov=awf",
+                        "parallel_workers": 20,
+                    },
                 },
-            },
-        }
-    )
-    async with factory() as session:
-        workspace = await WorkspaceRepository(session).create(
-            repo_url="git@github.com:example/awf.git",
-            branch_base="main",
-            task_title="parallel final coverage",
-            task_prompt="parallel final coverage",
-            agent="codex",
-            test_commands=[],
+            }
         )
-        task = await TaskRepository(session).create_or_get(
-            repo_url=workspace.repo_url,
-            base_branch=workspace.branch_base,
-            title=workspace.task_title,
-            prompt=workspace.task_prompt,
-            external_id=None,
-            idempotency_key=None,
-            task_class=None,
-            owned_paths=[],
-        )
-        attempt = await TaskAttemptRepository(session).create_for_workspace(
-            task=task,
-            workspace=workspace,
-        )
-        await ResourceReservationRepository(session).create(
-            workspace_id=workspace.id,
-            attempt_id=attempt.id,
-            node_id="local",
-            steady_cpu=3.0,
-            steady_memory_gb=10.0,
-            peak_cpu=6.0,
-            peak_memory_gb=16.0,
-            disk_mb=None,
-            phase="execution",
-        )
-        await session.commit()
-        workspace_id = workspace.id
+        async with factory() as session:
+            workspace = await WorkspaceRepository(session).create(
+                repo_url="git@github.com:example/awf.git",
+                branch_base="main",
+                task_title="parallel final coverage",
+                task_prompt="parallel final coverage",
+                agent="codex",
+                test_commands=[],
+            )
+            task = await TaskRepository(session).create_or_get(
+                repo_url=workspace.repo_url,
+                base_branch=workspace.branch_base,
+                title=workspace.task_title,
+                prompt=workspace.task_prompt,
+                external_id=None,
+                idempotency_key=None,
+                task_class=None,
+                owned_paths=[],
+            )
+            attempt = await TaskAttemptRepository(session).create_for_workspace(
+                task=task,
+                workspace=workspace,
+            )
+            await ResourceReservationRepository(session).create(
+                workspace_id=workspace.id,
+                attempt_id=attempt.id,
+                node_id="local",
+                steady_cpu=3.0,
+                steady_memory_gb=10.0,
+                peak_cpu=6.0,
+                peak_memory_gb=16.0,
+                disk_mb=None,
+                phase="execution",
+            )
+            await session.commit()
+            workspace_id = workspace.id
 
-    coverage = _coverage(tmp_path, percent=100, status="passed", reason_code="COVERAGE_OK")
-    validation = _CoverageValidation(coverage)
-    executor = WorkspaceExecutor(
-        session_factory=factory,
-        runner=FakeCommandRunner(),
-        compose=object(),  # type: ignore[arg-type]
-        validation=validation,  # type: ignore[arg-type]
-        pr_creator=object(),  # type: ignore[arg-type]
-        config=ExecutorConfig(
-            worktrees_root=tmp_path / "worktrees",
-            compose_projects_root=tmp_path / "compose",
-        ),
-    )
+        coverage = _coverage(tmp_path, percent=100, status="passed", reason_code="COVERAGE_OK")
+        validation = _CoverageValidation(coverage)
+        executor = WorkspaceExecutor(
+            session_factory=factory,
+            runner=FakeCommandRunner(),
+            compose=object(),  # type: ignore[arg-type]
+            validation=validation,  # type: ignore[arg-type]
+            pr_creator=object(),  # type: ignore[arg-type]
+            config=ExecutorConfig(
+                worktrees_root=tmp_path / "worktrees",
+                compose_projects_root=tmp_path / "compose",
+            ),
+        )
 
-    result = await executor._run_final_coverage_gate(
-        workspace_id=workspace_id,
-        compose_project="proj",
-        compose_file=tmp_path / "compose.yml",
-        profile=profile,
-        validation_tier=1,
-        workspace_head_sha="head",
-    )
+        result = await executor._run_final_coverage_gate(
+            workspace_id=workspace_id,
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            profile=profile,
+            validation_tier=1,
+            workspace_head_sha="head",
+        )
 
-    assert result.coverage is coverage
-    assert validation.kwargs[0]["parallel_worker_cpu_limit"] == 3
+        assert result.coverage is coverage
+        assert validation.kwargs[0]["parallel_worker_cpu_limit"] == 3
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -478,6 +478,66 @@ async def test_post_validation_conformance_rejects_committed_implementation_path
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_rejects_pre_dirty_committed_paths(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    runner.queue_result(
+        returncode=0,
+        stdout=" M src/unvalidated.py\n",
+    )  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="")  # clean status after conformance
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._git_rev_parse_head = AsyncMock(return_value="validated-head")  # type: ignore[method-assign]
+    executor._committed_paths_since = AsyncMock(  # type: ignore[method-assign]
+        return_value={Path("src/unvalidated.py")}
+    )
+    executor._commit_post_validation_conformance_report = AsyncMock(  # type: ignore[method-assign]
+        return_value=True
+    )
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(
+            '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.reason_code == AGENT_PLAN_PHASE_SCOPE_VIOLATION
+    assert failure.details is not None
+    assert failure.details["planning_scope"]["offending_paths"] == ["src/unvalidated.py"]
+    executor._commit_post_validation_conformance_report.assert_not_awaited()  # type: ignore[attr-defined]
+    executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
 async def test_post_validation_conformance_rejects_committed_paths_when_deviation_guard_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -43,7 +43,7 @@ from awf.control.executor import (
     _read_text_if_present,
     _RebaseRecoveryResult,
     _recover_missing_head_from_filesystem,
-    _validate_only_recovery_needs_existing_pr_push,
+    _recovery_needs_existing_pr_push,
     _validation_command_count,
     _validation_failure_message,
     _validation_run_command_records,
@@ -130,6 +130,18 @@ def _coverage(
             False,
         ),
         (
+            {"recovery_mode": "rebase_only", "source_head_sha": "old"},
+            "rebased",
+            _RebaseRecoveryResult(base_sha="base", head_sha="rebased"),
+            False,
+        ),
+        (
+            {"recovery_mode": "rebase_only", "source_head_sha": "old"},
+            "post-validation-report",
+            _RebaseRecoveryResult(base_sha="base", head_sha="rebased"),
+            True,
+        ),
+        (
             {"recovery_mode": "validate_only", "source_head_sha": "old"},
             "new",
             _RebaseRecoveryResult(base_sha="base", head_sha="rebased"),
@@ -155,14 +167,14 @@ def _coverage(
         ),
     ],
 )
-def test_validate_only_recovery_needs_existing_pr_push_edges(
+def test_recovery_needs_existing_pr_push_edges(
     recovery_payload: dict[str, object],
     head_sha: str | None,
     rebase_result: _RebaseRecoveryResult | None,
     expected: bool,
 ) -> None:
     assert (
-        _validate_only_recovery_needs_existing_pr_push(
+        _recovery_needs_existing_pr_push(
             recovery_payload,
             validated_workspace_head_sha=head_sha,
             rebase_recovery_result=rebase_result,

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -177,6 +177,7 @@ def test_validate_only_recovery_needs_existing_pr_push_edges(
     [
         ({"iteration": 2, "max_iterations": 5}, {}, 2, 5),
         ({}, {"iteration": 1, "max_iterations": 0}, 1, 0),
+        ({}, {}, 0, 3),
     ],
 )
 def test_recovery_conformance_handoff_preserves_iteration_budget(

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -500,6 +500,55 @@ async def test_post_validation_conformance_prefers_stdout_when_report_is_stale(
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_failure_counts_handoff_iterations(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="validated-head\n")
+    runner.queue_result(returncode=0, stdout="")  # changed paths after conformance
+    runner.queue_result(returncode=0, stdout="")  # committed paths since validated HEAD
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=1,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(
+            '{"status":"needs_iteration","summary":"docs still missing",'
+            '"gaps":["Document the validated endpoint."]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=tmp_path / "worktree",
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.details is not None
+    assert failure.details["conformance"]["iterations_used"] == 3
+    assert failure.details["conformance"]["max_iterations"] == 2
+
+
+@pytest.mark.unit
 async def test_post_validation_conformance_rejects_committed_implementation_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -35,6 +35,7 @@ from awf.control.executor import (
     _git_error_indicates_missing_head_object,
     _GitObjectRecoveryResult,
     _MonitorRebaseRecoveryError,
+    _planning_validation_handoff_from_recovery_payload,
     _profile_with_planning_iteration_default,
     _raw_profile_has_explicit_planning_max_iterations,
     _read_ref_sha,
@@ -63,6 +64,7 @@ from awf.db.session import make_session_factory
 from awf.profiles.models import ProfilePlanning, WorkspaceProfile
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
+    CONFORMANCE_REQUIRES_AWF_VALIDATION,
     PLAN_CONFORMANCE_UNSATISFIED,
 )
 from awf.runtime.validation import (
@@ -164,6 +166,50 @@ def test_validate_only_recovery_needs_existing_pr_push_edges(
         )
         is expected
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("conformance_fields", "payload_fields", "expected_iteration", "expected_max_iterations"),
+    [
+        ({"iteration": 2, "max_iterations": 5}, {}, 2, 5),
+        ({}, {"iteration": 1, "max_iterations": 0}, 1, 0),
+    ],
+)
+def test_recovery_conformance_handoff_preserves_iteration_budget(
+    conformance_fields: dict[str, object],
+    payload_fields: dict[str, object],
+    expected_iteration: int,
+    expected_max_iterations: int,
+) -> None:
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planned",
+            "planning": {
+                "required": True,
+                "max_iterations": 3,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+        }
+    )
+    handoff = _planning_validation_handoff_from_recovery_payload(
+        workspace_id="ws123",
+        profile=profile,
+        recovery_payload={
+            **payload_fields,
+            "conformance": {
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "summary": "AWF validation evidence is required.",
+                "gaps": ["rerun pytest under AWF"],
+                **conformance_fields,
+            },
+        },
+    )
+
+    assert handoff is not None
+    assert handoff.iteration == expected_iteration
+    assert handoff.max_iterations == expected_max_iterations
 
 
 class _PlanningAdapter:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -544,6 +544,64 @@ async def test_post_validation_conformance_prefers_stdout_when_report_is_stale(
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_ignores_stale_report_without_stdout(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    worktree_path = tmp_path / "worktree"
+    report_file = worktree_path / report_path
+    report_file.parent.mkdir(parents=True)
+    report_file.write_text(
+        '{"status":"satisfied","summary":"stale success","gaps":[]}',
+        encoding="utf-8",
+    )
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="validated-head\n")
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="")
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._commit_post_validation_conformance_report = AsyncMock(  # type: ignore[method-assign]
+        return_value=True
+    )
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(""),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.reason_code == PLAN_CONFORMANCE_UNSATISFIED
+    assert "Produce a valid plan-conformance JSON report." in failure.message
+    executor._commit_post_validation_conformance_report.assert_not_awaited()  # type: ignore[attr-defined]
+    executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
 async def test_post_validation_conformance_failure_counts_handoff_iterations(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 from pathlib import Path
@@ -289,6 +290,76 @@ class _CoverageValidation:
         self.calls.append(phase)
         self.kwargs.append(dict(_kwargs))
         return self.coverage
+
+
+@pytest.mark.unit
+async def test_post_validation_report_repairs_git_ownership_before_add(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    runner.queue_result(returncode=0)  # git add report
+    runner.queue_result(returncode=0, stdout=f"{report_path.as_posix()}\n")
+    runner.queue_result(returncode=0)  # git commit report
+    executor = _executor_with_runner(runner, tmp_path)
+    repair_events: list[tuple[str, int]] = []
+
+    async def record_repair(**kwargs: object) -> bool:
+        reason = kwargs["reason"]
+        assert isinstance(reason, str)
+        repair_events.append((reason, len(runner.calls)))
+        return True
+
+    executor._repair_agent_git_ownership = record_repair  # type: ignore[method-assign]
+
+    committed = await executor._commit_post_validation_conformance_report(
+        workspace_id="ws_post",
+        worktree_path=tmp_path / "worktree",
+        report_path=report_path,
+        validation_run_id="validation-run-1",
+    )
+
+    add_call_index = next(
+        index
+        for index, call in enumerate(runner.calls)
+        if call.args[-3:] == ["add", "--", report_path.as_posix()]
+    )
+    assert committed is True
+    assert repair_events[0] == (
+        "post_validation_conformance_report_git_add",
+        add_call_index,
+    )
+
+
+@pytest.mark.unit
+def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
+    oversized_percent = {f"pkg_{index}": "x" * 1000 for index in range(100)}
+    payload = {
+        "validation_run_id": "validation-run-1",
+        "status": "failed",
+        "reason_code": "COVERAGE_BELOW_THRESHOLD",
+        "coverage": {
+            "status": "failed",
+            "reason_code": "COVERAGE_BELOW_THRESHOLD",
+            "percent": oversized_percent,
+            "minimum_percent": 99,
+            "enforce": True,
+            "provider": "python",
+        },
+        "workspace_head_sha": "validated-head",
+        "target_branch": "main",
+        "commands": [{"command": "pytest", "stdout": "x" * 100000}],
+        "log_stream_refs": {"stdout": "x" * 100000},
+        "raw_output": "x" * 100000,
+    }
+
+    evidence = executor_mod._validation_evidence_json(payload)
+
+    assert len(evidence) <= executor_mod._VALIDATION_EVIDENCE_JSON_LIMIT
+    decoded = json.loads(evidence)
+    assert decoded["evidence_truncated"] is True
+    assert decoded["coverage"]["truncated"] is True
+    assert "percent" not in decoded["coverage"]
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -12,8 +12,8 @@ from unittest.mock import AsyncMock
 import pytest
 
 import awf.control.executor as executor_mod
-from awf.adapters.base import AgentDefaults
-from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
+from awf.adapters.base import AgentDefaults, AgentRunError
+from awf.common.commands import AsyncioSubprocessRunner, CommandResult, FakeCommandRunner
 from awf.control.executor import (
     GIT_OBJECT_MISSING_REASON_CODE,
     GIT_OBJECT_MISSING_RECOVERED_REASON_CODE,
@@ -53,7 +53,14 @@ from awf.control.executor import (
     _validation_run_reason_code,
     _validation_tier_for_workspace,
 )
-from awf.db.enums import FailureReason, OperationStatus, OperationType, TaskClass, WorkspaceStatus
+from awf.db.enums import (
+    AgentRuntime,
+    FailureReason,
+    OperationStatus,
+    OperationType,
+    TaskClass,
+    WorkspaceStatus,
+)
 from awf.db.repositories import (
     ResourceReservationRepository,
     TaskAttemptRepository,
@@ -3337,6 +3344,78 @@ def test_validation_failure_message_carries_coverage_context(tmp_path: Path) -> 
         )
         == "validation failed"
     )
+
+
+@pytest.mark.unit
+def test_post_validation_conformance_result_uses_attempt_from_failure_details(
+    tmp_path: Path,
+) -> None:
+    failure = executor_mod._PlanningRunFailure(  # noqa: SLF001
+        message="Plan conformance still requires validation evidence.",
+        details={
+            "attempt": 2,
+            "conformance": {
+                "summary": "AWF validation evidence is missing.",
+                "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "gaps": ["pytest coverage evidence is stale", "  ", 42],
+            },
+        },
+    )
+
+    result = executor_mod._post_validation_conformance_fix_result(  # noqa: SLF001
+        failure=failure,
+        workspace_id="ws_conformance",
+        artifacts_root=tmp_path,
+    )
+
+    command = result.commands[0]
+    assert command.stdout_path.name == "post_validation_conformance.2.stdout"
+    assert command.reason_code == PLAN_CONFORMANCE_UNSATISFIED
+    text = command.stdout_path.read_text(encoding="utf-8")
+    assert "Summary: AWF validation evidence is missing." in text
+    assert f"Report reason code: {CONFORMANCE_REQUIRES_AWF_VALIDATION}" in text
+    assert "- pytest coverage evidence is stale" in text
+    assert "- 42" in text
+
+
+@pytest.mark.unit
+def test_post_validation_conformance_agent_failure_details_include_output_and_agent_details() -> None:
+    exc = AgentRunError(
+        agent=AgentRuntime.codex,
+        result=CommandResult(returncode=2, stdout="stdout detail", stderr="stderr detail"),
+        reason_code="",
+        details={"provider": "codex", "retry": True},
+    )
+
+    details = executor_mod._post_validation_conformance_agent_failure_details(  # noqa: SLF001
+        exc,
+        validation_run_id="vr_123",
+    )
+
+    assert details["validation_run_id"] == "vr_123"
+    assert details["conformance"] == {
+        "phase": "post_validation",
+        "reason_code": "AGENT_CLI_FAILED",
+        "returncode": 2,
+        "stdout": "stdout detail",
+        "stderr": "stderr detail",
+    }
+    assert details["agent"] == {"provider": "codex", "retry": True}
+
+    stdout_only = AgentRunError(
+        agent=AgentRuntime.codex,
+        result=CommandResult(returncode=1, stdout="stdout only", stderr=""),
+    )
+    stdout_only_details = executor_mod._post_validation_conformance_agent_failure_details(  # noqa: SLF001
+        stdout_only,
+        validation_run_id="vr_456",
+    )
+    assert stdout_only_details["conformance"] == {
+        "phase": "post_validation",
+        "reason_code": "AGENT_CLI_FAILED",
+        "returncode": 1,
+        "stdout": "stdout only",
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -363,6 +363,21 @@ def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
 
 
 @pytest.mark.unit
+def test_validation_evidence_serializer_uses_evidence_limit_for_redaction_expansion() -> None:
+    payload = {"output": " ".join(["SECRET=a"] * 2166)}
+    raw_length = len(json.dumps(payload, default=str))
+    assert raw_length < executor_mod._VALIDATION_EVIDENCE_JSON_LIMIT
+
+    evidence = executor_mod._serialize_validation_evidence_payload(payload)
+
+    assert len(evidence) == executor_mod._VALIDATION_EVIDENCE_JSON_LIMIT + len("...[truncated]")
+    assert len(evidence) < raw_length + 4096
+    assert "[redacted]" in evidence
+    assert "SECRET=a" not in evidence
+    assert evidence.endswith("...[truncated]")
+
+
+@pytest.mark.unit
 async def test_satisfied_post_validation_conformance_report_is_committed(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -36,6 +36,7 @@ from awf.control.executor import (
     _GitObjectRecoveryResult,
     _MonitorRebaseRecoveryError,
     _planning_validation_handoff_from_recovery_payload,
+    _PlanningValidationHandoff,
     _profile_with_planning_iteration_default,
     _raw_profile_has_explicit_planning_max_iterations,
     _read_ref_sha,
@@ -66,6 +67,8 @@ from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     CONFORMANCE_REQUIRES_AWF_VALIDATION,
     PLAN_CONFORMANCE_UNSATISFIED,
+    PlanConformanceReport,
+    PlanConformanceStatus,
 )
 from awf.runtime.validation import (
     ValidationCommandResult,
@@ -237,6 +240,77 @@ class _CoverageValidation:
         self.calls.append(phase)
         self.kwargs.append(dict(_kwargs))
         return self.coverage
+
+
+@pytest.mark.unit
+async def test_satisfied_post_validation_conformance_report_is_committed(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    worktree_path = tmp_path / "worktree"
+    report_file = worktree_path / report_path
+    report_file.parent.mkdir(parents=True)
+    report_file.write_text(
+        '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}',
+        encoding="utf-8",
+    )
+    runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0)  # git add report
+    runner.queue_result(returncode=0, stdout=f"{report_path.as_posix()}\n")
+    runner.queue_result(returncode=0)  # git commit report
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    event_markers: list[tuple[str, int]] = []
+
+    async def record_event(**_kwargs: object) -> None:
+        event_markers.append(("record", len(runner.calls)))
+
+    executor._record_post_validation_conformance_event = record_event  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(
+            '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is None
+    add_index = next(
+        index
+        for index, call in enumerate(runner.calls)
+        if call.args[-3:] == ["add", "--", report_path.as_posix()]
+    )
+    commit_index = next(
+        index for index, call in enumerate(runner.calls) if "commit" in call.args
+    )
+    assert add_index < commit_index
+    assert event_markers == [("record", len(runner.calls))]
+    assert commit_index < event_markers[0][1]
 
 
 def _coordination_task_policy() -> dict[str, object]:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -317,6 +317,70 @@ async def test_satisfied_post_validation_conformance_report_is_committed(
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_prefers_stdout_when_report_is_stale(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    worktree_path = tmp_path / "worktree"
+    report_file = worktree_path / report_path
+    report_file.parent.mkdir(parents=True)
+    report_file.write_text(
+        (
+            '{"status":"needs_iteration","summary":"AWF validation evidence is missing.",'
+            f'"reason_code":"{CONFORMANCE_REQUIRES_AWF_VALIDATION}",'
+            '"gaps":["Run AWF validation."]}'
+        ),
+        encoding="utf-8",
+    )
+    satisfied_stdout = (
+        '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+    )
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="validated-head\n")
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="")
+    runner.queue_result(returncode=0)
+    runner.queue_result(returncode=0, stdout=f"{report_path.as_posix()}\n")
+    runner.queue_result(returncode=0)
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(satisfied_stdout),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is None
+    assert "validated evidence satisfies plan" in report_file.read_text(encoding="utf-8")
+    executor._record_post_validation_conformance_event.assert_awaited_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
 async def test_post_validation_conformance_rejects_committed_implementation_paths(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -216,6 +216,42 @@ def test_recovery_conformance_handoff_preserves_iteration_budget(
     assert handoff.max_iterations == expected_max_iterations
 
 
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_path_field", ["plan_path", "report_path"])
+def test_recovery_conformance_handoff_falls_back_when_payload_path_escapes_workspace(
+    invalid_path_field: str,
+) -> None:
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planned",
+            "planning": {
+                "required": True,
+                "max_iterations": 3,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+        }
+    )
+    conformance = {
+        "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        "summary": "AWF validation evidence is required.",
+        "gaps": ["rerun pytest under AWF"],
+        "plan_path": "docs/custom-plan.md",
+        "report_path": "docs/custom-report.json",
+        invalid_path_field: "../outside.json",
+    }
+
+    handoff = _planning_validation_handoff_from_recovery_payload(
+        workspace_id="ws123",
+        profile=profile,
+        recovery_payload={"conformance": conformance},
+    )
+
+    assert handoff is not None
+    assert handoff.plan_path == Path("docs/awf-plans/ws123.md")
+    assert handoff.report_path == Path("docs/awf-plans/ws123.conformance.json")
+
+
 class _PlanningAdapter:
     def __init__(self, *stdout_values: str) -> None:
         self.stdout_values = list(stdout_values)

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -772,6 +772,75 @@ async def test_post_validation_conformance_rejects_pre_dirty_committed_paths(
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_rejects_edits_to_pre_dirty_paths(
+    tmp_path: Path,
+) -> None:
+    worktree_path = tmp_path / "worktree"
+    dirty_path = worktree_path / "src" / "unvalidated.py"
+    dirty_path.parent.mkdir(parents=True)
+    dirty_path.write_text("validation dirty content", encoding="utf-8")
+    runner = FakeCommandRunner()
+    runner.queue_result(
+        returncode=0,
+        stdout=" M src/unvalidated.py\n",
+    )  # changed paths before conformance
+    runner.queue_result(
+        returncode=0,
+        stdout=" M src/unvalidated.py\n",
+    )  # same path remains dirty after conformance
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    executor._git_rev_parse_head = AsyncMock(return_value="validated-head")  # type: ignore[method-assign]
+    executor._committed_paths_since = AsyncMock(return_value=set())  # type: ignore[method-assign]
+    executor._commit_post_validation_conformance_report = AsyncMock(  # type: ignore[method-assign]
+        return_value=True
+    )
+    executor._record_post_validation_conformance_event = AsyncMock()  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    class _SamePathEditingAdapter(_PlanningAdapter):
+        async def run(self, **kwargs: object) -> SimpleNamespace:
+            dirty_path.write_text("conformance-only edit", encoding="utf-8")
+            return await super().run(**kwargs)
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_SamePathEditingAdapter(
+            '{"status":"satisfied","summary":"validated evidence satisfies plan","gaps":[]}'
+        ),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it"),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+    )
+
+    assert failure is not None
+    assert failure.reason_code == AGENT_PLAN_PHASE_SCOPE_VIOLATION
+    assert failure.details is not None
+    assert failure.details["planning_scope"]["offending_paths"] == ["src/unvalidated.py"]
+    executor._commit_post_validation_conformance_report.assert_not_awaited()  # type: ignore[attr-defined]
+    executor._record_post_validation_conformance_event.assert_not_awaited()  # type: ignore[attr-defined]
+
+
+@pytest.mark.unit
 async def test_post_validation_conformance_rejects_committed_paths_when_deviation_guard_disabled(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -397,6 +397,48 @@ async def test_post_validation_report_unstages_report_when_cached_diff_fails(
 
 
 @pytest.mark.unit
+async def test_post_validation_report_git_error_preserves_unstage_failure_metadata(
+    tmp_path: Path,
+) -> None:
+    runner = FakeCommandRunner()
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    runner.queue_result(returncode=0)  # git add report
+    runner.queue_result(
+        returncode=128,
+        stderr="fatal: index.lock exists",
+        reason_code="GIT_DIFF_FAILED",
+    )
+    runner.queue_result(
+        returncode=129,
+        stderr="fatal: could not reset",
+        reason_code="GIT_RESET_FAILED",
+    )
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._repair_agent_git_ownership = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    with pytest.raises(executor_mod._PostValidationConformanceReportGitError) as exc_info:
+        await executor._commit_post_validation_conformance_report(
+            workspace_id="ws_post",
+            worktree_path=tmp_path / "worktree",
+            report_path=report_path,
+            validation_run_id="validation-run-1",
+        )
+
+    assert exc_info.value.operation == "diff"
+    assert exc_info.value.command_reason_code == "GIT_DIFF_FAILED"
+    assert exc_info.value.cleanup_operation == "reset"
+    assert exc_info.value.cleanup_returncode == 129
+    assert exc_info.value.cleanup_command_reason_code == "GIT_RESET_FAILED"
+    assert "git reset failed" in str(exc_info.value)
+    assert runner.calls[-1].args[-4:] == [
+        "reset",
+        "-q",
+        "--",
+        report_path.as_posix(),
+    ]
+
+
+@pytest.mark.unit
 def test_validation_evidence_json_enforces_limit_on_minimal_fallback() -> None:
     oversized_percent = {f"pkg_{index}": "x" * 1000 for index in range(100)}
     payload = {

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -230,6 +230,35 @@ def test_recovery_conformance_handoff_preserves_iteration_budget(
 
 
 @pytest.mark.unit
+def test_recovery_conformance_handoff_reads_persisted_report_reason_code() -> None:
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "planned",
+            "planning": {
+                "required": True,
+                "max_iterations": 3,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+        }
+    )
+    handoff = _planning_validation_handoff_from_recovery_payload(
+        workspace_id="ws123",
+        profile=profile,
+        recovery_payload={
+            "conformance": {
+                "report_reason_code": " conformance-requires-awf-validation ",
+                "summary": "AWF validation evidence is required.",
+                "gaps": ["rerun pytest under AWF"],
+            },
+        },
+    )
+
+    assert handoff is not None
+    assert handoff.report.reason_code == CONFORMANCE_REQUIRES_AWF_VALIDATION
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("invalid_path_field", ["plan_path", "report_path"])
 def test_recovery_conformance_handoff_falls_back_when_payload_path_escapes_workspace(
     invalid_path_field: str,

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1473,6 +1473,7 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
         },
     )
 
+    report_path = f"docs/awf-plans/{ws_id}.conformance.json"
     _queue_validation_head(fake)
     fake.queue_result(returncode=0, stdout="tests ok")
     fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
@@ -1483,12 +1484,10 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     )
     fake.queue_result(
         returncode=0,
-        stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+        stdout=f"?? {report_path}\n",
     )
     fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
-    _queue_post_validation_conformance_report_commit(
-        fake, f"docs/awf-plans/{ws_id}.conformance.json"
-    )
+    _queue_post_validation_conformance_report_commit(fake, report_path)
 
     await executor.execute(ws_id)
 
@@ -1501,6 +1500,15 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     assert "Validation evidence" in prompt
     assert "VALIDATION_OK" in prompt
     assert "validation.01_validate.stdout" in prompt
+
+    git_calls = [call.args for call in fake.calls if call.args and call.args[0] == "git"]
+    assert any(call[-3:] == ["add", "--", report_path] for call in git_calls)
+    assert any(
+        "commit" in call
+        and "awf: post-validation conformance report" in call
+        and call[-1] == report_path
+        for call in git_calls
+    )
 
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(ws_id)

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -37,7 +37,10 @@ from awf.db.repositories import (
 )
 from awf.db.session import make_session_factory
 from awf.node.compose_manager import ComposeManager
-from awf.runtime.planning import CONFORMANCE_REQUIRES_AWF_VALIDATION
+from awf.runtime.planning import (
+    CONFORMANCE_REQUIRES_AWF_VALIDATION,
+    PLAN_CONFORMANCE_UNSATISFIED,
+)
 from awf.runtime.pr_creator import PullRequestCreator, PullRequestError
 from awf.runtime.validation import ValidationRunner
 from tests.postgres import postgres_test_engine
@@ -1543,6 +1546,101 @@ async def test_validate_only_recovery_with_conformance_handoff_pushes_report_com
     ]
     assert len(recovery_ops) == 1
     assert recovery_ops[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
+async def test_validate_only_recovery_conformance_failure_fails_without_fix_loop(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    executor = _make_executor(
+        fake=fake,
+        factory=factory,
+        tmp_path=tmp_path,
+        max_fix_passes=1,
+    )
+    ws_id = await _seed_ready_workspace_with_recovery(
+        factory,
+        resolved_profile={
+            "name": "planned-recovery",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+            "phases": {"validate": ["pytest -q"]},
+        },
+        recovery_payload_overrides={
+            "conformance": {
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "summary": "Recovery needs AWF-owned validation evidence.",
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        },
+    )
+
+    source_head = "d" * 40
+    unsatisfied_report = (
+        '{"status":"needs_iteration",'
+        '"summary":"validation evidence still does not satisfy the plan",'
+        '"reason_code":"PLAN_CONFORMANCE_VALIDATION_EVIDENCE_GAP",'
+        '"gaps":["profile validation evidence is still insufficient"]}'
+    )
+    _queue_validation_head(fake, head=source_head)
+    fake.queue_result(returncode=0, stdout="tests ok")
+    fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+    fake.queue_result(returncode=0, stdout=f"{source_head}\n")  # conformance scope HEAD
+    fake.queue_result(returncode=0, stdout=unsatisfied_report)
+    fake.queue_result(returncode=0, stdout="")  # post-validation conformance after status
+    fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+
+    # These entries document the old, wasteful path: a synthetic validation
+    # failure drove a fix prompt and a second full validation run. They must
+    # remain unused.
+    fake.queue_result(returncode=0, stdout="attempted fix")  # adapter.run (fix pass)
+    fake.queue_result(returncode=0)  # git add -A
+    fake.queue_result(returncode=0, stdout="")  # git diff --cached --name-only
+    _queue_validation_head(fake, head=source_head)
+    fake.queue_result(returncode=0, stdout="tests ok again")
+    fake.queue_result(returncode=0, stdout="")
+    fake.queue_result(returncode=0, stdout=f"{source_head}\n")
+    fake.queue_result(returncode=0, stdout=unsatisfied_report)
+    fake.queue_result(returncode=0, stdout="")
+    fake.queue_result(returncode=0, stdout="")
+
+    await executor.execute(ws_id)
+
+    adapter_args = _all_adapter_args(fake)
+    assert len(adapter_args) == 1
+    assert "## Conformance phase" in adapter_args[0][-1]
+    assert "Validation failed after your previous pass" not in adapter_args[0][-1]
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+        runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.failed.value
+    assert ws.failure_reason == "agent_failure"
+    assert ws.failure_message is not None
+    assert "post-validation plan conformance was not satisfied" in ws.failure_message
+    assert len(runs) == 1
+    assert runs[0].status == "succeeded"
+    recovery_ops = [
+        op
+        for op in ops
+        if op.type == OperationType.validate.value
+        and isinstance(op.payload, dict)
+        and op.payload.get("source") == "pr_monitor"
+        and op.payload.get("recovery_mode") == "validate_only"
+    ]
+    assert len(recovery_ops) == 1
+    assert recovery_ops[0].status == OperationStatus.failed.value
+    assert recovery_ops[0].error_code == PLAN_CONFORMANCE_UNSATISFIED
+    assert isinstance(recovery_ops[0].result, dict)
+    assert recovery_ops[0].result.get("reason_code") == PLAN_CONFORMANCE_UNSATISFIED
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -37,6 +37,7 @@ from awf.db.repositories import (
 )
 from awf.db.session import make_session_factory
 from awf.node.compose_manager import ComposeManager
+from awf.runtime.planning import CONFORMANCE_REQUIRES_AWF_VALIDATION
 from awf.runtime.pr_creator import PullRequestCreator, PullRequestError
 from awf.runtime.validation import ValidationRunner
 from tests.postgres import postgres_test_engine
@@ -155,6 +156,8 @@ async def _seed_ready_workspace_with_recovery(
     recovery_mode: str = "validate_only",
     source: str = "pr_monitor",
     operation_type: OperationType = OperationType.validate,
+    resolved_profile: dict[str, Any] | None = None,
+    recovery_payload_overrides: dict[str, Any] | None = None,
 ) -> str:
     """Insert a workspace already in ``ready`` with a pending `pr_monitor`
     validate operation — the shape the monitor's RECOVERY_DISPATCH path
@@ -170,6 +173,7 @@ async def _seed_ready_workspace_with_recovery(
             agent="codex",
             test_commands=["pytest -q"],
             requires_database=False,
+            resolved_profile=resolved_profile,
         )
         await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
         ws.branch_name = f"awf/{ws.id}"
@@ -187,24 +191,27 @@ async def _seed_ready_workspace_with_recovery(
         await repo.transition(ws, to=WorkspaceStatus.pushing, reason_code="X")
         await repo.transition(ws, to=WorkspaceStatus.monitoring_pr, reason_code="X")
         await repo.transition(ws, to=WorkspaceStatus.ready, reason_code="RECOVERY_DISPATCH")
+        payload = {
+            "owner": source,
+            "source": source,
+            "action": recovery_mode,
+            "requested_action": "rebase" if recovery_mode == "rebase_only" else "validate",
+            "reason": "validation_insufficient_tier",
+            "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+            "recovery_mode": recovery_mode,
+            "pr_number": pr_number,
+            "pr_url": pr_url,
+            "source_head_sha": ws.monitor_last_commit_sha,
+            "source_base_sha": ws.base_commit,
+            "target_branch": ws.branch_base,
+            "remote_branch": ws.remote_push_branch,
+        }
+        if recovery_payload_overrides:
+            payload.update(recovery_payload_overrides)
         await OperationRepository(s).create(
             workspace_id=ws.id,
             operation_type=operation_type,
-            payload={
-                "owner": source,
-                "source": source,
-                "action": recovery_mode,
-                "requested_action": "rebase" if recovery_mode == "rebase_only" else "validate",
-                "reason": "validation_insufficient_tier",
-                "reason_code": "VALIDATION_INSUFFICIENT_TIER",
-                "recovery_mode": recovery_mode,
-                "pr_number": pr_number,
-                "pr_url": pr_url,
-                "source_head_sha": ws.monitor_last_commit_sha,
-                "source_base_sha": ws.base_commit,
-                "target_branch": ws.branch_base,
-                "remote_branch": ws.remote_push_branch,
-            },
+            payload=payload,
             idempotency_key=f"{source}:{recovery_mode}:{ws.id}",
         )
         await s.commit()
@@ -1429,6 +1436,65 @@ async def test_validate_only_recovery_zero_adapter_calls_on_clean_pass(
 
     # Note: validation legitimately issues ``docker compose exec`` for profile
     # phase commands; only the *agent adapter* (coding CLI) must be absent.
+
+
+@pytest.mark.unit
+async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_check(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(
+        factory,
+        resolved_profile={
+            "name": "planned-recovery",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+            "phases": {"validate": ["pytest -q"]},
+        },
+        recovery_payload_overrides={
+            "conformance": {
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "summary": "Recovery needs AWF-owned validation evidence.",
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        },
+    )
+
+    _queue_validation_head(fake)
+    fake.queue_result(returncode=0, stdout="tests ok")
+    fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+    fake.queue_result(
+        returncode=0,
+        stdout='{"status":"satisfied","summary":"validated recovery","gaps":[]}',
+    )
+    fake.queue_result(
+        returncode=0,
+        stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+    )
+
+    await executor.execute(ws_id)
+
+    adapter_args = _all_adapter_args(fake)
+    assert len(adapter_args) == 1
+    prompt = adapter_args[0][-1]
+    assert "## Conformance phase" in prompt
+    assert "## Planning phase" not in prompt
+    assert "## Execution phase" not in prompt
+    assert "Validation evidence" in prompt
+    assert "VALIDATION_OK" in prompt
+    assert "validation.01_validate.stdout" in prompt
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.completed.value
+    assert ops[0].status == OperationStatus.succeeded.value
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1476,6 +1476,7 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     _queue_validation_head(fake)
     fake.queue_result(returncode=0, stdout="tests ok")
     fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+    fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
     fake.queue_result(
         returncode=0,
         stdout='{"status":"satisfied","summary":"validated recovery","gaps":[]}',
@@ -1484,6 +1485,7 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
         returncode=0,
         stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
     )
+    fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
     _queue_post_validation_conformance_report_commit(
         fake, f"docs/awf-plans/{ws_id}.conformance.json"
     )

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1549,6 +1549,85 @@ async def test_validate_only_recovery_with_conformance_handoff_pushes_report_com
 
 
 @pytest.mark.unit
+async def test_rebase_only_recovery_with_conformance_handoff_pushes_report_commit(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(
+        factory,
+        recovery_mode="rebase_only",
+        resolved_profile={
+            "name": "planned-rebase-recovery",
+            "planning": {
+                "required": True,
+                "plan_path": "docs/awf-plans/{workspace_id}.md",
+                "conformance_report_path": "docs/awf-plans/{workspace_id}.conformance.json",
+            },
+            "phases": {"validate": ["pytest -q"]},
+        },
+        recovery_payload_overrides={
+            "conformance": {
+                "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "summary": "Rebased recovery needs AWF-owned validation evidence.",
+                "gaps": ["AWF-owned validation evidence is missing for pytest."],
+            }
+        },
+    )
+
+    report_path = f"docs/awf-plans/{ws_id}.conformance.json"
+    rebased_head = "c" * 40
+    report_head = "f" * 40
+    _queue_rebase_recovery(fake)
+    _queue_validation_head(fake, head=rebased_head)
+    fake.queue_result(returncode=0, stdout="tests ok")
+    fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
+    fake.queue_result(returncode=0, stdout=f"{rebased_head}\n")  # conformance scope HEAD
+    fake.queue_result(
+        returncode=0,
+        stdout='{"status":"satisfied","summary":"validated rebased recovery","gaps":[]}',
+    )
+    fake.queue_result(returncode=0, stdout=f"?? {report_path}\n")
+    fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
+    _queue_post_validation_conformance_report_commit(fake, report_path)
+    fake.queue_result(returncode=0, stdout=f"{report_head}\n")  # post-report HEAD
+    fake.queue_result(returncode=0, stdout=f"src/awf/onboarding.py\n{report_path}\n")
+    _queue_existing_pr_push(fake, head=report_head)
+
+    await executor.execute(ws_id)
+
+    git_push_calls = [
+        call.args
+        for call in fake.calls
+        if call.args and call.args[0] == "git" and "push" in call.args
+    ]
+    assert any("--force-with-lease" in call for call in git_push_calls)
+    assert any("--force-with-lease" not in call for call in git_push_calls)
+    assert not any(
+        call[:3] == ["gh", "pr", "create"] for call in _all_push_and_pr_create_calls(fake)
+    )
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+        events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.completed.value
+    assert ws.monitor_last_commit_sha == report_head
+    assert runs[-1].workspace_head_sha == rebased_head
+    assert runs[-1].target_head_sha == report_head
+    assert any(
+        event.event_type == "workspace.audit.git_push" and event.reason_code == "REBASE_OK"
+        for event in events
+    )
+    assert any(
+        event.event_type == "workspace.audit.git_push" and event.reason_code == "PR_UPDATED"
+        for event in events
+    )
+
+
+@pytest.mark.unit
 async def test_validate_only_recovery_conformance_failure_fails_without_fix_loop(
     fake: FakeCommandRunner,
     factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import structlog
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -1688,12 +1689,20 @@ async def test_validate_only_recovery_conformance_failure_fails_without_fix_loop
     fake.queue_result(returncode=0, stdout="")
     fake.queue_result(returncode=0, stdout="")
 
-    await executor.execute(ws_id)
+    with structlog.testing.capture_logs() as captured:
+        await executor.execute(ws_id)
 
     adapter_args = _all_adapter_args(fake)
     assert len(adapter_args) == 1
     assert "## Conformance phase" in adapter_args[0][-1]
     assert "Validation failed after your previous pass" not in adapter_args[0][-1]
+    assert any(
+        event.get("event") == "executor.post_validation_conformance_recovery_single_attempt"
+        and event.get("workspace_id") == ws_id
+        and event.get("recovery_mode") == "validate_only"
+        and event.get("will_retry") is False
+        for event in captured
+    )
 
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(ws_id)

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1494,7 +1494,16 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
         ops = await OperationRepository(s).list_all(workspace_id=ws_id)
     assert ws is not None
     assert ws.status == WorkspaceStatus.completed.value
-    assert ops[0].status == OperationStatus.succeeded.value
+    recovery_ops = [
+        op
+        for op in ops
+        if op.type == OperationType.validate.value
+        and isinstance(op.payload, dict)
+        and op.payload.get("source") == "pr_monitor"
+        and op.payload.get("recovery_mode") == "validate_only"
+    ]
+    assert len(recovery_ops) == 1
+    assert recovery_ops[0].status == OperationStatus.succeeded.value
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -1447,7 +1447,7 @@ async def test_validate_only_recovery_zero_adapter_calls_on_clean_pass(
 
 
 @pytest.mark.unit
-async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_check(
+async def test_validate_only_recovery_with_conformance_handoff_pushes_report_commit(
     fake: FakeCommandRunner,
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -1474,10 +1474,12 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     )
 
     report_path = f"docs/awf-plans/{ws_id}.conformance.json"
-    _queue_validation_head(fake)
+    source_head = "d" * 40
+    report_head = "f" * 40
+    _queue_validation_head(fake, head=source_head)
     fake.queue_result(returncode=0, stdout="tests ok")
     fake.queue_result(returncode=0, stdout="")  # post-validation conformance before status
-    fake.queue_result(returncode=0, stdout="deadbeef01\n")  # conformance scope HEAD
+    fake.queue_result(returncode=0, stdout=f"{source_head}\n")  # conformance scope HEAD
     fake.queue_result(
         returncode=0,
         stdout='{"status":"satisfied","summary":"validated recovery","gaps":[]}',
@@ -1488,6 +1490,9 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     )
     fake.queue_result(returncode=0, stdout="")  # committed paths since scope HEAD
     _queue_post_validation_conformance_report_commit(fake, report_path)
+    fake.queue_result(returncode=0, stdout=f"{report_head}\n")  # post-report HEAD
+    fake.queue_result(returncode=0, stdout=f"src/awf/onboarding.py\n{report_path}\n")
+    _queue_existing_pr_push(fake, head=report_head)
 
     await executor.execute(ws_id)
 
@@ -1509,12 +1514,25 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
         and call[-1] == report_path
         for call in git_calls
     )
+    assert any(call[0] == "git" and "push" in call for call in git_calls)
+    assert not any(
+        call[:3] == ["gh", "pr", "create"] for call in _all_push_and_pr_create_calls(fake)
+    )
 
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(ws_id)
         ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+        runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+        events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
     assert ws is not None
     assert ws.status == WorkspaceStatus.completed.value
+    assert ws.monitor_last_commit_sha == report_head
+    assert runs[-1].workspace_head_sha == source_head
+    assert runs[-1].target_head_sha == report_head
+    assert any(
+        event.event_type == "workspace.audit.git_push" and event.reason_code == "PR_UPDATED"
+        for event in events
+    )
     recovery_ops = [
         op
         for op in ops

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -51,6 +51,14 @@ def _queue_validation_head(fake: FakeCommandRunner, head: str = "deadbeef01") ->
     fake.queue_result(returncode=0, stdout=f"{head}\n")  # pre-validation rev-parse HEAD
 
 
+def _queue_post_validation_conformance_report_commit(
+    fake: FakeCommandRunner, report_path: str
+) -> None:
+    fake.queue_result(returncode=0)  # git add report
+    fake.queue_result(returncode=0, stdout=f"{report_path}\n")  # cached report diff
+    fake.queue_result(returncode=0)  # commit refreshed report
+
+
 async def _force_workspace_status(
     factory: async_sessionmaker[AsyncSession],
     workspace_id: str,
@@ -1475,6 +1483,9 @@ async def test_validate_only_recovery_with_conformance_handoff_runs_evidence_che
     fake.queue_result(
         returncode=0,
         stdout=f"?? docs/awf-plans/{ws_id}.conformance.json\n",
+    )
+    _queue_post_validation_conformance_report_commit(
+        fake, f"docs/awf-plans/{ws_id}.conformance.json"
     )
 
     await executor.execute(ws_id)

--- a/tests/unit/control/test_validation_fix_cycle.py
+++ b/tests/unit/control/test_validation_fix_cycle.py
@@ -215,6 +215,21 @@ class TestBuildFixPrompt:
         assert "fix the failing pytest tests first, then revisit coverage" in prompt
         assert "tests/unit/test_widget.py::test_handles_edges" in prompt
 
+    @pytest.mark.unit
+    def test_retry_prompt_treats_provider_fail_under_as_coverage_work(self) -> None:
+        prompt = build_fix_prompt(
+            self._ctx(
+                failed_command="pytest --cov=awf --cov-report=term-missing",
+                reason_code="COVERAGE_FAIL_UNDER_NOT_REACHED",
+                coverage_percent=99.0,
+                coverage_minimum_percent=99.0,
+            )
+        ).lower()
+
+        assert "add meaningful tests" in prompt
+        assert "coverage provider reported fail-under was not reached" in prompt
+        assert "coverage already meets the configured threshold" not in prompt
+
 
 class TestValidationFixContext:
     @pytest.mark.unit

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -13,6 +13,10 @@ import structlog
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.control.worker import (
+    _STALE_ACTIVE_EXECUTION_EVENT_TYPE,
+    _STALE_ACTIVE_EXECUTION_REASON_CODE,
+    ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+    ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
     ControlWorker,
     WorkerConfig,
     _active_execution_preservation_claim_cleanup_payload,
@@ -580,6 +584,119 @@ def test_active_execution_preservation_claim_cleanup_preserves_unexpired_claim()
 
 
 @pytest.mark.unit
+async def test_active_execution_preservation_checks_skip_missing_workspaces(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+    candidate = _ActiveExecutionCandidate(
+        workspace_id="ws_missing",
+        status=WorkspaceStatus.running,
+        compose_project_name="awf_missing",
+    )
+
+    assert not await worker._has_operator_refresh_after_latest_preservation(candidate)  # noqa: SLF001
+    assert not await worker._has_current_preserved_active_execution(candidate)  # noqa: SLF001
+
+
+@pytest.mark.unit
+async def test_active_execution_event_queries_accept_event_floor(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+    event_floor = datetime.now(UTC)
+
+    async with factory() as session:
+        assert not await worker._has_stale_active_execution_event(  # noqa: SLF001
+            session,
+            "ws_missing",
+            event_floor=event_floor,
+        )
+        assert not await worker._has_preserved_active_execution_event(  # noqa: SLF001
+            session,
+            "ws_missing",
+            WorkspaceStatus.running,
+            event_floor=event_floor,
+        )
+        assert (
+            await worker._latest_preserved_active_execution_at(  # noqa: SLF001
+                session,
+                "ws_missing",
+                WorkspaceStatus.running,
+                event_floor=event_floor,
+            )
+            is None
+        )
+        assert not await worker._has_stale_active_execution_event(  # noqa: SLF001
+            session,
+            "ws_missing",
+        )
+        assert not await worker._has_preserved_active_execution_event(  # noqa: SLF001
+            session,
+            "ws_missing",
+            WorkspaceStatus.running,
+        )
+        assert (
+            await worker._latest_preserved_active_execution_at(  # noqa: SLF001
+                session,
+                "ws_missing",
+                WorkspaceStatus.running,
+            )
+            is None
+        )
+
+
+@pytest.mark.unit
+async def test_record_preserved_active_execution_skips_missing_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+
+    await worker._record_preserved_active_execution_after_restart(  # noqa: SLF001
+        _ActiveExecutionCandidate(
+            workspace_id="ws_missing",
+            status=WorkspaceStatus.running,
+            compose_project_name="awf_missing",
+        ),
+        RuntimeSnapshot(stack_state="running", services=[]),
+    )
+
+
+@pytest.mark.unit
+async def test_stale_active_execution_can_fail_rejects_preserved_runtime(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _seed_status(factory, WorkspaceStatus.running, title="preserved")
+    worker = _worker(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        ws.execution_claimed_by = "stale-worker"
+        ws.execution_claim_expires_at = datetime.now(UTC) - timedelta(seconds=30)
+        await repo.add_event(
+            ws,
+            event_type=_STALE_ACTIVE_EXECUTION_EVENT_TYPE,
+            reason_code=_STALE_ACTIVE_EXECUTION_REASON_CODE,
+            payload={"workspace_status": WorkspaceStatus.running.value},
+        )
+        await repo.add_event(
+            ws,
+            event_type=ACTIVE_EXECUTION_PRESERVED_EVENT_TYPE,
+            reason_code=ACTIVE_EXECUTION_PRESERVED_REASON_CODE,
+            payload={"workspace_status": WorkspaceStatus.running.value},
+        )
+        await session.commit()
+
+    assert not await worker._stale_active_execution_can_fail(  # noqa: SLF001
+        _ActiveExecutionCandidate(
+            workspace_id=workspace_id,
+            status=WorkspaceStatus.running,
+            compose_project_name=f"awf_{workspace_id}",
+        )
+    )
+
+
+@pytest.mark.unit
 def test_monitor_claim_staleness_and_json_datetime_handle_naive_datetimes() -> None:
     cutoff = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
 
@@ -734,6 +851,44 @@ async def test_execution_and_monitor_claim_helpers_skip_already_running_task(
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+
+@pytest.mark.unit
+async def test_dispatchable_execution_ids_stops_after_limit(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+
+    assert worker._dispatchable_execution_ids(["ws_one", "ws_two"], limit=1) == ["ws_one"]  # noqa: SLF001
+
+
+@pytest.mark.unit
+async def test_finish_monitor_recovery_operation_skips_wrong_workspace(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    workspace_id = await _seed_status(factory, WorkspaceStatus.monitoring_pr, title="operation")
+    worker = _worker(factory)
+    async with factory() as session:
+        operation = await OperationRepository(session).create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.remonitor,
+            status=OperationStatus.running,
+            payload={"requested_action": OperationType.remonitor.value},
+        )
+        operation_id = operation.id
+        await session.commit()
+
+    await worker._finish_monitor_recovery_operation(  # noqa: SLF001
+        "ws_other",
+        operation_id=operation_id,
+        status=OperationStatus.succeeded,
+    )
+
+    async with factory() as session:
+        operation = await OperationRepository(session).get(operation_id)
+
+    assert operation is not None
+    assert operation.status == OperationStatus.running.value
 
 
 @pytest.mark.unit

--- a/tests/unit/db/test_migration_graph.py
+++ b/tests/unit/db/test_migration_graph.py
@@ -17,16 +17,6 @@ from awf.db.session import make_engine
 from tests.postgres import postgres_empty_test_url
 
 
-def _has_op_call(call_nodes: list[ast.Call], name: str) -> bool:
-    return any(
-        isinstance(node.func, ast.Attribute)
-        and node.func.attr == name
-        and isinstance(node.func.value, ast.Name)
-        and node.func.value.id == "op"
-        for node in call_nodes
-    )
-
-
 @pytest.mark.unit
 def test_alembic_revision_graph_has_single_head() -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -54,10 +44,16 @@ def test_validation_run_coverage_migration_uses_metadata_only_column_ops() -> No
         for node in call_nodes
         if isinstance(node.func, ast.Attribute)
     ]
+    op_call_attrs = {
+        node.func.attr
+        for node in call_nodes
+        if isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+    }
 
     assert "batch_alter_table" not in call_attrs
-    assert _has_op_call(call_nodes, "add_column")
-    assert _has_op_call(call_nodes, "drop_column")
+    assert op_call_attrs == {"add_column", "drop_column"}
 
 
 @pytest.mark.unit

--- a/tests/unit/db/test_migration_graph.py
+++ b/tests/unit/db/test_migration_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import os
 import subprocess
 import sys
@@ -16,6 +17,16 @@ from awf.db.session import make_engine
 from tests.postgres import postgres_empty_test_url
 
 
+def _has_op_call(call_nodes: list[ast.Call], name: str) -> bool:
+    return any(
+        isinstance(node.func, ast.Attribute)
+        and node.func.attr == name
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "op"
+        for node in call_nodes
+    )
+
+
 @pytest.mark.unit
 def test_alembic_revision_graph_has_single_head() -> None:
     repo_root = Path(__file__).resolve().parents[3]
@@ -24,6 +35,29 @@ def test_alembic_revision_graph_has_single_head() -> None:
     script = ScriptDirectory.from_config(config)
 
     assert script.get_heads() == ["c5d6e7f8a9b0"]
+
+
+@pytest.mark.unit
+def test_validation_run_coverage_migration_uses_metadata_only_column_ops() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    migration_path = (
+        repo_root
+        / "migrations"
+        / "versions"
+        / "c5d6e7f8a9b0_validation_run_coverage.py"
+    )
+    tree = ast.parse(migration_path.read_text(encoding="utf-8"))
+
+    call_nodes = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    call_attrs = [
+        node.func.attr
+        for node in call_nodes
+        if isinstance(node.func, ast.Attribute)
+    ]
+
+    assert "batch_alter_table" not in call_attrs
+    assert _has_op_call(call_nodes, "add_column")
+    assert _has_op_call(call_nodes, "drop_column")
 
 
 @pytest.mark.unit

--- a/tests/unit/db/test_migration_graph.py
+++ b/tests/unit/db/test_migration_graph.py
@@ -23,7 +23,7 @@ def test_alembic_revision_graph_has_single_head() -> None:
     config.set_main_option("script_location", str(repo_root / "migrations"))
     script = ScriptDirectory.from_config(config)
 
-    assert script.get_heads() == ["b3c4d5e6f7a8"]
+    assert script.get_heads() == ["c5d6e7f8a9b0"]
 
 
 @pytest.mark.unit
@@ -194,6 +194,7 @@ async def test_alembic_upgrade_head_creates_scheduler_record_tables(
         "resolved_profile_digest",
         "environment_identity_digest",
         "environment_identity_inputs",
+        "coverage",
     } <= validation_run_columns
     assert "workspace_secret_leases" in tables
     assert {

--- a/tests/unit/db/test_repository_coverage.py
+++ b/tests/unit/db/test_repository_coverage.py
@@ -662,6 +662,7 @@ async def test_validation_run_finish_updates_metadata_and_handles_missing(
     assert finished is not None
     assert finished.status == "succeeded"
     assert finished.retry_count == 2
+    assert finished.coverage == {"total": 99.1}
     assert finished.log_stream_refs == {
         "stdout": "validation.stdout",
         "coverage": {"total": 99.1},
@@ -674,6 +675,7 @@ async def test_validation_run_finish_updates_metadata_and_handles_missing(
     assert updated.target_head_sha == "d" * 40
     assert updated.workspace_head_sha == "e" * 40
     assert plain_finished is not None
+    assert plain_finished.coverage is None
     assert plain_finished.log_stream_refs == {}
     assert plain_finished.commands == [{"command": "mypy"}]
     assert [row.id for row in listed] == [plain_run.id, run.id]

--- a/tests/unit/db/test_workspace_repository.py
+++ b/tests/unit/db/test_workspace_repository.py
@@ -378,6 +378,14 @@ class TestValidationRunRepository:
                 coverage={"status": "passed", "reason_code": "COVERAGE_OK", "percent": 99.0},
                 finished_at=now,
             )
+            run.log_stream_refs = {
+                "coverage": {
+                    "status": "failed",
+                    "reason_code": "COVERAGE_BELOW_THRESHOLD",
+                    "failing_test_node_ids": ["tests/unit/test_widget.py::test_failed"],
+                }
+            }
+            await s.flush()
 
             reused = await repo.find_reusable_coverage_evidence(
                 workspace_id=workspace.id,

--- a/tests/unit/node/test_provisioner.py
+++ b/tests/unit/node/test_provisioner.py
@@ -15,7 +15,7 @@ from typing import Any
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.db.enums import WorkspaceStatus
+from awf.db.enums import EgressDecision, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import (
     EgressAuditRepository,
@@ -32,7 +32,9 @@ from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
 from awf.node.provisioner import (
     Provisioner,
     ProvisionerConfig,
+    _egress_plan_decision,
     _egress_plan_destination_category,
+    _positive_int,
     _provision_checkout_base_branch,
     _provision_remote_push_branch,
 )
@@ -124,6 +126,38 @@ def test_egress_plan_destination_category_keeps_restricted_distinct_from_offline
     expected_category: str,
 ) -> None:
     assert _egress_plan_destination_category(mode) == expected_category
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("mode", "expected_decision"),
+    [
+        (EgressMode.open, EgressDecision.allow),
+        (EgressMode.offline, EgressDecision.deny),
+        (EgressMode.restricted, EgressDecision.deferred),
+    ],
+)
+def test_egress_plan_decision_maps_profile_modes(
+    mode: EgressMode,
+    expected_decision: EgressDecision,
+) -> None:
+    assert _egress_plan_decision(mode) == expected_decision
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (True, None),
+        (7, 7),
+        (0, None),
+        (" 5 ", 5),
+        ("0", None),
+        ("five", None),
+    ],
+)
+def test_positive_int_accepts_only_positive_int_values(value: object, expected: int | None) -> None:
+    assert _positive_int(value) == expected
 
 
 class TestSuccess:

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
+from awf.profiles.compose import merge_agent_environment
 from awf.profiles.lint import profile_lint_errors
 from awf.profiles.models import (
     DockerMode,
@@ -30,6 +31,14 @@ from awf.profiles.resolver import (
     _validation_error_message,
     resolve_workspace_profile,
 )
+
+
+@pytest.mark.unit
+def test_merge_environment_does_not_overwrite_existing_keys() -> None:
+    assert merge_agent_environment(
+        (("EXISTING", "base"),),
+        (("EXISTING", "override"), ("NEW", "value")),
+    ) == (("EXISTING", "base"), ("NEW", "value"))
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_events.py
+++ b/tests/unit/runtime/test_events.py
@@ -31,3 +31,15 @@ async def test_committed_workspace_events_are_broadcast(engine: AsyncEngine) -> 
 
     assert frame.workspace_id == workspace.id
     assert frame.event_type == "workspace.created"
+
+
+@pytest.mark.unit
+async def test_unsubscribe_keeps_workspace_entry_until_last_subscriber_exits() -> None:
+    workspace_id = "ws_two_subscribers"
+
+    async with WORKSPACE_EVENT_BROADCASTER.subscribe(workspace_id) as first:
+        async with WORKSPACE_EVENT_BROADCASTER.subscribe(workspace_id) as second:
+            assert first is not second
+        assert workspace_id in WORKSPACE_EVENT_BROADCASTER._subscribers  # noqa: SLF001
+
+    assert workspace_id not in WORKSPACE_EVENT_BROADCASTER._subscribers  # noqa: SLF001

--- a/tests/unit/runtime/test_inspection.py
+++ b/tests/unit/runtime/test_inspection.py
@@ -226,6 +226,9 @@ def test_runtime_helper_fallbacks() -> None:
     assert (
         inspection._command_from({}, {"Config": {"Cmd": ["sleep", "infinity"]}}) == "sleep infinity"
     )
+    assert inspection._command_from({}, {"Config": {"Cmd": ["sleep", None, "10"]}}) == "sleep 10"
+    assert inspection._command_from({}, {"Config": {"Cmd": [None]}}) is None
+    assert inspection._command_from({}, {"Config": {"Cmd": "python -m app"}}) == "python -m app"
     assert (
         inspection._command_from({"Command": "echo hi"}, {"Config": {"Cmd": ["sleep"]}})
         == "echo hi"

--- a/tests/unit/runtime/test_merge_eligibility.py
+++ b/tests/unit/runtime/test_merge_eligibility.py
@@ -8,6 +8,7 @@ from awf.db.repositories import sync_candidate_readiness
 from awf.runtime.merge_eligibility import (
     VALIDATION_INSUFFICIENT_TIER_STALE_REASON,
     _successful_validation_run_tier,
+    _validation_run_deferred_required_coverage,
     compute_stale_reason,
     compute_stale_reason_for_attempt,
 )
@@ -202,6 +203,21 @@ def test_successful_validation_run_tier_excludes_deferred_coverage_runs() -> Non
     )
 
     assert _successful_validation_run_tier(run) is None
+
+
+@pytest.mark.unit
+def test_validation_run_deferred_coverage_ignores_completed_coverage_command() -> None:
+    run = _validation_run(
+        tier=2,
+        started_at=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
+        commands=[
+            {"phase": "validate", "command": "pytest -q"},
+            {"phase": "coverage", "command": "pytest --cov=awf", "evidence_status": "complete"},
+        ],
+    )
+
+    assert not _validation_run_deferred_required_coverage(run)
+    assert _successful_validation_run_tier(run) == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 import pytest
 
 from awf.runtime.monitor_prompts import (
+    _clean_metadata_lines,
     address_review_comment_prompt,
     address_thread_prompt,
     fix_ci_prompt,
@@ -26,6 +27,13 @@ _ADVERSARIAL_REVIEW_LINES = [
 
 def _assert_only_quoted(prompt: str, phrase: str) -> None:
     assert [line for line in prompt.splitlines() if phrase in line] == [f"AWF-EVIDENCE> {phrase}"]
+
+
+@pytest.mark.unit
+def test_clean_metadata_lines_skips_blank_values() -> None:
+    assert _clean_metadata_lines((("path", "src/app.py"), ("line", " \n\t "))) == [
+        "path: src/app.py"
+    ]
 
 
 class TestAddressThread:

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -9,6 +9,7 @@ import pytest
 from awf.adapters.base import AgentRunError
 from awf.common.commands import CommandResult
 from awf.db.enums import AgentRuntime
+from awf.runtime import planning as planning_mod
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     AGENT_STALLED_IN_CONFORMANCE,
@@ -264,6 +265,18 @@ def test_conformance_requires_awf_validation_rejects_empty_gaps_even_with_reason
 
 
 @pytest.mark.unit
+def test_conformance_requires_awf_validation_rejects_satisfied_reports() -> None:
+    report = PlanConformanceReport(
+        status=PlanConformanceStatus.satisfied,
+        summary="Validation evidence is still missing, but status is final.",
+        gaps=("AWF validation evidence is missing for the required pytest gate.",),
+        reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+    )
+
+    assert not conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "gap",
     (
@@ -395,6 +408,28 @@ def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() ->
 
     assert not conformance_requires_awf_validation(mixed)
     assert not conformance_requires_awf_validation(ordinary)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "Missing approval artifact for the handoff.",
+        "Schema evidence is missing for the generated artifact.",
+        "AWF validation evidence is missing for code review logs.",
+    ),
+)
+def test_conformance_requires_awf_validation_rejects_non_validation_artifact_gaps(
+    gap: str,
+) -> None:
+    report = PlanConformanceReport(
+        status=PlanConformanceStatus.needs_iteration,
+        summary="Implementation appears complete.",
+        gaps=(gap,),
+        reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+    )
+
+    assert not conformance_requires_awf_validation(report)
 
 
 @pytest.mark.unit
@@ -1032,6 +1067,26 @@ def test_classify_conformance_stall_redacts_secrets_in_last_output_excerpt() -> 
     )
     assert leaked_token not in payload["last_output_excerpt"]
     assert "<redacted>" in payload["last_output_excerpt"]
+
+
+@pytest.mark.unit
+def test_stall_output_excerpt_falls_back_to_redacted_exception_text() -> None:
+    record = ConformanceIterationRecord(
+        iteration=1,
+        elapsed_seconds=1,
+        report_digest=None,
+        worktree_changed=False,
+        stdout="",
+        stderr="",
+    )
+
+    excerpt = planning_mod._stall_output_excerpt(  # noqa: SLF001
+        RuntimeError("provider failed with sk-test-secret"),
+        record,
+    )
+
+    assert "<redacted>" in excerpt
+    assert "sk-test-secret" not in excerpt
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -353,6 +353,27 @@ def test_conformance_requires_awf_validation_accepts_documentation_context_gaps(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "Run pytest under AWF validation.",
+        "rerun pytest under AWF.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_named_validation_command_handoff_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation command is needed.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() -> None:
     mixed = parse_conformance_report(
         '{"status":"needs_iteration",'

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -239,6 +239,28 @@ def test_conformance_requires_awf_validation_accepts_validation_evidence_only_ga
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "AWF validation run code coverage evidence is missing.",
+        "AWF-owned validation run code coverage has not been generated.",
+        "AWF-owned validation evidence is missing for the required reason_code.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_code_coverage_evidence_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() -> None:
     mixed = parse_conformance_report(
         '{"status":"needs_iteration",'

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -444,6 +444,7 @@ def test_conformance_requires_awf_validation_rejects_plan_and_documentation_arti
     "gap",
     (
         "Migration implementation is missing validation evidence.",
+        "Migration profile gate implementation is missing.",
         "Migration validation logic is missing.",
     ),
 )

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -270,6 +270,8 @@ def test_conformance_requires_awf_validation_rejects_empty_gaps_even_with_reason
         "AWF-owned coverage evidence is stale.",
         "Required profile gate logs are missing from the workspace artifacts.",
         "AWF functional test coverage logs are missing.",
+        "AWF unit test suite coverage evidence is missing.",
+        "AWF test runner coverage not found.",
         "AWF coverage classification log is missing.",
     ),
 )

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -261,6 +261,28 @@ def test_conformance_requires_awf_validation_accepts_code_coverage_evidence_gaps
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "AWF validation evidence is missing; see docs for profile gate configuration.",
+        "AWF validation evidence is missing; see the document for profile gate configuration.",
+        "AWF-owned validation evidence is missing, see documented profile gates.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_documentation_context_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() -> None:
     mixed = parse_conformance_report(
         '{"status":"needs_iteration",'
@@ -277,6 +299,27 @@ def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() ->
 
     assert not conformance_requires_awf_validation(mixed)
     assert not conformance_requires_awf_validation(ordinary)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "Document the validation provenance behavior before the gap is satisfied.",
+        "Update docs for the validation profile gate before the gap is satisfied.",
+    ),
+)
+def test_conformance_requires_awf_validation_rejects_documentation_work_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Documentation work remains.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert not conformance_requires_awf_validation(report)
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -367,6 +367,28 @@ def test_conformance_requires_awf_validation_rejects_plan_and_documentation_arti
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "Missing validation tests for the new parser.",
+        "Add validation tests for the new parser.",
+        "Write parser tests covering invalid input.",
+    ),
+)
+def test_conformance_requires_awf_validation_rejects_test_work_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Test work remains.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert not conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 def test_planning_prompt_is_plan_artifact_only_and_stops_before_implementation() -> None:
     plan = Path("docs/awf-plans/ws_scope_prompt.md")
 

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -252,6 +252,18 @@ def test_conformance_requires_awf_validation_accepts_hyphenated_reason_code() ->
 
 
 @pytest.mark.unit
+def test_conformance_requires_awf_validation_rejects_empty_gaps_even_with_reason_code() -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"No explicit gaps were provided.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        '"gaps":[]}'
+    )
+
+    assert not conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "gap",
     (

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -293,7 +293,9 @@ def test_conformance_requires_awf_validation_accepts_validation_subject_gaps_wit
     "gap",
     (
         "Migration validation evidence is missing.",
+        "Schema migration validation evidence is missing.",
         "AWF validation evidence is missing for the Alembic/profile migration gate.",
+        "Schema migration profile gate logs are missing from the workspace artifacts.",
         "Profile migration gate logs are missing from the workspace artifacts.",
     ),
 )

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -242,6 +242,27 @@ def test_conformance_requires_awf_validation_accepts_validation_evidence_only_ga
 @pytest.mark.parametrize(
     "gap",
     (
+        "AWF-owned coverage evidence is stale.",
+        "Required profile gate logs are missing from the workspace artifacts.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_validation_subject_gaps_without_literal_validation(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
         "AWF validation run code coverage evidence is missing.",
         "AWF-owned validation run code coverage has not been generated.",
         "AWF-owned validation evidence is missing for the required reason_code.",
@@ -315,6 +336,27 @@ def test_conformance_requires_awf_validation_rejects_documentation_work_gaps(
     report = parse_conformance_report(
         '{"status":"needs_iteration",'
         '"summary":"Documentation work remains.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert not conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "AWF validation evidence is missing from the saved plan.",
+        "AWF validation evidence is missing from the README documentation.",
+    ),
+)
+def test_conformance_requires_awf_validation_rejects_plan_and_documentation_artifact_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Plan or documentation artifact work remains.",'
         '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
         f'"gaps":["{gap}"]}}'
     )

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -395,6 +395,27 @@ def test_conformance_requires_awf_validation_accepts_named_validation_command_ha
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "AWF test suite, coverage report is missing.",
+        "AWF test run: coverage evidence is absent.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_punctuated_test_evidence_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
 def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() -> None:
     mixed = parse_conformance_report(
         '{"status":"needs_iteration",'

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -12,6 +12,7 @@ from awf.db.enums import AgentRuntime
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     AGENT_STALLED_IN_CONFORMANCE,
+    CONFORMANCE_REQUIRES_AWF_VALIDATION,
     MAX_CONFORMANCE_TEXT_CHARS,
     PLAN_CONFORMANCE_REPORTED,
     PLAN_CONFORMANCE_UNSATISFIED,
@@ -33,6 +34,7 @@ from awf.runtime.planning import (
     build_planning_scope_retry_prompt,
     changed_paths_from_porcelain,
     classify_conformance_stall,
+    conformance_requires_awf_validation,
     parse_conformance_report,
     render_coordination_warning_section,
     render_workspace_path,
@@ -207,6 +209,52 @@ def test_conformance_prompt_is_evidence_only_and_does_not_rerun_validation() -> 
         "git commit",
     ):
         assert command in prompt
+
+
+@pytest.mark.unit
+def test_conformance_prompt_documents_awf_validation_handoff_reason_code() -> None:
+    prompt = build_conformance_prompt(
+        task_prompt="Add metrics",
+        plan_path=Path("docs/awf-plans/ws_123.md"),
+        report_path=Path("docs/awf-plans/ws_123.conformance.json"),
+        iteration=0,
+    )
+
+    assert '"reason_code"' in prompt
+    assert CONFORMANCE_REQUIRES_AWF_VALIDATION in prompt
+    assert "only when every remaining gap is missing, stale, or insufficient AWF-owned validation evidence" in prompt
+    assert "Do not use it for implementation, API, plan, or documentation gaps" in prompt
+
+
+@pytest.mark.unit
+def test_conformance_requires_awf_validation_accepts_validation_evidence_only_gap() -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        '"gaps":["AWF-owned validation evidence is missing for the required pytest gate."]}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+def test_conformance_requires_awf_validation_rejects_mixed_or_ordinary_gaps() -> None:
+    mixed = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Validation evidence is missing and the API is incomplete.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        '"gaps":["AWF-owned validation evidence is missing.",'
+        '"Wire the API endpoint required by the plan."]}'
+    )
+    ordinary = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation gap remains.",'
+        '"gaps":["Wire the API endpoint required by the plan."]}'
+    )
+
+    assert not conformance_requires_awf_validation(mixed)
+    assert not conformance_requires_awf_validation(ordinary)
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -271,6 +271,7 @@ def test_conformance_requires_awf_validation_rejects_empty_gaps_even_with_reason
         "Required profile gate logs are missing from the workspace artifacts.",
         "AWF functional test coverage logs are missing.",
         "AWF unit test suite coverage evidence is missing.",
+        "AWF validation test suite evidence is missing.",
         "AWF test runner coverage not found.",
         "AWF coverage classification log is missing.",
     ),

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -286,6 +286,9 @@ def test_conformance_requires_awf_validation_rejects_satisfied_reports() -> None
         "AWF unit test suite coverage evidence is missing.",
         "AWF validation test suite evidence is missing.",
         "AWF test runner coverage not found.",
+        "AWF validation tests evidence is missing.",
+        "Validation test logs are absent.",
+        "AWF test provenance is missing.",
         "AWF coverage classification log is missing.",
     ),
 )

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -244,6 +244,8 @@ def test_conformance_requires_awf_validation_accepts_validation_evidence_only_ga
     (
         "AWF-owned coverage evidence is stale.",
         "Required profile gate logs are missing from the workspace artifacts.",
+        "AWF functional test coverage logs are missing.",
+        "AWF coverage classification log is missing.",
     ),
 )
 def test_conformance_requires_awf_validation_accepts_validation_subject_gaps_without_literal_validation(

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -20,6 +20,7 @@ from awf.runtime.planning import (
     ConformanceStallEvidence,
     ConformanceStallKind,
     ConformanceStallPolicy,
+    PlanConformanceReport,
     PlanConformanceStatus,
     _evidence_strings,
     _gaps_from_payload,
@@ -233,6 +234,18 @@ def test_conformance_requires_awf_validation_accepts_validation_evidence_only_ga
         '"summary":"Implementation appears complete; AWF validation evidence is missing.",'
         '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
         '"gaps":["AWF-owned validation evidence is missing for the required pytest gate."]}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+def test_conformance_requires_awf_validation_accepts_hyphenated_reason_code() -> None:
+    report = PlanConformanceReport(
+        status=PlanConformanceStatus.needs_iteration,
+        summary="Implementation appears complete; AWF validation evidence is missing.",
+        reason_code="CONFORMANCE-REQUIRES-AWF-VALIDATION",
+        gaps=("AWF-owned validation evidence is missing for the required pytest gate.",),
     )
 
     assert conformance_requires_awf_validation(report)

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -1424,6 +1424,11 @@ def test_build_conformance_stall_recovery_prompt_steers_agent_to_only_redo_compa
         assert command in prompt
     assert "- Add regression test" in prompt
     assert "- Wire retry endpoint" in prompt
-    assert '{"status":"satisfied|needs_iteration","summary":"...","gaps":["..."]}' in prompt
+    assert "also print the same JSON object as your final response" in prompt
+    assert "only when every remaining gap is missing, stale, or insufficient AWF-owned validation evidence" in prompt
+    assert (
+        '{"status":"satisfied|needs_iteration","summary":"...","gaps":["..."],'
+        '"reason_code":"optional reason code"}'
+    ) in prompt
     assert "### Original task" in prompt
     assert "Implement the billing retry flow." in prompt

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -265,6 +265,28 @@ def test_conformance_requires_awf_validation_accepts_validation_subject_gaps_wit
 @pytest.mark.parametrize(
     "gap",
     (
+        "Migration validation evidence is missing.",
+        "AWF validation evidence is missing for the Alembic/profile migration gate.",
+        "Profile migration gate logs are missing from the workspace artifacts.",
+    ),
+)
+def test_conformance_requires_awf_validation_accepts_migration_gate_evidence_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Implementation appears complete; AWF migration gate evidence is missing.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
         "AWF validation run code coverage evidence is missing.",
         "AWF-owned validation run code coverage has not been generated.",
         "AWF-owned validation evidence is missing for the required reason_code.",
@@ -359,6 +381,27 @@ def test_conformance_requires_awf_validation_rejects_plan_and_documentation_arti
     report = parse_conformance_report(
         '{"status":"needs_iteration",'
         '"summary":"Plan or documentation artifact work remains.",'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
+        f'"gaps":["{gap}"]}}'
+    )
+
+    assert not conformance_requires_awf_validation(report)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "gap",
+    (
+        "Migration implementation is missing validation evidence.",
+        "Migration validation logic is missing.",
+    ),
+)
+def test_conformance_requires_awf_validation_rejects_migration_implementation_gaps(
+    gap: str,
+) -> None:
+    report = parse_conformance_report(
+        '{"status":"needs_iteration",'
+        '"summary":"Migration implementation work remains.",'
         '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION",'
         f'"gaps":["{gap}"]}}'
     )

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -3696,6 +3696,66 @@ async def test_monitor_recovery_dispatch_preserves_planning_validation_handoff_c
 
 
 @pytest.mark.unit
+async def test_monitor_recovery_dispatch_ignores_resolved_planning_validation_handoff(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    pr_number = 79
+    head_sha = "f" * 40
+    workspace_id = await seed_monitoring_workspace(
+        factory,
+        pr_number=pr_number,
+        head_sha=head_sha,
+    )
+    await _mark_refactor_task(factory, workspace_id)
+    async with factory() as session:
+        workspace_repo = WorkspaceRepository(session)
+        workspace = await workspace_repo.get(workspace_id)
+        assert workspace is not None
+        await workspace_repo.add_event(
+            workspace,
+            event_type="workspace.planning_conformance_requires_awf_validation",
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+            payload={
+                "summary": "AWF validation evidence is required before conformance can pass.",
+                "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+                "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "plan_path": f"docs/awf-plans/{workspace_id}.md",
+                "report_path": f"docs/awf-plans/{workspace_id}.conformance.json",
+                "iteration": 0,
+                "max_iterations": 3,
+            },
+        )
+        await workspace_repo.add_event(
+            workspace,
+            event_type="workspace.post_validation_conformance_satisfied",
+            reason_code="PLAN_CONFORMANCE_SATISFIED",
+            payload={
+                "summary": "validation evidence satisfied the plan",
+                "plan_path": f"docs/awf-plans/{workspace_id}.md",
+                "report_path": f"docs/awf-plans/{workspace_id}.conformance.json",
+                "validation_run_id": "val-resolved",
+            },
+        )
+        await session.commit()
+
+    terminal = await _dispatch_merge_recovery(
+        factory=factory,
+        tmp_path=tmp_path,
+        workspace_id=workspace_id,
+        pr_number=pr_number,
+        head_sha=head_sha,
+    )
+
+    async with factory() as session:
+        operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
+
+    assert terminal is True
+    assert len(operations) == 1
+    assert "conformance" not in operations[0].payload
+
+
+@pytest.mark.unit
 async def test_monitor_runner_loads_persisted_state_on_resume(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -3696,7 +3696,7 @@ async def test_monitor_recovery_dispatch_preserves_planning_validation_handoff_c
 
 
 @pytest.mark.unit
-async def test_monitor_recovery_dispatch_preserves_satisfied_planning_validation_handoff(
+async def test_monitor_recovery_dispatch_omits_satisfied_planning_validation_handoff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
@@ -3752,17 +3752,7 @@ async def test_monitor_recovery_dispatch_preserves_satisfied_planning_validation
 
     assert terminal is True
     assert len(operations) == 1
-    assert operations[0].payload["conformance"] == {
-        "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
-        "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
-        "summary": "AWF validation evidence is required before conformance can pass.",
-        "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
-        "plan_path": f"docs/awf-plans/{workspace_id}.md",
-        "report_path": f"docs/awf-plans/{workspace_id}.conformance.json",
-        "iteration": 0,
-        "max_iterations": 3,
-    }
-    assert "validation_run_id" not in operations[0].payload["conformance"]
+    assert "conformance" not in operations[0].payload
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -46,6 +46,7 @@ from awf.db.repositories import (
     WorkspaceRepository,
 )
 from awf.db.session import make_session_factory
+from awf.runtime.planning import CONFORMANCE_REQUIRES_AWF_VALIDATION
 from awf.runtime.pr_monitor import (
     AddressComments,
     CheckFailure,
@@ -3632,6 +3633,66 @@ async def test_monitor_recovery_dispatch_records_operation_with_pr_and_sha_conte
     assert len(state_events) == 1
     assert state_events[0].old_state == WorkspaceStatus.monitoring_pr.value
     assert state_events[0].new_state == WorkspaceStatus.ready.value
+
+
+@pytest.mark.unit
+async def test_monitor_recovery_dispatch_preserves_planning_validation_handoff_context(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    pr_number = 78
+    head_sha = "e" * 40
+    workspace_id = await seed_monitoring_workspace(
+        factory,
+        pr_number=pr_number,
+        head_sha=head_sha,
+    )
+    await _mark_refactor_task(factory, workspace_id)
+    plan_path = f"docs/awf-plans/{workspace_id}.md"
+    report_path = f"docs/awf-plans/{workspace_id}.conformance.json"
+    async with factory() as session:
+        workspace_repo = WorkspaceRepository(session)
+        workspace = await workspace_repo.get(workspace_id)
+        assert workspace is not None
+        await workspace_repo.add_event(
+            workspace,
+            event_type="workspace.planning_conformance_requires_awf_validation",
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+            payload={
+                "summary": "AWF validation evidence is required before conformance can pass.",
+                "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+                "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+                "plan_path": plan_path,
+                "report_path": report_path,
+                "iteration": 1,
+                "max_iterations": 3,
+            },
+        )
+        await session.commit()
+
+    terminal = await _dispatch_merge_recovery(
+        factory=factory,
+        tmp_path=tmp_path,
+        workspace_id=workspace_id,
+        pr_number=pr_number,
+        head_sha=head_sha,
+    )
+
+    async with factory() as session:
+        operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
+
+    assert terminal is True
+    assert len(operations) == 1
+    assert operations[0].payload["conformance"] == {
+        "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        "summary": "AWF validation evidence is required before conformance can pass.",
+        "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+        "plan_path": plan_path,
+        "report_path": report_path,
+        "iteration": 1,
+        "max_iterations": 3,
+    }
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -3696,7 +3696,7 @@ async def test_monitor_recovery_dispatch_preserves_planning_validation_handoff_c
 
 
 @pytest.mark.unit
-async def test_monitor_recovery_dispatch_ignores_resolved_planning_validation_handoff(
+async def test_monitor_recovery_dispatch_preserves_satisfied_planning_validation_handoff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
@@ -3752,7 +3752,17 @@ async def test_monitor_recovery_dispatch_ignores_resolved_planning_validation_ha
 
     assert terminal is True
     assert len(operations) == 1
-    assert "conformance" not in operations[0].payload
+    assert operations[0].payload["conformance"] == {
+        "reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        "report_reason_code": CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        "summary": "AWF validation evidence is required before conformance can pass.",
+        "gaps": ["AWF-owned validation evidence is missing for the pytest gate."],
+        "plan_path": f"docs/awf-plans/{workspace_id}.md",
+        "report_path": f"docs/awf-plans/{workspace_id}.conformance.json",
+        "iteration": 0,
+        "max_iterations": 3,
+    }
+    assert "validation_run_id" not in operations[0].payload["conformance"]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -2071,6 +2071,55 @@ class TestCoverageEnforcement:
         )
 
     @pytest.mark.unit
+    async def test_run_profile_coverage_uses_provider_fail_under_exact_percent(
+        self, runner: tuple[FakeCommandRunner, ValidationRunner]
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name                                      Stmts   Miss  Cover   Missing\n"
+                "---------------------------------------------------------------------\n"
+                "src/awf/runtime/validation.py               674      7    99%\n"
+                "---------------------------------------------------------------------\n"
+                "TOTAL                                     28144    167    99%\n"
+                "FAIL Required test coverage of 99.0% not reached. Total coverage: 98.84%\n"
+                "============ 5579 passed, 7 skipped, 1 warning in 1675.12s ============\n"
+            ),
+        )
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "final-coverage-fail-under-exact-percent",
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 99,
+                        "enforce": True,
+                        "command": "pytest --cov=awf --cov-report=term-missing",
+                    }
+                },
+            }
+        )
+
+        result = await val.run_profile_coverage(
+            workspace_id="ws_final_coverage_fail_under_exact_percent",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase="final_coverage",
+        )
+
+        assert result is not None
+        assert result.percent == 98.84
+        assert result.status == "failed"
+        assert result.reason_code == "COVERAGE_BELOW_THRESHOLD"
+        assert not result.ok
+        assert result.provider_failure_evidence == [
+            "FAIL Required test coverage of 99.0% not reached. Total coverage: 98.84%"
+        ]
+        assert result.command_result is not None
+        assert result.command_result.reason_code == "COVERAGE_BELOW_THRESHOLD"
+
+    @pytest.mark.unit
     async def test_run_profile_coverage_preserves_below_threshold_reason_with_provider_fail_under(
         self, runner: tuple[FakeCommandRunner, ValidationRunner]
     ) -> None:

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -2122,6 +2122,66 @@ class TestCoverageEnforcement:
         assert result.command_result.reason_code == "COVERAGE_BELOW_THRESHOLD"
 
     @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "fail_under_lines",
+        (
+            (
+                "FAIL Required test coverage of 99.0% not reached.\n"
+                "Total coverage: 98.84%\n"
+            ),
+            (
+                "Total coverage: 98.84%\n"
+                "FAIL Required test coverage of 99.0% not reached.\n"
+            ),
+        ),
+    )
+    async def test_run_profile_coverage_uses_adjacent_provider_fail_under_exact_percent(
+        self,
+        runner: tuple[FakeCommandRunner, ValidationRunner],
+        fail_under_lines: str,
+    ) -> None:
+        fake, val = runner
+        fake.queue_result(
+            returncode=0,
+            stdout=(
+                "Name                                      Stmts   Miss  Cover   Missing\n"
+                "---------------------------------------------------------------------\n"
+                "src/awf/runtime/validation.py               674      7    99%\n"
+                "---------------------------------------------------------------------\n"
+                "TOTAL                                     28144    167    99%\n"
+                f"{fail_under_lines}"
+                "============ 5579 passed, 7 skipped, 1 warning in 1675.12s ============\n"
+            ),
+        )
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "final-coverage-fail-under-adjacent-exact-percent",
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 99,
+                        "enforce": True,
+                        "command": "pytest --cov=awf --cov-report=term-missing",
+                    }
+                },
+            }
+        )
+
+        result = await val.run_profile_coverage(
+            workspace_id="ws_final_coverage_fail_under_adjacent_exact_percent",
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            profile=profile,
+            phase="final_coverage",
+        )
+
+        assert result is not None
+        assert result.percent == 98.84
+        assert result.status == "failed"
+        assert result.reason_code == "COVERAGE_BELOW_THRESHOLD"
+        assert result.command_result is not None
+        assert result.command_result.reason_code == "COVERAGE_BELOW_THRESHOLD"
+
+    @pytest.mark.unit
     async def test_run_profile_coverage_preserves_below_threshold_reason_with_provider_fail_under(
         self, runner: tuple[FakeCommandRunner, ValidationRunner]
     ) -> None:

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -27,7 +27,9 @@ from awf.runtime.validation import (
     _healthcheck_attempt_timeout,
     _healthcheck_cli_args,
     _healthcheck_failure_reason,
+    _parse_coverage_provider_failure_evidence_from_files,
     _parse_python_coverage_percent_from_files,
+    _runs_pytest_under_coverage,
     profile_phase_command_plan,
 )
 from awf.runtime.validation_identity import (
@@ -2430,6 +2432,27 @@ class TestCoverageEnforcement:
         assert _parse_python_coverage_percent_from_files([coverage_output]) == 98
         assert _parse_python_coverage_percent_from_files([summary_only]) == 87.5
         assert _parse_python_coverage_percent_from_files([no_coverage]) is None
+
+    @pytest.mark.unit
+    def test_pytest_under_coverage_scan_continues_past_non_run_coverage_token(self) -> None:
+        assert _runs_pytest_under_coverage(
+            ["coverage", "report", "coverage", "run", "pytest"]
+        )
+
+    @pytest.mark.unit
+    def test_provider_failure_evidence_parser_skips_missing_and_blank_lines(
+        self, tmp_path: Path
+    ) -> None:
+        missing = tmp_path / "missing.txt"
+        output = tmp_path / "coverage.txt"
+        output.write_text(
+            "\nFAIL Required test coverage of 99.0% not reached. Total coverage: 98.84%\n",
+            encoding="utf-8",
+        )
+
+        assert _parse_coverage_provider_failure_evidence_from_files([missing, output]) == [
+            "FAIL Required test coverage of 99.0% not reached. Total coverage: 98.84%"
+        ]
 
     @pytest.mark.unit
     @pytest.mark.parametrize(

--- a/tests/unit/service/test_controls.py
+++ b/tests/unit/service/test_controls.py
@@ -4,6 +4,7 @@ import os
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -54,6 +55,13 @@ def test_idempotency_identity_matching_accepts_missing_identity_and_rejects_non_
         identity={"reason": "operator requested"},
         identity_keys=None,
     )
+
+
+@pytest.mark.unit
+def test_pr_monitor_recovery_operation_rejects_non_mapping_payload() -> None:
+    operation = SimpleNamespace(type=OperationType.validate.value, payload=["not", "mapping"])
+
+    assert not controls._is_pr_monitor_recovery_operation(operation)  # noqa: SLF001
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_gc.py
+++ b/tests/unit/service/test_gc.py
@@ -47,6 +47,13 @@ from awf.service.gc import (
 """Terminal workspace filesystem GC tests."""
 
 
+@pytest.mark.unit
+def test_gc_to_utc_accepts_naive_datetime() -> None:
+    naive = datetime(2026, 5, 8, 12, 30)
+
+    assert gc._to_utc(naive) == naive.replace(tzinfo=UTC)  # noqa: SLF001
+
+
 @pytest.fixture(autouse=True)
 def _mock_default_worktree_remover():
     with patch(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_c76512d8b0514eff9a3c8a38` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Implement the P0 backlog slice "Add an AWF-owned conformance-to-validation handoff" with strict TDD.

Context and acceptance:
- Regression source: ws_681eec29b3e44a0daa4a0264 failed as PLAN_CONFORMANCE_UNSATISFIED even though conformance reported implementation appeared complete and only AWF-owned validation evidence was missing.
- If conformance gaps are limited to missing or stale AWF validation evidence, AWF must transition to validation, run the required profile gates, persist validation provenance/log streams, then rerun conformance against that evidence.
- Deterministic plan/API/implementation gaps must still go back to the agent; do not use this path to hide real conformance failures.
- Add explicit reason codes and tests for CONFORMANCE_REQUIRES_AWF_VALIDATION, validation success -> conformance success, validation failure -> validation recovery, and real plan gap -> agent iteration.
- The behavior must apply to normal feature workspaces and PR-monitor recovery paths where conformance evidence is evaluated.

Boundaries:
- Do not change DB connection retry policy; that is a separate parallel P0 slice.
- Do not change terminal runtime cleanup policy; that is a separate parallel P0 slice.
- Do not implement broad validation parallelism changes; the xdist deterministic coverage slice is scheduled after this wave.
- Keep changes scoped to conformance classification, executor/control-flow handoff, validation provenance reuse, reason codes, and tests.

Validation:
- Follow TDD: add failing regression tests first, then implement.
- Run focused conformance/executor/validation tests, then the full coverage gate and keep coverage >= 99%.
- Push the branch and open/monitor the PR through AWF's normal workflow.

---
Validation: 5 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conformance→validation handoff when remaining gaps are AWF-owned validation evidence: runs AWF validation, persists normalized coverage evidence, injects validation evidence into conformance prompts, then performs a conformance-only recheck and records post-validation outcomes.

* **Database**
  * Added persistent coverage storage for validation runs via a migration.

* **Documentation**
  * New catalog entry and handoff spec documenting the reason code, operator workflow, and evidence expectations.

* **Tests**
  * Expanded unit tests covering handoff flows, evidence selection/redaction, recovery, git/report commit, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->