### PR TITLE
ci: add authoritative full coverage gate

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -40,6 +40,7 @@ awf:
     strategy:
       baseline_coverage: skip
       edit_gate: targeted
+      # PR-monitored workspaces defer this authoritative gate to GitHub Actions.
       final_gate: coverage
       reuse_evidence: true
       freshness_max_age_seconds: 86400

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,3 +211,40 @@ jobs:
         env:
           AWF_DATABASE_URL: postgresql+asyncpg://awf:awf_ci@localhost:5432/awf
         run: .venv/bin/pytest tests/integration/ -v
+
+  ci-required:
+    runs-on: ubuntu-latest
+    needs:
+      - lint-and-test
+      - python-full-coverage
+      - console
+      - release-artifacts
+      - integration
+    if: ${{ always() }}
+    timeout-minutes: 5
+    steps:
+      - name: Verify required jobs passed
+        env:
+          LINT_AND_TEST_RESULT: ${{ needs['lint-and-test'].result }}
+          PYTHON_FULL_COVERAGE_RESULT: ${{ needs['python-full-coverage'].result }}
+          CONSOLE_RESULT: ${{ needs.console.result }}
+          RELEASE_ARTIFACTS_RESULT: ${{ needs['release-artifacts'].result }}
+          INTEGRATION_RESULT: ${{ needs.integration.result }}
+        run: |
+          for result in \
+            "$LINT_AND_TEST_RESULT" \
+            "$PYTHON_FULL_COVERAGE_RESULT" \
+            "$CONSOLE_RESULT" \
+            "$RELEASE_ARTIFACTS_RESULT" \
+            "$INTEGRATION_RESULT"
+          do
+            if [ "$result" != "success" ]; then
+              echo "A required CI job did not pass."
+              echo "lint-and-test: $LINT_AND_TEST_RESULT"
+              echo "python-full-coverage: $PYTHON_FULL_COVERAGE_RESULT"
+              echo "console: $CONSOLE_RESULT"
+              echo "release-artifacts: $RELEASE_ARTIFACTS_RESULT"
+              echo "integration: $INTEGRATION_RESULT"
+              exit 1
+            fi
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,23 +38,60 @@ jobs:
         # against them generates noise without catching real bugs.
         run: .venv/bin/mypy
 
-      - name: Unit tests with coverage
-        # ``--cov-fail-under=0`` overrides the 90% bar from pyproject
-        # because unit tests alone don't exercise ``pr_monitor_runner.py``
-        # and similar runtime orchestrators — those have dedicated
-        # integration tests that run in the ``integration`` job below.
-        # Enforcing 90% here would force either coverage-theatre or
-        # pulling integration tests into the unit suite; neither is
-        # what we want. The test-authoring bar still applies: new
-        # modules should come with >90% unit coverage of their pure
-        # logic (see Phase 1.5d/1.5e helpers, both at 94-100%).
-        run: .venv/bin/pytest tests/unit/ -v --cov=awf --cov-report=term-missing --cov-report=xml --cov-fail-under=0
+      - name: Unit tests
+        run: .venv/bin/pytest tests/unit/ -v
 
-      - name: Upload coverage artifact
+  python-full-coverage:
+    runs-on: ubuntu-latest-8-cores
+    needs: lint-and-test
+    timeout-minutes: 60
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: awf
+          POSTGRES_PASSWORD: awf_ci
+          POSTGRES_DB: awf
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd "pg_isready -U awf"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "0.5.x"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --python 3.12 --extra dev
+
+      - name: Verify Docker and Compose
+        run: |
+          docker version
+          docker compose version
+
+      - name: Build agent runtime image
+        run: docker build -t awf-agent-runtime:latest -f docker/agent-runtime.Dockerfile .
+
+      - name: Full coverage
+        env:
+          CI: "true"
+          AWF_DATABASE_URL: postgresql+asyncpg://awf:awf_ci@localhost:5432/awf
+          AWF_TEST_DATABASE_URL: postgresql+asyncpg://awf:awf_ci@localhost:5432/awf
+        run: uv run --python 3.12 --extra dev pytest -n 8 --dist=loadscope --cov=awf --cov-report=term-missing --cov-report=xml --cov-fail-under=99
+
+      - name: Upload full coverage artifact
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-report
+          name: full-coverage-report
           path: coverage.xml
           retention-days: 14
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
           CI: "true"
           AWF_DATABASE_URL: postgresql+asyncpg://awf:awf_ci@localhost:5432/awf
           AWF_TEST_DATABASE_URL: postgresql+asyncpg://awf:awf_ci@localhost:5432/awf
-        run: uv run --python 3.12 --extra dev pytest -n 8 --dist=loadscope --cov=awf --cov-report=term-missing --cov-report=xml --cov-fail-under=99
+        run: uv run --python 3.12 pytest -n 8 --dist=loadscope --cov=awf --cov-report=term-missing --cov-report=xml --cov-fail-under=99
 
       - name: Upload full coverage artifact
         if: always()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,13 @@ npm --prefix apps/console run typecheck
 npm --prefix apps/console run build
 ```
 
+## Required GitHub Status Check
+
+Branch protection for `main` and `development` must require the CI
+`ci-required` job. That rollup job depends on `lint-and-test`,
+`python-full-coverage`, `console`, `release-artifacts`, and `integration`, so
+the 99% coverage gate cannot be bypassed by other green jobs in the workflow.
+
 Before a local Core release, run:
 
 ```bash
@@ -130,4 +137,3 @@ uv run --python 3.12 --extra dev pytest tests/unit/api -q
 uv run --python 3.12 --extra dev pytest tests/unit/runtime -q
 uv run --python 3.12 --extra dev pytest tests/unit/common/test_github_client.py -q
 ```
-

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -28,6 +28,7 @@ from awf.control.executor import (
     _coverage_has_failing_tests,
     _coverage_preserves_below_threshold_baseline,
     _coverage_wrapped_pytest_failure_message,
+    _defer_final_coverage_to_pr_monitor,
     _failure_reason_for_phase,
     _failure_salvage_payload,
     _format_failing_test_evidence,
@@ -456,6 +457,52 @@ def test_validation_command_records_can_mark_coverage_skipped_by_policy() -> Non
     assert records[-1]["phase"] == "coverage"
     assert records[-1]["evidence_status"] == "skipped_by_policy"
     assert records[-1]["evidence_reason_code"] == "TARGETED_EDIT_GATE"
+
+
+@pytest.mark.unit
+def test_pr_monitored_targeted_profile_defers_final_coverage_to_check_rollup() -> None:
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "awf-self",
+            "validation": {
+                "strategy": {
+                    "edit_gate": "targeted",
+                    "final_gate": "coverage",
+                },
+                "coverage": {
+                    "minimum_percent": 99,
+                    "enforce": True,
+                    "command": "uv run --python 3.12 --extra dev pytest --cov=awf",
+                },
+            },
+            "phases": {"validate": ["uv run pytest tests/unit/cli -q"]},
+        }
+    )
+
+    assert (
+        _defer_final_coverage_to_pr_monitor(
+            recovery=None,
+            has_pr_monitor=True,
+            profile=profile,
+        )
+        is True
+    )
+    assert (
+        _defer_final_coverage_to_pr_monitor(
+            recovery=None,
+            has_pr_monitor=False,
+            profile=profile,
+        )
+        is False
+    )
+    assert (
+        _defer_final_coverage_to_pr_monitor(
+            recovery={"recovery_mode": "validate_only"},
+            has_pr_monitor=True,
+            profile=profile,
+        )
+        is False
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -59,7 +59,7 @@ def test_ci_has_authoritative_python_full_coverage_job() -> None:
         step for step in job["steps"] if isinstance(step, dict) and step.get("name") == "Full coverage"
     ]
     assert len(coverage_steps) == 1
-    env = coverage_steps[0]["env"]
+    env = {**job.get("env", {}), **coverage_steps[0].get("env", {})}
     assert env["CI"] == "true"
     assert env["AWF_DATABASE_URL"] == DB_URL
     assert env["AWF_TEST_DATABASE_URL"] == DB_URL

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -11,6 +11,8 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 DB_URL = "postgresql+asyncpg://awf:awf_ci@localhost:5432/awf"
+DOCKER_SKIP_ENV = "AWF_SKIP_DOCKER_TESTS"
+TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 
 
 def _workflow() -> dict[str, Any]:
@@ -19,22 +21,90 @@ def _workflow() -> dict[str, Any]:
     return loaded
 
 
+def _job(workflow: dict[str, Any], name: str) -> dict[str, Any]:
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+    job = jobs.get(name)
+    assert isinstance(job, dict)
+    return job
+
+
+def _steps(job: dict[str, Any]) -> list[dict[str, Any]]:
+    steps = job.get("steps", [])
+    assert isinstance(steps, list)
+    return [step for step in steps if isinstance(step, dict)]
+
+
+def _named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
+    matches = [step for step in _steps(job) if step.get("name") == name]
+    assert len(matches) == 1
+    return matches[0]
+
+
 def _run_steps(job: dict[str, Any]) -> str:
-    return "\n".join(
-        str(step.get("run", "")) for step in job.get("steps", []) if isinstance(step, dict)
+    return "\n".join(str(step.get("run", "")) for step in _steps(job))
+
+
+def _env_mapping(scope: str, value: object) -> dict[str, Any]:
+    assert isinstance(value, dict), f"{scope} env must be a mapping"
+    return value
+
+
+def _env_scopes(
+    workflow: dict[str, Any],
+    job: dict[str, Any],
+    step: dict[str, Any],
+) -> tuple[tuple[str, dict[str, Any]], ...]:
+    return (
+        ("workflow", _env_mapping("workflow", workflow.get("env", {}))),
+        ("job", _env_mapping("job", job.get("env", {}))),
+        ("step", _env_mapping("step", step.get("env", {}))),
     )
+
+
+def _effective_env(
+    workflow: dict[str, Any],
+    job: dict[str, Any],
+    step: dict[str, Any],
+) -> dict[str, Any]:
+    env: dict[str, Any] = {}
+    for _scope, scoped_env in _env_scopes(workflow, job, step):
+        env.update(scoped_env)
+    return env
+
+
+def _env_truthy(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in TRUTHY_ENV_VALUES
+
+
+def _assert_docker_skip_env_disabled(
+    workflow: dict[str, Any],
+    job: dict[str, Any],
+    step: dict[str, Any],
+) -> None:
+    offenders = [
+        scope
+        for scope, scoped_env in _env_scopes(workflow, job, step)
+        if _env_truthy(scoped_env.get(DOCKER_SKIP_ENV, ""))
+    ]
+    assert not offenders, f"{DOCKER_SKIP_ENV} must not be truthy in: {', '.join(offenders)}"
 
 
 @pytest.mark.unit
 def test_ci_has_authoritative_python_full_coverage_job() -> None:
-    jobs = _workflow()["jobs"]
-    job = jobs["python-full-coverage"]
+    workflow = _workflow()
+    job = _job(workflow, "python-full-coverage")
 
-    assert job["runs-on"] == "ubuntu-latest-8-cores"
+    assert job.get("runs-on") == "ubuntu-latest-8-cores"
 
-    postgres = job["services"]["postgres"]
-    assert postgres["image"] == "postgres:16"
-    assert postgres["env"] == {
+    services = job.get("services", {})
+    assert isinstance(services, dict)
+    postgres = services.get("postgres")
+    assert isinstance(postgres, dict)
+    assert postgres.get("image") == "postgres:16"
+    assert postgres.get("env") == {
         "POSTGRES_USER": "awf",
         "POSTGRES_PASSWORD": "awf_ci",
         "POSTGRES_DB": "awf",
@@ -55,20 +125,46 @@ def test_ci_has_authoritative_python_full_coverage_job() -> None:
     assert "--cov-fail-under=0" not in commands
     assert "pytest tests/unit" not in commands
 
-    coverage_steps = [
-        step for step in job["steps"] if isinstance(step, dict) and step.get("name") == "Full coverage"
-    ]
-    assert len(coverage_steps) == 1
-    env = {**job.get("env", {}), **coverage_steps[0].get("env", {})}
-    assert env["CI"] == "true"
-    assert env["AWF_DATABASE_URL"] == DB_URL
-    assert env["AWF_TEST_DATABASE_URL"] == DB_URL
-    assert env.get("AWF_SKIP_DOCKER_TESTS") not in ("1", 1)
+    coverage_step = _named_step(job, "Full coverage")
+    env = _effective_env(workflow, job, coverage_step)
+    assert env.get("CI") == "true"
+    assert env.get("AWF_DATABASE_URL") == DB_URL
+    assert env.get("AWF_TEST_DATABASE_URL") == DB_URL
+    _assert_docker_skip_env_disabled(workflow, job, coverage_step)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("scope", "value"),
+    [
+        ("workflow", "true"),
+        ("job", "yes"),
+        ("step", "on"),
+        ("step", True),
+    ],
+)
+def test_full_coverage_job_rejects_truthy_docker_skip_env_at_any_scope(
+    scope: str,
+    value: object,
+) -> None:
+    workflow = {"env": {}, "jobs": {"python-full-coverage": {"env": {}, "steps": []}}}
+    job = workflow["jobs"]["python-full-coverage"]
+    step: dict[str, object] = {"env": {}}
+
+    if scope == "workflow":
+        workflow["env"][DOCKER_SKIP_ENV] = value
+    elif scope == "job":
+        job["env"][DOCKER_SKIP_ENV] = value
+    else:
+        step["env"][DOCKER_SKIP_ENV] = value
+
+    with pytest.raises(AssertionError, match=DOCKER_SKIP_ENV):
+        _assert_docker_skip_env_disabled(workflow, job, step)
 
 
 @pytest.mark.unit
 def test_unit_smoke_job_is_not_the_authoritative_coverage_gate() -> None:
-    commands = _run_steps(_workflow()["jobs"]["lint-and-test"])
+    commands = _run_steps(_job(_workflow(), "lint-and-test"))
 
     assert "pytest tests/unit/" in commands
     assert "--cov=awf" not in commands

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -42,6 +42,12 @@ def _named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
     return matches[0]
 
 
+def _step_run(job: dict[str, Any], name: str) -> str:
+    run = _named_step(job, name).get("run")
+    assert isinstance(run, str)
+    return run
+
+
 def _run_steps(job: dict[str, Any]) -> str:
     return "\n".join(str(step.get("run", "")) for step in _steps(job))
 
@@ -123,16 +129,17 @@ def test_ci_has_authoritative_python_full_coverage_job() -> None:
     assert "docker version" in commands
     assert "docker compose version" in commands
     assert "docker build -t awf-agent-runtime:latest -f docker/agent-runtime.Dockerfile ." in commands
-    assert "uv run --python 3.12 --extra dev pytest" in commands
-    assert "-n 8" in commands
-    assert "--dist=loadscope" in commands
-    assert "--cov=awf" in commands
-    assert "--cov-report=term-missing" in commands
-    assert "--cov-report=xml" in commands
-    assert "--cov-fail-under=99" in commands
 
-    assert "--cov-fail-under=0" not in commands
-    assert "pytest tests/unit" not in commands
+    full_coverage_run = _step_run(job, "Full coverage")
+    assert "uv run --python 3.12 pytest" in full_coverage_run
+    assert "-n 8" in full_coverage_run
+    assert "--dist=loadscope" in full_coverage_run
+    assert "--cov=awf" in full_coverage_run
+    assert "--cov-report=term-missing" in full_coverage_run
+    assert "--cov-report=xml" in full_coverage_run
+    assert "--cov-fail-under=99" in full_coverage_run
+    assert "--cov-fail-under=0" not in full_coverage_run
+    assert "pytest tests/unit" not in full_coverage_run
 
     coverage_step = _named_step(job, "Full coverage")
     env = _effective_env(workflow, job, coverage_step)

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -10,6 +10,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+CONTRIBUTING_PATH = REPO_ROOT / "CONTRIBUTING.md"
 DB_URL = "postgresql+asyncpg://awf:awf_ci@localhost:5432/awf"
 DOCKER_SKIP_ENV = "AWF_SKIP_DOCKER_TESTS"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
@@ -43,6 +44,14 @@ def _named_step(job: dict[str, Any], name: str) -> dict[str, Any]:
 
 def _run_steps(job: dict[str, Any]) -> str:
     return "\n".join(str(step.get("run", "")) for step in _steps(job))
+
+
+def _job_needs(job: dict[str, Any]) -> set[str]:
+    needs = job.get("needs", [])
+    if isinstance(needs, str):
+        return {needs}
+    assert isinstance(needs, list)
+    return {str(need) for need in needs}
 
 
 def _env_mapping(scope: str, value: object) -> dict[str, Any]:
@@ -169,3 +178,30 @@ def test_unit_smoke_job_is_not_the_authoritative_coverage_gate() -> None:
     assert "pytest tests/unit/" in commands
     assert "--cov=awf" not in commands
     assert "--cov-fail-under" not in commands
+
+
+@pytest.mark.unit
+def test_required_ci_gate_rolls_up_full_coverage_and_required_jobs() -> None:
+    job = _job(_workflow(), "ci-required")
+
+    assert job.get("if") == "${{ always() }}"
+    assert _job_needs(job) == {
+        "lint-and-test",
+        "python-full-coverage",
+        "console",
+        "release-artifacts",
+        "integration",
+    }
+
+    commands = _run_steps(job)
+    assert "A required CI job did not pass." in commands
+    assert '!= "success"' in commands
+
+
+@pytest.mark.unit
+def test_contributor_docs_require_ci_rollup_status_check() -> None:
+    docs = CONTRIBUTING_PATH.read_text(encoding="utf-8")
+
+    assert "branch protection" in docs.lower()
+    assert "ci-required" in docs
+    assert "python-full-coverage" in docs

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -1,0 +1,75 @@
+"""Regression tests for the authoritative GitHub Actions coverage gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+DB_URL = "postgresql+asyncpg://awf:awf_ci@localhost:5432/awf"
+
+
+def _workflow() -> dict[str, Any]:
+    loaded = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _run_steps(job: dict[str, Any]) -> str:
+    return "\n".join(
+        str(step.get("run", "")) for step in job.get("steps", []) if isinstance(step, dict)
+    )
+
+
+@pytest.mark.unit
+def test_ci_has_authoritative_python_full_coverage_job() -> None:
+    jobs = _workflow()["jobs"]
+    job = jobs["python-full-coverage"]
+
+    assert job["runs-on"] == "ubuntu-latest-8-cores"
+
+    postgres = job["services"]["postgres"]
+    assert postgres["image"] == "postgres:16"
+    assert postgres["env"] == {
+        "POSTGRES_USER": "awf",
+        "POSTGRES_PASSWORD": "awf_ci",
+        "POSTGRES_DB": "awf",
+    }
+
+    commands = _run_steps(job)
+    assert "docker version" in commands
+    assert "docker compose version" in commands
+    assert "docker build -t awf-agent-runtime:latest -f docker/agent-runtime.Dockerfile ." in commands
+    assert "uv run --python 3.12 --extra dev pytest" in commands
+    assert "-n 8" in commands
+    assert "--dist=loadscope" in commands
+    assert "--cov=awf" in commands
+    assert "--cov-report=term-missing" in commands
+    assert "--cov-report=xml" in commands
+    assert "--cov-fail-under=99" in commands
+
+    assert "--cov-fail-under=0" not in commands
+    assert "pytest tests/unit" not in commands
+
+    coverage_steps = [
+        step for step in job["steps"] if isinstance(step, dict) and step.get("name") == "Full coverage"
+    ]
+    assert len(coverage_steps) == 1
+    env = coverage_steps[0]["env"]
+    assert env["CI"] == "true"
+    assert env["AWF_DATABASE_URL"] == DB_URL
+    assert env["AWF_TEST_DATABASE_URL"] == DB_URL
+    assert env.get("AWF_SKIP_DOCKER_TESTS") not in ("1", 1)
+
+
+@pytest.mark.unit
+def test_unit_smoke_job_is_not_the_authoritative_coverage_gate() -> None:
+    commands = _run_steps(_workflow()["jobs"]["lint-and-test"])
+
+    assert "pytest tests/unit/" in commands
+    assert "--cov=awf" not in commands
+    assert "--cov-fail-under" not in commands

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -154,6 +154,7 @@ def test_ci_has_authoritative_python_full_coverage_job() -> None:
     ("scope", "value"),
     [
         ("workflow", "true"),
+        ("workflow", "True"),
         ("job", "yes"),
         ("step", "on"),
         ("step", True),


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions python-full-coverage job on the configured 8-core runner
- run full pytest coverage with Postgres, Docker/Compose, prebuilt awf-agent-runtime, xdist -n 8, and --cov-fail-under=99
- convert the old unit coverage job into a fast unit smoke so coverage authority lives in one CI gate
- add static workflow regression tests and executor coverage-deferral regression coverage

## Validation
- uv run --python 3.12 --extra dev pytest tests/unit/test_ci_workflow_full_coverage.py tests/unit/control/test_executor_coverage_edges.py -q -k 'ci_has_authoritative or unit_smoke_job or pr_monitored_targeted'
- uv run --python 3.12 --extra dev ruff check src/awf tests
- uv run --python 3.12 --extra dev mypy src/awf
- uv run --python 3.12 --extra dev pytest tests/unit -q

## Notes
This PR is intended to dogfood the new GitHub full-coverage gate. The runner label is assumed to exist as ubuntu-latest-8-cores; if it is not configured, CI should fail loudly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authoritative full-coverage CI job enforcing 99% coverage and a rollup "ci-required" job that fails when required checks do not succeed.

* **Bug Fixes**
  * Decoupled basic unit-test runs from coverage gating to speed feedback.

* **Tests**
  * Added tests validating the CI workflow, coverage gate behaviour, and rollup wiring.

* **Documentation**
  * Clarified that PR-monitored workspaces defer the authoritative coverage gate to CI and updated contributing guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/228)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->