### PR TITLE
Prevent duplicate PR monitor recovery dispatch

### DIFF
--- a/TODO/pre-gke-industrial-readiness.md
+++ b/TODO/pre-gke-industrial-readiness.md
@@ -73,9 +73,11 @@ Status values:
 
 ### Active Slices
 
-No active AWF slices are currently tracked in this ledger. The previously
-active PR-monitor slices for PRs #206, #212, #214, #216, #218, and #219 have
-landed on `codex/awf-post-merge-fixes` and are recorded under Completed Slices.
+| TODO area | Slice | Workspace | Agent / model | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| P0 Reliability, Cleanup, And SLOs | Harden Postgres/asyncpg connection resilience for long-running local control planes | `ws_b9cdd9b1c3474951876ee21d` | Codex `gpt-5.5` / `xhigh` | running | First-wave independent P0 slice. Scope: SQLAlchemy/asyncpg liveness, bounded retry/invalidation in API and worker read paths, worker polling continuity, and service-health diagnostics without terminalizing unrelated workspaces. |
+| P0 Reliability, Cleanup, And SLOs | Stop and release terminal failed runtime resources without destroying salvage evidence | `ws_de86ae75f42943d1830f1b0c` | Codex `gpt-5.5` / `xhigh` | running | First-wave independent P0 slice. Scope: terminal failed/cancelled/completed runtime teardown, reservation release, readiness/orphan-resource distinction between retained evidence and leaked live resources, and salvage-preserving cleanup tests. |
+| P0 Operation And Recovery Truth | Add an AWF-owned conformance-to-validation handoff | `ws_c76512d8b0514eff9a3c8a38` | Codex `gpt-5.5` / `xhigh` | running | First-wave independent P0 slice. Scope: conformance gaps limited to missing/stale AWF validation evidence transition to validation, rerun conformance after persisted validation evidence, and keep real plan/API gaps routed to agent iteration. |
 
 ### Reschedule Required Slices
 

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -510,7 +510,9 @@ def _agent_writable_git_targets(
         # lacks Docker ownership metadata and appears as unwritable root:root in
         # the control-plane container. Linux still gets writable object dirs.
         targets.append(_ChownTarget(objects, recursive=True, directories_only=True))
-    for child in ("refs", "logs"):
+    # Linked worktrees install hooks in the shared bare mirror; setup commands
+    # such as ``pre-commit install`` must be able to write there.
+    for child in ("hooks", "refs", "logs"):
         candidate = layout_mirror / child
         if candidate.exists():
             targets.append(_ChownTarget(candidate, recursive=True))

--- a/src/awf/runtime/pr_monitor_operations.py
+++ b/src/awf/runtime/pr_monitor_operations.py
@@ -16,6 +16,12 @@ from awf.db.enums import OperationStatus, OperationType
 from awf.db.models import Operation, Workspace
 from awf.db.repositories import OperationRepository
 
+_RETRYABLE_MONITOR_OPERATION_STATUSES = frozenset(
+    {
+        OperationStatus.failed.value,
+        OperationStatus.cancelled.value,
+    }
+)
 _MONITOR_REDACTED_ASSIGNMENT_RE = re.compile(
     r"\b(?:[A-Za-z][A-Za-z0-9_]*_)?"
     r"(?:TOKEN|API[_-]?KEY|ACCESS[_-]?KEY|PASSWORD|PASSWD|SECRET)"
@@ -111,12 +117,13 @@ async def retryable_monitor_operation_idempotency_key(
     source_base_sha: str | None,
     extra: Sequence[object] = (),
 ) -> str:
-    """Return an idempotency key that can retry a failed monitor operation.
+    """Return an idempotency key that can retry an unhandled monitor operation.
 
     The base key is stable for a single monitor-observed PR state, which is
-    what prevents duplicate active dispatches. Once the operation has failed,
-    the same stable key would point back at the failed row forever, so retries
-    derive their identity from the failed operation that triggered them.
+    what prevents duplicate active dispatches. Once the operation has failed or
+    been cancelled, the same stable key would point back at a terminal row
+    forever, so retries derive their identity from the operation that triggered
+    them.
     """
     retry_extra = tuple(extra)
     while True:
@@ -130,11 +137,12 @@ async def retryable_monitor_operation_idempotency_key(
             extra=retry_extra,
         )
         existing = await repo.get_by_idempotency_key(idempotency_key)
-        if existing is None or existing.status != OperationStatus.failed.value:
+        if existing is None or existing.status not in _RETRYABLE_MONITOR_OPERATION_STATUSES:
             return idempotency_key
+        retry_marker = f"retry_after_{existing.status}_operation"
         retry_extra = (
             *tuple(extra),
-            "retry_after_failed_operation",
+            retry_marker,
             existing.id,
         )
 

--- a/src/awf/runtime/pr_monitor_operations.py
+++ b/src/awf/runtime/pr_monitor_operations.py
@@ -16,7 +16,7 @@ from awf.db.enums import OperationStatus, OperationType
 from awf.db.models import Operation, Workspace
 from awf.db.repositories import OperationRepository
 
-_RETRYABLE_MONITOR_OPERATION_STATUSES = frozenset(
+RETRYABLE_MONITOR_OPERATION_STATUSES = frozenset(
     {
         OperationStatus.failed.value,
         OperationStatus.cancelled.value,
@@ -137,7 +137,7 @@ async def retryable_monitor_operation_idempotency_key(
             extra=retry_extra,
         )
         existing = await repo.get_by_idempotency_key(idempotency_key)
-        if existing is None or existing.status not in _RETRYABLE_MONITOR_OPERATION_STATUSES:
+        if existing is None or existing.status not in RETRYABLE_MONITOR_OPERATION_STATUSES:
             return idempotency_key
         retry_marker = f"retry_after_{existing.status}_operation"
         retry_extra = (

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2528,6 +2528,7 @@ class PullRequestMonitorRunner:
         return _supply_chain_policy_blocked_message(blocking_codes)
 
     async def _recovery_dispatch_status_is_stale(self, workspace_id: str) -> bool:
+        """Return whether a recovery-dispatch callback no longer owns the workspace."""
         from awf.db.repositories import WorkspaceRepository
 
         async with self._deps.session_factory() as s:
@@ -2754,6 +2755,7 @@ class PullRequestMonitorRunner:
         monitor_log: WorkspaceLogSink | None,
         skip_initial_review_grace: bool = False,
     ) -> bool | None:
+        """Handle merge-gate blocks by waiting, dispatching recovery, or notifying humans."""
         stale_reason = gate.stale_reason
         req_action = gate.req_action
         ws = gate.workspace

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2535,15 +2535,7 @@ class PullRequestMonitorRunner:
             if ws.status == WorkspaceStatus.monitoring_pr.value:
                 return False
             active_recovery = any(
-                op.status
-                in (
-                    OperationStatus.pending.value,
-                    OperationStatus.running.value,
-                )
-                and op.type != OperationType.monitor_state.value
-                and isinstance(op.payload, dict)
-                and op.payload.get("source") == "pr_monitor"
-                for op in ws.operations
+                _is_active_pr_monitor_recovery_operation(op) for op in ws.operations
             )
             if active_recovery:
                 return False

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -311,9 +311,10 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
 def _is_active_pr_monitor_recovery_operation(operation: Operation) -> bool:
     return (
         operation.status in _ACTIVE_RECOVERY_OPERATION_STATUSES
-        and operation.type != OperationType.monitor_state.value
+        and operation.type == OperationType.validate.value
         and isinstance(operation.payload, dict)
         and operation.payload.get("source") == "pr_monitor"
+        and operation.payload.get("recovery_mode") is not None
     )
 
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -263,6 +263,12 @@ _ACTIVE_RECOVERY_OPERATION_STATUSES = frozenset(
         OperationStatus.running.value,
     }
 )
+_RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES = frozenset(
+    {
+        OperationStatus.failed.value,
+        OperationStatus.cancelled.value,
+    }
+)
 _TERMINAL_WORKSPACE_STATUSES = {
     WorkspaceStatus.completed.value,
     WorkspaceStatus.failed.value,
@@ -2989,15 +2995,31 @@ class PullRequestMonitorRunner:
                     source_head_sha=status.head_sha,
                     source_base_sha=_ws.base_commit,
                 )
-                operation, created = await operation_repo.create_idempotent(
-                    workspace_id=workspace_id,
-                    operation_type="validate",
-                    payload=operation_payload,
-                    idempotency_key=idempotency_key,
-                )
-                if not created:
+                while True:
+                    operation, created = await operation_repo.create_idempotent(
+                        workspace_id=workspace_id,
+                        operation_type="validate",
+                        payload=operation_payload,
+                        idempotency_key=idempotency_key,
+                    )
+                    if created:
+                        break
                     existing_operation_id = operation.id
                     existing_operation_status = operation.status
+                    if (
+                        existing_operation_status
+                        in _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES
+                    ):
+                        idempotency_key = await retryable_monitor_operation_idempotency_key(
+                            operation_repo,
+                            workspace_id=workspace_id,
+                            action=recovery_mode,
+                            pr_number=pr_number,
+                            reason_code=recovery_reason_code,
+                            source_head_sha=status.head_sha,
+                            source_base_sha=_ws.base_commit,
+                        )
+                        continue
                     wait_payload = {
                         "recovery_mode": recovery_mode,
                         "stale_reason": stale_reason,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2994,17 +2994,6 @@ class PullRequestMonitorRunner:
                 )
                 while True:
                     await s.refresh(_ws, attribute_names=["status"])
-                    if _is_callback_terminal_workspace_status(_ws.status):
-                        await workspace_repo.record_ignored_stale_callback(
-                            _ws,
-                            callback_source="pr_monitor",
-                            callback_action="recovery_dispatch",
-                            expected_status=WorkspaceStatus.monitoring_pr,
-                            requested_status=WorkspaceStatus.ready,
-                            reason_code="STALE_CALLBACK_IGNORED",
-                        )
-                        await s.commit()
-                        return True
                     if _ws.status != WorkspaceStatus.monitoring_pr.value:
                         await workspace_repo.record_ignored_stale_callback(
                             _ws,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -385,6 +385,12 @@ class _NonCheckReviewerSettleDecision:
     state_changed: bool = False
 
 
+@dataclass(frozen=True)
+class _NonCheckReviewerSettleWaitOperationContext:
+    extra_payload: dict[str, object]
+    extra_identity: tuple[object, ...]
+
+
 class ProviderRecoveryFallbackError(Exception):
     """Raised when a retryable provider failure triggers a fallback workspace."""
 
@@ -1831,6 +1837,10 @@ class PullRequestMonitorRunner:
             )
             if settle_decision.wait_seconds > 0:
                 requested_action = "validate" if pending_validation_gate is not None else "merge"
+                settle_operation_context = _non_check_reviewer_settle_wait_operation_context(
+                    self._config,
+                    settle_decision,
+                )
                 await self._sleep_with_monitor_state_operation(
                     workspace_id=workspace_id,
                     action="reviewer_settle_wait",
@@ -1848,18 +1858,8 @@ class PullRequestMonitorRunner:
                     remote_branch=remote_branch,
                     wait_seconds=settle_decision.wait_seconds,
                     monitor_log=monitor_log,
-                    extra_payload={
-                        "settle_seconds": self._config.non_check_reviewer_settle_seconds,
-                        "configured_reviewers": list(settle_decision.configured_reviewers),
-                        "missing_reviewers": list(settle_decision.missing_reviewers),
-                        "visible_reviewers": list(settle_decision.visible_reviewers),
-                        "elapsed_seconds": settle_decision.elapsed_seconds,
-                    },
-                    extra_identity=(
-                        *settle_decision.configured_reviewers,
-                        *settle_decision.missing_reviewers,
-                        settle_decision.started_at,
-                    ),
+                    extra_payload=settle_operation_context.extra_payload,
+                    extra_identity=settle_operation_context.extra_identity,
                 )
                 return False
 
@@ -2342,6 +2342,12 @@ class PullRequestMonitorRunner:
                             monitor_log=monitor_log,
                         )
                         if settle_decision.wait_seconds > 0:
+                            settle_operation_context = (
+                                _non_check_reviewer_settle_wait_operation_context(
+                                    settle_config,
+                                    settle_decision,
+                                )
+                            )
                             await self._sleep_with_monitor_state_operation(
                                 workspace_id=workspace_id,
                                 action="reviewer_settle_wait",
@@ -2357,22 +2363,8 @@ class PullRequestMonitorRunner:
                                 remote_branch=remote_branch,
                                 wait_seconds=settle_decision.wait_seconds,
                                 monitor_log=monitor_log,
-                                extra_payload={
-                                    "settle_seconds": (
-                                        self._config.non_check_reviewer_settle_seconds
-                                    ),
-                                    "configured_reviewers": list(
-                                        settle_decision.configured_reviewers
-                                    ),
-                                    "missing_reviewers": list(settle_decision.missing_reviewers),
-                                    "visible_reviewers": list(settle_decision.visible_reviewers),
-                                    "elapsed_seconds": settle_decision.elapsed_seconds,
-                                },
-                                extra_identity=(
-                                    *settle_decision.configured_reviewers,
-                                    *settle_decision.missing_reviewers,
-                                    settle_decision.started_at,
-                                ),
+                                extra_payload=settle_operation_context.extra_payload,
+                                extra_identity=settle_operation_context.extra_identity,
                             )
                             return False
 
@@ -5744,6 +5736,26 @@ def _non_check_reviewer_settle_decision(
         started_at=started_at,
         elapsed_seconds=elapsed_seconds,
         state_changed=started_now,
+    )
+
+
+def _non_check_reviewer_settle_wait_operation_context(
+    config: MonitorConfig,
+    decision: _NonCheckReviewerSettleDecision,
+) -> _NonCheckReviewerSettleWaitOperationContext:
+    return _NonCheckReviewerSettleWaitOperationContext(
+        extra_payload={
+            "settle_seconds": config.non_check_reviewer_settle_seconds,
+            "configured_reviewers": list(decision.configured_reviewers),
+            "missing_reviewers": list(decision.missing_reviewers),
+            "visible_reviewers": list(decision.visible_reviewers),
+            "elapsed_seconds": decision.elapsed_seconds,
+        },
+        extra_identity=(
+            *decision.configured_reviewers,
+            *decision.missing_reviewers,
+            decision.started_at,
+        ),
     )
 
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2993,6 +2993,29 @@ class PullRequestMonitorRunner:
                     source_base_sha=_ws.base_commit,
                 )
                 while True:
+                    await s.refresh(_ws, attribute_names=["status"])
+                    if _is_callback_terminal_workspace_status(_ws.status):
+                        await workspace_repo.record_ignored_stale_callback(
+                            _ws,
+                            callback_source="pr_monitor",
+                            callback_action="recovery_dispatch",
+                            expected_status=WorkspaceStatus.monitoring_pr,
+                            requested_status=WorkspaceStatus.ready,
+                            reason_code="STALE_CALLBACK_IGNORED",
+                        )
+                        await s.commit()
+                        return True
+                    if _ws.status != WorkspaceStatus.monitoring_pr.value:
+                        await workspace_repo.record_ignored_stale_callback(
+                            _ws,
+                            callback_source="pr_monitor",
+                            callback_action="recovery_dispatch",
+                            expected_status=WorkspaceStatus.monitoring_pr,
+                            requested_status=WorkspaceStatus.ready,
+                            reason_code="STALE_CALLBACK_IGNORED",
+                        )
+                        await s.commit()
+                        return True
                     operation, created = await operation_repo.create_idempotent(
                         workspace_id=workspace_id,
                         operation_type="validate",

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -232,6 +232,7 @@ _GIT_MIRROR_BROKEN_REF_REMOVED_REASON = "GIT_MIRROR_BROKEN_REF_REMOVED"
 _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
 _PROTECTED_SCOPE_REPAIR_FAILED_REASON = "PROTECTED_SCOPE_REPAIR_FAILED"
 _VALIDATION_INSUFFICIENT_STALE_REASON = "validation_insufficient_tier"
+_RECOVERY_SNAPSHOT_ALREADY_HANDLED_REASON = "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
 _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
 _AUDIT_MERGE_ATTEMPT_EVENT = "workspace.audit.merge_attempt"
 _AUDIT_MERGE_RESULT_EVENT = "workspace.audit.merge_result"
@@ -256,6 +257,12 @@ _BROKEN_AWF_REF_RE = re.compile(r"refs/heads/awf/(ws_[A-Za-z0-9_-]+)")
 _BASE_FETCH_RETRY_COUNT_KEY_PREFIX = "__awf_base_fetch_retry_count:"
 _SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY = "__awf_sync_base_no_progress_signature"
 _SYNC_BASE_NO_PROGRESS_COUNT_KEY = "__awf_sync_base_no_progress_count"
+_ACTIVE_RECOVERY_OPERATION_STATUSES = frozenset(
+    {
+        OperationStatus.pending.value,
+        OperationStatus.running.value,
+    }
+)
 _TERMINAL_WORKSPACE_STATUSES = {
     WorkspaceStatus.completed.value,
     WorkspaceStatus.failed.value,
@@ -299,6 +306,15 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
                 conformance[key] = payload[key]
         return {"conformance": conformance}
     return None
+
+
+def _is_active_pr_monitor_recovery_operation(operation: Operation) -> bool:
+    return (
+        operation.status in _ACTIVE_RECOVERY_OPERATION_STATUSES
+        and operation.type != OperationType.monitor_state.value
+        and isinstance(operation.payload, dict)
+        and operation.payload.get("source") == "pr_monitor"
+    )
 
 
 class BaseFetchError(Exception):
@@ -2920,15 +2936,7 @@ class PullRequestMonitorRunner:
                     await s.commit()
                     return True
                 active_recovery = any(
-                    op.status
-                    in (
-                        OperationStatus.pending.value,
-                        OperationStatus.running.value,
-                    )
-                    and op.type != OperationType.monitor_state.value
-                    and isinstance(op.payload, dict)
-                    and op.payload.get("source") == "pr_monitor"
-                    for op in _ws.operations
+                    _is_active_pr_monitor_recovery_operation(op) for op in _ws.operations
                 )
                 if active_recovery:
                     await s.commit()
@@ -2991,12 +2999,74 @@ class PullRequestMonitorRunner:
                     source_head_sha=status.head_sha,
                     source_base_sha=_ws.base_commit,
                 )
-                await operation_repo.create_idempotent(
+                operation, created = await operation_repo.create_idempotent(
                     workspace_id=workspace_id,
                     operation_type="validate",
                     payload=operation_payload,
                     idempotency_key=idempotency_key,
                 )
+                if not created:
+                    existing_operation_id = operation.id
+                    existing_operation_status = operation.status
+                    await s.commit()
+                    if existing_operation_status in _ACTIVE_RECOVERY_OPERATION_STATUSES:
+                        await self._sleep_with_monitor_state_operation(
+                            workspace_id=workspace_id,
+                            action="recovery_wait",
+                            requested_action=requested_action,
+                            reason="Waiting for an active PR monitor recovery operation to finish.",
+                            reason_code="RECOVERY_IN_PROGRESS",
+                            pr_number=pr_number,
+                            status=status,
+                            base_branch=base_branch,
+                            remote_branch=remote_branch,
+                            wait_seconds=self._config.poll_interval_seconds,
+                            monitor_log=monitor_log,
+                            stale_reason=stale_reason,
+                            extra_payload={
+                                "recovery_mode": recovery_mode,
+                                "stale_reason": stale_reason,
+                                "operation_id": existing_operation_id,
+                                "operation_status": existing_operation_status,
+                            },
+                            extra_identity=(
+                                recovery_mode,
+                                stale_reason,
+                                existing_operation_id,
+                                existing_operation_status,
+                            ),
+                        )
+                    else:
+                        await self._sleep_with_monitor_state_operation(
+                            workspace_id=workspace_id,
+                            action="recovery_already_handled",
+                            requested_action=requested_action,
+                            reason=(
+                                "A prior PR monitor recovery operation already handled this "
+                                "observed PR snapshot."
+                            ),
+                            reason_code=_RECOVERY_SNAPSHOT_ALREADY_HANDLED_REASON,
+                            pr_number=pr_number,
+                            status=status,
+                            base_branch=base_branch,
+                            remote_branch=remote_branch,
+                            wait_seconds=self._config.poll_interval_seconds,
+                            monitor_log=monitor_log,
+                            stale_reason=stale_reason,
+                            extra_payload={
+                                "recovery_mode": recovery_mode,
+                                "stale_reason": stale_reason,
+                                "operation_id": existing_operation_id,
+                                "operation_status": existing_operation_status,
+                            },
+                            extra_identity=(
+                                recovery_mode,
+                                stale_reason,
+                                existing_operation_id,
+                                existing_operation_status,
+                            ),
+                        )
+                    return False
                 await workspace_repo.transition(
                     _ws,
                     to=WorkspaceStatus.ready,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -3003,10 +3003,7 @@ class PullRequestMonitorRunner:
                         break
                     existing_operation_id = operation.id
                     existing_operation_status = operation.status
-                    if (
-                        existing_operation_status
-                        in _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES
-                    ):
+                    if existing_operation_status in _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES:
                         idempotency_key = await retryable_monitor_operation_idempotency_key(
                             operation_repo,
                             workspace_id=workspace_id,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -3008,6 +3008,18 @@ class PullRequestMonitorRunner:
                 if not created:
                     existing_operation_id = operation.id
                     existing_operation_status = operation.status
+                    wait_payload = {
+                        "recovery_mode": recovery_mode,
+                        "stale_reason": stale_reason,
+                        "operation_id": existing_operation_id,
+                        "operation_status": existing_operation_status,
+                    }
+                    wait_identity = (
+                        recovery_mode,
+                        stale_reason,
+                        existing_operation_id,
+                        existing_operation_status,
+                    )
                     await s.commit()
                     if existing_operation_status in _ACTIVE_RECOVERY_OPERATION_STATUSES:
                         await self._sleep_with_monitor_state_operation(
@@ -3023,18 +3035,8 @@ class PullRequestMonitorRunner:
                             wait_seconds=self._config.poll_interval_seconds,
                             monitor_log=monitor_log,
                             stale_reason=stale_reason,
-                            extra_payload={
-                                "recovery_mode": recovery_mode,
-                                "stale_reason": stale_reason,
-                                "operation_id": existing_operation_id,
-                                "operation_status": existing_operation_status,
-                            },
-                            extra_identity=(
-                                recovery_mode,
-                                stale_reason,
-                                existing_operation_id,
-                                existing_operation_status,
-                            ),
+                            extra_payload=wait_payload,
+                            extra_identity=wait_identity,
                         )
                     else:
                         await self._sleep_with_monitor_state_operation(
@@ -3053,18 +3055,8 @@ class PullRequestMonitorRunner:
                             wait_seconds=self._config.poll_interval_seconds,
                             monitor_log=monitor_log,
                             stale_reason=stale_reason,
-                            extra_payload={
-                                "recovery_mode": recovery_mode,
-                                "stale_reason": stale_reason,
-                                "operation_id": existing_operation_id,
-                                "operation_status": existing_operation_status,
-                            },
-                            extra_identity=(
-                                recovery_mode,
-                                stale_reason,
-                                existing_operation_id,
-                                existing_operation_status,
-                            ),
+                            extra_payload=wait_payload,
+                            extra_identity=wait_identity,
                         )
                     return False
                 await workspace_repo.transition(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -309,6 +309,7 @@ def _monitor_recovery_conformance_payload(workspace: Workspace) -> dict[str, Any
 
 
 def _is_active_pr_monitor_recovery_operation(operation: Operation) -> bool:
+    """Return whether an operation is an unfinished PR monitor recovery action."""
     return (
         operation.status in _ACTIVE_RECOVERY_OPERATION_STATUSES
         and operation.type == OperationType.validate.value
@@ -387,6 +388,8 @@ class _NonCheckReviewerSettleDecision:
 
 @dataclass(frozen=True)
 class _NonCheckReviewerSettleWaitOperationContext:
+    """Monitor-state payload and identity fields for reviewer-settle waits."""
+
     extra_payload: dict[str, object]
     extra_identity: tuple[object, ...]
 
@@ -5735,6 +5738,7 @@ def _non_check_reviewer_settle_wait_operation_context(
     config: MonitorConfig,
     decision: _NonCheckReviewerSettleDecision,
 ) -> _NonCheckReviewerSettleWaitOperationContext:
+    """Build persisted wait-operation context for non-check reviewer settle state."""
     return _NonCheckReviewerSettleWaitOperationContext(
         extra_payload={
             "settle_seconds": config.non_check_reviewer_settle_seconds,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -105,6 +105,9 @@ from awf.runtime.pr_monitor import (
     sync_base_no_progress_signature,
 )
 from awf.runtime.pr_monitor_operations import (
+    RETRYABLE_MONITOR_OPERATION_STATUSES as _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES,
+)
+from awf.runtime.pr_monitor_operations import (
     MonitorOperationHandle,
     begin_monitor_state_operation,
     build_monitor_operation_payload,
@@ -261,12 +264,6 @@ _ACTIVE_RECOVERY_OPERATION_STATUSES = frozenset(
     {
         OperationStatus.pending.value,
         OperationStatus.running.value,
-    }
-)
-_RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES = frozenset(
-    {
-        OperationStatus.failed.value,
-        OperationStatus.cancelled.value,
     }
 )
 _TERMINAL_WORKSPACE_STATUSES = {

--- a/tests/integration/test_workspace_services_sidecar_compose.py
+++ b/tests/integration/test_workspace_services_sidecar_compose.py
@@ -61,10 +61,35 @@ def _run(cmd: list[str], *, timeout: int = 60) -> subprocess.CompletedProcess[st
     )
 
 
+def _compose_exec(
+    *,
+    project_name: str,
+    compose_file: Path,
+    service: str,
+    python: str,
+) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [
+            "docker",
+            "compose",
+            "-p",
+            project_name,
+            "-f",
+            str(compose_file),
+            "exec",
+            "-T",
+            service,
+            "python",
+            "-c",
+            python,
+        ]
+    )
+
+
 @pytest.mark.integration
 @pytest.mark.docker
 @pytest.mark.slow
-@pytest.mark.timeout(180)
+@pytest.mark.timeout(300)
 async def test_workspace_services_are_reachable_by_service_name(tmp_path: Path) -> None:
     assert _FIXTURE.is_dir(), "workspace-services fixture is missing"
     workspace_id = f"test_ws_services_{tmp_path.name}"
@@ -80,10 +105,19 @@ async def test_workspace_services_are_reachable_by_service_name(tmp_path: Path) 
     paths = manager.render(spec)
     rendered = yaml.safe_load(paths.compose_file.read_text())
     del rendered["services"]["agent"]
+    rendered["services"]["probe"] = {
+        "image": "python:3.12-alpine",
+        "command": ["sleep", "infinity"],
+        "depends_on": {
+            "app": {"condition": "service_healthy"},
+            "redis": {"condition": "service_healthy"},
+        },
+        "networks": ["awf_net"],
+        "restart": "no",
+    }
     paths.compose_file.write_text(yaml.safe_dump(rendered), encoding="utf-8")
 
     project_name = spec.project_name()
-    network_name = f"awf-{workspace_id}-net"
 
     try:
         await manager._compose(  # noqa: SLF001 - integration smoke uses rendered file.
@@ -93,42 +127,28 @@ async def test_workspace_services_are_reachable_by_service_name(tmp_path: Path) 
             operation="up",
         )
 
-        app_probe = _run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--network",
-                network_name,
-                "python:3.12-alpine",
-                "python",
-                "-c",
-                (
-                    "import urllib.request; "
-                    "print(urllib.request.urlopen('http://app:8080/healthz', timeout=5)"
-                    ".read().decode())"
-                ),
-            ]
+        app_probe = _compose_exec(
+            project_name=project_name,
+            compose_file=paths.compose_file,
+            service="probe",
+            python=(
+                "import urllib.request; "
+                "print(urllib.request.urlopen('http://app:8080/healthz', timeout=5)"
+                ".read().decode())"
+            ),
         )
         assert app_probe.stdout.strip() == "ok"
 
-        redis_probe = _run(
-            [
-                "docker",
-                "run",
-                "--rm",
-                "--network",
-                network_name,
-                "python:3.12-alpine",
-                "python",
-                "-c",
-                (
-                    "import socket; "
-                    "s=socket.create_connection(('redis', 6379), 5); "
-                    "s.sendall(b'*1\\r\\n$4\\r\\nPING\\r\\n'); "
-                    "print(s.recv(64).decode())"
-                ),
-            ]
+        redis_probe = _compose_exec(
+            project_name=project_name,
+            compose_file=paths.compose_file,
+            service="probe",
+            python=(
+                "import socket; "
+                "s=socket.create_connection(('redis', 6379), 5); "
+                "s.sendall(b'*1\\r\\n$4\\r\\nPING\\r\\n'); "
+                "print(s.recv(64).decode())"
+            ),
         )
         assert "+PONG" in redis_probe.stdout
 

--- a/tests/unit/fixtures/test_node_next_browser_validator_server.py
+++ b/tests/unit/fixtures/test_node_next_browser_validator_server.py
@@ -23,6 +23,7 @@ _FIXTURE_ROOT = (
     / "node_next_browser_app"
 )
 _VALIDATOR_SERVER = _FIXTURE_ROOT / "browser" / "validator-server.mjs"
+_HEALTHCHECK_PROCESS_TIMEOUT_SECONDS = 10
 
 pytestmark = pytest.mark.unit
 
@@ -133,8 +134,33 @@ class _TrailingWhitespaceHealthHandler(BaseHTTPRequestHandler):
         return
 
 
+class _SlowTrailingWhitespaceHealthHandler(_TrailingWhitespaceHealthHandler):
+    def do_GET(self) -> None:
+        time.sleep(2.25)
+        super().do_GET()
+
+
 class _HangingHealthServer(ThreadingHTTPServer):
     daemon_threads = True
+
+
+def _run_healthcheck(
+    *,
+    port: int,
+    extra_env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    return subprocess.run(
+        ["node", "scripts/healthcheck.mjs", "app"],
+        cwd=_FIXTURE_ROOT,
+        env={
+            **os.environ,
+            "APP_BASE_URL": f"http://127.0.0.1:{port}",
+            **(extra_env or {}),
+        },
+        capture_output=True,
+        timeout=_HEALTHCHECK_PROCESS_TIMEOUT_SECONDS,
+        check=False,
+    )
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
@@ -146,14 +172,25 @@ def test_healthcheck_accepts_trimmed_ok_response() -> None:
 
     try:
         port = server.server_address[1]
-        result = subprocess.run(
-            ["node", "scripts/healthcheck.mjs", "app"],
-            cwd=_FIXTURE_ROOT,
-            env={**os.environ, "APP_BASE_URL": f"http://127.0.0.1:{port}"},
-            capture_output=True,
-            timeout=2,
-            check=False,
-        )
+        result = _run_healthcheck(port=port)
+    finally:
+        server.shutdown()
+        server.server_close()
+
+    assert result.returncode == 0
+    assert result.stdout == b"ok\r\n  "
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")
+def test_healthcheck_process_timeout_allows_script_fetch_budget() -> None:
+    """The test harness should not kill healthchecks before their own timeout."""
+    server = _HangingHealthServer(("127.0.0.1", 0), _SlowTrailingWhitespaceHealthHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        port = server.server_address[1]
+        result = _run_healthcheck(port=port)
     finally:
         server.shutdown()
         server.server_close()
@@ -171,25 +208,16 @@ def test_healthcheck_fetch_times_out_when_service_hangs() -> None:
 
     try:
         port = server.server_address[1]
-        result = subprocess.run(
-            ["node", "scripts/healthcheck.mjs", "app"],
-            cwd=_FIXTURE_ROOT,
-            env={
-                **os.environ,
-                "APP_BASE_URL": f"http://127.0.0.1:{port}",
-                "AWF_HEALTHCHECK_FETCH_TIMEOUT_MS": "50",
-            },
-            capture_output=True,
-            text=True,
-            timeout=2,
-            check=False,
+        result = _run_healthcheck(
+            port=port,
+            extra_env={"AWF_HEALTHCHECK_FETCH_TIMEOUT_MS": "50"},
         )
     finally:
         server.shutdown()
         server.server_close()
 
     assert result.returncode != 0
-    assert "timed out fetching app health response after 50ms" in result.stderr
+    assert b"timed out fetching app health response after 50ms" in result.stderr
 
 
 @pytest.mark.skipif(shutil.which("node") is None, reason="Node.js is required")

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -258,6 +258,7 @@ class TestAddWorktree:
 
         assert (layout.worktree_path, 1000, 1000) in chowned
         assert (layout.mirror_path, 1000, 1000) in chowned
+        assert (layout.mirror_path / "hooks", 1000, 1000) in chowned
         assert (layout.mirror_path / "objects", 1000, 1000) in chowned
         assert (layout.mirror_path / "refs", 1000, 1000) in chowned
         assert (layout.mirror_path / "worktrees", 1000, 1000) in chowned
@@ -272,6 +273,9 @@ class TestAddWorktree:
         ]
         assert object_files
         assert all((path, 1000, 1000) not in chowned for path in object_files)
+        hook_files = [path for path in (layout.mirror_path / "hooks").glob("*") if path.is_file()]
+        assert hook_files
+        assert any((path, 1000, 1000) in chowned for path in hook_files)
 
     @pytest.mark.unit
     async def test_agent_owner_repair_skips_unwritable_loose_object_files(
@@ -596,10 +600,12 @@ class TestAgentWorktreeWritable:
         # commits in the worktree (HEAD update, ref log, lock files).
         assert layout.worktree_path in target_paths
         assert layout.mirror_path in target_paths
+        assert layout.mirror_path / "hooks" in target_paths
         assert layout.mirror_path / "refs" in target_paths
         assert layout.mirror_path / "logs" in target_paths
         assert layout.mirror_path / "worktrees" in target_paths
         assert layout.mirror_path / "objects" in target_paths
+        assert layout.mirror_path / "hooks" in recursive_paths
 
         # Loose object files must not be chowned recursively. Docker Desktop
         # on macOS rejects the chown when host metadata is missing, which

--- a/tests/unit/runtime/test_pr_monitor_merge_safety.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_safety.py
@@ -760,6 +760,7 @@ async def test_auto_merge_dispatches_recovery_despite_active_monitor_non_recover
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
+    """Active non-recovery monitor work must not block stale validation recovery."""
     seed = await _seed_merge_candidate(
         factory,
         pr_number=511,

--- a/tests/unit/runtime/test_pr_monitor_merge_safety.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_safety.py
@@ -753,6 +753,67 @@ async def test_auto_merge_does_not_duplicate_active_monitor_recovery(
 
 
 @pytest.mark.unit
+async def test_auto_merge_dispatches_recovery_despite_active_monitor_non_recovery_operation(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    seed = await _seed_merge_candidate(
+        factory,
+        pr_number=511,
+        same_attempt_validation_tier=1,
+    )
+    async with factory() as session:
+        await OperationRepository(session).create(
+            workspace_id=seed.workspace_id,
+            operation_type=OperationType.comment_repair,
+            status=OperationStatus.running,
+            payload={
+                "owner": "pr_monitor",
+                "source": "pr_monitor",
+                "action": "comment_repair",
+                "requested_action": "address_comments",
+                "reason": "Unresolved PR review comments required repair.",
+                "reason_code": "COMMENT_REPAIR",
+                "pr_number": seed.pr_number,
+            },
+        )
+        await session.commit()
+
+    terminal = await _execute_merge(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        tmp_path=tmp_path,
+        seed=seed,
+    )
+
+    async with factory() as session:
+        operations = await OperationRepository(session).list_all(
+            workspace_id=seed.workspace_id,
+        )
+
+    assert terminal is True
+    assert sleep_fn.calls == []
+    assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+    recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+    wait_operations = [
+        op
+        for op in operations
+        if op.type == OperationType.monitor_state.value
+        and op.payload.get("reason_code") == "RECOVERY_IN_PROGRESS"
+    ]
+    assert len(recovery_operations) == 1
+    assert wait_operations == []
+    assert recovery_operations[0].status == OperationStatus.pending.value
+    assert recovery_operations[0].payload["recovery_mode"] == "validate_only"
+    assert recovery_operations[0].payload["reason_code"] == "VALIDATION_INSUFFICIENT_TIER"
+
+
+@pytest.mark.unit
 async def test_auto_merge_retries_failed_monitor_recovery_with_new_operation(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,

--- a/tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py
+++ b/tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py
@@ -31,6 +31,7 @@ from awf.runtime.pr_monitor_runner import (
     _non_check_reviewer_settle_done_key,
     _non_check_reviewer_settle_skip_visible_key,
     _non_check_reviewer_settle_started_key,
+    _non_check_reviewer_settle_wait_operation_context,
     _normalize_non_check_reviewer_logins,
 )
 from tests.postgres import postgres_test_engine
@@ -303,6 +304,40 @@ def test_pr_166_regression_visible_greptile_check_still_waits_for_codex_review()
             _non_check_reviewer_settle_started_key(pr_number=166, head_sha="head-a")
         ]
         == "1000.000000"
+    )
+
+
+@pytest.mark.unit
+def test_non_check_reviewer_wait_operation_context_centralizes_payload_and_identity() -> None:
+    state = MonitorState()
+    cfg = MonitorConfig(
+        auto_merge=True,
+        poll_interval_seconds=60,
+        non_check_reviewer_settle_seconds=900,
+        non_check_reviewer_logins=("greptile-apps", "chatgpt-codex-connector"),
+    )
+    decision = _non_check_reviewer_settle_decision(
+        _ready_status(checks=(CheckTiming(name="Greptile Review", conclusion="SUCCESS"),)),
+        state,
+        cfg,
+        pr_number=166,
+        now=1000.0,
+    )
+
+    context = _non_check_reviewer_settle_wait_operation_context(cfg, decision)
+
+    assert context.extra_payload == {
+        "settle_seconds": 900,
+        "configured_reviewers": ["greptile-apps", "chatgpt-codex-connector"],
+        "missing_reviewers": ["chatgpt-codex-connector"],
+        "visible_reviewers": ["greptile-apps"],
+        "elapsed_seconds": 0.0,
+    }
+    assert context.extra_identity == (
+        "greptile-apps",
+        "chatgpt-codex-connector",
+        "chatgpt-codex-connector",
+        1000.0,
     )
 
 

--- a/tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py
+++ b/tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py
@@ -309,6 +309,7 @@ def test_pr_166_regression_visible_greptile_check_still_waits_for_codex_review()
 
 @pytest.mark.unit
 def test_non_check_reviewer_wait_operation_context_centralizes_payload_and_identity() -> None:
+    """The settle wait helper owns the persisted payload and idempotency identity."""
     state = MonitorState()
     cfg = MonitorConfig(
         auto_merge=True,

--- a/tests/unit/runtime/test_pr_monitor_operations.py
+++ b/tests/unit/runtime/test_pr_monitor_operations.py
@@ -18,6 +18,16 @@ from tests.unit.helpers import create_workspace
 
 
 @pytest.mark.unit
+def test_recovery_runner_reuses_monitor_retryable_statuses() -> None:
+    from awf.runtime import pr_monitor_runner as runner
+
+    assert (
+        runner._RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES
+        is operations.RETRYABLE_MONITOR_OPERATION_STATUSES
+    )
+
+
+@pytest.mark.unit
 def test_redact_monitor_operation_value_preserves_llm_token_usage_metadata() -> None:
     value = {
         "usage": {

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -768,6 +768,7 @@ async def test_stale_recovery_callback_ignores_active_pr_monitor_non_recovery_op
     tmp_path: Path,
     operation_type: OperationType,
 ) -> None:
+    """Non-recovery monitor work must not keep a completed dispatch callback live."""
     workspace_id = await seed_monitoring_workspace(factory)
     async with factory() as s:
         repo = WorkspaceRepository(s)
@@ -928,6 +929,7 @@ async def test_recovery_dispatch_retries_cancelled_idempotent_snapshot(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
+    """A cancelled snapshot is retryable and must produce a fresh recovery operation."""
     cmd = FakeCommandRunner()
     sleep_fn = RecordedSleep()
     adapter = FakeAdapter()
@@ -1056,6 +1058,7 @@ async def test_recovery_dispatch_waits_when_idempotent_create_loses_race_to_acti
         payload: dict[str, object] | None = None,
         idempotency_key: str,
     ) -> tuple[object, bool]:
+        """Simulate a concurrent recovery create winning before the runner insert."""
         nonlocal inserted
         if not inserted:
             inserted = True

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -1137,3 +1137,132 @@ async def test_recovery_dispatch_waits_when_idempotent_create_loses_race_to_acti
         assert len(wait_operations) == 1
         events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
         assert events == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("terminal_status", "error_code"),
+    [
+        (OperationStatus.failed, "COMMAND_FAILED"),
+        (OperationStatus.cancelled, "OPERATOR_REMONITOR"),
+    ],
+)
+async def test_recovery_dispatch_retries_when_idempotent_create_loses_race_to_terminal_op(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal_status: OperationStatus,
+    error_code: str,
+) -> None:
+    """A competing monitor can finish the same recovery key before our insert.
+
+    The returned terminal operation must feed the retryable idempotency-key flow
+    immediately, not get classified as an already-handled snapshot.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+    original_create_idempotent = OperationRepository.create_idempotent
+    inserted = False
+
+    async def _race_create_idempotent(
+        self: OperationRepository,
+        *,
+        workspace_id: str,
+        operation_type: OperationType | str,
+        status: OperationStatus | str = OperationStatus.pending,
+        payload: dict[str, object] | None = None,
+        idempotency_key: str,
+    ) -> tuple[object, bool]:
+        """Simulate a concurrent recovery create and terminal finish winning."""
+        nonlocal inserted
+        if not inserted:
+            inserted = True
+            async with factory() as s:
+                repo = OperationRepository(s)
+                operation = await repo.create(
+                    workspace_id=workspace_id,
+                    operation_type=operation_type,
+                    status=OperationStatus.running,
+                    payload={
+                        "owner": "pr_monitor",
+                        "source": "pr_monitor",
+                        "action": "validate_only",
+                        "requested_action": "validate",
+                        "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+                        "stale_reason": "validation_insufficient_tier",
+                        "recovery_mode": "validate_only",
+                    },
+                    idempotency_key=idempotency_key,
+                )
+                await repo.finish(
+                    operation,
+                    status=terminal_status,
+                    result={"reason_code": error_code},
+                    error_code=error_code,
+                )
+                await s.commit()
+        return await original_create_idempotent(
+            self,
+            workspace_id=workspace_id,
+            operation_type=operation_type,
+            status=status,
+            payload=payload,
+            idempotency_key=idempotency_key,
+        )
+
+    monkeypatch.setattr(OperationRepository, "create_idempotent", _race_create_idempotent)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert sleep_fn.calls == []
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.ready.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+        wait_operations = [
+            op
+            for op in operations
+            if op.type == OperationType.monitor_state.value
+            and op.payload.get("reason_code") == "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
+        ]
+        assert len(recovery_operations) == 2
+        assert len(wait_operations) == 0
+        retry = next(op for op in recovery_operations if op.status == OperationStatus.pending.value)
+        terminal_recovery = next(
+            op for op in recovery_operations if op.status == terminal_status.value
+        )
+        assert retry.idempotency_key != terminal_recovery.idempotency_key
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert len(events) == 1

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -34,6 +34,7 @@ from awf.runtime.pr_monitor import (
     MonitorState,
     PRStatus,
 )
+from awf.runtime.pr_monitor_operations import monitor_operation_idempotency_key
 from awf.runtime.pr_monitor_runner import _initial_review_grace_started_key
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import (
@@ -748,5 +749,218 @@ async def test_recovery_dispatch_is_idempotent_when_active_recovery_op_exists(
         assert wait_operations[0].status == OperationStatus.succeeded.value
         # No monitor.recovery_dispatched event fires the second time
         # (the original dispatch already emitted it).
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert events == []
+
+
+@pytest.mark.unit
+async def test_recovery_dispatch_does_not_requeue_already_succeeded_snapshot(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A terminal recovery op for the same observed PR snapshot means the
+    recovery was already handled. The monitor must keep polling instead of
+    moving the workspace back to ready without an active operation for the
+    executor to consume.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+    idempotency_key = monitor_operation_idempotency_key(
+        workspace_id=workspace_id,
+        action="validate_only",
+        pr_number=42,
+        reason_code="VALIDATION_INSUFFICIENT_TIER",
+        source_head_sha="abc1234567890def",
+        source_base_sha="a" * 40,
+    )
+
+    async with factory() as s:
+        repo = OperationRepository(s)
+        operation = await repo.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.running,
+            payload={
+                "owner": "pr_monitor",
+                "source": "pr_monitor",
+                "action": "validate_only",
+                "requested_action": "validate",
+                "reason": "Required validation tier has not passed for this merge candidate.",
+                "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+                "stale_reason": "validation_insufficient_tier",
+                "recovery_mode": "validate_only",
+                "pr_number": 42,
+                "pr_url": "https://github.com/dimileeh/aira-web/pull/42",
+                "source_head_sha": "abc1234567890def",
+                "source_base_sha": "a" * 40,
+                "target_branch": "development",
+                "remote_branch": f"awf/{workspace_id}",
+            },
+            idempotency_key=idempotency_key,
+        )
+        await repo.finish(
+            operation,
+            status=OperationStatus.succeeded,
+            result={"reason_code": "VALIDATION_OK"},
+        )
+        await s.commit()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert sleep_fn.calls == [runner._config.poll_interval_seconds]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+        wait_operations = [
+            op
+            for op in operations
+            if op.type == OperationType.monitor_state.value
+            and op.payload.get("reason_code") == "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
+        ]
+        assert len(recovery_operations) == 1
+        assert recovery_operations[0].status == OperationStatus.succeeded.value
+        assert len(wait_operations) == 1
+        assert wait_operations[0].payload["action"] == "recovery_already_handled"
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert events == []
+
+
+@pytest.mark.unit
+async def test_recovery_dispatch_waits_when_idempotent_create_loses_race_to_active_op(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If another monitor loop creates the recovery op after the active-op
+    precheck, the idempotent create return value must still keep the workspace
+    in monitoring_pr.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+    original_create_idempotent = OperationRepository.create_idempotent
+    inserted = False
+
+    async def _race_create_idempotent(
+        self: OperationRepository,
+        *,
+        workspace_id: str,
+        operation_type: OperationType | str,
+        status: OperationStatus | str = OperationStatus.pending,
+        payload: dict[str, object] | None = None,
+        idempotency_key: str,
+    ) -> tuple[object, bool]:
+        nonlocal inserted
+        if not inserted:
+            inserted = True
+            async with factory() as s:
+                await OperationRepository(s).create(
+                    workspace_id=workspace_id,
+                    operation_type=operation_type,
+                    status=OperationStatus.pending,
+                    payload={
+                        "owner": "pr_monitor",
+                        "source": "pr_monitor",
+                        "action": "validate_only",
+                        "requested_action": "validate",
+                        "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+                        "stale_reason": "validation_insufficient_tier",
+                        "recovery_mode": "validate_only",
+                    },
+                    idempotency_key=idempotency_key,
+                )
+                await s.commit()
+        return await original_create_idempotent(
+            self,
+            workspace_id=workspace_id,
+            operation_type=operation_type,
+            status=status,
+            payload=payload,
+            idempotency_key=idempotency_key,
+        )
+
+    monkeypatch.setattr(OperationRepository, "create_idempotent", _race_create_idempotent)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert sleep_fn.calls == [runner._config.poll_interval_seconds]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+        wait_operations = [
+            op
+            for op in operations
+            if op.type == OperationType.monitor_state.value
+            and op.payload.get("reason_code") == "RECOVERY_IN_PROGRESS"
+        ]
+        assert len(recovery_operations) == 1
+        assert recovery_operations[0].status == OperationStatus.pending.value
+        assert len(wait_operations) == 1
         events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
         assert events == []

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -13,11 +13,13 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import RepoRef
 from awf.db.enums import OperationStatus, OperationType, TaskClass, WorkspaceStatus
+from awf.db.models import Workspace
 from awf.db.repositories import (
     MergeCandidateRepository,
     OperationRepository,
@@ -1264,3 +1266,123 @@ async def test_recovery_dispatch_retries_when_idempotent_create_loses_race_to_te
         assert retry.idempotency_key != terminal_recovery.idempotency_key
         events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
         assert len(events) == 1
+
+
+@pytest.mark.unit
+async def test_recovery_dispatch_rechecks_workspace_before_retrying_idempotency_key(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A retryable terminal recovery op does not justify dispatching if
+    ownership was lost before the retry key is used.
+    """
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+    original_create_idempotent = OperationRepository.create_idempotent
+    inserted = False
+
+    async def _race_create_idempotent(
+        self: OperationRepository,
+        *,
+        workspace_id: str,
+        operation_type: OperationType | str,
+        status: OperationStatus | str = OperationStatus.pending,
+        payload: dict[str, object] | None = None,
+        idempotency_key: str,
+    ) -> tuple[object, bool]:
+        """Simulate another actor finishing recovery and completing the workspace."""
+        nonlocal inserted
+        if not inserted:
+            inserted = True
+            async with factory() as s:
+                repo = OperationRepository(s)
+                operation = await repo.create(
+                    workspace_id=workspace_id,
+                    operation_type=operation_type,
+                    status=OperationStatus.running,
+                    payload={
+                        "owner": "pr_monitor",
+                        "source": "pr_monitor",
+                        "action": "validate_only",
+                        "requested_action": "validate",
+                        "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+                        "stale_reason": "validation_insufficient_tier",
+                        "recovery_mode": "validate_only",
+                    },
+                    idempotency_key=idempotency_key,
+                )
+                await repo.finish(
+                    operation,
+                    status=OperationStatus.cancelled,
+                    result={"reason_code": "OPERATOR_REMONITOR"},
+                    error_code="OPERATOR_REMONITOR",
+                )
+                await s.execute(
+                    sa_update(Workspace)
+                    .where(Workspace.id == workspace_id)
+                    .values(status=WorkspaceStatus.completed.value)
+                )
+                await s.commit()
+        return await original_create_idempotent(
+            self,
+            workspace_id=workspace_id,
+            operation_type=operation_type,
+            status=status,
+            payload=payload,
+            idempotency_key=idempotency_key,
+        )
+
+    monkeypatch.setattr(OperationRepository, "create_idempotent", _race_create_idempotent)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert sleep_fn.calls == []
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+        assert len(recovery_operations) == 1
+        assert recovery_operations[0].status == OperationStatus.cancelled.value
+        ignored_events = [
+            event for event in ws.events if event.event_type == "workspace.stale_callback_ignored"
+        ]
+        dispatch_events = [
+            event for event in ws.events if event.event_type == "monitor.recovery_dispatched"
+        ]
+        assert ignored_events[-1].reason_code == "STALE_CALLBACK_IGNORED"
+        assert ignored_events[-1].payload["callback_action"] == "recovery_dispatch"
+        assert ignored_events[-1].payload["actual_status"] == WorkspaceStatus.completed.value
+        assert dispatch_events == []

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -808,9 +808,7 @@ async def test_stale_recovery_callback_ignores_active_pr_monitor_non_recovery_op
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
         stale_events = [
-            event
-            for event in ws.events
-            if event.event_type == "workspace.stale_callback_ignored"
+            event for event in ws.events if event.event_type == "workspace.stale_callback_ignored"
         ]
     assert len(stale_events) == 1
     assert stale_events[0].reason_code == "STALE_CALLBACK_IGNORED"

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -754,6 +754,70 @@ async def test_recovery_dispatch_is_idempotent_when_active_recovery_op_exists(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "operation_type",
+    [
+        OperationType.sync_base,
+        OperationType.ci_repair,
+        OperationType.comment_repair,
+        OperationType.human_wait,
+    ],
+)
+async def test_stale_recovery_callback_ignores_active_pr_monitor_non_recovery_operation(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    operation_type: OperationType,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        await repo.transition(
+            ws,
+            to=WorkspaceStatus.ready,
+            reason_code="TEST_READY_AFTER_RECOVERY_DISPATCH",
+        )
+        await OperationRepository(s).create(
+            workspace_id=workspace_id,
+            operation_type=operation_type,
+            status=OperationStatus.running,
+            payload={
+                "owner": "pr_monitor",
+                "source": "pr_monitor",
+                "action": operation_type.value,
+                "requested_action": operation_type.value,
+                "reason_code": operation_type.value.upper(),
+            },
+        )
+        await s.commit()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    stale = await runner._recovery_dispatch_status_is_stale(workspace_id)
+
+    assert stale is True
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        stale_events = [
+            event
+            for event in ws.events
+            if event.event_type == "workspace.stale_callback_ignored"
+        ]
+    assert len(stale_events) == 1
+    assert stale_events[0].reason_code == "STALE_CALLBACK_IGNORED"
+    assert stale_events[0].payload["callback_action"] == "recovery_dispatch"
+    assert stale_events[0].payload["actual_status"] == WorkspaceStatus.ready.value
+
+
+@pytest.mark.unit
 async def test_recovery_dispatch_does_not_requeue_already_succeeded_snapshot(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_recovery_grace.py
+++ b/tests/unit/runtime/test_pr_monitor_recovery_grace.py
@@ -860,6 +860,112 @@ async def test_recovery_dispatch_does_not_requeue_already_succeeded_snapshot(
 
 
 @pytest.mark.unit
+async def test_recovery_dispatch_retries_cancelled_idempotent_snapshot(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _mark_refactor_task(factory, workspace_id, auto_merge=True)
+    idempotency_key = monitor_operation_idempotency_key(
+        workspace_id=workspace_id,
+        action="validate_only",
+        pr_number=42,
+        reason_code="VALIDATION_INSUFFICIENT_TIER",
+        source_head_sha="abc1234567890def",
+        source_base_sha="a" * 40,
+    )
+
+    async with factory() as s:
+        repo = OperationRepository(s)
+        operation = await repo.create(
+            workspace_id=workspace_id,
+            operation_type=OperationType.validate,
+            status=OperationStatus.running,
+            payload={
+                "owner": "pr_monitor",
+                "source": "pr_monitor",
+                "action": "validate_only",
+                "requested_action": "validate",
+                "reason": "Required validation tier has not passed for this merge candidate.",
+                "reason_code": "VALIDATION_INSUFFICIENT_TIER",
+                "stale_reason": "validation_insufficient_tier",
+                "recovery_mode": "validate_only",
+                "pr_number": 42,
+                "pr_url": "https://github.com/dimileeh/aira-web/pull/42",
+                "source_head_sha": "abc1234567890def",
+                "source_base_sha": "a" * 40,
+                "target_branch": "development",
+                "remote_branch": f"awf/{workspace_id}",
+            },
+            idempotency_key=idempotency_key,
+        )
+        await repo.finish(
+            operation,
+            status=OperationStatus.cancelled,
+            result={"reason_code": "OPERATOR_REMONITOR"},
+            error_code="OPERATOR_REMONITOR",
+        )
+        await s.commit()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=900,
+    )
+    state = MonitorState(started_at=0.0)
+    state.mark_addressed(
+        _initial_review_grace_started_key(42),
+        f"{0.0:.6f}",
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_green_pr_status(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert sleep_fn.calls == []
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.ready.value
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        recovery_operations = [op for op in operations if op.type == OperationType.validate.value]
+        wait_operations = [
+            op
+            for op in operations
+            if op.type == OperationType.monitor_state.value
+            and op.payload.get("reason_code") == "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
+        ]
+        assert len(recovery_operations) == 2
+        assert len(wait_operations) == 0
+        retry = next(op for op in recovery_operations if op.status == OperationStatus.pending.value)
+        cancelled = next(
+            op for op in recovery_operations if op.status == OperationStatus.cancelled.value
+        )
+        assert cancelled.idempotency_key == idempotency_key
+        assert retry.idempotency_key != idempotency_key
+        events = [e for e in ws.events if e.event_type == "monitor.recovery_dispatched"]
+        assert len(events) == 1
+
+
+@pytest.mark.unit
 async def test_recovery_dispatch_waits_when_idempotent_create_loses_race_to_active_op(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- keep PR-monitor recovery idempotency checks authoritative after `create_idempotent` returns an existing operation
- keep workspaces in `monitoring_pr` when the observed PR snapshot is already being recovered or was already handled
- add regression coverage for terminal handled snapshots and races where another monitor creates the recovery operation after the active-op precheck

## Validation
- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner.py tests/unit/runtime/test_pr_monitor_recovery_grace.py`
- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_recovery_grace.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PR monitor recovery now avoids duplicate dispatches, properly waits for active recoveries, and treats cancelled recoveries as retryable.

* **Tests**
  * Added extensive unit tests for recovery idempotency, race conditions, merge-gate recovery dispatch, and reviewer-settle wait behavior.

* **Documentation**
  * Active Slices ledger updated to list newly tracked running workspaces and statuses.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/230)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->