### PR TITLE
Align AWF local validation with SCM checks

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -40,19 +40,6 @@ awf:
     strategy:
       baseline_coverage: skip
       edit_gate: targeted
-      # PR-monitored workspaces defer this authoritative gate to GitHub Actions.
-      final_gate: coverage
-      reuse_evidence: true
-      freshness_max_age_seconds: 86400
-      full_gate_concurrency: 0
-    coverage:
-      minimum_percent: 99
-      enforce: true
-      provider: python
-      parallel_workers: 3
-      command:
-        command: uv run --python 3.12 --extra dev pytest --cov=awf --cov-report=term-missing
-        timeout_seconds: 7200
   phases:
     setup:
       - command: uv sync --extra dev

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2110,16 +2110,8 @@ class WorkspaceExecutor:
             run_local_coverage = _should_run_local_coverage(profile)
             coverage_evidence = _CoverageEvidenceResult(
                 coverage=None,
-                evidence_status=(
-                    "executed"
-                    if run_local_coverage
-                    else None
-                ),
-                reason_code=(
-                    "VALIDATION_EVIDENCE_EXECUTED"
-                    if run_local_coverage
-                    else None
-                ),
+                evidence_status=("executed" if run_local_coverage else None),
+                reason_code=("VALIDATION_EVIDENCE_EXECUTED" if run_local_coverage else None),
             )
             try:
                 await self._update_subphase(workspace_id, "validation")

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -3829,7 +3829,7 @@ class WorkspaceExecutor:
             compose_project=compose_project,
             compose_file=compose_file,
             profile=profile,
-            phase="final_coverage",
+            phase="coverage",
             parallel_worker_cpu_limit=await self._parallel_worker_cpu_limit_for_workspace(
                 workspace_id,
                 profile=profile,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2108,11 +2108,7 @@ class WorkspaceExecutor:
                 tier=validation_tier,
             )
             run_local_coverage = _should_run_local_coverage(profile)
-            coverage_evidence = _CoverageEvidenceResult(
-                coverage=None,
-                evidence_status=("executed" if run_local_coverage else None),
-                reason_code=("VALIDATION_EVIDENCE_EXECUTED" if run_local_coverage else None),
-            )
+            coverage_evidence = _CoverageEvidenceResult(coverage=None)
             try:
                 await self._update_subphase(workspace_id, "validation")
                 val_result = await self._validation.run_profile_phases(
@@ -2123,8 +2119,18 @@ class WorkspaceExecutor:
                     phase_names=("post_agent", "validate"),
                     run_healthchecks=True,
                     worktree_path=worktree_path,
-                    include_coverage=run_local_coverage,
+                    include_coverage=False,
                 )
+                if run_local_coverage and val_result.all_passed:
+                    coverage_evidence = await self._run_final_coverage_gate(
+                        workspace_id=workspace_id,
+                        compose_project=compose_project,
+                        compose_file=compose_file,
+                        profile=profile,
+                        validation_tier=validation_tier,
+                        workspace_head_sha=validation_workspace_head_sha,
+                    )
+                    val_result = replace(val_result, coverage=coverage_evidence.coverage)
             except ComposeExecCleanupError as exc:
                 message = cleanup_failure_message(exc)
                 _log.error(

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -2107,33 +2107,17 @@ class WorkspaceExecutor:
                 target_head_sha=None,
                 tier=validation_tier,
             )
-            run_coverage_during_edit_gate = not (
-                profile.validation.strategy.edit_gate == "targeted"
-                and profile.validation.strategy.final_gate == "coverage"
-            )
-            defer_final_coverage_to_pr_monitor = _defer_final_coverage_to_pr_monitor(
-                recovery=recovery,
-                has_pr_monitor=self._pr_monitor is not None or self._pr_monitor_factory is not None,
-                profile=profile,
-            )
+            run_local_coverage = _should_run_local_coverage(profile)
             coverage_evidence = _CoverageEvidenceResult(
                 coverage=None,
                 evidence_status=(
                     "executed"
-                    if run_coverage_during_edit_gate
-                    and profile.validation.coverage.command is not None
-                    else "skipped_by_policy"
-                    if not run_coverage_during_edit_gate
-                    and profile.validation.coverage.command is not None
+                    if run_local_coverage
                     else None
                 ),
                 reason_code=(
                     "VALIDATION_EVIDENCE_EXECUTED"
-                    if run_coverage_during_edit_gate
-                    and profile.validation.coverage.command is not None
-                    else "TARGETED_EDIT_GATE"
-                    if not run_coverage_during_edit_gate
-                    and profile.validation.coverage.command is not None
+                    if run_local_coverage
                     else None
                 ),
             )
@@ -2147,23 +2131,8 @@ class WorkspaceExecutor:
                     phase_names=("post_agent", "validate"),
                     run_healthchecks=True,
                     worktree_path=worktree_path,
-                    include_coverage=run_coverage_during_edit_gate,
+                    include_coverage=run_local_coverage,
                 )
-                if (
-                    not run_coverage_during_edit_gate
-                    and val_result.all_passed
-                    and profile.validation.strategy.final_gate == "coverage"
-                    and not defer_final_coverage_to_pr_monitor
-                ):
-                    coverage_evidence = await self._run_final_coverage_gate(
-                        workspace_id=workspace_id,
-                        compose_project=compose_project,
-                        compose_file=compose_file,
-                        profile=profile,
-                        validation_tier=validation_tier,
-                        workspace_head_sha=validation_workspace_head_sha,
-                    )
-                    val_result = replace(val_result, coverage=coverage_evidence.coverage)
             except ComposeExecCleanupError as exc:
                 message = cleanup_failure_message(exc)
                 _log.error(
@@ -3796,7 +3765,7 @@ class WorkspaceExecutor:
                 reason_code="BASELINE_COVERAGE_SKIPPED_BY_POLICY",
             )
             return None
-        if coverage.command is None and coverage.minimum_percent <= 0:
+        if coverage.command is None:
             return None
         result = await self._validation.run_profile_coverage(
             workspace_id=workspace_id,
@@ -3826,7 +3795,7 @@ class WorkspaceExecutor:
         workspace_head_sha: str | None,
     ) -> _CoverageEvidenceResult:
         coverage = profile.validation.coverage
-        if coverage.command is None and coverage.minimum_percent <= 0:
+        if coverage.command is None:
             return _CoverageEvidenceResult(coverage=None)
 
         command_records = _validation_run_command_records(
@@ -6509,19 +6478,8 @@ def _validation_tier_for_workspace(workspace: Workspace, profile: WorkspaceProfi
     return max(profile_tier, task_class_tier)
 
 
-def _defer_final_coverage_to_pr_monitor(
-    *,
-    recovery: Mapping[str, Any] | None,
-    has_pr_monitor: bool,
-    profile: WorkspaceProfile,
-) -> bool:
-    return (
-        recovery is None
-        and has_pr_monitor
-        and profile.validation.strategy.edit_gate == "targeted"
-        and profile.validation.strategy.final_gate == "coverage"
-        and profile.validation.coverage.command is not None
-    )
+def _should_run_local_coverage(profile: WorkspaceProfile) -> bool:
+    return profile.validation.coverage.command is not None
 
 
 def _validation_run_log_stream_refs(

--- a/src/awf/db/resilience.py
+++ b/src/awf/db/resilience.py
@@ -34,6 +34,11 @@ _CLOSED_CONNECTION_MESSAGE_FRAGMENTS = (
     "closed connection",
     "server closed the connection",
 )
+_ASYNC_PG_TRANSIENT_PROTOCOL_STATE_FRAGMENTS = (
+    "cannot switch to state",
+    "another operation",
+    "is in progress",
+)
 _MAX_CLOSED_CONNECTION_MESSAGE_SCAN_CHARS = 512
 
 
@@ -56,9 +61,10 @@ def is_transient_closed_connection_error(
             return True
         if current.__class__.__name__ in _CLOSED_CONNECTION_ERROR_NAMES:
             return True
-        if _message_indicates_closed_connection(
-            str(current)[:_MAX_CLOSED_CONNECTION_MESSAGE_SCAN_CHARS]
-        ):
+        message = str(current)[:_MAX_CLOSED_CONNECTION_MESSAGE_SCAN_CHARS]
+        if _message_indicates_closed_connection(message):
+            return True
+        if _is_asyncpg_transient_protocol_state_error(current, message):
             return True
     return False
 
@@ -204,3 +210,12 @@ def _exception_chain(
 def _message_indicates_closed_connection(message: str) -> bool:
     normalized = message.lower()
     return any(fragment in normalized for fragment in _CLOSED_CONNECTION_MESSAGE_FRAGMENTS)
+
+
+def _is_asyncpg_transient_protocol_state_error(exc: BaseException, message: str) -> bool:
+    if exc.__class__.__name__ != "InternalClientError":
+        return False
+    if not exc.__class__.__module__.startswith("asyncpg."):
+        return False
+    normalized = message.lower()
+    return all(fragment in normalized for fragment in _ASYNC_PG_TRANSIENT_PROTOCOL_STATE_FRAGMENTS)

--- a/src/awf/db/session.py
+++ b/src/awf/db/session.py
@@ -23,7 +23,10 @@ from sqlalchemy.pool import NullPool
 
 from awf.common.logging import get_logger
 from awf.db.dialect import SESSION_DIALECT_NAME_KEY
-from awf.db.resilience import invalidate_or_rollback_session
+from awf.db.resilience import (
+    invalidate_or_rollback_session,
+    is_transient_closed_connection_error,
+)
 from awf.runtime.events import ensure_workspace_event_broadcasting
 
 DEFAULT_POOL_RECYCLE_SECONDS = 1800
@@ -111,7 +114,36 @@ def make_engine(
     if "async_creator" not in engine_options:
         create_kwargs["connect_args"] = resolved_connect_args
 
-    return create_async_engine(parsed_url.render_as_string(hide_password=False), **create_kwargs)
+    engine = create_async_engine(parsed_url.render_as_string(hide_password=False), **create_kwargs)
+    _patch_asyncpg_pre_ping_disconnect_detection(engine)
+    return engine
+
+
+def _patch_asyncpg_pre_ping_disconnect_detection(engine: AsyncEngine) -> None:
+    """Teach SQLAlchemy's asyncpg pre-ping about raw asyncpg protocol disconnects."""
+
+    sync_engine = getattr(engine, "sync_engine", None)
+    dialect = getattr(sync_engine, "dialect", None)
+    if dialect is None:
+        return
+    if (
+        getattr(dialect, "name", None) != "postgresql"
+        or getattr(dialect, "driver", None) != "asyncpg"
+    ):
+        return
+    do_ping = getattr(dialect, "do_ping", None)
+    if not callable(do_ping):
+        return
+
+    def _do_ping_with_awf_disconnect_detection(dbapi_connection: object) -> bool:
+        try:
+            return bool(do_ping(dbapi_connection))
+        except Exception as exc:
+            if is_transient_closed_connection_error(exc):
+                return False
+            raise
+
+    dialect.do_ping = _do_ping_with_awf_disconnect_detection
 
 
 def _single_query_value(value: object | None) -> str | None:

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -246,6 +246,11 @@ class ProfileCoverage(BaseModel):
                 raise ValueError(
                     "validation.coverage.command is required when coverage parallelism is set"
                 )
+        if self.parallel_worker_max is not None and self.parallel_workers is None:
+            raise ValueError(
+                "validation.coverage.parallel_worker_max requires "
+                "validation.coverage.parallel_workers"
+            )
         if (
             self.parallel_workers is not None
             and self.command is not None

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -236,6 +236,16 @@ class ProfileCoverage(BaseModel):
 
     @model_validator(mode="after")
     def _validate_parallel_policy(self) -> ProfileCoverage:
+        if self.command is None:
+            if self.minimum_percent > 0:
+                raise ValueError(
+                    "validation.coverage.command is required when "
+                    "validation.coverage.minimum_percent is greater than 0"
+                )
+            if self.parallel_workers is not None or self.parallel_worker_max is not None:
+                raise ValueError(
+                    "validation.coverage.command is required when coverage parallelism is set"
+                )
         if (
             self.parallel_workers is not None
             and self.command is not None

--- a/src/awf/runtime/merge_eligibility.py
+++ b/src/awf/runtime/merge_eligibility.py
@@ -90,13 +90,8 @@ def compute_stale_reason(workspace: Workspace) -> tuple[str | None, str | None]:
             actual_tier = max(actual_tier, op_tier)
 
     satisfied_validation_run_tier = 0
-    deferred_required_coverage = False
     for run in validation_runs:
         if rebase_time and run.started_at <= rebase_time:
-            continue
-
-        if run.status == "succeeded" and _validation_run_deferred_required_coverage(run):
-            deferred_required_coverage = True
             continue
 
         run_tier = _successful_validation_run_tier(run)
@@ -105,9 +100,6 @@ def compute_stale_reason(workspace: Workspace) -> tuple[str | None, str | None]:
 
         satisfied_validation_run_tier = max(satisfied_validation_run_tier, run_tier)
         actual_tier = max(actual_tier, run_tier)
-
-    if deferred_required_coverage and satisfied_validation_run_tier < required_tier:
-        return VALIDATION_INSUFFICIENT_TIER_STALE_REASON, "validate"
 
     if actual_tier < required_tier:
         return VALIDATION_INSUFFICIENT_TIER_STALE_REASON, "validate"
@@ -160,26 +152,4 @@ def compute_stale_reason_for_attempt(
 def _successful_validation_run_tier(run: ValidationRun) -> int | None:
     if run.status != "succeeded":
         return None
-    if _validation_run_deferred_required_coverage(run):
-        return None
     return run.tier
-
-
-def _validation_run_deferred_required_coverage(run: ValidationRun) -> bool:
-    """Return True when a successful run only satisfied the targeted edit gate.
-
-    PR-bound workspaces may intentionally skip the expensive final coverage
-    command before opening/updating a PR. That targeted-only run is useful
-    evidence for the edit, but it must not clear merge eligibility for a
-    profile whose final gate is coverage.
-    """
-
-    for command in run.commands or []:
-        if command.get("phase") != "coverage":
-            continue
-        if (
-            command.get("evidence_status") == "skipped_by_policy"
-            and command.get("evidence_reason_code") == "TARGETED_EDIT_GATE"
-        ):
-            return True
-    return False

--- a/src/awf/runtime/validation.py
+++ b/src/awf/runtime/validation.py
@@ -1391,7 +1391,7 @@ def _pytest_token_index(tokens: list[str]) -> int | None:
 
 
 def _coverage_requested(coverage: ProfileCoverage) -> bool:
-    return coverage.command is not None or coverage.minimum_percent > 0
+    return coverage.command is not None
 
 
 def _coverage_output_paths(results: list[ValidationCommandResult]) -> list[Path]:

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -1816,6 +1816,7 @@ async def test_final_coverage_gate_caps_parallel_workers_to_active_reservation(
         )
 
         assert result.coverage is coverage
+        assert validation.calls == ["coverage"]
         assert validation.kwargs[0]["parallel_worker_cpu_limit"] == 3
     finally:
         await engine.dispose()

--- a/tests/unit/control/test_executor_coverage_edges.py
+++ b/tests/unit/control/test_executor_coverage_edges.py
@@ -29,7 +29,6 @@ from awf.control.executor import (
     _coverage_has_failing_tests,
     _coverage_preserves_below_threshold_baseline,
     _coverage_wrapped_pytest_failure_message,
-    _defer_final_coverage_to_pr_monitor,
     _failure_reason_for_phase,
     _failure_salvage_payload,
     _format_failing_test_evidence,
@@ -46,6 +45,7 @@ from awf.control.executor import (
     _RebaseRecoveryResult,
     _recover_missing_head_from_filesystem,
     _recovery_needs_existing_pr_push,
+    _should_run_local_coverage,
     _validation_command_count,
     _validation_failure_message,
     _validation_run_command_records,
@@ -1304,11 +1304,10 @@ def test_validation_run_command_records_run_pending_healthchecks_after_refresh_w
 
 
 @pytest.mark.unit
-def test_validation_command_records_can_mark_coverage_skipped_by_policy() -> None:
+def test_validation_command_records_omit_coverage_when_no_local_command_is_declared() -> None:
     profile = WorkspaceProfile.model_validate(
         {
             "name": "records",
-            "validation": {"coverage": {"command": "pytest --cov=awf"}},
             "phases": {"validate": ["pytest tests/unit -q"]},
         }
     )
@@ -1317,25 +1316,27 @@ def test_validation_command_records_can_mark_coverage_skipped_by_policy() -> Non
         profile=profile,
         phase_names=("validate",),
         run_healthchecks=False,
-        coverage_evidence_status="skipped_by_policy",
-        coverage_evidence_reason_code="TARGETED_EDIT_GATE",
     )
 
-    assert records[-1]["phase"] == "coverage"
-    assert records[-1]["evidence_status"] == "skipped_by_policy"
-    assert records[-1]["evidence_reason_code"] == "TARGETED_EDIT_GATE"
+    assert [(record["phase"], record["command"]) for record in records] == [
+        ("validate", "pytest tests/unit -q")
+    ]
 
 
 @pytest.mark.unit
-def test_pr_monitored_targeted_profile_defers_final_coverage_to_check_rollup() -> None:
-    profile = WorkspaceProfile.model_validate(
+def test_local_coverage_runs_only_when_profile_declares_coverage_command() -> None:
+    no_local_coverage = WorkspaceProfile.model_validate(
         {
             "name": "awf-self",
+            "validation": {"strategy": {"edit_gate": "targeted"}},
+            "phases": {"validate": ["uv run pytest tests/unit/cli -q"]},
+        }
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "explicit-local-coverage",
             "validation": {
-                "strategy": {
-                    "edit_gate": "targeted",
-                    "final_gate": "coverage",
-                },
+                "strategy": {"edit_gate": "targeted"},
                 "coverage": {
                     "minimum_percent": 99,
                     "enforce": True,
@@ -1346,30 +1347,8 @@ def test_pr_monitored_targeted_profile_defers_final_coverage_to_check_rollup() -
         }
     )
 
-    assert (
-        _defer_final_coverage_to_pr_monitor(
-            recovery=None,
-            has_pr_monitor=True,
-            profile=profile,
-        )
-        is True
-    )
-    assert (
-        _defer_final_coverage_to_pr_monitor(
-            recovery=None,
-            has_pr_monitor=False,
-            profile=profile,
-        )
-        is False
-    )
-    assert (
-        _defer_final_coverage_to_pr_monitor(
-            recovery={"recovery_mode": "validate_only"},
-            has_pr_monitor=True,
-            profile=profile,
-        )
-        is False
-    )
+    assert _should_run_local_coverage(no_local_coverage) is False
+    assert _should_run_local_coverage(profile) is True
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -40,10 +40,12 @@ from awf.control.executor import (
     WorkspaceExecutor,
     _call_pr_monitor_factory,
     _required_metadata_str,
+    _validation_run_command_records,
 )
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import MergeCandidate, Operation, TaskAttempt, Workspace, WorkspaceEvent
 from awf.db.repositories import (
+    ResourceReservationRepository,
     TaskAttemptRepository,
     TaskRepository,
     ValidationRunRepository,
@@ -56,7 +58,13 @@ from awf.node.compose_manager import ComposeManager, ComposeOperationError
 from awf.profiles.models import ProfileMonitor, WorkspaceProfile
 from awf.runtime.logs import LogStore
 from awf.runtime.pr_creator import PullRequestCreator, PullRequestResult
-from awf.runtime.validation import ValidationResult, ValidationRunner
+from awf.runtime.validation import (
+    ValidationCommandResult,
+    ValidationCoverageResult,
+    ValidationResult,
+    ValidationRunner,
+)
+from awf.runtime.validation_identity import environment_identity_digest, resolved_profile_digest
 from awf.service.pr_monitor_adoption import PullRequestMonitorAdoptionService
 from tests.postgres import create_postgres_test_engine, postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import (
@@ -98,6 +106,7 @@ def _make_executor(
     validation: Any = None,
     pr_creator: Any = None,
     log_store: LogStore | None = None,
+    max_validation_fix_passes: int = 5,
 ) -> WorkspaceExecutor:
     compose = compose or _NoopResumeCompose()
     validation = validation or ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
@@ -111,6 +120,7 @@ def _make_executor(
         config=ExecutorConfig(
             worktrees_root=tmp_path / "work" / "worktrees",
             compose_projects_root=tmp_path / "work" / "compose",
+            max_validation_fix_passes=max_validation_fix_passes,
             default_models={
                 AgentRuntime.codex: "gpt-5",
                 AgentRuntime.claude_code: "sonnet",
@@ -135,22 +145,91 @@ class _NoopResumeCompose:
 
 
 class _RecordingValidation:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        phase_result: ValidationResult | None = None,
+        coverage_result: ValidationCoverageResult | None = None,
+    ) -> None:
+        self._phase_result = phase_result or ValidationResult()
+        self._coverage_result = coverage_result
         self.calls: list[tuple[str, ...]] = []
         self.coverage_calls: list[str | None] = []
+        self.phase_kwargs: list[dict[str, Any]] = []
+        self.coverage_kwargs: list[dict[str, Any]] = []
 
     async def run_profile_phases(
         self,
         *,
         phase_names: tuple[str, ...],
-        **_kwargs: Any,
+        **kwargs: Any,
     ) -> ValidationResult:
         self.calls.append(phase_names)
-        return ValidationResult()
+        self.phase_kwargs.append(dict(kwargs))
+        if phase_names == ("setup", "pre_agent"):
+            return ValidationResult()
+        return self._phase_result
 
-    async def run_profile_coverage(self, **_kwargs: Any) -> None:
+    async def run_profile_coverage(self, **_kwargs: Any) -> ValidationCoverageResult | None:
+        self.coverage_kwargs.append(dict(_kwargs))
         phase = _kwargs.get("phase")
         self.coverage_calls.append(phase if isinstance(phase, str) else None)
+        return self._coverage_result
+
+
+class _RecordingPrCreator:
+    async def push_and_open(self, *, branch_name: str, **_kwargs: Any) -> PullRequestResult:
+        return PullRequestResult(
+            url="https://github.com/x/y/pull/123",
+            branch=branch_name,
+            head_sha="b" * 40,
+        )
+
+
+def _validation_command_result(
+    tmp_path: Path,
+    *,
+    returncode: int,
+    reason_code: str,
+) -> ValidationCommandResult:
+    stdout_path = tmp_path / "validation.stdout"
+    stderr_path = tmp_path / "validation.stderr"
+    stdout_path.write_text("validation stdout\n", encoding="utf-8")
+    stderr_path.write_text("validation stderr\n", encoding="utf-8")
+    return ValidationCommandResult(
+        command="pytest -q",
+        returncode=returncode,
+        duration_seconds=0.1,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        phase="validate",
+        reason_code=reason_code,
+    )
+
+
+def _coverage_result(tmp_path: Path, *, percent: float = 99.5) -> ValidationCoverageResult:
+    stdout_path = tmp_path / "coverage.stdout"
+    stderr_path = tmp_path / "coverage.stderr"
+    stdout_path.write_text(f"TOTAL 10 0 {percent:.1f}%\n", encoding="utf-8")
+    stderr_path.write_text("", encoding="utf-8")
+    command_result = ValidationCommandResult(
+        command="pytest --cov=awf",
+        returncode=0,
+        duration_seconds=0.1,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+        phase="coverage",
+        reason_code="COVERAGE_OK",
+    )
+    return ValidationCoverageResult(
+        provider="python",
+        percent=percent,
+        minimum_percent=99.0,
+        enforce=True,
+        status="passed",
+        reason_code="COVERAGE_OK",
+        command_result=command_result,
+    )
 
 
 class _ExplodingValidation:
@@ -2283,6 +2362,216 @@ class TestPullRequestUnexpectedError:
         assert len(runs) == 1
         coverage_commands = [cmd for cmd in runs[0].commands if cmd.get("phase") == "coverage"]
         assert coverage_commands == []
+
+    @pytest.mark.unit
+    async def test_local_coverage_is_not_marked_executed_when_phase_validation_fails(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        profile = WorkspaceProfile(
+            name="local-coverage-failure",
+            source="test",
+            phases={"validate": ["pytest -q"]},
+            validation={
+                "strategy": {"baseline_coverage": "skip"},
+                "coverage": {
+                    "minimum_percent": 99,
+                    "command": "pytest --cov=awf",
+                },
+            },
+        )
+        ws_id = await _seed_ready(factory, resolved_profile=profile.model_dump(mode="json"))
+        validation = _RecordingValidation(
+            phase_result=ValidationResult(
+                commands=[
+                    _validation_command_result(
+                        tmp_path,
+                        returncode=1,
+                        reason_code="COMMAND_FAILED",
+                    )
+                ]
+            ),
+            coverage_result=_coverage_result(tmp_path),
+        )
+
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # drift-check: on expected branch
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="src/awf/runtime/pr_monitor_runner.py\n")
+        fake.queue_result(returncode=0)  # commit staged implementation output
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        fake.queue_result(returncode=0, stdout="validated-head\n")  # pre-validation HEAD
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_creator=_RecordingPrCreator(),
+            max_validation_fix_passes=0,
+        )
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+
+        assert validation.coverage_calls == []
+        assert len(runs) == 1
+        assert runs[0].status == "failed"
+        coverage_commands = [cmd for cmd in runs[0].commands if cmd.get("phase") == "coverage"]
+        assert len(coverage_commands) == 1
+        assert "evidence_status" not in coverage_commands[0]
+        assert "evidence_reason_code" not in coverage_commands[0]
+
+    @pytest.mark.unit
+    async def test_local_coverage_reuses_fresh_evidence_before_running_command(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        profile = WorkspaceProfile(
+            name="local-coverage-reuse",
+            source="test",
+            phases={"validate": ["pytest -q"]},
+            validation={
+                "strategy": {
+                    "baseline_coverage": "skip",
+                    "reuse_evidence": True,
+                    "freshness_max_age_seconds": 3600,
+                },
+                "coverage": {
+                    "minimum_percent": 99,
+                    "command": "pytest --cov=awf",
+                },
+            },
+        )
+        ws_id = await _seed_ready(factory, resolved_profile=profile.model_dump(mode="json"))
+        commands = _validation_run_command_records(
+            profile=profile,
+            phase_names=("post_agent", "validate"),
+            run_healthchecks=True,
+        )
+        async with factory() as s:
+            source_run = await ValidationRunRepository(s).start(
+                workspace_id=ws_id,
+                attempt_id=None,
+                tier=1,
+                commands=commands,
+                base_commit="base",
+                target_branch="development",
+                target_head_sha=None,
+                workspace_head_sha="validated-head",
+                resolved_profile_digest=resolved_profile_digest(profile),
+                environment_identity_digest=environment_identity_digest(profile),
+                log_stream_refs={},
+            )
+            await ValidationRunRepository(s).finish(
+                source_run.id,
+                status="succeeded",
+                reason_code="VALIDATION_OK",
+                coverage=_coverage_result(tmp_path).as_metadata(),
+            )
+            await s.commit()
+            source_run_id = source_run.id
+
+        validation = _RecordingValidation(coverage_result=_coverage_result(tmp_path))
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # drift-check: on expected branch
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="src/awf/runtime/pr_monitor_runner.py\n")
+        fake.queue_result(returncode=0)  # commit staged implementation output
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        fake.queue_result(returncode=0, stdout="validated-head\n")  # pre-validation HEAD
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_creator=_RecordingPrCreator(),
+        )
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+
+        assert validation.coverage_calls == []
+        new_run = next(run for run in runs if run.id != source_run_id)
+        coverage_command = next(cmd for cmd in new_run.commands if cmd.get("phase") == "coverage")
+        assert coverage_command["evidence_status"] == "reused"
+        assert coverage_command["evidence_reason_code"] == "VALIDATION_EVIDENCE_REUSED"
+        assert coverage_command["evidence_source_run_id"] == source_run_id
+
+    @pytest.mark.unit
+    async def test_local_coverage_uses_workspace_cpu_cap_for_parallel_workers(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        profile = WorkspaceProfile(
+            name="local-coverage-parallel",
+            source="test",
+            phases={"validate": ["pytest -q"]},
+            validation={
+                "strategy": {"baseline_coverage": "skip"},
+                "coverage": {
+                    "minimum_percent": 99,
+                    "command": "pytest --cov=awf",
+                    "parallel_workers": 20,
+                },
+            },
+        )
+        ws_id = await _seed_ready(
+            factory,
+            resolved_profile=profile.model_dump(mode="json"),
+            create_task_attempt=True,
+        )
+        async with factory() as s:
+            attempt = await TaskAttemptRepository(s).get_by_workspace_id(ws_id)
+            assert attempt is not None
+            await ResourceReservationRepository(s).create(
+                workspace_id=ws_id,
+                attempt_id=attempt.id,
+                node_id="local",
+                steady_cpu=3.0,
+                steady_memory_gb=10.0,
+                peak_cpu=6.0,
+                peak_memory_gb=16.0,
+                disk_mb=None,
+                phase="execution",
+            )
+            await s.commit()
+
+        validation = _RecordingValidation(coverage_result=_coverage_result(tmp_path))
+        fake.queue_result(returncode=0, stdout="adapter ok")
+        fake.queue_result(returncode=0, stdout="awf/x\n")  # drift-check: on expected branch
+        fake.queue_result(returncode=0)  # git add -A
+        fake.queue_result(returncode=0, stdout="src/awf/runtime/pr_monitor_runner.py\n")
+        fake.queue_result(returncode=0)  # commit staged implementation output
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list count
+        fake.queue_result(returncode=0)  # merge-base --is-ancestor
+        fake.queue_result(returncode=0, stdout="validated-head\n")  # pre-validation HEAD
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_creator=_RecordingPrCreator(),
+        )
+
+        await executor.execute(ws_id)
+
+        assert validation.coverage_calls == ["final_coverage"]
+        assert validation.coverage_kwargs[0]["parallel_worker_cpu_limit"] == 3
 
     @pytest.mark.unit
     async def test_unexpected_pr_creation_error_marks_failed(

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -2212,7 +2212,7 @@ class TestPullRequestUnexpectedError:
         assert validation.calls == [("setup", "pre_agent"), ("post_agent", "validate")]
 
     @pytest.mark.unit
-    async def test_fresh_pr_workspace_defers_final_coverage_to_pr_monitor(
+    async def test_fresh_pr_workspace_without_local_coverage_records_no_coverage_command(
         self,
         fake: FakeCommandRunner,
         factory: async_sessionmaker[AsyncSession],
@@ -2238,20 +2238,13 @@ class TestPullRequestUnexpectedError:
 
         monitor = _Monitor()
         profile = WorkspaceProfile(
-            name="defer-final-coverage",
+            name="scm-check-coverage",
             source="test",
             phases={"validate": ["pytest tests/unit/cli -q"]},
             validation={
                 "strategy": {
                     "baseline_coverage": "skip",
                     "edit_gate": "targeted",
-                    "final_gate": "coverage",
-                },
-                "coverage": {
-                    "minimum_percent": 99,
-                    "enforce": True,
-                    "provider": "python",
-                    "command": "pytest --cov=awf --cov-report=term-missing",
                 },
             },
         )
@@ -2289,9 +2282,7 @@ class TestPullRequestUnexpectedError:
         assert monitor.calls == [ws_id]
         assert len(runs) == 1
         coverage_commands = [cmd for cmd in runs[0].commands if cmd.get("phase") == "coverage"]
-        assert coverage_commands
-        assert coverage_commands[0]["evidence_status"] == "skipped_by_policy"
-        assert coverage_commands[0]["evidence_reason_code"] == "TARGETED_EDIT_GATE"
+        assert coverage_commands == []
 
     @pytest.mark.unit
     async def test_unexpected_pr_creation_error_marks_failed(

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -2570,7 +2570,7 @@ class TestPullRequestUnexpectedError:
 
         await executor.execute(ws_id)
 
-        assert validation.coverage_calls == ["final_coverage"]
+        assert validation.coverage_calls == ["coverage"]
         assert validation.coverage_kwargs[0]["parallel_worker_cpu_limit"] == 3
 
     @pytest.mark.unit

--- a/tests/unit/db/test_connection_resilience.py
+++ b/tests/unit/db/test_connection_resilience.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncpg
 import pytest
 import structlog
 from sqlalchemy import text
@@ -62,6 +63,47 @@ def test_make_engine_configures_asyncpg_liveness_pool_options(
         "timeout": 7.0,
         "server_settings": {"search_path": "awf_test"},
     }
+
+
+@pytest.mark.unit
+def test_make_engine_marks_asyncpg_internal_pre_ping_protocol_error_as_disconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Dialect:
+        name = "postgresql"
+        driver = "asyncpg"
+
+        def __init__(self) -> None:
+            self.error: BaseException = asyncpg.exceptions.InternalClientError(
+                "cannot switch to state 15; another operation (2) is in progress"
+            )
+
+        def do_ping(self, _dbapi_connection: object) -> bool:
+            raise self.error
+
+    class _SyncEngine:
+        def __init__(self) -> None:
+            self.dialect = _Dialect()
+
+    class _Engine:
+        def __init__(self) -> None:
+            self.sync_engine = _SyncEngine()
+
+    engine = _Engine()
+
+    def _fake_create_async_engine(_url: str, **_kwargs: object) -> object:
+        return engine
+
+    monkeypatch.setattr(session_mod, "create_async_engine", _fake_create_async_engine)
+
+    returned_engine = make_engine("postgresql+asyncpg://awf:awf@example.test/awf")
+
+    assert returned_engine is engine
+    assert engine.sync_engine.dialect.do_ping(object()) is False
+
+    engine.sync_engine.dialect.error = RuntimeError("ordinary ping failure")
+    with pytest.raises(RuntimeError, match="ordinary ping failure"):
+        engine.sync_engine.dialect.do_ping(object())
 
 
 @pytest.mark.unit
@@ -138,6 +180,17 @@ def test_closed_connection_classifier_matches_asyncpg_interface_error_names() ->
     assert is_transient_closed_connection_error(cursor_interface_error) is False
     assert is_transient_closed_connection_error(unrelated) is False
     assert is_transient_closed_connection_error(ValueError("not a DB failure")) is False
+
+
+@pytest.mark.unit
+def test_closed_connection_classifier_matches_asyncpg_internal_protocol_state_error() -> None:
+    protocol_error = asyncpg.exceptions.InternalClientError(
+        "cannot switch to state 15; another operation (2) is in progress"
+    )
+    unrelated_internal_error = asyncpg.exceptions.InternalClientError("unexpected asyncpg bug")
+
+    assert is_transient_closed_connection_error(protocol_error) is True
+    assert is_transient_closed_connection_error(unrelated_internal_error) is False
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -218,6 +218,17 @@ def test_profile_schema_accepts_validation_coverage_policy() -> None:
 
 
 @pytest.mark.unit
+def test_profile_schema_rejects_coverage_threshold_without_local_command() -> None:
+    with pytest.raises(ValueError, match="validation.coverage.command is required"):
+        WorkspaceProfile.model_validate(
+            {
+                "name": "ambiguous-coverage",
+                "validation": {"coverage": {"minimum_percent": 99}},
+            }
+        )
+
+
+@pytest.mark.unit
 def test_profile_schema_accepts_parallel_coverage_workers() -> None:
     profile = WorkspaceProfile.model_validate(
         {
@@ -745,9 +756,11 @@ def test_awf_self_profile_uses_targeted_edit_validation_and_final_coverage_gate(
 
     assert profile.validation.strategy.baseline_coverage == "skip"
     assert profile.validation.strategy.edit_gate == "targeted"
-    assert profile.validation.strategy.final_gate == "coverage"
-    assert profile.validation.strategy.reuse_evidence is True
+    assert profile.validation.strategy.final_gate == "none"
+    assert profile.validation.strategy.reuse_evidence is False
     assert profile.validation.strategy.full_gate_concurrency == 0
+    assert profile.validation.coverage.minimum_percent == 0
+    assert profile.validation.coverage.command is None
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -249,6 +249,26 @@ def test_profile_schema_accepts_parallel_coverage_workers() -> None:
 
 
 @pytest.mark.unit
+def test_profile_schema_rejects_parallel_worker_max_without_parallel_workers() -> None:
+    with pytest.raises(
+        ValueError,
+        match="validation.coverage.parallel_worker_max requires",
+    ):
+        WorkspaceProfile.model_validate(
+            {
+                "name": "parallel-coverage-misconfigured",
+                "validation": {
+                    "coverage": {
+                        "minimum_percent": 99,
+                        "parallel_worker_max": 4,
+                        "command": "uv run pytest --cov=awf --cov-report=term",
+                    }
+                },
+            }
+        )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "parallel_workers",
     [0, -1, "auto", 1.5],
@@ -748,7 +768,7 @@ def test_validation_strategy_defaults_preserve_legacy_behavior() -> None:
 
 
 @pytest.mark.unit
-def test_awf_self_profile_uses_targeted_edit_validation_and_final_coverage_gate() -> None:
+def test_awf_self_profile_uses_targeted_edit_validation_without_local_coverage_gate() -> None:
     profile_path = Path(__file__).resolve().parents[3] / ".awf" / "workspace.yml"
     profile = WorkspaceProfile.model_validate(
         yaml.safe_load(profile_path.read_text(encoding="utf-8"))["awf"]

--- a/tests/unit/runtime/test_merge_eligibility.py
+++ b/tests/unit/runtime/test_merge_eligibility.py
@@ -8,7 +8,6 @@ from awf.db.repositories import sync_candidate_readiness
 from awf.runtime.merge_eligibility import (
     VALIDATION_INSUFFICIENT_TIER_STALE_REASON,
     _successful_validation_run_tier,
-    _validation_run_deferred_required_coverage,
     compute_stale_reason,
     compute_stale_reason_for_attempt,
 )
@@ -160,7 +159,7 @@ def test_compute_stale_reason_uses_persisted_validation_run_tier() -> None:
 
 
 @pytest.mark.unit
-def test_compute_stale_reason_rejects_targeted_only_validation_when_coverage_was_deferred() -> None:
+def test_compute_stale_reason_accepts_targeted_validation_when_no_local_coverage_gate() -> None:
     workspace = _workspace_with_operations(
         task_class=TaskClass.refactor_task.value,
         operations=[],
@@ -171,69 +170,30 @@ def test_compute_stale_reason_rejects_targeted_only_validation_when_coverage_was
             started_at=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
             commands=[
                 {"phase": "validate", "command": "pytest tests/unit/cli -q"},
-                {
-                    "phase": "coverage",
-                    "command": "pytest --cov=awf",
-                    "evidence_status": "skipped_by_policy",
-                    "evidence_reason_code": "TARGETED_EDIT_GATE",
-                },
             ],
         )
     ]
 
-    assert compute_stale_reason(workspace) == (
-        VALIDATION_INSUFFICIENT_TIER_STALE_REASON,
-        "validate",
-    )
+    assert compute_stale_reason(workspace) == (None, None)
 
 
 @pytest.mark.unit
-def test_successful_validation_run_tier_excludes_deferred_coverage_runs() -> None:
+def test_successful_validation_run_tier_counts_targeted_validation_without_local_gate() -> None:
     run = _validation_run(
         tier=2,
         started_at=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
-        commands=[
-            {
-                "phase": "coverage",
-                "command": "pytest --cov=awf",
-                "evidence_status": "skipped_by_policy",
-                "evidence_reason_code": "TARGETED_EDIT_GATE",
-            }
-        ],
+        commands=[{"phase": "validate", "command": "pytest tests/unit/cli -q"}],
     )
 
-    assert _successful_validation_run_tier(run) is None
-
-
-@pytest.mark.unit
-def test_validation_run_deferred_coverage_ignores_completed_coverage_command() -> None:
-    run = _validation_run(
-        tier=2,
-        started_at=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
-        commands=[
-            {"phase": "validate", "command": "pytest -q"},
-            {"phase": "coverage", "command": "pytest --cov=awf", "evidence_status": "complete"},
-        ],
-    )
-
-    assert not _validation_run_deferred_required_coverage(run)
     assert _successful_validation_run_tier(run) == 2
 
 
 @pytest.mark.unit
-def test_sync_candidate_readiness_keeps_tier_one_deferred_coverage_stale() -> None:
+def test_sync_candidate_readiness_accepts_targeted_validation_without_local_gate() -> None:
     validation_run = _validation_run(
         tier=1,
         started_at=datetime(2026, 4, 27, 12, 0, tzinfo=UTC),
-        commands=[
-            {"phase": "validate", "command": "pytest tests/unit/cli -q"},
-            {
-                "phase": "coverage",
-                "command": "pytest --cov=awf",
-                "evidence_status": "skipped_by_policy",
-                "evidence_reason_code": "TARGETED_EDIT_GATE",
-            },
-        ],
+        commands=[{"phase": "validate", "command": "pytest tests/unit/cli -q"}],
     )
     validate_operation = _operation(
         operation_type="validate",
@@ -253,7 +213,7 @@ def test_sync_candidate_readiness_keeps_tier_one_deferred_coverage_stale() -> No
         is_canonical_for_merge=True,
     )
     candidate = MergeCandidate(
-        id="mc_tier_one_deferred_coverage",
+        id="mc_tier_one_scm_check_coverage",
         workspace=workspace,
         attempt=attempt,
         status="open",
@@ -262,9 +222,9 @@ def test_sync_candidate_readiness_keeps_tier_one_deferred_coverage_stale() -> No
 
     sync_candidate_readiness(candidate, workspace=workspace, attempt=attempt)
 
-    assert candidate.ready is False
-    assert candidate.stale is True
-    assert candidate.stale_reason == VALIDATION_INSUFFICIENT_TIER_STALE_REASON
+    assert candidate.ready is True
+    assert candidate.stale is False
+    assert candidate.stale_reason is None
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_validation.py
+++ b/tests/unit/runtime/test_validation.py
@@ -11,7 +11,7 @@ import pytest
 from awf.common.commands import CommandResult, FakeCommandRunner
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.profiles import compose as profile_compose
-from awf.profiles.models import ProfileHealthCheck, WorkspaceProfile
+from awf.profiles.models import ProfileCoverage, ProfileHealthCheck, WorkspaceProfile
 from awf.runtime import validation as validation_module
 from awf.runtime import validation_identity as validation_identity_module
 from awf.runtime.logs import CommandLogSinks, LogStore
@@ -1635,6 +1635,7 @@ class TestCoverageEnforcement:
                         "provider": "go",
                         "minimum_percent": 80,
                         "enforce": False,
+                        "command": "go test ./...",
                     }
                 },
             }
@@ -1647,6 +1648,7 @@ class TestCoverageEnforcement:
                         "provider": "go",
                         "minimum_percent": 80,
                         "enforce": True,
+                        "command": "go test ./...",
                     }
                 },
             }
@@ -1745,12 +1747,7 @@ class TestCoverageEnforcement:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        no_command = WorkspaceProfile.model_validate(
-            {
-                "name": "no-command",
-                "validation": {"coverage": {"minimum_percent": 99, "parallel_workers": 3}},
-            }
-        ).validation.coverage
+        no_command = ProfileCoverage()
         non_pytest = WorkspaceProfile.model_validate(
             {
                 "name": "non-pytest",
@@ -2384,7 +2381,7 @@ class TestCoverageEnforcement:
         assert result.first_failure.reason_code == "COVERAGE_BELOW_THRESHOLD"
 
     @pytest.mark.unit
-    async def test_coverage_without_command_streams_artifacts_instead_of_eager_reads(
+    async def test_coverage_without_command_is_not_parsed_from_validation_artifacts(
         self,
         runner: tuple[FakeCommandRunner, ValidationRunner],
         monkeypatch: pytest.MonkeyPatch,
@@ -2402,12 +2399,6 @@ class TestCoverageEnforcement:
             {
                 "name": "coverage-from-validation-artifacts",
                 "phases": {"validate": ["pytest --cov=awf --cov-report=term"]},
-                "validation": {
-                    "coverage": {
-                        "minimum_percent": 90,
-                        "enforce": True,
-                    }
-                },
             }
         )
 
@@ -2425,8 +2416,7 @@ class TestCoverageEnforcement:
         )
 
         assert result.all_passed
-        assert result.coverage is not None
-        assert result.coverage.percent == 96
+        assert result.coverage is None
 
     @pytest.mark.unit
     async def test_runs_baseline_coverage_with_distinct_artifact_label(


### PR DESCRIPTION
## Summary\n- Treat SCM/check-rollup status as the authoritative PR merge gate and run local coverage only when a workspace profile declares a coverage command.\n- Remove AWF self-repo local full coverage from .awf/workspace.yml so dogfood workspaces rely on GitHub Actions for the 99% coverage gate.\n- Reject ambiguous coverage thresholds without local coverage commands and update merge eligibility/tests accordingly.\n\n## Validation\n- uv run --python 3.12 --extra dev ruff check src/awf tests\n- uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_profiles.py tests/unit/control/test_executor_coverage_edges.py tests/unit/control/test_executor_error_paths.py tests/unit/runtime/test_merge_eligibility.py tests/unit/runtime/test_validation.py -q\n- uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing (5797 passed, 99.04%)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Coverage flow simplified: coverage is only collected when an explicit coverage command is configured; implicit threshold-triggered and deferred gating removed.
  * Profile validation tightened to reject inconsistent coverage/parallel settings.

* **Bug Fixes**
  * Validation runs no longer trigger coverage when no command is declared.
  * Merge-eligibility logic updated to stop treating deferred coverage specially.
  * Improved DB connection resilience and liveness handling.

* **Tests**
  * Updated and added unit tests for coverage, validation, merge-eligibility, and connection resilience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/231)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->