### PR TITLE
Fix agent prompt transport for large PR feedback

### DIFF
--- a/scripts/salvage_workspace.py
+++ b/scripts/salvage_workspace.py
@@ -61,7 +61,7 @@ class _NoOpAdapter(AgentAdapter):
     def name(self) -> AgentRuntime:  # type: ignore[override]
         return self._runtime
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+    def _cli_args(self, *, model: str | None) -> list[str]:
         return []
 
     async def run(  # type: ignore[override]
@@ -114,7 +114,7 @@ def _make_noop_factory(runtime_value: AgentRuntime) -> type[AgentAdapter]:
         def name(self) -> AgentRuntime:
             return self._runtime
 
-        def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+        def _cli_args(self, *, model: str | None) -> list[str]:
             return []
 
         async def run(

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -43,8 +43,7 @@ DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS = 1800.0
 
 
 # Prepended to every agent prompt. Encodes contract invariants the
-# agent must honour inside an AWF workspace. Kept short — most agent
-# CLIs accept prompts as command-line args and some have length caps.
+# agent must honour inside an AWF workspace.
 _AWF_PROMPT_PREAMBLE = """\
 ## AWF workspace contract (DO NOT VIOLATE)
 
@@ -148,7 +147,10 @@ class AgentAdapter(ABC):
     def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
         """Return the CLI-specific argv (after ``agent`` service name).
 
-        Example for Codex: ``["codex", "exec", "--model", model, prompt]``.
+        The wrapped prompt is streamed through stdin by ``run``. Implementations
+        must not place it in argv: review comments can exceed Linux's per-arg
+        length limit, and argv prompt transport leaks large prompts into process
+        listings.
         """
 
     async def run(
@@ -176,6 +178,7 @@ class AgentAdapter(ABC):
         ``control/executor.py`` form a belt-and-braces defence.
         """
         wrapped_prompt = _AWF_PROMPT_PREAMBLE + prompt
+        prompt_input = wrapped_prompt.encode("utf-8")
         cli_args = self._cli_args(prompt=wrapped_prompt, model=model or self._default_model)
         invocation = build_tracked_compose_exec(
             compose_project=compose_project,
@@ -183,6 +186,7 @@ class AgentAdapter(ABC):
             cli_args=cli_args,
             source=log_source,
             label=self.name.value,
+            preserve_stdin=True,
         )
         args = invocation.args
         _log.info(
@@ -195,11 +199,11 @@ class AgentAdapter(ABC):
             wall_timeout_seconds=self._agent_wall_timeout_seconds,
             idle_timeout_seconds=self._agent_idle_timeout_seconds,
             source=log_source,
+            prompt_bytes=len(prompt_input),
         )
-        # Close stdin explicitly. Some CLIs (Codex in particular) read
-        # "additional input" from stdin after argv parsing; if AWF is
-        # launched from an interactive terminal, inheriting that open
-        # stream makes the agent wait forever for EOF.
+        # Stream the prompt on stdin and close it explicitly. This avoids OS
+        # argv length limits for large review comments while still preventing
+        # CLIs from waiting forever for inherited interactive input.
         sinks = None
         if self._log_store is not None and workspace_id is not None:
             sinks = await self._log_store.open_command_streams(
@@ -217,7 +221,7 @@ class AgentAdapter(ABC):
                 if run_streaming is not None:
                     result = await run_streaming(
                         args,
-                        input_bytes=b"",
+                        input_bytes=prompt_input,
                         on_stdout=sinks.write_stdout if sinks is not None else None,
                         on_stderr=sinks.write_stderr if sinks is not None else None,
                         wall_timeout_seconds=self._agent_wall_timeout_seconds,
@@ -231,7 +235,7 @@ class AgentAdapter(ABC):
                         workspace_id=workspace_id,
                         reason="runner does not support run_streaming",
                     )
-                    result = await self._runner.run(args, input_bytes=b"")
+                    result = await self._runner.run(args, input_bytes=prompt_input)
                     if sinks is not None:
                         await sinks.write_stdout(result.stdout)
                         await sinks.write_stderr(result.stderr)

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -144,7 +144,7 @@ class AgentAdapter(ABC):
     def get_provider(self, model: str | None) -> str: ...  # pragma: no cover
 
     @abstractmethod
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+    def _cli_args(self, *, model: str | None) -> list[str]:
         """Return the CLI-specific argv (after ``agent`` service name).
 
         The wrapped prompt is streamed through stdin by ``run``. Implementations
@@ -179,7 +179,7 @@ class AgentAdapter(ABC):
         """
         wrapped_prompt = _AWF_PROMPT_PREAMBLE + prompt
         prompt_input = wrapped_prompt.encode("utf-8")
-        cli_args = self._cli_args(prompt=wrapped_prompt, model=model or self._default_model)
+        cli_args = self._cli_args(model=model or self._default_model)
         invocation = build_tracked_compose_exec(
             compose_project=compose_project,
             compose_file=compose_file,

--- a/src/awf/adapters/claude_code.py
+++ b/src/awf/adapters/claude_code.py
@@ -23,8 +23,7 @@ class ClaudeCodeAdapter(AgentAdapter):
         del model
         return "anthropic"
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-        del prompt
+    def _cli_args(self, *, model: str | None) -> list[str]:
         args = ["claude", "--dangerously-skip-permissions"]
         if model:
             args += ["--model", model]

--- a/src/awf/adapters/claude_code.py
+++ b/src/awf/adapters/claude_code.py
@@ -24,12 +24,13 @@ class ClaudeCodeAdapter(AgentAdapter):
         return "anthropic"
 
     def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+        del prompt
         args = ["claude", "--dangerously-skip-permissions"]
         if model:
             args += ["--model", model]
         if self._default_effort:
             args += ["--effort", _claude_effort_for_awf_effort(self._default_effort)]
-        args += ["-p", prompt]
+        args.append("-p")
         return args
 
 

--- a/src/awf/adapters/codex.py
+++ b/src/awf/adapters/codex.py
@@ -23,8 +23,7 @@ class CodexAdapter(AgentAdapter):
         del model
         return "openai"
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-        del prompt
+    def _cli_args(self, *, model: str | None) -> list[str]:
         args = ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
         if model:
             args += ["--model", model]

--- a/src/awf/adapters/codex.py
+++ b/src/awf/adapters/codex.py
@@ -24,10 +24,11 @@ class CodexAdapter(AgentAdapter):
         return "openai"
 
     def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+        del prompt
         args = ["codex", "exec", "--dangerously-bypass-approvals-and-sandbox"]
         if model:
             args += ["--model", model]
         if self._default_effort:
             args += ["-c", f'model_reasoning_effort="{self._default_effort}"']
-        args.append(prompt)
+        args.append("-")
         return args

--- a/src/awf/adapters/gemini.py
+++ b/src/awf/adapters/gemini.py
@@ -23,12 +23,10 @@ class GeminiAdapter(AgentAdapter):
         del model
         return "google"
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-        del prompt
+    def _cli_args(self, *, model: str | None) -> list[str]:
         args = ["--skip-trust", "--yolo"]
         if model:
             args += ["--model", model]
-        args += ["-p", ""]
         if not self._default_effort:
             return ["gemini", *args]
 

--- a/src/awf/adapters/gemini.py
+++ b/src/awf/adapters/gemini.py
@@ -24,7 +24,10 @@ class GeminiAdapter(AgentAdapter):
         return "google"
 
     def _cli_args(self, *, model: str | None) -> list[str]:
-        args = ["--skip-trust", "--yolo"]
+        # Gemini CLI 0.41.2 documents -p/--prompt as non-interactive mode;
+        # its value is appended to stdin, so AWF keeps the real prompt on
+        # stdin and uses an empty value only as the headless-mode trigger.
+        args = ["--skip-trust", "--yolo", "-p", ""]
         if model:
             args += ["--model", model]
         if not self._default_effort:

--- a/src/awf/adapters/gemini.py
+++ b/src/awf/adapters/gemini.py
@@ -24,10 +24,11 @@ class GeminiAdapter(AgentAdapter):
         return "google"
 
     def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+        del prompt
         args = ["--skip-trust", "--yolo"]
         if model:
             args += ["--model", model]
-        args += ["-p", prompt]
+        args += ["-p", ""]
         if not self._default_effort:
             return ["gemini", *args]
 

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -23,7 +23,6 @@ OPENCODE_OLLAMA_CLOUD_MODELS = (
 """Ollama Cloud models AWF exposes through the OpenCode adapter."""
 
 DEFAULT_OLLAMA_OPENAI_BASE_URL = "http://host.docker.internal:11434/v1"
-OPENCODE_PROMPT_PATH = "/tmp/awf-opencode-prompt.md"
 
 
 @register_adapter
@@ -40,8 +39,7 @@ class OpenCodeAdapter(AgentAdapter):
             return active_model.split("/", 1)[0]
         return "ollama"
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-        del prompt
+    def _cli_args(self, *, model: str | None) -> list[str]:
         selected_model = _qualified_model(model or OPENCODE_OLLAMA_CLOUD_MODELS[0])
         script = _opencode_launcher_script(effort=self._default_effort)
         args = [
@@ -55,13 +53,7 @@ class OpenCodeAdapter(AgentAdapter):
         ]
         if variant := _variant_for_effort(self._default_effort):
             args.extend(["--variant", variant, "--thinking"])
-        args.extend(
-            [
-                "--file",
-                OPENCODE_PROMPT_PATH,
-                "Follow the instructions in the attached AWF prompt file exactly.",
-            ]
-        )
+        args.append("Follow the instructions in the attached AWF prompt file exactly.")
         return args
 
 
@@ -76,16 +68,26 @@ def _opencode_launcher_script(*, effort: str | None) -> str:
     config_json = json.dumps(config, separators=(",", ":"))
     return (
         "set -eu\n"
+        "prompt_path=\n"
+        "config_path=\n"
+        "cleanup() {\n"
+        '  [ -n "$prompt_path" ] && rm -f "$prompt_path" 2>/dev/null || true\n'
+        '  [ -n "$config_path" ] && rm -f "$config_path" 2>/dev/null || true\n'
+        "}\n"
+        "trap cleanup EXIT\n"
+        "trap 'cleanup; exit 143' HUP INT TERM\n"
+        'config_path="$(mktemp "${TMPDIR:-/tmp}/awf-opencode-config.XXXXXX.json")"\n'
         "export AWF_OPENCODE_OLLAMA_BASE_URL="
         '"${AWF_OPENCODE_OLLAMA_BASE_URL:-'
         f"{DEFAULT_OLLAMA_OPENAI_BASE_URL}"
         '}"\n'
-        "cat > /tmp/awf-opencode-config.json <<'AWF_OPENCODE_CONFIG'\n"
+        "cat > \"$config_path\" <<'AWF_OPENCODE_CONFIG'\n"
         f"{config_json}\n"
         "AWF_OPENCODE_CONFIG\n"
-        'export OPENCODE_CONFIG_CONTENT="$(cat /tmp/awf-opencode-config.json)"\n'
-        f"cat > {OPENCODE_PROMPT_PATH!r}\n"
-        'exec opencode run "$@"\n'
+        'export OPENCODE_CONFIG_CONTENT="$(cat "$config_path")"\n'
+        'prompt_path="$(mktemp "${TMPDIR:-/tmp}/awf-opencode-prompt.XXXXXX.md")"\n'
+        'cat > "$prompt_path"\n'
+        'opencode run --file "$prompt_path" "$@"\n'
     )
 
 

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -23,6 +23,7 @@ OPENCODE_OLLAMA_CLOUD_MODELS = (
 """Ollama Cloud models AWF exposes through the OpenCode adapter."""
 
 DEFAULT_OLLAMA_OPENAI_BASE_URL = "http://host.docker.internal:11434/v1"
+OPENCODE_PROMPT_PATH = "/tmp/awf-opencode-prompt.md"
 
 
 @register_adapter
@@ -40,6 +41,7 @@ class OpenCodeAdapter(AgentAdapter):
         return "ollama"
 
     def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+        del prompt
         selected_model = _qualified_model(model or OPENCODE_OLLAMA_CLOUD_MODELS[0])
         script = _opencode_launcher_script(effort=self._default_effort)
         args = [
@@ -53,7 +55,13 @@ class OpenCodeAdapter(AgentAdapter):
         ]
         if variant := _variant_for_effort(self._default_effort):
             args.extend(["--variant", variant, "--thinking"])
-        args.append(prompt)
+        args.extend(
+            [
+                "--file",
+                OPENCODE_PROMPT_PATH,
+                "Follow the instructions in the attached AWF prompt file exactly.",
+            ]
+        )
         return args
 
 
@@ -76,6 +84,7 @@ def _opencode_launcher_script(*, effort: str | None) -> str:
         f"{config_json}\n"
         "AWF_OPENCODE_CONFIG\n"
         'export OPENCODE_CONFIG_CONTENT="$(cat /tmp/awf-opencode-config.json)"\n'
+        f"cat > {OPENCODE_PROMPT_PATH!r}\n"
         'exec opencode run "$@"\n'
     )
 

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -70,12 +70,29 @@ def _opencode_launcher_script(*, effort: str | None) -> str:
         "set -eu\n"
         "prompt_path=\n"
         "config_path=\n"
+        "child_pid=\n"
         "cleanup() {\n"
+        '  if [ -n "$child_pid" ] && kill -0 "$child_pid" 2>/dev/null; then\n'
+        '    kill "$child_pid" 2>/dev/null || true\n'
+        '    wait "$child_pid" 2>/dev/null || true\n'
+        "  fi\n"
         '  [ -n "$prompt_path" ] && rm -f "$prompt_path" 2>/dev/null || true\n'
         '  [ -n "$config_path" ] && rm -f "$config_path" 2>/dev/null || true\n'
         "}\n"
+        "forward_signal() {\n"
+        '  sig="$1"\n'
+        '  code="$2"\n'
+        '  if [ -n "$child_pid" ]; then\n'
+        '    kill "-$sig" "$child_pid" 2>/dev/null || true\n'
+        '    wait "$child_pid" 2>/dev/null || true\n'
+        "    child_pid=\n"
+        "  fi\n"
+        '  exit "$code"\n'
+        "}\n"
         "trap cleanup EXIT\n"
-        "trap 'cleanup; exit 143' HUP INT TERM\n"
+        "trap 'forward_signal HUP 129' HUP\n"
+        "trap 'forward_signal INT 130' INT\n"
+        "trap 'forward_signal TERM 143' TERM\n"
         'config_path="$(mktemp "${TMPDIR:-/tmp}/awf-opencode-config.XXXXXX.json")"\n'
         "export AWF_OPENCODE_OLLAMA_BASE_URL="
         '"${AWF_OPENCODE_OLLAMA_BASE_URL:-'
@@ -87,7 +104,14 @@ def _opencode_launcher_script(*, effort: str | None) -> str:
         'export OPENCODE_CONFIG_CONTENT="$(cat "$config_path")"\n'
         'prompt_path="$(mktemp "${TMPDIR:-/tmp}/awf-opencode-prompt.XXXXXX.md")"\n'
         'cat > "$prompt_path"\n'
-        'opencode run --file "$prompt_path" "$@"\n'
+        'opencode run --file "$prompt_path" "$@" &\n'
+        "child_pid=$!\n"
+        "set +e\n"
+        'wait "$child_pid"\n'
+        "status=$?\n"
+        "set -e\n"
+        "child_pid=\n"
+        'exit "$status"\n'
     )
 
 

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -259,9 +259,11 @@ chmod 700 "$awf_exec_dir" 2>/dev/null || true
 """.strip()
         stdin_setup = """
 stdin_path="$awf_exec_dir/stdin"
+previous_umask="$(umask)"
 umask 077
 cat > "$stdin_path"
 cat_status=$?
+umask "$previous_umask"
 if [ "$cat_status" -ne 0 ]; then
   rm -f "$stdin_path" 2>/dev/null || true
   exit "$cat_status"

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -71,6 +71,7 @@ def build_tracked_compose_exec(
     service: str = "agent",
     workdir: str = "/workspace",
     invocation_id: str | None = None,
+    preserve_stdin: bool = False,
 ) -> TrackedComposeExec:
     """Build a compose-exec argv that tags the in-container command."""
 
@@ -78,7 +79,7 @@ def build_tracked_compose_exec(
         raise ValueError("cli_args must not be empty")
     invocation_id = invocation_id or _new_invocation_id()
     _validate_invocation_id(invocation_id)
-    wrapper_script = _tracked_exec_wrapper_script()
+    wrapper_script = _tracked_exec_wrapper_script(preserve_stdin=preserve_stdin)
     cleanup_script = _cleanup_script(invocation_id)
     args = [
         *_compose_exec_prefix(
@@ -243,28 +244,37 @@ def _validate_invocation_id(invocation_id: str) -> None:
         raise ValueError("invocation_id contains unsupported shell characters")
 
 
-def _tracked_exec_wrapper_script() -> str:
+def _tracked_exec_wrapper_script(*, preserve_stdin: bool = False) -> str:
     # Positional argv after ``sh -lc <script>`` is:
     #   $0=awf-exec, $1=<invocation_id>, $2...=<original command argv>
     # The real command is never shell-joined; ``shift`` leaves it as "$@".
-    return r"""
+    stdin_setup = ""
+    stdin_redirect = "</dev/null"
+    if preserve_stdin:
+        stdin_setup = """
+stdin_path="$awf_exec_dir/stdin"
+cat > "$stdin_path"
+""".strip()
+        stdin_redirect = '< "$stdin_path"'
+    return f"""
 set +e
 invocation_id=$1
 shift
 export AWF_EXEC_INVOCATION_ID="$invocation_id"
 awf_exec_dir="/tmp/awf-exec/$invocation_id"
 mkdir -p "$awf_exec_dir" 2>/dev/null || true
-printf '%s\n' "$$" > "$awf_exec_dir/wrapper_pid" 2>/dev/null || true
+printf '%s\\n' "$$" > "$awf_exec_dir/wrapper_pid" 2>/dev/null || true
+{stdin_setup}
 if command -v setsid >/dev/null 2>&1; then
-  setsid "$@" &
+  setsid "$@" {stdin_redirect} &
   child_pid=$!
-  printf '%s\n' "$child_pid" > "$awf_exec_dir/pid" 2>/dev/null || true
-  printf '%s\n' "$child_pid" > "$awf_exec_dir/pgid" 2>/dev/null || true
+  printf '%s\\n' "$child_pid" > "$awf_exec_dir/pid" 2>/dev/null || true
+  printf '%s\\n' "$child_pid" > "$awf_exec_dir/pgid" 2>/dev/null || true
   wait "$child_pid"
   exit $?
 fi
-printf '%s\n' "$$" > "$awf_exec_dir/pid" 2>/dev/null || true
-exec "$@"
+printf '%s\\n' "$$" > "$awf_exec_dir/pid" 2>/dev/null || true
+exec "$@" {stdin_redirect}
 """.strip()
 
 

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -252,15 +252,21 @@ def _tracked_exec_wrapper_script(*, preserve_stdin: bool = False) -> str:
     setsid_stdin_redirect = "</dev/null"
     setsid_stdin_cleanup = ""
     exec_stdin_setup = "exec </dev/null"
+    permissions_setup = ""
     if preserve_stdin:
+        permissions_setup = """
+chmod 700 "$awf_exec_dir" 2>/dev/null || true
+""".strip()
         stdin_setup = """
 stdin_path="$awf_exec_dir/stdin"
+umask 077
 cat > "$stdin_path"
 cat_status=$?
 if [ "$cat_status" -ne 0 ]; then
   rm -f "$stdin_path" 2>/dev/null || true
   exit "$cat_status"
 fi
+chmod 600 "$stdin_path" 2>/dev/null || true
 """.strip()
         setsid_stdin_redirect = '< "$stdin_path"'
         setsid_stdin_cleanup = 'rm -f "$stdin_path" 2>/dev/null || true'
@@ -280,6 +286,7 @@ shift
 export AWF_EXEC_INVOCATION_ID="$invocation_id"
 awf_exec_dir="/tmp/awf-exec/$invocation_id"
 mkdir -p "$awf_exec_dir" 2>/dev/null || true
+{permissions_setup}
 printf '%s\\n' "$$" > "$awf_exec_dir/wrapper_pid" 2>/dev/null || true
 {stdin_setup}
 if command -v setsid >/dev/null 2>&1; then

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -249,13 +249,30 @@ def _tracked_exec_wrapper_script(*, preserve_stdin: bool = False) -> str:
     #   $0=awf-exec, $1=<invocation_id>, $2...=<original command argv>
     # The real command is never shell-joined; ``shift`` leaves it as "$@".
     stdin_setup = ""
-    stdin_redirect = "</dev/null"
+    setsid_stdin_redirect = "</dev/null"
+    setsid_stdin_cleanup = ""
+    exec_stdin_setup = "exec </dev/null"
     if preserve_stdin:
         stdin_setup = """
 stdin_path="$awf_exec_dir/stdin"
 cat > "$stdin_path"
+cat_status=$?
+if [ "$cat_status" -ne 0 ]; then
+  rm -f "$stdin_path" 2>/dev/null || true
+  exit "$cat_status"
+fi
 """.strip()
-        stdin_redirect = '< "$stdin_path"'
+        setsid_stdin_redirect = '< "$stdin_path"'
+        setsid_stdin_cleanup = 'rm -f "$stdin_path" 2>/dev/null || true'
+        exec_stdin_setup = """
+exec < "$stdin_path"
+exec_status=$?
+if [ "$exec_status" -ne 0 ]; then
+  rm -f "$stdin_path" 2>/dev/null || true
+  exit "$exec_status"
+fi
+rm -f "$stdin_path" 2>/dev/null || true
+""".strip()
     return f"""
 set +e
 invocation_id=$1
@@ -266,15 +283,17 @@ mkdir -p "$awf_exec_dir" 2>/dev/null || true
 printf '%s\\n' "$$" > "$awf_exec_dir/wrapper_pid" 2>/dev/null || true
 {stdin_setup}
 if command -v setsid >/dev/null 2>&1; then
-  setsid "$@" {stdin_redirect} &
+  setsid "$@" {setsid_stdin_redirect} &
   child_pid=$!
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pid" 2>/dev/null || true
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pgid" 2>/dev/null || true
+  {setsid_stdin_cleanup}
   wait "$child_pid"
   exit $?
 fi
 printf '%s\\n' "$$" > "$awf_exec_dir/pid" 2>/dev/null || true
-exec "$@" {stdin_redirect}
+{exec_stdin_setup}
+exec "$@"
 """.strip()
 
 

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -270,8 +270,16 @@ if [ "$cat_status" -ne 0 ]; then
 fi
 chmod 600 "$stdin_path" 2>/dev/null || true
 """.strip()
-        setsid_stdin_redirect = '< "$stdin_path"'
-        setsid_stdin_cleanup = 'rm -f "$stdin_path" 2>/dev/null || true'
+        setsid_stdin_redirect = "<&9"
+        setsid_stdin_cleanup = """
+exec 9< "$stdin_path"
+exec_status=$?
+if [ "$exec_status" -ne 0 ]; then
+  rm -f "$stdin_path" 2>/dev/null || true
+  exit "$exec_status"
+fi
+rm -f "$stdin_path" 2>/dev/null || true
+""".strip()
         exec_stdin_setup = """
 exec < "$stdin_path"
 exec_status=$?
@@ -292,11 +300,12 @@ mkdir -p "$awf_exec_dir" 2>/dev/null || true
 printf '%s\\n' "$$" > "$awf_exec_dir/wrapper_pid" 2>/dev/null || true
 {stdin_setup}
 if command -v setsid >/dev/null 2>&1; then
+  {setsid_stdin_cleanup}
   setsid "$@" {setsid_stdin_redirect} &
   child_pid=$!
+  exec 9<&-
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pid" 2>/dev/null || true
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pgid" 2>/dev/null || true
-  {setsid_stdin_cleanup}
   wait "$child_pid"
   exit $?
 fi

--- a/tests/integration/runtime/test_pr_monitor_recovery_cycle.py
+++ b/tests/integration/runtime/test_pr_monitor_recovery_cycle.py
@@ -63,7 +63,7 @@ class _FakeAdapter(AgentAdapter):
     def name(self) -> AgentRuntime:  # type: ignore[override]
         return AgentRuntime.claude_code
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+    def _cli_args(self, *, model: str | None) -> list[str]:
         return []
 
     def queue(self, *, stdout: str = "", returncode: int = 0) -> None:

--- a/tests/integration/runtime/test_pr_monitor_runner.py
+++ b/tests/integration/runtime/test_pr_monitor_runner.py
@@ -67,7 +67,7 @@ class FakeAdapter(AgentAdapter):
     def name(self) -> AgentRuntime:  # type: ignore[override]
         return AgentRuntime.claude_code
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+    def _cli_args(self, *, model: str | None) -> list[str]:
         return []
 
     def queue(self, *, stdout: str = "", returncode: int = 0, raise_error: bool = False) -> None:

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import inspect
+import os
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,7 @@ from awf.adapters.opencode import (
     OPENCODE_OLLAMA_CLOUD_MODELS,
     OpenCodeAdapter,
     _opencode_config_for_effort,
+    _opencode_launcher_script,
     _qualified_model,
     _thinking_enabled,
     _variant_for_effort,
@@ -829,6 +831,80 @@ class TestOpenCodeAdapter:
         low_config = _opencode_config_for_effort(effort=None)
         models = low_config["provider"]["ollama"]["models"]  # type: ignore[index]
         assert all("options" not in model for model in models.values())
+
+    @pytest.mark.unit
+    async def test_opencode_launcher_forwards_termination_and_cleans_temp_files(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        bin_dir = tmp_path / "bin"
+        tmp_dir = tmp_path / "tmp"
+        bin_dir.mkdir()
+        tmp_dir.mkdir()
+        fake_opencode = bin_dir / "opencode"
+        fake_started = tmp_path / "started"
+        fake_signal = tmp_path / "signal"
+        fake_prompt = tmp_path / "prompt-copy"
+        fake_opencode.write_text(
+            "#!/bin/sh\n"
+            "set -eu\n"
+            "prompt_path=\n"
+            'while [ "$#" -gt 0 ]; do\n'
+            '  if [ "$1" = "--file" ]; then\n'
+            "    shift\n"
+            '    prompt_path="$1"\n'
+            "  fi\n"
+            "  shift || true\n"
+            "done\n"
+            'cat "$prompt_path" > "$AWF_FAKE_PROMPT_COPY"\n'
+            "trap 'printf TERM > \"$AWF_FAKE_SIGNAL\"; exit 143' TERM\n"
+            'printf started > "$AWF_FAKE_STARTED"\n'
+            "while :; do sleep 1; done\n"
+        )
+        fake_opencode.chmod(0o755)
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "TMPDIR": str(tmp_dir),
+                "AWF_FAKE_STARTED": str(fake_started),
+                "AWF_FAKE_SIGNAL": str(fake_signal),
+                "AWF_FAKE_PROMPT_COPY": str(fake_prompt),
+            }
+        )
+
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-lc",
+            _opencode_launcher_script(effort="xhigh"),
+            "awf-opencode",
+            "--model",
+            "ollama/kimi-k2.6:cloud",
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write(b"workspace prompt")
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+
+        for _ in range(50):
+            if fake_started.exists():
+                break
+            await asyncio.sleep(0.02)
+        assert fake_started.exists()
+
+        proc.terminate()
+        await asyncio.wait_for(proc.wait(), timeout=5)
+
+        assert proc.returncode == 143
+        assert fake_signal.read_text() == "TERM"
+        assert fake_prompt.read_text() == "workspace prompt"
+        assert list(tmp_dir.glob("awf-opencode-prompt.*.md")) == []
+        assert list(tmp_dir.glob("awf-opencode-config.*.json")) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -22,7 +22,7 @@ import structlog
 # Importing the registry module forces adapter self-registration.
 import awf.adapters.registry  # noqa: F401
 from awf.adapters import get_adapter  # noqa: F401 - populates registry via __init__
-from awf.adapters.base import AgentRunError
+from awf.adapters.base import AgentAdapter, AgentRunError
 from awf.adapters.claude_code import ClaudeCodeAdapter, _claude_effort_for_awf_effort
 from awf.adapters.codex import CodexAdapter
 from awf.adapters.defaults import DEFAULT_AGENT_DEFAULTS
@@ -42,6 +42,7 @@ from awf.common.compose_exec import ComposeExecCleanupError
 from awf.db.enums import AgentRuntime
 
 _PROMPT = "Add a one-line docstring to src/module/__init__.py."
+_LONG_PROMPT = "Review this oversized PR comment.\n" + ("x" * 140_000)
 _COMPOSE_PROJECT = "awf_ws_xyz"
 _COMPOSE_FILE = Path("/fake/path/compose.yml")
 
@@ -54,6 +55,19 @@ def _assert_docker_exec_prefix(args: list[str]) -> None:
     exec_idx = args.index("exec")
     assert args[exec_idx : exec_idx + 4] == ["exec", "-T", "-w", "/workspace"]
     assert "agent" in args
+
+
+def _assert_prompt_sent_on_stdin(runner: FakeCommandRunner, prompt: str = _PROMPT) -> str:
+    input_bytes = runner.calls[0].input_bytes
+    assert input_bytes is not None
+    wrapped_prompt = input_bytes.decode()
+    assert wrapped_prompt.endswith(prompt)
+    assert "AWF workspace contract" in wrapped_prompt
+    return wrapped_prompt
+
+
+def _assert_prompt_not_in_argv(args: list[str], prompt: str = _PROMPT) -> None:
+    assert all(prompt not in arg for arg in args)
 
 
 class _TimeoutStreamingRunner:
@@ -234,15 +248,28 @@ class TestCodexAdapter:
             "exec",
             "--dangerously-bypass-approvals-and-sandbox",
         ]
-        # AWF prepends a contract preamble ("do not switch branches")
-        # before the user-supplied prompt; the last argv element is
-        # therefore the wrapped form. Check the user prompt is the
-        # trailing substring so the assertion survives preamble edits.
-        assert args[-1].endswith(_PROMPT)
-        assert "AWF workspace contract" in args[-1]
+        assert args[-1] == "-"
+        _assert_prompt_not_in_argv(args)
+        _assert_prompt_sent_on_stdin(runner)
         assert "--model" in args and "gpt-5" in args
         assert "-c" in args
         assert 'model_reasoning_effort="xhigh"' in args
+
+    @pytest.mark.unit
+    async def test_large_prompt_uses_stdin_not_argv(self) -> None:
+        runner = FakeCommandRunner()
+        adapter = CodexAdapter(runner=runner, default_model="gpt-5", default_effort="xhigh")
+
+        await adapter.run(
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            prompt=_LONG_PROMPT,
+        )
+
+        args = runner.calls[0].args
+        assert max(len(arg) for arg in args) < 10_000
+        assert all(_LONG_PROMPT not in arg for arg in args)
+        _assert_prompt_sent_on_stdin(runner, _LONG_PROMPT)
 
     @pytest.mark.unit
     async def test_no_model_omits_model_flags(self) -> None:
@@ -274,7 +301,7 @@ class TestCodexAdapter:
         assert "codex: auth required" in exc.value.result.stderr
 
     @pytest.mark.unit
-    async def test_closes_stdin_for_noninteractive_exec(self) -> None:
+    async def test_streams_prompt_on_stdin_for_noninteractive_exec(self) -> None:
         runner = FakeCommandRunner()
         adapter = CodexAdapter(runner=runner)
 
@@ -284,7 +311,7 @@ class TestCodexAdapter:
             prompt=_PROMPT,
         )
 
-        assert runner.calls[0].input_bytes == b""
+        _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
     async def test_wall_timeout_raises_structured_error_and_closes_log_streams(self) -> None:
@@ -481,7 +508,8 @@ class TestCodexAdapter:
 
         assert result.stdout == "legacy stdout"
         assert result.stderr == "legacy stderr"
-        assert runner.calls[0]["input_bytes"] == b""
+        assert runner.calls[0]["input_bytes"] is not None
+        assert _PROMPT.encode() in runner.calls[0]["input_bytes"]
         assert log_store.sinks.stdout_data == ["legacy stdout"]
         assert log_store.sinks.stderr_data == ["legacy stderr"]
         assert log_store.sinks.closed is True
@@ -510,14 +538,11 @@ class TestClaudeCodeAdapter:
             "claude",
             "--dangerously-skip-permissions",
         ]
-        # -p signals non-interactive print mode.
-        assert args[-2] == "-p"
-        # AWF prepends a contract preamble ("do not switch branches")
-        # before the user-supplied prompt; the last argv element is
-        # therefore the wrapped form. Check the user prompt is the
-        # trailing substring so the assertion survives preamble edits.
-        assert args[-1].endswith(_PROMPT)
-        assert "AWF workspace contract" in args[-1]
+        # -p signals non-interactive print mode; AWF streams the prompt
+        # on stdin so large review comments never become one argv item.
+        assert args[-1] == "-p"
+        _assert_prompt_not_in_argv(args)
+        _assert_prompt_sent_on_stdin(runner)
         assert "--model" in args and "sonnet" in args
         assert "--effort" in args and "max" in args
 
@@ -622,12 +647,9 @@ class TestGeminiAdapter:
             "--yolo",
         ]
         assert args[-2] == "-p"
-        # AWF prepends a contract preamble ("do not switch branches")
-        # before the user-supplied prompt; the last argv element is
-        # therefore the wrapped form. Check the user prompt is the
-        # trailing substring so the assertion survives preamble edits.
-        assert args[-1].endswith(_PROMPT)
-        assert "AWF workspace contract" in args[-1]
+        assert args[-1] == ""
+        _assert_prompt_not_in_argv(args)
+        _assert_prompt_sent_on_stdin(runner)
         assert "--model" in args and "gemini-2.5-pro" in args
 
     @pytest.mark.unit
@@ -673,7 +695,9 @@ class TestGeminiAdapter:
         assert "GEMINI_CLI_TRUST_WORKSPACE" in script
         assert "exec gemini" in script
         assert "--model" in args and "gemini-3.1-pro-preview" in args
-        assert args[-1].endswith(_PROMPT)
+        assert args[-2] == "-p"
+        assert args[-1] == ""
+        _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
     def test_gemini_effort_helpers_map_only_high_effort_to_high_thinking(self) -> None:
@@ -742,8 +766,10 @@ class TestOpenCodeAdapter:
         assert "--variant" in args
         assert "max" in args
         assert "--thinking" in args
-        assert args[-1].endswith(_PROMPT)
-        assert "AWF workspace contract" in args[-1]
+        assert "--file" in args
+        assert args[-1] == "Follow the instructions in the attached AWF prompt file exactly."
+        _assert_prompt_not_in_argv(args)
+        _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
     async def test_preserves_fully_qualified_model_name(self) -> None:
@@ -797,6 +823,40 @@ class TestOpenCodeAdapter:
         low_config = _opencode_config_for_effort(effort=None)
         models = low_config["provider"]["ollama"]["models"]  # type: ignore[index]
         assert all("options" not in model for model in models.values())
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("adapter_cls", "runtime"),
+    [
+        (ClaudeCodeAdapter, AgentRuntime.claude_code),
+        (CodexAdapter, AgentRuntime.codex),
+        (GeminiAdapter, AgentRuntime.gemini),
+        (OpenCodeAdapter, AgentRuntime.opencode),
+    ],
+)
+async def test_all_adapters_keep_oversized_prompts_out_of_argv(
+    adapter_cls: type[AgentAdapter],
+    runtime: AgentRuntime,
+) -> None:
+    runner = FakeCommandRunner()
+    defaults = DEFAULT_AGENT_DEFAULTS[runtime]
+    adapter = adapter_cls(
+        runner=runner,
+        default_model=defaults.model,
+        default_effort=defaults.effort,
+    )
+
+    await adapter.run(
+        compose_project=_COMPOSE_PROJECT,
+        compose_file=_COMPOSE_FILE,
+        prompt=_LONG_PROMPT,
+    )
+
+    args = runner.calls[0].args
+    assert max(len(arg) for arg in args) < 10_000
+    assert all(_LONG_PROMPT not in arg for arg in args)
+    _assert_prompt_sent_on_stdin(runner, _LONG_PROMPT)
 
 
 class TestCentralDefaults:

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -646,8 +647,9 @@ class TestGeminiAdapter:
             "--skip-trust",
             "--yolo",
         ]
-        assert args[-2] == "-p"
-        assert args[-1] == ""
+        gemini_args = args[gemini_start:]
+        assert "-p" not in gemini_args
+        assert "--prompt" not in gemini_args
         _assert_prompt_not_in_argv(args)
         _assert_prompt_sent_on_stdin(runner)
         assert "--model" in args and "gemini-2.5-pro" in args
@@ -695,8 +697,9 @@ class TestGeminiAdapter:
         assert "GEMINI_CLI_TRUST_WORKSPACE" in script
         assert "exec gemini" in script
         assert "--model" in args and "gemini-3.1-pro-preview" in args
-        assert args[-2] == "-p"
-        assert args[-1] == ""
+        gemini_args = args[sh_start:]
+        assert "-p" not in gemini_args
+        assert "--prompt" not in gemini_args
         _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
@@ -756,7 +759,10 @@ class TestOpenCodeAdapter:
         assert "OPENCODE_CONFIG_CONTENT" in script
         assert "AWF_OPENCODE_OLLAMA_BASE_URL" in script
         assert "host.docker.internal:11434/v1" in script
-        assert "exec opencode run" in script
+        assert "opencode run" in script
+        assert "mktemp" in script
+        assert "/tmp/awf-opencode-prompt.md" not in script
+        assert '--file "$prompt_path"' in script
         assert '"permission":"allow"' in script
         assert '"think":true' in script
         assert model in script
@@ -766,7 +772,7 @@ class TestOpenCodeAdapter:
         assert "--variant" in args
         assert "max" in args
         assert "--thinking" in args
-        assert "--file" in args
+        assert "--file" not in args
         assert args[-1] == "Follow the instructions in the attached AWF prompt file exactly."
         _assert_prompt_not_in_argv(args)
         _assert_prompt_sent_on_stdin(runner)
@@ -857,6 +863,12 @@ async def test_all_adapters_keep_oversized_prompts_out_of_argv(
     assert max(len(arg) for arg in args) < 10_000
     assert all(_LONG_PROMPT not in arg for arg in args)
     _assert_prompt_sent_on_stdin(runner, _LONG_PROMPT)
+
+
+@pytest.mark.unit
+def test_adapter_cli_args_contract_excludes_prompt_payload() -> None:
+    for adapter_cls in (ClaudeCodeAdapter, CodexAdapter, GeminiAdapter, OpenCodeAdapter):
+        assert "prompt" not in inspect.signature(adapter_cls._cli_args).parameters
 
 
 class TestCentralDefaults:

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -650,7 +650,7 @@ class TestGeminiAdapter:
             "--yolo",
         ]
         gemini_args = args[gemini_start:]
-        assert "-p" not in gemini_args
+        assert gemini_args[3:5] == ["-p", ""]
         assert "--prompt" not in gemini_args
         _assert_prompt_not_in_argv(args)
         _assert_prompt_sent_on_stdin(runner)
@@ -674,6 +674,7 @@ class TestGeminiAdapter:
             "--skip-trust",
             "--yolo",
         ]
+        assert args[gemini_start + 3 : gemini_start + 5] == ["-p", ""]
         assert "--model" not in args
 
     @pytest.mark.unit
@@ -700,7 +701,8 @@ class TestGeminiAdapter:
         assert "exec gemini" in script
         assert "--model" in args and "gemini-3.1-pro-preview" in args
         gemini_args = args[sh_start:]
-        assert "-p" not in gemini_args
+        assert "-p" in gemini_args
+        assert gemini_args[gemini_args.index("-p") + 1] == ""
         assert "--prompt" not in gemini_args
         _assert_prompt_sent_on_stdin(runner)
 

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 
 import pytest
 
 import awf.common.compose_exec as compose_exec
-from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.common.commands import AsyncioSubprocessRunner, CommandResult, FakeCommandRunner
 from awf.common.compose_exec import (
     ComposeExecCleanupError,
     build_cleanup_compose_exec,
@@ -123,6 +124,46 @@ def test_rejects_empty_or_unsafe_invocation_inputs() -> None:
             label="codex",
             invocation_id="bad;id",
         )
+
+
+async def test_tracked_exec_wrapper_preserves_stdin_when_requested() -> None:
+    script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
+    result = await AsyncioSubprocessRunner().run(
+        [
+            "sh",
+            "-lc",
+            script,
+            "awf-exec",
+            "awf_stdin_probe",
+            sys.executable,
+            "-c",
+            "import sys; print(sys.stdin.read(), end='')",
+        ],
+        input_bytes=b"stdin-ok",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "stdin-ok"
+
+
+async def test_tracked_exec_wrapper_closes_stdin_by_default() -> None:
+    script = compose_exec._tracked_exec_wrapper_script()  # noqa: SLF001
+    result = await AsyncioSubprocessRunner().run(
+        [
+            "sh",
+            "-lc",
+            script,
+            "awf-exec",
+            "awf_stdin_closed",
+            sys.executable,
+            "-c",
+            "import sys; print(sys.stdin.read(), end='')",
+        ],
+        input_bytes=b"should-not-reach-child",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""
 
 
 async def test_cleanup_success_accepts_killed_result() -> None:

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -175,19 +175,32 @@ async def test_tracked_exec_wrapper_restricts_preserved_stdin_permissions() -> N
             sys.executable,
             "-c",
             "import os, stat, sys; "
+            "current_umask = os.umask(0); "
+            "os.umask(current_umask); "
+            "expected_child_mode = 0o666 & ~current_umask; "
             "open('/tmp/awf-exec/awf_stdin_permissions/child-created', 'w').close(); "
             "dir_mode = stat.S_IMODE(os.stat('/tmp/awf-exec/awf_stdin_permissions').st_mode); "
             "stdin_mode = stat.S_IMODE(os.fstat(0).st_mode); "
             "child_mode = stat.S_IMODE("
             "os.stat('/tmp/awf-exec/awf_stdin_permissions/child-created').st_mode"
             "); "
-            "print(f'{dir_mode:o} {stdin_mode:o} {child_mode:o} {sys.stdin.read()}', end='')",
+            "print("
+            "f'{dir_mode:o} {stdin_mode:o} {child_mode:o} {expected_child_mode:o} "
+            "{sys.stdin.read()}', "
+            "end='',"
+            ")",
         ],
         input_bytes=b"private-prompt",
     )
 
     assert result.returncode == 0
-    assert result.stdout == "700 600 664 private-prompt"
+    dir_mode, stdin_mode, child_mode, expected_child_mode, prompt = result.stdout.split(" ", 4)
+    assert (dir_mode, stdin_mode, child_mode, prompt) == (
+        "700",
+        "600",
+        expected_child_mode,
+        "private-prompt",
+    )
     assert not stdin_path.exists()
     child_path.unlink(missing_ok=True)
 

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -150,6 +150,32 @@ async def test_tracked_exec_wrapper_preserves_stdin_when_requested() -> None:
 
 
 @pytest.mark.unit
+async def test_tracked_exec_wrapper_restricts_preserved_stdin_permissions() -> None:
+    stdin_path = Path("/tmp/awf-exec/awf_stdin_permissions/stdin")
+    script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
+    result = await AsyncioSubprocessRunner().run(
+        [
+            "sh",
+            "-lc",
+            script,
+            "awf-exec",
+            "awf_stdin_permissions",
+            sys.executable,
+            "-c",
+            "import os, stat, sys; "
+            "dir_mode = stat.S_IMODE(os.stat('/tmp/awf-exec/awf_stdin_permissions').st_mode); "
+            "stdin_mode = stat.S_IMODE(os.fstat(0).st_mode); "
+            "print(f'{dir_mode:o} {stdin_mode:o} {sys.stdin.read()}', end='')",
+        ],
+        input_bytes=b"private-prompt",
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == "700 600 private-prompt"
+    assert not stdin_path.exists()
+
+
+@pytest.mark.unit
 async def test_tracked_exec_wrapper_fails_when_preserved_stdin_cannot_be_spooled() -> None:
     blocked_path = Path("/tmp/awf-exec/awf_stdin_spool_blocked")
     blocked_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -152,6 +152,8 @@ async def test_tracked_exec_wrapper_preserves_stdin_when_requested() -> None:
 @pytest.mark.unit
 async def test_tracked_exec_wrapper_restricts_preserved_stdin_permissions() -> None:
     stdin_path = Path("/tmp/awf-exec/awf_stdin_permissions/stdin")
+    child_path = Path("/tmp/awf-exec/awf_stdin_permissions/child-created")
+    child_path.unlink(missing_ok=True)
     script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
     result = await AsyncioSubprocessRunner().run(
         [
@@ -163,16 +165,21 @@ async def test_tracked_exec_wrapper_restricts_preserved_stdin_permissions() -> N
             sys.executable,
             "-c",
             "import os, stat, sys; "
+            "open('/tmp/awf-exec/awf_stdin_permissions/child-created', 'w').close(); "
             "dir_mode = stat.S_IMODE(os.stat('/tmp/awf-exec/awf_stdin_permissions').st_mode); "
             "stdin_mode = stat.S_IMODE(os.fstat(0).st_mode); "
-            "print(f'{dir_mode:o} {stdin_mode:o} {sys.stdin.read()}', end='')",
+            "child_mode = stat.S_IMODE("
+            "os.stat('/tmp/awf-exec/awf_stdin_permissions/child-created').st_mode"
+            "); "
+            "print(f'{dir_mode:o} {stdin_mode:o} {child_mode:o} {sys.stdin.read()}', end='')",
         ],
         input_bytes=b"private-prompt",
     )
 
     assert result.returncode == 0
-    assert result.stdout == "700 600 private-prompt"
+    assert result.stdout == "700 600 664 private-prompt"
     assert not stdin_path.exists()
+    child_path.unlink(missing_ok=True)
 
 
 @pytest.mark.unit

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -105,6 +105,16 @@ def test_cleanup_command_bounds_integer_sleep_fallback_wait() -> None:
     assert "awf_cleanup_wait_limit=2" in script
 
 
+def test_preserved_stdin_setsid_path_uses_open_fd_not_path_redirection() -> None:
+    script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
+    setsid_block = script[script.index("if command -v setsid") : script.index('wait "$child_pid"')]
+
+    assert 'exec 9< "$stdin_path"' in setsid_block
+    assert 'setsid "$@" <&9 &' in setsid_block
+    assert 'setsid "$@" < "$stdin_path" &' not in setsid_block
+    assert setsid_block.index('rm -f "$stdin_path"') < setsid_block.index('setsid "$@" <&9 &')
+
+
 def test_rejects_empty_or_unsafe_invocation_inputs() -> None:
     with pytest.raises(ValueError, match="cli_args"):
         build_tracked_compose_exec(

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -126,7 +126,9 @@ def test_rejects_empty_or_unsafe_invocation_inputs() -> None:
         )
 
 
+@pytest.mark.unit
 async def test_tracked_exec_wrapper_preserves_stdin_when_requested() -> None:
+    stdin_path = Path("/tmp/awf-exec/awf_stdin_probe/stdin")
     script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
     result = await AsyncioSubprocessRunner().run(
         [
@@ -144,8 +146,37 @@ async def test_tracked_exec_wrapper_preserves_stdin_when_requested() -> None:
 
     assert result.returncode == 0
     assert result.stdout == "stdin-ok"
+    assert not stdin_path.exists()
 
 
+@pytest.mark.unit
+async def test_tracked_exec_wrapper_fails_when_preserved_stdin_cannot_be_spooled() -> None:
+    blocked_path = Path("/tmp/awf-exec/awf_stdin_spool_blocked")
+    blocked_path.parent.mkdir(parents=True, exist_ok=True)
+    blocked_path.write_text("not a directory", encoding="utf-8")
+    try:
+        script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
+        result = await AsyncioSubprocessRunner().run(
+            [
+                "sh",
+                "-lc",
+                script,
+                "awf-exec",
+                "awf_stdin_spool_blocked",
+                sys.executable,
+                "-c",
+                "print('should-not-run')",
+            ],
+            input_bytes=b"stdin-will-not-spool",
+        )
+    finally:
+        blocked_path.unlink(missing_ok=True)
+
+    assert result.returncode != 0
+    assert "should-not-run" not in result.stdout
+
+
+@pytest.mark.unit
 async def test_tracked_exec_wrapper_closes_stdin_by_default() -> None:
     script = compose_exec._tracked_exec_wrapper_script()  # noqa: SLF001
     result = await AsyncioSubprocessRunner().run(

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -2435,7 +2435,7 @@ class TestHappyPath:
             def get_provider(self, model: str | None) -> str:
                 return "openai"
 
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+            def _cli_args(self, *, model: str | None) -> list[str]:
                 return []
 
             async def run(self, *, prompt: str, **kwargs: Any) -> AgentRunResult:
@@ -2623,7 +2623,7 @@ class TestHappyPath:
             def get_provider(self, model: str | None) -> str:
                 return "openai"
 
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
+            def _cli_args(self, *, model: str | None) -> list[str]:
                 return []
 
             async def run(self, *, prompt: str, **kwargs: Any) -> AgentRunResult:

--- a/tests/unit/control/test_executor.py
+++ b/tests/unit/control/test_executor.py
@@ -11,6 +11,7 @@ import json
 from collections.abc import AsyncIterator, Mapping
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import Any
 
 import pytest
 from sqlalchemy import text
@@ -137,6 +138,26 @@ def _created_pr_body(fake: FakeCommandRunner) -> str:
 
 def _json_value(value: object) -> object:
     return json.loads(value) if isinstance(value, str) else value
+
+
+def _adapter_prompt_from_call(call: Any) -> str:
+    input_bytes = call.input_bytes
+    assert input_bytes is not None
+    return input_bytes.decode()
+
+
+def _adapter_prompt_calls(fake: FakeCommandRunner) -> list[tuple[int, str]]:
+    return [
+        (index, _adapter_prompt_from_call(call))
+        for index, call in enumerate(fake.calls)
+        if call.args[:2] == ["docker", "compose"]
+        and "codex" in call.args
+        and call.input_bytes is not None
+    ]
+
+
+def _adapter_prompts(fake: FakeCommandRunner) -> list[str]:
+    return [prompt for _, prompt in _adapter_prompt_calls(fake)]
 
 
 async def _insert_validate_handoff_recovery_operation(
@@ -670,11 +691,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         assert len(adapter_prompts) == 3
         assert "Planning phase" in adapter_prompts[0]
         assert "Execution phase" in adapter_prompts[1]
@@ -764,11 +781,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompt_calls = [
-            (index, call.args[-1])
-            for index, call in enumerate(fake.calls)
-            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
-        ]
+        adapter_prompt_calls = _adapter_prompt_calls(fake)
         prompts = [prompt for _, prompt in adapter_prompt_calls]
         validation_call_index = next(
             index
@@ -1145,11 +1158,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         post_validation_conformance_prompts = [
             prompt
             for prompt in adapter_prompts
@@ -1785,11 +1794,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         fix_prompt_index = next(
             index
             for index, prompt in enumerate(adapter_prompts)
@@ -1922,11 +1927,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         fix_prompts = [
             prompt
             for prompt in adapter_prompts
@@ -2076,11 +2077,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and "codex" in call.args
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         fix_prompts = [
             prompt
             for prompt in adapter_prompts
@@ -2170,11 +2167,7 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
-        ]
+        adapter_prompts = _adapter_prompts(fake)
         assert len(adapter_prompts) == 5
         assert "Iteration 1" in adapter_prompts[3]
 
@@ -2241,11 +2234,8 @@ class TestHappyPath:
 
         await executor.execute(ws_id)
 
-        adapter_prompts = [
-            call.args[-1]
-            for call in fake.calls
-            if call.args[:2] == ["docker", "compose"] and call.args[-1].startswith("## ")
-        ]
+        adapter_prompt_calls = _adapter_prompt_calls(fake)
+        adapter_prompts = [prompt for _, prompt in adapter_prompt_calls]
         validation_call_index = next(
             index
             for index, call in enumerate(fake.calls)
@@ -2253,8 +2243,8 @@ class TestHappyPath:
         )
         iteration_prompt_index = next(
             index
-            for index, call in enumerate(fake.calls)
-            if "## Execution phase" in call.args[-1] and "Iteration 1" in call.args[-1]
+            for index, prompt in adapter_prompt_calls
+            if "## Execution phase" in prompt and "Iteration 1" in prompt
         )
 
         assert len(adapter_prompts) == 5
@@ -2400,8 +2390,6 @@ class TestHappyPath:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from typing import Any
-
         from awf.adapters import base as adapter_base
         from awf.adapters.base import AgentRunResult
         from awf.common.commands import CommandResult
@@ -2581,8 +2569,6 @@ class TestHappyPath:
         the current compare call; otherwise the iteration is treated as
         no_output by the stall classifier.
         """
-        from typing import Any
-
         from awf.adapters import base as adapter_base
         from awf.adapters.base import AgentRunResult
         from awf.common.commands import CommandResult

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -600,8 +600,8 @@ class TestUnexpectedErrorDuringAgentRun:
             def get_provider(self, model: str | None) -> str:
                 return "google"
 
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-                del prompt, model
+            def _cli_args(self, *, model: str | None) -> list[str]:
+                del model
                 return ["gemini", "run"]
 
         monkeypatch.setitem(
@@ -782,8 +782,8 @@ class TestUnexpectedErrorDuringAgentRun:
             def get_provider(self, model: str | None) -> str:
                 return "google"
 
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-                del prompt, model
+            def _cli_args(self, *, model: str | None) -> list[str]:
+                del model
                 return ["gemini", "run"]
 
         monkeypatch.setitem(
@@ -873,8 +873,8 @@ class TestUnexpectedErrorDuringAgentRun:
             def get_provider(self, model: str | None) -> str:
                 return "openai"
 
-            def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:
-                del prompt, model
+            def _cli_args(self, *, model: str | None) -> list[str]:
+                del model
                 return ["codex", "exec"]
 
         monkeypatch.setitem(
@@ -964,7 +964,7 @@ class TestUnexpectedErrorDuringAgentRun:
             def name(self) -> AgentRuntime:
                 return AgentRuntime.codex
 
-            def _cli_args(self, *, prompt: str, model: Any) -> list[str]:
+            def _cli_args(self, *, model: Any) -> list[str]:
                 return []
 
             async def run(

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -416,9 +416,20 @@ def _all_adapter_args(fake: FakeCommandRunner) -> list[list[str]]:
     return [c.args for c in fake.calls if "exec" in c.args and "codex" in c.args]
 
 
+def _all_adapter_prompt_values(fake: FakeCommandRunner) -> list[str]:
+    """Every prompt streamed to `docker compose exec ... codex ...` on stdin."""
+    prompts: list[str] = []
+    for call in fake.calls:
+        if "exec" not in call.args or "codex" not in call.args:
+            continue
+        if call.input_bytes is not None:
+            prompts.append(call.input_bytes.decode())
+    return prompts
+
+
 def _all_adapter_prompts(fake: FakeCommandRunner) -> str:
     """Concatenate every adapter prompt invocation into a single string for substring search."""
-    return "\n".join(" ".join(args) for args in _all_adapter_args(fake))
+    return "\n".join(_all_adapter_prompt_values(fake))
 
 
 @pytest.mark.unit
@@ -1506,7 +1517,7 @@ async def test_validate_only_recovery_with_conformance_handoff_pushes_report_com
 
     adapter_args = _all_adapter_args(fake)
     assert len(adapter_args) == 1
-    prompt = adapter_args[0][-1]
+    prompt = _all_adapter_prompt_values(fake)[0]
     assert "## Conformance phase" in prompt
     assert "## Planning phase" not in prompt
     assert "## Execution phase" not in prompt
@@ -1698,8 +1709,9 @@ async def test_validate_only_recovery_conformance_failure_fails_without_fix_loop
 
     adapter_args = _all_adapter_args(fake)
     assert len(adapter_args) == 1
-    assert "## Conformance phase" in adapter_args[0][-1]
-    assert "Validation failed after your previous pass" not in adapter_args[0][-1]
+    prompt = _all_adapter_prompt_values(fake)[0]
+    assert "## Conformance phase" in prompt
+    assert "Validation failed after your previous pass" not in prompt
     assert any(
         event.get("event") == "executor.post_validation_conformance_recovery_single_attempt"
         and event.get("workspace_id") == ws_id

--- a/tests/unit/control/test_executor_validation_fix_cycle.py
+++ b/tests/unit/control/test_executor_validation_fix_cycle.py
@@ -358,10 +358,8 @@ class TestFixCycleRecoversAfterOneFailure:
         factory: async_sessionmaker[AsyncSession],
         tmp_path: Path,
     ) -> None:
-        """The fix prompt — the payload handed to the CLI on the second
-        call — must carry the failing command + its tail output so the
-        CLI knows what to fix. The adapter passes the prompt as the
-        last CLI arg, so we can grep it out of the subprocess args."""
+        """The fix prompt handed to the CLI on the second call must carry
+        the failing command + its tail output so the CLI knows what to fix."""
         executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path, max_fix_passes=5)
         ws_id = await _seed_ready_workspace(factory)
         _queue_initial_pass(fake)
@@ -376,10 +374,11 @@ class TestFixCycleRecoversAfterOneFailure:
 
         await executor.execute(ws_id)
 
-        # The 2nd adapter call's prompt arg is the fix prompt.
+        # The 2nd adapter call streams the fix prompt on stdin.
         adapter_calls = [c for c in fake.calls if "codex" in c.args and "exec" in c.args]
         assert len(adapter_calls) == 2
-        fix_prompt = " ".join(adapter_calls[1].args)
+        assert adapter_calls[1].input_bytes is not None
+        fix_prompt = adapter_calls[1].input_bytes.decode()
         assert "Validation failed" in fix_prompt
         assert "pytest -q" in fix_prompt  # the failing command
         assert "attempt 1 of 5" in fix_prompt

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -59,7 +59,7 @@ class FakeAdapter(AgentAdapter):
     def name(self) -> AgentRuntime:  # type: ignore[override]
         return AgentRuntime.claude_code
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+    def _cli_args(self, *, model: str | None) -> list[str]:
         return []
 
     def queue(

--- a/tests/unit/runtime/test_release_pr_monitor.py
+++ b/tests/unit/runtime/test_release_pr_monitor.py
@@ -29,7 +29,7 @@ class _StubAdapter(AgentAdapter):
     def name(self) -> AgentRuntime:  # type: ignore[override]
         return AgentRuntime.claude_code
 
-    def _cli_args(self, *, prompt: str, model: str | None) -> list[str]:  # type: ignore[override]
+    def _cli_args(self, *, model: str | None) -> list[str]:
         return []
 
     async def run(  # type: ignore[override]

--- a/tests/unit/scripts/test_salvage_workspace.py
+++ b/tests/unit/scripts/test_salvage_workspace.py
@@ -87,7 +87,7 @@ class TestClosureCapture:
         assert result.returncode == 0
         assert "skipping agent run" in result.stdout
         # _cli_args returns empty — this adapter never launches a CLI.
-        assert adapter._cli_args(prompt="x", model=None) == []
+        assert adapter._cli_args(model=None) == []
 
 
 # ── _main CLI ───────────────────────────────────────────────────────────────
@@ -249,7 +249,7 @@ class TestNoOpAdapterDirect:
         refactor doesn't silently remove a public API."""
         adapter = salvage_workspace._NoOpAdapter(runtime=AgentRuntime.codex)
         assert adapter.name == AgentRuntime.codex
-        assert adapter._cli_args(prompt="x", model=None) == []
+        assert adapter._cli_args(model=None) == []
         result = await adapter.run(
             compose_project="p",
             compose_file=Path("/tmp/c.yml"),


### PR DESCRIPTION
## Summary
- stream AWF agent prompts through stdin instead of passing large review prompts as argv
- preserve stdin through the tracked compose-exec wrapper only for agent adapter runs, while keeping other tracked exec calls stdin-closed by default
- hand OpenCode prompts through an in-container prompt file attached with `--file`
- update executor/recovery tests to inspect stdin-carried prompts and add oversized-prompt regression coverage across all adapters

## Root Cause
PR monitor recovery for ws_b5889d497a1249a7b26f014d failed with `OSError(7, Argument list too long)` because a CodeRabbit PR comment was over 130KB. AWF wrapped that full comment in the agent prompt and passed it as a single argv item to `docker compose exec ... codex exec ...`. Linux rejects a single argument around that size.

## Validation
- `uv run --python 3.12 --extra dev pytest tests/unit/common/test_compose_exec_cleanup.py::test_tracked_exec_wrapper_preserves_stdin_when_requested tests/unit/common/test_compose_exec_cleanup.py::test_tracked_exec_wrapper_closes_stdin_by_default tests/unit/adapters/test_adapters.py -q`
- `uv run --python 3.12 --extra dev ruff check src/awf/adapters src/awf/common/compose_exec.py tests/unit/adapters/test_adapters.py tests/unit/common/test_compose_exec_cleanup.py tests/unit/control/test_executor.py tests/unit/control/test_executor_monitor_recovery.py tests/unit/control/test_executor_validation_fix_cycle.py`
- `uv run --python 3.12 --extra dev mypy src/awf/adapters src/awf/common/compose_exec.py`
- `uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing` -> 5804 passed, coverage 99.05%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prompts are now streamed over stdin for adapter runs and preserved for containerized executions, avoiding argv size limits and improving reliability for large prompts.

* **New Features**
  * Runner support for optional stdin preservation and delivery of prompts via stdin or temporary prompt files; launcher scripts now forward termination and exit codes.

* **Tests**
  * Expanded tests enforce stdin-based prompt delivery, oversized-prompt handling, temp-file cleanup, and adapter interface contract.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/232)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->