### PR TITLE
Scope compose-exec fd 9 cleanup to preserved stdin

### DIFF
--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -251,6 +251,7 @@ def _tracked_exec_wrapper_script(*, preserve_stdin: bool = False) -> str:
     stdin_setup = ""
     setsid_stdin_redirect = "</dev/null"
     setsid_stdin_cleanup = ""
+    setsid_stdin_fd_close = ""
     exec_stdin_setup = "exec </dev/null"
     permissions_setup = ""
     if preserve_stdin:
@@ -280,6 +281,7 @@ if [ "$exec_status" -ne 0 ]; then
 fi
 rm -f "$stdin_path" 2>/dev/null || true
 """.strip()
+        setsid_stdin_fd_close = "exec 9<&-"
         exec_stdin_setup = """
 exec < "$stdin_path"
 exec_status=$?
@@ -303,7 +305,7 @@ if command -v setsid >/dev/null 2>&1; then
   {setsid_stdin_cleanup}
   setsid "$@" {setsid_stdin_redirect} &
   child_pid=$!
-  exec 9<&-
+  {setsid_stdin_fd_close}
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pid" 2>/dev/null || true
   printf '%s\\n' "$child_pid" > "$awf_exec_dir/pgid" 2>/dev/null || true
   wait "$child_pid"

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -113,6 +113,16 @@ def test_preserved_stdin_setsid_path_uses_open_fd_not_path_redirection() -> None
     assert 'setsid "$@" <&9 &' in setsid_block
     assert 'setsid "$@" < "$stdin_path" &' not in setsid_block
     assert setsid_block.index('rm -f "$stdin_path"') < setsid_block.index('setsid "$@" <&9 &')
+    assert "exec 9<&-" in setsid_block
+
+
+def test_default_stdin_setsid_path_does_not_touch_fd_9() -> None:
+    script = compose_exec._tracked_exec_wrapper_script()  # noqa: SLF001
+    setsid_block = script[script.index("if command -v setsid") : script.index('wait "$child_pid"')]
+
+    assert 'exec 9< "$stdin_path"' not in setsid_block
+    assert "exec 9<&-" not in setsid_block
+    assert 'setsid "$@" </dev/null &' in setsid_block
 
 
 def test_rejects_empty_or_unsafe_invocation_inputs() -> None:


### PR DESCRIPTION
## Summary

Fixes the unresolved Greptile follow-up from merged PR #232: `exec 9<&-` was emitted in the shared tracked exec wrapper even when `preserve_stdin=false`, where fd 9 is never opened.

The wrapper now emits the fd 9 close only on the preserved-stdin path. The default non-preserved path keeps `/dev/null` stdin redirection and never touches fd 9.

## Validation

- `uv run --python 3.12 --extra dev pytest tests/unit/common/test_compose_exec_cleanup.py -q`
- `uv run --python 3.12 --extra dev ruff format --check src/awf/common/compose_exec.py tests/unit/common/test_compose_exec_cleanup.py`
- `uv run --python 3.12 --extra dev ruff check src/awf/common/compose_exec.py tests/unit/common/test_compose_exec_cleanup.py`
- `uv run --python 3.12 --extra dev mypy src/awf/common/compose_exec.py`

## Review Source

Follow-up for https://github.com/dimileeh/aira-agent-workspace-fabric/pull/232#discussion_r3215552462

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stdin file descriptor handling in `docker compose exec` operations with conditional closure based on preservation settings.

* **Tests**
  * Enhanced test coverage validating correct file descriptor behavior in default and stdin-preservation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/233)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->