### PR TITLE
Teach agents about workspace sidecars

### DIFF
--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -142,6 +142,7 @@ from awf.runtime.validation_identity import (
     environment_identity_inputs,
     resolved_profile_digest,
 )
+from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
 from awf.service.conformance_salvage import (
     CONFORMANCE_SALVAGE_APPLIED_EVENT_TYPE,
     CONFORMANCE_SALVAGE_APPLIED_REASON,
@@ -4203,6 +4204,7 @@ class WorkspaceExecutor:
         coordination_warnings = coordination_warnings_from_task_policy(
             getattr(workspace, "task_policy", None)
         )
+        workspace_runtime_context = render_workspace_runtime_context(profile)
         if not planning.required:
             await self._update_subphase(workspace.id, "agent")
             result = await adapter.run(
@@ -4211,6 +4213,7 @@ class WorkspaceExecutor:
                 prompt=build_agent_task_prompt(
                     task_prompt=workspace.task_prompt,
                     coordination_warnings=coordination_warnings,
+                    workspace_runtime_context=workspace_runtime_context,
                 ),
                 model=model,
                 workspace_id=workspace.id,
@@ -4253,6 +4256,7 @@ class WorkspaceExecutor:
                 task_prompt=workspace.task_prompt,
                 plan_path=plan_path,
                 coordination_warnings=coordination_warnings,
+                workspace_runtime_context=workspace_runtime_context,
             ),
             model=model,
             workspace_id=workspace.id,
@@ -4328,6 +4332,7 @@ class WorkspaceExecutor:
                     iteration=iteration,
                     gaps=gaps,
                     coordination_warnings=coordination_warnings,
+                    workspace_runtime_context=workspace_runtime_context,
                 ),
                 model=model,
                 workspace_id=workspace.id,

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -152,13 +152,14 @@ def sync_base_conflict_prompt(
     files_block = (
         "\n".join(f"  - {p}" for p in conflicting_files) or "  (run git status for the list)"
     )
+    runtime_context_section = _workspace_runtime_context_section(workspace_runtime_context)
+    post_files_gap = runtime_context_section or "\n\n"
     return (
         f"PR #{pr_number} ({repo_slug}) has merge conflicts with base branch "
         f"`{base_branch}`. "
-        f"{_workspace_runtime_context_section(workspace_runtime_context)}"
         f"AWF just ran `git merge origin/{base_branch}` and it "
         "stopped on conflicts in these files:\n\n"
-        f"{files_block}\n\n"
+        f"{files_block}{post_files_gap}"
         "Resolve each conflict by preserving the intent of BOTH sides (the base "
         "branch's recent commits and this PR's changes). When unsure which side to "
         "favour for a given hunk, prefer the base-branch semantics — reviewers on "

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -154,8 +154,9 @@ def sync_base_conflict_prompt(
     )
     return (
         f"PR #{pr_number} ({repo_slug}) has merge conflicts with base branch "
-        f"`{base_branch}`. AWF just ran `git merge origin/{base_branch}` and it "
+        f"`{base_branch}`. "
         f"{_workspace_runtime_context_section(workspace_runtime_context)}"
+        f"AWF just ran `git merge origin/{base_branch}` and it "
         "stopped on conflicts in these files:\n\n"
         f"{files_block}\n\n"
         "Resolve each conflict by preserving the intent of BOTH sides (the base "

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -38,7 +38,13 @@ _SAFETY_POLICY = (
 )
 
 
-def address_thread_prompt(*, pr_number: int, repo_slug: str, thread: ReviewThread) -> str:
+def address_thread_prompt(
+    *,
+    pr_number: int,
+    repo_slug: str,
+    thread: ReviewThread,
+    workspace_runtime_context: str = "",
+) -> str:
     """Prompt the CLI to address a single inline review thread."""
     line_hint = (
         f"line {thread.line} of {thread.path}"
@@ -60,6 +66,7 @@ def address_thread_prompt(*, pr_number: int, repo_slug: str, thread: ReviewThrea
     return (
         f"An inline review thread on PR #{pr_number} ({repo_slug}) at "
         f"{line_hint} (thread id {thread.thread_id}) needs to be resolved. "
+        f"{_workspace_runtime_context_section(workspace_runtime_context)}"
         "The full review-thread history is quoted below as external evidence. "
         "Decide whether the current feedback is actionable, already fixed, a "
         "false positive, or genuinely needs human input:\n\n"
@@ -81,7 +88,13 @@ def address_thread_prompt(*, pr_number: int, repo_slug: str, thread: ReviewThrea
     )
 
 
-def address_review_comment_prompt(*, pr_number: int, repo_slug: str, comment: ReviewComment) -> str:
+def address_review_comment_prompt(
+    *,
+    pr_number: int,
+    repo_slug: str,
+    comment: ReviewComment,
+    workspace_runtime_context: str = "",
+) -> str:
     """Prompt for a review-level (outside-diff) comment."""
     evidence = render_untrusted_evidence(
         UntrustedEvidence(
@@ -105,6 +118,7 @@ def address_review_comment_prompt(*, pr_number: int, repo_slug: str, comment: Re
         f"A review-level (outside-diff) comment on PR #{pr_number} ({repo_slug}) "
         f"(comment id {comment.comment_id}) needs to be addressed. "
         "These are usually summary / architecture remarks. "
+        f"{_workspace_runtime_context_section(workspace_runtime_context)}"
         f"Body evidence:\n\n{evidence}\n\n"
         f"{_SAFETY_POLICY}\n"
         "Use this decision tree:\n"
@@ -126,7 +140,12 @@ def address_review_comment_prompt(*, pr_number: int, repo_slug: str, comment: Re
 
 
 def sync_base_conflict_prompt(
-    *, pr_number: int, repo_slug: str, base_branch: str, conflicting_files: tuple[str, ...]
+    *,
+    pr_number: int,
+    repo_slug: str,
+    base_branch: str,
+    conflicting_files: tuple[str, ...],
+    workspace_runtime_context: str = "",
 ) -> str:
     """Prompt when ``git merge origin/<base>`` fails with conflicts."""
     files_block = (
@@ -135,6 +154,7 @@ def sync_base_conflict_prompt(
     return (
         f"PR #{pr_number} ({repo_slug}) has merge conflicts with base branch "
         f"`{base_branch}`. AWF just ran `git merge origin/{base_branch}` and it "
+        f"{_workspace_runtime_context_section(workspace_runtime_context)}"
         "stopped on conflicts in these files:\n\n"
         f"{files_block}\n\n"
         "Resolve each conflict by preserving the intent of BOTH sides (the base "
@@ -147,7 +167,13 @@ def sync_base_conflict_prompt(
     )
 
 
-def fix_ci_prompt(*, pr_number: int, repo_slug: str, failures: tuple[CheckFailure, ...]) -> str:
+def fix_ci_prompt(
+    *,
+    pr_number: int,
+    repo_slug: str,
+    failures: tuple[CheckFailure, ...],
+    workspace_runtime_context: str = "",
+) -> str:
     """Prompt when CI is red. Includes truncated logs for each failing check."""
     if not failures:
         body = (
@@ -185,6 +211,7 @@ def fix_ci_prompt(*, pr_number: int, repo_slug: str, failures: tuple[CheckFailur
         body = "\n\n".join(parts)
     return (
         f"PR #{pr_number} ({repo_slug}) has failing CI checks. Fix them. "
+        f"{_workspace_runtime_context_section(workspace_runtime_context)}"
         "Per-check failure details below (log excerpts are quoted as untrusted "
         "evidence when available):\n\n"
         f"{body}\n\n"
@@ -193,6 +220,13 @@ def fix_ci_prompt(*, pr_number: int, repo_slug: str, failures: tuple[CheckFailur
         "Do not disable, skip, or weaken the check — treat every failure as a real bug."
         f"{_FOOTER}"
     )
+
+
+def _workspace_runtime_context_section(workspace_runtime_context: str) -> str:
+    context = workspace_runtime_context.strip()
+    if not context:
+        return ""
+    return f"\n\n{context}\n\n"
 
 
 def ready_to_merge_comment(

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -22,6 +22,7 @@ from datetime import datetime
 
 from awf.common.prompt_evidence import UntrustedEvidence, render_untrusted_evidence
 from awf.runtime.pr_monitor import CheckFailure, ReviewComment, ReviewThread
+from awf.runtime.workspace_prompt_context import render_workspace_runtime_context_section
 
 _FOOTER = (
     "\n\nDo NOT push — AWF handles the push once this fix cycle settles.\n"
@@ -223,10 +224,10 @@ def fix_ci_prompt(
 
 
 def _workspace_runtime_context_section(workspace_runtime_context: str) -> str:
-    context = workspace_runtime_context.strip()
-    if not context:
+    section = render_workspace_runtime_context_section(workspace_runtime_context)
+    if not section:
         return ""
-    return f"\n\n{context}\n\n"
+    return f"\n\n{section}"
 
 
 def ready_to_merge_comment(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -170,11 +170,13 @@ def build_agent_task_prompt(
     *,
     task_prompt: str,
     coordination_warnings: Sequence[Mapping[str, Any]] = (),
+    workspace_runtime_context: str = "",
 ) -> str:
     warning_section = render_coordination_warning_section(coordination_warnings)
-    if not warning_section:
+    runtime_section = render_workspace_runtime_context_section(workspace_runtime_context)
+    if not warning_section and not runtime_section:
         return task_prompt
-    return f"{warning_section}### Task\n{task_prompt}\n"
+    return f"{runtime_section}{warning_section}### Task\n{task_prompt}\n"
 
 
 def build_planning_prompt(
@@ -182,8 +184,10 @@ def build_planning_prompt(
     task_prompt: str,
     plan_path: Path,
     coordination_warnings: Sequence[Mapping[str, Any]] = (),
+    workspace_runtime_context: str = "",
 ) -> str:
     warning_section = render_coordination_warning_section(coordination_warnings)
+    runtime_section = render_workspace_runtime_context_section(workspace_runtime_context)
     return (
         "## Planning phase\n\n"
         "Create a concrete implementation plan for the task below.\n\n"
@@ -202,6 +206,7 @@ def build_planning_prompt(
         "- tests to write first;\n"
         "- validation commands;\n"
         "- risks, assumptions, and explicit non-goals.\n\n"
+        f"{runtime_section}"
         f"{warning_section}"
         f"### Task\n{task_prompt}\n"
     )
@@ -256,6 +261,7 @@ def build_execution_prompt(
     iteration: int,
     gaps: tuple[str, ...],
     coordination_warnings: Sequence[Mapping[str, Any]] = (),
+    workspace_runtime_context: str = "",
 ) -> str:
     if iteration == 0:
         instruction = (
@@ -271,14 +277,23 @@ def build_execution_prompt(
         )
 
     warning_section = render_coordination_warning_section(coordination_warnings)
+    runtime_section = render_workspace_runtime_context_section(workspace_runtime_context)
     return (
         "## Execution phase\n\n"
         f"Read `{plan_path.as_posix()}` and use it as the implementation contract.\n"
         f"{instruction}\n\n"
         "Do not switch branches, push, or open a PR. AWF owns branch and PR lifecycle.\n\n"
+        f"{runtime_section}"
         f"{warning_section}"
         f"### Task\n{task_prompt}\n"
     )
+
+
+def render_workspace_runtime_context_section(workspace_runtime_context: str) -> str:
+    context = workspace_runtime_context.strip()
+    if not context:
+        return ""
+    return f"{context}\n\n"
 
 
 def build_conformance_prompt(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 
 from awf.common.coordination import MAX_COORDINATION_WARNING_OVERLAPS
 from awf.common.redaction import redact_secrets
+from awf.runtime.workspace_prompt_context import render_workspace_runtime_context_section
 
 if TYPE_CHECKING:
     from awf.adapters.base import AgentRunError
@@ -287,13 +288,6 @@ def build_execution_prompt(
         f"{warning_section}"
         f"### Task\n{task_prompt}\n"
     )
-
-
-def render_workspace_runtime_context_section(workspace_runtime_context: str) -> str:
-    context = workspace_runtime_context.strip()
-    if not context:
-        return ""
-    return f"{context}\n\n"
 
 
 def build_conformance_prompt(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -427,6 +427,7 @@ class PullRequestMonitorRunner:
         log_store: LogStore | None = None,
         merge_coordinator: MergeCoordinator | None = None,
         post_merge_target_reconciler: PostMergeTargetReconciler | None = None,
+        workspace_runtime_context: str = "",
     ) -> None:
         self._deps = _RunnerDeps(
             session_factory=session_factory,
@@ -439,6 +440,7 @@ class PullRequestMonitorRunner:
         )
         self._config = monitor_config or MonitorConfig()
         self._runner_config = runner_config or MonitorRunnerConfig()
+        self._workspace_runtime_context = workspace_runtime_context
         self._merge_coordinator = merge_coordinator or DEFAULT_MERGE_COORDINATOR
         self._worktrees_root = worktrees_root
         self._work_dir = _infer_service_work_dir(worktrees_root)
@@ -3640,7 +3642,12 @@ class PullRequestMonitorRunner:
         compose_file: Path,
         state: MonitorState | None = None,
     ) -> Verdict:
-        prompt = address_thread_prompt(pr_number=pr_number, repo_slug=repo.slug(), thread=thread)
+        prompt = address_thread_prompt(
+            pr_number=pr_number,
+            repo_slug=repo.slug(),
+            thread=thread,
+            workspace_runtime_context=self._workspace_runtime_context,
+        )
         return await self._invoke_cli_for_verdict(
             workspace_id=workspace_id,
             prompt=prompt,
@@ -3684,7 +3691,10 @@ class PullRequestMonitorRunner:
         state: MonitorState | None = None,
     ) -> VerdictResult:
         prompt = address_review_comment_prompt(
-            pr_number=pr_number, repo_slug=repo.slug(), comment=comment
+            pr_number=pr_number,
+            repo_slug=repo.slug(),
+            comment=comment,
+            workspace_runtime_context=self._workspace_runtime_context,
         )
         return await self._invoke_cli_for_verdict_result(
             workspace_id=workspace_id,
@@ -3830,6 +3840,7 @@ class PullRequestMonitorRunner:
                 repo_slug=repo.slug(),
                 base_branch=base_branch,
                 conflicting_files=conflicting_files,
+                workspace_runtime_context=self._workspace_runtime_context,
             )
             agent_run_err = None
             command_evidence: list[str] = []
@@ -3899,7 +3910,12 @@ class PullRequestMonitorRunner:
         remote_branch: str,
         remote_push_url: str | None = None,
     ) -> _GitPushResult:
-        prompt = fix_ci_prompt(pr_number=pr_number, repo_slug=repo.slug(), failures=failures)
+        prompt = fix_ci_prompt(
+            pr_number=pr_number,
+            repo_slug=repo.slug(),
+            failures=failures,
+            workspace_runtime_context=self._workspace_runtime_context,
+        )
         agent_run_err = None
         command_evidence: list[str] = []
         if await self._provider_recovery_suppresses_cli(workspace_id):

--- a/src/awf/runtime/release_pr_monitor.py
+++ b/src/awf/runtime/release_pr_monitor.py
@@ -57,6 +57,7 @@ def build_release_pr_monitor(
     max_fix_cycle_passes: int = 5,
     merge_coordinator: MergeCoordinator | None = None,
     post_merge_target_reconciler: PostMergeTargetReconciler | None = None,
+    workspace_runtime_context: str = "",
 ) -> PullRequestMonitorRunner:
     """Instantiate a ``PullRequestMonitorRunner`` preconfigured for
     release PRs — the single divergence from a feature PR is
@@ -84,6 +85,7 @@ def build_release_pr_monitor(
         log_store=log_store,
         merge_coordinator=merge_coordinator,
         post_merge_target_reconciler=post_merge_target_reconciler,
+        workspace_runtime_context=workspace_runtime_context,
     )
 
 
@@ -106,6 +108,7 @@ def build_feature_pr_monitor(
     max_fix_cycle_passes: int = 5,
     merge_coordinator: MergeCoordinator | None = None,
     post_merge_target_reconciler: PostMergeTargetReconciler | None = None,
+    workspace_runtime_context: str = "",
 ) -> PullRequestMonitorRunner:
     """Instantiate a ``PullRequestMonitorRunner`` for feature→development
     work. ``auto_merge=True``; on green gates the monitor squash-merges
@@ -133,4 +136,5 @@ def build_feature_pr_monitor(
         log_store=log_store,
         merge_coordinator=merge_coordinator,
         post_merge_target_reconciler=post_merge_target_reconciler,
+        workspace_runtime_context=workspace_runtime_context,
     )

--- a/src/awf/runtime/workspace_prompt_context.py
+++ b/src/awf/runtime/workspace_prompt_context.py
@@ -131,11 +131,7 @@ def _environment_lines(
     endpoint_keys = {endpoint.key for endpoint in env_endpoints}
     lines: list[str] = []
     for key, value in sorted(environment.items()):
-        if (
-            key not in endpoint_keys
-            and key not in generated_endpoint_keys
-            and not _is_connection_env_key(key)
-        ):
+        if key not in endpoint_keys and key not in generated_endpoint_keys:
             continue
         if _is_sensitive_env_key(key):
             lines.append(f"- `${key}` is set.")

--- a/src/awf/runtime/workspace_prompt_context.py
+++ b/src/awf/runtime/workspace_prompt_context.py
@@ -1,0 +1,166 @@
+"""Trusted workspace runtime context for agent prompts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from awf.common.audit import redact_audit_text
+from awf.profiles.models import DockerMode, ProfileService, WorkspaceProfile
+
+_CONNECTION_ENV_KEY_PARTS = (
+    "URL",
+    "URI",
+    "DSN",
+    "DATABASE",
+    "POSTGRES",
+    "REDIS",
+    "CACHE",
+    "MONGO",
+    "MYSQL",
+)
+_SENSITIVE_ENV_KEY_PARTS = ("PASSWORD", "PASSWD", "SECRET", "TOKEN", "API_KEY", "AUTH")
+
+
+@dataclass(frozen=True)
+class _EnvEndpoint:
+    key: str
+    value: str
+    host: str
+    port: int | None
+
+    @property
+    def endpoint(self) -> str:
+        if self.port is None:
+            return self.host
+        return f"{self.host}:{self.port}"
+
+
+def render_workspace_runtime_context(profile: WorkspaceProfile) -> str:
+    """Render trusted profile service/env context for non-interactive agents.
+
+    The generated text intentionally does not expose service secrets. Agents
+    should use the live environment variables inside the workspace container,
+    while the prompt only explains where sidecars are reachable.
+    """
+
+    services = tuple(profile.services)
+    env_endpoints = _env_endpoints(profile, services)
+    env_lines = _environment_lines(profile, env_endpoints)
+    if not services and not env_lines:
+        return ""
+
+    lines = [
+        "### Workspace runtime context",
+        "Trusted AWF-provided context from the resolved workspace profile:",
+    ]
+    if services:
+        lines.append("Services:")
+        lines.extend(_service_lines(services, env_endpoints))
+    if env_lines:
+        lines.append("Agent environment:")
+        lines.extend(env_lines)
+        lines.append(
+            "- Use these environment variables directly inside the workspace; "
+            "do not copy redacted prompt values into code or tests."
+        )
+    if services:
+        lines.append(
+            "- Important: localhost is the agent container. Use Compose service "
+            "DNS names such as `postgres:5432` for sidecars, not `localhost`."
+        )
+        if profile.docker.mode == DockerMode.none:
+            lines.append(
+                "- Docker may be unavailable in this workspace; AWF already started "
+                "the declared sidecar services."
+            )
+        else:
+            lines.append(
+                "- AWF already started the declared sidecar services; do not start "
+                "duplicate copies for ordinary validation."
+            )
+    return "\n".join(lines)
+
+
+def _service_lines(
+    services: tuple[ProfileService, ...],
+    env_endpoints: tuple[_EnvEndpoint, ...],
+) -> list[str]:
+    lines: list[str] = []
+    for service in services:
+        endpoints = _service_endpoints(service, env_endpoints)
+        endpoint_text = (
+            " internal endpoints: " + ", ".join(f"`{endpoint}`" for endpoint in endpoints)
+            if endpoints
+            else f" Compose DNS: `{service.name}`"
+        )
+        health_text = "; AWF waits for its healthcheck" if service.healthcheck_cmd else ""
+        lines.append(
+            f"- Service `{service.name}` is already started by AWF;{endpoint_text}{health_text}."
+        )
+    return lines
+
+
+def _service_endpoints(
+    service: ProfileService,
+    env_endpoints: tuple[_EnvEndpoint, ...],
+) -> tuple[str, ...]:
+    endpoints = {endpoint.endpoint for endpoint in env_endpoints if endpoint.host == service.name}
+    for container_port, _host_port in service.ports:
+        endpoints.add(f"{service.name}:{container_port}")
+    return tuple(sorted(endpoints))
+
+
+def _environment_lines(
+    profile: WorkspaceProfile,
+    env_endpoints: tuple[_EnvEndpoint, ...],
+) -> list[str]:
+    endpoint_keys = {endpoint.key for endpoint in env_endpoints}
+    lines: list[str] = []
+    for key, value in sorted(profile.runtime.environment.items()):
+        if key not in endpoint_keys and not _is_connection_env_key(key):
+            continue
+        if _is_sensitive_env_key(key):
+            lines.append(f"- `${key}` is set.")
+            continue
+        lines.append(f"- `${key}` = `{redact_audit_text(value, limit=500)}`")
+    return lines
+
+
+def _env_endpoints(
+    profile: WorkspaceProfile,
+    services: tuple[ProfileService, ...],
+) -> tuple[_EnvEndpoint, ...]:
+    service_names = {service.name for service in services}
+    endpoints: list[_EnvEndpoint] = []
+    for key, value in sorted(profile.runtime.environment.items()):
+        endpoint = _env_endpoint(key=key, value=value)
+        if endpoint is not None and endpoint.host in service_names:
+            endpoints.append(endpoint)
+    return tuple(endpoints)
+
+
+def _env_endpoint(*, key: str, value: str) -> _EnvEndpoint | None:
+    if not _is_connection_env_key(key) and "://" not in value:
+        return None
+    try:
+        parsed = urlsplit(value)
+    except ValueError:
+        return None
+    if not parsed.scheme or not parsed.hostname:
+        return None
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+    return _EnvEndpoint(key=key, value=value, host=parsed.hostname, port=port)
+
+
+def _is_connection_env_key(key: str) -> bool:
+    upper = key.upper()
+    return any(part in upper for part in _CONNECTION_ENV_KEY_PARTS)
+
+
+def _is_sensitive_env_key(key: str) -> bool:
+    upper = key.upper()
+    return any(part in upper for part in _SENSITIVE_ENV_KEY_PARTS)

--- a/src/awf/runtime/workspace_prompt_context.py
+++ b/src/awf/runtime/workspace_prompt_context.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 from urllib.parse import urlsplit
 
 from awf.common.audit import redact_audit_text
+from awf.profiles.compose import profile_app_endpoint_environment
 from awf.profiles.models import DockerMode, ProfileService, WorkspaceProfile
 
 _CONNECTION_ENV_KEY_PARTS = (
@@ -45,8 +47,9 @@ def render_workspace_runtime_context(profile: WorkspaceProfile) -> str:
     """
 
     services = tuple(profile.services)
-    env_endpoints = _env_endpoints(profile, services)
-    env_lines = _environment_lines(profile, env_endpoints)
+    environment, generated_endpoint_keys = _prompt_environment(profile)
+    env_endpoints = _env_endpoints(environment, services)
+    env_lines = _environment_lines(environment, env_endpoints, generated_endpoint_keys)
     if not services and not env_lines:
         return ""
 
@@ -112,13 +115,18 @@ def _service_endpoints(
 
 
 def _environment_lines(
-    profile: WorkspaceProfile,
+    environment: Mapping[str, str],
     env_endpoints: tuple[_EnvEndpoint, ...],
+    generated_endpoint_keys: frozenset[str],
 ) -> list[str]:
     endpoint_keys = {endpoint.key for endpoint in env_endpoints}
     lines: list[str] = []
-    for key, value in sorted(profile.runtime.environment.items()):
-        if key not in endpoint_keys and not _is_connection_env_key(key):
+    for key, value in sorted(environment.items()):
+        if (
+            key not in endpoint_keys
+            and key not in generated_endpoint_keys
+            and not _is_connection_env_key(key)
+        ):
             continue
         if _is_sensitive_env_key(key):
             lines.append(f"- `${key}` is set.")
@@ -128,16 +136,23 @@ def _environment_lines(
 
 
 def _env_endpoints(
-    profile: WorkspaceProfile,
+    environment: Mapping[str, str],
     services: tuple[ProfileService, ...],
 ) -> tuple[_EnvEndpoint, ...]:
     service_names = {service.name for service in services}
     endpoints: list[_EnvEndpoint] = []
-    for key, value in sorted(profile.runtime.environment.items()):
+    for key, value in sorted(environment.items()):
         endpoint = _env_endpoint(key=key, value=value)
         if endpoint is not None and endpoint.host in service_names:
             endpoints.append(endpoint)
     return tuple(endpoints)
+
+
+def _prompt_environment(profile: WorkspaceProfile) -> tuple[dict[str, str], frozenset[str]]:
+    generated_endpoint_env = profile_app_endpoint_environment(profile)
+    environment = dict(profile.runtime.environment)
+    environment.update(generated_endpoint_env)
+    return environment, frozenset(key for key, _value in generated_endpoint_env)
 
 
 def _env_endpoint(*, key: str, value: str) -> _EnvEndpoint | None:

--- a/src/awf/runtime/workspace_prompt_context.py
+++ b/src/awf/runtime/workspace_prompt_context.py
@@ -85,6 +85,15 @@ def render_workspace_runtime_context(profile: WorkspaceProfile) -> str:
     return "\n".join(lines)
 
 
+def render_workspace_runtime_context_section(workspace_runtime_context: str) -> str:
+    """Render optional trusted runtime context as a prompt section."""
+
+    context = workspace_runtime_context.strip()
+    if not context:
+        return ""
+    return f"{context}\n\n"
+
+
 def _service_lines(
     services: tuple[ProfileService, ...],
     env_endpoints: tuple[_EnvEndpoint, ...],

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -39,6 +39,7 @@ from awf.runtime.merge_coordinator import (
 from awf.runtime.pr_creator import PullRequestCreator
 from awf.runtime.release_pr_monitor import build_feature_pr_monitor, build_release_pr_monitor
 from awf.runtime.validation import ValidationRunner
+from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
 from awf.service.config import ServiceSettings
 from awf.service.staleness import TargetBranchState
 from awf.service.target_branch_monitor import (
@@ -172,6 +173,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             "log_store": log_store,
             "merge_coordinator": merge_coordinator,
             "post_merge_target_reconciler": _post_merge_reconciler,
+            "workspace_runtime_context": render_workspace_runtime_context(profile),
         }
         return monitor_builder(**monitor_kwargs)
 

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -56,6 +56,19 @@ class TestAddressThread:
         assert "reviewer-bot" in prompt
 
     @pytest.mark.unit
+    def test_includes_trusted_workspace_runtime_context(self) -> None:
+        thread = ReviewThread(thread_id="T", path="x", line=1, body_excerpt="x")
+        prompt = address_thread_prompt(
+            pr_number=1,
+            repo_slug="a/b",
+            thread=thread,
+            workspace_runtime_context="Workspace runtime context\n- Service `postgres`: use `postgres:5432`.",
+        )
+
+        assert "Workspace runtime context" in prompt
+        assert "postgres:5432" in prompt
+
+    @pytest.mark.unit
     def test_forbids_push_in_footer(self) -> None:
         thread = ReviewThread(thread_id="T", path="x", line=1, body_excerpt="")
         prompt = address_thread_prompt(pr_number=1, repo_slug="a/b", thread=thread)
@@ -244,6 +257,19 @@ class TestAddressReviewComment:
         assert "print `AWF-VERDICT: FALSE POSITIVE:" in prompt
 
     @pytest.mark.unit
+    def test_includes_trusted_workspace_runtime_context(self) -> None:
+        c = ReviewComment(comment_id="C", body_excerpt="x")
+        prompt = address_review_comment_prompt(
+            pr_number=1,
+            repo_slug="a/b",
+            comment=c,
+            workspace_runtime_context="Workspace runtime context\n- Use `$AWF_TEST_DATABASE_URL`.",
+        )
+
+        assert "Workspace runtime context" in prompt
+        assert "$AWF_TEST_DATABASE_URL" in prompt
+
+    @pytest.mark.unit
     def test_forbids_push(self) -> None:
         c = ReviewComment(comment_id="C", body_excerpt="")
         prompt = address_review_comment_prompt(pr_number=1, repo_slug="a/b", comment=c)
@@ -365,6 +391,19 @@ class TestSyncBaseConflictPrompt:
         )
         assert "run git status" in prompt
 
+    @pytest.mark.unit
+    def test_includes_trusted_workspace_runtime_context(self) -> None:
+        prompt = sync_base_conflict_prompt(
+            pr_number=1,
+            repo_slug="a/b",
+            base_branch="main",
+            conflicting_files=("src/app.py",),
+            workspace_runtime_context="Workspace runtime context\n- Sidecar services are running.",
+        )
+
+        assert "Workspace runtime context" in prompt
+        assert "Sidecar services are running" in prompt
+
 
 class TestFixCiPrompt:
     @pytest.mark.unit
@@ -391,6 +430,18 @@ class TestFixCiPrompt:
     def test_falls_back_when_failures_empty(self) -> None:
         prompt = fix_ci_prompt(pr_number=1, repo_slug="a/b", failures=())
         assert "gh run list" in prompt
+
+    @pytest.mark.unit
+    def test_includes_trusted_workspace_runtime_context(self) -> None:
+        prompt = fix_ci_prompt(
+            pr_number=1,
+            repo_slug="a/b",
+            failures=(),
+            workspace_runtime_context="Workspace runtime context\n- Use `$DATABASE_URL`.",
+        )
+
+        assert "Workspace runtime context" in prompt
+        assert "$DATABASE_URL" in prompt
 
     @pytest.mark.unit
     def test_marks_missing_log_as_not_available_without_quoting_it_as_evidence(self) -> None:

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -403,6 +403,10 @@ class TestSyncBaseConflictPrompt:
 
         assert "Workspace runtime context" in prompt
         assert "Sidecar services are running" in prompt
+        assert (
+            "AWF just ran `git merge origin/main` and it stopped on conflicts in these files:"
+            in prompt
+        )
 
 
 class TestFixCiPrompt:

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -407,6 +407,13 @@ class TestSyncBaseConflictPrompt:
             "AWF just ran `git merge origin/main` and it stopped on conflicts in these files:"
             in prompt
         )
+        assert (
+            "AWF just ran `git merge origin/main` and it stopped on conflicts in these files:\n\n"
+            "  - src/app.py\n\n"
+            "Workspace runtime context\n"
+            "- Sidecar services are running.\n\n"
+            "Resolve each conflict" in prompt
+        )
 
 
 class TestFixCiPrompt:

--- a/tests/unit/runtime/test_planning.py
+++ b/tests/unit/runtime/test_planning.py
@@ -188,6 +188,33 @@ def test_prompts_reference_plan_and_report_paths() -> None:
 
 
 @pytest.mark.unit
+def test_agent_planning_and_execution_prompts_include_workspace_runtime_context() -> None:
+    plan = Path("docs/awf-plans/ws_123.md")
+    context = "Workspace runtime context\n- Use `$AWF_TEST_DATABASE_URL` for DB tests."
+
+    agent_prompt = build_agent_task_prompt(
+        task_prompt="Add metrics",
+        workspace_runtime_context=context,
+    )
+    planning_prompt = build_planning_prompt(
+        task_prompt="Add metrics",
+        plan_path=plan,
+        workspace_runtime_context=context,
+    )
+    execution_prompt = build_execution_prompt(
+        task_prompt="Add metrics",
+        plan_path=plan,
+        iteration=0,
+        gaps=(),
+        workspace_runtime_context=context,
+    )
+
+    for prompt in (agent_prompt, planning_prompt, execution_prompt):
+        assert "Workspace runtime context" in prompt
+        assert "$AWF_TEST_DATABASE_URL" in prompt
+
+
+@pytest.mark.unit
 def test_conformance_prompt_is_evidence_only_and_does_not_rerun_validation() -> None:
     prompt = build_conformance_prompt(
         task_prompt="Add metrics",

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -126,6 +126,7 @@ def _monitor_runner(
     fake: FakeCommandRunner,
     *,
     session_factory: async_sessionmaker[AsyncSession] | None = None,
+    workspace_runtime_context: str = "",
 ) -> PullRequestMonitorRunner:
     return PullRequestMonitorRunner(
         session_factory=session_factory or object(),  # type: ignore[arg-type]
@@ -133,6 +134,7 @@ def _monitor_runner(
         adapter=object(),  # type: ignore[arg-type]
         gh=object(),  # type: ignore[arg-type]
         worktrees_root=tmp_path / "work" / "git" / "worktrees",
+        workspace_runtime_context=workspace_runtime_context,
     )
 
 
@@ -147,6 +149,38 @@ def _green_status(*, pr_number: int = 42, head_sha: str = "abc1234567890def") ->
         base_behind_count=0,
         merge_state_status=MergeStateStatus.CLEAN,
     )
+
+
+@pytest.mark.unit
+async def test_address_review_comment_prompt_receives_workspace_runtime_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = "Workspace runtime context\n- Use `$AWF_TEST_DATABASE_URL`."
+    runner = _monitor_runner(
+        tmp_path,
+        FakeCommandRunner(),
+        workspace_runtime_context=context,
+    )
+    captured: dict[str, str] = {}
+
+    async def _capture_verdict(**kwargs: object) -> VerdictResult:
+        captured["prompt"] = str(kwargs["prompt"])
+        return VerdictResult(verdict="false_positive", reason="covered")
+
+    monkeypatch.setattr(runner, "_invoke_cli_for_verdict_result", _capture_verdict)
+
+    await runner._address_review_comment_result(
+        workspace_id="ws_1",
+        repo=RepoRef(owner="acme", name="repo"),
+        pr_number=12,
+        comment=ReviewComment(comment_id="issue:1", body_excerpt="please check DB test"),
+        compose_project="awf_ws_1",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert "Workspace runtime context" in captured["prompt"]
+    assert "$AWF_TEST_DATABASE_URL" in captured["prompt"]
 
 
 def _gh_pr_merge_calls(cmd: FakeCommandRunner) -> list[list[str]]:

--- a/tests/unit/runtime/test_workspace_prompt_context.py
+++ b/tests/unit/runtime/test_workspace_prompt_context.py
@@ -90,6 +90,35 @@ def test_workspace_runtime_context_keeps_generic_non_database_sidecars() -> None
 
 
 @pytest.mark.unit
+def test_workspace_runtime_context_omits_connection_env_for_external_hosts() -> None:
+    profile = WorkspaceProfile(
+        name="external-db",
+        runtime=ProfileRuntime(
+            environment={
+                "DATABASE_URL": "postgresql://awf:secret@postgres:5432/awf",
+                "EXTERNAL_POSTGRES_URL": (
+                    "postgresql://awf:external-secret@external.example.com:5432/awf"
+                ),
+                "REDIS_URL": "redis://cache.example.com:6379/0",
+            }
+        ),
+        services=[
+            ProfileService(name="postgres", image="postgres:16-alpine"),
+        ],
+    )
+
+    context = render_workspace_runtime_context(profile)
+
+    assert "$DATABASE_URL" in context
+    assert "postgresql://[redacted]@postgres:5432/awf" in context
+    assert "$EXTERNAL_POSTGRES_URL" not in context
+    assert "external.example.com" not in context
+    assert "$REDIS_URL" not in context
+    assert "cache.example.com" not in context
+    assert "external-secret" not in context
+
+
+@pytest.mark.unit
 def test_workspace_runtime_context_includes_generated_app_endpoint_env() -> None:
     profile = WorkspaceProfile(
         name="node-browser",

--- a/tests/unit/runtime/test_workspace_prompt_context.py
+++ b/tests/unit/runtime/test_workspace_prompt_context.py
@@ -1,0 +1,88 @@
+"""Workspace runtime context prompt rendering tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.profiles.models import (
+    DockerMode,
+    ProfileDocker,
+    ProfileRuntime,
+    ProfileService,
+    WorkspaceProfile,
+)
+from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
+
+
+@pytest.mark.unit
+def test_workspace_runtime_context_describes_sidecar_database_env_without_secrets() -> None:
+    profile = WorkspaceProfile(
+        name="awf-self",
+        docker=ProfileDocker(mode=DockerMode.none),
+        runtime=ProfileRuntime(
+            environment={
+                "AWF_DATABASE_URL": (
+                    "postgresql+asyncpg://awf:super-secret-password@postgres:5432/awf"
+                ),
+                "AWF_TEST_DATABASE_URL": (
+                    "postgresql+asyncpg://awf:super-secret-password@postgres:5432/awf"
+                ),
+                "PYTHONUNBUFFERED": "1",
+            }
+        ),
+        services=[
+            ProfileService(
+                name="postgres",
+                image="postgres:16-alpine",
+                environment={
+                    "POSTGRES_DB": "awf",
+                    "POSTGRES_PASSWORD": "super-secret-password",
+                    "POSTGRES_USER": "awf",
+                },
+                healthcheck_cmd="pg_isready -U awf -d awf",
+            )
+        ],
+    )
+
+    context = render_workspace_runtime_context(profile)
+
+    assert "Workspace runtime context" in context
+    assert "postgres" in context
+    assert "postgres:5432" in context
+    assert "$AWF_TEST_DATABASE_URL" in context
+    assert "postgresql+asyncpg://[redacted]@postgres:5432/awf" in context
+    assert "localhost is the agent container" in context
+    assert "AWF already started" in context
+    assert "Docker may be unavailable" in context
+    assert "super-secret-password" not in context
+
+
+@pytest.mark.unit
+def test_workspace_runtime_context_keeps_generic_non_database_sidecars() -> None:
+    profile = WorkspaceProfile(
+        name="redis-app",
+        runtime=ProfileRuntime(
+            environment={
+                "APP_BASE_URL": "http://app:8080",
+                "CACHE_URL": "redis://redis:6379/0",
+            }
+        ),
+        services=[
+            ProfileService(name="app", image="example/app:latest", ports=[(8080, 18080)]),
+            ProfileService(name="redis", image="redis:7-alpine"),
+        ],
+    )
+
+    context = render_workspace_runtime_context(profile)
+
+    assert "app" in context
+    assert "app:8080" in context
+    assert "redis" in context
+    assert "redis:6379" in context
+    assert "$APP_BASE_URL" in context
+    assert "$CACHE_URL" in context
+
+
+@pytest.mark.unit
+def test_workspace_runtime_context_is_empty_without_services_or_runtime_env() -> None:
+    assert render_workspace_runtime_context(WorkspaceProfile(name="plain")) == ""

--- a/tests/unit/runtime/test_workspace_prompt_context.py
+++ b/tests/unit/runtime/test_workspace_prompt_context.py
@@ -6,6 +6,9 @@ import pytest
 
 from awf.profiles.models import (
     DockerMode,
+    EndpointVisibility,
+    ProfileAppEndpoint,
+    ProfileAppEndpointHealth,
     ProfileDocker,
     ProfileRuntime,
     ProfileService,
@@ -81,6 +84,49 @@ def test_workspace_runtime_context_keeps_generic_non_database_sidecars() -> None
     assert "redis:6379" in context
     assert "$APP_BASE_URL" in context
     assert "$CACHE_URL" in context
+
+
+@pytest.mark.unit
+def test_workspace_runtime_context_includes_generated_app_endpoint_env() -> None:
+    profile = WorkspaceProfile(
+        name="node-browser",
+        services=[
+            ProfileService(name="app", image="node:20-alpine"),
+            ProfileService(name="browser", image="mcr.microsoft.com/playwright:v1"),
+        ],
+        app_endpoints=[
+            ProfileAppEndpoint(name="app", service="app", port=3000),
+            ProfileAppEndpoint(
+                name="browser_validation",
+                service="browser",
+                port=9323,
+                path="/validate",
+                health=ProfileAppEndpointHealth(path="/healthz"),
+                visibility=EndpointVisibility.validation,
+            ),
+            ProfileAppEndpoint(
+                name="operator_notes",
+                service="app",
+                port=3000,
+                path="/operator",
+                visibility=EndpointVisibility.console,
+            ),
+        ],
+    )
+
+    context = render_workspace_runtime_context(profile)
+
+    assert "Service `app` is already started by AWF; internal endpoints: `app:3000`." in context
+    assert (
+        "Service `browser` is already started by AWF; internal endpoints: `browser:9323`."
+        in context
+    )
+    assert "$AWF_APP_ENDPOINTS_JSON" in context
+    assert "$AWF_APP_ENDPOINT_APP_URL" in context
+    assert "http://app:3000/" in context
+    assert "$AWF_APP_ENDPOINT_BROWSER_VALIDATION_URL" in context
+    assert "http://browser:9323/validate" in context
+    assert "operator_notes" not in context
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_workspace_prompt_context.py
+++ b/tests/unit/runtime/test_workspace_prompt_context.py
@@ -14,7 +14,10 @@ from awf.profiles.models import (
     ProfileService,
     WorkspaceProfile,
 )
-from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
+from awf.runtime.workspace_prompt_context import (
+    render_workspace_runtime_context,
+    render_workspace_runtime_context_section,
+)
 
 
 @pytest.mark.unit
@@ -132,3 +135,14 @@ def test_workspace_runtime_context_includes_generated_app_endpoint_env() -> None
 @pytest.mark.unit
 def test_workspace_runtime_context_is_empty_without_services_or_runtime_env() -> None:
     assert render_workspace_runtime_context(WorkspaceProfile(name="plain")) == ""
+
+
+@pytest.mark.unit
+def test_workspace_runtime_context_section_trims_and_preserves_prompt_gap() -> None:
+    assert (
+        render_workspace_runtime_context_section(
+            "\n Workspace runtime context\n- Use `$DATABASE_URL`. \n"
+        )
+        == "Workspace runtime context\n- Use `$DATABASE_URL`.\n\n"
+    )
+    assert render_workspace_runtime_context_section(" \n\t ") == ""

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -302,7 +302,8 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     expected_runtime_context = created["feature_monitor_kwargs"]["workspace_runtime_context"]
     assert "Workspace runtime context" in expected_runtime_context
     assert "$AWF_TEST_DATABASE_URL" in expected_runtime_context
-    assert "secret" not in expected_runtime_context
+    assert "postgresql+asyncpg://[redacted]@postgres:5432/awf" in expected_runtime_context
+    assert "://awf:secret@" not in expected_runtime_context
     assert "post_merge_target_reconciler" in created["feature_monitor_kwargs"]
     reconciler = created["feature_monitor_kwargs"]["post_merge_target_reconciler"]
     assert callable(reconciler)
@@ -334,7 +335,8 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert release_runtime_context == expected_runtime_context
     assert "Workspace runtime context" in release_runtime_context
     assert "$AWF_TEST_DATABASE_URL" in release_runtime_context
-    assert "secret" not in release_runtime_context
+    assert "postgresql+asyncpg://[redacted]@postgres:5432/awf" in release_runtime_context
+    assert "://awf:secret@" not in release_runtime_context
     assert (
         created["release_monitor_kwargs"]["merge_coordinator"]
         is created["feature_monitor_kwargs"]["merge_coordinator"]

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -10,6 +10,7 @@ from typing import Any
 import pytest
 import structlog
 
+from awf.common.audit import REDACTION_MARKER
 from awf.common.config import Settings
 from awf.profiles.models import ProfileMonitor, ProfileRuntime, ProfileService, WorkspaceProfile
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
@@ -273,13 +274,12 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
         "chatgpt-codex-connector",
     ]
 
+    raw_database_password = "runtime-db-password"
+    raw_database_url = f"postgresql+asyncpg://awf:{raw_database_password}@postgres:5432/awf"
+    redacted_database_url = f"postgresql+asyncpg://{REDACTION_MARKER}@postgres:5432/awf"
     profile = WorkspaceProfile(
         name="custom",
-        runtime=ProfileRuntime(
-            environment={
-                "AWF_TEST_DATABASE_URL": "postgresql+asyncpg://awf:secret@postgres:5432/awf"
-            }
-        ),
+        runtime=ProfileRuntime(environment={"AWF_TEST_DATABASE_URL": raw_database_url}),
         services=[ProfileService(name="postgres", image="postgres:16-alpine")],
         monitor=ProfileMonitor(
             initial_review_grace_period_seconds=321,
@@ -302,8 +302,9 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     expected_runtime_context = created["feature_monitor_kwargs"]["workspace_runtime_context"]
     assert "Workspace runtime context" in expected_runtime_context
     assert "$AWF_TEST_DATABASE_URL" in expected_runtime_context
-    assert "postgresql+asyncpg://[redacted]@postgres:5432/awf" in expected_runtime_context
-    assert "://awf:secret@" not in expected_runtime_context
+    assert redacted_database_url in expected_runtime_context
+    assert raw_database_url not in expected_runtime_context
+    assert raw_database_password not in expected_runtime_context
     assert "post_merge_target_reconciler" in created["feature_monitor_kwargs"]
     reconciler = created["feature_monitor_kwargs"]["post_merge_target_reconciler"]
     assert callable(reconciler)
@@ -335,8 +336,9 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert release_runtime_context == expected_runtime_context
     assert "Workspace runtime context" in release_runtime_context
     assert "$AWF_TEST_DATABASE_URL" in release_runtime_context
-    assert "postgresql+asyncpg://[redacted]@postgres:5432/awf" in release_runtime_context
-    assert "://awf:secret@" not in release_runtime_context
+    assert redacted_database_url in release_runtime_context
+    assert raw_database_url not in release_runtime_context
+    assert raw_database_password not in release_runtime_context
     assert (
         created["release_monitor_kwargs"]["merge_coordinator"]
         is created["feature_monitor_kwargs"]["merge_coordinator"]

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -299,14 +299,10 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["feature_monitor_kwargs"]["non_check_reviewer_logins"] == ["custom-reviewer"]
     assert created["feature_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["feature_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
-    assert (
-        "Workspace runtime context"
-        in created["feature_monitor_kwargs"]["workspace_runtime_context"]
-    )
-    assert (
-        "$AWF_TEST_DATABASE_URL" in created["feature_monitor_kwargs"]["workspace_runtime_context"]
-    )
-    assert "secret" not in created["feature_monitor_kwargs"]["workspace_runtime_context"]
+    expected_runtime_context = created["feature_monitor_kwargs"]["workspace_runtime_context"]
+    assert "Workspace runtime context" in expected_runtime_context
+    assert "$AWF_TEST_DATABASE_URL" in expected_runtime_context
+    assert "secret" not in expected_runtime_context
     assert "post_merge_target_reconciler" in created["feature_monitor_kwargs"]
     reconciler = created["feature_monitor_kwargs"]["post_merge_target_reconciler"]
     assert callable(reconciler)
@@ -334,6 +330,11 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["release_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["release_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
     assert "post_merge_target_reconciler" in created["release_monitor_kwargs"]
+    release_runtime_context = created["release_monitor_kwargs"]["workspace_runtime_context"]
+    assert release_runtime_context == expected_runtime_context
+    assert "Workspace runtime context" in release_runtime_context
+    assert "$AWF_TEST_DATABASE_URL" in release_runtime_context
+    assert "secret" not in release_runtime_context
     assert (
         created["release_monitor_kwargs"]["merge_coordinator"]
         is created["feature_monitor_kwargs"]["merge_coordinator"]

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -11,7 +11,7 @@ import pytest
 import structlog
 
 from awf.common.config import Settings
-from awf.profiles.models import ProfileMonitor, WorkspaceProfile
+from awf.profiles.models import ProfileMonitor, ProfileRuntime, ProfileService, WorkspaceProfile
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
 from awf.service import worker as worker_mod
 from awf.service.config import ServiceSettings, resolve_service_settings
@@ -275,6 +275,12 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
 
     profile = WorkspaceProfile(
         name="custom",
+        runtime=ProfileRuntime(
+            environment={
+                "AWF_TEST_DATABASE_URL": "postgresql+asyncpg://awf:secret@postgres:5432/awf"
+            }
+        ),
+        services=[ProfileService(name="postgres", image="postgres:16-alpine")],
         monitor=ProfileMonitor(
             initial_review_grace_period_seconds=321,
             non_check_reviewer_settle_seconds=45,
@@ -293,6 +299,14 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["feature_monitor_kwargs"]["non_check_reviewer_logins"] == ["custom-reviewer"]
     assert created["feature_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["feature_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
+    assert (
+        "Workspace runtime context"
+        in created["feature_monitor_kwargs"]["workspace_runtime_context"]
+    )
+    assert (
+        "$AWF_TEST_DATABASE_URL" in created["feature_monitor_kwargs"]["workspace_runtime_context"]
+    )
+    assert "secret" not in created["feature_monitor_kwargs"]["workspace_runtime_context"]
     assert "post_merge_target_reconciler" in created["feature_monitor_kwargs"]
     reconciler = created["feature_monitor_kwargs"]["post_merge_target_reconciler"]
     assert callable(reconciler)


### PR DESCRIPTION
## Summary
- Adds a trusted workspace runtime context renderer from the resolved AWF profile.
- Includes sidecar service DNS names and redacted connection env vars in initial agent and PR-monitor repair prompts.
- Wires profile-derived context through executor planning/execution prompts and PR monitor factory creation.

## Validation
- uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_workspace_prompt_context.py tests/unit/runtime/test_monitor_prompts.py tests/unit/runtime/test_planning.py::test_agent_planning_and_execution_prompts_include_workspace_runtime_context tests/unit/runtime/test_pr_monitor_runner.py::test_address_review_comment_prompt_receives_workspace_runtime_context tests/unit/service/test_worker.py::test_build_worker_runtime_wires_executor_and_feature_monitor_factory -q
- uv run --python 3.12 --extra dev ruff check src/awf/runtime/workspace_prompt_context.py src/awf/runtime/monitor_prompts.py src/awf/runtime/planning.py src/awf/runtime/pr_monitor_runner.py src/awf/runtime/release_pr_monitor.py src/awf/control/executor.py src/awf/service/worker.py tests/unit/runtime/test_workspace_prompt_context.py tests/unit/runtime/test_monitor_prompts.py tests/unit/runtime/test_planning.py tests/unit/runtime/test_pr_monitor_runner.py tests/unit/service/test_worker.py
- uv run --python 3.12 --extra dev ruff format --check src/awf/runtime/workspace_prompt_context.py src/awf/runtime/monitor_prompts.py src/awf/runtime/planning.py src/awf/runtime/pr_monitor_runner.py src/awf/runtime/release_pr_monitor.py src/awf/control/executor.py src/awf/service/worker.py tests/unit/runtime/test_workspace_prompt_context.py tests/unit/runtime/test_monitor_prompts.py tests/unit/runtime/test_planning.py tests/unit/runtime/test_pr_monitor_runner.py tests/unit/service/test_worker.py
- uv run --python 3.12 --extra dev mypy src/awf/runtime/workspace_prompt_context.py src/awf/runtime/monitor_prompts.py src/awf/runtime/planning.py src/awf/runtime/pr_monitor_runner.py src/awf/runtime/release_pr_monitor.py src/awf/control/executor.py src/awf/service/worker.py
- uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_workspace_prompt_context.py tests/unit/runtime/test_monitor_prompts.py tests/unit/runtime/test_planning.py tests/unit/runtime/test_pr_monitor_runner.py tests/unit/service/test_worker.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace runtime context rendering added and surfaced in CLI prompts, agent planning/execution prompts, and PR monitor inputs.
  * Monitor builders and runtime components accept and propagate per-workspace runtime context; worker runtime supplies this context to monitors.

* **Tests**
  * New and expanded unit tests ensure workspace runtime context is rendered, redacted appropriately, and included across prompts and monitor flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/234)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->