### PR TITLE
Fix transient CI rerun recovery before agent repair

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -205,6 +205,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf workspace remonitor <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#protected_scope_diff_unavailable](#protected_scope_diff_unavailable)
 
+### PROTECTED_SCOPE_PUSH_BLOCKED
+**Problem:** The PR monitor refused to push because committed changes touched protected quality-gate paths outside the workspace owned paths.
+**Likely Cause:** A CI-fix, sync-base, or comment-addressing push included protected quality-gate files that the workspace profile does not own.
+**Operator Fix:** Inspect the blocked paths in the monitor event, remove or revert the out-of-scope quality-gate changes, then remonitor the workspace.
+**Related Command:** `awf workspace logs <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#protected_scope_push_blocked](#protected_scope_push_blocked)
+
 ### PR_ADOPTION_INPUT_REQUIRED
 **Problem:** A PR monitor adoption request omitted required input.
 **Likely Cause:** The request did not include enough repository or PR information to identify the PR.

--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -9,6 +9,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service logs`
 **Docs Link:** [docs/REASON_CATALOG.md#api_unreachable](#api_unreachable)
 
+### CI_TRANSIENT_RERUN_FAILED
+**Problem:** AWF could not request a GitHub rerun for CI failures classified as transient infrastructure failures.
+**Likely Cause:** GitHub rejected the rerun request, the workflow run no longer exists, or the token lacks permission to rerun workflow jobs.
+**Operator Fix:** Verify `gh run rerun <run_id> --failed` works with the AWF GitHub token, then remonitor the workspace if the failure was transient.
+**Related Command:** `gh run rerun <run_id> --failed`
+**Docs Link:** [docs/REASON_CATALOG.md#ci_transient_rerun_failed](#ci_transient_rerun_failed)
+
 ### CLAUDE_AUTH_MISSING
 **Problem:** No Claude Code auth signal was visible.
 **Likely Cause:** Missing Claude API credentials.

--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -198,6 +198,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service doctor`
 **Docs Link:** [docs/REASON_CATALOG.md#port_config_invalid](#port_config_invalid)
 
+### PROTECTED_SCOPE_DIFF_UNAVAILABLE
+**Problem:** The PR monitor could not verify protected-scope changes against the remote PR branch before push.
+**Likely Cause:** The PR branch diff baseline could not be fetched because of a GitHub/network failure, a missing remote ref, or delayed ref replication.
+**Operator Fix:** Verify GitHub/network access and the PR branch ref, then remonitor the workspace once the remote branch is reachable.
+**Related Command:** `awf workspace remonitor <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#protected_scope_diff_unavailable](#protected_scope_diff_unavailable)
+
 ### PR_ADOPTION_INPUT_REQUIRED
 **Problem:** A PR monitor adoption request omitted required input.
 **Likely Cause:** The request did not include enough repository or PR information to identify the PR.

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -946,9 +946,36 @@ class GitHubClient:
                     name=run.get("name") or f"run/{run_id}",
                     conclusion=conclusion.upper(),
                     log_excerpt=_tail(log_text, log_tail_chars),
+                    run_id=run_id,
                 )
             )
         return tuple(failures)
+
+    async def rerun_failed_workflow_jobs(self, *, repo: RepoRef, run_id: str) -> None:
+        """Rerun only failed jobs for a workflow run.
+
+        Used by the PR monitor before involving a coding agent when the
+        failure evidence points at GitHub/runner/package-download
+        infrastructure rather than repository code.
+        """
+
+        result = await self._runner.run(
+            [
+                "gh",
+                "run",
+                "rerun",
+                run_id,
+                "--repo",
+                repo.slug(),
+                "--failed",
+            ]
+        )
+        if not result.ok:
+            raise GitHubClientError(
+                operation="rerun_failed_workflow_jobs",
+                returncode=result.returncode,
+                stderr=result.stderr,
+            )
 
     async def resolve_thread(self, *, thread_id: str) -> None:
         await self._graphql(

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -948,7 +948,8 @@ class GitHubClient:
             log_text = log.stdout if log is not None else ""
             failures.append(
                 CheckFailure(
-                    name=run.get("name") or f"run/{run_id}",
+                    name=run.get("name")
+                    or (f"run/{run_id}" if run_id is not None else "run/unknown"),
                     conclusion=conclusion.upper(),
                     log_excerpt=_tail(log_text, log_tail_chars),
                     run_id=run_id,

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -926,19 +926,24 @@ class GitHubClient:
             conclusion = run.get("conclusion") or ""
             if conclusion.upper() not in {"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"}:
                 continue
-            run_id = str(run["databaseId"])
-            log = await self._run_gh(
-                [
-                    "gh",
-                    "run",
-                    "view",
-                    run_id,
-                    "--repo",
-                    repo.slug(),
-                    "--log-failed",
-                ],
-                operation="view_run_log",
-                strict=False,  # logs may be purged; don't fail the monitor
+            database_id = run.get("databaseId")
+            run_id = str(database_id) if database_id is not None else None
+            log = (
+                await self._run_gh(
+                    [
+                        "gh",
+                        "run",
+                        "view",
+                        run_id,
+                        "--repo",
+                        repo.slug(),
+                        "--log-failed",
+                    ],
+                    operation="view_run_log",
+                    strict=False,  # logs may be purged; don't fail the monitor
+                )
+                if run_id is not None
+                else None
             )
             log_text = log.stdout if log is not None else ""
             failures.append(

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -614,8 +614,7 @@ def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
         return False
     if any(pattern.search(log_text) for pattern in _CI_CODE_FAILURE_PATTERNS):
         return False
-    transient_text = f"{failure.conclusion}\n{failure.log_excerpt}".lower()
-    return any(marker in transient_text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
+    return any(marker in log_text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
 
 
 def _supports_failed_job_rerun(failure: CheckFailure) -> bool:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -511,6 +511,8 @@ def _sync_base_no_progress_exhausted(
 
 _CI_TRANSIENT_RERUN_KEY_PREFIX = "__awf_ci_rerun:"
 
+_CI_FAILED_JOB_RERUN_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT"})
+
 _CI_CODE_FAILURE_MARKERS = (
     "failed tests/",
     "failed test",
@@ -614,6 +616,10 @@ def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
     return any(marker in text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
 
 
+def _supports_failed_job_rerun(failure: CheckFailure) -> bool:
+    return failure.conclusion.upper() in _CI_FAILED_JOB_RERUN_CONCLUSIONS
+
+
 def _should_rerun_transient_ci(
     status: PRStatus,
     state: MonitorState,
@@ -624,6 +630,8 @@ def _should_rerun_transient_ci(
     if not status.ci_failures:
         return False
     if any(not failure.run_id for failure in status.ci_failures):
+        return False
+    if any(not _supports_failed_job_rerun(failure) for failure in status.ci_failures):
         return False
     if not all(_looks_like_transient_ci_failure(failure) for failure in status.ci_failures):
         return False

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -514,7 +514,6 @@ _CI_TRANSIENT_RERUN_KEY_PREFIX = "__awf_ci_rerun:"
 _CI_FAILED_JOB_RERUN_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT"})
 
 _CI_CODE_FAILURE_MARKERS = (
-    "failed tests/",
     "failed test",
     "pytest failed",
     "assertionerror",
@@ -610,6 +609,8 @@ def _ci_transient_rerun_count(
 
 def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
     log_text = failure.log_excerpt.lower()
+    if not log_text.strip():
+        return bool(failure.run_id) and failure.conclusion.upper() == "TIMED_OUT"
     if any(marker in log_text for marker in _CI_CODE_FAILURE_MARKERS):
         return False
     if any(pattern.search(log_text) for pattern in _CI_CODE_FAILURE_PATTERNS):

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -518,7 +518,7 @@ _CI_CODE_FAILURE_MARKERS = (
     "failed test",
     "pytest failed",
     "assertionerror",
-    "assert ",
+    "assert failed",
     "coverage failure",
     "fail-under",
     "typecheck",

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -537,6 +537,7 @@ _CI_CODE_FAILURE_PATTERNS = (
 )
 
 _CI_TRANSIENT_FAILURE_MARKERS = (
+    "timed_out",
     "http status server error",
     "http 500",
     "http 502",

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -156,6 +156,7 @@ class CheckFailure:
     name: str
     conclusion: str  # FAILURE / TIMED_OUT / CANCELLED / ACTION_REQUIRED
     log_excerpt: str  # tail of the failing step's log, truncated
+    run_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -275,6 +276,10 @@ class MonitorConfig:
     prevents stale git mirrors or unreproducible GitHub DIRTY states from
     burning monitor iterations forever."""
 
+    ci_transient_rerun_max_attempts: int = 2
+    """Maximum deterministic GitHub reruns for the same transient CI
+    failure signature before falling back to agent CI repair."""
+
 
 # ── Actions — the vocabulary decide() returns to the runner ────────────────
 
@@ -313,6 +318,13 @@ class AddressComments:
 @dataclass(frozen=True)
 class ReportCiFailure:
     """Re-invoke the CLI with logs of the failing checks."""
+
+    failures: tuple[CheckFailure, ...]
+
+
+@dataclass(frozen=True)
+class RerunTransientCI:
+    """Ask GitHub to rerun failed jobs for infra-like CI failures."""
 
     failures: tuple[CheckFailure, ...]
 
@@ -361,6 +373,7 @@ class Abort:
 MonitorAction = (
     AddressComments
     | ReportCiFailure
+    | RerunTransientCI
     | SyncBase
     | WaitForCI
     | Merge
@@ -492,6 +505,123 @@ def _sync_base_no_progress_exhausted(
         config.max_no_progress_sync_base_attempts > 0
         and state.sync_base_no_progress_signature == sync_base_no_progress_signature(status)
         and state.sync_base_no_progress_count >= config.max_no_progress_sync_base_attempts
+    )
+
+
+_CI_TRANSIENT_RERUN_KEY_PREFIX = "__awf_ci_rerun:"
+
+_CI_CODE_FAILURE_MARKERS = (
+    "failed tests/",
+    "failed test",
+    "pytest failed",
+    "assertionerror",
+    "assert ",
+    "coverage failure",
+    "fail-under",
+    "ruff",
+    "mypy",
+    "eslint",
+    "typecheck",
+    "type check",
+    "syntaxerror",
+    "traceback (most recent call last)",
+)
+
+_CI_TRANSIENT_FAILURE_MARKERS = (
+    "http status server error",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "500 internal server",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "service unavailable",
+    "temporarily unavailable",
+    "try again",
+    "timed out waiting for",
+    "timeout awaiting",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "recv failure",
+    "tls handshake timeout",
+    "failed to download",
+    "network is unreachable",
+    "runner has received a shutdown signal",
+    "lost communication with the server",
+)
+
+
+def _ci_transient_rerun_state_key(
+    head_sha: str,
+    failures: tuple[CheckFailure, ...],
+) -> str:
+    """Stable retry-budget key for one PR head/failing-run signature.
+
+    The key deliberately excludes free-form log text. A rerun can produce
+    slightly different infrastructure wording while still representing the
+    same failing workflow run on the same PR head.
+    """
+
+    signature = "|".join(
+        f"{failure.run_id or ''}:{failure.name}:{failure.conclusion}"
+        for failure in sorted(
+            failures,
+            key=lambda item: (item.run_id or "", item.name, item.conclusion),
+        )
+    )
+    digest = hashlib.sha256(signature.encode("utf-8")).hexdigest()[:12]
+    return f"{_CI_TRANSIENT_RERUN_KEY_PREFIX}{head_sha}:{digest}"
+
+
+def _ci_transient_rerun_count(
+    state: MonitorState,
+    *,
+    head_sha: str,
+    failures: tuple[CheckFailure, ...],
+) -> int:
+    raw_count = state.threads_addressed_ids.get(
+        _ci_transient_rerun_state_key(head_sha, failures),
+        "0",
+    )
+    try:
+        return int(raw_count)
+    except ValueError:
+        return 0
+
+
+def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
+    text = f"{failure.name}\n{failure.conclusion}\n{failure.log_excerpt}".lower()
+    if any(marker in text for marker in _CI_CODE_FAILURE_MARKERS):
+        return False
+    return any(marker in text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
+
+
+def _should_rerun_transient_ci(
+    status: PRStatus,
+    state: MonitorState,
+    config: MonitorConfig,
+) -> bool:
+    if config.ci_transient_rerun_max_attempts <= 0:
+        return False
+    if not status.ci_failures:
+        return False
+    if any(not failure.run_id for failure in status.ci_failures):
+        return False
+    if not all(_looks_like_transient_ci_failure(failure) for failure in status.ci_failures):
+        return False
+    return (
+        _ci_transient_rerun_count(
+            state,
+            head_sha=status.head_sha,
+            failures=status.ci_failures,
+        )
+        < config.ci_transient_rerun_max_attempts
     )
 
 
@@ -627,6 +757,8 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
             # grab ``gh run view --log-failed`` on its end; we still hand
             # off a ReportCiFailure action.
             return ReportCiFailure(failures=())
+        if _should_rerun_transient_ci(status, state, config):
+            return RerunTransientCI(failures=status.ci_failures)
         return ReportCiFailure(failures=status.ci_failures)
 
     # 5. CI still running, or GitHub is still computing state → passive wait.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -518,13 +519,19 @@ _CI_CODE_FAILURE_MARKERS = (
     "assert ",
     "coverage failure",
     "fail-under",
-    "ruff",
-    "mypy",
-    "eslint",
     "typecheck",
     "type check",
+    "would reformat:",
+    "found lint errors",
+    "found type errors",
     "syntaxerror",
     "traceback (most recent call last)",
+)
+
+_CI_CODE_FAILURE_PATTERNS = (
+    re.compile(r"(?m)^[^\n:]+:\d+:\d+:\s+[A-Z]\d{3}\b"),
+    re.compile(r"(?m)^[^\n:]+:\d+:\s+error:\s+.+\[[a-z0-9-]+\]"),
+    re.compile(r"\b(?:ruff|mypy|eslint)\b[^\n]*\b(?:failed|found|would reformat|errors?)\b"),
 )
 
 _CI_TRANSIENT_FAILURE_MARKERS = (
@@ -568,12 +575,15 @@ def _ci_transient_rerun_state_key(
     same failing workflow run on the same PR head.
     """
 
-    signature = "|".join(
-        f"{failure.run_id or ''}:{failure.name}:{failure.conclusion}"
-        for failure in sorted(
-            failures,
-            key=lambda item: (item.run_id or "", item.name, item.conclusion),
-        )
+    signature = json.dumps(
+        [
+            (failure.run_id or "", failure.name, failure.conclusion)
+            for failure in sorted(
+                failures,
+                key=lambda item: (item.run_id or "", item.name, item.conclusion),
+            )
+        ],
+        separators=(",", ":"),
     )
     digest = hashlib.sha256(signature.encode("utf-8")).hexdigest()[:12]
     return f"{_CI_TRANSIENT_RERUN_KEY_PREFIX}{head_sha}:{digest}"
@@ -598,6 +608,8 @@ def _ci_transient_rerun_count(
 def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
     text = f"{failure.name}\n{failure.conclusion}\n{failure.log_excerpt}".lower()
     if any(marker in text for marker in _CI_CODE_FAILURE_MARKERS):
+        return False
+    if any(pattern.search(text) for pattern in _CI_CODE_FAILURE_PATTERNS):
         return False
     return any(marker in text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
 

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -609,12 +609,13 @@ def _ci_transient_rerun_count(
 
 
 def _looks_like_transient_ci_failure(failure: CheckFailure) -> bool:
-    text = f"{failure.name}\n{failure.conclusion}\n{failure.log_excerpt}".lower()
-    if any(marker in text for marker in _CI_CODE_FAILURE_MARKERS):
+    log_text = failure.log_excerpt.lower()
+    if any(marker in log_text for marker in _CI_CODE_FAILURE_MARKERS):
         return False
-    if any(pattern.search(text) for pattern in _CI_CODE_FAILURE_PATTERNS):
+    if any(pattern.search(log_text) for pattern in _CI_CODE_FAILURE_PATTERNS):
         return False
-    return any(marker in text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
+    transient_text = f"{failure.conclusion}\n{failure.log_excerpt}".lower()
+    return any(marker in transient_text for marker in _CI_TRANSIENT_FAILURE_MARKERS)
 
 
 def _supports_failed_job_rerun(failure: CheckFailure) -> bool:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -88,12 +88,14 @@ from awf.runtime.pr_monitor import (
     NotifyHuman,
     PRStatus,
     ReportCiFailure,
+    RerunTransientCI,
     ReviewComment,
     ReviewThread,
     ShortCircuitCompleted,
     SyncBase,
     WaitForCI,
     _agent_can_triage_review_comment,
+    _ci_transient_rerun_state_key,
     _is_bot_author,
     _is_bot_review_thread,
     _mark_review_thread_addressed,
@@ -233,7 +235,10 @@ _GIT_BASE_FETCH_TRANSIENT_RETRY_EXHAUSTED_REASON = "GIT_BASE_FETCH_TRANSIENT_RET
 _GIT_BASE_BEHIND_FAILED_REASON = "GIT_BASE_BEHIND_FAILED"
 _GIT_MIRROR_BROKEN_REF_REMOVED_REASON = "GIT_MIRROR_BROKEN_REF_REMOVED"
 _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
+_CI_TRANSIENT_RERUN_REASON = "CI_TRANSIENT_RERUN"
+_CI_TRANSIENT_RERUN_FAILED_REASON = "CI_TRANSIENT_RERUN_FAILED"
 _PROTECTED_SCOPE_REPAIR_FAILED_REASON = "PROTECTED_SCOPE_REPAIR_FAILED"
+_PROTECTED_SCOPE_PUSH_BLOCKED_REASON = "PROTECTED_SCOPE_PUSH_BLOCKED"
 _VALIDATION_INSUFFICIENT_STALE_REASON = "validation_insufficient_tier"
 _RECOVERY_SNAPSHOT_ALREADY_HANDLED_REASON = "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
 _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
@@ -1472,6 +1477,116 @@ class PullRequestMonitorRunner:
                 operation_id=operation.operation_id if operation is not None else None,
                 operation_type=OperationType.sync_base.value,
                 monitor_log=monitor_log,
+            )
+            state.iter_count += 1
+            return False
+
+        if isinstance(action, RerunTransientCI):
+            attempt = _ci_transient_rerun_attempt(
+                state,
+                head_sha=status.head_sha,
+                failures=action.failures,
+            )
+            run_ids = tuple(dict.fromkeys(failure.run_id for failure in action.failures if failure.run_id))
+            failures_payload = [_ci_failure_payload(failure) for failure in action.failures]
+            operation = await self._begin_monitor_operation(
+                workspace_id=workspace_id,
+                operation_type=OperationType.ci_repair,
+                action="ci_transient_rerun",
+                requested_action="rerun_failed_ci",
+                reason=(
+                    "CI failure logs matched transient infrastructure signatures; "
+                    "rerunning failed GitHub jobs before invoking an agent."
+                ),
+                reason_code=_CI_TRANSIENT_RERUN_REASON,
+                pr_number=pr_number,
+                status=status,
+                base_branch=base_branch,
+                remote_branch=remote_branch,
+                monitor_log=monitor_log,
+                extra_payload={
+                    "attempt": attempt,
+                    "failures": failures_payload,
+                    "run_ids": list(run_ids),
+                },
+                extra_identity=(attempt, *run_ids),
+            )
+            event_payload: dict[str, object] = {
+                "attempt": attempt,
+                "failures": failures_payload,
+                "run_ids": list(run_ids),
+                "head_sha": status.head_sha,
+            }
+            try:
+                for run_id in run_ids:
+                    await self._deps.gh.rerun_failed_workflow_jobs(repo=repo, run_id=run_id)
+            except GitHubClientError as exc:
+                error_message = _redact_and_truncate_github_error(str(exc))
+                await self._finish_monitor_operation(
+                    operation,
+                    status=OperationStatus.failed,
+                    result={
+                        "status": "failed",
+                        "outcome": "ci_transient_rerun_failed",
+                        "reason_code": _CI_TRANSIENT_RERUN_FAILED_REASON,
+                        **event_payload,
+                    },
+                    error_code=_CI_TRANSIENT_RERUN_FAILED_REASON,
+                    error_message=error_message,
+                )
+                await self._write_monitor_log(
+                    monitor_log,
+                    {
+                        "event": "monitor.ci_transient_rerun_failed",
+                        "workspace_id": workspace_id,
+                        "pr_number": pr_number,
+                        "reason_code": _CI_TRANSIENT_RERUN_FAILED_REASON,
+                        "error": error_message,
+                        **event_payload,
+                    },
+                )
+                await self._append_workspace_events(
+                    workspace_id=workspace_id,
+                    events=[
+                        WorkspaceEventCreate(
+                            event_type="workspace.monitor_ci_transient_rerun_failed",
+                            reason_code=_CI_TRANSIENT_RERUN_FAILED_REASON,
+                            payload={**event_payload, "error": error_message},
+                        )
+                    ],
+                )
+                state.iter_count += 1
+                return False
+
+            await self._finish_monitor_operation(
+                operation,
+                status=OperationStatus.succeeded,
+                result={
+                    "status": "succeeded",
+                    "outcome": "ci_transient_rerun_requested",
+                    "reason_code": _CI_TRANSIENT_RERUN_REASON,
+                    **event_payload,
+                },
+            )
+            await self._write_monitor_log(
+                monitor_log,
+                {
+                    "event": "monitor.ci_transient_rerun_requested",
+                    "workspace_id": workspace_id,
+                    "pr_number": pr_number,
+                    "reason_code": _CI_TRANSIENT_RERUN_REASON,
+                    **event_payload,
+                },
+            )
+            await self._append_workspace_events(
+                workspace_id=workspace_id,
+                events=[
+                    WorkspaceEventCreate(
+                        event_type="workspace.monitor_ci_transient_rerun_requested",
+                        reason_code=_CI_TRANSIENT_RERUN_REASON,
+                        payload=event_payload,
+                    )
+                ],
             )
             state.iter_count += 1
             return False
@@ -3480,10 +3595,24 @@ class PullRequestMonitorRunner:
 
         # 3) Push everything we committed.
         worktree_path = self._worktrees_root / workspace_id
-        push_result = await self._git_push_result(
+        protected_scope_message = await self._protected_scope_push_block_message(
+            workspace_id=workspace_id,
             worktree_path=worktree_path,
             remote_branch=remote_branch,
-            remote_url=remote_push_url,
+        )
+        push_result = (
+            _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=1,
+                stderr=protected_scope_message,
+            )
+            if protected_scope_message is not None
+            else await self._git_push_result(
+                worktree_path=worktree_path,
+                remote_branch=remote_branch,
+                remote_url=remote_push_url,
+            )
         )
         pushed_head_sha: str | None = None
         if push_result.failed:
@@ -3962,6 +4091,18 @@ class PullRequestMonitorRunner:
                 workspace_id=workspace_id,
                 stderr=agent_run_err.result.stderr[:400],
             )
+        protected_scope_message = await self._protected_scope_push_block_message(
+            workspace_id=workspace_id,
+            worktree_path=self._worktrees_root / workspace_id,
+            remote_branch=remote_branch,
+        )
+        if protected_scope_message is not None:
+            return _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=1,
+                stderr=protected_scope_message,
+            )
         return await self._git_push_result(
             worktree_path=self._worktrees_root / workspace_id,
             remote_branch=remote_branch,
@@ -4160,6 +4301,91 @@ class PullRequestMonitorRunner:
             changed_paths=changed_paths,
             owned_paths=owned_paths,
         )
+
+    async def _protected_scope_violations_for_unpushed_commits(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        remote_branch: str,
+    ) -> list[QualityGateViolation]:
+        async with self._deps.session_factory() as session:
+            workspace = await WorkspaceRepository(session).get(workspace_id)
+            if workspace is None:
+                return []
+            owned_paths = list(workspace.owned_paths)
+
+        changed_paths = await self._changed_paths_since_remote_branch(
+            worktree_path=worktree_path,
+            remote_branch=remote_branch,
+        )
+        if not changed_paths:
+            return []
+        return find_protected_quality_gate_changes(
+            changed_paths=changed_paths,
+            owned_paths=owned_paths,
+        )
+
+    async def _changed_paths_since_remote_branch(
+        self,
+        *,
+        worktree_path: Path,
+        remote_branch: str,
+    ) -> tuple[str, ...]:
+        for revision_range in (f"origin/{remote_branch}..HEAD", "@{upstream}..HEAD"):
+            result = await self._deps.runner.run(
+                [
+                    "git",
+                    "-C",
+                    str(worktree_path),
+                    "diff",
+                    "--name-only",
+                    revision_range,
+                    "--",
+                ]
+            )
+            if result.ok:
+                return tuple(
+                    line.strip()
+                    for line in result.stdout.splitlines()
+                    if line.strip()
+                )
+        return ()
+
+    async def _protected_scope_push_block_message(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        remote_branch: str,
+    ) -> str | None:
+        if not worktree_path.exists():
+            return None
+        violations = await self._protected_scope_violations_for_unpushed_commits(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            remote_branch=remote_branch,
+        )
+        if not violations:
+            return None
+        message = quality_gate_violation_message(violations)
+        await self._append_workspace_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type="workspace.monitor_protected_scope_push_blocked",
+                    reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                    payload={
+                        "paths": [violation.path for violation in violations],
+                        "protected_patterns": [
+                            violation.protected_pattern for violation in violations
+                        ],
+                        "message": message,
+                    },
+                )
+            ],
+        )
+        return message
 
     async def _protected_scope_repair_prompt(
         self,
@@ -5637,6 +5863,31 @@ def _increment_base_fetch_retry_count(state: MonitorState, context: str) -> int:
 def _clear_transient_base_fetch_retry_state(state: MonitorState, *, context: str) -> bool:
     key = _base_fetch_retry_count_key(context)
     return state.threads_addressed_ids.pop(key, None) is not None
+
+
+def _ci_transient_rerun_attempt(
+    state: MonitorState,
+    *,
+    head_sha: str,
+    failures: tuple[CheckFailure, ...],
+) -> int:
+    key = _ci_transient_rerun_state_key(head_sha, failures)
+    raw_count = state.threads_addressed_ids.get(key, "0")
+    try:
+        current = int(raw_count)
+    except ValueError:
+        current = 0
+    attempt = current + 1
+    state.threads_addressed_ids[key] = str(attempt)
+    return attempt
+
+
+def _ci_failure_payload(failure: CheckFailure) -> dict[str, str | None]:
+    return {
+        "name": failure.name,
+        "conclusion": failure.conclusion,
+        "run_id": failure.run_id,
+    }
 
 
 def _base_fetch_retry_wait_seconds(

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -4484,11 +4484,37 @@ class PullRequestMonitorRunner:
                 f"stdout={fetch_result.stdout.strip() or '<empty>'} "
                 f"stderr={fetch_result.stderr.strip() or '<empty>'}"
             )
-        return await self._changed_paths_between_ref_and_head(
+        local_base = await self._merge_base_with_head(
             worktree_path=worktree_path,
             ref="FETCH_HEAD",
             error_context="against the remote PR branch",
         )
+        return await self._changed_paths_between_ref_and_head(
+            worktree_path=worktree_path,
+            ref=local_base,
+            error_context="against the remote PR branch",
+        )
+
+    async def _merge_base_with_head(
+        self,
+        *,
+        worktree_path: Path,
+        ref: str,
+        error_context: str,
+    ) -> str:
+        merge_base_result = await self._deps.runner.run(
+            ["git", "-C", str(worktree_path), "merge-base", ref, "HEAD"]
+        )
+        merge_base = merge_base_result.stdout.strip()
+        if not merge_base_result.ok or not merge_base:
+            raise ProtectedScopeDiffError(
+                f"Could not resolve committed diff {error_context} "
+                "for protected-scope validation: "
+                f"merge-base {ref} HEAD exit={merge_base_result.returncode} "
+                f"stdout={merge_base or '<empty>'} "
+                f"stderr={merge_base_result.stderr.strip() or '<empty>'}"
+            )
+        return merge_base
 
     async def _changed_paths_between_ref_and_head(
         self,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1552,6 +1552,7 @@ class PullRequestMonitorRunner:
                     remote_push_url=remote_push_url,
                 )
             failures_payload = [_ci_failure_payload(failure) for failure in action.failures]
+            rerun_signature = _ci_transient_rerun_state_key(status.head_sha, action.failures)
             operation = await self._begin_monitor_operation(
                 workspace_id=workspace_id,
                 operation_type=OperationType.ci_repair,
@@ -1572,7 +1573,7 @@ class PullRequestMonitorRunner:
                     "failures": failures_payload,
                     "run_ids": list(run_ids),
                 },
-                extra_identity=(attempt, *run_ids),
+                extra_identity=(rerun_signature, attempt, *run_ids),
             )
             event_payload: dict[str, object] = {
                 "attempt": attempt,
@@ -1675,7 +1676,7 @@ class PullRequestMonitorRunner:
                 wait_seconds=self._config.poll_interval_seconds,
                 monitor_log=monitor_log,
                 extra_payload=event_payload,
-                extra_identity=(attempt, *run_ids, "wait"),
+                extra_identity=(rerun_signature, attempt, *run_ids, "wait"),
             )
             state.iter_count += 1
             return False

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1504,6 +1504,22 @@ class PullRequestMonitorRunner:
             run_ids = tuple(
                 dict.fromkeys(failure.run_id for failure in action.failures if failure.run_id)
             )
+            if not run_ids:
+                return await self._execute(
+                    action=ReportCiFailure(failures=action.failures),
+                    workspace_id=workspace_id,
+                    repo_url=repo_url,
+                    repo=repo,
+                    pr_number=pr_number,
+                    status=status,
+                    state=state,
+                    base_branch=base_branch,
+                    remote_branch=remote_branch,
+                    compose_project=compose_project,
+                    compose_file=compose_file,
+                    monitor_log=monitor_log,
+                    remote_push_url=remote_push_url,
+                )
             failures_payload = [_ci_failure_payload(failure) for failure in action.failures]
             operation = await self._begin_monitor_operation(
                 workspace_id=workspace_id,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1449,16 +1449,18 @@ class PullRequestMonitorRunner:
                 )
                 return True
             if push_result.failed:
+                reason_code = push_result.reason_code
+                outcome = _git_push_failure_outcome(push_result)
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,
                     result={
                         "status": "failed",
-                        "outcome": "git_push_failed",
-                        "reason_code": _GIT_PUSH_FAILED_REASON,
+                        "outcome": outcome,
+                        "reason_code": reason_code,
                         "pushed": False,
                     },
-                    error_code=_GIT_PUSH_FAILED_REASON,
+                    error_code=reason_code,
                     error_message=push_result.error_message,
                 )
                 await self._record_pr_monitor_audit_event(
@@ -1466,7 +1468,7 @@ class PullRequestMonitorRunner:
                     event_type=_AUDIT_GIT_PUSH_EVENT,
                     action="sync_base_push",
                     outcome="failed",
-                    reason_code=_GIT_PUSH_FAILED_REASON,
+                    reason_code=reason_code,
                     pr_number=pr_number,
                     status=status,
                     base_branch=base_branch,
@@ -1476,6 +1478,13 @@ class PullRequestMonitorRunner:
                     monitor_log=monitor_log,
                     evidence=push_result.failure_evidence(),
                 )
+                if push_result.protected_scope_blocked:
+                    await self._terminate_failed(
+                        workspace_id,
+                        message=push_result.error_message or push_result.reason_code,
+                        reason_code=push_result.reason_code,
+                    )
+                    return True
                 self._record_sync_base_progress(
                     state=state,
                     status=status,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1537,6 +1537,13 @@ class PullRequestMonitorRunner:
                 for run_id in run_ids:
                     await self._deps.gh.rerun_failed_workflow_jobs(repo=repo, run_id=run_id)
             except GitHubClientError as exc:
+                recorded_attempt = _ci_transient_rerun_attempt(
+                    state,
+                    head_sha=status.head_sha,
+                    failures=action.failures,
+                )
+                event_payload["attempt"] = recorded_attempt
+                await self._persist_state(workspace_id, state)
                 error_message = _redact_and_truncate_github_error(str(exc))
                 await self._finish_monitor_operation(
                     operation,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -4125,6 +4125,7 @@ class PullRequestMonitorRunner:
             worktree_path=worktree_path,
             remote_branch=remote_branch,
             remote_push_url=remote_push_url,
+            base_branch=base_branch,
         )
         if protected_scope_block is not None:
             return _GitPushResult(
@@ -4474,26 +4475,77 @@ class PullRequestMonitorRunner:
                 f"stdout={fetch_result.stdout.strip() or '<empty>'} "
                 f"stderr={fetch_result.stderr.strip() or '<empty>'}"
             )
+        return await self._changed_paths_between_ref_and_head(
+            worktree_path=worktree_path,
+            ref="FETCH_HEAD",
+            error_context="against the remote PR branch",
+        )
+
+    async def _changed_paths_between_ref_and_head(
+        self,
+        *,
+        worktree_path: Path,
+        ref: str,
+        error_context: str,
+    ) -> tuple[str, ...]:
+        diff_spec = f"{ref}..HEAD"
         diff_result = await self._deps.runner.run(
-            [
-                "git",
-                "-C",
-                str(worktree_path),
-                "diff",
-                "--name-only",
-                "FETCH_HEAD..HEAD",
-                "--",
-            ]
+            ["git", "-C", str(worktree_path), "diff", "--name-only", diff_spec, "--"]
         )
         if not diff_result.ok:
             raise ProtectedScopeDiffError(
-                "Could not resolve committed diff against the remote PR branch "
+                f"Could not resolve committed diff {error_context} "
                 "for protected-scope validation: "
-                f"diff FETCH_HEAD..HEAD exit={diff_result.returncode} "
+                f"diff {diff_spec} exit={diff_result.returncode} "
                 f"stdout={diff_result.stdout.strip() or '<empty>'} "
                 f"stderr={diff_result.stderr.strip() or '<empty>'}"
             )
         return tuple(line.strip() for line in diff_result.stdout.splitlines() if line.strip())
+
+    async def _protected_scope_violations_for_sync_base_push(
+        self,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        remote_branch: str,
+        base_branch: str,
+        remote_push_url: str | None = None,
+    ) -> list[QualityGateViolation]:
+        async with self._deps.session_factory() as session:
+            workspace = await WorkspaceRepository(session).get(workspace_id)
+            if workspace is None:
+                raise ProtectedScopeDiffError(
+                    f"Workspace row {workspace_id} disappeared; cannot load owned_paths "
+                    "for protected-scope validation."
+                )
+            owned_paths = list(workspace.owned_paths)
+
+        changed_from_remote = await self._changed_paths_since_remote_branch(
+            worktree_path=worktree_path,
+            remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
+        )
+        if not changed_from_remote:
+            return []
+
+        changed_from_base = await self._changed_paths_between_ref_and_head(
+            worktree_path=worktree_path,
+            ref=f"origin/{base_branch}",
+            error_context="against the refreshed base branch",
+        )
+        if not changed_from_base:
+            return []
+
+        changed_from_base_set = set(changed_from_base)
+        sync_base_authored_paths = tuple(
+            path for path in changed_from_remote if path in changed_from_base_set
+        )
+        if not sync_base_authored_paths:
+            return []
+        return find_protected_quality_gate_changes(
+            changed_paths=sync_base_authored_paths,
+            owned_paths=owned_paths,
+        )
 
     async def _protected_scope_push_block(
         self,
@@ -4502,16 +4554,26 @@ class PullRequestMonitorRunner:
         worktree_path: Path,
         remote_branch: str,
         remote_push_url: str | None = None,
+        base_branch: str | None = None,
     ) -> _ProtectedScopePushBlock | None:
         if not worktree_path.exists():
             return None
         try:
-            violations = await self._protected_scope_violations_for_unpushed_commits(
-                workspace_id=workspace_id,
-                worktree_path=worktree_path,
-                remote_branch=remote_branch,
-                remote_push_url=remote_push_url,
-            )
+            if base_branch is None:
+                violations = await self._protected_scope_violations_for_unpushed_commits(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    remote_branch=remote_branch,
+                    remote_push_url=remote_push_url,
+                )
+            else:
+                violations = await self._protected_scope_violations_for_sync_base_push(
+                    workspace_id=workspace_id,
+                    worktree_path=worktree_path,
+                    remote_branch=remote_branch,
+                    base_branch=base_branch,
+                    remote_push_url=remote_push_url,
+                )
         except ProtectedScopeDiffError as exc:
             redacted_error = redact_audit_text(str(exc), limit=1000)
             message = (

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -95,6 +95,7 @@ from awf.runtime.pr_monitor import (
     SyncBase,
     WaitForCI,
     _agent_can_triage_review_comment,
+    _ci_transient_rerun_count,
     _ci_transient_rerun_state_key,
     _is_bot_author,
     _is_bot_review_thread,
@@ -335,6 +336,10 @@ class BaseBehindCountError(Exception):
     """Base-behind calculation failed; PR monitor must not assume zero."""
 
 
+class ProtectedScopeDiffError(Exception):
+    """Committed diff against the remote PR branch could not be verified."""
+
+
 @dataclass
 class _RunnerDeps:
     """All side-effect collaborators in one bag — easy to fake in tests."""
@@ -364,6 +369,7 @@ class _GitPushResult:
     stdout: str = ""
     stderr: str = ""
     recovered_by_resync: bool = False
+    reason_code: str = _GIT_PUSH_FAILED_REASON
 
     @property
     def error_message(self) -> str | None:
@@ -371,11 +377,16 @@ class _GitPushResult:
             return None
         return self.stderr.strip() or "<no output>"
 
+    @property
+    def protected_scope_blocked(self) -> bool:
+        return self.failed and self.reason_code == _PROTECTED_SCOPE_PUSH_BLOCKED_REASON
+
     def failure_evidence(self) -> dict[str, object]:
         evidence: dict[str, object] = {
             "operation": "git push",
             "returncode": self.returncode,
             "error_message": self.error_message or "<no output>",
+            "reason_code": self.reason_code,
         }
         if self.recovered_by_resync:
             evidence["recovered_by_resync"] = True
@@ -1482,12 +1493,17 @@ class PullRequestMonitorRunner:
             return False
 
         if isinstance(action, RerunTransientCI):
-            attempt = _ci_transient_rerun_attempt(
-                state,
-                head_sha=status.head_sha,
-                failures=action.failures,
+            attempt = (
+                _ci_transient_rerun_count(
+                    state,
+                    head_sha=status.head_sha,
+                    failures=action.failures,
+                )
+                + 1
             )
-            run_ids = tuple(dict.fromkeys(failure.run_id for failure in action.failures if failure.run_id))
+            run_ids = tuple(
+                dict.fromkeys(failure.run_id for failure in action.failures if failure.run_id)
+            )
             failures_payload = [_ci_failure_payload(failure) for failure in action.failures]
             operation = await self._begin_monitor_operation(
                 workspace_id=workspace_id,
@@ -1558,6 +1574,14 @@ class PullRequestMonitorRunner:
                 state.iter_count += 1
                 return False
 
+            recorded_attempt = _ci_transient_rerun_attempt(
+                state,
+                head_sha=status.head_sha,
+                failures=action.failures,
+            )
+            event_payload["attempt"] = recorded_attempt
+            await self._persist_state(workspace_id, state)
+
             await self._finish_monitor_operation(
                 operation,
                 status=OperationStatus.succeeded,
@@ -1587,6 +1611,25 @@ class PullRequestMonitorRunner:
                         payload=event_payload,
                     )
                 ],
+            )
+            await self._sleep_with_monitor_state_operation(
+                workspace_id=workspace_id,
+                action="ci_transient_rerun_wait",
+                requested_action="wait_for_rerun_rollup",
+                reason=(
+                    "GitHub accepted the failed-job rerun; waiting before the "
+                    "next PR status poll so the rollup can leave its stale "
+                    "failure snapshot."
+                ),
+                reason_code=_CI_TRANSIENT_RERUN_REASON,
+                pr_number=pr_number,
+                status=status,
+                base_branch=base_branch,
+                remote_branch=remote_branch,
+                wait_seconds=self._config.poll_interval_seconds,
+                monitor_log=monitor_log,
+                extra_payload=event_payload,
+                extra_identity=(attempt, *run_ids, "wait"),
             )
             state.iter_count += 1
             return False
@@ -1674,17 +1717,23 @@ class PullRequestMonitorRunner:
                 )
                 return True
             if push_result.failed:
+                reason_code = push_result.reason_code
+                outcome = (
+                    "protected_scope_push_blocked"
+                    if push_result.protected_scope_blocked
+                    else "git_push_failed"
+                )
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,
                     result={
                         "status": "failed",
-                        "outcome": "git_push_failed",
-                        "reason_code": _GIT_PUSH_FAILED_REASON,
+                        "outcome": outcome,
+                        "reason_code": reason_code,
                         "failure_count": len(action.failures),
                         "pushed": False,
                     },
-                    error_code=_GIT_PUSH_FAILED_REASON,
+                    error_code=reason_code,
                     error_message=push_result.error_message,
                 )
                 await self._record_pr_monitor_audit_event(
@@ -1692,7 +1741,7 @@ class PullRequestMonitorRunner:
                     event_type=_AUDIT_GIT_PUSH_EVENT,
                     action="ci_repair_push",
                     outcome="failed",
-                    reason_code=_GIT_PUSH_FAILED_REASON,
+                    reason_code=reason_code,
                     pr_number=pr_number,
                     status=status,
                     base_branch=base_branch,
@@ -1702,6 +1751,13 @@ class PullRequestMonitorRunner:
                     monitor_log=monitor_log,
                     evidence=push_result.failure_evidence(),
                 )
+                if push_result.protected_scope_blocked:
+                    await self._terminate_failed(
+                        workspace_id,
+                        message=push_result.error_message or _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                    )
+                    return True
                 state.iter_count += 1
                 return False
             await self._finish_monitor_operation(
@@ -1821,20 +1877,33 @@ class PullRequestMonitorRunner:
                 )
                 return True
             if push_result.failed:
+                reason_code = push_result.reason_code
+                outcome = (
+                    "protected_scope_push_blocked"
+                    if push_result.protected_scope_blocked
+                    else "git_push_failed"
+                )
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,
                     result={
                         "status": "failed",
-                        "outcome": "git_push_failed",
-                        "reason_code": _GIT_PUSH_FAILED_REASON,
+                        "outcome": outcome,
+                        "reason_code": reason_code,
                         "thread_count": len(action.threads),
                         "review_comment_count": len(action.review_comments),
                         "pushed": False,
                     },
-                    error_code=_GIT_PUSH_FAILED_REASON,
+                    error_code=reason_code,
                     error_message=push_result.error_message,
                 )
+                if push_result.protected_scope_blocked:
+                    await self._terminate_failed(
+                        workspace_id,
+                        message=push_result.error_message or _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                    )
+                    return True
                 state.iter_count += 1
                 return False
             await self._finish_monitor_operation(
@@ -3599,6 +3668,7 @@ class PullRequestMonitorRunner:
             workspace_id=workspace_id,
             worktree_path=worktree_path,
             remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
         )
         push_result = (
             _GitPushResult(
@@ -3606,6 +3676,7 @@ class PullRequestMonitorRunner:
                 failed=True,
                 returncode=1,
                 stderr=protected_scope_message,
+                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
             )
             if protected_scope_message is not None
             else await self._git_push_result(
@@ -3616,6 +3687,7 @@ class PullRequestMonitorRunner:
         )
         pushed_head_sha: str | None = None
         if push_result.failed:
+            reason_code = push_result.reason_code
             for item_id in publish_dependent_ids:
                 _clear_addressed_state_by_id(state, item_id)
             await self._record_pr_monitor_audit_event(
@@ -3623,7 +3695,7 @@ class PullRequestMonitorRunner:
                 event_type=_AUDIT_GIT_PUSH_EVENT,
                 action="comment_repair_push",
                 outcome="failed",
-                reason_code=_GIT_PUSH_FAILED_REASON,
+                reason_code=reason_code,
                 pr_number=pr_number,
                 status=None,
                 base_branch=base_branch or "",
@@ -4095,6 +4167,7 @@ class PullRequestMonitorRunner:
             workspace_id=workspace_id,
             worktree_path=self._worktrees_root / workspace_id,
             remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
         )
         if protected_scope_message is not None:
             return _GitPushResult(
@@ -4102,6 +4175,7 @@ class PullRequestMonitorRunner:
                 failed=True,
                 returncode=1,
                 stderr=protected_scope_message,
+                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
             )
         return await self._git_push_result(
             worktree_path=self._worktrees_root / workspace_id,
@@ -4308,16 +4382,21 @@ class PullRequestMonitorRunner:
         workspace_id: str,
         worktree_path: Path,
         remote_branch: str,
+        remote_push_url: str | None = None,
     ) -> list[QualityGateViolation]:
         async with self._deps.session_factory() as session:
             workspace = await WorkspaceRepository(session).get(workspace_id)
             if workspace is None:
-                return []
+                raise ProtectedScopeDiffError(
+                    f"Workspace row {workspace_id} disappeared; cannot load owned_paths "
+                    "for protected-scope validation."
+                )
             owned_paths = list(workspace.owned_paths)
 
         changed_paths = await self._changed_paths_since_remote_branch(
             worktree_path=worktree_path,
             remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
         )
         if not changed_paths:
             return []
@@ -4331,26 +4410,47 @@ class PullRequestMonitorRunner:
         *,
         worktree_path: Path,
         remote_branch: str,
+        remote_push_url: str | None = None,
     ) -> tuple[str, ...]:
-        for revision_range in (f"origin/{remote_branch}..HEAD", "@{upstream}..HEAD"):
-            result = await self._deps.runner.run(
-                [
-                    "git",
-                    "-C",
-                    str(worktree_path),
-                    "diff",
-                    "--name-only",
-                    revision_range,
-                    "--",
-                ]
+        remote = remote_push_url or "origin"
+        fetch_result = await self._deps.runner.run(
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "fetch",
+                remote,
+                f"refs/heads/{remote_branch}",
+            ]
+        )
+        if not fetch_result.ok:
+            raise ProtectedScopeDiffError(
+                "Could not resolve committed diff against the remote PR branch "
+                "for protected-scope validation: "
+                f"fetch refs/heads/{remote_branch} exit={fetch_result.returncode} "
+                f"stdout={fetch_result.stdout.strip() or '<empty>'} "
+                f"stderr={fetch_result.stderr.strip() or '<empty>'}"
             )
-            if result.ok:
-                return tuple(
-                    line.strip()
-                    for line in result.stdout.splitlines()
-                    if line.strip()
-                )
-        return ()
+        diff_result = await self._deps.runner.run(
+            [
+                "git",
+                "-C",
+                str(worktree_path),
+                "diff",
+                "--name-only",
+                "FETCH_HEAD..HEAD",
+                "--",
+            ]
+        )
+        if not diff_result.ok:
+            raise ProtectedScopeDiffError(
+                "Could not resolve committed diff against the remote PR branch "
+                "for protected-scope validation: "
+                f"diff FETCH_HEAD..HEAD exit={diff_result.returncode} "
+                f"stdout={diff_result.stdout.strip() or '<empty>'} "
+                f"stderr={diff_result.stderr.strip() or '<empty>'}"
+            )
+        return tuple(line.strip() for line in diff_result.stdout.splitlines() if line.strip())
 
     async def _protected_scope_push_block_message(
         self,
@@ -4358,14 +4458,39 @@ class PullRequestMonitorRunner:
         workspace_id: str,
         worktree_path: Path,
         remote_branch: str,
+        remote_push_url: str | None = None,
     ) -> str | None:
         if not worktree_path.exists():
             return None
-        violations = await self._protected_scope_violations_for_unpushed_commits(
-            workspace_id=workspace_id,
-            worktree_path=worktree_path,
-            remote_branch=remote_branch,
-        )
+        try:
+            violations = await self._protected_scope_violations_for_unpushed_commits(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                remote_branch=remote_branch,
+                remote_push_url=remote_push_url,
+            )
+        except ProtectedScopeDiffError as exc:
+            redacted_error = redact_audit_text(str(exc), limit=1000)
+            message = (
+                "AWF could not verify protected-scope changes before push; "
+                "refusing to push this repair until the PR branch diff baseline "
+                f"is available. {redacted_error}"
+            )
+            await self._append_workspace_events(
+                workspace_id=workspace_id,
+                events=[
+                    WorkspaceEventCreate(
+                        event_type="workspace.monitor_protected_scope_push_blocked",
+                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        payload={
+                            "reason": "diff_baseline_unavailable",
+                            "remote_branch": remote_branch,
+                            "error": redacted_error,
+                        },
+                    )
+                ],
+            )
+            return message
         if not violations:
             return None
         message = quality_gate_violation_message(violations)

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -4647,10 +4647,15 @@ class PullRequestMonitorRunner:
                 f"Could not refresh the base branch for protected-scope validation: {exc}"
             ) from exc
 
-        changed_from_base = await self._changed_paths_between_ref_and_head(
+        merged_base = await self._merge_base_with_head(
             worktree_path=worktree_path,
             ref=f"origin/{base_branch}",
-            error_context="against the refreshed base branch",
+            error_context="against the merged base branch",
+        )
+        changed_from_base = await self._changed_paths_between_ref_and_head(
+            worktree_path=worktree_path,
+            ref=merged_base,
+            error_context="against the merged base commit",
         )
         if not changed_from_base:
             return []

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -4537,6 +4537,17 @@ class PullRequestMonitorRunner:
         if not changed_from_remote:
             return []
 
+        try:
+            await self._fetch_base(
+                workspace_id=workspace_id,
+                worktree_path=worktree_path,
+                base_branch=base_branch,
+            )
+        except BaseFetchError as exc:
+            raise ProtectedScopeDiffError(
+                f"Could not refresh the base branch for protected-scope validation: {exc}"
+            ) from exc
+
         changed_from_base = await self._changed_paths_between_ref_and_head(
             worktree_path=worktree_path,
             ref=f"origin/{base_branch}",

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1549,17 +1549,17 @@ class PullRequestMonitorRunner:
                 "run_ids": list(run_ids),
                 "head_sha": status.head_sha,
             }
+            recorded_attempt = _ci_transient_rerun_attempt(
+                state,
+                head_sha=status.head_sha,
+                failures=action.failures,
+            )
+            event_payload["attempt"] = recorded_attempt
+            await self._persist_state(workspace_id, state)
             try:
                 for run_id in run_ids:
                     await self._deps.gh.rerun_failed_workflow_jobs(repo=repo, run_id=run_id)
             except GitHubClientError as exc:
-                recorded_attempt = _ci_transient_rerun_attempt(
-                    state,
-                    head_sha=status.head_sha,
-                    failures=action.failures,
-                )
-                event_payload["attempt"] = recorded_attempt
-                await self._persist_state(workspace_id, state)
                 error_message = _redact_and_truncate_github_error(str(exc))
                 await self._finish_monitor_operation(
                     operation,
@@ -1596,14 +1596,6 @@ class PullRequestMonitorRunner:
                 )
                 state.iter_count += 1
                 return False
-
-            recorded_attempt = _ci_transient_rerun_attempt(
-                state,
-                head_sha=status.head_sha,
-                failures=action.failures,
-            )
-            event_payload["attempt"] = recorded_attempt
-            await self._persist_state(workspace_id, state)
 
             await self._finish_monitor_operation(
                 operation,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1588,11 +1588,83 @@ class PullRequestMonitorRunner:
             )
             event_payload["attempt"] = recorded_attempt
             await self._persist_state(workspace_id, state)
+            accepted_run_ids: list[str] = []
+            failed_run_id: str | None = None
             try:
                 for run_id in run_ids:
-                    await self._deps.gh.rerun_failed_workflow_jobs(repo=repo, run_id=run_id)
+                    try:
+                        await self._deps.gh.rerun_failed_workflow_jobs(repo=repo, run_id=run_id)
+                    except GitHubClientError:
+                        failed_run_id = run_id
+                        raise
+                    accepted_run_ids.append(run_id)
             except GitHubClientError as exc:
                 error_message = _redact_and_truncate_github_error(str(exc))
+                if accepted_run_ids:
+                    partial_event_payload = {
+                        **event_payload,
+                        "accepted_run_ids": accepted_run_ids,
+                        "failed_run_id": failed_run_id,
+                        "error": error_message,
+                    }
+                    await self._finish_monitor_operation(
+                        operation,
+                        status=OperationStatus.succeeded,
+                        result={
+                            "status": "succeeded",
+                            "outcome": "ci_transient_rerun_partially_requested",
+                            "reason_code": _CI_TRANSIENT_RERUN_REASON,
+                            **partial_event_payload,
+                        },
+                    )
+                    await self._write_monitor_log(
+                        monitor_log,
+                        {
+                            "event": "monitor.ci_transient_rerun_partially_requested",
+                            "workspace_id": workspace_id,
+                            "pr_number": pr_number,
+                            "reason_code": _CI_TRANSIENT_RERUN_REASON,
+                            **partial_event_payload,
+                        },
+                    )
+                    await self._append_workspace_events(
+                        workspace_id=workspace_id,
+                        events=[
+                            WorkspaceEventCreate(
+                                event_type=(
+                                    "workspace.monitor_ci_transient_rerun_partially_requested"
+                                ),
+                                reason_code=_CI_TRANSIENT_RERUN_REASON,
+                                payload=partial_event_payload,
+                            )
+                        ],
+                    )
+                    await self._sleep_with_monitor_state_operation(
+                        workspace_id=workspace_id,
+                        action="ci_transient_rerun_wait",
+                        requested_action="wait_for_rerun_rollup",
+                        reason=(
+                            "GitHub accepted at least one failed-job rerun; "
+                            "waiting before the next PR status poll so the "
+                            "rollup can leave its stale failure snapshot."
+                        ),
+                        reason_code=_CI_TRANSIENT_RERUN_REASON,
+                        pr_number=pr_number,
+                        status=status,
+                        base_branch=base_branch,
+                        remote_branch=remote_branch,
+                        wait_seconds=self._config.poll_interval_seconds,
+                        monitor_log=monitor_log,
+                        extra_payload=partial_event_payload,
+                        extra_identity=(
+                            rerun_signature,
+                            attempt,
+                            *accepted_run_ids,
+                            "partial_wait",
+                        ),
+                    )
+                    state.iter_count += 1
+                    return False
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -4106,6 +4106,20 @@ class PullRequestMonitorRunner:
                 )
 
         # Whether or not we hit conflicts, push what we have.
+        protected_scope_message = await self._protected_scope_push_block_message(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            remote_branch=remote_branch,
+            remote_push_url=remote_push_url,
+        )
+        if protected_scope_message is not None:
+            return _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=1,
+                stderr=protected_scope_message,
+                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+            )
         return await self._git_push_result(
             worktree_path=worktree_path,
             remote_branch=remote_branch,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -240,6 +240,7 @@ _CI_TRANSIENT_RERUN_REASON = "CI_TRANSIENT_RERUN"
 _CI_TRANSIENT_RERUN_FAILED_REASON = "CI_TRANSIENT_RERUN_FAILED"
 _PROTECTED_SCOPE_REPAIR_FAILED_REASON = "PROTECTED_SCOPE_REPAIR_FAILED"
 _PROTECTED_SCOPE_PUSH_BLOCKED_REASON = "PROTECTED_SCOPE_PUSH_BLOCKED"
+_PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON = "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
 _VALIDATION_INSUFFICIENT_STALE_REASON = "validation_insufficient_tier"
 _RECOVERY_SNAPSHOT_ALREADY_HANDLED_REASON = "RECOVERY_SNAPSHOT_ALREADY_HANDLED"
 _AUDIT_GIT_PUSH_EVENT = "workspace.audit.git_push"
@@ -379,7 +380,14 @@ class _GitPushResult:
 
     @property
     def protected_scope_blocked(self) -> bool:
-        return self.failed and self.reason_code == _PROTECTED_SCOPE_PUSH_BLOCKED_REASON
+        return self.failed and self.reason_code in {
+            _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+            _PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON,
+        }
+
+    @property
+    def protected_scope_diff_unavailable(self) -> bool:
+        return self.failed and self.reason_code == _PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON
 
     def failure_evidence(self) -> dict[str, object]:
         evidence: dict[str, object] = {
@@ -391,6 +399,20 @@ class _GitPushResult:
         if self.recovered_by_resync:
             evidence["recovered_by_resync"] = True
         return evidence
+
+
+@dataclass(frozen=True)
+class _ProtectedScopePushBlock:
+    message: str
+    reason_code: str
+
+
+def _git_push_failure_outcome(push_result: _GitPushResult) -> str:
+    if push_result.protected_scope_diff_unavailable:
+        return "protected_scope_diff_unavailable"
+    if push_result.protected_scope_blocked:
+        return "protected_scope_push_blocked"
+    return "git_push_failed"
 
 
 @dataclass(frozen=True)
@@ -1733,11 +1755,7 @@ class PullRequestMonitorRunner:
                 return True
             if push_result.failed:
                 reason_code = push_result.reason_code
-                outcome = (
-                    "protected_scope_push_blocked"
-                    if push_result.protected_scope_blocked
-                    else "git_push_failed"
-                )
+                outcome = _git_push_failure_outcome(push_result)
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,
@@ -1769,8 +1787,8 @@ class PullRequestMonitorRunner:
                 if push_result.protected_scope_blocked:
                     await self._terminate_failed(
                         workspace_id,
-                        message=push_result.error_message or _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
-                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        message=push_result.error_message or push_result.reason_code,
+                        reason_code=push_result.reason_code,
                     )
                     return True
                 state.iter_count += 1
@@ -1893,11 +1911,7 @@ class PullRequestMonitorRunner:
                 return True
             if push_result.failed:
                 reason_code = push_result.reason_code
-                outcome = (
-                    "protected_scope_push_blocked"
-                    if push_result.protected_scope_blocked
-                    else "git_push_failed"
-                )
+                outcome = _git_push_failure_outcome(push_result)
                 await self._finish_monitor_operation(
                     operation,
                     status=OperationStatus.failed,
@@ -1915,8 +1929,8 @@ class PullRequestMonitorRunner:
                 if push_result.protected_scope_blocked:
                     await self._terminate_failed(
                         workspace_id,
-                        message=push_result.error_message or _PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
-                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        message=push_result.error_message or push_result.reason_code,
+                        reason_code=push_result.reason_code,
                     )
                     return True
                 state.iter_count += 1
@@ -3679,7 +3693,7 @@ class PullRequestMonitorRunner:
 
         # 3) Push everything we committed.
         worktree_path = self._worktrees_root / workspace_id
-        protected_scope_message = await self._protected_scope_push_block_message(
+        protected_scope_block = await self._protected_scope_push_block(
             workspace_id=workspace_id,
             worktree_path=worktree_path,
             remote_branch=remote_branch,
@@ -3690,10 +3704,10 @@ class PullRequestMonitorRunner:
                 pushed=False,
                 failed=True,
                 returncode=1,
-                stderr=protected_scope_message,
-                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                stderr=protected_scope_block.message,
+                reason_code=protected_scope_block.reason_code,
             )
-            if protected_scope_message is not None
+            if protected_scope_block is not None
             else await self._git_push_result(
                 worktree_path=worktree_path,
                 remote_branch=remote_branch,
@@ -4106,19 +4120,19 @@ class PullRequestMonitorRunner:
                 )
 
         # Whether or not we hit conflicts, push what we have.
-        protected_scope_message = await self._protected_scope_push_block_message(
+        protected_scope_block = await self._protected_scope_push_block(
             workspace_id=workspace_id,
             worktree_path=worktree_path,
             remote_branch=remote_branch,
             remote_push_url=remote_push_url,
         )
-        if protected_scope_message is not None:
+        if protected_scope_block is not None:
             return _GitPushResult(
                 pushed=False,
                 failed=True,
                 returncode=1,
-                stderr=protected_scope_message,
-                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                stderr=protected_scope_block.message,
+                reason_code=protected_scope_block.reason_code,
             )
         return await self._git_push_result(
             worktree_path=worktree_path,
@@ -4192,19 +4206,19 @@ class PullRequestMonitorRunner:
                 workspace_id=workspace_id,
                 stderr=agent_run_err.result.stderr[:400],
             )
-        protected_scope_message = await self._protected_scope_push_block_message(
+        protected_scope_block = await self._protected_scope_push_block(
             workspace_id=workspace_id,
             worktree_path=self._worktrees_root / workspace_id,
             remote_branch=remote_branch,
             remote_push_url=remote_push_url,
         )
-        if protected_scope_message is not None:
+        if protected_scope_block is not None:
             return _GitPushResult(
                 pushed=False,
                 failed=True,
                 returncode=1,
-                stderr=protected_scope_message,
-                reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                stderr=protected_scope_block.message,
+                reason_code=protected_scope_block.reason_code,
             )
         return await self._git_push_result(
             worktree_path=self._worktrees_root / workspace_id,
@@ -4481,14 +4495,14 @@ class PullRequestMonitorRunner:
             )
         return tuple(line.strip() for line in diff_result.stdout.splitlines() if line.strip())
 
-    async def _protected_scope_push_block_message(
+    async def _protected_scope_push_block(
         self,
         *,
         workspace_id: str,
         worktree_path: Path,
         remote_branch: str,
         remote_push_url: str | None = None,
-    ) -> str | None:
+    ) -> _ProtectedScopePushBlock | None:
         if not worktree_path.exists():
             return None
         try:
@@ -4510,7 +4524,7 @@ class PullRequestMonitorRunner:
                 events=[
                     WorkspaceEventCreate(
                         event_type="workspace.monitor_protected_scope_push_blocked",
-                        reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+                        reason_code=_PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON,
                         payload={
                             "reason": "diff_baseline_unavailable",
                             "remote_branch": remote_branch,
@@ -4519,7 +4533,10 @@ class PullRequestMonitorRunner:
                     )
                 ],
             )
-            return message
+            return _ProtectedScopePushBlock(
+                message=message,
+                reason_code=_PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON,
+            )
         if not violations:
             return None
         message = quality_gate_violation_message(violations)
@@ -4539,7 +4556,10 @@ class PullRequestMonitorRunner:
                 )
             ],
         )
-        return message
+        return _ProtectedScopePushBlock(
+            message=message,
+            reason_code=_PROTECTED_SCOPE_PUSH_BLOCKED_REASON,
+        )
 
     async def _protected_scope_repair_prompt(
         self,

--- a/src/awf/service/doctor/reasons.py
+++ b/src/awf/service/doctor/reasons.py
@@ -199,6 +199,22 @@ _REASON_TEXT: dict[str, _ReasonText] = {
         "awf workspace remonitor <workspace_id>",
         "docs/REASON_CATALOG.md#git_base_fetch_transient_retry_exhausted",
     ),
+    "CI_TRANSIENT_RERUN_FAILED": _ReasonText(
+        (
+            "AWF could not request a GitHub rerun for CI failures classified "
+            "as transient infrastructure failures."
+        ),
+        (
+            "Verify `gh run rerun <run_id> --failed` works with the AWF "
+            "GitHub token, then remonitor the workspace if the failure was transient."
+        ),
+        (
+            "GitHub rejected the rerun request, the workflow run no longer "
+            "exists, or the token lacks permission to rerun workflow jobs."
+        ),
+        "gh run rerun <run_id> --failed",
+        "docs/REASON_CATALOG.md#ci_transient_rerun_failed",
+    ),
     "CODEX_AUTH_MISSING": _ReasonText(
         "No Codex auth signal was visible.",
         "Mount ~/.codex or set OPENAI_API_KEY, OPENAI_API_TOKEN, CODEX_API_KEY, or CODEX_AUTH_TOKEN.",

--- a/src/awf/service/doctor/reasons.py
+++ b/src/awf/service/doctor/reasons.py
@@ -215,6 +215,38 @@ _REASON_TEXT: dict[str, _ReasonText] = {
         "gh run rerun <run_id> --failed",
         "docs/REASON_CATALOG.md#ci_transient_rerun_failed",
     ),
+    "PROTECTED_SCOPE_DIFF_UNAVAILABLE": _ReasonText(
+        (
+            "The PR monitor could not verify protected-scope changes against "
+            "the remote PR branch before push."
+        ),
+        (
+            "Verify GitHub/network access and the PR branch ref, then remonitor "
+            "the workspace once the remote branch is reachable."
+        ),
+        (
+            "The PR branch diff baseline could not be fetched because of a "
+            "GitHub/network failure, a missing remote ref, or delayed ref replication."
+        ),
+        "awf workspace remonitor <workspace_id>",
+        "docs/REASON_CATALOG.md#protected_scope_diff_unavailable",
+    ),
+    "PROTECTED_SCOPE_PUSH_BLOCKED": _ReasonText(
+        (
+            "The PR monitor refused to push because committed changes touched "
+            "protected quality-gate paths outside the workspace owned paths."
+        ),
+        (
+            "Inspect the blocked paths in the monitor event, remove or revert the "
+            "out-of-scope quality-gate changes, then remonitor the workspace."
+        ),
+        (
+            "A CI-fix, sync-base, or comment-addressing push included protected "
+            "quality-gate files that the workspace profile does not own."
+        ),
+        "awf workspace logs <workspace_id>",
+        "docs/REASON_CATALOG.md#protected_scope_push_blocked",
+    ),
     "CODEX_AUTH_MISSING": _ReasonText(
         "No Codex auth signal was visible.",
         "Mount ~/.codex or set OPENAI_API_KEY, OPENAI_API_TOKEN, CODEX_API_KEY, or CODEX_AUTH_TOKEN.",

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -1753,6 +1753,7 @@ class TestFetchFailingCheckLogs:
         assert len(failures) == 2
         names = {f.name for f in failures}
         assert names == {"playwright", "unit-tests"}
+        assert {f.run_id for f in failures} == {"2", "3"}
         for f in failures:
             if f.name == "playwright":
                 # Truncated to ~200 chars + prefix marker.
@@ -1818,6 +1819,41 @@ class TestFetchFailingCheckLogs:
 
         assert failures == ()
         assert len(fake.calls) == 1
+
+    @pytest.mark.unit
+    async def test_reruns_failed_jobs_for_workflow_run(self) -> None:
+        fake = FakeCommandRunner()
+        client = GitHubClient(fake)
+
+        await client.rerun_failed_workflow_jobs(
+            repo=RepoRef(owner="o", name="r"),
+            run_id="25655330295",
+        )
+
+        assert fake.calls[0].args == [
+            "gh",
+            "run",
+            "rerun",
+            "25655330295",
+            "--repo",
+            "o/r",
+            "--failed",
+        ]
+
+    @pytest.mark.unit
+    async def test_rerun_failed_jobs_raises_client_error_on_gh_failure(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=1, stderr="HTTP 403")
+        client = GitHubClient(fake)
+
+        with pytest.raises(GitHubClientError) as exc_info:
+            await client.rerun_failed_workflow_jobs(
+                repo=RepoRef(owner="o", name="r"),
+                run_id="25655330295",
+            )
+
+        assert exc_info.value.operation == "rerun_failed_workflow_jobs"
+        assert exc_info.value.stderr == "HTTP 403"
 
 
 # ── resolve_thread / post_comment / merge_pr ───────────────────────────────

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -1789,6 +1789,33 @@ class TestFetchFailingCheckLogs:
         assert failures[0].log_excerpt == ""
 
     @pytest.mark.unit
+    async def test_missing_run_database_id_stays_nullable(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": None,
+                        "name": "lint-and-type",
+                        "conclusion": "FAILURE",
+                        "status": "completed",
+                    }
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
+        )
+
+        assert len(failures) == 1
+        assert failures[0].run_id is None
+        assert failures[0].log_excerpt == ""
+        assert len(fake.calls) == 1
+
+    @pytest.mark.unit
     async def test_ignores_non_failure_runs(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -1816,6 +1816,34 @@ class TestFetchFailingCheckLogs:
         assert len(fake.calls) == 1
 
     @pytest.mark.unit
+    async def test_missing_run_database_id_and_name_uses_unknown_fallback(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": None,
+                        "name": None,
+                        "conclusion": "FAILURE",
+                        "status": "completed",
+                    }
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
+        )
+
+        assert len(failures) == 1
+        assert failures[0].name == "run/unknown"
+        assert failures[0].run_id is None
+        assert failures[0].log_excerpt == ""
+        assert len(fake.calls) == 1
+
+    @pytest.mark.unit
     async def test_ignores_non_failure_runs(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -967,6 +967,7 @@ class TestMonitorDirtyWorktreeSalvage:
         cmd.queue_result(returncode=0)  # git commit
         cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
         cmd.queue_result(returncode=0)  # fetch remote branch for committed diff
+        cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
         cmd.queue_result(returncode=0, stdout="src/foo.py\n")  # pre-push protected-scope diff
         cmd.queue_result(returncode=0)  # push
         cmd.queue_result(returncode=0, stdout="head2\n")  # rev-parse
@@ -1053,6 +1054,7 @@ class TestMonitorDirtyWorktreeSalvage:
         cmd.queue_result(returncode=0)  # git commit
         cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
         cmd.queue_result(returncode=0)  # fetch remote branch for committed diff
+        cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
         cmd.queue_result(
             returncode=0,
             stdout="tests/integration/test_workspace_agent_git_in_workspace.py\n",

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -966,6 +966,7 @@ class TestMonitorDirtyWorktreeSalvage:
         cmd.queue_result(returncode=1)  # git diff --cached --quiet
         cmd.queue_result(returncode=0)  # git commit
         cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
+        cmd.queue_result(returncode=0, stdout="src/foo.py\n")  # pre-push protected-scope diff
         cmd.queue_result(returncode=0)  # push
         cmd.queue_result(returncode=0, stdout="head2\n")  # rev-parse
         cmd.queue_result(returncode=0, stdout=json.dumps({"data": {}}))  # resolve thread

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -966,6 +966,7 @@ class TestMonitorDirtyWorktreeSalvage:
         cmd.queue_result(returncode=1)  # git diff --cached --quiet
         cmd.queue_result(returncode=0)  # git commit
         cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
+        cmd.queue_result(returncode=0)  # fetch remote branch for committed diff
         cmd.queue_result(returncode=0, stdout="src/foo.py\n")  # pre-push protected-scope diff
         cmd.queue_result(returncode=0)  # push
         cmd.queue_result(returncode=0, stdout="head2\n")  # rev-parse
@@ -1051,6 +1052,11 @@ class TestMonitorDirtyWorktreeSalvage:
         cmd.queue_result(returncode=1)  # git diff --cached --quiet
         cmd.queue_result(returncode=0)  # git commit
         cmd.queue_result(returncode=0, stdout=pr_payload())  # settle fetch
+        cmd.queue_result(returncode=0)  # fetch remote branch for committed diff
+        cmd.queue_result(
+            returncode=0,
+            stdout="tests/integration/test_workspace_agent_git_in_workspace.py\n",
+        )  # pre-push protected-scope diff
         cmd.queue_result(returncode=0)  # push
         cmd.queue_result(returncode=0, stdout="head2\n")  # rev-parse
         cmd.queue_result(returncode=0, stdout=json.dumps({"data": {}}))  # resolve thread

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -602,6 +602,24 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
+    def test_infra_assert_log_does_not_mask_transient_ci_rerun(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt="assert passed while reconnecting runner\nHTTP 502 Bad Gateway",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
     def test_transient_rerun_helper_rejects_empty_failure_snapshot(self) -> None:
         assert not _should_rerun_transient_ci(
             _status(check_state=CheckState.FAILURE, ci_failures=()),

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -461,7 +461,7 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
-    def test_timed_out_failure_without_logs_dispatches_rerun(self) -> None:
+    def test_timed_out_failure_without_log_marker_dispatches_agent_repair(self) -> None:
         failure = CheckFailure(
             name="python-full-coverage",
             conclusion="TIMED_OUT",
@@ -475,7 +475,7 @@ class TestCiFailure:
             MonitorConfig(),
         )
 
-        assert isinstance(action, RerunTransientCI)
+        assert isinstance(action, ReportCiFailure)
         assert action.failures == (failure,)
 
     @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -421,6 +421,73 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
+    def test_transient_tool_download_failure_dispatches_rerun(self) -> None:
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion="FAILURE",
+            log_excerpt=(
+                "Install tools\n"
+                "Failed to download ruff from PyPI\n"
+                "curl: (56) Recv failure: Connection reset by peer"
+            ),
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_tool_diagnostics_still_dispatch_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="lint-and-type",
+            conclusion="FAILURE",
+            log_excerpt=(
+                "Would reformat: src/awf/runtime/pr_monitor_runner.py\n"
+                "src/awf/runtime/pr_monitor.py:12: error: Incompatible types [assignment]"
+            ),
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_rerun_state_key_uses_structured_failure_signature(self) -> None:
+        left = (
+            CheckFailure(
+                name="lint:type",
+                conclusion="FAILURE",
+                log_excerpt="HTTP 502",
+                run_id="run",
+            ),
+        )
+        right = (
+            CheckFailure(
+                name="type",
+                conclusion="FAILURE",
+                log_excerpt="HTTP 502",
+                run_id="run:lint",
+            ),
+        )
+
+        assert _ci_transient_rerun_state_key("head", left) != _ci_transient_rerun_state_key(
+            "head",
+            right,
+        )
+
+    @pytest.mark.unit
     def test_transient_failure_falls_back_to_agent_after_rerun_budget(self) -> None:
         failure = CheckFailure(
             name="CI",

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -443,6 +443,28 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("conclusion", ["CANCELLED", "ACTION_REQUIRED"])
+    def test_transient_non_failed_job_conclusions_dispatch_agent_repair(
+        self,
+        conclusion: str,
+    ) -> None:
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion=conclusion,
+            log_excerpt="runner has received a shutdown signal",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
     def test_tool_diagnostics_still_dispatch_agent_repair(self) -> None:
         failure = CheckFailure(
             name="lint-and-type",

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -443,6 +443,24 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
+    def test_transient_failure_with_code_like_check_name_dispatches_rerun(self) -> None:
+        failure = CheckFailure(
+            name="TypeCheck / ubuntu-latest",
+            conclusion="FAILURE",
+            log_excerpt="runner has received a shutdown signal",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
     def test_timed_out_failure_without_logs_dispatches_rerun(self) -> None:
         failure = CheckFailure(
             name="python-full-coverage",

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -461,12 +461,30 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
-    def test_timed_out_failure_without_log_marker_dispatches_agent_repair(self) -> None:
+    def test_timed_out_failure_without_logs_dispatches_rerun(self) -> None:
         failure = CheckFailure(
             name="python-full-coverage",
             conclusion="TIMED_OUT",
             log_excerpt="",
             run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_timed_out_failure_without_logs_or_run_id_dispatches_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion="TIMED_OUT",
+            log_excerpt="",
+            run_id=None,
         )
 
         action = decide(

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -20,14 +20,17 @@ from awf.runtime.pr_monitor import (
     NotifyHuman,
     PRStatus,
     ReportCiFailure,
+    RerunTransientCI,
     ReviewComment,
     ReviewThread,
     ReviewThreadComment,
     ShortCircuitCompleted,
     SyncBase,
     WaitForCI,
+    _ci_transient_rerun_state_key,
     _mark_review_thread_addressed,
     _review_thread_needs_attention,
+    _should_rerun_transient_ci,
     decide,
 )
 
@@ -395,6 +398,127 @@ class TestAddressComments:
 
 
 class TestCiFailure:
+    @pytest.mark.unit
+    def test_transient_failure_dispatches_rerun_before_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt=(
+                "Set up Python\n"
+                "error: Failed to download cpython-3.12.9\n"
+                "HTTP status server error (502 Bad Gateway)"
+            ),
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_transient_failure_falls_back_to_agent_after_rerun_budget(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt="curl: (56) Recv failure: Connection reset by peer",
+            run_id="25655330295",
+        )
+        status = _status(check_state=CheckState.FAILURE, ci_failures=(failure,))
+        state = MonitorState()
+        state.threads_addressed_ids[
+            _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+        ] = "2"
+
+        action = decide(status, state, MonitorConfig(ci_transient_rerun_max_attempts=2))
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_transient_failure_with_disabled_rerun_budget_dispatches_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt="HTTP status server error (503 Service Unavailable)",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(ci_transient_rerun_max_attempts=0),
+        )
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_transient_failure_corrupt_rerun_count_is_treated_as_zero(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt="curl: (56) Recv failure: Connection reset by peer",
+            run_id="25655330295",
+        )
+        status = _status(check_state=CheckState.FAILURE, ci_failures=(failure,))
+        state = MonitorState()
+        state.threads_addressed_ids[
+            _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+        ] = "not-an-int"
+
+        action = decide(status, state, MonitorConfig())
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_transient_rerun_helper_rejects_empty_failure_snapshot(self) -> None:
+        assert not _should_rerun_transient_ci(
+            _status(check_state=CheckState.FAILURE, ci_failures=()),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+    @pytest.mark.unit
+    def test_transient_failure_without_run_id_dispatches_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="CI",
+            conclusion="FAILURE",
+            log_excerpt="HTTP status server error (502 Bad Gateway)",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    def test_code_like_failure_still_dispatches_agent_repair(self) -> None:
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion="FAILURE",
+            log_excerpt="FAILED tests/unit/test_thing.py::test_case - AssertionError",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
     @pytest.mark.unit
     def test_failure_with_per_check_details(self) -> None:
         failure = CheckFailure(

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -443,6 +443,24 @@ class TestCiFailure:
         assert action.failures == (failure,)
 
     @pytest.mark.unit
+    def test_timed_out_failure_without_logs_dispatches_rerun(self) -> None:
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion="TIMED_OUT",
+            log_excerpt="",
+            run_id="25655330295",
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, RerunTransientCI)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
     @pytest.mark.parametrize("conclusion", ["CANCELLED", "ACTION_REQUIRED"])
     def test_transient_non_failed_job_conclusions_dispatch_agent_repair(
         self,

--- a/tests/unit/runtime/test_pr_monitor.py
+++ b/tests/unit/runtime/test_pr_monitor.py
@@ -628,11 +628,16 @@ class TestCiFailure:
         )
 
     @pytest.mark.unit
-    def test_transient_failure_without_run_id_dispatches_agent_repair(self) -> None:
+    @pytest.mark.parametrize("run_id", [None, ""])
+    def test_transient_failure_without_run_id_dispatches_agent_repair(
+        self,
+        run_id: str | None,
+    ) -> None:
         failure = CheckFailure(
             name="CI",
             conclusion="FAILURE",
             log_excerpt="HTTP status server error (502 Bad Gateway)",
+            run_id=run_id,
         )
 
         action = decide(

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -587,6 +587,94 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
 
 
 @pytest.mark.unit
+async def test_rerun_transient_ci_waits_after_partial_rerun_acceptance(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=1, stderr="HTTP 502: try again")
+    adapter = FakeAdapter()
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    first_failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    second_failure = CheckFailure(
+        name="console-build",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330301",
+    )
+    status = _status(
+        check_state=CheckState.FAILURE,
+        ci_failures=(first_failure, second_failure),
+        head_sha="abc1234567890def",
+    )
+    state_key = _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=RerunTransientCI(failures=(first_failure, second_failure)),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert adapter.calls == []
+    assert state.iter_count == 1
+    assert state.threads_addressed_ids[state_key] == "1"
+    assert [call.args[3] for call in cmd.calls] == ["25655330295", "25655330301"]
+    assert sleep_fn.calls == [60]
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        partial_events = [
+            event
+            for event in workspace.events
+            if event.event_type == "workspace.monitor_ci_transient_rerun_partially_requested"
+        ]
+        assert len(partial_events) == 1
+        assert partial_events[0].reason_code == "CI_TRANSIENT_RERUN"
+        assert partial_events[0].payload is not None
+        assert partial_events[0].payload["run_ids"] == ["25655330295", "25655330301"]
+        assert partial_events[0].payload["accepted_run_ids"] == ["25655330295"]
+        assert partial_events[0].payload["failed_run_id"] == "25655330301"
+        assert "try again" in partial_events[0].payload["error"]
+        failed_events = [
+            event
+            for event in workspace.events
+            if event.event_type == "workspace.monitor_ci_transient_rerun_failed"
+        ]
+        assert failed_events == []
+        operations = list((await session.execute(select(Operation))).scalars())
+        rerun_operations = [
+            op for op in operations if (op.payload or {}).get("action") == "ci_transient_rerun"
+        ]
+        assert len(rerun_operations) == 1
+        assert rerun_operations[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
 async def test_rerun_transient_ci_without_run_ids_dispatches_agent_repair(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -364,6 +364,87 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
 
 
 @pytest.mark.unit
+async def test_rerun_transient_ci_operation_identity_includes_failure_signature(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    head_sha = "abc1234567890def"
+    first_failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    second_failure = CheckFailure(
+        name="console-build",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    state = MonitorState()
+
+    for failure in (first_failure, second_failure):
+        terminal = await runner._execute(
+            action=RerunTransientCI(failures=(failure,)),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=_status(
+                check_state=CheckState.FAILURE,
+                ci_failures=(failure,),
+                head_sha=head_sha,
+            ),
+            state=state,
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+
+        assert terminal is False
+
+    first_state_key = _ci_transient_rerun_state_key(head_sha, (first_failure,))
+    second_state_key = _ci_transient_rerun_state_key(head_sha, (second_failure,))
+    assert state.threads_addressed_ids[first_state_key] == "1"
+    assert state.threads_addressed_ids[second_state_key] == "1"
+    assert [call.args[3] for call in cmd.calls] == ["25655330295", "25655330295"]
+    assert sleep_fn.calls == [60, 60]
+
+    async with factory() as session:
+        operations = list((await session.execute(select(Operation))).scalars())
+
+    rerun_operations = [
+        op for op in operations if (op.payload or {}).get("action") == "ci_transient_rerun"
+    ]
+    wait_operations = [
+        op for op in operations if (op.payload or {}).get("action") == "ci_transient_rerun_wait"
+    ]
+
+    assert len(rerun_operations) == 2
+    assert len(wait_operations) == 2
+    assert {op.idempotency_key for op in rerun_operations} != {None}
+    assert len({op.idempotency_key for op in rerun_operations}) == 2
+    assert len({op.idempotency_key for op in wait_operations}) == 2
+    assert {
+        tuple(failure_payload["name"] for failure_payload in (op.payload or {})["failures"])
+        for op in rerun_operations
+    } == {("python-full-coverage",), ("console-build",)}
+
+
+@pytest.mark.unit
 async def test_rerun_transient_ci_action_persists_attempt_before_github_rerun(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -356,7 +356,9 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
         assert events[0].payload is not None
         assert events[0].payload["run_ids"] == ["25655330295"]
         operations = list((await session.execute(select(Operation))).scalars())
-        rerun_operations = [op for op in operations if op.payload["action"] == "ci_transient_rerun"]
+        rerun_operations = [
+            op for op in operations if (op.payload or {}).get("action") == "ci_transient_rerun"
+        ]
         assert len(rerun_operations) == 1
         assert rerun_operations[0].status == OperationStatus.succeeded.value
 
@@ -495,7 +497,9 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
         assert events[0].payload["run_ids"] == ["25655330295"]
         assert "workflow scope required" in events[0].payload["error"]
         operations = list((await session.execute(select(Operation))).scalars())
-        rerun_operations = [op for op in operations if op.payload["action"] == "ci_transient_rerun"]
+        rerun_operations = [
+            op for op in operations if (op.payload or {}).get("action") == "ci_transient_rerun"
+        ]
         assert len(rerun_operations) == 1
         assert rerun_operations[0].status == OperationStatus.failed.value
         assert rerun_operations[0].error_code == "CI_TRANSIENT_RERUN_FAILED"
@@ -558,7 +562,7 @@ async def test_rerun_transient_ci_without_run_ids_dispatches_agent_repair(
     assert state_key not in state.threads_addressed_ids
     async with factory() as session:
         operations = list((await session.execute(select(Operation))).scalars())
-    assert [op.payload["action"] for op in operations] == ["ci_repair"]
+    assert [(op.payload or {}).get("action") for op in operations] == ["ci_repair"]
     assert operations[0].status == OperationStatus.succeeded.value
 
 

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -410,6 +410,67 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
 
 
 @pytest.mark.unit
+async def test_rerun_transient_ci_without_run_ids_dispatches_agent_repair(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    cmd = FakeCommandRunner()
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+    )
+    status = _status(
+        check_state=CheckState.FAILURE,
+        ci_failures=(failure,),
+        head_sha="abc1234567890def",
+    )
+    state = MonitorState()
+    state_key = _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+    ci_fix_calls: list[dict[str, object]] = []
+
+    async def _record_ci_fix(**kwargs: object) -> _GitPushResult:
+        ci_fix_calls.append(kwargs)
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    mocker.patch.object(runner, "_run_ci_fix", _record_ci_fix)
+
+    terminal = await runner._execute(
+        action=RerunTransientCI(failures=(failure,)),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert cmd.calls == []
+    assert ci_fix_calls[0]["failures"] == (failure,)
+    assert state_key not in state.threads_addressed_ids
+    async with factory() as session:
+        operations = list((await session.execute(select(Operation))).scalars())
+    assert [op.payload["action"] for op in operations] == ["ci_repair"]
+    assert operations[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
 def test_ci_transient_rerun_attempt_treats_corrupt_count_as_zero() -> None:
     failure = CheckFailure(
         name="python-full-coverage",

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -147,6 +147,38 @@ class PersistCheckingSleep(RecordedSleep):
         await super().__call__(seconds)
 
 
+class PersistCheckingCommandRunner(FakeCommandRunner):
+    def __init__(
+        self,
+        *,
+        factory: async_sessionmaker[AsyncSession],
+        workspace_id: str,
+        state_key: str,
+        expected_value: str,
+    ) -> None:
+        super().__init__()
+        self._factory = factory
+        self._workspace_id = workspace_id
+        self._state_key = state_key
+        self._expected_value = expected_value
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        input_bytes: bytes | None = None,
+        cwd: str | None = None,
+    ) -> CommandResult:
+        if args[:3] == ["gh", "run", "rerun"]:
+            async with self._factory() as session:
+                workspace = await WorkspaceRepository(session).get(self._workspace_id)
+                assert workspace is not None
+                assert (
+                    workspace.monitor_threads_addressed.get(self._state_key) == self._expected_value
+                )
+        return await super().run(args, input_bytes=input_bytes, cwd=cwd)
+
+
 def _monitor_runner(
     tmp_path: Path,
     fake: FakeCommandRunner,
@@ -327,6 +359,66 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
         rerun_operations = [op for op in operations if op.payload["action"] == "ci_transient_rerun"]
         assert len(rerun_operations) == 1
         assert rerun_operations[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
+async def test_rerun_transient_ci_action_persists_attempt_before_github_rerun(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    adapter = FakeAdapter()
+    workspace_id = await seed_monitoring_workspace(factory)
+    failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    status = _status(
+        check_state=CheckState.FAILURE,
+        ci_failures=(failure,),
+        head_sha="abc1234567890def",
+    )
+    state_key = _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+    cmd = PersistCheckingCommandRunner(
+        factory=factory,
+        workspace_id=workspace_id,
+        state_key=state_key,
+        expected_value="1",
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    terminal = await runner._execute(
+        action=RerunTransientCI(failures=(failure,)),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert cmd.calls[0].args == [
+        "gh",
+        "run",
+        "rerun",
+        "25655330295",
+        "--repo",
+        "dimileeh/aira-web",
+        "--failed",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -357,6 +357,7 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
         ci_failures=(failure,),
         head_sha="abc1234567890def",
     )
+    state_key = _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
     state = MonitorState()
 
     terminal = await runner._execute(
@@ -377,7 +378,7 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
     assert terminal is False
     assert adapter.calls == []
     assert state.iter_count == 1
-    assert state.threads_addressed_ids == {}
+    assert state.threads_addressed_ids[state_key] == "1"
     assert cmd.calls[0].args == [
         "gh",
         "run",
@@ -390,6 +391,7 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
         assert workspace is not None
+        assert workspace.monitor_threads_addressed[state_key] == "1"
         events = [
             event
             for event in workspace.events

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -59,12 +59,14 @@ from awf.runtime.pr_monitor import (
     NotifyHuman,
     PRStatus,
     ReportCiFailure,
+    RerunTransientCI,
     ReviewComment,
     ReviewThread,
     ReviewThreadComment,
     ShortCircuitCompleted,
     SyncBase,
     WaitForCI,
+    _ci_transient_rerun_state_key,
     _mark_review_thread_addressed,
     _review_thread_body_state_key,
 )
@@ -220,6 +222,152 @@ class _CapturingGH:
         if self.post_errors:
             raise self.post_errors.pop(0)
         self.posted_comments.append((repo, pr_number, body))
+
+
+@pytest.mark.unit
+async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_attempt(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    adapter = FakeAdapter()
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    status = _status(
+        check_state=CheckState.FAILURE,
+        ci_failures=(failure,),
+        head_sha="abc1234567890def",
+    )
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=RerunTransientCI(failures=(failure,)),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert adapter.calls == []
+    assert cmd.calls[0].args == [
+        "gh",
+        "run",
+        "rerun",
+        "25655330295",
+        "--repo",
+        "dimileeh/aira-web",
+        "--failed",
+    ]
+    assert (
+        state.threads_addressed_ids[
+            _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+        ]
+        == "1"
+    )
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        events = [
+            event
+            for event in workspace.events
+            if event.event_type == "workspace.monitor_ci_transient_rerun_requested"
+        ]
+        assert len(events) == 1
+        assert events[0].payload is not None
+        assert events[0].payload["run_ids"] == ["25655330295"]
+        operations = list((await session.execute(select(Operation))).scalars())
+        rerun_operations = [op for op in operations if op.payload["action"] == "ci_transient_rerun"]
+        assert len(rerun_operations) == 1
+        assert rerun_operations[0].status == OperationStatus.succeeded.value
+
+
+@pytest.mark.unit
+async def test_rerun_transient_ci_action_records_failed_rerun_request(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=1, stderr="HTTP 403: workflow scope required")
+    adapter = FakeAdapter()
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    status = _status(
+        check_state=CheckState.FAILURE,
+        ci_failures=(failure,),
+        head_sha="abc1234567890def",
+    )
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=RerunTransientCI(failures=(failure,)),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert adapter.calls == []
+    assert state.iter_count == 1
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        events = [
+            event
+            for event in workspace.events
+            if event.event_type == "workspace.monitor_ci_transient_rerun_failed"
+        ]
+        assert len(events) == 1
+        assert events[0].reason_code == "CI_TRANSIENT_RERUN_FAILED"
+        assert events[0].payload is not None
+        assert events[0].payload["run_ids"] == ["25655330295"]
+        assert "workflow scope required" in events[0].payload["error"]
+        operations = list((await session.execute(select(Operation))).scalars())
+        rerun_operations = [op for op in operations if op.payload["action"] == "ci_transient_rerun"]
+        assert len(rerun_operations) == 1
+        assert rerun_operations[0].status == OperationStatus.failed.value
+        assert rerun_operations[0].error_code == "CI_TRANSIENT_RERUN_FAILED"
 
 
 def _provider_recovery_policy(

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -79,6 +79,7 @@ from awf.runtime.pr_monitor_runner import (
     PullRequestMonitorRunner,
     VerdictResult,
     _as_utc,
+    _ci_transient_rerun_attempt,
     _collect_defer_items,
     _drop_stale_review_comment_addressed_state,
     _drop_stale_review_thread_addressed_state,
@@ -121,6 +122,29 @@ from tests.unit.runtime.test_pr_monitor import _status
 async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
     async with postgres_test_engine() as engine:
         yield make_session_factory(engine)
+
+
+class PersistCheckingSleep(RecordedSleep):
+    def __init__(
+        self,
+        *,
+        factory: async_sessionmaker[AsyncSession],
+        workspace_id: str,
+        state_key: str,
+        expected_value: str,
+    ) -> None:
+        super().__init__()
+        self._factory = factory
+        self._workspace_id = workspace_id
+        self._state_key = state_key
+        self._expected_value = expected_value
+
+    async def __call__(self, seconds: float) -> None:
+        async with self._factory() as session:
+            workspace = await WorkspaceRepository(session).get(self._workspace_id)
+            assert workspace is not None
+            assert workspace.monitor_threads_addressed[self._state_key] == self._expected_value
+        await super().__call__(seconds)
 
 
 def _monitor_runner(
@@ -231,15 +255,7 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
 ) -> None:
     cmd = FakeCommandRunner()
     adapter = FakeAdapter()
-    sleep_fn = RecordedSleep()
     workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=cmd,
-        adapter=adapter,
-        sleep_fn=sleep_fn,
-        worktrees_root=tmp_path / "worktrees",
-    )
     failure = CheckFailure(
         name="python-full-coverage",
         conclusion="FAILURE",
@@ -250,6 +266,20 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
         check_state=CheckState.FAILURE,
         ci_failures=(failure,),
         head_sha="abc1234567890def",
+    )
+    state_key = _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
+    sleep_fn = PersistCheckingSleep(
+        factory=factory,
+        workspace_id=workspace_id,
+        state_key=state_key,
+        expected_value="1",
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
     )
     state = MonitorState()
 
@@ -279,15 +309,12 @@ async def test_rerun_transient_ci_action_requests_failed_job_rerun_and_records_a
         "dimileeh/aira-web",
         "--failed",
     ]
-    assert (
-        state.threads_addressed_ids[
-            _ci_transient_rerun_state_key(status.head_sha, status.ci_failures)
-        ]
-        == "1"
-    )
+    assert sleep_fn.calls == [60]
+    assert state.threads_addressed_ids[state_key] == "1"
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
         assert workspace is not None
+        assert workspace.monitor_threads_addressed[state_key] == "1"
         events = [
             event
             for event in workspace.events
@@ -350,6 +377,16 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
     assert terminal is False
     assert adapter.calls == []
     assert state.iter_count == 1
+    assert state.threads_addressed_ids == {}
+    assert cmd.calls[0].args == [
+        "gh",
+        "run",
+        "rerun",
+        "25655330295",
+        "--repo",
+        "dimileeh/aira-web",
+        "--failed",
+    ]
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
         assert workspace is not None
@@ -368,6 +405,27 @@ async def test_rerun_transient_ci_action_records_failed_rerun_request(
         assert len(rerun_operations) == 1
         assert rerun_operations[0].status == OperationStatus.failed.value
         assert rerun_operations[0].error_code == "CI_TRANSIENT_RERUN_FAILED"
+
+
+@pytest.mark.unit
+def test_ci_transient_rerun_attempt_treats_corrupt_count_as_zero() -> None:
+    failure = CheckFailure(
+        name="python-full-coverage",
+        conclusion="FAILURE",
+        log_excerpt="HTTP status server error (502 Bad Gateway)",
+        run_id="25655330295",
+    )
+    state = MonitorState()
+    state.threads_addressed_ids[_ci_transient_rerun_state_key("head", (failure,))] = "corrupt"
+
+    attempt = _ci_transient_rerun_attempt(
+        state,
+        head_sha="head",
+        failures=(failure,),
+    )
+
+    assert attempt == 1
+    assert state.threads_addressed_ids[_ci_transient_rerun_state_key("head", (failure,))] == "1"
 
 
 def _provider_recovery_policy(

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -1706,6 +1706,8 @@ async def test_resolve_thread_transient_failure_requeues_thread_safely(
         ["git", "-C", str(tmp_path / "worktrees" / workspace_id)],
         ["gh", "api", "graphql"],
     ]
+    assert cmd.calls[1].args[3] == "push"
+    assert cmd.calls[2].args[3:5] == ["rev-parse", "HEAD"]
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -2413,6 +2415,7 @@ async def test_execute_report_ci_failure_push_failure_records_failed_audit(
     adapter.queue(stdout="partial CI fix")
     workspace_id = await seed_monitoring_workspace(factory)
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
+    cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(
         returncode=128,
@@ -3393,6 +3396,171 @@ async def test_git_push_result_blocks_existing_supply_chain_finding_before_git_p
     assert push_result.pushed is False
     assert "SUPPLY_CHAIN_REMOTE_SCRIPT_EXECUTION" in push_result.stderr
     assert cmd.calls == []
+
+
+@pytest.mark.unit
+async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed locally.")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+
+    push_result = await runner._run_ci_fix(
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        failures=(CheckFailure(name="ci", conclusion="FAILURE", log_excerpt="failing check"),),
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+        workspace_id=workspace_id,
+        remote_branch=f"awf/{workspace_id}",
+    )
+
+    assert push_result.failed is True
+    assert push_result.pushed is False
+    assert ".github/workflows/ci.yml" in push_result.stderr
+    assert [call.args for call in cmd.calls] == [
+        ["git", "-C", str(worktree), "status", "--porcelain"],
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "diff",
+            "--name-only",
+            f"origin/awf/{workspace_id}..HEAD",
+            "--",
+        ]
+    ]
+    async with factory() as s:
+        events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+    assert len(events) == 1
+    assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert events[0].payload is not None
+    assert events[0].payload["paths"] == [".github/workflows/ci.yml"]
+
+
+@pytest.mark.unit
+async def test_protected_scope_push_check_skips_missing_worktree_without_git_diff(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    message = await runner._protected_scope_push_block_message(
+        workspace_id="ws_missing_worktree",
+        worktree_path=tmp_path / "worktrees" / "ws_missing_worktree",
+        remote_branch="awf/ws_missing_worktree",
+    )
+
+    assert message is None
+    assert cmd.calls == []
+
+
+@pytest.mark.unit
+async def test_protected_scope_unpushed_commit_check_skips_missing_workspace_before_git_diff(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / "ws_missing_row"
+    worktree.mkdir(parents=True)
+
+    assert (
+        await runner._protected_scope_violations_for_unpushed_commits(
+            workspace_id="ws_missing_row",
+            worktree_path=worktree,
+            remote_branch="awf/ws_missing_row",
+        )
+        == []
+    )
+    assert cmd.calls == []
+
+
+@pytest.mark.unit
+async def test_changed_paths_since_remote_branch_falls_back_to_upstream_ref(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=128, stderr="unknown revision")
+    cmd.queue_result(returncode=0, stdout="src/fix.py\n\n tests/test_fix.py \n")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    paths = await runner._changed_paths_since_remote_branch(
+        worktree_path=tmp_path / "worktree",
+        remote_branch="awf/ws_remote_missing",
+    )
+
+    assert paths == ("src/fix.py", "tests/test_fix.py")
+    assert cmd.calls[0].args[3:6] == ["diff", "--name-only", "origin/awf/ws_remote_missing..HEAD"]
+    assert cmd.calls[1].args[3:6] == ["diff", "--name-only", "@{upstream}..HEAD"]
+
+
+@pytest.mark.unit
+async def test_changed_paths_since_remote_branch_returns_empty_when_refs_are_unavailable(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=128, stderr="unknown remote ref")
+    cmd.queue_result(returncode=128, stderr="no upstream")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    paths = await runner._changed_paths_since_remote_branch(
+        worktree_path=tmp_path / "worktree",
+        remote_branch="awf/ws_remote_missing",
+    )
+
+    assert paths == ()
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -3658,7 +3658,7 @@ async def test_sync_base_allows_base_owned_protected_changes_when_base_advances_
 
 
 @pytest.mark.unit
-async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
+async def test_ci_fix_commits_and_pushes_even_if_agent_fails(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -194,6 +194,32 @@ def _retry_events(ws: Workspace) -> list:
     ]
 
 
+def _assert_committed_diff_phase_ran(
+    cmd: FakeCommandRunner,
+    *,
+    worktree_path: Path,
+    remote_branch: str,
+    remote: str = "origin",
+) -> None:
+    call_args = [call.args for call in cmd.calls]
+    assert [
+        "git",
+        "-C",
+        str(worktree_path),
+        "fetch",
+        remote,
+        f"refs/heads/{remote_branch}",
+    ] in call_args
+    assert [
+        "git",
+        "-C",
+        str(worktree_path),
+        "merge-base",
+        "FETCH_HEAD",
+        "HEAD",
+    ] in call_args
+
+
 async def _mark_refactor_task(
     factory: async_sessionmaker[AsyncSession],
     workspace_id: str,
@@ -2345,7 +2371,8 @@ async def test_execute_report_ci_failure_dispatches_fix_and_increments_iteration
     adapter = FakeAdapter()
     adapter.queue(returncode=1, stdout="partial CI fix")
     workspace_id = await seed_monitoring_workspace(factory)
-    (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
     cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
@@ -2380,6 +2407,11 @@ async def test_execute_report_ci_failure_dispatches_fix_and_increments_iteration
     assert terminal is False
     assert state.iter_count == 1
     assert "traceback" in adapter.calls[0]
+    _assert_committed_diff_phase_ran(
+        cmd,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
     assert cmd.calls[-1].args[-2:] == ["origin", f"HEAD:refs/heads/awf/{workspace_id}"]
     async with factory() as s:
         operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
@@ -2418,7 +2450,8 @@ async def test_execute_report_ci_failure_push_failure_records_failed_audit(
     adapter = FakeAdapter()
     adapter.queue(stdout="partial CI fix")
     workspace_id = await seed_monitoring_workspace(factory)
-    (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
     cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
@@ -2455,6 +2488,11 @@ async def test_execute_report_ci_failure_push_failure_records_failed_audit(
 
     assert terminal is False
     assert state.iter_count == 1
+    _assert_committed_diff_phase_ran(
+        cmd,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
     async with factory() as s:
         operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
         push_events = await WorkspaceEventRepository(s).list(
@@ -3280,7 +3318,8 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
     adapter = FakeAdapter()
     adapter.queue(returncode=1, stdout="partial conflict resolution")
     workspace_id = await seed_monitoring_workspace(factory)
-    (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
     for result in [
         (0, "", ""),
         (0, "", ""),
@@ -3316,6 +3355,11 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
 
     assert len(adapter.calls) == 1
     assert "src/conflict.py" in adapter.calls[0]
+    _assert_committed_diff_phase_ran(
+        cmd,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
     assert [call.args[-2:] for call in cmd.calls[:2]] == [
         ["merge", "--abort"],
         ["origin", "+refs/heads/development:refs/remotes/origin/development"],
@@ -3505,6 +3549,11 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
 
     assert push_result.failed is False
     assert push_result.pushed is True
+    _assert_committed_diff_phase_ran(
+        cmd,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
     call_args = [call.args for call in cmd.calls]
     assert any(
         args[:1] == ["git"]
@@ -3532,7 +3581,8 @@ async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
     adapter = FakeAdapter()
     adapter.queue(returncode=1, stdout="format failed")
     workspace_id = await seed_monitoring_workspace(factory)
-    (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
     for result in [
         (0, " M tests/test_app.py\n", ""),
         (0, "", ""),
@@ -3564,6 +3614,11 @@ async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
 
     assert len(adapter.calls) == 1
     assert "assert 1 == 2" in adapter.calls[0]
+    _assert_committed_diff_phase_ran(
+        cmd,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
     assert cmd.calls[-1].args[-2:] == ["origin", f"HEAD:refs/heads/awf/{workspace_id}"]
 
 

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -12,7 +12,7 @@ import structlog
 from sqlalchemy import update as sa_update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.common.commands import AsyncioSubprocessRunner, CommandResult, FakeCommandRunner
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.db.enums import OperationStatus, OperationType, TaskClass, WorkspaceStatus
@@ -2347,6 +2347,9 @@ async def test_execute_report_ci_failure_dispatches_fix_and_increments_iteration
     workspace_id = await seed_monitoring_workspace(factory)
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
     cmd.queue_result(returncode=0, stdout="")
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
+    cmd.queue_result(returncode=0, stdout="")  # committed diff has no protected paths
     cmd.queue_result(returncode=0, stderr="Everything up-to-date")
     runner = make_runner(
         factory=factory,
@@ -2418,6 +2421,7 @@ async def test_execute_report_ci_failure_push_failure_records_failed_audit(
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
     cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout="")  # committed diff has no protected paths
     cmd.queue_result(
         returncode=128,
@@ -2976,6 +2980,7 @@ async def test_execute_sync_base_protected_scope_block_is_terminal(
     cmd.queue_result(returncode=0)  # fetch base
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
@@ -3285,6 +3290,9 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
         (0, "", ""),
         (1, "", ""),
         (0, "", ""),
+        (0, "", ""),  # fetch remote branch for committed diff
+        (0, "merge-base-sha\n", ""),
+        (0, "src/conflict.py\n", ""),
         (0, "", ""),
     ]:
         cmd.queue_result(returncode=result[0], stdout=result[1], stderr=result[2])
@@ -3396,6 +3404,7 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
     cmd.queue_result(returncode=0)  # fetch base
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
@@ -3469,6 +3478,7 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
     cmd.queue_result(returncode=0)  # fetch base
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout="")  # diff against refreshed base excludes base changes
@@ -3529,6 +3539,7 @@ async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
         (1, "", ""),
         (0, "", ""),
         (0, "", ""),  # fetch remote branch for committed diff
+        (0, "merge-base-sha\n", ""),
         (0, "tests/test_app.py\n", ""),  # committed diff is inside ordinary test files
         (0, "", ""),
     ]:
@@ -3710,6 +3721,7 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     adapter = FakeAdapter()
     adapter.queue(stdout="Committed locally.")
@@ -3746,7 +3758,7 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
         args[:1] == ["git"]
         and "diff" in args
         and "--name-only" in args
-        and "FETCH_HEAD..HEAD" in args
+        and "merge-base-sha..HEAD" in args
         for args in call_args
     )
     assert not any(args[:1] == ["git"] and "push" in args for args in call_args)
@@ -3777,6 +3789,7 @@ async def test_execute_ci_fix_protected_scope_block_is_terminal(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     adapter = FakeAdapter()
     adapter.queue(stdout="Committed locally.")
@@ -3965,6 +3978,7 @@ async def test_changed_paths_since_remote_branch_fetches_real_push_remote(
 ) -> None:
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout="src/fix.py\n\n tests/test_fix.py \n")
     runner = make_runner(
         factory=factory,
@@ -3989,7 +4003,79 @@ async def test_changed_paths_since_remote_branch_fetches_real_push_remote(
         "https://github.com/org/fork.git",
         "refs/heads/awf/ws_remote_missing",
     ]
-    assert cmd.calls[1].args[3:6] == ["diff", "--name-only", "FETCH_HEAD..HEAD"]
+    assert cmd.calls[1].args == [
+        "git",
+        "-C",
+        str(tmp_path / "worktree"),
+        "merge-base",
+        "FETCH_HEAD",
+        "HEAD",
+    ]
+    assert cmd.calls[2].args[3:6] == ["diff", "--name-only", "merge-base-sha..HEAD"]
+
+
+@pytest.mark.unit
+async def test_changed_paths_since_remote_branch_reports_only_local_paths_when_remote_diverged(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    command_runner = AsyncioSubprocessRunner()
+
+    async def run(*args: str, cwd: Path | None = None) -> None:
+        result = await command_runner.run(list(args), cwd=str(cwd) if cwd else None)
+        assert result.ok, result.stderr
+
+    remote = tmp_path / "remote.git"
+    seed = tmp_path / "seed"
+    local = tmp_path / "local"
+    remote_writer = tmp_path / "remote-writer"
+    remote_branch = "awf/ws_remote_diverged"
+
+    await run("git", "init", "--bare", str(remote))
+    await run("git", "clone", str(remote), str(seed))
+    await run("git", "config", "user.email", "awf@example.com", cwd=seed)
+    await run("git", "config", "user.name", "AWF Test", cwd=seed)
+    (seed / "README.md").write_text("base\n")
+    await run("git", "add", "README.md", cwd=seed)
+    await run("git", "commit", "-m", "base", cwd=seed)
+    await run("git", "branch", "-M", "main", cwd=seed)
+    await run("git", "push", "origin", "main", cwd=seed)
+    await run("git", "checkout", "-b", remote_branch, cwd=seed)
+    await run("git", "push", "origin", remote_branch, cwd=seed)
+
+    await run("git", "clone", str(remote), str(local))
+    await run("git", "checkout", remote_branch, cwd=local)
+    await run("git", "config", "user.email", "awf@example.com", cwd=local)
+    await run("git", "config", "user.name", "AWF Test", cwd=local)
+    (local / "src").mkdir()
+    (local / "src" / "fix.py").write_text("print('local fix')\n")
+    await run("git", "add", "src/fix.py", cwd=local)
+    await run("git", "commit", "-m", "local fix", cwd=local)
+
+    await run("git", "clone", str(remote), str(remote_writer))
+    await run("git", "checkout", remote_branch, cwd=remote_writer)
+    await run("git", "config", "user.email", "awf@example.com", cwd=remote_writer)
+    await run("git", "config", "user.name", "AWF Test", cwd=remote_writer)
+    (remote_writer / ".github" / "workflows").mkdir(parents=True)
+    (remote_writer / ".github" / "workflows" / "ci.yml").write_text("name: ci\n")
+    await run("git", "add", ".github/workflows/ci.yml", cwd=remote_writer)
+    await run("git", "commit", "-m", "remote ci", cwd=remote_writer)
+    await run("git", "push", "origin", remote_branch, cwd=remote_writer)
+
+    runner = make_runner(
+        factory=factory,
+        cmd=command_runner,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    paths = await runner._changed_paths_since_remote_branch(
+        worktree_path=local,
+        remote_branch=remote_branch,
+    )
+
+    assert paths == ("src/fix.py",)
 
 
 @pytest.mark.unit
@@ -4019,13 +4105,13 @@ async def test_changed_paths_since_remote_branch_fails_closed_when_refs_are_unav
 
 
 @pytest.mark.unit
-async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
+async def test_changed_paths_since_remote_branch_fails_closed_when_merge_base_fails(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")
-    cmd.queue_result(returncode=128, stderr="bad revision FETCH_HEAD")
+    cmd.queue_result(returncode=1, stderr="no merge base")
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -4041,8 +4127,36 @@ async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
         )
 
     message = str(exc_info.value)
-    assert "diff FETCH_HEAD..HEAD" in message
-    assert "bad revision FETCH_HEAD" in message
+    assert "merge-base FETCH_HEAD HEAD" in message
+    assert "no merge base" in message
+
+
+@pytest.mark.unit
+async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
+    cmd.queue_result(returncode=128, stderr="bad revision merge-base-sha")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    with pytest.raises(ProtectedScopeDiffError) as exc_info:
+        await runner._changed_paths_since_remote_branch(
+            worktree_path=tmp_path / "worktree",
+            remote_branch="awf/ws_remote_missing",
+        )
+
+    message = str(exc_info.value)
+    assert "diff merge-base-sha..HEAD" in message
+    assert "bad revision merge-base-sha" in message
 
 
 @pytest.mark.unit
@@ -4053,6 +4167,7 @@ async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
     workspace_id = await seed_monitoring_workspace(factory)
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against remote PR branch
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch
     cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against refreshed base
@@ -4081,7 +4196,15 @@ async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
             "origin",
             f"refs/heads/awf/{workspace_id}",
         ],
-        ["git", "-C", str(worktree), "diff", "--name-only", "FETCH_HEAD..HEAD", "--"],
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "merge-base",
+            "FETCH_HEAD",
+            "HEAD",
+        ],
+        ["git", "-C", str(worktree), "diff", "--name-only", "merge-base-sha..HEAD", "--"],
         [
             "git",
             "-C",

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -3323,6 +3323,7 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -3356,6 +3357,13 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
         and f"refs/heads/awf/{workspace_id}" in args
         for args in call_args
     )
+    assert any(
+        args[:1] == ["git"]
+        and "diff" in args
+        and "--name-only" in args
+        and "origin/development..HEAD" in args
+        for args in call_args
+    )
     assert not any(args[:1] == ["git"] and "push" in args for args in call_args)
     async with factory() as s:
         events = await WorkspaceEventRepository(s).list(
@@ -3367,6 +3375,66 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
     assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
     assert events[0].payload is not None
     assert events[0].payload["paths"] == [".github/workflows/ci.yml"]
+
+
+@pytest.mark.unit
+async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # merge --abort
+    cmd.queue_result(returncode=0)  # fetch base
+    cmd.queue_result(returncode=0)  # merge
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\n")
+    cmd.queue_result(returncode=0, stdout="")  # diff against refreshed base excludes base changes
+    cmd.queue_result(returncode=0, stdout="", stderr="pushed")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+
+    push_result = await runner._run_sync_base(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert push_result.failed is False
+    assert push_result.pushed is True
+    call_args = [call.args for call in cmd.calls]
+    assert any(
+        args[:1] == ["git"]
+        and "diff" in args
+        and "--name-only" in args
+        and "origin/development..HEAD" in args
+        for args in call_args
+    )
+    assert any(args[:1] == ["git"] and "push" in args for args in call_args)
+    async with factory() as s:
+        events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+    assert events == []
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -4069,7 +4069,7 @@ async def test_changed_paths_since_remote_branch_fetches_real_push_remote(
     assert cmd.calls[2].args[3:6] == ["diff", "--name-only", "merge-base-sha..HEAD"]
 
 
-@pytest.mark.unit
+@pytest.mark.integration
 async def test_changed_paths_since_remote_branch_reports_only_local_paths_when_remote_diverged(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -49,6 +49,7 @@ from awf.runtime.pr_monitor_runner import (
     BaseBehindCountError,
     BaseFetchError,
     MonitorRunnerConfig,
+    ProtectedScopeDiffError,
     ProviderRecoveryFallbackError,
     ProviderRecoveryRetryError,
     PullRequestMonitorRunner,
@@ -2416,7 +2417,8 @@ async def test_execute_report_ci_failure_push_failure_records_failed_audit(
     workspace_id = await seed_monitoring_workspace(factory)
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
     cmd.queue_result(returncode=0, stdout="")
-    cmd.queue_result(returncode=0, stdout="")
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="")  # committed diff has no protected paths
     cmd.queue_result(
         returncode=128,
         stderr=("fatal: unable to access https://user:ghp_should_not_persist@github.com/org/repo"),
@@ -3226,13 +3228,15 @@ async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
     cmd = FakeCommandRunner()
     adapter = FakeAdapter()
     adapter.queue(returncode=1, stdout="format failed")
-    workspace_id = "ws_ci_fix"
+    workspace_id = await seed_monitoring_workspace(factory)
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
     for result in [
         (0, " M tests/test_app.py\n", ""),
         (0, "", ""),
         (1, "", ""),
         (0, "", ""),
+        (0, "", ""),  # fetch remote branch for committed diff
+        (0, "tests/test_app.py\n", ""),  # committed diff is inside ordinary test files
         (0, "", ""),
     ]:
         cmd.queue_result(returncode=result[0], stdout=result[1], stderr=result[2])
@@ -3251,12 +3255,12 @@ async def test_ci_fix_records_agent_failure_but_commits_and_pushes_changes(
         compose_project="proj",
         compose_file=tmp_path / "compose.yml",
         workspace_id=workspace_id,
-        remote_branch="awf/ws_ci_fix",
+        remote_branch=f"awf/{workspace_id}",
     )
 
     assert len(adapter.calls) == 1
     assert "assert 1 == 2" in adapter.calls[0]
-    assert cmd.calls[-1].args[-2:] == ["origin", "HEAD:refs/heads/awf/ws_ci_fix"]
+    assert cmd.calls[-1].args[-2:] == ["origin", f"HEAD:refs/heads/awf/{workspace_id}"]
 
 
 @pytest.mark.unit
@@ -3412,6 +3416,7 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
 
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     adapter = FakeAdapter()
     adapter.queue(stdout="Committed locally.")
@@ -3437,6 +3442,7 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
 
     assert push_result.failed is True
     assert push_result.pushed is False
+    assert push_result.reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
     assert ".github/workflows/ci.yml" in push_result.stderr
     assert [call.args for call in cmd.calls] == [
         ["git", "-C", str(worktree), "status", "--porcelain"],
@@ -3444,11 +3450,19 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
             "git",
             "-C",
             str(worktree),
+            "fetch",
+            "origin",
+            f"refs/heads/awf/{workspace_id}",
+        ],
+        [
+            "git",
+            "-C",
+            str(worktree),
             "diff",
             "--name-only",
-            f"origin/awf/{workspace_id}..HEAD",
+            "FETCH_HEAD..HEAD",
             "--",
-        ]
+        ],
     ]
     async with factory() as s:
         events = await WorkspaceEventRepository(s).list(
@@ -3460,6 +3474,76 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
     assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
     assert events[0].payload is not None
     assert events[0].payload["paths"] == [".github/workflows/ci.yml"]
+
+
+@pytest.mark.unit
+async def test_execute_ci_fix_protected_scope_block_is_terminal(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed locally.")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=ReportCiFailure(
+            failures=(CheckFailure(name="ci", conclusion="FAILURE", log_excerpt="failing check"),)
+        ),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert state.iter_count == 0
+    assert not any(call.args[:1] == ["git"] and "push" in call.args for call in cmd.calls)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
+        push_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.git_push",
+            limit=10,
+        )
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.failed.value
+    ci_operation = next(operation for operation in operations if operation.type == "ci_repair")
+    assert ci_operation.status == OperationStatus.failed.value
+    assert ci_operation.error_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert len(push_events) == 1
+    assert push_events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert push_events[0].payload is not None
+    assert push_events[0].payload["action"] == "ci_repair_push"
+    assert push_events[0].payload["outcome"] == "failed"
 
 
 @pytest.mark.unit
@@ -3487,7 +3571,7 @@ async def test_protected_scope_push_check_skips_missing_worktree_without_git_dif
 
 
 @pytest.mark.unit
-async def test_protected_scope_unpushed_commit_check_skips_missing_workspace_before_git_diff(
+async def test_protected_scope_unpushed_commit_check_fails_closed_for_missing_workspace(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
@@ -3502,24 +3586,22 @@ async def test_protected_scope_unpushed_commit_check_skips_missing_workspace_bef
     worktree = tmp_path / "worktrees" / "ws_missing_row"
     worktree.mkdir(parents=True)
 
-    assert (
+    with pytest.raises(ProtectedScopeDiffError, match="Workspace row ws_missing_row"):
         await runner._protected_scope_violations_for_unpushed_commits(
             workspace_id="ws_missing_row",
             worktree_path=worktree,
             remote_branch="awf/ws_missing_row",
         )
-        == []
-    )
     assert cmd.calls == []
 
 
 @pytest.mark.unit
-async def test_changed_paths_since_remote_branch_falls_back_to_upstream_ref(
+async def test_changed_paths_since_remote_branch_fetches_real_push_remote(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=128, stderr="unknown revision")
+    cmd.queue_result(returncode=0, stdout="")
     cmd.queue_result(returncode=0, stdout="src/fix.py\n\n tests/test_fix.py \n")
     runner = make_runner(
         factory=factory,
@@ -3532,21 +3614,28 @@ async def test_changed_paths_since_remote_branch_falls_back_to_upstream_ref(
     paths = await runner._changed_paths_since_remote_branch(
         worktree_path=tmp_path / "worktree",
         remote_branch="awf/ws_remote_missing",
+        remote_push_url="https://github.com/org/fork.git",
     )
 
     assert paths == ("src/fix.py", "tests/test_fix.py")
-    assert cmd.calls[0].args[3:6] == ["diff", "--name-only", "origin/awf/ws_remote_missing..HEAD"]
-    assert cmd.calls[1].args[3:6] == ["diff", "--name-only", "@{upstream}..HEAD"]
+    assert cmd.calls[0].args == [
+        "git",
+        "-C",
+        str(tmp_path / "worktree"),
+        "fetch",
+        "https://github.com/org/fork.git",
+        "refs/heads/awf/ws_remote_missing",
+    ]
+    assert cmd.calls[1].args[3:6] == ["diff", "--name-only", "FETCH_HEAD..HEAD"]
 
 
 @pytest.mark.unit
-async def test_changed_paths_since_remote_branch_returns_empty_when_refs_are_unavailable(
+async def test_changed_paths_since_remote_branch_fails_closed_when_refs_are_unavailable(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=128, stderr="unknown remote ref")
-    cmd.queue_result(returncode=128, stderr="no upstream")
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -3555,12 +3644,81 @@ async def test_changed_paths_since_remote_branch_returns_empty_when_refs_are_una
         worktrees_root=tmp_path / "worktrees",
     )
 
-    paths = await runner._changed_paths_since_remote_branch(
-        worktree_path=tmp_path / "worktree",
-        remote_branch="awf/ws_remote_missing",
+    with pytest.raises(ProtectedScopeDiffError) as exc_info:
+        await runner._changed_paths_since_remote_branch(
+            worktree_path=tmp_path / "worktree",
+            remote_branch="awf/ws_remote_missing",
+        )
+
+    message = str(exc_info.value)
+    assert "fetch refs/heads/awf/ws_remote_missing" in message
+    assert "unknown remote ref" in message
+
+
+@pytest.mark.unit
+async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")
+    cmd.queue_result(returncode=128, stderr="bad revision FETCH_HEAD")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
     )
 
-    assert paths == ()
+    with pytest.raises(ProtectedScopeDiffError) as exc_info:
+        await runner._changed_paths_since_remote_branch(
+            worktree_path=tmp_path / "worktree",
+            remote_branch="awf/ws_remote_missing",
+        )
+
+    message = str(exc_info.value)
+    assert "diff FETCH_HEAD..HEAD" in message
+    assert "bad revision FETCH_HEAD" in message
+
+
+@pytest.mark.unit
+async def test_protected_scope_push_check_blocks_when_diff_baseline_cannot_be_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=128, stderr="unknown remote ref")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+
+    message = await runner._protected_scope_push_block_message(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+    )
+
+    assert message is not None
+    assert "could not verify protected-scope changes before push" in message
+    assert "unknown remote ref" in message
+    async with factory() as s:
+        events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+    assert len(events) == 1
+    assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert events[0].payload is not None
+    assert events[0].payload["reason"] == "diff_baseline_unavailable"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -2977,6 +2977,7 @@ async def test_execute_sync_base_protected_scope_block_is_terminal(
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     runner = make_runner(
         factory=factory,
@@ -3396,6 +3397,7 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     runner = make_runner(
         factory=factory,
@@ -3468,6 +3470,7 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\n")
+    cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
     cmd.queue_result(returncode=0, stdout="")  # diff against refreshed base excludes base changes
     cmd.queue_result(returncode=0, stdout="", stderr="pushed")
     runner = make_runner(
@@ -4040,6 +4043,63 @@ async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
     message = str(exc_info.value)
     assert "diff FETCH_HEAD..HEAD" in message
     assert "bad revision FETCH_HEAD" in message
+
+
+@pytest.mark.unit
+async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against remote PR branch
+    cmd.queue_result(returncode=0, stdout="")  # refresh base branch
+    cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against refreshed base
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktree"
+
+    await runner._protected_scope_violations_for_sync_base_push(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        base_branch="development",
+    )
+
+    assert [call.args for call in cmd.calls] == [
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "fetch",
+            "origin",
+            f"refs/heads/awf/{workspace_id}",
+        ],
+        ["git", "-C", str(worktree), "diff", "--name-only", "FETCH_HEAD..HEAD", "--"],
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "fetch",
+            "origin",
+            "+refs/heads/development:refs/remotes/origin/development",
+        ],
+        [
+            "git",
+            "-C",
+            str(worktree),
+            "diff",
+            "--name-only",
+            "origin/development..HEAD",
+            "--",
+        ],
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -3115,7 +3115,7 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
     cmd = FakeCommandRunner()
     adapter = FakeAdapter()
     adapter.queue(returncode=1, stdout="partial conflict resolution")
-    workspace_id = "ws_sync_conflict"
+    workspace_id = await seed_monitoring_workspace(factory)
     (tmp_path / "worktrees" / workspace_id).mkdir(parents=True)
     for result in [
         (0, "", ""),
@@ -3142,7 +3142,7 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
         repo=RepoRef(owner="dimileeh", name="aira-web"),
         pr_number=42,
         base_branch="development",
-        remote_branch="awf/ws_sync_conflict",
+        remote_branch=f"awf/{workspace_id}",
         compose_project="proj",
         compose_file=tmp_path / "compose.yml",
     )
@@ -3153,7 +3153,7 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
         ["merge", "--abort"],
         ["origin", "+refs/heads/development:refs/remotes/origin/development"],
     ]
-    assert cmd.calls[-1].args[-2:] == ["origin", "HEAD:refs/heads/awf/ws_sync_conflict"]
+    assert cmd.calls[-1].args[-2:] == ["origin", f"HEAD:refs/heads/awf/{workspace_id}"]
 
 
 @pytest.mark.unit
@@ -3218,6 +3218,70 @@ async def test_sync_base_conflict_supply_chain_command_evidence_blocks_before_co
     assert [finding.reason_code for finding in findings] == ["SUPPLY_CHAIN_REMOTE_SCRIPT_EXECUTION"]
     assert not any(call.args[:1] == ["git"] and "commit" in call.args for call in cmd.calls)
     assert not any(call.args[:1] == ["git"] and "push" in call.args for call in cmd.calls)
+
+
+@pytest.mark.unit
+async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_push(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # merge --abort
+    cmd.queue_result(returncode=0)  # fetch base
+    cmd.queue_result(returncode=0)  # merge
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+
+    push_result = await runner._run_sync_base(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        remote_push_url="https://github.com/org/fork.git",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert push_result.failed is True
+    assert push_result.pushed is False
+    assert push_result.reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert ".github/workflows/ci.yml" in push_result.stderr
+    call_args = [call.args for call in cmd.calls]
+    assert any(
+        args[:1] == ["git"]
+        and "fetch" in args
+        and "https://github.com/org/fork.git" in args
+        and f"refs/heads/awf/{workspace_id}" in args
+        for args in call_args
+    )
+    assert not any(args[:1] == ["git"] and "push" in args for args in call_args)
+    async with factory() as s:
+        events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+    assert len(events) == 1
+    assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert events[0].payload is not None
+    assert events[0].payload["paths"] == [".github/workflows/ci.yml"]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -2701,6 +2701,91 @@ async def test_monitor_comment_repair_push_failure_records_failed_audit_and_requ
 
 
 @pytest.mark.unit
+async def test_monitor_comment_diff_baseline_unavailable_terminates_with_diff_reason(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    cmd = FakeCommandRunner()
+    adapter = FakeAdapter()
+    adapter.queue(stdout="fixed locally")
+    workspace_id = await seed_monitoring_workspace(factory)
+    thread = ReviewThread(
+        thread_id="T_diff_unavailable",
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+    cmd.queue_result(returncode=0, stdout="")  # clean worktree after agent run
+    cmd.queue_result(returncode=0, stdout=pr_payload())  # settle-window status poll
+    cmd.queue_result(returncode=128, stderr="network reset")  # committed-diff baseline fetch
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=AddressComments(threads=(thread,), review_comments=()),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(threads=(thread,)),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert state.iter_count == 0
+    assert not any(call.args[:1] == ["git"] and "push" in call.args for call in cmd.calls)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
+        push_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.git_push",
+            limit=10,
+        )
+        scope_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.failed.value
+    assert workspace.events[-1].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    comment_operation = next(
+        operation for operation in operations if operation.type == "comment_repair"
+    )
+    assert comment_operation.status == OperationStatus.failed.value
+    assert comment_operation.error_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert comment_operation.result is not None
+    assert comment_operation.result["outcome"] == "protected_scope_diff_unavailable"
+    assert comment_operation.result["reason_code"] == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert len(push_events) == 1
+    assert push_events[0].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert push_events[0].payload is not None
+    assert push_events[0].payload["action"] == "comment_repair_push"
+    assert push_events[0].payload["outcome"] == "failed"
+    assert push_events[0].payload["evidence"]["reason_code"] == ("PROTECTED_SCOPE_DIFF_UNAVAILABLE")
+    assert len(scope_events) == 1
+    assert scope_events[0].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert scope_events[0].payload is not None
+    assert scope_events[0].payload["reason"] == "diff_baseline_unavailable"
+
+
+@pytest.mark.unit
 async def test_monitor_sync_base_cleanup_failure_terminates_without_push(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -3604,6 +3689,83 @@ async def test_execute_ci_fix_protected_scope_block_is_terminal(
 
 
 @pytest.mark.unit
+async def test_execute_ci_fix_diff_baseline_unavailable_terminates_with_diff_reason(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout="")  # clean worktree: agent committed locally itself
+    cmd.queue_result(returncode=128, stderr="network reset")  # committed-diff baseline fetch
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed locally.")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=ReportCiFailure(
+            failures=(CheckFailure(name="ci", conclusion="FAILURE", log_excerpt="failing check"),)
+        ),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert state.iter_count == 0
+    assert not any(call.args[:1] == ["git"] and "push" in call.args for call in cmd.calls)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
+        push_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.git_push",
+            limit=10,
+        )
+        scope_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.monitor_protected_scope_push_blocked",
+            limit=10,
+        )
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.failed.value
+    assert workspace.events[-1].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    ci_operation = next(operation for operation in operations if operation.type == "ci_repair")
+    assert ci_operation.status == OperationStatus.failed.value
+    assert ci_operation.error_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert ci_operation.result is not None
+    assert ci_operation.result["outcome"] == "protected_scope_diff_unavailable"
+    assert ci_operation.result["reason_code"] == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert len(push_events) == 1
+    assert push_events[0].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert push_events[0].payload is not None
+    assert push_events[0].payload["action"] == "ci_repair_push"
+    assert push_events[0].payload["outcome"] == "failed"
+    assert push_events[0].payload["evidence"]["reason_code"] == ("PROTECTED_SCOPE_DIFF_UNAVAILABLE")
+    assert len(scope_events) == 1
+    assert scope_events[0].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert scope_events[0].payload is not None
+    assert scope_events[0].payload["reason"] == "diff_baseline_unavailable"
+
+
+@pytest.mark.unit
 async def test_protected_scope_push_check_skips_missing_worktree_without_git_diff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -3617,13 +3779,13 @@ async def test_protected_scope_push_check_skips_missing_worktree_without_git_dif
         worktrees_root=tmp_path / "worktrees",
     )
 
-    message = await runner._protected_scope_push_block_message(
+    block = await runner._protected_scope_push_block(
         workspace_id="ws_missing_worktree",
         worktree_path=tmp_path / "worktrees" / "ws_missing_worktree",
         remote_branch="awf/ws_missing_worktree",
     )
 
-    assert message is None
+    assert block is None
     assert cmd.calls == []
 
 
@@ -3757,15 +3919,16 @@ async def test_protected_scope_push_check_blocks_when_diff_baseline_cannot_be_re
     worktree = tmp_path / "worktrees" / workspace_id
     worktree.mkdir(parents=True)
 
-    message = await runner._protected_scope_push_block_message(
+    block = await runner._protected_scope_push_block(
         workspace_id=workspace_id,
         worktree_path=worktree,
         remote_branch=f"awf/{workspace_id}",
     )
 
-    assert message is not None
-    assert "could not verify protected-scope changes before push" in message
-    assert "unknown remote ref" in message
+    assert block is not None
+    assert block.reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
+    assert "could not verify protected-scope changes before push" in block.message
+    assert "unknown remote ref" in block.message
     async with factory() as s:
         events = await WorkspaceEventRepository(s).list(
             workspace_id=workspace_id,
@@ -3773,7 +3936,7 @@ async def test_protected_scope_push_check_blocks_when_diff_baseline_cannot_be_re
             limit=10,
         )
     assert len(events) == 1
-    assert events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert events[0].reason_code == "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
     assert events[0].payload is not None
     assert events[0].payload["reason"] == "diff_baseline_unavailable"
 

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -2960,6 +2960,79 @@ async def test_execute_sync_base_push_failure_records_failed_audit(
 
 
 @pytest.mark.unit
+async def test_execute_sync_base_protected_scope_block_is_terminal(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # merge --abort
+    cmd.queue_result(returncode=0)  # fetch base
+    cmd.queue_result(returncode=0)  # merge
+    cmd.queue_result(returncode=0, stdout="")  # fetch remote branch for committed diff
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=SyncBase(),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert state.iter_count == 0
+    assert not any(call.args[:1] == ["git"] and "push" in call.args for call in cmd.calls)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
+        push_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.git_push",
+            limit=10,
+        )
+
+    assert workspace is not None
+    assert workspace.status == WorkspaceStatus.failed.value
+    sync_operation = next(operation for operation in operations if operation.type == "sync_base")
+    assert sync_operation.status == OperationStatus.failed.value
+    assert sync_operation.error_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert sync_operation.result is not None
+    assert sync_operation.result["outcome"] == "protected_scope_push_blocked"
+    assert sync_operation.result["reason_code"] == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert len(push_events) == 1
+    assert push_events[0].reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
+    assert push_events[0].payload is not None
+    assert push_events[0].payload["action"] == "sync_base_push"
+    assert push_events[0].payload["outcome"] == "failed"
+    assert push_events[0].payload["evidence"]["reason_code"] == "PROTECTED_SCOPE_PUSH_BLOCKED"
+
+
+@pytest.mark.unit
 async def test_fix_cycle_addresses_new_review_burst_before_push(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -3444,26 +3444,19 @@ async def test_ci_fix_blocks_committed_protected_quality_gate_edits_before_push(
     assert push_result.pushed is False
     assert push_result.reason_code == "PROTECTED_SCOPE_PUSH_BLOCKED"
     assert ".github/workflows/ci.yml" in push_result.stderr
-    assert [call.args for call in cmd.calls] == [
-        ["git", "-C", str(worktree), "status", "--porcelain"],
-        [
-            "git",
-            "-C",
-            str(worktree),
-            "fetch",
-            "origin",
-            f"refs/heads/awf/{workspace_id}",
-        ],
-        [
-            "git",
-            "-C",
-            str(worktree),
-            "diff",
-            "--name-only",
-            "FETCH_HEAD..HEAD",
-            "--",
-        ],
-    ]
+    call_args = [call.args for call in cmd.calls]
+    assert any(
+        args[:1] == ["git"] and "status" in args and args[-1:] == ["--porcelain"]
+        for args in call_args
+    )
+    assert any(
+        args[:1] == ["git"]
+        and "diff" in args
+        and "--name-only" in args
+        and "FETCH_HEAD..HEAD" in args
+        for args in call_args
+    )
+    assert not any(args[:1] == ["git"] and "push" in args for args in call_args)
     async with factory() as s:
         events = await WorkspaceEventRepository(s).list(
             workspace_id=workspace_id,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges.py
@@ -3021,6 +3021,7 @@ async def test_execute_sync_base_protected_scope_block_is_terminal(
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
+    cmd.queue_result(returncode=0, stdout="merged-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     runner = make_runner(
         factory=factory,
@@ -3332,6 +3333,9 @@ async def test_sync_base_conflict_invokes_agent_and_pushes_salvaged_resolution(
         (0, "", ""),  # fetch remote branch for committed diff
         (0, "merge-base-sha\n", ""),
         (0, "src/conflict.py\n", ""),
+        (0, "", ""),  # refresh base branch for sync-base diff
+        (0, "merged-base-sha\n", ""),
+        (0, "", ""),
         (0, "", ""),
     ]:
         cmd.queue_result(returncode=result[0], stdout=result[1], stderr=result[2])
@@ -3451,6 +3455,7 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
+    cmd.queue_result(returncode=0, stdout="merged-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\nsrc/fix.py\n")
     runner = make_runner(
         factory=factory,
@@ -3489,7 +3494,7 @@ async def test_sync_base_blocks_committed_protected_quality_gate_edits_before_pu
         args[:1] == ["git"]
         and "diff" in args
         and "--name-only" in args
-        and "origin/development..HEAD" in args
+        and "merged-base-sha..HEAD" in args
         for args in call_args
     )
     assert not any(args[:1] == ["git"] and "push" in args for args in call_args)
@@ -3525,7 +3530,8 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout=".github/workflows/ci.yml\n")
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch for sync-base diff
-    cmd.queue_result(returncode=0, stdout="")  # diff against refreshed base excludes base changes
+    cmd.queue_result(returncode=0, stdout="merged-base-sha\n")
+    cmd.queue_result(returncode=0, stdout="")  # diff against merged base excludes base changes
     cmd.queue_result(returncode=0, stdout="", stderr="pushed")
     runner = make_runner(
         factory=factory,
@@ -3559,7 +3565,7 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
         args[:1] == ["git"]
         and "diff" in args
         and "--name-only" in args
-        and "origin/development..HEAD" in args
+        and "merged-base-sha..HEAD" in args
         for args in call_args
     )
     assert any(args[:1] == ["git"] and "push" in args for args in call_args)
@@ -3570,6 +3576,85 @@ async def test_sync_base_allows_base_owned_protected_quality_gate_changes_before
             limit=10,
         )
     assert events == []
+
+
+@pytest.mark.unit
+async def test_sync_base_allows_base_owned_protected_changes_when_base_advances_again(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as s:
+        workspace = await WorkspaceRepository(s).get(workspace_id)
+        assert workspace is not None
+        workspace.owned_paths = ["src/**"]
+        await s.commit()
+
+    class AdvancingBaseRunner(FakeCommandRunner):
+        async def run(
+            self,
+            args: list[str],
+            *,
+            input_bytes: bytes | None = None,
+            cwd: str | None = None,
+        ) -> CommandResult:
+            await super().run(args, input_bytes=input_bytes, cwd=cwd)
+            if args[-1:] == [f"refs/heads/awf/{workspace_id}"]:
+                return CommandResult(returncode=0, stdout="", stderr="")
+            if args[-2:] == ["FETCH_HEAD", "HEAD"]:
+                return CommandResult(returncode=0, stdout="remote-branch-base-sha\n", stderr="")
+            if "remote-branch-base-sha..HEAD" in args:
+                return CommandResult(returncode=0, stdout=".github/workflows/ci.yml\n", stderr="")
+            if args[-1:] == ["+refs/heads/development:refs/remotes/origin/development"]:
+                return CommandResult(returncode=0, stdout="", stderr="")
+            if args[-2:] == ["origin/development", "HEAD"]:
+                return CommandResult(returncode=0, stdout="merged-base-sha\n", stderr="")
+            if "merged-base-sha..HEAD" in args:
+                return CommandResult(returncode=0, stdout="", stderr="")
+            if "origin/development..HEAD" in args:
+                return CommandResult(
+                    returncode=0,
+                    stdout=".github/workflows/ci.yml\n",
+                    stderr="",
+                )
+            return CommandResult(returncode=0, stdout="", stderr="")
+
+    cmd = AdvancingBaseRunner()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    violations = await runner._protected_scope_violations_for_sync_base_push(
+        workspace_id=workspace_id,
+        worktree_path=tmp_path / "worktree",
+        remote_branch=f"awf/{workspace_id}",
+        base_branch="development",
+    )
+
+    assert violations == []
+    call_args = [call.args for call in cmd.calls]
+    assert [
+        "git",
+        "-C",
+        str(tmp_path / "worktree"),
+        "diff",
+        "--name-only",
+        "origin/development..HEAD",
+        "--",
+    ] not in call_args
+    assert [
+        "git",
+        "-C",
+        str(tmp_path / "worktree"),
+        "diff",
+        "--name-only",
+        "merged-base-sha..HEAD",
+        "--",
+    ] in call_args
 
 
 @pytest.mark.unit
@@ -4215,7 +4300,7 @@ async def test_changed_paths_since_remote_branch_fails_closed_when_diff_fails(
 
 
 @pytest.mark.unit
-async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
+async def test_sync_base_protected_scope_resolves_merged_base_before_base_diff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
@@ -4225,7 +4310,8 @@ async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
     cmd.queue_result(returncode=0, stdout="merge-base-sha\n")
     cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against remote PR branch
     cmd.queue_result(returncode=0, stdout="")  # refresh base branch
-    cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against refreshed base
+    cmd.queue_result(returncode=0, stdout="merged-base-sha\n")
+    cmd.queue_result(returncode=0, stdout="src/fix.py\n")  # diff against merged base
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -4272,9 +4358,17 @@ async def test_sync_base_protected_scope_refreshes_base_before_base_diff(
             "git",
             "-C",
             str(worktree),
+            "merge-base",
+            "origin/development",
+            "HEAD",
+        ],
+        [
+            "git",
+            "-C",
+            str(worktree),
             "diff",
             "--name-only",
-            "origin/development..HEAD",
+            "merged-base-sha..HEAD",
             "--",
         ],
     ]

--- a/tests/unit/service/test_doctor_reasons.py
+++ b/tests/unit/service/test_doctor_reasons.py
@@ -7,6 +7,24 @@ import pytest
 from awf.service.doctor.reasons import _REASON_TEXT
 
 
+@pytest.mark.unit
+def test_protected_scope_terminal_reasons_have_doctor_guidance() -> None:
+    expected_codes = {
+        "PROTECTED_SCOPE_DIFF_UNAVAILABLE",
+        "PROTECTED_SCOPE_PUSH_BLOCKED",
+    }
+
+    missing_codes = expected_codes - set(_REASON_TEXT)
+
+    assert not missing_codes
+    for code in expected_codes:
+        reason = _REASON_TEXT[code]
+        assert reason.message
+        assert reason.likely_cause
+        assert reason.action
+        assert reason.docs_link == f"docs/REASON_CATALOG.md#{code.lower()}"
+
+
 def generate_expected_catalog(existing_content: str = "") -> str:
     lines = [
         "# AWF Reason and Error Code Catalog\n",


### PR DESCRIPTION
## Summary
- classify infrastructure-like CI failures and rerun failed GitHub workflow jobs before dispatching agent CI repair
- persist a bounded rerun budget per PR head/failing run signature and record rerun success/failure operations/events
- keep code-like CI failures on the existing agent repair path
- block agent-repair pushes when already-committed local changes touch protected quality-gate files outside owned_paths
- document `CI_TRANSIENT_RERUN_FAILED` in the generated reason catalog

## Validation
- `uv run --python 3.12 --extra dev ruff check src/awf tests`
- `uv run --python 3.12 --extra dev mypy src/awf`
- `uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing`
  - 5843 passed
  - coverage 99.02%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic transient CI reruns for qualifying failed workflow runs (uses GitHub rerun flow) before agent repair; records rerun attempts and emits success/failure diagnostics.

* **Improvements**
  * Persistent per-PR/per-failure retry tracking with configurable limits and idempotent attempt accounting.
  * Pre-push protected-scope checks block unsafe pushes and fail closed when diffs are unavailable, emitting guarded diagnostics.

* **Documentation**
  * Added CI_TRANSIENT_RERUN_FAILED and PROTECTED_SCOPE_DIFF_UNAVAILABLE catalog entries with operator guidance.

* **Tests**
  * Expanded unit coverage for transient reruns, protected-scope validation, and related success/failure paths.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/235)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->