### PR TITLE
fix(monitor): classify provider auth failures

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -212,13 +212,6 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service doctor`
 **Docs Link:** [docs/REASON_CATALOG.md#port_config_invalid](#port_config_invalid)
 
-### PROVIDER_AUTH_FAILED
-**Problem:** A workspace agent or PR monitor could not run because the selected LLM provider authentication failed.
-**Likely Cause:** The provider token is expired, reused, missing inside the workspace runtime, or rejected by the provider CLI/API.
-**Operator Fix:** Refresh the provider credentials, restart or rebuild the AWF service/runtime if credentials are mounted into containers, then remonitor or reschedule the workspace.
-**Related Command:** `awf service doctor`
-**Docs Link:** [docs/REASON_CATALOG.md#provider_auth_failed](#provider_auth_failed)
-
 ### POST_AGENT_COMMIT_FAILED
 **Problem:** The post-agent ``git commit`` exited non-zero for a reason unrelated to a pre-commit hook (e.g. missing git identity, detached HEAD, "nothing to commit").
 **Likely Cause:** Git environment misconfiguration in the workspace container or an agent that left the worktree in an unexpected state (orphan HEAD, empty index after stage).
@@ -267,6 +260,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Operator Fix:** Inspect the blocked paths in the monitor event, remove or revert the out-of-scope quality-gate changes, then remonitor the workspace.
 **Related Command:** `awf workspace logs <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#protected_scope_push_blocked](#protected_scope_push_blocked)
+
+### PROVIDER_AUTH_FAILED
+**Problem:** A workspace agent or PR monitor could not run because the selected LLM provider authentication failed.
+**Likely Cause:** The provider token is expired, reused, missing inside the workspace runtime, or rejected by the provider CLI/API.
+**Operator Fix:** Refresh the provider credentials, restart or rebuild the AWF service/runtime if credentials are mounted into containers, then remonitor or reschedule the workspace.
+**Related Command:** `awf service doctor`
+**Docs Link:** [docs/REASON_CATALOG.md#provider_auth_failed](#provider_auth_failed)
 
 ### PR_ADOPTION_INPUT_REQUIRED
 **Problem:** A PR monitor adoption request omitted required input.

--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -212,6 +212,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service doctor`
 **Docs Link:** [docs/REASON_CATALOG.md#port_config_invalid](#port_config_invalid)
 
+### PROVIDER_AUTH_FAILED
+**Problem:** A workspace agent or PR monitor could not run because the selected LLM provider authentication failed.
+**Likely Cause:** The provider token is expired, reused, missing inside the workspace runtime, or rejected by the provider CLI/API.
+**Operator Fix:** Refresh the provider credentials, restart or rebuild the AWF service/runtime if credentials are mounted into containers, then remonitor or reschedule the workspace.
+**Related Command:** `awf service doctor`
+**Docs Link:** [docs/REASON_CATALOG.md#provider_auth_failed](#provider_auth_failed)
+
 ### POST_AGENT_COMMIT_FAILED
 **Problem:** The post-agent ``git commit`` exited non-zero for a reason unrelated to a pre-commit hook (e.g. missing git identity, detached HEAD, "nothing to commit").
 **Likely Cause:** Git environment misconfiguration in the workspace container or an agent that left the worktree in an unexpected state (orphan HEAD, empty index after stage).

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -129,6 +129,7 @@ from awf.service.merge_queue import (
     list_merge_queue_blockers_for_workspace,
 )
 from awf.service.provider_recovery import (
+    PROVIDER_AUTH_FAILED,
     PROVIDER_MODEL_CIRCUIT_OPEN_REASON,
     PROVIDER_RECOVERY_COOLDOWN_EVENT,
     create_provider_recovery_attempt_row,
@@ -441,6 +442,10 @@ class ProviderRecoveryFallbackError(Exception):
 
 class ProviderRecoveryRetryError(Exception):
     """Raised when an operation should back off and retry later due to a provider error."""
+
+
+class ProviderRecoveryAuthError(Exception):
+    """Raised when PR-monitor repair cannot continue because provider auth is broken."""
 
 
 class _MonitorPolicyBlockedError(Exception):
@@ -848,7 +853,7 @@ class PullRequestMonitorRunner:
         self,
         workspace_id: str,
         exc: AgentRunError,
-    ) -> Literal["fallback", "retry", "deterministic"]:
+    ) -> Literal["fallback", "retry", "auth_failed", "deterministic"]:
         message = exc.result.stderr.strip() or exc.result.stdout.strip()
         async with self._deps.session_factory() as s:
             repo = WorkspaceRepository(s)
@@ -863,12 +868,18 @@ class PullRequestMonitorRunner:
             )
             if metadata is None:
                 return "deterministic"
+            provider_auth_failed = (
+                metadata.get("failure_type") == "auth"
+                or metadata.get("reason_code") == "AGENT_AUTH_FAILED"
+            )
             result = await create_provider_recovery_attempt_row(
                 s,
                 workspace_id,
                 metadata=metadata,
             )
             await s.commit()
+            if provider_auth_failed:
+                return "auth_failed"
             if result == "terminal" or result == "stale":
                 return "deterministic"
             if result is not None and result.action == "fallback" and not result.in_place:
@@ -889,6 +900,8 @@ class PullRequestMonitorRunner:
             raise ProviderRecoveryFallbackError() from exc
         if action == "retry":
             raise ProviderRecoveryRetryError()
+        if action == "auth_failed":
+            raise ProviderRecoveryAuthError() from exc
 
     async def _record_pr_monitor_audit_event(
         self,
@@ -1185,6 +1198,23 @@ class PullRequestMonitorRunner:
                 reason_code="PROVIDER_FALLBACK",
             )
             return
+        except ProviderRecoveryAuthError:
+            await self._write_monitor_log(
+                monitor_log,
+                {
+                    "event": "monitor.provider_auth_failed",
+                    "workspace_id": workspace_id,
+                    "reason_code": PROVIDER_AUTH_FAILED,
+                },
+            )
+            if state is not None:
+                await self._persist_state(workspace_id, state)
+            await self._terminate_failed(
+                workspace_id,
+                message="monitor: provider authentication failed",
+                reason_code=PROVIDER_AUTH_FAILED,
+            )
+            return
         finally:
             await self._write_monitor_log(
                 monitor_log,
@@ -1388,6 +1418,20 @@ class PullRequestMonitorRunner:
                     },
                     error_code="PROVIDER_FALLBACK",
                     error_message="Provider recovery triggered fallback",
+                )
+                raise
+            except ProviderRecoveryAuthError:
+                await self._finish_monitor_operation(
+                    operation,
+                    status=OperationStatus.failed,
+                    result={
+                        "status": "failed",
+                        "outcome": "provider_auth_failed",
+                        "reason_code": PROVIDER_AUTH_FAILED,
+                        "pushed": False,
+                    },
+                    error_code=PROVIDER_AUTH_FAILED,
+                    error_message="Provider authentication failed",
                 )
                 raise
             except BaseFetchError as exc:
@@ -1818,6 +1862,21 @@ class PullRequestMonitorRunner:
                     error_message="Provider recovery triggered fallback",
                 )
                 raise
+            except ProviderRecoveryAuthError:
+                await self._finish_monitor_operation(
+                    operation,
+                    status=OperationStatus.failed,
+                    result={
+                        "status": "failed",
+                        "outcome": "provider_auth_failed",
+                        "reason_code": PROVIDER_AUTH_FAILED,
+                        "failure_count": len(action.failures),
+                        "pushed": False,
+                    },
+                    error_code=PROVIDER_AUTH_FAILED,
+                    error_message="Provider authentication failed",
+                )
+                raise
             except ComposeExecCleanupError as exc:
                 await self._finish_monitor_operation(
                     operation,
@@ -1972,6 +2031,20 @@ class PullRequestMonitorRunner:
                     },
                     error_code="PROVIDER_FALLBACK",
                     error_message="Provider recovery triggered fallback",
+                )
+                raise
+            except ProviderRecoveryAuthError:
+                await self._finish_monitor_operation(
+                    operation,
+                    status=OperationStatus.failed,
+                    result={
+                        "status": "failed",
+                        "outcome": "provider_auth_failed",
+                        "reason_code": PROVIDER_AUTH_FAILED,
+                        "pushed": False,
+                    },
+                    error_code=PROVIDER_AUTH_FAILED,
+                    error_message="Provider authentication failed",
                 )
                 raise
             except ComposeExecCleanupError as exc:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -132,6 +132,7 @@ from awf.service.provider_recovery import (
     PROVIDER_AUTH_FAILED,
     PROVIDER_MODEL_CIRCUIT_OPEN_REASON,
     PROVIDER_RECOVERY_COOLDOWN_EVENT,
+    _is_auth_failure_metadata,
     create_provider_recovery_attempt_row,
     provider_cooldown_not_before,
     provider_for_agent_model,
@@ -576,6 +577,28 @@ class PullRequestMonitorRunner:
             )
             await session.commit()
 
+    async def _finish_provider_auth_failed_operation(
+        self,
+        handle: MonitorOperationHandle | None,
+        *,
+        extra_result: Mapping[str, Any] | None = None,
+    ) -> None:
+        result: dict[str, Any] = {
+            "status": "failed",
+            "outcome": "provider_auth_failed",
+            "reason_code": PROVIDER_AUTH_FAILED,
+        }
+        if extra_result:
+            result.update(extra_result)
+        result["pushed"] = False
+        await self._finish_monitor_operation(
+            handle,
+            status=OperationStatus.failed,
+            result=result,
+            error_code=PROVIDER_AUTH_FAILED,
+            error_message="Provider authentication failed",
+        )
+
     async def _begin_monitor_state_operation(
         self,
         *,
@@ -868,10 +891,7 @@ class PullRequestMonitorRunner:
             )
             if metadata is None:
                 return "deterministic"
-            provider_auth_failed = (
-                metadata.get("failure_type") == "auth"
-                or metadata.get("reason_code") == "AGENT_AUTH_FAILED"
-            )
+            provider_auth_failed = _is_auth_failure_metadata(metadata)
             result = await create_provider_recovery_attempt_row(
                 s,
                 workspace_id,
@@ -1421,18 +1441,7 @@ class PullRequestMonitorRunner:
                 )
                 raise
             except ProviderRecoveryAuthError:
-                await self._finish_monitor_operation(
-                    operation,
-                    status=OperationStatus.failed,
-                    result={
-                        "status": "failed",
-                        "outcome": "provider_auth_failed",
-                        "reason_code": PROVIDER_AUTH_FAILED,
-                        "pushed": False,
-                    },
-                    error_code=PROVIDER_AUTH_FAILED,
-                    error_message="Provider authentication failed",
-                )
+                await self._finish_provider_auth_failed_operation(operation)
                 raise
             except BaseFetchError as exc:
                 base_fetch_result = await self._wait_after_transient_base_fetch_error(
@@ -1863,18 +1872,9 @@ class PullRequestMonitorRunner:
                 )
                 raise
             except ProviderRecoveryAuthError:
-                await self._finish_monitor_operation(
+                await self._finish_provider_auth_failed_operation(
                     operation,
-                    status=OperationStatus.failed,
-                    result={
-                        "status": "failed",
-                        "outcome": "provider_auth_failed",
-                        "reason_code": PROVIDER_AUTH_FAILED,
-                        "failure_count": len(action.failures),
-                        "pushed": False,
-                    },
-                    error_code=PROVIDER_AUTH_FAILED,
-                    error_message="Provider authentication failed",
+                    extra_result={"failure_count": len(action.failures)},
                 )
                 raise
             except ComposeExecCleanupError as exc:
@@ -2034,18 +2034,7 @@ class PullRequestMonitorRunner:
                 )
                 raise
             except ProviderRecoveryAuthError:
-                await self._finish_monitor_operation(
-                    operation,
-                    status=OperationStatus.failed,
-                    result={
-                        "status": "failed",
-                        "outcome": "provider_auth_failed",
-                        "reason_code": PROVIDER_AUTH_FAILED,
-                        "pushed": False,
-                    },
-                    error_code=PROVIDER_AUTH_FAILED,
-                    error_message="Provider authentication failed",
-                )
+                await self._finish_provider_auth_failed_operation(operation)
                 raise
             except ComposeExecCleanupError as exc:
                 await self._finish_monitor_operation(

--- a/src/awf/service/provider_recovery.py
+++ b/src/awf/service/provider_recovery.py
@@ -11,6 +11,7 @@ from typing import Any, Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.adapters.provider_failures import (
+    AGENT_AUTH_FAILED,
     AGENT_PROVIDER_CAPACITY_EXHAUSTED,
     classify_provider_failure,
     infer_provider,
@@ -35,6 +36,7 @@ PROVIDER_RECOVERY_COOLDOWN_EVENT = "workspace.provider_recovery_cooldown"
 PROVIDER_MODEL_CIRCUIT_OPEN_REASON = "PROVIDER_MODEL_CIRCUIT_OPEN"
 PROVIDER_RETRY_DELAYED_REASON = "PROVIDER_RETRY_DELAYED"
 PROVIDER_FALLBACK_SELECTED_REASON = "PROVIDER_FALLBACK_SELECTED"
+PROVIDER_AUTH_FAILED = "PROVIDER_AUTH_FAILED"
 PROVIDER_RECOVERY_NO_LOOP_REASON = "REPEATED_PROVIDER_FAILURE_FINGERPRINT"
 NON_RETRYABLE_PROVIDER_FAILURE = "NON_RETRYABLE_PROVIDER_FAILURE"
 PROVIDER_RECOVERY_ATTEMPTS_EXHAUSTED = "PROVIDER_RECOVERY_ATTEMPTS_EXHAUSTED"
@@ -46,6 +48,7 @@ PROVIDER_RECOVERY_REASON_CODES: frozenset[str] = frozenset(
         PROVIDER_MODEL_CIRCUIT_OPEN_REASON,
         PROVIDER_RETRY_DELAYED_REASON,
         PROVIDER_FALLBACK_SELECTED_REASON,
+        PROVIDER_AUTH_FAILED,
         PROVIDER_RECOVERY_NO_LOOP_REASON,
         NON_RETRYABLE_PROVIDER_FAILURE,
         PROVIDER_RECOVERY_ATTEMPTS_EXHAUSTED,
@@ -134,10 +137,17 @@ def provider_recovery_metadata_from_failure(
 
     policy = parse_provider_recovery_policy(task_policy)
     state = parse_provider_recovery_state(task_policy)
+    auth_failure = _is_auth_failure_metadata(metadata)
+    if auth_failure:
+        metadata["retryable"] = False
     metadata["fallback_allowed"] = (
-        bool(policy.fallbacks)
-        and state.fallback_attempt_number < policy.max_fallback_attempts
-        and bool(metadata.get("retryable"))
+        False
+        if auth_failure
+        else (
+            bool(policy.fallbacks)
+            and state.fallback_attempt_number < policy.max_fallback_attempts
+            and bool(metadata.get("retryable"))
+        )
     )
     metadata["recommended_action"] = _metadata_recommended_action(metadata)
     if isinstance(message, str) and message:
@@ -162,6 +172,8 @@ def decide_provider_recovery(
     )
     model = _metadata_str(metadata, "model") or current_model
 
+    if _is_auth_failure_metadata(metadata):
+        return _terminal_decision(PROVIDER_AUTH_FAILED, state=state)
     if not bool(metadata.get("retryable")):
         return _terminal_decision("NON_RETRYABLE_PROVIDER_FAILURE", state=state)
     if fingerprint is not None and fingerprint in state.failure_fingerprints:
@@ -198,6 +210,13 @@ def decide_provider_recovery(
         )
 
     return _terminal_decision("PROVIDER_RECOVERY_ATTEMPTS_EXHAUSTED", state=state)
+
+
+def _is_auth_failure_metadata(metadata: Mapping[str, Any]) -> bool:
+    return (
+        _metadata_str(metadata, "failure_type") == "auth"
+        or _metadata_str(metadata, "reason_code") == AGENT_AUTH_FAILED
+    )
 
 
 async def create_provider_recovery_attempt_row(
@@ -594,6 +613,8 @@ def _classification_metadata(
 
 
 def _metadata_recommended_action(metadata: Mapping[str, Any]) -> str:
+    if _is_auth_failure_metadata(metadata):
+        return "Refresh provider credentials before retrying this workspace."
     existing = metadata.get("recommended_action")
     if isinstance(existing, str) and existing.strip():
         return existing.strip()

--- a/tests/unit/api/test_provider_recovery_schemas.py
+++ b/tests/unit/api/test_provider_recovery_schemas.py
@@ -13,6 +13,7 @@ from awf.api.schemas import (
     WorkspaceResponse,
 )
 from awf.service.provider_recovery import (
+    PROVIDER_AUTH_FAILED,
     PROVIDER_FALLBACK_SELECTED_REASON,
     PROVIDER_MODEL_CIRCUIT_OPEN_REASON,
     PROVIDER_RECOVERY_NO_LOOP_REASON,
@@ -24,6 +25,7 @@ from awf.service.provider_recovery import (
 def test_provider_recovery_reason_codes_are_stable() -> None:
     expected = frozenset(
         {
+            PROVIDER_AUTH_FAILED,
             "PROVIDER_MODEL_CIRCUIT_OPEN",
             "PROVIDER_RETRY_DELAYED",
             "PROVIDER_FALLBACK_SELECTED",
@@ -36,6 +38,7 @@ def test_provider_recovery_reason_codes_are_stable() -> None:
 
 
 def test_provider_recovery_reason_code_constant_values() -> None:
+    assert PROVIDER_AUTH_FAILED == "PROVIDER_AUTH_FAILED"
     assert PROVIDER_MODEL_CIRCUIT_OPEN_REASON == "PROVIDER_MODEL_CIRCUIT_OPEN"
     assert PROVIDER_RETRY_DELAYED_REASON == "PROVIDER_RETRY_DELAYED"
     assert PROVIDER_FALLBACK_SELECTED_REASON == "PROVIDER_FALLBACK_SELECTED"

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -74,6 +74,7 @@ from awf.runtime.pr_monitor_runner import (
     BaseBehindCountError,
     BaseFetchError,
     MonitorRunnerConfig,
+    ProviderRecoveryAuthError,
     ProviderRecoveryFallbackError,
     ProviderRecoveryRetryError,
     PullRequestMonitorRunner,
@@ -3392,11 +3393,69 @@ async def test_provider_agent_error_still_raises_full_fallback_for_non_monitor_r
 
 
 @pytest.mark.unit
+async def test_provider_agent_auth_failure_raises_provider_auth_failed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _configure_provider_monitor_workspace(
+        factory,
+        workspace_id,
+        agent="codex",
+        model="gpt-5.5",
+        fallback_agent="gemini",
+        fallback_provider="google",
+        fallback_model="gemini-3.1-pro-preview",
+        max_same_provider_retries=3,
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    exc = AgentRunError(
+        agent=AgentRuntime.codex,
+        result=CommandResult(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "Failed to refresh token: Your access token could not be refreshed "
+                "because your refresh token was already used. websocket 401 Unauthorized "
+                "token_expired"
+            ),
+        ),
+        details={"provider": "openai", "model": "gpt-5.5"},
+    )
+
+    with pytest.raises(ProviderRecoveryAuthError):
+        await runner._handle_provider_agent_run_error(workspace_id, exc)
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        terminal_events = [
+            event
+            for event in workspace.events
+            if event.event_type == "workspace.provider_recovery_terminal"
+        ]
+
+    assert len(terminal_events) == 1
+    assert terminal_events[0].reason_code == "PROVIDER_AUTH_FAILED"
+    assert workspace.task_policy["provider_recovery_state"]["action"] == "terminal"
+    assert workspace.task_policy["provider_recovery_state"]["source_reason_code"] == (
+        "AGENT_AUTH_FAILED"
+    )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("error_cls", "outcome", "reason_code"),
     [
         (ProviderRecoveryRetryError, "provider_retry", "PROVIDER_OUTAGE"),
         (ProviderRecoveryFallbackError, "provider_fallback", "PROVIDER_FALLBACK"),
+        (ProviderRecoveryAuthError, "provider_auth_failed", "PROVIDER_AUTH_FAILED"),
     ],
 )
 async def test_sync_base_provider_recovery_exceptions_finish_operation(
@@ -3457,6 +3516,7 @@ async def test_sync_base_provider_recovery_exceptions_finish_operation(
     [
         (ProviderRecoveryRetryError, "provider_retry", "PROVIDER_OUTAGE"),
         (ProviderRecoveryFallbackError, "provider_fallback", "PROVIDER_FALLBACK"),
+        (ProviderRecoveryAuthError, "provider_auth_failed", "PROVIDER_AUTH_FAILED"),
     ],
 )
 async def test_ci_repair_provider_recovery_exceptions_finish_operation(
@@ -3511,6 +3571,63 @@ async def test_ci_repair_provider_recovery_exceptions_finish_operation(
         "pushed": False,
     }
     assert operation.error_code == reason_code
+
+
+@pytest.mark.unit
+async def test_comment_repair_provider_auth_exception_finishes_operation(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    thread = ReviewThread(
+        thread_id="T_auth",
+        path="src/app.py",
+        line=12,
+        body_excerpt="please fix",
+        author="reviewer",
+    )
+
+    async def _raise_provider_auth(**_kwargs: object) -> object:
+        raise ProviderRecoveryAuthError()
+
+    mocker.patch.object(runner, "_run_fix_cycle", _raise_provider_auth)
+
+    with pytest.raises(ProviderRecoveryAuthError):
+        await runner._execute(
+            action=AddressComments(threads=(thread,), review_comments=()),
+            workspace_id=workspace_id,
+            repo_url="git@github.com:dimileeh/aira-web.git",
+            repo=RepoRef(owner="dimileeh", name="aira-web"),
+            pr_number=42,
+            status=replace(_green_status(), unresolved_inline_threads=(thread,)),
+            state=MonitorState(started_at=0.0),
+            base_branch="development",
+            remote_branch=f"awf/{workspace_id}",
+            compose_project="proj",
+            compose_file=tmp_path / "compose.yml",
+            monitor_log=None,
+        )
+
+    async with factory() as session:
+        operations = await OperationRepository(session).list_all(workspace_id=workspace_id)
+    operation = operations[0]
+    assert operation.type == "comment_repair"
+    assert operation.status == OperationStatus.failed.value
+    assert operation.result == {
+        "status": "failed",
+        "outcome": "provider_auth_failed",
+        "reason_code": "PROVIDER_AUTH_FAILED",
+        "pushed": False,
+    }
+    assert operation.error_code == "PROVIDER_AUTH_FAILED"
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_provider_recovery.py
+++ b/tests/unit/service/test_provider_recovery.py
@@ -23,6 +23,7 @@ from awf.db.session import make_session_factory
 from awf.profiles.models import ProfileMonitor, WorkspaceProfile
 from awf.service import provider_recovery as provider_recovery_mod
 from awf.service.provider_recovery import (
+    PROVIDER_AUTH_FAILED,
     FallbackTarget,
     ProviderRecoveryDecision,
     ProviderRecoveryPolicy,
@@ -245,6 +246,24 @@ def test_provider_recovery_metadata_derives_from_persisted_failure_details() -> 
     assert "<redacted>" in metadata["failure_fingerprint"]
 
 
+def test_provider_recovery_metadata_disables_fallback_for_auth_failure() -> None:
+    metadata = provider_recovery_metadata_from_failure(
+        reason_code=AGENT_AUTH_FAILED,
+        message="Codex token_expired websocket 401 Unauthorized",
+        details={"provider": "openai", "model": "gpt-5.5"},
+        task_policy=v2_task_policy_snapshot(_request()),
+    )
+
+    assert metadata is not None
+    assert metadata["reason_code"] == AGENT_AUTH_FAILED
+    assert metadata["failure_type"] == "auth"
+    assert metadata["retryable"] is False
+    assert metadata["fallback_allowed"] is False
+    assert metadata["recommended_action"] == (
+        "Refresh provider credentials before retrying this workspace."
+    )
+
+
 def test_provider_recovery_value_helpers_normalize_payloads() -> None:
     explicit = FallbackTarget(agent="codex", provider="openai", model="gpt-5.5")
     inferred = FallbackTarget(agent="codex", provider=None, model="gpt-5.5")
@@ -378,6 +397,34 @@ def test_non_retryable_provider_failure_is_terminal() -> None:
     assert decision.action == "terminal"
     assert decision.retryable is False
     assert decision.terminal_reason == "NON_RETRYABLE_PROVIDER_FAILURE"
+
+
+def test_auth_provider_failure_is_terminal_even_with_retry_or_fallback_budget() -> None:
+    decision = decide_provider_recovery(
+        {
+            "reason_code": AGENT_AUTH_FAILED,
+            "failure_type": "auth",
+            "retryable": True,
+            "provider": "openai",
+            "model": "gpt-5.5",
+            "failure_fingerprint": "auth:openai:gpt-5.5",
+        },
+        task_policy={
+            "provider_recovery": {
+                "fallbacks": [{"agent": "gemini", "model": "gemini-3.1-pro-preview"}],
+                "max_fallback_attempts": 1,
+                "max_same_provider_retries": 3,
+            }
+        },
+        current_agent="codex",
+        current_model="gpt-5.5",
+        now=datetime(2026, 5, 13, 12, 0, tzinfo=UTC),
+    )
+
+    assert decision.action == "terminal"
+    assert decision.retryable is False
+    assert decision.reason_code == PROVIDER_AUTH_FAILED
+    assert decision.terminal_reason == PROVIDER_AUTH_FAILED
 
 
 def test_retryable_failure_without_available_fallback_is_terminal_after_retry_budget() -> None:

--- a/tests/unit/service/test_provider_recovery_observability.py
+++ b/tests/unit/service/test_provider_recovery_observability.py
@@ -11,6 +11,7 @@ from awf.service.metrics import (
     ProviderRecoveryStateSummary,
 )
 from awf.service.provider_recovery import (
+    PROVIDER_AUTH_FAILED,
     PROVIDER_FALLBACK_SELECTED_REASON,
     PROVIDER_RECOVERY_COOLDOWN_EVENT,
     PROVIDER_RECOVERY_REASON_CODES,
@@ -350,6 +351,7 @@ def test_metrics_failure_analysis_includes_provider_recovery_breakdown() -> None
 def test_provider_recovery_reason_codes_includes_all_contract_values() -> None:
     expected = frozenset(
         {
+            PROVIDER_AUTH_FAILED,
             "PROVIDER_MODEL_CIRCUIT_OPEN",
             "PROVIDER_RETRY_DELAYED",
             "PROVIDER_FALLBACK_SELECTED",


### PR DESCRIPTION
## Summary
- classify provider auth failures as terminal PROVIDER_AUTH_FAILED instead of generic provider outage
- finish PR-monitor operations with provider_auth_failed outcomes for sync-base, CI repair, and comment repair
- document PROVIDER_AUTH_FAILED and add TDD coverage for Codex token-expired/401 failures

## Validation
- uv run --python 3.12 --extra dev ruff check src/awf/service/provider_recovery.py src/awf/runtime/pr_monitor_runner.py tests/unit/service/test_provider_recovery.py tests/unit/runtime/test_pr_monitor_runner.py
- uv run --python 3.12 --extra dev mypy src/awf/service/provider_recovery.py src/awf/runtime/pr_monitor_runner.py
- uv run --python 3.12 --extra dev pytest tests/unit/service/test_provider_recovery.py tests/unit/runtime/test_pr_monitor_runner.py tests/unit/docs/test_catalog_coverage.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider authentication failures are now classified as terminal (non-retryable) and cause operations to finish with a distinct provider-auth-failed outcome.
  * Recommendations now direct operators to refresh credentials instead of attempting fallback or automatic retries.

* **Documentation**
  * Added documentation entry for the new provider-auth-failed reason code and operator guidance.

* **Tests**
  * Added and updated tests to cover provider-auth-failed behavior and reason-code stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/240)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->