### PR TITLE
P2: clarify PR monitor review feedback log metrics

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -257,6 +257,14 @@ The merge gate is intentionally conservative. A PR can merge only after:
 - the branch is not behind the base branch,
 - the final short pre-merge settle recheck still sees the same green state.
 
+For operator visibility, `monitor.action` logs now report:
+
+- `review_feedback`: total outside-diff/issue review items fetched in `unresolved_review_comments`.
+- `pending_review_feedback`: items in that set still requiring agent triage after monitor-state/body-hash/verdict checks.
+- `blocking_reviews`: count of effective GitHub blockers in `status.blocking_reviews`.
+- `unresolved_reviews`: maintained as a backward-compatible alias of `review_feedback` for
+  existing log consumers.
+
 ### AddressComments
 
 `AddressComments` is the review-fix loop.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -202,6 +202,9 @@ class PRStatus:
 
     ``unresolved_review_comments`` intentionally preserves advisory review
     bodies and top-level issue comments for the address-comments loop.
+
+    This field is also mirrored as the raw ``review_feedback``/``unresolved_reviews``
+    operator log metric, which intentionally remains for backward compatibility.
     """
     merge_state_status: MergeStateStatus = MergeStateStatus.UNKNOWN
     """GitHub's authoritative merge-state signal. Combined with

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -196,15 +196,15 @@ class PRStatus:
     check_state: CheckState
     unresolved_inline_threads: tuple[ReviewThread, ...]
     unresolved_review_comments: tuple[ReviewComment, ...]
-    base_behind_count: int  # commits on base not in head (local rev-list)
-    blocking_reviews: tuple[ReviewComment, ...] = ()
-    """Effective review-level blockers used only for merge gating.
-
-    ``unresolved_review_comments`` intentionally preserves advisory review
+    """``unresolved_review_comments`` intentionally preserves advisory review
     bodies and top-level issue comments for the address-comments loop.
 
     This field is also mirrored as the raw ``review_feedback``/``unresolved_reviews``
     operator log metric, which intentionally remains for backward compatibility.
+    """
+    base_behind_count: int  # commits on base not in head (local rev-list)
+    blocking_reviews: tuple[ReviewComment, ...] = ()
+    """Effective review-level blockers used only for merge gating.
     """
     merge_state_status: MergeStateStatus = MergeStateStatus.UNKNOWN
     """GitHub's authoritative merge-state signal. Combined with

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2499,6 +2499,8 @@ class PullRequestMonitorRunner:
                                 fresh_action=type(checked_action).__name__,
                                 head_sha=checked_status.head_sha[:10],
                                 unresolved_threads=len(checked_status.unresolved_inline_threads),
+                                # compatibility alias retained for downstream consumers of
+                                # historical monitor logs.
                                 unresolved_reviews=review_feedback,
                                 review_feedback=review_feedback,
                                 pending_review_feedback=pending_review_feedback,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -7640,7 +7640,8 @@ def _pending_review_feedback_count(status: PRStatus, state: MonitorState) -> int
     return sum(
         1
         for comment in status.unresolved_review_comments
-        if not comment.blocks_merge and _review_comment_needs_attention(state, comment)
+        if _agent_can_triage_review_comment(comment)
+        and _review_comment_needs_attention(state, comment)
     )
 
 

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -2487,6 +2487,7 @@ class PullRequestMonitorRunner:
                         if not isinstance(checked_action, Merge):
                             fresh_action = checked_action
                             fresh_status = checked_status
+                            review_feedback = len(checked_status.unresolved_review_comments)
                             pending_review_feedback = _pending_review_feedback_count(
                                 checked_status, state
                             )
@@ -2498,8 +2499,8 @@ class PullRequestMonitorRunner:
                                 fresh_action=type(checked_action).__name__,
                                 head_sha=checked_status.head_sha[:10],
                                 unresolved_threads=len(checked_status.unresolved_inline_threads),
-                                unresolved_reviews=len(checked_status.unresolved_review_comments),
-                                review_feedback=len(checked_status.unresolved_review_comments),
+                                unresolved_reviews=review_feedback,
+                                review_feedback=review_feedback,
                                 pending_review_feedback=pending_review_feedback,
                                 blocking_reviews=len(checked_status.blocking_reviews),
                                 check_state=checked_status.check_state.value,

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -1395,6 +1395,8 @@ class PullRequestMonitorRunner:
         # downstream. Regression guard for PR 342: the monitor ran 200+
         # iterations silently because only handoff_to_pr_monitor and
         # compose_teardown_ok fired.
+        review_feedback = len(status.unresolved_review_comments)
+        pending_review_feedback = _pending_review_feedback_count(status, state)
         _log.info(
             "monitor.action",
             workspace_id=workspace_id,
@@ -1405,7 +1407,11 @@ class PullRequestMonitorRunner:
             base_behind=status.base_behind_count,
             merge_state=(status.merge_state_status.value if status.merge_state_status else None),
             unresolved_threads=len(status.unresolved_inline_threads),
-            unresolved_reviews=len(status.unresolved_review_comments),
+            # compatibility alias retained for downstream consumers of
+            # historical monitor logs.
+            unresolved_reviews=review_feedback,
+            review_feedback=review_feedback,
+            pending_review_feedback=pending_review_feedback,
             blocking_reviews=len(status.blocking_reviews),
         )
         await self._write_monitor_log(
@@ -1422,7 +1428,9 @@ class PullRequestMonitorRunner:
                     status.merge_state_status.value if status.merge_state_status else None
                 ),
                 "unresolved_threads": len(status.unresolved_inline_threads),
-                "unresolved_reviews": len(status.unresolved_review_comments),
+                "unresolved_reviews": review_feedback,
+                "review_feedback": review_feedback,
+                "pending_review_feedback": pending_review_feedback,
                 "blocking_reviews": len(status.blocking_reviews),
             },
         )
@@ -2479,6 +2487,9 @@ class PullRequestMonitorRunner:
                         if not isinstance(checked_action, Merge):
                             fresh_action = checked_action
                             fresh_status = checked_status
+                            pending_review_feedback = _pending_review_feedback_count(
+                                checked_status, state
+                            )
                             _log.info(
                                 "monitor.pre_merge_recheck_changed_action",
                                 workspace_id=workspace_id,
@@ -2488,6 +2499,8 @@ class PullRequestMonitorRunner:
                                 head_sha=checked_status.head_sha[:10],
                                 unresolved_threads=len(checked_status.unresolved_inline_threads),
                                 unresolved_reviews=len(checked_status.unresolved_review_comments),
+                                review_feedback=len(checked_status.unresolved_review_comments),
+                                pending_review_feedback=pending_review_feedback,
                                 blocking_reviews=len(checked_status.blocking_reviews),
                                 check_state=checked_status.check_state.value,
                                 merge_state=(
@@ -7610,6 +7623,26 @@ def _collect_defer_items(
             }
         )
     return bot_items, human_items
+
+
+def _pending_review_feedback_count(status: PRStatus, state: MonitorState) -> int:
+    """Count review feedback still requiring agent attention under monitor state.
+
+    This is the operator-facing counterpart to `unresolved_review_comments`:
+    raw outside-diff feedback count stays in ``review_feedback`` (and the
+    compatibility alias ``unresolved_reviews``), while this metric only counts
+    items that can still be triaged now, after body hash and prior verdict state
+    are applied.
+    """
+    return sum(
+        1
+        for comment in status.unresolved_review_comments
+        if (
+            not comment.blocks_merge
+            and _agent_can_triage_review_comment(comment)
+            and _review_comment_needs_attention(state, comment)
+        )
+    )
 
 
 def _changed_paths_from_porcelain(status_stdout: str) -> list[str]:

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -7637,11 +7637,7 @@ def _pending_review_feedback_count(status: PRStatus, state: MonitorState) -> int
     return sum(
         1
         for comment in status.unresolved_review_comments
-        if (
-            not comment.blocks_merge
-            and _agent_can_triage_review_comment(comment)
-            and _review_comment_needs_attention(state, comment)
-        )
+        if not comment.blocks_merge and _review_comment_needs_attention(state, comment)
     )
 
 

--- a/tests/unit/runtime/test_monitor_action_logging.py
+++ b/tests/unit/runtime/test_monitor_action_logging.py
@@ -107,6 +107,9 @@ class TestMonitorActionLogging:
         assert entry["merge_state"] == "CLEAN"
         assert entry["unresolved_threads"] == 0
         assert entry["unresolved_reviews"] == 0
+        assert entry["review_feedback"] == 0
+        assert entry["pending_review_feedback"] == 0
+        assert entry["unresolved_reviews"] == entry["review_feedback"]
         assert entry["blocking_reviews"] == 0
         assert entry["head_sha"].startswith("abc1234567")
         async with factory() as s:
@@ -193,6 +196,8 @@ class TestMonitorActionLogging:
         assert '"event": "monitor.start"' in log_text
         assert '"event": "monitor.action"' in log_text
         assert '"action": "Merge"' in log_text
+        assert '"review_feedback": 0' in log_text
+        assert '"pending_review_feedback": 0' in log_text
         assert '"blocking_reviews": 0' in log_text
 
     @pytest.mark.unit
@@ -941,13 +946,24 @@ class TestMonitorActionLogging:
         assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
         assert len(adapter.calls) == 1
         assert "Trigger review before merging" in adapter.calls[0]
+        merge_action = _action_entries(captured)[0]
+        address_action = _action_entries(captured)[1]
+        assert merge_action["unresolved_reviews"] == 0
+        assert merge_action["review_feedback"] == 0
+        assert merge_action["pending_review_feedback"] == 0
+        assert merge_action["blocking_reviews"] == 0
+        assert address_action["review_feedback"] == 1
+        assert address_action["pending_review_feedback"] == 1
+        assert address_action["unresolved_reviews"] == address_action["review_feedback"]
         changed_action = next(
             r
             for r in captured
             if r.get("event") == "monitor.pre_merge_recheck_changed_action"
             and r.get("fresh_action") == "AddressComments"
         )
-        assert changed_action["unresolved_reviews"] == 1
+        assert changed_action["review_feedback"] == 1
+        assert changed_action["pending_review_feedback"] == 1
+        assert changed_action["unresolved_reviews"] == changed_action["review_feedback"]
         assert changed_action["blocking_reviews"] == 0
 
 

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -2740,6 +2740,7 @@ def test_changed_review_comment_body_requeues_private_verdict() -> None:
 
 @pytest.mark.unit
 def test_pending_review_feedback_count_excludes_blocking_reviews_and_honors_state_hash() -> None:
+    """Verify resolved, stale, and merge-blocking feedback is handled when counting pending triage items."""
     state = MonitorState()
     pending_comment = ReviewComment(
         comment_id="issue:pending",
@@ -2806,6 +2807,7 @@ def test_pending_review_feedback_count_excludes_blocking_reviews_and_honors_stat
 
 @pytest.mark.unit
 def test_pending_review_feedback_count_includes_triageable_blocking_issue_comment() -> None:
+    """Verify merge-blocking issue comments from bots can still count as pending feedback."""
     state = MonitorState()
     triageable_blocker = ReviewComment(
         comment_id="issue:blocked-bot",

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -2805,6 +2805,32 @@ def test_pending_review_feedback_count_excludes_blocking_reviews_and_honors_stat
 
 
 @pytest.mark.unit
+def test_pending_review_feedback_count_includes_triageable_blocking_issue_comment() -> None:
+    state = MonitorState()
+    triageable_blocker = ReviewComment(
+        comment_id="issue:blocked-bot",
+        body_excerpt="Please update required checks",
+        body="Please update required checks",
+        author="coderabbitai[bot]",
+        source_kind="issue",
+        blocks_merge=True,
+    )
+
+    status = PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(triageable_blocker,),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+    assert _pending_review_feedback_count(status, state) == 1
+
+
+@pytest.mark.unit
 def test_changed_review_thread_history_requeues_private_verdict() -> None:
     state = MonitorState()
     original = ReviewThread(

--- a/tests/unit/runtime/test_pr_monitor_runner.py
+++ b/tests/unit/runtime/test_pr_monitor_runner.py
@@ -104,6 +104,7 @@ from awf.runtime.pr_monitor_runner import (
     _notify_human_reason,
     _parse_verdict,
     _parse_verdict_result,
+    _pending_review_feedback_count,
     _review_comment_body_state_key,
     _stale_pending_check_warning_key,
     _stale_pending_check_warnings,
@@ -2735,6 +2736,72 @@ def test_changed_review_comment_body_requeues_private_verdict() -> None:
     assert changed is True
     assert "issue:handled" not in state.threads_addressed_ids
     assert _review_comment_body_state_key("issue:handled") not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+def test_pending_review_feedback_count_excludes_blocking_reviews_and_honors_state_hash() -> None:
+    state = MonitorState()
+    pending_comment = ReviewComment(
+        comment_id="issue:pending",
+        body_excerpt="please add test coverage",
+        body="please add test coverage",
+        author="reviewer",
+    )
+    handled_comment = ReviewComment(
+        comment_id="issue:handled",
+        body_excerpt="already handled",
+        body="already handled",
+        author="reviewer",
+    )
+    _mark_review_comment_addressed(state, handled_comment, "false_positive")
+    agent_failed_comment = ReviewComment(
+        comment_id="issue:agent-failed",
+        body_excerpt="still failing",
+        body="still failing",
+        author="coderabbitai",
+    )
+    _mark_review_comment_addressed(state, agent_failed_comment, "agent_failed")
+    blocked_comment = ReviewComment(
+        comment_id="issue:blocked",
+        body_excerpt="changes requested",
+        body="changes requested",
+        author="reviewer",
+        blocks_merge=True,
+    )
+    stale_comment_old = ReviewComment(
+        comment_id="issue:stale-body",
+        body_excerpt="old body",
+        body="old body",
+        author="reviewer",
+    )
+    _mark_review_comment_addressed(state, stale_comment_old, "false_positive")
+    stale_comment_current = ReviewComment(
+        comment_id="issue:stale-body",
+        body_excerpt="new body that requires new triage",
+        body="new body that requires new triage",
+        author="reviewer",
+    )
+
+    status = PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(
+            pending_comment,
+            handled_comment,
+            agent_failed_comment,
+            stale_comment_current,
+            blocked_comment,
+        ),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+        blocking_reviews=(blocked_comment,),
+    )
+
+    assert _pending_review_feedback_count(status, state) == 3
+    assert len(status.unresolved_review_comments) == 5
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_368fd86207c441dcaf9d7e54` (agent: `codex`, model: `gpt-5.3-codex-spark`, effort: `xhigh`).


### Task
Implement a narrow AWF PR monitor observability fix: clarify the misleading `monitor.action` review feedback metrics for outside-diff PR feedback.

Context:
- `PRStatus.unresolved_review_comments` intentionally contains review-level bodies and top-level PR issue comments because GitHub does not expose a resolvable thread state for those items.
- Those items are used by the address-comments loop, but they are not merge blockers unless represented separately in `PRStatus.blocking_reviews`.
- Operators currently see log lines like `unresolved_reviews=23, blocking_reviews=0` and can read that as 23 unresolved GitHub reviews. In reality it is raw outside-diff review feedback, often advisory bot review summaries/comments.

Required behavior:
1. Do not change merge decision semantics.
2. Do not change inline review thread gating.
3. Keep advisory review bodies/top-level comments available to the AddressComments path.
4. Improve `monitor.action` structured logs so operator-facing fields distinguish:
   - raw outside-diff review feedback count, e.g. `review_feedback` or equivalent;
   - feedback still pending agent attention based on monitor state/body hash/verdict, e.g. `pending_review_feedback`;
   - effective merge blockers, still `blocking_reviews`.
5. Avoid misleading new log text that implies COMMENTED bot reviews are GitHub-resolvable unresolved reviews.
6. Preserve backward compatibility if existing consumers/tests depend on `unresolved_reviews`, but mark/alias it clearly in code comments/tests if retained.
7. Add or update focused tests for these semantics.
8. Update a short docs note if there is an existing PR monitor docs section explaining review/comment handling.

Important AWF dogfood instruction:
- Do not encode task-specific shell validation commands in the prompt, saved plan, or conformance artifact.
- The repository profile `.awf/workspace.yml` is the validation authority. The saved plan should state behavioral acceptance criteria and that AWF profile validation owns command execution/evidence.
- Follow the repo planning protocol and TDD, but keep the slice narrow and avoid broad refactors.

---
Validation: 4 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated monitoring contract to surface new review metrics: review_feedback, pending_review_feedback, blocking_reviews, and unresolved_reviews (backward-compatible alias retained).

* **Tests**
  * Expanded monitor-logging tests to validate emitted review_feedback, pending_review_feedback, blocking_reviews, and unresolved_reviews across merge and pre-merge recheck flows, plus unit coverage for pending-triage counting logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/273?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->