### PR TITLE
Fix issue #276: stale PR monitor execution slots

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -226,6 +226,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf workspace show <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#mcp_egress_audit_error](#mcp_egress_audit_error)
 
+### MONITOR_RECOVERY_CANCELLED
+**Problem:** AWF cancelled a PR-monitor recovery (remonitor) operation before it finished resuming the monitor.
+**Likely Cause:** A stale-monitor reconcile cancelled the resume task because the workspace left the monitoring_pr state while recovery was still dispatching. This is the expected outcome of normal reconciliation, not a runtime error.
+**Operator Fix:** No action is usually required. If the workspace should still be monitored, remonitor it and confirm it is in monitoring_pr.
+**Related Command:** `awf workspace show <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#monitor_recovery_cancelled](#monitor_recovery_cancelled)
+
 ### NETWORK_POSTURE_OPEN_ACTIVE
 **Problem:** One or more active workspaces have unrestricted internet access.
 **Likely Cause:** Workspaces were started with --network=open.

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -643,7 +643,16 @@ class ControlWorker:
         await self._maybe_release_terminal_runtime()
 
         if self._executor is not None:
+            # Preserved-active-validation redispatches enqueued during recovery
+            # occupy execution slots but never flow through the monitor/ready
+            # dispatch paths below, so diff the tracked tasks to count them.
+            # Otherwise a recovery-only cycle that fills the last slot looks idle
+            # to _update_execution_slot_saturation and falsely ticks saturation.
+            tracked_execution_ids_before_recovery = set(self._execution_tasks)
             await self._maybe_recover_stale_active_executions()
+            execution_dispatched_ids.update(
+                set(self._execution_tasks) - tracked_execution_ids_before_recovery
+            )
 
         if _local_capacity_configured(self._config):
             requested_ids = await self._claim_requested_ids()

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -4716,6 +4716,22 @@ class ControlWorker:
             return False
         try:
             await self._executor.resume_pr_monitor(workspace_id)
+        except asyncio.CancelledError:
+            # A stale-monitor reconcile cancels this task once its workspace has
+            # left monitoring_pr. CancelledError is a BaseException, so it skips
+            # the Exception handler below; without finalizing here the remonitor
+            # operation stays stuck in running while the caller's finally drops
+            # _monitor_recovery_operation_ids, losing the handle to finish it
+            # later. Mark it cancelled, then re-raise so the task still ends
+            # cancelled and the slot drains as usual.
+            await self._finish_monitor_recovery_operation(
+                workspace_id,
+                operation_id=recovery_operation_id,
+                status=OperationStatus.cancelled,
+                error_code="MONITOR_RECOVERY_CANCELLED",
+                error_message="Monitor resume cancelled after workspace left monitoring_pr.",
+            )
+            raise
         except Exception as exc:
             # The monitor runner owns normal terminal transitions. Recovery
             # dispatch still must not take the service worker down if a single

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -25,6 +25,7 @@ import uuid
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
+from enum import StrEnum
 from functools import partial
 from inspect import getattr_static
 from pathlib import Path
@@ -314,6 +315,20 @@ def _preserved_active_execution_status_values(
     return (workspace_status.value,)
 
 
+class _ExecutionTaskKind(StrEnum):
+    """Kind of work tracked in ``ControlWorker._execution_tasks`` slot accounting."""
+
+    MONITOR_RESUME = "monitor_resume"
+    READY = "ready"
+    PRESERVED_ACTIVE = "preserved_active"
+
+
+# Emit ``worker.execution_slots_saturated`` every Nth consecutive idle cycle in
+# which every execution slot stays occupied. Keeps the signal low-noise while
+# still surfacing wedged-slot starvation for operators.
+_EXECUTION_SLOTS_SATURATED_LOG_INTERVAL = 10
+
+
 @dataclass(frozen=True)
 class WorkerConfig:
     poll_interval_seconds: float = 1.0
@@ -585,6 +600,8 @@ class ControlWorker:
         self._config = config
         self._stopped = asyncio.Event()
         self._execution_tasks: dict[str, asyncio.Task[None]] = {}
+        self._execution_task_kinds: dict[str, _ExecutionTaskKind] = {}
+        self._consecutive_saturated_cycles: int = 0
         self._monitor_recovery_operation_ids: dict[str, str] = {}
         # Session-local advisory state; reset on restart and bounded below.
         self._active_salvage_monitor_recovery_operation_ids: dict[str, None] = {}
@@ -612,6 +629,8 @@ class ControlWorker:
         and should immediately loop again.
         """
         dispatched_ids: set[str] = set()
+
+        await self._reconcile_stale_monitor_execution_tasks()
 
         await self._maybe_expire_due_secret_leases()
         await self._maybe_release_terminal_runtime()
@@ -701,6 +720,7 @@ class ControlWorker:
                 )
                 dispatched_ids.update(ready_dispatched)
 
+        self._update_execution_slot_saturation(dispatched=len(dispatched_ids))
         return len(dispatched_ids)
 
     async def wait_for_execution_tasks(self) -> None:
@@ -711,6 +731,7 @@ class ControlWorker:
             for workspace_id, task in list(self._execution_tasks.items()):
                 if task.done():
                     self._execution_tasks.pop(workspace_id, None)
+                    self._execution_task_kinds.pop(workspace_id, None)
 
     async def run_forever(self) -> None:
         while not self._stopped.is_set():
@@ -1145,6 +1166,24 @@ class ControlWorker:
             on_retry=self._log_transient_db_retry,
         )
 
+    async def _load_workspace_statuses(self, workspace_ids: list[str]) -> dict[str, str]:
+        """Bulk-read current ``status`` for the given workspace IDs.
+
+        Callers (``_filter_current_status`` and reconciliation) guard against an
+        empty list, so this is only invoked with at least one ID.
+        """
+
+        async def _operation(session: AsyncSession) -> dict[str, str]:
+            stmt = select(Workspace.id, Workspace.status).where(Workspace.id.in_(workspace_ids))
+            result = await session.execute(stmt)
+            return {row[0]: row[1] for row in result.all()}
+
+        return await run_db_operation_with_retry(
+            self._session_factory,
+            _operation,
+            on_retry=self._log_transient_db_retry,
+        )
+
     async def _filter_current_status(
         self,
         workspace_ids: list[str],
@@ -1155,16 +1194,7 @@ class ControlWorker:
         if not workspace_ids:
             return []
 
-        async def _operation(session: AsyncSession) -> dict[str, str]:
-            stmt = select(Workspace.id, Workspace.status).where(Workspace.id.in_(workspace_ids))
-            result = await session.execute(stmt)
-            return {row[0]: row[1] for row in result.all()}
-
-        statuses = await run_db_operation_with_retry(
-            self._session_factory,
-            _operation,
-            on_retry=self._log_transient_db_retry,
-        )
+        statuses = await self._load_workspace_statuses(workspace_ids)
 
         current_ids: list[str] = []
         for workspace_id in workspace_ids:
@@ -4463,8 +4493,7 @@ class ControlWorker:
                 self._safely_execute_claimed(workspace_id),
                 name=f"awf-execute-{workspace_id}",
             )
-            self._execution_tasks[workspace_id] = task
-            task.add_done_callback(partial(self._forget_execution_task, workspace_id))
+            self._track_execution_task(workspace_id, task, kind=_ExecutionTaskKind.READY)
             dispatched.add(workspace_id)
         return dispatched
 
@@ -4484,8 +4513,7 @@ class ControlWorker:
                 ),
                 name=f"awf-monitor-{workspace_id}",
             )
-            self._execution_tasks[workspace_id] = task
-            task.add_done_callback(partial(self._forget_execution_task, workspace_id))
+            self._track_execution_task(workspace_id, task, kind=_ExecutionTaskKind.MONITOR_RESUME)
             dispatched.add(workspace_id)
         return dispatched
 
@@ -4500,12 +4528,86 @@ class ControlWorker:
             self._safely_execute_claimed(workspace_id),
             name=f"awf-preserved-active-validate-{workspace_id}",
         )
-        self._execution_tasks[workspace_id] = task
-        task.add_done_callback(partial(self._forget_execution_task, workspace_id))
+        self._track_execution_task(workspace_id, task, kind=_ExecutionTaskKind.PRESERVED_ACTIVE)
         return True
 
-    def _forget_execution_task(self, workspace_id: str, _task: asyncio.Task[None]) -> None:
-        self._execution_tasks.pop(workspace_id, None)
+    def _track_execution_task(
+        self,
+        workspace_id: str,
+        task: asyncio.Task[None],
+        *,
+        kind: _ExecutionTaskKind,
+    ) -> None:
+        self._execution_tasks[workspace_id] = task
+        self._execution_task_kinds[workspace_id] = kind
+        task.add_done_callback(partial(self._forget_execution_task, workspace_id))
+
+    def _forget_execution_task(self, workspace_id: str, task: asyncio.Task[None]) -> None:
+        # Identity-guarded: a reconcile-driven cancel can free a slot and re-dispatch
+        # the same workspace within one run_once, so only forget the task we tracked.
+        if self._execution_tasks.get(workspace_id) is task:
+            self._execution_tasks.pop(workspace_id, None)
+            self._execution_task_kinds.pop(workspace_id, None)
+
+    def _tracked_monitor_workspace_ids(self) -> list[str]:
+        return [
+            workspace_id
+            for workspace_id, kind in self._execution_task_kinds.items()
+            if kind is _ExecutionTaskKind.MONITOR_RESUME
+        ]
+
+    async def _reconcile_stale_monitor_execution_tasks(self) -> None:
+        """Cancel tracked PR-monitor tasks whose workspace has left ``monitoring_pr``.
+
+        A wedged monitor resume coroutine keeps occupying an execution slot
+        forever. Once its workspace row is gone or has transitioned away from
+        ``monitoring_pr`` the resume is stale, so we cancel it and free the slot
+        synchronously in the current ``run_once`` (the done-callback alone runs
+        asynchronously and would not free the slot before ready dispatch). Only
+        ``MONITOR_RESUME`` tasks are inspected, so ready/preserved-active
+        executions are never touched here.
+        """
+        monitor_ids = self._tracked_monitor_workspace_ids()
+        if not monitor_ids:
+            return
+        statuses = await self._load_workspace_statuses(monitor_ids)
+        for workspace_id in monitor_ids:
+            status = statuses.get(workspace_id)
+            if status == WorkspaceStatus.monitoring_pr.value:
+                continue
+            task = self._execution_tasks.get(workspace_id)
+            if task is None:
+                self._execution_task_kinds.pop(workspace_id, None)
+                continue
+            _log.warning(
+                "worker.stale_monitor_execution_task_cancelled",
+                workspace_id=workspace_id,
+                status=status,
+            )
+            task.cancel()
+            self._execution_tasks.pop(workspace_id, None)
+            self._execution_task_kinds.pop(workspace_id, None)
+
+    def _update_execution_slot_saturation(self, *, dispatched: int) -> None:
+        saturated = (
+            self._can_dispatch_execution_when_slot_available()
+            and dispatched == 0
+            and self._available_execution_slots() <= 0
+        )
+        if not saturated:
+            self._consecutive_saturated_cycles = 0
+            return
+        self._consecutive_saturated_cycles += 1
+        if self._consecutive_saturated_cycles % _EXECUTION_SLOTS_SATURATED_LOG_INTERVAL != 0:
+            return
+        _log.warning(
+            "worker.execution_slots_saturated",
+            slot_limit=self._config.max_concurrent_executions,
+            tracked_count=len(self._execution_tasks),
+            tracked_workspace_ids=sorted(self._execution_tasks),
+            tracked_monitor_ids=sorted(self._tracked_monitor_workspace_ids()),
+            consecutive_saturated_cycles=self._consecutive_saturated_cycles,
+        )
 
     async def _safely_provision_claimed(self, workspace_id: str) -> None:
         try:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -4734,9 +4734,10 @@ class ControlWorker:
             # the Exception handler below; without finalizing here the remonitor
             # operation stays stuck in running while the caller's finally drops
             # _monitor_recovery_operation_ids, losing the handle to finish it
-            # later. Mark it cancelled, then re-raise so the task still ends
-            # cancelled and the slot drains as usual.
-            await self._finish_monitor_recovery_operation(
+            # later. Finalize through the shielded helper so a second cancellation
+            # (e.g. worker shutdown) landing mid-write cannot re-orphan it, then
+            # re-raise so the task still ends cancelled and the slot drains.
+            await self._finish_monitor_recovery_operation_after_cancellation(
                 workspace_id,
                 operation_id=recovery_operation_id,
                 status=OperationStatus.cancelled,
@@ -5367,6 +5368,44 @@ class ControlWorker:
                 operation_id=operation_id,
                 status=status.value,
             )
+
+    async def _finish_monitor_recovery_operation_after_cancellation(
+        self,
+        workspace_id: str,
+        *,
+        operation_id: str | None,
+        status: OperationStatus,
+        error_code: str | None = None,
+        error_message: str | None = None,
+    ) -> None:
+        """Finalize the recovery operation even if cancelled again mid-write.
+
+        The CancelledError handler must persist this status before re-raising,
+        but the finalize is itself a cancellable DB write. A second cancellation
+        (e.g. worker shutdown cancelling outstanding tasks) landing mid-write
+        would leave the operation stuck in ``running`` once the caller's
+        ``finally`` drops its ``_monitor_recovery_operation_ids`` handle, with
+        nothing able to finish it later. Shield the write and re-await across
+        repeated cancellations so it always runs to completion, mirroring
+        ``cleanup_compose_exec_invocation_after_cancellation``.
+        """
+        finalize_task = asyncio.create_task(
+            self._finish_monitor_recovery_operation(
+                workspace_id,
+                operation_id=operation_id,
+                status=status,
+                error_code=error_code,
+                error_message=error_message,
+            ),
+            name=f"awf-monitor-recovery-finalize-{workspace_id}",
+        )
+        while True:
+            try:
+                await asyncio.shield(finalize_task)
+                return
+            except asyncio.CancelledError:
+                if finalize_task.done():
+                    return
 
     async def _refresh_monitoring_pr_claim_loop(self, workspace_id: str) -> None:
         interval = max(1.0, min(60.0, self._config.monitor_claim_lease_seconds / 3))

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -4490,10 +4490,20 @@ class ControlWorker:
 
     def _available_execution_slots(self) -> int:
         # Draining tasks (cancelled monitors not yet stopped) stay tracked for
-        # same-workspace dedup but must not count against the slot budget, or a
-        # wedged monitor would keep starving other workspaces (issue #276).
-        occupied = len(self._execution_tasks) - self._draining_execution_task_count()
-        return max(0, self._config.max_concurrent_executions - occupied)
+        # same-workspace dedup but are excluded from the slot budget so a wedged
+        # monitor does not keep starving other workspaces (issue #276).
+        #
+        # That exclusion is capped, though: cancel() is cooperative, so a steady
+        # supply of stale-and-wedged monitors could otherwise accumulate draining
+        # coroutines without bound and let dispatch run arbitrarily far past the
+        # budget, exhausting runtime resources. Excluding at most
+        # max_concurrent_executions draining tasks bounds total in-flight
+        # coroutines at 2x the budget; beyond that, surplus draining tasks count
+        # as occupied and throttle fresh dispatch until they truly stop.
+        max_executions = self._config.max_concurrent_executions
+        excluded_draining = min(self._draining_execution_task_count(), max_executions)
+        occupied = len(self._execution_tasks) - excluded_draining
+        return max(0, max_executions - occupied)
 
     def _can_dispatch_execution_when_slot_available(self) -> bool:
         return self._executor is not None and self._config.max_concurrent_executions > 0

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -629,6 +629,7 @@ class ControlWorker:
         and should immediately loop again.
         """
         dispatched_ids: set[str] = set()
+        execution_dispatched_ids: set[str] = set()
 
         await self._reconcile_stale_monitor_execution_tasks()
 
@@ -694,6 +695,7 @@ class ControlWorker:
                     limit=execution_slots,
                 )
                 dispatched_ids.update(monitor_dispatched)
+                execution_dispatched_ids.update(monitor_dispatched)
 
             execution_slots = self._available_execution_slots()
             if execution_slots > 0:
@@ -719,8 +721,11 @@ class ControlWorker:
                     limit=execution_slots,
                 )
                 dispatched_ids.update(ready_dispatched)
+                execution_dispatched_ids.update(ready_dispatched)
 
-        self._update_execution_slot_saturation(dispatched=len(dispatched_ids))
+        # Saturation reflects execution slots only; provisioning dispatches must
+        # not mask a worker whose execution slots are wedged with stuck tasks.
+        self._update_execution_slot_saturation(dispatched=len(execution_dispatched_ids))
         return len(dispatched_ids)
 
     async def wait_for_execution_tasks(self) -> None:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -321,6 +321,12 @@ class _ExecutionTaskKind(StrEnum):
     MONITOR_RESUME = "monitor_resume"
     READY = "ready"
     PRESERVED_ACTIVE = "preserved_active"
+    # A monitor resume that reconcile has cancelled but whose coroutine has not
+    # yet stopped. Cancellation is cooperative, so the task can keep running
+    # after ``cancel()`` returns. We keep it tracked under its workspace_id so a
+    # fresh dispatch for the *same* workspace stays blocked, but exclude it from
+    # the slot budget so it does not starve *other* workspaces.
+    MONITOR_DRAINING = "monitor_draining"
 
 
 # Emit ``worker.execution_slots_saturated`` every Nth consecutive idle cycle in
@@ -732,7 +738,9 @@ class ControlWorker:
         """Wait for ready execution or monitor-resume tasks started by this worker."""
         while self._execution_tasks:
             tasks = tuple(self._execution_tasks.values())
-            await asyncio.gather(*tasks)
+            # A cancelled monitor that is still draining stays tracked here, so
+            # swallow its CancelledError rather than aborting the drain wait.
+            await asyncio.gather(*tasks, return_exceptions=True)
             for workspace_id, task in list(self._execution_tasks.items()):
                 if task.done():
                     self._execution_tasks.pop(workspace_id, None)
@@ -4464,8 +4472,19 @@ class ControlWorker:
         )
         return (await session.execute(stmt)).scalar_one_or_none() is not None
 
+    def _draining_execution_task_count(self) -> int:
+        return sum(
+            1
+            for kind in self._execution_task_kinds.values()
+            if kind is _ExecutionTaskKind.MONITOR_DRAINING
+        )
+
     def _available_execution_slots(self) -> int:
-        return max(0, self._config.max_concurrent_executions - len(self._execution_tasks))
+        # Draining tasks (cancelled monitors not yet stopped) stay tracked for
+        # same-workspace dedup but must not count against the slot budget, or a
+        # wedged monitor would keep starving other workspaces (issue #276).
+        occupied = len(self._execution_tasks) - self._draining_execution_task_count()
+        return max(0, self._config.max_concurrent_executions - occupied)
 
     def _can_dispatch_execution_when_slot_available(self) -> bool:
         return self._executor is not None and self._config.max_concurrent_executions > 0
@@ -4566,11 +4585,16 @@ class ControlWorker:
 
         A wedged monitor resume coroutine keeps occupying an execution slot
         forever. Once its workspace row is gone or has transitioned away from
-        ``monitoring_pr`` the resume is stale, so we cancel it and free the slot
-        synchronously in the current ``run_once`` (the done-callback alone runs
-        asynchronously and would not free the slot before ready dispatch). Only
-        ``MONITOR_RESUME`` tasks are inspected, so ready/preserved-active
-        executions are never touched here.
+        ``monitoring_pr`` the resume is stale, so we cancel it and reclassify it
+        as ``MONITOR_DRAINING``. Reclassifying frees its slot for *other*
+        workspaces synchronously in the current ``run_once`` (the slot budget
+        excludes draining tasks) while keeping the task tracked under its
+        workspace_id. ``cancel()`` is cooperative, so the coroutine can keep
+        running afterwards; retaining the tracking reference keeps slot dedup
+        blocking a fresh dispatch for the *same* workspace until it truly stops,
+        and the existing done-callback drops it once it does. Only
+        ``MONITOR_RESUME`` tasks are inspected, so ready/preserved-active and
+        already-draining executions are never touched here.
         """
         monitor_ids = self._tracked_monitor_workspace_ids()
         if not monitor_ids:
@@ -4590,8 +4614,7 @@ class ControlWorker:
                 status=status,
             )
             task.cancel()
-            self._execution_tasks.pop(workspace_id, None)
-            self._execution_task_kinds.pop(workspace_id, None)
+            self._execution_task_kinds[workspace_id] = _ExecutionTaskKind.MONITOR_DRAINING
 
     def _update_execution_slot_saturation(self, *, dispatched: int) -> None:
         saturated = (

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -747,20 +747,24 @@ class ControlWorker:
         """Wait for ready execution or monitor-resume tasks started by this worker."""
         while self._execution_tasks:
             tasks = tuple(self._execution_tasks.values())
-            # A cancelled monitor that is still draining stays tracked here, so
-            # tolerate its CancelledError rather than aborting the drain wait.
-            # Any other task failure must still surface so once=True runs fail
-            # loud instead of exiting as if successful.
-            results = await asyncio.gather(*tasks, return_exceptions=True)
+            # Wait for the FIRST task to finish instead of gather()-ing them all:
+            # a cancelled monitor can drain (or stay wedged) indefinitely, and
+            # gather() would block on it, so a genuine execution failure would
+            # never surface — wait_for_execution_tasks() would hang and once=True
+            # runs would exit as if successful. Inspecting tasks as they complete
+            # lets a real failure raise immediately while a draining monitor's
+            # CancelledError is still tolerated.
+            done, _pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
             for workspace_id, task in list(self._execution_tasks.items()):
-                if task.done():
+                if task in done:
                     self._execution_tasks.pop(workspace_id, None)
                     self._execution_task_kinds.pop(workspace_id, None)
-            for result in results:
-                if isinstance(result, BaseException) and not isinstance(
-                    result, asyncio.CancelledError
-                ):
-                    raise result
+            for task in done:
+                if task.cancelled():
+                    continue
+                exc = task.exception()
+                if exc is not None:
+                    raise exc
 
     async def run_forever(self) -> None:
         while not self._stopped.is_set():

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -4610,6 +4610,13 @@ class ControlWorker:
             if kind is _ExecutionTaskKind.MONITOR_RESUME
         ]
 
+    def _tracked_draining_workspace_ids(self) -> list[str]:
+        return [
+            workspace_id
+            for workspace_id, kind in self._execution_task_kinds.items()
+            if kind is _ExecutionTaskKind.MONITOR_DRAINING
+        ]
+
     async def _reconcile_stale_monitor_execution_tasks(self) -> None:
         """Cancel tracked PR-monitor tasks whose workspace has left ``monitoring_pr``.
 
@@ -4664,6 +4671,7 @@ class ControlWorker:
             tracked_count=len(self._execution_tasks),
             tracked_workspace_ids=sorted(self._execution_tasks),
             tracked_monitor_ids=sorted(self._tracked_monitor_workspace_ids()),
+            tracked_draining_ids=sorted(self._tracked_draining_workspace_ids()),
             consecutive_saturated_cycles=self._consecutive_saturated_cycles,
         )
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -748,12 +748,19 @@ class ControlWorker:
         while self._execution_tasks:
             tasks = tuple(self._execution_tasks.values())
             # A cancelled monitor that is still draining stays tracked here, so
-            # swallow its CancelledError rather than aborting the drain wait.
-            await asyncio.gather(*tasks, return_exceptions=True)
+            # tolerate its CancelledError rather than aborting the drain wait.
+            # Any other task failure must still surface so once=True runs fail
+            # loud instead of exiting as if successful.
+            results = await asyncio.gather(*tasks, return_exceptions=True)
             for workspace_id, task in list(self._execution_tasks.items()):
                 if task.done():
                     self._execution_tasks.pop(workspace_id, None)
                     self._execution_task_kinds.pop(workspace_id, None)
+            for result in results:
+                if isinstance(result, BaseException) and not isinstance(
+                    result, asyncio.CancelledError
+                ):
+                    raise result
 
     async def run_forever(self) -> None:
         while not self._stopped.is_set():

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6398,6 +6398,101 @@ class TestRunOnceExecution:
             )
 
     @pytest.mark.unit
+    async def test_stale_monitor_cancellation_finalizes_despite_second_cancel(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        # The CancelledError finalize is itself a cancellable DB write. If a
+        # second cancellation (e.g. worker shutdown cancelling outstanding tasks)
+        # lands mid-write, the remonitor op must still reach cancelled rather than
+        # stay stuck in running once the caller's finally drops the recovery
+        # handle. The finalize is shielded, so it runs to completion across the
+        # second cancel.
+        monitor_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "double-cancel-monitor"
+        )
+        executor = _BlockingMonitorExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        monitor_task: asyncio.Task[None] | None = None
+        try:
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 1
+            )
+            await asyncio.wait_for(executor.started.wait(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            monitor_task = worker._execution_tasks[monitor_id]  # noqa: SLF001
+
+            async with session_factory() as s:
+                operations = await OperationRepository(s).list_all(workspace_id=monitor_id)
+            remonitor_operations = [
+                operation
+                for operation in operations
+                if operation.type == OperationType.remonitor.value
+            ]
+            assert len(remonitor_operations) == 1
+            operation_id = remonitor_operations[0].id
+            assert remonitor_operations[0].status == OperationStatus.running.value
+
+            # Inject a second cancellation the instant the finalize DB write
+            # begins, reproducing a shutdown cancel arriving mid-write. Without
+            # the shield this would abort the write and orphan the op in running.
+            original_finish = worker._finish_monitor_recovery_operation  # noqa: SLF001
+            second_cancel_injected = False
+
+            async def _finish_with_second_cancel(*args: Any, **kwargs: Any) -> None:
+                nonlocal second_cancel_injected
+                if not second_cancel_injected and monitor_task is not None:
+                    second_cancel_injected = True
+                    monitor_task.cancel()
+                await original_finish(*args, **kwargs)
+
+            worker._finish_monitor_recovery_operation = _finish_with_second_cancel  # type: ignore[method-assign]  # noqa: SLF001
+
+            # Workspace leaves monitoring_pr, so the resume is stale and reconcile
+            # cancels it (the first cancellation).
+            async with session_factory() as s:
+                await s.execute(
+                    update(Workspace)
+                    .where(Workspace.id == monitor_id)
+                    .values(status=WorkspaceStatus.ready.value)
+                )
+                await s.commit()
+            await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+            assert monitor_task.cancelling() > 0
+
+            executor.release.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
+            # The second cancel fired during finalize, but the shielded write
+            # still completed: the op is cancelled, not stuck in running.
+            assert second_cancel_injected
+            async with session_factory() as s:
+                finalized = await OperationRepository(s).get(operation_id)
+            assert finalized is not None
+            assert finalized.status == OperationStatus.cancelled.value
+            assert finalized.error_code == "MONITOR_RECOVERY_CANCELLED"
+            assert monitor_id not in worker._monitor_recovery_operation_ids  # noqa: SLF001
+        finally:
+            executor.release.set()
+            if monitor_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            await asyncio.wait_for(
+                worker.wait_for_execution_tasks(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+
+    @pytest.mark.unit
     async def test_draining_exclusion_is_capped_to_bound_in_flight_coroutines(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6598,6 +6598,67 @@ class TestRunOnceExecution:
             with contextlib.suppress(asyncio.CancelledError):
                 await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
 
+    @pytest.mark.unit
+    async def test_recovery_redispatch_counts_as_execution_progress(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        # A preserved-active-validation redispatch enqueued during stale-active
+        # recovery occupies the only execution slot but never flows through the
+        # monitor/ready dispatch paths. It is real execution progress, so a
+        # recovery-only cycle that fills the last slot must not tick saturation.
+        recovery_id = await _create_monitoring_pr(
+            session_factory, origin_repo, "recovery-redispatch"
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        slot_task = asyncio.create_task(_pending_execution_task())
+
+        async def _recover_via_preserved_active_validation() -> None:
+            # Mirror _dispatch_preserved_active_validation: occupy the slot under
+            # a PRESERVED_ACTIVE task without going through the monitor/ready paths.
+            worker._track_execution_task(  # noqa: SLF001
+                recovery_id,
+                slot_task,
+                kind=worker_module._ExecutionTaskKind.PRESERVED_ACTIVE,  # noqa: SLF001
+            )
+
+        worker._maybe_recover_stale_active_executions = (  # type: ignore[method-assign]  # noqa: SLF001
+            _recover_via_preserved_active_validation
+        )
+
+        async def _empty_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            return []
+
+        worker._list_monitoring_pr = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+        worker._list_ready = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+
+        try:
+            await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            # The recovery dispatch was counted, so the cycle is not idle-saturated.
+            assert worker._consecutive_saturated_cycles == 0  # noqa: SLF001
+            assert recovery_id in worker._execution_tasks  # noqa: SLF001
+        finally:
+            worker._execution_tasks.pop(recovery_id, None)  # noqa: SLF001
+            worker._execution_task_kinds.pop(recovery_id, None)  # noqa: SLF001
+            slot_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
 
 class TestRunOnceMonitorRecovery:
     @pytest.mark.unit

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6636,6 +6636,7 @@ class TestRunOnceExecution:
             assert event["tracked_count"] == 1
             assert event["tracked_workspace_ids"] == [monitor_id]
             assert event["tracked_monitor_ids"] == [monitor_id]
+            assert event["tracked_draining_ids"] == []
             assert event["consecutive_saturated_cycles"] == interval
 
             # Fires again only on the next multiple of the cadence interval.
@@ -6677,6 +6678,77 @@ class TestRunOnceExecution:
             slot_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
+    @pytest.mark.unit
+    async def test_execution_slots_saturation_log_surfaces_draining_ids(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # When starvation is driven by draining tasks past the 2x cap, no
+        # MONITOR_RESUME tasks remain, so tracked_monitor_ids is empty. The log
+        # must still name the occupying workspaces via tracked_draining_ids,
+        # otherwise an operator sees tracked_count > 0 with no IDs to explain it.
+        interval = worker_module._EXECUTION_SLOTS_SATURATED_LOG_INTERVAL  # noqa: SLF001
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        # Two draining tasks against a budget of 1: the cap excludes only one, so
+        # the surplus counts as occupied and the slot stays saturated every cycle.
+        draining_ids = ["drain-a", "drain-b"]
+        draining_tasks: list[asyncio.Task[None]] = []
+        for workspace_id in draining_ids:
+            task = asyncio.create_task(_pending_execution_task(), name=workspace_id)
+            draining_tasks.append(task)
+            worker._track_execution_task(  # noqa: SLF001
+                workspace_id,
+                task,
+                kind=worker_module._ExecutionTaskKind.MONITOR_DRAINING,  # noqa: SLF001
+            )
+
+        async def _empty_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            return []
+
+        worker._list_monitoring_pr = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+        worker._list_ready = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+
+        try:
+            assert worker._available_execution_slots() == 0  # noqa: SLF001
+            with structlog.testing.capture_logs() as captured:
+                for _ in range(interval):
+                    assert (
+                        await asyncio.wait_for(
+                            worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+                        )
+                        == 0
+                    )
+            events = [
+                event
+                for event in captured
+                if event.get("event") == "worker.execution_slots_saturated"
+            ]
+            assert len(events) == 1
+            event = events[0]
+            assert event["tracked_count"] == 2
+            assert event["tracked_workspace_ids"] == sorted(draining_ids)
+            assert event["tracked_monitor_ids"] == []
+            assert event["tracked_draining_ids"] == sorted(draining_ids)
+        finally:
+            for task in draining_tasks:
+                task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.gather(*draining_tasks, return_exceptions=True)
 
     @pytest.mark.unit
     async def test_provisioning_dispatch_does_not_mask_execution_saturation(

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6320,6 +6320,84 @@ class TestRunOnceExecution:
             )
 
     @pytest.mark.unit
+    async def test_stale_monitor_cancellation_finalizes_recovery_operation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        # CancelledError is a BaseException, so a stale-monitor reconcile cancel
+        # skips the resume coroutine's Exception handler. Without an explicit
+        # CancelledError finalizer the remonitor operation would stay stuck in
+        # running while the caller's finally drops the recovery handle, leaving
+        # nothing able to finish it. The resume must mark it cancelled instead.
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "cancelled-monitor")
+        executor = _BlockingMonitorExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        monitor_task: asyncio.Task[None] | None = None
+        try:
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 1
+            )
+            await asyncio.wait_for(executor.started.wait(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            monitor_task = worker._execution_tasks[monitor_id]  # noqa: SLF001
+
+            # Claiming + dispatching the monitor records a running remonitor op.
+            async with session_factory() as s:
+                operations = await OperationRepository(s).list_all(workspace_id=monitor_id)
+            remonitor_operations = [
+                operation
+                for operation in operations
+                if operation.type == OperationType.remonitor.value
+            ]
+            assert len(remonitor_operations) == 1
+            operation_id = remonitor_operations[0].id
+            assert remonitor_operations[0].status == OperationStatus.running.value
+
+            # The workspace leaves monitoring_pr, so the resume is now stale and
+            # reconcile cancels it.
+            async with session_factory() as s:
+                await s.execute(
+                    update(Workspace)
+                    .where(Workspace.id == monitor_id)
+                    .values(status=WorkspaceStatus.ready.value)
+                )
+                await s.commit()
+            await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+            assert monitor_task.cancelling() > 0
+
+            # Drain the cancelled resume coroutine to completion.
+            executor.release.set()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
+            # The remonitor op is finalized as cancelled, not stuck in running.
+            async with session_factory() as s:
+                finalized = await OperationRepository(s).get(operation_id)
+            assert finalized is not None
+            assert finalized.status == OperationStatus.cancelled.value
+            assert finalized.error_code == "MONITOR_RECOVERY_CANCELLED"
+            # The recovery handle is dropped only after the op is finalized.
+            assert monitor_id not in worker._monitor_recovery_operation_ids  # noqa: SLF001
+        finally:
+            executor.release.set()
+            if monitor_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            await asyncio.wait_for(
+                worker.wait_for_execution_tasks(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+
+    @pytest.mark.unit
     async def test_draining_exclusion_is_capped_to_bound_in_flight_coroutines(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6452,6 +6452,65 @@ class TestRunOnceExecution:
             with contextlib.suppress(asyncio.CancelledError):
                 await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
 
+    @pytest.mark.unit
+    async def test_provisioning_dispatch_does_not_mask_execution_saturation(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        # A worker whose only execution slot is wedged by a still-monitoring task is
+        # execution-saturated. Provisioning a fresh workspace in the same cycle is
+        # worker activity but not execution progress, so it must not reset the
+        # saturation counter nor silence the warning.
+        requested_id = await _create_requested(
+            session_factory, origin_repo, "provisioning-while-saturated"
+        )
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "wedged-monitor")
+        provisioner = _TransitioningProvisioner(session_factory)
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=provisioner,  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_provisions=3,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        slot_task = asyncio.create_task(_pending_execution_task())
+        worker._execution_tasks[monitor_id] = slot_task  # noqa: SLF001
+        worker._execution_task_kinds[monitor_id] = (  # noqa: SLF001
+            worker_module._ExecutionTaskKind.MONITOR_RESUME
+        )
+
+        async def _empty_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            return []
+
+        worker._list_monitoring_pr = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+        worker._list_ready = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+
+        try:
+            dispatched = await asyncio.wait_for(
+                worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+            # The provision dispatch is real worker activity (non-zero return) ...
+            assert dispatched == 1
+            assert requested_id in provisioner.calls
+            # ... but the execution slot was never freed, so saturation still ticks.
+            assert worker._consecutive_saturated_cycles == 1  # noqa: SLF001
+        finally:
+            worker._execution_tasks.pop(monitor_id, None)  # noqa: SLF001
+            worker._execution_task_kinds.pop(monitor_id, None)  # noqa: SLF001
+            slot_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
 
 class TestRunOnceMonitorRecovery:
     @pytest.mark.unit

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6320,6 +6320,67 @@ class TestRunOnceExecution:
             )
 
     @pytest.mark.unit
+    async def test_draining_exclusion_is_capped_to_bound_in_flight_coroutines(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        # cancel() is cooperative, so wedged monitors can keep running as
+        # MONITOR_DRAINING tasks indefinitely. Draining tasks are excluded from
+        # the slot budget (issue #276) so a wedged monitor does not starve other
+        # workspaces -- but that exclusion is capped at max_concurrent_executions.
+        # A flood of stale-and-wedged monitors must NOT let dispatch run unbounded
+        # past the budget, or in-flight coroutines could exhaust runtime resources.
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=2,
+            ),
+        )
+
+        stop = asyncio.Event()
+        tasks: list[asyncio.Task[None]] = []
+
+        def _add_draining(workspace_id: str) -> None:
+            async def _pending() -> None:
+                await stop.wait()
+
+            task = asyncio.create_task(_pending(), name=workspace_id)
+            tasks.append(task)
+            worker._track_execution_task(  # noqa: SLF001
+                workspace_id,
+                task,
+                kind=worker_module._ExecutionTaskKind.MONITOR_DRAINING,  # noqa: SLF001
+            )
+
+        try:
+            # Up to the budget, every wedged monitor still frees its slot so other
+            # workspaces keep moving (issue #276): 1 then 2 draining -> 2 free.
+            _add_draining("drain-1")
+            assert worker._available_execution_slots() == 2  # noqa: SLF001
+            _add_draining("drain-2")
+            assert worker._available_execution_slots() == 2  # noqa: SLF001
+
+            # Beyond the budget the exclusion is capped, so surplus draining tasks
+            # count as occupied. (The uncapped behavior would still report 2 free
+            # here no matter how many monitors wedged.) This bounds total in-flight
+            # coroutines at 2x the budget: available reaches 0 and stays there.
+            _add_draining("drain-3")
+            assert worker._available_execution_slots() == 1  # noqa: SLF001
+            _add_draining("drain-4")
+            assert worker._available_execution_slots() == 0  # noqa: SLF001
+            _add_draining("drain-5")
+            assert worker._available_execution_slots() == 0  # noqa: SLF001
+        finally:
+            stop.set()
+            for task in tasks:
+                task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.gather(*tasks, return_exceptions=True)
+
+    @pytest.mark.unit
     async def test_healthy_monitor_still_monitoring_pr_is_not_cancelled(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6233,6 +6233,93 @@ class TestRunOnceExecution:
             )
 
     @pytest.mark.unit
+    async def test_stale_monitor_stays_tracked_as_draining_until_stopped(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        # cancel() is cooperative: a wedged monitor coroutine can keep running
+        # after reconcile cancels it. The slot must free for OTHER workspaces,
+        # but the cancelled task must stay tracked so a fresh dispatch for the
+        # SAME workspace is blocked until it truly stops.
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "wedged-monitor")
+        executor = _BlockingMonitorExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        monitor_task: asyncio.Task[None] | None = None
+        try:
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 1
+            )
+            await asyncio.wait_for(executor.started.wait(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            monitor_task = worker._execution_tasks[monitor_id]  # noqa: SLF001
+            assert worker._available_execution_slots() == 0  # noqa: SLF001
+
+            # The workspace leaves monitoring_pr, so the resume is now stale.
+            async with session_factory() as s:
+                await s.execute(
+                    update(Workspace)
+                    .where(Workspace.id == monitor_id)
+                    .values(status=WorkspaceStatus.ready.value)
+                )
+                await s.commit()
+
+            # Drive reconcile directly (not via run_once): there is no await
+            # between cancel() and its return, so we observe the task mid-drain
+            # before the cooperative cancellation can run to completion.
+            with structlog.testing.capture_logs() as captured:
+                await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+
+            assert any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                and event.get("workspace_id") == monitor_id
+                for event in captured
+            )
+            # Cancellation was requested but the coroutine has not stopped yet.
+            assert monitor_task.cancelling() > 0
+            assert not monitor_task.done()
+            # The task stays tracked under its workspace_id, reclassified as draining.
+            assert worker._execution_tasks[monitor_id] is monitor_task  # noqa: SLF001
+            assert (
+                worker._execution_task_kinds[monitor_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.MONITOR_DRAINING
+            )
+            # Same-workspace dispatch stays blocked while it drains ...
+            assert worker._dispatchable_execution_ids([monitor_id], limit=1) == []  # noqa: SLF001
+            # ... yet the slot is excluded from accounting, so it frees for others.
+            assert worker._available_execution_slots() == 1  # noqa: SLF001
+
+            # A second reconcile pass leaves the already-draining task alone:
+            # no re-cancel and no duplicate warning.
+            with structlog.testing.capture_logs() as second_pass:
+                await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+            assert not any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                for event in second_pass
+            )
+            assert (
+                worker._execution_task_kinds[monitor_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.MONITOR_DRAINING
+            )
+        finally:
+            executor.release.set()
+            if monitor_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            await asyncio.wait_for(
+                worker.wait_for_execution_tasks(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+
+    @pytest.mark.unit
     async def test_healthy_monitor_still_monitoring_pr_is_not_cancelled(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -6156,6 +6156,302 @@ class TestRunOnceExecution:
 
         assert calls == [ready_id]
 
+    @pytest.mark.unit
+    async def test_stale_monitor_moved_to_ready_is_cancelled_and_frees_slot(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "wedged-monitor")
+        executor = _BlockingMonitorExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        monitor_task: asyncio.Task[None] | None = None
+        try:
+            # First cycle dispatches and blocks the monitor resume, occupying the slot.
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 1
+            )
+            await asyncio.wait_for(executor.started.wait(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            assert worker._available_execution_slots() == 0  # noqa: SLF001
+            assert (
+                worker._execution_task_kinds[monitor_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.MONITOR_RESUME
+            )
+            monitor_task = worker._execution_tasks[monitor_id]  # noqa: SLF001
+
+            # The workspace leaves monitoring_pr; a fresh ready workspace appears.
+            async with session_factory() as s:
+                await s.execute(
+                    update(Workspace)
+                    .where(Workspace.id == monitor_id)
+                    .values(status=WorkspaceStatus.ready.value)
+                )
+                await s.commit()
+            await _create_ready(session_factory, origin_repo, "ready-after-wedge")
+
+            with structlog.testing.capture_logs() as captured:
+                dispatched = await asyncio.wait_for(
+                    worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+                )
+
+            assert any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                and event.get("log_level") == "warning"
+                and event.get("workspace_id") == monitor_id
+                for event in captured
+            )
+            # The stale monitor task was cancelled and is no longer tracked as a monitor
+            # (its freed slot may be immediately reused by a ready execution this cycle).
+            assert monitor_task.cancelling() > 0
+            assert (
+                worker._execution_task_kinds.get(monitor_id)  # noqa: SLF001
+                is not worker_module._ExecutionTaskKind.MONITOR_RESUME
+            )
+            # A ready execution dispatched in the same cycle that freed the slot.
+            assert dispatched >= 1
+            assert (
+                worker_module._ExecutionTaskKind.READY  # noqa: SLF001
+                in worker._execution_task_kinds.values()  # noqa: SLF001
+            )
+        finally:
+            executor.release.set()
+            if monitor_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(monitor_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            await asyncio.wait_for(
+                worker.wait_for_execution_tasks(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+
+    @pytest.mark.unit
+    async def test_healthy_monitor_still_monitoring_pr_is_not_cancelled(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "healthy-monitor")
+        executor = _BlockingMonitorExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        try:
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 1
+            )
+            await asyncio.wait_for(executor.started.wait(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            monitor_task = worker._execution_tasks[monitor_id]  # noqa: SLF001
+
+            # Status stays monitoring_pr: reconcile must leave the healthy monitor alone.
+            with structlog.testing.capture_logs() as captured:
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
+            assert not any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                for event in captured
+            )
+            assert not monitor_task.cancelled()
+            assert not monitor_task.done()
+            assert monitor_id in worker._execution_tasks  # noqa: SLF001
+            assert (
+                worker._execution_task_kinds[monitor_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.MONITOR_RESUME
+            )
+        finally:
+            executor.release.set()
+            await asyncio.wait_for(
+                worker.wait_for_execution_tasks(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+            )
+
+    @pytest.mark.unit
+    async def test_monitor_reconcile_does_not_cancel_ready_or_preserved_tasks(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        ready_id = await _create_ready(session_factory, origin_repo, "ready-execution")
+        preserved_id = await _create_ready(session_factory, origin_repo, "preserved-execution")
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=3,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        ready_task = asyncio.create_task(_pending_execution_task())
+        preserved_task = asyncio.create_task(_pending_execution_task())
+        worker._execution_tasks[ready_id] = ready_task  # noqa: SLF001
+        worker._execution_tasks[preserved_id] = preserved_task  # noqa: SLF001
+        worker._execution_task_kinds[ready_id] = (  # noqa: SLF001
+            worker_module._ExecutionTaskKind.READY
+        )
+        worker._execution_task_kinds[preserved_id] = (  # noqa: SLF001
+            worker_module._ExecutionTaskKind.PRESERVED_ACTIVE
+        )
+
+        async def _empty_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            return []
+
+        worker._list_monitoring_pr = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+        worker._list_ready = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+
+        try:
+            with structlog.testing.capture_logs() as captured:
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
+            assert not any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                for event in captured
+            )
+            assert not ready_task.cancelled()
+            assert not preserved_task.cancelled()
+            assert worker._execution_tasks[ready_id] is ready_task  # noqa: SLF001
+            assert worker._execution_tasks[preserved_id] is preserved_task  # noqa: SLF001
+            assert (
+                worker._execution_task_kinds[ready_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.READY
+            )
+            assert (
+                worker._execution_task_kinds[preserved_id]  # noqa: SLF001
+                is worker_module._ExecutionTaskKind.PRESERVED_ACTIVE
+            )
+        finally:
+            for task in (ready_task, preserved_task):
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await asyncio.wait_for(task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            worker._execution_tasks.clear()  # noqa: SLF001
+            worker._execution_task_kinds.clear()  # noqa: SLF001
+
+    @pytest.mark.unit
+    async def test_execution_slots_saturation_logs_only_at_intended_cadence(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        interval = worker_module._EXECUTION_SLOTS_SATURATED_LOG_INTERVAL  # noqa: SLF001
+        monitor_id = await _create_monitoring_pr(session_factory, origin_repo, "saturating-monitor")
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=1,
+            ),
+        )
+        worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+
+        # Occupy the single slot with a still-monitoring monitor task so reconcile
+        # leaves it in place every cycle and the slot stays saturated.
+        slot_task = asyncio.create_task(_pending_execution_task())
+        worker._execution_tasks[monitor_id] = slot_task  # noqa: SLF001
+        worker._execution_task_kinds[monitor_id] = (  # noqa: SLF001
+            worker_module._ExecutionTaskKind.MONITOR_RESUME
+        )
+
+        async def _empty_list(
+            *,
+            limit: int | None = None,
+            exclude_ids: set[str] | None = None,
+        ) -> list[str]:
+            return []
+
+        worker._list_monitoring_pr = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+        worker._list_ready = _empty_list  # type: ignore[method-assign]  # noqa: SLF001
+
+        def _saturation_events(captured: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            return [
+                event
+                for event in captured
+                if event.get("event") == "worker.execution_slots_saturated"
+            ]
+
+        try:
+            with structlog.testing.capture_logs() as captured:
+                for _ in range(interval):
+                    assert (
+                        await asyncio.wait_for(
+                            worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+                        )
+                        == 0
+                    )
+            events = _saturation_events(captured)
+            assert len(events) == 1
+            event = events[0]
+            assert event.get("log_level") == "warning"
+            assert event["slot_limit"] == 1
+            assert event["tracked_count"] == 1
+            assert event["tracked_workspace_ids"] == [monitor_id]
+            assert event["tracked_monitor_ids"] == [monitor_id]
+            assert event["consecutive_saturated_cycles"] == interval
+
+            # Fires again only on the next multiple of the cadence interval.
+            with structlog.testing.capture_logs() as captured_again:
+                for _ in range(interval):
+                    assert (
+                        await asyncio.wait_for(
+                            worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS
+                        )
+                        == 0
+                    )
+            events_again = _saturation_events(captured_again)
+            assert len(events_again) == 1
+            assert events_again[0]["consecutive_saturated_cycles"] == 2 * interval
+
+            # A non-saturated cycle (slot free) resets the counter.
+            worker._execution_tasks.pop(monitor_id, None)  # noqa: SLF001
+            worker._execution_task_kinds.pop(monitor_id, None)  # noqa: SLF001
+            assert (
+                await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS) == 0
+            )
+            assert worker._consecutive_saturated_cycles == 0  # noqa: SLF001
+
+            # The next saturated run restarts at 1 and does not immediately log.
+            worker._execution_tasks[monitor_id] = slot_task  # noqa: SLF001
+            worker._execution_task_kinds[monitor_id] = (  # noqa: SLF001
+                worker_module._ExecutionTaskKind.MONITOR_RESUME
+            )
+            with structlog.testing.capture_logs() as captured_restart:
+                assert (
+                    await asyncio.wait_for(worker.run_once(), timeout=WORKER_TEST_TIMEOUT_SECONDS)
+                    == 0
+                )
+            assert worker._consecutive_saturated_cycles == 1  # noqa: SLF001
+            assert _saturation_events(captured_restart) == []
+        finally:
+            worker._execution_tasks.pop(monitor_id, None)  # noqa: SLF001
+            worker._execution_task_kinds.pop(monitor_id, None)  # noqa: SLF001
+            slot_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(slot_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+
 
 class TestRunOnceMonitorRecovery:
     @pytest.mark.unit

--- a/tests/unit/control/test_worker_coverage_edges.py
+++ b/tests/unit/control/test_worker_coverage_edges.py
@@ -1998,3 +1998,61 @@ async def test_salvage_monitor_cooldown_active_evicts_expired_entries(
 
     assert not worker._active_salvage_monitor_resume_cooldown_active("ws_expired")  # noqa: SLF001
     assert "ws_expired" not in worker._active_salvage_monitor_resume_cooldowns  # noqa: SLF001
+
+
+@pytest.mark.unit
+async def test_forget_execution_task_ignores_replaced_task(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+
+    async def _pending() -> None:
+        await asyncio.Event().wait()
+
+    tracked = asyncio.create_task(_pending())
+    stale = asyncio.create_task(_pending())
+    worker._execution_tasks["ws_replaced"] = tracked  # noqa: SLF001
+    worker._execution_task_kinds["ws_replaced"] = (  # noqa: SLF001
+        worker_module._ExecutionTaskKind.READY
+    )
+    try:
+        # A late done-callback from a previously cancelled task must not evict the
+        # task that currently owns the slot (identity guard).
+        worker._forget_execution_task("ws_replaced", stale)  # noqa: SLF001
+        assert worker._execution_tasks["ws_replaced"] is tracked  # noqa: SLF001
+        assert (
+            worker._execution_task_kinds["ws_replaced"]  # noqa: SLF001
+            is worker_module._ExecutionTaskKind.READY
+        )
+
+        # The matching task clears both slot-accounting maps together.
+        worker._forget_execution_task("ws_replaced", tracked)  # noqa: SLF001
+        assert "ws_replaced" not in worker._execution_tasks  # noqa: SLF001
+        assert "ws_replaced" not in worker._execution_task_kinds  # noqa: SLF001
+    finally:
+        for task in (tracked, stale):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+@pytest.mark.unit
+async def test_reconcile_drops_monitor_kind_when_task_already_gone(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    worker = _worker(factory)
+    # Simulate a monitor resume that finished concurrently during the status load:
+    # the kind entry lingers while its task is already gone and the workspace row
+    # is absent (so it is no longer monitoring_pr). Reconcile should drop the stale
+    # kind entry without logging a cancellation or raising.
+    worker._execution_task_kinds["ws_vanished"] = (  # noqa: SLF001
+        worker_module._ExecutionTaskKind.MONITOR_RESUME
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+
+    assert "ws_vanished" not in worker._execution_task_kinds  # noqa: SLF001
+    assert not any(
+        event.get("event") == "worker.stale_monitor_execution_task_cancelled" for event in captured
+    )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_ae9df0615b114d7c983c4370` (agent: `claude_code`, model: `claude-opus-4-7`, effort: `xhigh`).

**External task ID**: github-issue-276

### Task
Implement GitHub issue #276 against development.

Problem: ControlWorker tracks running execution/monitor asyncio tasks only by workspace_id -> Task. If a PR monitor coroutine wedges, it remains in _execution_tasks forever. _available_execution_slots() subtracts len(_execution_tasks), so wedged monitor tasks can exhaust execution capacity and prevent ready workspaces or operator rebase operations from dispatching until the worker restarts.

Important context: PR #275 is already merged into development. Preserve its SyncBase staleness-refresh behavior in src/awf/runtime/pr_monitor_runner.py unless tests expose a direct interaction bug.

Required implementation:
- In src/awf/control/worker.py, add private metadata for tracked execution tasks so the worker can distinguish PR monitor resumes from ready/preserved execution work.
- At the start of run_once, reconcile tracked PR monitor tasks with current DB status. Bulk-read statuses for tracked monitor workspace IDs. If a tracked monitor workspace is missing or no longer monitoring_pr, log worker.stale_monitor_execution_task_cancelled, cancel the task, and remove it from slot accounting immediately. Do not cancel ready or preserved validation tasks through this path.
- Add low-noise saturation logging for repeated idle cycles where all execution slots are occupied. Emit worker.execution_slots_saturated with slot limit, tracked count, tracked workspace IDs, tracked monitor IDs, and consecutive saturated cycle count.
- Add unit tests proving: stale monitor task moved to ready is cancelled and ready execution dispatches in the same run_once; monitor task still in monitoring_pr is not cancelled; ready/preserved execution tasks are not cancelled by monitor reconciliation; saturation logging fires only at the intended cadence.
- Update existing direct _execution_tasks tests only as needed for metadata cleanup.

Repository process requirements:
- Follow plans/PLAN_EXECUTION_PROTOCOL.md. Create plans/WORKER_STALE_MONITOR_SLOT_PLAN.md before coding and plans/WORKER_STALE_MONITOR_SLOT_VALIDATION.md after implementation.
- Do not add explicit validation commands to the AWF task or rely on prompt-specific validation lists; the workspace profile .awf/workspace.yml defines validation.
- Keep the change scoped and preserve unrelated behavior.

Open a PR for the fix and let AWF monitor it.

---
Validation: 4 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancel stale monitoring tasks when a workspace stops monitoring; reclassify them as draining so slots are freed for others while remaining tracked until fully stopped.
  * Prevent accidental loss of task bookkeeping when tasks finish or are replaced; tolerate cancelled/draining tasks during waits and surface non-cancelled errors immediately.

* **New Features**
  * Track task kinds for finer scheduling and slot accounting.
  * Throttle execution-saturation warnings and cap draining-task exclusion.
  * Bulk-fetch workspace statuses before dispatch.

* **Tests**
  * Added comprehensive unit tests for reconciliation, draining behavior, slot reuse, saturation cadence, and edge-case cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->