### PR TITLE
Implement sync release PR task and remove redundant release monitor kind

### DIFF
--- a/docs/PLAN_PR_MONITOR.md
+++ b/docs/PLAN_PR_MONITOR.md
@@ -216,10 +216,14 @@ Responsibilities:
 
 ### 5. dev → main: notification-only variant
 
-A new task shape `task_kind: "monitor_release_pr"` that:
+Selected by `auto_merge=False` (no dedicated task kind). To monitor an
+existing release/manual PR, adopt it via the PR-adoption flow with
+`auto_merge=false`; to open/maintain the `development → main` release PR
+automatically, use the `sync_release_pr` task kind. (The earlier
+`monitor_release_pr` task kind is deprecated and rejected.) This variant:
 
 - Does NOT clone a repo or run the initial coding agent.
-- Does NOT create a PR (one already exists).
+- Does NOT create a PR when adopting one that already exists.
 - Runs the same monitor loop against the supplied PR number, but with `auto_merge=False`.
 - On the `Merge` branch of the decision tree: posts a GitHub PR comment "All gates green — ready for human merge", records the ready-SHA, and keeps polling until the PR is actually merged or closed. Never calls `gh pr merge`.
 - If new comments arrive AFTER the "ready" notification but before human merge: re-enters the fix cycle as normal. The CLI still addresses them. New commits push. Checks re-run. The "ready" notification re-posts only when the ready-SHA advances, so the human isn't pinged per-poll.
@@ -327,7 +331,7 @@ would land in "ready but not merged" terminal state.
 - `mypy` / `ruff` clean.
 - Alembic migration up + down: new columns `pr_merge_sha`, `monitor_iter_count`, `monitor_threads_addressed`, `monitor_started_at` on `workspaces`.
 - Manual local run: schedule a small aira-agent task, wait for CodeRabbit + Cursor to comment, observe the workspace cycle through `monitoring_pr` and end in `completed` with the PR merged.
-- Manual release run: create a dev→main PR, schedule a `monitor_release_pr` task, verify a "ready to merge" comment appears when all gates are green and the PR is NOT merged.
+- Manual release run: schedule a `sync_release_pr` task (or adopt an existing dev→main PR with `auto_merge=false`), verify a "ready to merge" comment appears when all gates are green and the PR is NOT merged.
 
 ## Risks + mitigations
 

--- a/docs/PLAN_RELEASE_PR_SYNC.md
+++ b/docs/PLAN_RELEASE_PR_SYNC.md
@@ -67,16 +67,18 @@ triggers; tunable to N = 3 if you want to batch more).
 
 ## Approach
 
-### Core idea: a new task kind `sync_release_pr`
+### Core idea: the task kind `sync_release_pr`
 
-Extend the existing `TaskKind` enum (added in Phase 1.5 for
-`monitor_release_pr`) with a third value:
+`sync_release_pr` is a real `TaskKind`. The earlier `monitor_release_pr`
+kind is deprecated and removed — monitoring an existing release/manual
+PR now goes through the generic PR-adoption flow with `auto_merge=false`,
+which selects `build_release_pr_monitor`.
 
 ```python
 class TaskKind(StrEnum):
-    feature_branch_pr = "feature_branch_pr"       # existing
-    monitor_release_pr = "monitor_release_pr"     # existing
-    sync_release_pr = "sync_release_pr"           # NEW
+    feature_branch_pr = "feature_branch_pr"   # everyday coding-agent PR
+    sync_release_pr = "sync_release_pr"        # open/reuse source→target release PR
+    sync_feature_pr = "sync_feature_pr"        # adopt an existing feature PR
 ```
 
 A `sync_release_pr` workspace is short-lived and semantically distinct

--- a/openapi.json
+++ b/openapi.json
@@ -9437,6 +9437,19 @@
             "title": "Base Branch",
             "type": "string"
           },
+          "source_branch": {
+            "anyOf": [
+              {
+                "maxLength": 256,
+                "minLength": 1,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Branch"
+          },
           "url": {
             "maxLength": 512,
             "minLength": 1,

--- a/plans/RELEASE_SYNC_TASK_KIND_PLAN.md
+++ b/plans/RELEASE_SYNC_TASK_KIND_PLAN.md
@@ -1,0 +1,150 @@
+# RELEASE_SYNC_TASK_KIND_PLAN
+
+## Problem statement & scope
+
+Operator resolution of the hunter-report release task-kind bug:
+
+1. `monitor_release_pr` is redundant and must be **deprecated** as a public task
+   kind. Monitoring an existing PR (feature→development, branch→branch, or
+   development→main/master) should go through AWF's generic PR-adoption path with
+   `auto_merge=false`, which already selects the release/manual monitor.
+2. `sync_release_pr` must become a **real** task kind: create or reuse a
+   source→target release PR, then monitor it with release/manual behavior and
+   never auto-merge. No coding agent and no feature PR.
+3. Public task-kind admission must be **hardened** so unknown/deprecated kinds
+   never fall through to feature provisioning/execution.
+4. Remove the **duplicate** `_GITHUB_PULL_HEAD_REF` regex in
+   `src/awf/node/git_manager.py`.
+
+Generic AWF core behavior only — no hard-coded repositories or branch names. No
+scheduler/cron system. Rely on `.awf/workspace.yml` for validation; no
+prompt-specific validation commands.
+
+## Requirements checklist
+
+| # | Requirement |
+|---|-------------|
+| 1 | Remove `monitor_release_pr` from `TaskKind` and public docs |
+| 1 | Legacy `monitor_release_pr` fails fast with a clear deprecated message; never runs as feature work |
+| 2 | `sync_release_pr` runs no coding agent and creates no feature PR |
+| 2 | Check whether source is ahead of target; default source `development`, default target `repo.base_branch` (falls back to `main`); `master`/explicit target supported |
+| 2 | No commits ahead → complete cleanly with a clear reason/event (`NO_CHANGES_TO_SYNC`) |
+| 2 | Reuse an existing open source→target PR; otherwise create one with a clear title/body |
+| 2 | Transition into `monitoring_pr` with PR metadata recorded and `auto_merge=false`/release monitor behavior |
+| 2 | Preserve the generic PR-adoption monitor path for arbitrary existing PRs |
+| 3 | REST/MCP workspace creation rejects arbitrary unknown task kinds |
+| 3 | Supported direct kinds = `feature_branch_pr` + `sync_release_pr`; `sync_feature_pr` remains adoption-only |
+| 3 | Legacy/unsupported values never fall through to feature provisioning/execution |
+| 3 | CLI/API/MCP surfaces expose/ document task-kind selection |
+| 4 | `_GITHUB_PULL_HEAD_REF` defined exactly once |
+
+## Design / implementation steps
+
+- **`src/awf/db/enums.py`** — drop the `monitor_release_pr` enum member; keep
+  `feature_branch_pr`, `sync_release_pr`, `sync_feature_pr` and refresh the
+  `sync_release_pr` docstring to the source→target model.
+- **`src/awf/runtime/release_pr_sync.py` (new)** — pure, DB-free helpers backing
+  the handoff: `count_commits_ahead` (fetch + `rev-list --count`),
+  `find_or_create_release_pr` (reuse open source→target PR or `gh pr create`),
+  `prepare_release_pr_sync` (returns `ReleasePrSyncNoOp | ReleasePrSyncResult`),
+  `release_pr_title`/`release_pr_body`, `ReleasePrSyncError`.
+- **`src/awf/common/github_client.py`** — add `GitHubClient.create_pull_request`
+  (`gh pr create`), reusing existing `RepoRef`,
+  `list_open_pull_requests_for_branch`, `fetch_pull_request_adoption_metadata`,
+  `parse_github_pull_request_url`, `PullRequestAdoptionMetadata`.
+- **`src/awf/control/executor.py`** — replace the `sync_feature_pr`-only branch
+  with `_dispatch_non_feature_task_kind`: `sync_feature_pr`→existing handoff,
+  `sync_release_pr`→new `_handoff_sync_release_pr_monitor`, `monitor_release_pr`→
+  fail fast (`policy_failure`, `DEPRECATED_TASK_KIND`), unknown→fail fast
+  (`policy_failure`, `UNSUPPORTED_TASK_KIND`), `feature_branch_pr`→return `False`
+  so the coding-agent path continues. Add the release handoff (no-op completion;
+  open/reuse PR; record metadata; `running→validating→monitoring_pr`), a shared
+  `_build_handoff_pr_monitor`, no-op completion, and source/target branch +
+  policy-metadata helpers.
+- **`src/awf/node/provisioner.py`** — `sync_release_pr` provisions a
+  `release-sync/<id>` local branch, checks out the source branch (default
+  `development`), and sets the source branch as the remote push branch.
+- **`src/awf/api/schemas.py`** — `PUBLIC_DIRECT_CREATE_TASK_KINDS =
+  {feature_branch_pr, sync_release_pr}`; `WorkspaceTask.kind` field validator
+  rejects deprecated `monitor_release_pr`, adoption-only `sync_feature_pr`, and
+  unknown kinds; add optional `WorkspaceRepo.source_branch`.
+- **`src/awf/service/workspaces.py`** —
+  `_assert_supported_direct_create_task_kind` defense-in-depth re-check;
+  `_effective_auto_merge` forces `auto_merge=False` for `sync_release_pr`;
+  `workspace_create_task_policy_snapshot` writes a `release_sync` policy block
+  (`source_branch`, `target_branch`); drop `monitor_release_pr` from the retry
+  preserve set.
+- **`src/awf/control/worker.py`, `src/awf/service/provider_recovery.py`** — drop
+  `monitor_release_pr` from the preserved-remote-push-branch task-kind sets.
+- **`src/awf/node/git_manager.py`** — remove the duplicate
+  `_GITHUB_PULL_HEAD_REF` definition.
+- **`src/awf/cli/main.py`** — `workspace create` gains `--task-kind` and
+  `--source-branch`.
+- **`src/awf/mcp/server.py`** — update the `task_kind` field description.
+- **Docs/schema** — `src/awf/runtime/pr_monitor.py`, `docs/PLAN_PR_MONITOR.md`,
+  `docs/PLAN_RELEASE_PR_SYNC.md`, `skills/awf-scheduler/SKILL.md`, `openapi.json`
+  aligned to the new model.
+
+No new state-machine transitions: `running→validating`,
+`validating→completed` (no-op), and `validating→monitoring_pr` (handoff) already
+exist.
+
+## Tests (TDD)
+
+- `tests/unit/runtime/test_release_pr_sync.py` (new) — ahead-count parse,
+  fetch/rev-list/non-numeric failures, find-or-create reuse vs create,
+  unparseable-URL error, prepare no-op/create/reuse, title/body.
+- `tests/unit/control/test_executor_error_paths.py` — legacy
+  `monitor_release_pr`→`DEPRECATED_TASK_KIND` (no validation/gh calls); unknown→
+  `UNSUPPORTED_TASK_KIND`; release handoff no-op completion; create→
+  `monitoring_pr` with `auto_merge=False` + open MergeCandidate; reuse; invalid
+  repo URL; fetch failure; stale-skip; recheck blocks monitor run; helper
+  resolution.
+- `tests/unit/api/test_schema_coverage_edges.py` — enum drops
+  `monitor_release_pr`; accepts public kinds; rejects unknown/deprecated/direct
+  `sync_feature_pr`; optional `source_branch`; create-request rejects deprecated.
+- `tests/unit/node/test_provisioner.py` — `sync_release_pr` checks out source +
+  `release-sync/<id>`; `feature_branch_pr` keeps the prefix branch.
+- `tests/unit/node/test_git_manager.py` — `_GITHUB_PULL_HEAD_REF` defined once.
+- `tests/unit/common/test_github_client.py` — `create_pull_request` argv/URL +
+  error.
+- `tests/unit/service/test_workspace_retry.py`,
+  `tests/unit/service/test_workspaces_observability.py` — new kind set; retry/
+  observability; `sync_feature_pr` seeded via adoption, not direct create.
+
+## Verification commands & pass criteria
+
+Focused only — AWF/GitHub CI owns the full suite, coverage gates, and
+`.awf/workspace.yml` validation post-agent.
+
+```bash
+uv run ruff format <changed files>
+uv run ruff format --check <changed files>   # must report nothing to reformat
+uv run ruff check <changed src files>
+uv run pytest -q \
+  tests/unit/runtime/test_release_pr_sync.py \
+  tests/unit/control/test_executor_error_paths.py \
+  tests/unit/api/test_schema_coverage_edges.py \
+  tests/unit/node/test_provisioner.py \
+  tests/unit/node/test_git_manager.py \
+  tests/unit/common/test_github_client.py \
+  tests/unit/service/test_workspace_retry.py \
+  tests/unit/service/test_workspaces_observability.py
+```
+
+Pass criteria: `ruff format --check` reports nothing to reformat; focused
+`ruff`/`pytest` are green.
+
+## Assumptions / Changes
+
+- Mode is **salvage continuation**: AWF restored a near-complete implementation
+  diff from a prior run that timed out at the post-agent commit step (only the
+  `ruff format --check` pre-commit hook failed; `ruff check` had passed). Code
+  and tests were recovered; this plan documents the implemented design, and the
+  execution phase applies formatting, runs the focused checks, and adds the
+  required `plans/` process docs.
+- Default source `development`; default target `repo.base_branch` (falls back to
+  `main`); `master`/explicit target via the `release_sync` policy block.
+- `auto_merge=false` is the single switch selecting `build_release_pr_monitor`
+  (release/manual behavior), enforced at the service boundary for
+  `sync_release_pr`.

--- a/plans/RELEASE_SYNC_TASK_KIND_VALIDATION.md
+++ b/plans/RELEASE_SYNC_TASK_KIND_VALIDATION.md
@@ -1,0 +1,75 @@
+# RELEASE_SYNC_TASK_KIND_VALIDATION
+
+Plan reference: [RELEASE_SYNC_TASK_KIND_PLAN.md](RELEASE_SYNC_TASK_KIND_PLAN.md)
+
+Mode: salvage continuation. AWF restored a near-complete implementation diff from
+a prior run that timed out at the post-agent git commit step (only the
+`ruff format --check` pre-commit hook failed; `ruff check` had already passed).
+This phase verified the recovered code against the focused checks, applied the
+missing formatting, and added the required `plans/` process docs. No behavioral
+defects surfaced, so no source logic was changed during this phase.
+
+## Requirement-by-requirement status
+
+| # | Requirement | Status | Evidence |
+|---|-------------|--------|----------|
+| 1 | Remove `monitor_release_pr` from `TaskKind` + public docs | Complete | `src/awf/db/enums.py` (member removed; `sync_release_pr` docstring rewritten); docs in `docs/PLAN_PR_MONITOR.md`, `docs/PLAN_RELEASE_PR_SYNC.md`, `skills/awf-scheduler/SKILL.md`, `src/awf/runtime/pr_monitor.py`, `openapi.json` |
+| 1 | Legacy `monitor_release_pr` fails fast; never feature work | Complete | `src/awf/control/executor.py` `_dispatch_non_feature_task_kind` → `policy_failure` / `DEPRECATED_TASK_KIND`; `src/awf/api/schemas.py` `WorkspaceTask._validate_kind` rejects it. Tests: `test_executor_error_paths.py::TestTaskKindFailFast`, `test_schema_coverage_edges.py` |
+| 2 | `sync_release_pr` runs no coding agent / no feature PR | Complete | `_handoff_sync_release_pr_monitor` returns before the agent CLI step; dispatch returns `True` to short-circuit. Test: `TestSyncReleasePrHandoff` |
+| 2 | Check source ahead of target; default source `development`, target `repo.base_branch`/`main`, master/explicit supported | Complete | `src/awf/runtime/release_pr_sync.py` `count_commits_ahead`; `executor._release_sync_source_branch`/`_release_sync_target_branch`; `service/workspaces.py` `release_sync` policy block. Tests: `test_release_pr_sync.py`, `TestReleaseSyncHelpers` |
+| 2 | No commits ahead → complete cleanly with reason/event | Complete | `prepare_release_pr_sync` → `ReleasePrSyncNoOp`; `executor._complete_release_pr_sync_no_op` emits `NO_CHANGES_TO_SYNC` and completes. Tests: `test_release_pr_sync.py` (prepare no-op), `TestSyncReleasePrHandoff` (no-op completes w/o PR or monitor) |
+| 2 | Reuse existing open source→target PR; else create | Complete | `find_or_create_release_pr` (reuse vs `gh pr create`). Tests: `test_release_pr_sync.py` (reuse/create), `TestSyncReleasePrHandoff` (reuse existing PR) |
+| 2 | Enter `monitoring_pr` with PR metadata + `auto_merge=false`/release monitor | Complete | `executor._handoff_sync_release_pr_monitor` records pr_url/number/sha + `release_sync.pr` policy, transitions `running→validating→monitoring_pr`; `service._effective_auto_merge` forces `False`. Tests: `TestSyncReleasePrHandoff` (monitoring_pr, auto_merge=False captured, MergeCandidate open) |
+| 2 | Preserve generic PR-adoption monitor path | Complete | `src/awf/service/pr_monitor_adoption.py` untouched; `sync_feature_pr` handoff retained via shared `_build_handoff_pr_monitor`. Tests: `test_workspaces_observability.py`, `test_workspace_retry.py` adoption cases pass |
+| 3 | REST/MCP reject arbitrary unknown task kinds | Complete | `schemas.WorkspaceTask._validate_kind` (REST + MCP funnel through it). Tests: `test_schema_coverage_edges.py` (rejects unknown/deprecated/direct `sync_feature_pr`) |
+| 3 | Direct kinds = `feature_branch_pr` + `sync_release_pr`; `sync_feature_pr` adoption-only | Complete | `schemas.PUBLIC_DIRECT_CREATE_TASK_KINDS`; `service._assert_supported_direct_create_task_kind`. Tests: `test_schema_coverage_edges.py`, `test_workspaces_observability.py` |
+| 3 | Legacy/unsupported never fall through to feature provisioning | Complete | executor dispatch fails fast for deprecated/unknown; service re-check raises. Tests: `TestTaskKindFailFast` |
+| 3 | Update CLI/API/MCP surfaces | Complete | `cli/main.py` `--task-kind`/`--source-branch`; `mcp/server.py` description; `schemas.WorkspaceRepo.source_branch`; `openapi.json` |
+| 4 | `_GITHUB_PULL_HEAD_REF` defined once | Complete | `src/awf/node/git_manager.py` (duplicate removed). Test: `test_git_manager.py` |
+
+All planned requirements: **Complete**. No `Partial`/`Missing` items, so no
+iteration section is required.
+
+## Commands run (focused; AWF/CI owns broad gating)
+
+- `uv run pytest -q` over the focused set (plan §"Tests") →
+  **496 passed in 279.90s**:
+  - `tests/unit/runtime/test_release_pr_sync.py`
+  - `tests/unit/control/test_executor_error_paths.py`
+  - `tests/unit/api/test_schema_coverage_edges.py`
+  - `tests/unit/node/test_provisioner.py`
+  - `tests/unit/node/test_git_manager.py`
+  - `tests/unit/common/test_github_client.py`
+  - `tests/unit/service/test_workspace_retry.py`
+  - `tests/unit/service/test_workspaces_observability.py`
+- `uv run ruff format <changed files>` → 5 files reformatted
+  (`src/awf/node/provisioner.py`, `src/awf/runtime/release_pr_sync.py`,
+  `tests/unit/api/test_schema_coverage_edges.py`,
+  `tests/unit/control/test_executor_error_paths.py`,
+  `tests/unit/node/test_provisioner.py`) — the original post-agent timeout cause.
+- `uv run ruff format --check <all changed files>` → **21 files already
+  formatted** (clean).
+- `uv run ruff check <changed source files>` → **All checks passed!**
+- `uv run mypy src/awf/runtime/release_pr_sync.py src/awf/control/executor.py
+  src/awf/node/provisioner.py src/awf/api/schemas.py
+  src/awf/service/workspaces.py` → **Success: no issues found in 5 source files**.
+
+Broad validation (full suite, coverage gates, `.awf/workspace.yml`) is owned by
+AWF and GitHub CI after agent completion and was intentionally not run here.
+
+## Files changed
+
+New: `src/awf/runtime/release_pr_sync.py`,
+`tests/unit/runtime/test_release_pr_sync.py`,
+`plans/RELEASE_SYNC_TASK_KIND_PLAN.md`,
+`plans/RELEASE_SYNC_TASK_KIND_VALIDATION.md`.
+
+Modified: `src/awf/db/enums.py`, `src/awf/control/executor.py`,
+`src/awf/common/github_client.py`, `src/awf/node/provisioner.py`,
+`src/awf/node/git_manager.py`, `src/awf/api/schemas.py`,
+`src/awf/service/workspaces.py`, `src/awf/control/worker.py`,
+`src/awf/service/provider_recovery.py`, `src/awf/cli/main.py`,
+`src/awf/mcp/server.py`, `src/awf/runtime/pr_monitor.py`,
+`docs/PLAN_PR_MONITOR.md`, `docs/PLAN_RELEASE_PR_SYNC.md`,
+`skills/awf-scheduler/SKILL.md`, `openapi.json`, and the corresponding test
+modules under `tests/unit/`.

--- a/skills/awf-scheduler/SKILL.md
+++ b/skills/awf-scheduler/SKILL.md
@@ -318,11 +318,16 @@ monitor for any PR whose ``run_awf.py`` process isn't in ``ps``.
 
 ### Release PR (``development → main``)
 
-Dev-to-main PRs must NEVER be auto-merged. Use the
-``monitor_release_pr`` task kind (planned field — currently selected
-via ``build_release_pr_monitor`` instead of
-``build_feature_pr_monitor``). Everything else is identical to the
-feature flow — comment resolution, CI fixes, base sync — except:
+Dev-to-main PRs must NEVER be auto-merged. To open/maintain the release
+PR automatically, create a ``sync_release_pr`` task (it opens or reuses
+the ``development → main`` PR and attaches the release monitor with
+``auto_merge=false``). To monitor an already-open release/manual PR,
+adopt it via the PR-adoption flow with ``auto_merge=false`` — that
+selects ``build_release_pr_monitor`` instead of
+``build_feature_pr_monitor``. (The old ``monitor_release_pr`` task kind
+is deprecated and rejected; use PR adoption instead.) Everything else is
+identical to the feature flow — comment resolution, CI fixes, base sync
+— except:
 
 - No ``gh pr merge`` call. Ever.
 - When all 5 gates are green, AWF posts a "✅ Ready to merge at commit

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -18,7 +18,7 @@ from awf.common.callback_targets import (
     is_public_callback_target_host,
     validate_callback_target_url_port,
 )
-from awf.db.enums import AgentRuntime, OperationStatus, TaskClass, WorkspaceStatus
+from awf.db.enums import AgentRuntime, OperationStatus, TaskClass, TaskKind, WorkspaceStatus
 from awf.profiles.models import OutOfScopeChangePolicy, WorkspaceProfile
 
 OwnedPath = Annotated[str, Field(min_length=1, max_length=512)]
@@ -64,6 +64,13 @@ _MAX_LOG_STREAM_REF_DEPTH = 64
 _DEFAULT_REPO_BASE_BRANCH = "main"
 _LEGACY_FLAT_REPO_BASE_BRANCH_DEFAULT = "development"
 _LEGACY_DATABASE_PROFILE_REF = "aira"
+_DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
+# Task kinds operators may request directly via REST/MCP workspace creation.
+# ``sync_feature_pr`` is intentionally absent: it is created through the
+# PR-adoption endpoint, not direct workspace creation.
+PUBLIC_DIRECT_CREATE_TASK_KINDS = frozenset(
+    {TaskKind.feature_branch_pr.value, TaskKind.sync_release_pr.value}
+)
 
 
 class MergeCandidateReadinessResponse(BaseModel):
@@ -84,6 +91,9 @@ class WorkspaceRepo(BaseModel):
     base_branch: Annotated[
         str, Field(default=_DEFAULT_REPO_BASE_BRANCH, min_length=1, max_length=256)
     ]
+    source_branch: Annotated[str | None, Field(default=None, min_length=1, max_length=256)] = None
+    """Optional source branch for ``sync_release_pr`` (defaults to ``development``).
+    The release PR is opened ``source_branch`` → ``base_branch``."""
 
 
 class WorkspaceProviderFallbackTarget(BaseModel):
@@ -147,6 +157,31 @@ class WorkspaceTask(BaseModel):
         le=86400,
     )
     provider_recovery: WorkspaceProviderRecoveryPolicy | None = None
+
+    @field_validator("kind")
+    @classmethod
+    def _validate_kind(cls, value: str) -> str:
+        """Admit only the public direct-create task kinds.
+
+        Rejects the deprecated ``monitor_release_pr``, the adoption-only
+        ``sync_feature_pr``, and any unknown string so unsupported kinds can
+        never reach feature provisioning/execution. Covers REST and MCP, which
+        both funnel through this schema.
+        """
+        if value in PUBLIC_DIRECT_CREATE_TASK_KINDS:
+            return value
+        if value == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
+            raise ValueError(
+                "task kind 'monitor_release_pr' is deprecated; monitor an existing "
+                "release/manual PR via PR adoption with auto_merge=false instead."
+            )
+        if value == TaskKind.sync_feature_pr.value:
+            raise ValueError(
+                "task kind 'sync_feature_pr' is created through the PR-adoption "
+                "endpoint, not direct workspace creation."
+            )
+        supported = ", ".join(sorted(PUBLIC_DIRECT_CREATE_TASK_KINDS))
+        raise ValueError(f"unsupported task kind {value!r}; supported kinds are: {supported}.")
 
 
 class WorkspaceProfileSelection(BaseModel):

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -18,7 +18,14 @@ from awf.common.callback_targets import (
     is_public_callback_target_host,
     validate_callback_target_url_port,
 )
-from awf.db.enums import AgentRuntime, OperationStatus, TaskClass, TaskKind, WorkspaceStatus
+from awf.db.enums import (
+    DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND,
+    AgentRuntime,
+    OperationStatus,
+    TaskClass,
+    TaskKind,
+    WorkspaceStatus,
+)
 from awf.profiles.models import OutOfScopeChangePolicy, WorkspaceProfile
 
 OwnedPath = Annotated[str, Field(min_length=1, max_length=512)]
@@ -64,7 +71,6 @@ _MAX_LOG_STREAM_REF_DEPTH = 64
 _DEFAULT_REPO_BASE_BRANCH = "main"
 _LEGACY_FLAT_REPO_BASE_BRANCH_DEFAULT = "development"
 _LEGACY_DATABASE_PROFILE_REF = "aira"
-_DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
 # Task kinds operators may request directly via REST/MCP workspace creation.
 # ``sync_feature_pr`` is intentionally absent: it is created through the
 # PR-adoption endpoint, not direct workspace creation.
@@ -170,7 +176,7 @@ class WorkspaceTask(BaseModel):
         """
         if value in PUBLIC_DIRECT_CREATE_TASK_KINDS:
             return value
-        if value == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
+        if value == DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
             raise ValueError(
                 "task kind 'monitor_release_pr' is deprecated; monitor an existing "
                 "release/manual PR via PR adoption with auto_merge=false instead."

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -2368,6 +2368,16 @@ def workspace_create(
     task_title: str = typer.Option(..., "--title"),
     task_prompt: str = typer.Option(..., "--prompt"),
     branch_base: str = typer.Option("development", "--base"),
+    task_kind: str = typer.Option(
+        "feature_branch_pr",
+        "--task-kind",
+        help="feature_branch_pr (default) or sync_release_pr.",
+    ),
+    source_branch: str | None = typer.Option(
+        None,
+        "--source-branch",
+        help="Source branch for sync_release_pr release PRs (default development).",
+    ),
     agent: str = typer.Option("codex", "--agent"),
     model: str | None = typer.Option(None, "--model"),
     effort: str | None = typer.Option(
@@ -2434,13 +2444,16 @@ def workspace_create(
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
     """Submit a workspace creation request."""
+    repo_body: dict[str, Any] = {"url": repo_url, "base_branch": branch_base}
+    if source_branch is not None:
+        repo_body["source_branch"] = source_branch
     body: dict[str, Any] = {
-        "repo": {"url": repo_url, "base_branch": branch_base},
+        "repo": repo_body,
         "task": {
             "title": task_title,
             "prompt": task_prompt,
             "agent": agent,
-            "kind": "feature_branch_pr",
+            "kind": task_kind,
             "auto_merge": auto_merge,
             "initial_review_grace_period_seconds": initial_review_grace_period_seconds,
         },

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -36,7 +36,14 @@ from click.core import ParameterSource
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.urls import normalize_api_url, sanitize_request_url
-from awf.db.enums import AgentRuntime, OperationStatus, OperationType, TaskClass, WorkspaceStatus
+from awf.db.enums import (
+    AgentRuntime,
+    OperationStatus,
+    OperationType,
+    TaskClass,
+    TaskKind,
+    WorkspaceStatus,
+)
 from awf.service.gc import WorkspaceGCComposeTeardownResult, WorkspaceGCWorktreeRemoveResult
 from awf.service.logs import DEFAULT_LOG_TAIL, ServiceLogName
 from awf.service.smoke import _PROFILE_MARKER_PATHS as _PROJECT_PROFILE_MARKER_PATHS
@@ -2367,7 +2374,14 @@ def workspace_create(
     repo_url: str = typer.Option(..., "--repo", help="Git URL."),
     task_title: str = typer.Option(..., "--title"),
     task_prompt: str = typer.Option(..., "--prompt"),
-    branch_base: str = typer.Option("development", "--base"),
+    branch_base: str | None = typer.Option(
+        None,
+        "--base",
+        help=(
+            "Base/target branch. Defaults to 'development' for feature_branch_pr "
+            "and 'main' for sync_release_pr."
+        ),
+    ),
     task_kind: str = typer.Option(
         "feature_branch_pr",
         "--task-kind",
@@ -2444,6 +2458,8 @@ def workspace_create(
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
     """Submit a workspace creation request."""
+    if branch_base is None:
+        branch_base = "main" if task_kind == TaskKind.sync_release_pr.value else "development"
     repo_body: dict[str, Any] = {"url": repo_url, "base_branch": branch_base}
     if source_branch is not None:
         repo_body["source_branch"] = source_branch

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -1334,6 +1334,45 @@ class GitHubClient:
                 stderr=result.stderr,
             )
 
+    async def create_pull_request(
+        self,
+        *,
+        repo: RepoRef,
+        base: str,
+        head: str,
+        title: str,
+        body: str,
+    ) -> str:
+        """Open a PR for an existing ``head`` branch against ``base``.
+
+        Both branches already exist on origin (no worktree push), so this is
+        a plain ``gh pr create`` and returns the new PR URL printed on stdout.
+        """
+        result = await self._runner.run(
+            [
+                "gh",
+                "pr",
+                "create",
+                "--repo",
+                repo.slug(),
+                "--base",
+                base,
+                "--head",
+                head,
+                "--title",
+                title,
+                "--body",
+                body,
+            ],
+        )
+        if not result.ok:
+            raise GitHubClientError(
+                operation="gh pr create",
+                returncode=result.returncode,
+                stderr=result.stderr,
+            )
+        return result.stdout.strip()
+
     async def merge_pr(
         self,
         *,

--- a/src/awf/common/workspace_policy.py
+++ b/src/awf/common/workspace_policy.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
+# Fallback source branch for ``sync_release_pr`` worktrees. Shared across the
+# control, service, and node layers so the release-sync default cannot drift
+# between task admission, provisioning, and execution.
+DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
+
 
 def agent_model_from_task_policy(task_policy: object) -> str | None:
     """Return the nonblank task policy agent model, if one is configured."""

--- a/src/awf/common/workspace_policy.py
+++ b/src/awf/common/workspace_policy.py
@@ -11,6 +11,23 @@ from typing import Any, cast
 DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
 
 
+def release_sync_source_branch(task_policy: object) -> str:
+    """Return the ``sync_release_pr`` source branch from policy, or the default.
+
+    Centralizes the ``task_policy["release_sync"]["source_branch"]`` navigation
+    so the control (executor) and node (provisioner) layers cannot drift in how
+    they read or default the persisted release-sync source branch.
+    """
+
+    if isinstance(task_policy, Mapping):
+        block = task_policy.get("release_sync")
+        if isinstance(block, Mapping):
+            source = block.get("source_branch")
+            if isinstance(source, str) and source.strip():
+                return source.strip()
+    return DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+
+
 def agent_model_from_task_policy(task_policy: object) -> str | None:
     """Return the nonblank task policy agent model, if one is configured."""
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1490,27 +1490,50 @@ class WorkspaceExecutor:
         caller's current status so the failure transition matches it (a
         mismatched status is treated as a stale-action skip by
         :meth:`_mark_failed`, so passing the wrong one would silently no-op).
+
+        When a reclaimed workspace still carries an active validate/rebase
+        recovery operation (the worker-restart salvage of a stale ``running``
+        claim), those pending/running rows are finalized as ``failed`` with the
+        same terminal reason code *before* the workspace is failed, mirroring
+        the recovery branches in :meth:`execute`; otherwise the workspace would
+        go terminal while the recovery operation lingered unresolved.
         """
         task_kind = workspace.task_kind
         if task_kind == DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
+            message = (
+                "task kind 'monitor_release_pr' is deprecated; monitor an existing "
+                "release/manual PR via PR adoption with auto_merge=false instead."
+            )
+            if _get_active_recovery_payload(workspace) is not None:
+                await self._finish_active_recovery_operations(
+                    workspace_id=workspace_id,
+                    status=OperationStatus.failed,
+                    reason_code=_DEPRECATED_TASK_KIND_REASON_CODE,
+                    error_message=message,
+                )
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=from_status,
                 failure_reason=FailureReason.policy_failure,
-                message=(
-                    "task kind 'monitor_release_pr' is deprecated; monitor an existing "
-                    "release/manual PR via PR adoption with auto_merge=false instead."
-                ),
+                message=message,
                 reason_code=_DEPRECATED_TASK_KIND_REASON_CODE,
                 details={"task_kind": task_kind},
             )
             return True
         if task_kind not in _SUPPORTED_TASK_KINDS:
+            message = f"unsupported task kind {task_kind!r}; cannot run as feature work."
+            if _get_active_recovery_payload(workspace) is not None:
+                await self._finish_active_recovery_operations(
+                    workspace_id=workspace_id,
+                    status=OperationStatus.failed,
+                    reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
+                    error_message=message,
+                )
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=from_status,
                 failure_reason=FailureReason.policy_failure,
-                message=f"unsupported task kind {task_kind!r}; cannot run as feature work.",
+                message=message,
                 reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
                 details={"task_kind": task_kind},
             )

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -58,7 +58,7 @@ from awf.common.github_client import (
     RepoRef,
 )
 from awf.common.logging import get_logger
-from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+from awf.common.workspace_policy import release_sync_source_branch
 from awf.control.protected_file_diffs import (
     committed_changed_paths_since,
     git_show_text,
@@ -8000,10 +8000,7 @@ def _release_sync_policy(ws: Workspace) -> Mapping[str, object]:
 
 
 def _release_sync_source_branch(ws: Workspace) -> str:
-    return (
-        _nonblank_metadata_str(_release_sync_policy(ws), "source_branch")
-        or DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
-    )
+    return release_sync_source_branch(ws.task_policy)
 
 
 def _release_sync_target_branch(ws: Workspace) -> str:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -58,6 +58,7 @@ from awf.common.github_client import (
     RepoRef,
 )
 from awf.common.logging import get_logger
+from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 from awf.control.protected_file_diffs import (
     committed_changed_paths_since,
     git_show_text,
@@ -256,7 +257,6 @@ _SUPPORTED_TASK_KINDS = frozenset({"feature_branch_pr", "sync_feature_pr", "sync
 _RELEASE_SYNC_REPO_INVALID_REASON_CODE = "RELEASE_SYNC_REPO_INVALID"
 _RELEASE_SYNC_GITHUB_ERROR_REASON_CODE = "RELEASE_SYNC_GITHUB_ERROR"
 _RELEASE_SYNC_NO_CHANGES_EVENT = "workspace.release_pr_sync_no_changes"
-_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
 _DEFAULT_RELEASE_SYNC_TARGET_BRANCH = "main"
 _EXCEPTION_TRACEBACK_LIMIT = 4000
 _VALIDATION_EVIDENCE_JSON_LIMIT = 20000
@@ -7959,7 +7959,7 @@ def _release_sync_policy(ws: Workspace) -> Mapping[str, object]:
 def _release_sync_source_branch(ws: Workspace) -> str:
     return (
         _nonblank_metadata_str(_release_sync_policy(ws), "source_branch")
-        or _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+        or DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
     )
 
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -50,7 +50,7 @@ from awf.common.compose_exec import (
     cleanup_failure_message,
 )
 from awf.common.git_identity import git_identity_config_args, git_safe_directory_config_args
-from awf.common.github_client import RepoRef
+from awf.common.github_client import GitHubClient, PullRequestAdoptionMetadata, RepoRef
 from awf.common.logging import get_logger
 from awf.control.protected_file_diffs import (
     committed_changed_paths_since,
@@ -138,6 +138,14 @@ from awf.runtime.pr_monitor_operations import (
     monitor_operation_idempotency_key,
 )
 from awf.runtime.pr_push_remote import remote_push_url_for_workspace
+from awf.runtime.release_pr_sync import (
+    NO_CHANGES_REASON_CODE,
+    ReleasePrSyncError,
+    ReleasePrSyncNoOp,
+    prepare_release_pr_sync,
+    release_pr_body,
+    release_pr_title,
+)
 from awf.runtime.validation import (
     DATABASE_GENERATED_SETUP_TIMEOUT,
     DATABASE_REFRESH_TIMEOUT,
@@ -232,6 +240,13 @@ _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"
 _PR_ADOPTION_SKIP_AGENT_REASON_CODE = "PR_ADOPTION_SKIP_AGENT"
 _PR_ADOPTION_METADATA_MISSING_REASON_CODE = "PR_ADOPTION_METADATA_MISSING"
 _PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE = "PR_ADOPTION_MONITOR_UNAVAILABLE"
+_DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
+_DEPRECATED_TASK_KIND_REASON_CODE = "DEPRECATED_TASK_KIND"
+_UNSUPPORTED_TASK_KIND_REASON_CODE = "UNSUPPORTED_TASK_KIND"
+_RELEASE_SYNC_REPO_INVALID_REASON_CODE = "RELEASE_SYNC_REPO_INVALID"
+_RELEASE_SYNC_NO_CHANGES_EVENT = "workspace.release_pr_sync_no_changes"
+_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
+_DEFAULT_RELEASE_SYNC_TARGET_BRANCH = "main"
 _EXCEPTION_TRACEBACK_LIMIT = 4000
 _VALIDATION_EVIDENCE_JSON_LIMIT = 20000
 _VALIDATION_EVIDENCE_COVERAGE_PRIORITY_KEYS = (
@@ -1441,7 +1456,7 @@ class WorkspaceExecutor:
             suffix = "" if existing.endswith("\n") or not existing else "\n"
             exclude_path.write_text(f"{existing}{suffix}{pattern}\n", encoding="utf-8")
 
-    async def _handoff_sync_feature_pr_monitor(
+    async def _dispatch_non_feature_task_kind(
         self,
         *,
         workspace_id: str,
@@ -1449,28 +1464,72 @@ class WorkspaceExecutor:
         compose_project: str,
         compose_file: Path,
         worktree_path: Path,
-    ) -> None:
-        metadata = _sync_feature_pr_adoption_metadata(workspace)
-        missing = _missing_sync_feature_pr_adoption_metadata(workspace, metadata)
-        if missing:
+    ) -> bool:
+        """Route non-default task kinds; return True if the workspace is handled.
+
+        Returns False only for ``feature_branch_pr`` so the caller continues to
+        the coding-agent path. ``sync_feature_pr``/``sync_release_pr`` hand off
+        to their monitors; the deprecated ``monitor_release_pr`` and any unknown
+        kind fail fast so they never run as feature work.
+        """
+        task_kind = workspace.task_kind
+        if task_kind == "sync_feature_pr":
+            await self._handoff_sync_feature_pr_monitor(
+                workspace_id=workspace_id,
+                workspace=workspace,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                worktree_path=worktree_path,
+            )
+            return True
+        if task_kind == "sync_release_pr":
+            await self._handoff_sync_release_pr_monitor(
+                workspace_id=workspace_id,
+                workspace=workspace,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                worktree_path=worktree_path,
+            )
+            return True
+        if task_kind == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,
-                failure_reason=FailureReason.infrastructure_failure,
-                message=_sync_feature_pr_missing_metadata_message(missing),
-                reason_code=_PR_ADOPTION_METADATA_MISSING_REASON_CODE,
-                details={"missing": missing},
+                failure_reason=FailureReason.policy_failure,
+                message=(
+                    "task kind 'monitor_release_pr' is deprecated; monitor an existing "
+                    "release/manual PR via PR adoption with auto_merge=false instead."
+                ),
+                reason_code=_DEPRECATED_TASK_KIND_REASON_CODE,
+                details={"task_kind": task_kind},
             )
-            return
+            return True
+        if task_kind != "feature_branch_pr":
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.policy_failure,
+                message=f"unsupported task kind {task_kind!r}; cannot run as feature work.",
+                reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
+                details={"task_kind": task_kind},
+            )
+            return True
+        return False
 
-        if not await self._ensure_worktree_available(
-            workspace_id=workspace_id,
-            worktree_path=worktree_path,
-            expected=WorkspaceStatus.running,
-            action="sync_feature_pr_handoff",
-        ):
-            return
+    async def _build_handoff_pr_monitor(
+        self,
+        *,
+        workspace_id: str,
+        workspace: Workspace,
+        worktree_path: Path,
+        build_failed_log_event: str,
+        build_failed_message_prefix: str,
+    ) -> _MonitorRunnerProto | None:
+        """Build the PR monitor for a handoff, marking the workspace failed on error.
 
+        Shared by the ``sync_feature_pr`` and ``sync_release_pr`` handoffs. Returns
+        ``None`` (after transitioning to ``failed``) when no monitor can be built.
+        """
         monitor: _MonitorRunnerProto | None = self._pr_monitor
         try:
             if monitor is None and self._pr_monitor_factory is not None:
@@ -1501,7 +1560,7 @@ class WorkspaceExecutor:
                 )
         except Exception as exc:
             _log.error(
-                "executor.sync_feature_pr_monitor_build_failed",
+                build_failed_log_event,
                 workspace_id=workspace_id,
                 redacted_traceback=_redacted_exception_traceback(exc),
             )
@@ -1510,19 +1569,271 @@ class WorkspaceExecutor:
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,
                 failure_reason=FailureReason.infrastructure_failure,
-                message=f"adopted PR monitor handoff failed: {safe_exception}"[:2000],
+                message=f"{build_failed_message_prefix}{safe_exception}"[:2000],
                 reason_code=_PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE,
             )
-            return
+            return None
 
         if monitor is None:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,
                 failure_reason=FailureReason.infrastructure_failure,
-                message="adopted PR monitor handoff failed: no PR monitor configured",
+                message=f"{build_failed_message_prefix}no PR monitor configured",
                 reason_code=_PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE,
             )
+            return None
+        return monitor
+
+    async def _handoff_sync_release_pr_monitor(
+        self,
+        *,
+        workspace_id: str,
+        workspace: Workspace,
+        compose_project: str,
+        compose_file: Path,
+        worktree_path: Path,
+    ) -> None:
+        """Open/reuse a source→target release PR, then monitor it (never auto-merge).
+
+        No coding agent, no feature PR. When the source branch has no commits
+        ahead of the target, the workspace completes cleanly without a PR.
+        """
+        if not await self._ensure_worktree_available(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            expected=WorkspaceStatus.running,
+            action="sync_release_pr_handoff",
+        ):
+            return
+
+        source_branch = _release_sync_source_branch(workspace)
+        target_branch = _release_sync_target_branch(workspace)
+        try:
+            repo = RepoRef.from_url(workspace.repo_url)
+        except ValueError as exc:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=f"sync_release_pr cannot parse repo URL: {redact_audit_text(str(exc))}",
+                reason_code=_RELEASE_SYNC_REPO_INVALID_REASON_CODE,
+            )
+            return
+
+        try:
+            outcome = await prepare_release_pr_sync(
+                runner=self._runner,
+                gh=GitHubClient(self._runner),
+                repo=repo,
+                cwd=str(worktree_path),
+                source_branch=source_branch,
+                target_branch=target_branch,
+                title=release_pr_title(source_branch=source_branch, target_branch=target_branch),
+                body=release_pr_body(source_branch=source_branch, target_branch=target_branch),
+            )
+        except ReleasePrSyncError as exc:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=f"sync_release_pr failed: {exc.message}",
+                reason_code=exc.reason_code,
+                details=exc.detail,
+            )
+            return
+
+        if isinstance(outcome, ReleasePrSyncNoOp):
+            await self._complete_release_pr_sync_no_op(
+                workspace_id=workspace_id,
+                source_branch=source_branch,
+                target_branch=target_branch,
+            )
+            return
+
+        monitor = await self._build_handoff_pr_monitor(
+            workspace_id=workspace_id,
+            workspace=workspace,
+            worktree_path=worktree_path,
+            build_failed_log_event="executor.sync_release_pr_monitor_build_failed",
+            build_failed_message_prefix="release PR monitor handoff failed: ",
+        )
+        if monitor is None:
+            return
+
+        metadata = outcome.metadata
+        async with self._session_factory() as session:
+            repo_db = WorkspaceRepository(session)
+            persisted = await repo_db.get(workspace_id)
+            if persisted is None:  # pragma: no cover - destroyed mid-flight
+                return
+            if persisted.status != WorkspaceStatus.running.value:
+                await self._record_stale_action_skip(
+                    repo_db,
+                    persisted,
+                    action="sync_release_pr_handoff",
+                    expected=WorkspaceStatus.running,
+                    reason_code="EXECUTOR_STALE_STATUS",
+                )
+                await session.commit()
+                return
+
+            persisted.pr_url = metadata.url
+            persisted.pr_number = metadata.number
+            persisted.remote_push_branch = source_branch
+            persisted.monitor_last_commit_sha = metadata.head_sha
+            persisted.base_commit = metadata.base_sha
+            persisted.task_policy = _with_release_sync_pr_metadata(
+                persisted.task_policy,
+                metadata=metadata,
+                created=outcome.created,
+            )
+            await repo_db.add_event(
+                persisted,
+                event_type=_PR_MONITOR_ADOPTED_EVENT,
+                reason_code=_PR_MONITOR_ADOPTED_REASON_CODE,
+                payload={
+                    "pr_number": metadata.number,
+                    "pr_url": metadata.url,
+                    "head_ref": metadata.head_ref,
+                    "base_ref": metadata.base_ref,
+                    "head_sha": metadata.head_sha,
+                    "base_sha": metadata.base_sha,
+                    "source_branch": source_branch,
+                    "target_branch": target_branch,
+                    "created": outcome.created,
+                    "source": "release_pr_sync",
+                },
+            )
+            await repo_db.transition(
+                persisted,
+                to=WorkspaceStatus.validating,
+                reason_code=_PR_ADOPTION_SKIP_AGENT_REASON_CODE,
+                payload={"source": "release_pr_sync"},
+            )
+            await repo_db.transition(
+                persisted,
+                to=WorkspaceStatus.monitoring_pr,
+                reason_code=_PR_MONITOR_ADOPTED_REASON_CODE,
+                payload={
+                    "pr_number": metadata.number,
+                    "pr_url": metadata.url,
+                    "head_sha": metadata.head_sha,
+                    "base_sha": metadata.base_sha,
+                    "source": "release_pr_sync",
+                },
+            )
+            await session.commit()
+
+        _log.info(
+            "executor.sync_release_pr_handoff_to_monitor",
+            workspace_id=workspace_id,
+            pr_url=metadata.url,
+            created=outcome.created,
+        )
+        if not await self._recheck_status(
+            workspace_id,
+            expected=WorkspaceStatus.monitoring_pr,
+            action="run_pr_monitor",
+        ):
+            return
+        await monitor.run(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=compose_file,
+        )
+
+    async def _complete_release_pr_sync_no_op(
+        self,
+        *,
+        workspace_id: str,
+        source_branch: str,
+        target_branch: str,
+    ) -> None:
+        """Complete a ``sync_release_pr`` workspace that has nothing to sync."""
+        async with self._session_factory() as session:
+            repo_db = WorkspaceRepository(session)
+            persisted = await repo_db.get(workspace_id)
+            if persisted is None:  # pragma: no cover - destroyed mid-flight
+                return
+            if persisted.status != WorkspaceStatus.running.value:
+                await self._record_stale_action_skip(
+                    repo_db,
+                    persisted,
+                    action="sync_release_pr_handoff",
+                    expected=WorkspaceStatus.running,
+                    reason_code="EXECUTOR_STALE_STATUS",
+                )
+                await session.commit()
+                return
+            await repo_db.add_event(
+                persisted,
+                event_type=_RELEASE_SYNC_NO_CHANGES_EVENT,
+                reason_code=NO_CHANGES_REASON_CODE,
+                payload={"source_branch": source_branch, "target_branch": target_branch},
+            )
+            await repo_db.transition(
+                persisted,
+                to=WorkspaceStatus.validating,
+                reason_code=NO_CHANGES_REASON_CODE,
+                payload={"source": "release_pr_sync"},
+            )
+            await repo_db.transition(
+                persisted,
+                to=WorkspaceStatus.completed,
+                reason_code=NO_CHANGES_REASON_CODE,
+                payload={
+                    "source_branch": source_branch,
+                    "target_branch": target_branch,
+                    "source": "release_pr_sync",
+                },
+            )
+            await session.commit()
+        _log.info(
+            "executor.sync_release_pr_no_changes",
+            workspace_id=workspace_id,
+            source_branch=source_branch,
+            target_branch=target_branch,
+        )
+
+    async def _handoff_sync_feature_pr_monitor(
+        self,
+        *,
+        workspace_id: str,
+        workspace: Workspace,
+        compose_project: str,
+        compose_file: Path,
+        worktree_path: Path,
+    ) -> None:
+        metadata = _sync_feature_pr_adoption_metadata(workspace)
+        missing = _missing_sync_feature_pr_adoption_metadata(workspace, metadata)
+        if missing:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=_sync_feature_pr_missing_metadata_message(missing),
+                reason_code=_PR_ADOPTION_METADATA_MISSING_REASON_CODE,
+                details={"missing": missing},
+            )
+            return
+
+        if not await self._ensure_worktree_available(
+            workspace_id=workspace_id,
+            worktree_path=worktree_path,
+            expected=WorkspaceStatus.running,
+            action="sync_feature_pr_handoff",
+        ):
+            return
+
+        monitor = await self._build_handoff_pr_monitor(
+            workspace_id=workspace_id,
+            workspace=workspace,
+            worktree_path=worktree_path,
+            build_failed_log_event="executor.sync_feature_pr_monitor_build_failed",
+            build_failed_message_prefix="adopted PR monitor handoff failed: ",
+        )
+        if monitor is None:
             return
 
         async with self._session_factory() as session:
@@ -1687,14 +1998,13 @@ class WorkspaceExecutor:
                 return
             recovery = guard_result.recovery
 
-        if ws.task_kind == "sync_feature_pr" and recovery is None:
-            await self._handoff_sync_feature_pr_monitor(
-                workspace_id=workspace_id,
-                workspace=ws,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                worktree_path=worktree_path,
-            )
+        if recovery is None and await self._dispatch_non_feature_task_kind(
+            workspace_id=workspace_id,
+            workspace=ws,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            worktree_path=worktree_path,
+        ):
             return
 
         # ── Step 1: agent CLI runs the task inside the container ────────────
@@ -7584,6 +7894,52 @@ def _sync_feature_pr_adoption_metadata(ws: Workspace) -> Mapping[str, object]:
     policy = ws.task_policy if isinstance(ws.task_policy, Mapping) else {}
     adoption = policy.get("pr_adoption")
     return adoption if isinstance(adoption, Mapping) else {}
+
+
+def _release_sync_policy(ws: Workspace) -> Mapping[str, object]:
+    policy = ws.task_policy if isinstance(ws.task_policy, Mapping) else {}
+    block = policy.get("release_sync")
+    return block if isinstance(block, Mapping) else {}
+
+
+def _release_sync_source_branch(ws: Workspace) -> str:
+    return (
+        _nonblank_metadata_str(_release_sync_policy(ws), "source_branch")
+        or _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+    )
+
+
+def _release_sync_target_branch(ws: Workspace) -> str:
+    target = _nonblank_metadata_str(_release_sync_policy(ws), "target_branch")
+    if target is not None:
+        return target
+    base = ws.branch_base
+    if isinstance(base, str) and base.strip():
+        return base.strip()
+    return _DEFAULT_RELEASE_SYNC_TARGET_BRANCH
+
+
+def _with_release_sync_pr_metadata(
+    task_policy: object,
+    *,
+    metadata: PullRequestAdoptionMetadata,
+    created: bool,
+) -> dict[str, Any]:
+    """Return a copy of ``task_policy`` recording the resolved release PR."""
+    policy: dict[str, Any] = dict(task_policy) if isinstance(task_policy, Mapping) else {}
+    block_source = policy.get("release_sync")
+    block: dict[str, Any] = dict(block_source) if isinstance(block_source, Mapping) else {}
+    block["pr"] = {
+        "number": metadata.number,
+        "url": metadata.url,
+        "head_ref": metadata.head_ref,
+        "base_ref": metadata.base_ref,
+        "head_sha": metadata.head_sha,
+        "base_sha": metadata.base_sha,
+        "created": created,
+    }
+    policy["release_sync"] = block
+    return policy
 
 
 def _existing_pr_remote_push_url(ws: Workspace) -> str | None:

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -1472,6 +1472,7 @@ class WorkspaceExecutor:
         *,
         workspace_id: str,
         workspace: Workspace,
+        from_status: WorkspaceStatus = WorkspaceStatus.running,
     ) -> bool:
         """Fail fast deprecated/unknown task kinds; return True if rejected.
 
@@ -1482,12 +1483,19 @@ class WorkspaceExecutor:
         ``sync_release_pr`` monitors are intentionally left untouched here
         (returns False) so their recovery resumption stays intact; the sync
         handoffs are routed later by :meth:`_dispatch_non_feature_task_kind`.
+
+        Shared by both entrypoints so the policy can't drift: :meth:`execute`
+        rejects from ``running`` and :meth:`resume_pr_monitor` rejects a
+        persisted legacy row from ``monitoring_pr``. ``from_status`` is the
+        caller's current status so the failure transition matches it (a
+        mismatched status is treated as a stale-action skip by
+        :meth:`_mark_failed`, so passing the wrong one would silently no-op).
         """
         task_kind = workspace.task_kind
         if task_kind == DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
             await self._mark_failed(
                 workspace_id=workspace_id,
-                from_status=WorkspaceStatus.running,
+                from_status=from_status,
                 failure_reason=FailureReason.policy_failure,
                 message=(
                     "task kind 'monitor_release_pr' is deprecated; monitor an existing "
@@ -1500,7 +1508,7 @@ class WorkspaceExecutor:
         if task_kind not in _SUPPORTED_TASK_KINDS:
             await self._mark_failed(
                 workspace_id=workspace_id,
-                from_status=WorkspaceStatus.running,
+                from_status=from_status,
                 failure_reason=FailureReason.policy_failure,
                 message=f"unsupported task kind {task_kind!r}; cannot run as feature work.",
                 reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
@@ -4095,6 +4103,18 @@ class WorkspaceExecutor:
             workspace_id,
             expected=WorkspaceStatus.monitoring_pr,
             action="resume_pr_monitor",
+        ):
+            return
+
+        # A legacy ``monitor_release_pr`` (or otherwise unsupported) row may have
+        # reached ``monitoring_pr`` before the kind was deprecated; the worker
+        # restart path would otherwise resume monitoring it indefinitely. Apply
+        # the same fail-fast guard execute() uses, from ``monitoring_pr`` so the
+        # failure transition lands instead of being skipped as stale.
+        if await self._reject_unsupported_task_kind(
+            workspace_id=workspace_id,
+            workspace=ws,
+            from_status=WorkspaceStatus.monitoring_pr,
         ):
             return
 

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -249,6 +249,10 @@ _PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE = "PR_ADOPTION_MONITOR_UNAVAILABLE"
 _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
 _DEPRECATED_TASK_KIND_REASON_CODE = "DEPRECATED_TASK_KIND"
 _UNSUPPORTED_TASK_KIND_REASON_CODE = "UNSUPPORTED_TASK_KIND"
+# Task kinds the executor may legitimately drive (directly or via a monitor
+# handoff). Anything else — including the deprecated ``monitor_release_pr`` —
+# must fail fast and never run as feature work or recovery validation.
+_SUPPORTED_TASK_KINDS = frozenset({"feature_branch_pr", "sync_feature_pr", "sync_release_pr"})
 _RELEASE_SYNC_REPO_INVALID_REASON_CODE = "RELEASE_SYNC_REPO_INVALID"
 _RELEASE_SYNC_GITHUB_ERROR_REASON_CODE = "RELEASE_SYNC_GITHUB_ERROR"
 _RELEASE_SYNC_NO_CHANGES_EVENT = "workspace.release_pr_sync_no_changes"
@@ -1463,6 +1467,48 @@ class WorkspaceExecutor:
             suffix = "" if existing.endswith("\n") or not existing else "\n"
             exclude_path.write_text(f"{existing}{suffix}{pattern}\n", encoding="utf-8")
 
+    async def _reject_unsupported_task_kind(
+        self,
+        *,
+        workspace_id: str,
+        workspace: Workspace,
+    ) -> bool:
+        """Fail fast deprecated/unknown task kinds; return True if rejected.
+
+        Runs unconditionally — independent of any active provider recovery — so
+        a deprecated ``monitor_release_pr`` or unrecognized kind can never fall
+        through to the coding-agent path or resume recovery validation as
+        feature work. ``feature_branch_pr`` and the ``sync_feature_pr`` /
+        ``sync_release_pr`` monitors are intentionally left untouched here
+        (returns False) so their recovery resumption stays intact; the sync
+        handoffs are routed later by :meth:`_dispatch_non_feature_task_kind`.
+        """
+        task_kind = workspace.task_kind
+        if task_kind == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.policy_failure,
+                message=(
+                    "task kind 'monitor_release_pr' is deprecated; monitor an existing "
+                    "release/manual PR via PR adoption with auto_merge=false instead."
+                ),
+                reason_code=_DEPRECATED_TASK_KIND_REASON_CODE,
+                details={"task_kind": task_kind},
+            )
+            return True
+        if task_kind not in _SUPPORTED_TASK_KINDS:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.policy_failure,
+                message=f"unsupported task kind {task_kind!r}; cannot run as feature work.",
+                reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
+                details={"task_kind": task_kind},
+            )
+            return True
+        return False
+
     async def _dispatch_non_feature_task_kind(
         self,
         *,
@@ -1472,12 +1518,12 @@ class WorkspaceExecutor:
         compose_file: Path,
         worktree_path: Path,
     ) -> bool:
-        """Route non-default task kinds; return True if the workspace is handled.
+        """Route sync PR task kinds to their monitors; return True if handled.
 
-        Returns False only for ``feature_branch_pr`` so the caller continues to
-        the coding-agent path. ``sync_feature_pr``/``sync_release_pr`` hand off
-        to their monitors; the deprecated ``monitor_release_pr`` and any unknown
-        kind fail fast so they never run as feature work.
+        Only invoked when no provider recovery is active. Deprecated/unknown
+        kinds are already rejected by :meth:`_reject_unsupported_task_kind`, so
+        by this point the kind is ``feature_branch_pr`` (returns False to
+        continue to the coding-agent path) or a ``sync_*`` monitor handoff.
         """
         task_kind = workspace.task_kind
         if task_kind == "sync_feature_pr":
@@ -1496,29 +1542,6 @@ class WorkspaceExecutor:
                 compose_project=compose_project,
                 compose_file=compose_file,
                 worktree_path=worktree_path,
-            )
-            return True
-        if task_kind == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
-            await self._mark_failed(
-                workspace_id=workspace_id,
-                from_status=WorkspaceStatus.running,
-                failure_reason=FailureReason.policy_failure,
-                message=(
-                    "task kind 'monitor_release_pr' is deprecated; monitor an existing "
-                    "release/manual PR via PR adoption with auto_merge=false instead."
-                ),
-                reason_code=_DEPRECATED_TASK_KIND_REASON_CODE,
-                details={"task_kind": task_kind},
-            )
-            return True
-        if task_kind != "feature_branch_pr":
-            await self._mark_failed(
-                workspace_id=workspace_id,
-                from_status=WorkspaceStatus.running,
-                failure_reason=FailureReason.policy_failure,
-                message=f"unsupported task kind {task_kind!r}; cannot run as feature work.",
-                reason_code=_UNSUPPORTED_TASK_KIND_REASON_CODE,
-                details={"task_kind": task_kind},
             )
             return True
         return False
@@ -1999,6 +2022,21 @@ class WorkspaceExecutor:
         )
         compose_project = ws.compose_project_name or f"awf_{workspace_id}"
         worktree_path = self._config.worktrees_root / workspace_id
+
+        # Deprecated/unsupported task kinds must fail fast unconditionally,
+        # BEFORE branching on recovery. The recovery branch below skips
+        # ``_dispatch_non_feature_task_kind``, so a ``monitor_release_pr`` or
+        # unknown kind that re-entered the executor with an active validate /
+        # rebase recovery (e.g. a worker-restart salvage of a stale ``running``
+        # claim) would otherwise bypass the guard and resume the validation
+        # path — the "silently run as feature work" scenario this is meant to
+        # forbid. ``sync_feature_pr`` / ``sync_release_pr`` are NOT rejected
+        # here so their recovery resumption stays intact.
+        if await self._reject_unsupported_task_kind(
+            workspace_id=workspace_id,
+            workspace=ws,
+        ):
+            return
 
         # When the PR monitor's RECOVERY_DISPATCH path delivered this
         # workspace, the executor must NOT re-run planning, the agent

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -80,6 +80,7 @@ from awf.control.validation_fix_cycle import (
     read_output_tail,
 )
 from awf.db.enums import (
+    DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND,
     AgentRuntime,
     FailureReason,
     OperationStatus,
@@ -247,7 +248,6 @@ _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"
 _PR_ADOPTION_SKIP_AGENT_REASON_CODE = "PR_ADOPTION_SKIP_AGENT"
 _PR_ADOPTION_METADATA_MISSING_REASON_CODE = "PR_ADOPTION_METADATA_MISSING"
 _PR_ADOPTION_MONITOR_UNAVAILABLE_REASON_CODE = "PR_ADOPTION_MONITOR_UNAVAILABLE"
-_DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
 _DEPRECATED_TASK_KIND_REASON_CODE = "DEPRECATED_TASK_KIND"
 _UNSUPPORTED_TASK_KIND_REASON_CODE = "UNSUPPORTED_TASK_KIND"
 # Task kinds the executor may legitimately drive (directly or via a monitor
@@ -1484,7 +1484,7 @@ class WorkspaceExecutor:
         handoffs are routed later by :meth:`_dispatch_non_feature_task_kind`.
         """
         task_kind = workspace.task_kind
-        if task_kind == _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
+        if task_kind == DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -50,7 +50,13 @@ from awf.common.compose_exec import (
     cleanup_failure_message,
 )
 from awf.common.git_identity import git_identity_config_args, git_safe_directory_config_args
-from awf.common.github_client import GitHubClient, PullRequestAdoptionMetadata, RepoRef
+from awf.common.github_client import (
+    GitHubClient,
+    GitHubClientError,
+    PullRequestAdoptionMetadata,
+    PullRequestMetadataError,
+    RepoRef,
+)
 from awf.common.logging import get_logger
 from awf.control.protected_file_diffs import (
     committed_changed_paths_since,
@@ -244,6 +250,7 @@ _DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
 _DEPRECATED_TASK_KIND_REASON_CODE = "DEPRECATED_TASK_KIND"
 _UNSUPPORTED_TASK_KIND_REASON_CODE = "UNSUPPORTED_TASK_KIND"
 _RELEASE_SYNC_REPO_INVALID_REASON_CODE = "RELEASE_SYNC_REPO_INVALID"
+_RELEASE_SYNC_GITHUB_ERROR_REASON_CODE = "RELEASE_SYNC_GITHUB_ERROR"
 _RELEASE_SYNC_NO_CHANGES_EVENT = "workspace.release_pr_sync_no_changes"
 _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
 _DEFAULT_RELEASE_SYNC_TARGET_BRANCH = "main"
@@ -1632,7 +1639,7 @@ class WorkspaceExecutor:
                 title=release_pr_title(source_branch=source_branch, target_branch=target_branch),
                 body=release_pr_body(source_branch=source_branch, target_branch=target_branch),
             )
-        except ReleasePrSyncError as exc:
+        except (ReleasePrSyncError, PullRequestMetadataError) as exc:
             await self._mark_failed(
                 workspace_id=workspace_id,
                 from_status=WorkspaceStatus.running,
@@ -1640,6 +1647,15 @@ class WorkspaceExecutor:
                 message=f"sync_release_pr failed: {exc.message}",
                 reason_code=exc.reason_code,
                 details=exc.detail,
+            )
+            return
+        except GitHubClientError as exc:
+            await self._mark_failed(
+                workspace_id=workspace_id,
+                from_status=WorkspaceStatus.running,
+                failure_reason=FailureReason.infrastructure_failure,
+                message=f"sync_release_pr GitHub error ({exc.operation}): {exc.stderr or str(exc)}",
+                reason_code=_RELEASE_SYNC_GITHUB_ERROR_REASON_CODE,
             )
             return
 

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -193,7 +193,6 @@ _ACTIVE_EXECUTION_SALVAGE_BLOCKED_SUBPHASE = "runtime_preserved_salvage_blocked"
 _PR_NUMBER_RE = re.compile(r"/pull/(\d+)(?=[/?#]|$)")
 _PRESERVED_ACTIVE_REPLACEMENT_REMOTE_PUSH_BRANCH_TASK_KINDS = frozenset(
     {
-        TaskKind.monitor_release_pr.value,
         TaskKind.sync_release_pr.value,
         TaskKind.sync_feature_pr.value,
     }

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -123,19 +123,19 @@ class TaskKind(StrEnum):
     """Default: clone repo, run coding CLI, push PR against base branch,
     monitor comments + CI, squash-merge into base. The everyday path."""
 
-    monitor_release_pr = "monitor_release_pr"
-    """No clone, no initial coding-CLI run, no PR creation. Given an
-    existing PR number, monitor the 5 gates and — when all green — post
-    a "ready to merge" comment. Never auto-merges (dev→main is human-only)."""
-
     sync_release_pr = "sync_release_pr"
-    """Automated development→main release-PR maintenance. Checks for
-    divergence; opens a PR if one doesn't exist; attaches the release-
-    PR monitor (auto_merge=False). Intended to be fired by a watcher /
-    webhook whenever development advances beyond main. Never merges;
-    only posts "ready to merge" when all gates green. The existing open
-    PR is kept current via the monitor's SyncBase cycle as more feature
-    branches land on development."""
+    """Automated source→target release-PR maintenance (default
+    development→``repo.base_branch``). No coding agent and no feature PR:
+    checks whether the source branch is ahead of the target; completes
+    cleanly when nothing is ahead; otherwise reuses an existing open
+    source→target PR or opens one, then attaches the release-PR monitor
+    (auto_merge forced ``False``). Never merges; only posts "ready to
+    merge" when all gates are green. The open PR is kept current via the
+    monitor's SyncBase cycle as more work lands on the source branch.
+
+    To monitor an arbitrary already-open PR (any base/head), use the
+    generic PR-adoption flow with ``auto_merge=false`` instead of a task
+    kind — that selects the same release/manual monitor behavior."""
 
     sync_feature_pr = "sync_feature_pr"
     """Adopt an already-open feature PR into AWF's service monitor.

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -144,6 +144,12 @@ class TaskKind(StrEnum):
     handing the workspace to the normal PR monitor."""
 
 
+# Legacy task-kind value removed from ``TaskKind`` above. Kept here as the
+# single canonical literal so the REST/MCP admission validator and the executor
+# fail-fast guard reject ``monitor_release_pr`` identically and cannot drift.
+DEPRECATED_MONITOR_RELEASE_PR_TASK_KIND = "monitor_release_pr"
+
+
 class TaskClass(StrEnum):
     """PRD task policy class used by scheduling, validation, and overlap risk."""
 

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -214,7 +214,13 @@ def build_mcp_server(
         task_prompt: str = Field(..., description="Full prompt to hand to the coding CLI."),
         task_kind: str = Field(
             default="feature_branch_pr",
-            description="Task kind for scheduling/monitor behavior.",
+            description=(
+                "Task kind: 'feature_branch_pr' (default) or 'sync_release_pr' "
+                "(open/reuse a source->target release PR, monitored without "
+                "auto-merge). The deprecated 'monitor_release_pr' and the "
+                "adoption-only 'sync_feature_pr' are rejected here; to monitor an "
+                "existing PR, adopt it with auto_merge=false."
+            ),
         ),
         agent: AgentRuntime = Field(
             default=AgentRuntime.codex,

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -43,7 +43,14 @@ from awf.api.schemas import (
 )
 from awf.common.audit import redact_audit_text
 from awf.common.config import Settings, get_settings
-from awf.db.enums import AgentRuntime, OperationStatus, OperationType, TaskClass, WorkspaceStatus
+from awf.db.enums import (
+    AgentRuntime,
+    OperationStatus,
+    OperationType,
+    TaskClass,
+    TaskKind,
+    WorkspaceStatus,
+)
 from awf.db.repositories import TaskExternalIdConflictError, WorkspaceRepository
 from awf.profiles.resolver import ProfileResolutionError
 from awf.service import config as service_config
@@ -125,6 +132,10 @@ RuntimeHealthSummaryProvider = Callable[
 _IDEMPOTENCY_KEY_REQUIRED_MESSAGE = "Idempotency-Key header is required for this endpoint."
 _OPERATION_TYPE_FILTER_ALIAS = AliasChoices("type", "operation_type")
 _MCP_LEGACY_BASE_BRANCH_DEFAULT = "development"
+# sync_release_pr omits base_branch -> target the release branch (main), not the
+# legacy development default, so the release PR is opened development -> main
+# instead of degenerating to development -> development (NO_CHANGES_TO_SYNC).
+_MCP_RELEASE_SYNC_BASE_BRANCH_DEFAULT = "main"
 
 
 class ReadinessProvider(Protocol):
@@ -200,8 +211,10 @@ def build_mcp_server(
             max_length=256,
             json_schema_extra={"default": _MCP_LEGACY_BASE_BRANCH_DEFAULT},
             description=(
-                "Branch to branch FROM; feature branch is created off it. "
-                f"Defaults to {_MCP_LEGACY_BASE_BRANCH_DEFAULT} when omitted."
+                "Target branch: feature_branch_pr branches FROM it; "
+                "sync_release_pr opens the release PR against it. Defaults to "
+                f"{_MCP_LEGACY_BASE_BRANCH_DEFAULT} for feature_branch_pr and "
+                f"{_MCP_RELEASE_SYNC_BASE_BRANCH_DEFAULT} for sync_release_pr when omitted."
             ),
         ),
         branch_base: str | None = Field(
@@ -365,7 +378,12 @@ def build_mcp_server(
                 "Provide either requires_database or profile_ref/env_profile='aira'.",
             )
 
-        effective_base_branch = branch_base or base_branch or _MCP_LEGACY_BASE_BRANCH_DEFAULT
+        default_base_branch = (
+            _MCP_RELEASE_SYNC_BASE_BRANCH_DEFAULT
+            if task_kind == TaskKind.sync_release_pr.value
+            else _MCP_LEGACY_BASE_BRANCH_DEFAULT
+        )
+        effective_base_branch = branch_base or base_branch or default_base_branch
         effective_validation_commands = (
             test_commands if test_commands is not None else validation_commands or []
         )

--- a/src/awf/mcp/server.py
+++ b/src/awf/mcp/server.py
@@ -43,6 +43,7 @@ from awf.api.schemas import (
 )
 from awf.common.audit import redact_audit_text
 from awf.common.config import Settings, get_settings
+from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 from awf.db.enums import (
     AgentRuntime,
     OperationStatus,
@@ -223,6 +224,18 @@ def build_mcp_server(
             max_length=256,
             description="Legacy alias for base_branch.",
         ),
+        source_branch: str | None = Field(
+            default=None,
+            min_length=1,
+            max_length=256,
+            json_schema_extra={"default": DEFAULT_RELEASE_SYNC_SOURCE_BRANCH},
+            description=(
+                "Source branch for sync_release_pr: the release PR is opened "
+                f"source_branch -> base_branch. Defaults to "
+                f"{DEFAULT_RELEASE_SYNC_SOURCE_BRANCH} when omitted. Ignored for "
+                "feature_branch_pr."
+            ),
+        ),
         task_title: str = Field(..., description="Short title of the task (≤ 512 chars)."),
         task_prompt: str = Field(..., description="Full prompt to hand to the coding CLI."),
         task_kind: str = Field(
@@ -389,7 +402,11 @@ def build_mcp_server(
         )
         effective_profile_ref = "aira" if requires_database else env_profile or profile_ref
         req = WorkspaceCreateRequest(
-            repo={"url": repo_url, "base_branch": effective_base_branch},
+            repo={
+                "url": repo_url,
+                "base_branch": effective_base_branch,
+                "source_branch": source_branch,
+            },
             task={
                 k: v
                 for k, v in {

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -34,7 +34,6 @@ _log = get_logger(__name__)
 _GITHUB_PULL_HEAD_REF = re.compile(r"^refs/pull/([1-9][0-9]*)/head$")
 AGENT_RUNTIME_UID = 1000
 AGENT_RUNTIME_GID = 1000
-_GITHUB_PULL_HEAD_REF = re.compile(r"^refs/pull/([1-9][0-9]*)/head$")
 
 
 class GitOperationError(Exception):

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -46,6 +46,8 @@ from awf.service.secret_leases import (
 
 _log = get_logger(__name__)
 
+_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
+
 
 @dataclass(frozen=True)
 class ProvisionerConfig:
@@ -659,7 +661,7 @@ def _release_sync_source_branch(ws: Workspace) -> str | None:
         source = block.get("source_branch")
         if isinstance(source, str) and source.strip():
             return source.strip()
-    return "development"
+    return _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 
 
 def _sync_feature_pr_head_ref(ws: Workspace) -> str | None:

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -627,15 +627,39 @@ def _provision_local_branch_name(
 ) -> str:
     if ws.task_kind == "sync_feature_pr":
         return f"feature-sync/{workspace_id}"
+    if ws.task_kind == "sync_release_pr":
+        return f"release-sync/{workspace_id}"
     return f"{branch_prefix}/{workspace_id}"
 
 
 def _provision_checkout_base_branch(ws: Workspace) -> str:
-    return _sync_feature_pr_pull_head_ref(ws) or _sync_feature_pr_head_ref(ws) or ws.branch_base
+    return (
+        _sync_feature_pr_pull_head_ref(ws)
+        or _sync_feature_pr_head_ref(ws)
+        or _release_sync_source_branch(ws)
+        or ws.branch_base
+    )
 
 
 def _provision_remote_push_branch(ws: Workspace) -> str | None:
-    return _sync_feature_pr_head_ref(ws) or ws.remote_push_branch
+    return _sync_feature_pr_head_ref(ws) or _release_sync_source_branch(ws) or ws.remote_push_branch
+
+
+def _release_sync_source_branch(ws: Workspace) -> str | None:
+    """Source branch for a ``sync_release_pr`` worktree (default ``development``).
+
+    The worktree checks out the source branch so the release monitor can drive
+    comment/CI/base-sync against the PR head once the PR is opened.
+    """
+    if ws.task_kind != "sync_release_pr":
+        return None
+    policy = ws.task_policy if isinstance(ws.task_policy, dict) else {}
+    block = policy.get("release_sync")
+    if isinstance(block, dict):
+        source = block.get("source_branch")
+        if isinstance(source, str) and source.strip():
+            return source.strip()
+    return "development"
 
 
 def _sync_feature_pr_head_ref(ws: Workspace) -> str | None:

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -24,7 +24,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.logging import get_logger
-from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+from awf.common.workspace_policy import release_sync_source_branch
 from awf.db.enums import EgressDecision, FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import (
@@ -654,13 +654,7 @@ def _release_sync_source_branch(ws: Workspace) -> str | None:
     """
     if ws.task_kind != "sync_release_pr":
         return None
-    policy = ws.task_policy if isinstance(ws.task_policy, dict) else {}
-    block = policy.get("release_sync")
-    if isinstance(block, dict):
-        source = block.get("source_branch")
-        if isinstance(source, str) and source.strip():
-            return source.strip()
-    return DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+    return release_sync_source_branch(ws.task_policy)
 
 
 def _sync_feature_pr_head_ref(ws: Workspace) -> str | None:

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -24,6 +24,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.logging import get_logger
+from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 from awf.db.enums import EgressDecision, FailureReason, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import (
@@ -45,8 +46,6 @@ from awf.service.secret_leases import (
 )
 
 _log = get_logger(__name__)
-
-_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
 
 
 @dataclass(frozen=True)
@@ -661,7 +660,7 @@ def _release_sync_source_branch(ws: Workspace) -> str | None:
         source = block.get("source_branch")
         if isinstance(source, str) and source.strip():
             return source.strip()
-    return _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+    return DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 
 
 def _sync_feature_pr_head_ref(ws: Workspace) -> str | None:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -21,11 +21,11 @@ Design notes:
 * **Thread dedup is the caller's problem**. The runner drops stale
   addressed-state when fetched review-thread/comment evidence changes,
   then ``decide`` skips only the still-current addressed items.
-* **Release-PR variant** (``task_kind="monitor_release_pr"``) differs in
-  exactly one place: when all 5 gates are green it returns
-  ``NotifyHuman`` instead of ``Merge``. The runner treats that as a live
-  wait state, not a terminal completion, and keeps polling until the PR
-  is actually merged or closed.
+* **Release-PR variant** (``auto_merge=False`` — used by ``sync_release_pr``
+  and by PR adoption of release/manual PRs) differs in exactly one place:
+  when all 5 gates are green it returns ``NotifyHuman`` instead of ``Merge``.
+  The runner treats that as a live wait state, not a terminal completion, and
+  keeps polling until the PR is actually merged or closed.
 """
 
 from __future__ import annotations

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -119,6 +119,18 @@ async def count_commits_ahead(
         ) from exc
 
 
+def _is_duplicate_pull_request_error(exc: GitHubClientError) -> bool:
+    """True when ``gh pr create`` failed because the PR already exists.
+
+    ``gh`` exits 1 with stderr like ``a pull request for branch "X" into
+    branch "Y" already exists`` when a concurrent run or a human opened the
+    source→target PR first. Only this signal is treated as a recoverable
+    TOCTOU race; auth/network/branch-protection failures must propagate.
+    """
+
+    return exc.returncode == 1 and "already exists" in exc.stderr.lower()
+
+
 async def _find_open_same_repo_pr_number(
     *,
     runner: AsyncCommandRunner,
@@ -179,12 +191,16 @@ async def find_or_create_release_pr(
                 title=title,
                 body=body,
             )
-        except GitHubClientError:
+        except GitHubClientError as exc:
             # TOCTOU: the list above can race a concurrent sync run or a human
             # opening the same source→target PR before this create. GitHub
-            # rejects the duplicate, so re-check and adopt the now-existing PR
-            # instead of failing the workspace; a genuine create failure (no
-            # PR appeared) re-raises.
+            # rejects the duplicate with a recognisable "already exists" error,
+            # so only then re-check and adopt the now-existing PR instead of
+            # failing the workspace. Any other failure (auth, network, branch
+            # protection) re-raises immediately with its original context
+            # rather than being masked by a second, unrelated list call.
+            if not _is_duplicate_pull_request_error(exc):
+                raise
             raced_number = await _find_open_same_repo_pr_number(
                 runner=runner,
                 repo=repo,

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -133,14 +133,19 @@ async def find_or_create_release_pr(
     Returns the resolved adoption metadata plus a ``created`` flag.
     """
 
+    repo_slug = repo.slug()
     existing = await list_open_pull_requests_for_branch(
         runner=runner,
         repo=repo,
         branch_name=source_branch,
         base_branch=target_branch,
     )
-    if existing:
-        pr_number = existing[0].number
+    # ``gh pr list --head`` matches by branch name alone, so a fork PR opened
+    # against this repo with an identically-named head branch can show up here.
+    # Only adopt a PR whose head lives in the requested repo; otherwise create.
+    same_repo_existing = [pr for pr in existing if pr.head_repo_slug.lower() == repo_slug.lower()]
+    if same_repo_existing:
+        pr_number = same_repo_existing[0].number
         created = False
     else:
         pr_url = await gh.create_pull_request(
@@ -151,13 +156,24 @@ async def find_or_create_release_pr(
             body=body,
         )
         try:
-            _repo, pr_number = parse_github_pull_request_url(pr_url)
+            parsed_repo, pr_number = parse_github_pull_request_url(pr_url)
         except ValueError as exc:
             raise ReleasePrSyncError(
                 reason_code="RELEASE_SYNC_PR_URL_INVALID",
                 message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
                 detail={"source_branch": source_branch, "target_branch": target_branch},
             ) from exc
+        if parsed_repo.slug().lower() != repo_slug.lower():
+            raise ReleasePrSyncError(
+                reason_code="RELEASE_SYNC_PR_REPO_MISMATCH",
+                message=(f"gh pr create returned a PR URL for a different repository: {pr_url!r}"),
+                detail={
+                    "expected_repo": repo_slug,
+                    "parsed_repo": parsed_repo.slug(),
+                    "source_branch": source_branch,
+                    "target_branch": target_branch,
+                },
+            )
         created = True
     metadata = await fetch_pull_request_adoption_metadata(
         runner=runner,

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass
 from awf.common.commands import AsyncCommandRunner
 from awf.common.github_client import (
     GitHubClient,
+    GitHubClientError,
     PullRequestAdoptionMetadata,
     RepoRef,
     fetch_pull_request_adoption_metadata,
@@ -118,6 +119,32 @@ async def count_commits_ahead(
         ) from exc
 
 
+async def _find_open_same_repo_pr_number(
+    *,
+    runner: AsyncCommandRunner,
+    repo: RepoRef,
+    source_branch: str,
+    target_branch: str,
+) -> int | None:
+    """Number of an open same-repo ``source→target`` PR, or ``None`` if none.
+
+    ``gh pr list --head`` matches by branch name alone, so a fork PR opened
+    against this repo with an identically-named head branch can show up here.
+    Only a PR whose head lives in the requested repo is eligible; fork
+    collisions are ignored.
+    """
+
+    repo_slug = repo.slug()
+    existing = await list_open_pull_requests_for_branch(
+        runner=runner,
+        repo=repo,
+        branch_name=source_branch,
+        base_branch=target_branch,
+    )
+    same_repo_existing = [pr for pr in existing if pr.head_repo_slug.lower() == repo_slug.lower()]
+    return same_repo_existing[0].number if same_repo_existing else None
+
+
 async def find_or_create_release_pr(
     *,
     runner: AsyncCommandRunner,
@@ -134,47 +161,63 @@ async def find_or_create_release_pr(
     """
 
     repo_slug = repo.slug()
-    existing = await list_open_pull_requests_for_branch(
+    existing_number = await _find_open_same_repo_pr_number(
         runner=runner,
         repo=repo,
-        branch_name=source_branch,
-        base_branch=target_branch,
+        source_branch=source_branch,
+        target_branch=target_branch,
     )
-    # ``gh pr list --head`` matches by branch name alone, so a fork PR opened
-    # against this repo with an identically-named head branch can show up here.
-    # Only adopt a PR whose head lives in the requested repo; otherwise create.
-    same_repo_existing = [pr for pr in existing if pr.head_repo_slug.lower() == repo_slug.lower()]
-    if same_repo_existing:
-        pr_number = same_repo_existing[0].number
+    if existing_number is not None:
+        pr_number = existing_number
         created = False
     else:
-        pr_url = await gh.create_pull_request(
-            repo=repo,
-            base=target_branch,
-            head=source_branch,
-            title=title,
-            body=body,
-        )
         try:
-            parsed_repo, pr_number = parse_github_pull_request_url(pr_url)
-        except ValueError as exc:
-            raise ReleasePrSyncError(
-                reason_code="RELEASE_SYNC_PR_URL_INVALID",
-                message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
-                detail={"source_branch": source_branch, "target_branch": target_branch},
-            ) from exc
-        if parsed_repo.slug().lower() != repo_slug.lower():
-            raise ReleasePrSyncError(
-                reason_code="RELEASE_SYNC_PR_REPO_MISMATCH",
-                message=(f"gh pr create returned a PR URL for a different repository: {pr_url!r}"),
-                detail={
-                    "expected_repo": repo_slug,
-                    "parsed_repo": parsed_repo.slug(),
-                    "source_branch": source_branch,
-                    "target_branch": target_branch,
-                },
+            pr_url = await gh.create_pull_request(
+                repo=repo,
+                base=target_branch,
+                head=source_branch,
+                title=title,
+                body=body,
             )
-        created = True
+        except GitHubClientError:
+            # TOCTOU: the list above can race a concurrent sync run or a human
+            # opening the same source→target PR before this create. GitHub
+            # rejects the duplicate, so re-check and adopt the now-existing PR
+            # instead of failing the workspace; a genuine create failure (no
+            # PR appeared) re-raises.
+            raced_number = await _find_open_same_repo_pr_number(
+                runner=runner,
+                repo=repo,
+                source_branch=source_branch,
+                target_branch=target_branch,
+            )
+            if raced_number is None:
+                raise
+            pr_number = raced_number
+            created = False
+        else:
+            try:
+                parsed_repo, pr_number = parse_github_pull_request_url(pr_url)
+            except ValueError as exc:
+                raise ReleasePrSyncError(
+                    reason_code="RELEASE_SYNC_PR_URL_INVALID",
+                    message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
+                    detail={"source_branch": source_branch, "target_branch": target_branch},
+                ) from exc
+            if parsed_repo.slug().lower() != repo_slug.lower():
+                raise ReleasePrSyncError(
+                    reason_code="RELEASE_SYNC_PR_REPO_MISMATCH",
+                    message=(
+                        f"gh pr create returned a PR URL for a different repository: {pr_url!r}"
+                    ),
+                    detail={
+                        "expected_repo": repo_slug,
+                        "parsed_repo": parsed_repo.slug(),
+                        "source_branch": source_branch,
+                        "target_branch": target_branch,
+                    },
+                )
+            created = True
     metadata = await fetch_pull_request_adoption_metadata(
         runner=runner,
         repo=repo,

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -1,0 +1,235 @@
+"""Release-PR sync — compute source→target divergence and find/create the PR.
+
+Pure, unit-testable helpers backing the executor's ``sync_release_pr`` handoff.
+No DB access and no workspace state here: callers pass an ``AsyncCommandRunner``
+(for local git in the worktree), a ``GitHubClient`` (for ``gh``), and a parsed
+``RepoRef``. The handoff owns persistence + monitor launch.
+
+Flow:
+
+1. ``git fetch origin`` then ``git rev-list --count origin/<target>..origin/<source>``
+   to learn how many commits ``source`` is ahead of ``target``.
+2. If zero, return a :class:`ReleasePrSyncNoOp` — the handoff completes the
+   workspace cleanly without opening a PR or running the monitor.
+3. Otherwise reuse an existing open ``source→target`` PR, or create one, then
+   resolve its full adoption metadata and return a :class:`ReleasePrSyncResult`.
+
+Generic AWF core behaviour — no hard-coded repositories or branch names.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from awf.common.commands import AsyncCommandRunner
+from awf.common.github_client import (
+    GitHubClient,
+    PullRequestAdoptionMetadata,
+    RepoRef,
+    fetch_pull_request_adoption_metadata,
+    list_open_pull_requests_for_branch,
+    parse_github_pull_request_url,
+)
+from awf.common.logging import get_logger
+
+_log = get_logger(__name__)
+
+NO_CHANGES_REASON_CODE = "NO_CHANGES_TO_SYNC"
+
+
+class ReleasePrSyncError(Exception):
+    """Structured failure while preparing a release-PR sync."""
+
+    def __init__(
+        self,
+        *,
+        reason_code: str,
+        message: str,
+        detail: dict[str, object] | None = None,
+    ) -> None:
+        self.reason_code = reason_code
+        self.message = message
+        self.detail = detail
+        super().__init__(message)
+
+
+@dataclass(frozen=True)
+class ReleasePrSyncNoOp:
+    """No commits to sync — the workspace should complete without a PR."""
+
+    source_branch: str
+    target_branch: str
+    reason_code: str = NO_CHANGES_REASON_CODE
+
+
+@dataclass(frozen=True)
+class ReleasePrSyncResult:
+    """A release PR exists (reused or freshly created) and is ready to monitor."""
+
+    metadata: PullRequestAdoptionMetadata
+    created: bool
+    commits_ahead: int
+    source_branch: str
+    target_branch: str
+
+
+async def count_commits_ahead(
+    *,
+    runner: AsyncCommandRunner,
+    cwd: str,
+    source_branch: str,
+    target_branch: str,
+) -> int:
+    """Return how many commits ``origin/<source>`` is ahead of ``origin/<target>``."""
+
+    fetch = await runner.run(
+        ["git", "fetch", "origin", target_branch, source_branch],
+        cwd=cwd,
+    )
+    if fetch.returncode != 0:
+        raise ReleasePrSyncError(
+            reason_code="RELEASE_SYNC_FETCH_FAILED",
+            message=(fetch.stderr or f"git fetch origin exited {fetch.returncode}").strip(),
+            detail={"source_branch": source_branch, "target_branch": target_branch},
+        )
+    rev_list = await runner.run(
+        [
+            "git",
+            "rev-list",
+            "--count",
+            f"origin/{target_branch}..origin/{source_branch}",
+        ],
+        cwd=cwd,
+    )
+    if rev_list.returncode != 0:
+        raise ReleasePrSyncError(
+            reason_code="RELEASE_SYNC_REV_LIST_FAILED",
+            message=(rev_list.stderr or f"git rev-list exited {rev_list.returncode}").strip(),
+            detail={"source_branch": source_branch, "target_branch": target_branch},
+        )
+    text = rev_list.stdout.strip()
+    try:
+        return int(text)
+    except ValueError as exc:
+        raise ReleasePrSyncError(
+            reason_code="RELEASE_SYNC_REV_LIST_INVALID",
+            message=f"git rev-list --count returned non-numeric output: {text!r}",
+            detail={"source_branch": source_branch, "target_branch": target_branch},
+        ) from exc
+
+
+async def find_or_create_release_pr(
+    *,
+    runner: AsyncCommandRunner,
+    gh: GitHubClient,
+    repo: RepoRef,
+    source_branch: str,
+    target_branch: str,
+    title: str,
+    body: str,
+) -> tuple[PullRequestAdoptionMetadata, bool]:
+    """Reuse an open ``source→target`` PR if present, else create one.
+
+    Returns the resolved adoption metadata plus a ``created`` flag.
+    """
+
+    existing = await list_open_pull_requests_for_branch(
+        runner=runner,
+        repo=repo,
+        branch_name=source_branch,
+        base_branch=target_branch,
+    )
+    if existing:
+        pr_number = existing[0].number
+        created = False
+    else:
+        pr_url = await gh.create_pull_request(
+            repo=repo,
+            base=target_branch,
+            head=source_branch,
+            title=title,
+            body=body,
+        )
+        try:
+            _repo, pr_number = parse_github_pull_request_url(pr_url)
+        except ValueError as exc:
+            raise ReleasePrSyncError(
+                reason_code="RELEASE_SYNC_PR_URL_INVALID",
+                message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
+                detail={"source_branch": source_branch, "target_branch": target_branch},
+            ) from exc
+        created = True
+    metadata = await fetch_pull_request_adoption_metadata(
+        runner=runner,
+        repo=repo,
+        pr_number=pr_number,
+    )
+    return metadata, created
+
+
+async def prepare_release_pr_sync(
+    *,
+    runner: AsyncCommandRunner,
+    gh: GitHubClient,
+    repo: RepoRef,
+    cwd: str,
+    source_branch: str,
+    target_branch: str,
+    title: str,
+    body: str,
+) -> ReleasePrSyncNoOp | ReleasePrSyncResult:
+    """Decide what the handoff should do: no-op, or monitor a (reused/new) PR."""
+
+    commits_ahead = await count_commits_ahead(
+        runner=runner,
+        cwd=cwd,
+        source_branch=source_branch,
+        target_branch=target_branch,
+    )
+    if commits_ahead <= 0:
+        _log.info(
+            "release_pr_sync.no_changes",
+            repo=repo.slug(),
+            source_branch=source_branch,
+            target_branch=target_branch,
+        )
+        return ReleasePrSyncNoOp(source_branch=source_branch, target_branch=target_branch)
+
+    metadata, created = await find_or_create_release_pr(
+        runner=runner,
+        gh=gh,
+        repo=repo,
+        source_branch=source_branch,
+        target_branch=target_branch,
+        title=title,
+        body=body,
+    )
+    _log.info(
+        "release_pr_sync.pr_ready",
+        repo=repo.slug(),
+        source_branch=source_branch,
+        target_branch=target_branch,
+        pr_number=metadata.number,
+        created=created,
+        commits_ahead=commits_ahead,
+    )
+    return ReleasePrSyncResult(
+        metadata=metadata,
+        created=created,
+        commits_ahead=commits_ahead,
+        source_branch=source_branch,
+        target_branch=target_branch,
+    )
+
+
+def release_pr_title(*, source_branch: str, target_branch: str) -> str:
+    return f"Release: merge {source_branch} into {target_branch}"
+
+
+def release_pr_body(*, source_branch: str, target_branch: str) -> str:
+    return (
+        f"Automated AWF release PR syncing `{source_branch}` into `{target_branch}`.\n\n"
+        "Opened by the `sync_release_pr` task kind and monitored with "
+        "release/manual behavior (auto-merge disabled). Merging into the "
+        "release target stays human-gated."
+    )

--- a/src/awf/service/provider_recovery.py
+++ b/src/awf/service/provider_recovery.py
@@ -483,7 +483,7 @@ async def create_provider_recovery_attempt_row(
         idempotency_key=None,
         task_kind=source.task_kind,
         remote_push_branch=source.remote_push_branch
-        if source.task_kind in {"monitor_release_pr", "sync_release_pr", "sync_feature_pr"}
+        if source.task_kind in {"sync_release_pr", "sync_feature_pr"}
         else None,
     )
 

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -20,6 +20,7 @@ from awf.common.github_client import BranchOpenPullRequestResolver, GitHubClient
 from awf.common.logging import get_logger
 from awf.control.executor import ExecutorConfig, WorkspaceExecutor
 from awf.control.worker import ControlWorker, WorkerConfig
+from awf.db.enums import TaskKind
 from awf.db.models import Workspace
 from awf.db.session import make_engine, make_session_factory
 from awf.node.auth_mounts import ServiceAuthMountResolver
@@ -153,8 +154,15 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         *,
         provider_recovery_default_model: str | None = None,
     ) -> Any:
+        # sync_release_pr's contract is "auto_merge forced False; never merges"
+        # (TaskKind.sync_release_pr). Bind the release monitor to the task kind so
+        # the human-gated guarantee can't hinge on the persisted auto_merge flag
+        # being False at every monitor (re)build.
+        force_release_monitor = workspace.task_kind == TaskKind.sync_release_pr.value
         monitor_builder = (
-            build_feature_pr_monitor if workspace.auto_merge else build_release_pr_monitor
+            build_feature_pr_monitor
+            if workspace.auto_merge and not force_release_monitor
+            else build_release_pr_monitor
         )
         grace_seconds = (
             workspace.initial_review_grace_period_seconds

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -19,6 +19,7 @@ from sqlalchemy.exc import NoInspectionAvailable
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.api.schemas import (
+    PUBLIC_DIRECT_CREATE_TASK_KINDS,
     EgressAuditRecordResponse,
     FallbackTargetResponse,
     OperationResponse,
@@ -43,7 +44,7 @@ from awf.common.audit import redact_audit_value
 from awf.common.config import Settings, get_settings
 from awf.common.logging import get_logger
 from awf.common.redaction import redact_secrets
-from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, TaskKind, WorkspaceStatus
 from awf.db.models import (
     EgressAuditRecord,
     Operation,
@@ -183,7 +184,7 @@ RETRYABLE_WORKSPACE_STATUSES = (
 )
 MAX_CONFORMANCE_RETRY_ATTEMPTS = 4
 PRESERVE_RETRY_REMOTE_PUSH_BRANCH_TASK_KINDS = frozenset(
-    {"monitor_release_pr", "sync_release_pr", "sync_feature_pr"}
+    {TaskKind.sync_release_pr.value, TaskKind.sync_feature_pr.value}
 )
 _REDACTED_TEXT = "<redacted>"
 _IDEMPOTENCY_CONFLICT_MESSAGE = (
@@ -977,6 +978,7 @@ async def create_workspace_row(
     http_get: HttpGet | None = None,
 ) -> Workspace:
     """Persist one rich workspace create request without committing the session."""
+    _assert_supported_direct_create_task_kind(payload.task.kind)
     resolved_settings = settings or get_settings()
     repo = WorkspaceRepository(session)
     base_task_policy = workspace_create_task_policy_snapshot(payload)
@@ -1014,7 +1016,7 @@ async def create_workspace_row(
         task_class=(payload.task.task_class.value if payload.task.task_class is not None else None),
         owned_paths=payload.task.owned_paths,
         task_policy=task_policy,
-        auto_merge=payload.task.auto_merge,
+        auto_merge=_effective_auto_merge(payload),
         initial_review_grace_period_seconds=(payload.task.initial_review_grace_period_seconds),
         agent=payload.task.agent.value,
         env_profile=None,
@@ -2935,6 +2937,32 @@ def workspace_create_profile_snapshots(
     return requested_profile, resolved_profile
 
 
+RELEASE_SYNC_POLICY_KEY = "release_sync"
+_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
+
+
+def _assert_supported_direct_create_task_kind(task_kind: str) -> None:
+    """Defense-in-depth re-check of the public direct-create task-kind allow-set.
+
+    The ``WorkspaceTask`` schema validator already rejects unsupported kinds on
+    REST/MCP; this guards internal callers that build a request another way.
+    Adoption bypasses this function (it calls ``WorkspaceRepository.create``).
+    """
+    if task_kind not in PUBLIC_DIRECT_CREATE_TASK_KINDS:
+        supported = ", ".join(sorted(PUBLIC_DIRECT_CREATE_TASK_KINDS))
+        raise ValueError(
+            f"unsupported task kind {task_kind!r} for direct workspace creation; "
+            f"supported kinds are: {supported}."
+        )
+
+
+def _effective_auto_merge(payload: WorkspaceCreateRequest) -> bool:
+    """Release-PR syncs must never auto-merge; force it off at the boundary."""
+    if payload.task.kind == TaskKind.sync_release_pr.value:
+        return False
+    return payload.task.auto_merge
+
+
 def workspace_create_task_policy_snapshot(payload: WorkspaceCreateRequest) -> dict[str, Any]:
     """Build a task policy dictionary from a rich create request."""
     policy: dict[str, Any] = {}
@@ -2945,6 +2973,11 @@ def workspace_create_task_policy_snapshot(payload: WorkspaceCreateRequest) -> di
     policy[VALIDATION_POLICY_KEY] = {
         VALIDATION_REQUESTED_TIER_POLICY_KEY: payload.validation.requested_tier
     }
+    if payload.task.kind == TaskKind.sync_release_pr.value:
+        policy[RELEASE_SYNC_POLICY_KEY] = {
+            "source_branch": payload.repo.source_branch or _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH,
+            "target_branch": payload.repo.base_branch,
+        }
     if payload.task.priority != 0 or payload.task.human_boost != 0:
         policy["scheduler"] = scheduler_policy_snapshot(
             base_priority=payload.task.priority,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1153,6 +1153,11 @@ def _release_sync_source_branch_matches(
     requested = payload.repo.source_branch or DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
     release_sync = _stored_task_policy(existing).get(RELEASE_SYNC_POLICY_KEY)
     stored = release_sync.get("source_branch") if isinstance(release_sync, Mapping) else None
+    if stored is None:
+        # Legacy rows predate the source_branch snapshot (added with the input
+        # itself), so they could only have synced the default; treat a missing
+        # field as the historical default to keep identical replays idempotent.
+        stored = DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
     return stored == requested
 
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1135,7 +1135,7 @@ def workspace_create_payload_matches(
 def _stored_auto_merge_matches(existing: Workspace, payload: WorkspaceCreateRequest) -> bool:
     """Check stored auto-merge intent, treating legacy NULL as the old default."""
     stored = getattr(existing, "auto_merge", None)
-    return (stored is not False) == payload.task.auto_merge
+    return (stored is not False) == _effective_auto_merge(payload)
 
 
 def _profile_ref_matches(existing: Workspace, payload: WorkspaceCreateRequest) -> bool:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -44,6 +44,7 @@ from awf.common.audit import redact_audit_value
 from awf.common.config import Settings, get_settings
 from awf.common.logging import get_logger
 from awf.common.redaction import redact_secrets
+from awf.common.workspace_policy import DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, TaskKind, WorkspaceStatus
 from awf.db.models import (
     EgressAuditRecord,
@@ -2938,7 +2939,6 @@ def workspace_create_profile_snapshots(
 
 
 RELEASE_SYNC_POLICY_KEY = "release_sync"
-_DEFAULT_RELEASE_SYNC_SOURCE_BRANCH = "development"
 
 
 def _assert_supported_direct_create_task_kind(task_kind: str) -> None:
@@ -2975,7 +2975,7 @@ def workspace_create_task_policy_snapshot(payload: WorkspaceCreateRequest) -> di
     }
     if payload.task.kind == TaskKind.sync_release_pr.value:
         policy[RELEASE_SYNC_POLICY_KEY] = {
-            "source_branch": payload.repo.source_branch or _DEFAULT_RELEASE_SYNC_SOURCE_BRANCH,
+            "source_branch": payload.repo.source_branch or DEFAULT_RELEASE_SYNC_SOURCE_BRANCH,
             "target_branch": payload.repo.base_branch,
         }
     if payload.task.priority != 0 or payload.task.human_boost != 0:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1117,6 +1117,7 @@ def workspace_create_payload_matches(
         and _stored_task_agent_effort(existing) == payload.task.effort
         and _stored_task_scheduler_policy(existing) == _requested_task_scheduler_policy(payload)
         and _stored_auto_merge_matches(existing, payload)
+        and _release_sync_source_branch_matches(existing, payload)
         and (
             getattr(existing, "initial_review_grace_period_seconds", None)
             == payload.task.initial_review_grace_period_seconds
@@ -1136,6 +1137,23 @@ def _stored_auto_merge_matches(existing: Workspace, payload: WorkspaceCreateRequ
     """Check stored auto-merge intent, treating legacy NULL as the old default."""
     stored = getattr(existing, "auto_merge", None)
     return (stored is not False) == _effective_auto_merge(payload)
+
+
+def _release_sync_source_branch_matches(
+    existing: Workspace, payload: WorkspaceCreateRequest
+) -> bool:
+    """Check the stored release-sync source branch for sync_release_pr replays.
+
+    ``repo.source_branch`` selects which branch the release PR syncs, so a replay
+    that changes it must conflict instead of silently reusing the original
+    workspace and syncing the wrong branch. Other task kinds ignore the field.
+    """
+    if payload.task.kind != TaskKind.sync_release_pr.value:
+        return True
+    requested = payload.repo.source_branch or DEFAULT_RELEASE_SYNC_SOURCE_BRANCH
+    release_sync = _stored_task_policy(existing).get(RELEASE_SYNC_POLICY_KEY)
+    stored = release_sync.get("source_branch") if isinstance(release_sync, Mapping) else None
+    return stored == requested
 
 
 def _profile_ref_matches(existing: Workspace, payload: WorkspaceCreateRequest) -> bool:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1135,6 +1135,13 @@ def workspace_create_payload_matches(
 
 def _stored_auto_merge_matches(existing: Workspace, payload: WorkspaceCreateRequest) -> bool:
     """Check stored auto-merge intent, treating legacy NULL as the old default."""
+    if payload.task.kind == TaskKind.sync_release_pr.value:
+        # Release-PR syncs force auto_merge off at persistence and execution, so
+        # the stored value carries no idempotency signal. Rows written before
+        # that canonicalization snapshotted the raw request (default True), and
+        # comparing them against the effective False would spuriously conflict on
+        # an otherwise identical replay. The kind itself is matched separately.
+        return True
     stored = getattr(existing, "auto_merge", None)
     return (stored is not False) == _effective_auto_merge(payload)
 

--- a/tests/unit/api/test_schema_coverage_edges.py
+++ b/tests/unit/api/test_schema_coverage_edges.py
@@ -6,6 +6,82 @@ import pytest
 from pydantic import ValidationError
 
 from awf.api import schemas as api_schemas
+from awf.db.enums import TaskKind
+
+
+@pytest.mark.unit
+def test_task_kind_enum_drops_deprecated_monitor_release_pr() -> None:
+    values = {member.value for member in TaskKind}
+    assert "monitor_release_pr" not in values
+    assert {"feature_branch_pr", "sync_release_pr", "sync_feature_pr"} <= values
+    assert (
+        frozenset({"feature_branch_pr", "sync_release_pr"})
+        == api_schemas.PUBLIC_DIRECT_CREATE_TASK_KINDS
+    )
+
+
+def _task(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "title": "t",
+        "prompt": "p",
+        "agent": "codex",
+        "kind": "feature_branch_pr",
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("kind", ["feature_branch_pr", "sync_release_pr"])
+def test_workspace_task_accepts_public_direct_create_kinds(kind: str) -> None:
+    task = api_schemas.WorkspaceTask.model_validate(_task(kind=kind))
+    assert task.kind == kind
+
+
+@pytest.mark.unit
+def test_workspace_task_rejects_unknown_kind() -> None:
+    with pytest.raises(ValidationError) as exc:
+        api_schemas.WorkspaceTask.model_validate(_task(kind="totally_made_up"))
+    assert "unsupported task kind" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_workspace_task_rejects_deprecated_monitor_release_pr() -> None:
+    with pytest.raises(ValidationError) as exc:
+        api_schemas.WorkspaceTask.model_validate(_task(kind="monitor_release_pr"))
+    message = str(exc.value)
+    assert "deprecated" in message
+    assert "PR adoption" in message
+    assert "auto_merge=false" in message
+
+
+@pytest.mark.unit
+def test_workspace_task_rejects_direct_sync_feature_pr() -> None:
+    with pytest.raises(ValidationError) as exc:
+        api_schemas.WorkspaceTask.model_validate(_task(kind="sync_feature_pr"))
+    assert "PR-adoption endpoint" in str(exc.value)
+
+
+@pytest.mark.unit
+def test_workspace_repo_accepts_optional_source_branch() -> None:
+    repo = api_schemas.WorkspaceRepo.model_validate(
+        {"url": "git@github.com:o/r.git", "base_branch": "main", "source_branch": "development"}
+    )
+    assert repo.source_branch == "development"
+    default_repo = api_schemas.WorkspaceRepo.model_validate({"url": "git@github.com:o/r.git"})
+    assert default_repo.source_branch is None
+
+
+@pytest.mark.unit
+def test_workspace_create_request_rejects_deprecated_kind() -> None:
+    with pytest.raises(ValidationError):
+        api_schemas.WorkspaceCreateRequest.model_validate(
+            {
+                "repo": {"url": "git@github.com:o/r.git", "base_branch": "main"},
+                "task": _task(kind="monitor_release_pr"),
+                "validation": {"commands": ["pytest -q"], "requested_tier": 1},
+            }
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_cli.py
+++ b/tests/unit/cli/test_cli.py
@@ -105,6 +105,61 @@ class TestWorkspaceCreate:
         assert body["task"]["agent"] == "codex"
         assert body["task"]["auto_merge"] is True
         assert body["task"]["initial_review_grace_period_seconds"] is None
+        assert body["repo"]["base_branch"] == "development"
+
+    @pytest.mark.unit
+    def test_sync_release_pr_defaults_base_to_main(self) -> None:
+        """Without --base, a sync_release_pr targets main so it syncs development → main."""
+        response = _mock_response(status_code=202, payload={"workspace_id": "ws_rel"})
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "create",
+                    "--repo",
+                    "git@github.com:x/y.git",
+                    "--title",
+                    "Release sync",
+                    "--prompt",
+                    "Open the release PR.",
+                    "--task-kind",
+                    "sync_release_pr",
+                ],
+            )
+
+        assert result.exit_code == 0
+        body = mock.call_args.kwargs["json"]
+        assert body["task"]["kind"] == "sync_release_pr"
+        assert body["repo"]["base_branch"] == "main"
+        assert "source_branch" not in body["repo"]
+
+    @pytest.mark.unit
+    def test_sync_release_pr_respects_explicit_base(self) -> None:
+        """An explicit --base always wins over the task-kind default."""
+        response = _mock_response(status_code=202, payload={"workspace_id": "ws_rel2"})
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "create",
+                    "--repo",
+                    "git@github.com:x/y.git",
+                    "--title",
+                    "Release sync",
+                    "--prompt",
+                    "Open the release PR.",
+                    "--task-kind",
+                    "sync_release_pr",
+                    "--base",
+                    "release",
+                ],
+            )
+
+        assert result.exit_code == 0
+        body = mock.call_args.kwargs["json"]
+        assert body["repo"]["base_branch"] == "release"
 
     @pytest.mark.unit
     def test_monitor_policy_flags_are_sent(self) -> None:

--- a/tests/unit/common/test_github_client.py
+++ b/tests/unit/common/test_github_client.py
@@ -3301,6 +3301,47 @@ class TestMutations:
             await client.post_comment(repo=RepoRef(owner="o", name="r"), pr_number=1, body="x")
 
     @pytest.mark.unit
+    async def test_create_pull_request_argv_and_url(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout="https://github.com/o/r/pull/321\n",
+        )
+        client = GitHubClient(fake)
+
+        url = await client.create_pull_request(
+            repo=RepoRef(owner="o", name="r"),
+            base="main",
+            head="development",
+            title="Release: merge development into main",
+            body="auto release sync",
+        )
+
+        args = fake.calls[0].args
+        assert args[:3] == ["gh", "pr", "create"]
+        assert "--repo" in args and "o/r" in args
+        assert args[args.index("--base") + 1] == "main"
+        assert args[args.index("--head") + 1] == "development"
+        assert args[args.index("--title") + 1] == "Release: merge development into main"
+        assert args[args.index("--body") + 1] == "auto release sync"
+        assert url == "https://github.com/o/r/pull/321"
+
+    @pytest.mark.unit
+    async def test_create_pull_request_raises_on_error(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=1, stderr="no commits between main and development")
+        client = GitHubClient(fake)
+        with pytest.raises(GitHubClientError) as exc:
+            await client.create_pull_request(
+                repo=RepoRef(owner="o", name="r"),
+                base="main",
+                head="development",
+                title="t",
+                body="b",
+            )
+        assert "no commits between" in str(exc.value)
+
+    @pytest.mark.unit
     async def test_merge_pr_squash_delete_branch_default(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0)  # merge

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -15,6 +15,7 @@ file targets specific error branches that need dedicated fixtures:
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import shutil
@@ -4782,6 +4783,11 @@ def _release_open_pr_list_payload(*, number: int = 321) -> str:
 _RELEASE_SYNC_POLICY = {"release_sync": {"source_branch": "development", "target_branch": "main"}}
 
 
+def _release_sync_policy() -> dict[str, Any]:
+    """Return an independent copy so tests can't share nested policy state."""
+    return copy.deepcopy(_RELEASE_SYNC_POLICY)
+
+
 class TestTaskKindFailFast:
     @pytest.mark.unit
     async def test_legacy_monitor_release_pr_fails_fast_without_feature_work(
@@ -4860,7 +4866,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
@@ -4924,7 +4930,7 @@ class TestSyncReleasePrHandoff:
             task_kind="sync_release_pr",
             auto_merge=False,
             create_task_attempt=True,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         def _monitor_factory(*_args: Any, **kwargs: Any) -> object:
@@ -4993,7 +4999,7 @@ class TestSyncReleasePrHandoff:
             task_kind="sync_release_pr",
             auto_merge=False,
             create_task_attempt=True,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         executor = _make_executor(
@@ -5025,7 +5031,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)
@@ -5060,7 +5066,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
@@ -5092,7 +5098,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
@@ -5125,7 +5131,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
@@ -5158,7 +5164,7 @@ class TestSyncReleasePrHandoff:
             factory,
             task_kind="sync_release_pr",
             auto_merge=False,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         executor = _make_executor(fake, factory, tmp_path)
@@ -5201,7 +5207,7 @@ class TestSyncReleasePrHandoff:
             task_kind="sync_release_pr",
             auto_merge=False,
             create_task_attempt=True,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         class _Monitor:
@@ -5251,7 +5257,7 @@ class TestSyncReleasePrHandoff:
             task_kind="sync_release_pr",
             auto_merge=False,
             create_task_attempt=True,
-            task_policy=dict(_RELEASE_SYNC_POLICY),
+            task_policy=_release_sync_policy(),
         )
 
         class _Monitor:

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -5078,6 +5078,72 @@ class TestSyncReleasePrHandoff:
             assert ws.events[-1].reason_code == "RELEASE_SYNC_FETCH_FAILED"
 
     @pytest.mark.unit
+    async def test_open_pr_lookup_error_fails_cleanly_before_monitor(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # git rev-list --count
+        fake.queue_result(returncode=1, stderr="gh: not authorized")  # gh pr list fails
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
+            raise AssertionError("monitor must not run after an open-PR lookup failure")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert ws.events[-1].reason_code == "OPEN_PR_LOOKUP_FAILED"
+
+    @pytest.mark.unit
+    async def test_pr_create_github_error_fails_cleanly_before_monitor(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # git rev-list --count
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> no existing PR
+        fake.queue_result(returncode=1, stderr="gh: API rate limit exceeded")  # gh pr create fails
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
+            raise AssertionError("monitor must not run after a gh pr create failure")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert ws.events[-1].reason_code == "RELEASE_SYNC_GITHUB_ERROR"
+            assert "gh pr create" in (ws.failure_message or "")
+
+    @pytest.mark.unit
     async def test_no_op_skips_when_status_changes_mid_flight(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -39,8 +39,11 @@ from awf.control.executor import (
     ExecutorConfig,
     WorkspaceExecutor,
     _call_pr_monitor_factory,
+    _release_sync_source_branch,
+    _release_sync_target_branch,
     _required_metadata_str,
     _validation_run_command_records,
+    _with_release_sync_pr_metadata,
 )
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import MergeCandidate, Operation, TaskAttempt, Workspace, WorkspaceEvent
@@ -4703,9 +4706,7 @@ class TestExecutorCoverageEdges:
             assert ws.events[-1].reason_code == "MONITOR_RECOVERY_METADATA_MISSING"
 
     @pytest.mark.unit
-    @pytest.mark.parametrize(
-        "task_kind", ["monitor_release_pr", "sync_release_pr", "sync_feature_pr"]
-    )
+    @pytest.mark.parametrize("task_kind", ["sync_release_pr", "sync_feature_pr"])
     async def test_sync_and_release_resume_fail_when_remote_push_branch_is_unknown(
         self,
         task_kind: str,
@@ -4735,3 +4736,541 @@ class TestExecutorCoverageEdges:
             assert "remote_push_branch" in (ws.failure_message or "")
             assert task_kind in (ws.failure_message or "")
             assert ws.remote_push_branch is None
+
+
+def _release_adoption_payload(
+    *,
+    number: int = 321,
+    head_ref: str = "development",
+    base_ref: str = "main",
+    head_sha: str = "h" * 40,
+    base_sha: str = "b" * 40,
+) -> str:
+    return json.dumps(
+        {
+            "number": number,
+            "headRefName": head_ref,
+            "headRepository": {"name": "y", "nameWithOwner": "x/y"},
+            "isCrossRepository": False,
+            "baseRefName": base_ref,
+            "headRefOid": head_sha,
+            "baseRefOid": base_sha,
+            "state": "OPEN",
+            "isDraft": False,
+            "author": {"login": "octocat"},
+            "url": f"https://github.com/x/y/pull/{number}",
+            "title": "Release",
+        }
+    )
+
+
+def _release_open_pr_list_payload(*, number: int = 321) -> str:
+    return json.dumps(
+        [
+            {
+                "number": number,
+                "url": f"https://github.com/x/y/pull/{number}",
+                "headRefName": "development",
+                "headRefOid": "h" * 40,
+                "headRepository": {"name": "y", "nameWithOwner": "x/y"},
+                "headRepositoryOwner": {"login": "x"},
+            }
+        ]
+    )
+
+
+_RELEASE_SYNC_POLICY = {"release_sync": {"source_branch": "development", "target_branch": "main"}}
+
+
+class TestTaskKindFailFast:
+    @pytest.mark.unit
+    async def test_legacy_monitor_release_pr_fails_fast_without_feature_work(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        validation = _RecordingValidation()
+
+        class _UnexpectedPrCreator:
+            async def push_and_open(self, **_kwargs: Any) -> PullRequestResult:
+                raise AssertionError("deprecated kinds must not create a PR")
+
+        ws_id = await _seed_ready(factory, task_kind="monitor_release_pr")
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_creator=_UnexpectedPrCreator(),
+        )
+
+        await executor.execute(ws_id)
+
+        assert validation.calls == []
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "policy_failure"
+            assert "deprecated" in (ws.failure_message or "")
+            assert "auto_merge=false" in (ws.failure_message or "")
+            assert ws.events[-1].reason_code == "DEPRECATED_TASK_KIND"
+
+    @pytest.mark.unit
+    async def test_unknown_task_kind_fails_fast_without_feature_work(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        validation = _RecordingValidation()
+        ws_id = await _seed_ready(factory, task_kind="totally_made_up")
+
+        executor = _make_executor(fake, factory, tmp_path, validation=validation)
+
+        await executor.execute(ws_id)
+
+        assert validation.calls == []
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "policy_failure"
+            assert "unsupported task kind" in (ws.failure_message or "")
+            assert ws.events[-1].reason_code == "UNSUPPORTED_TASK_KIND"
+
+
+class TestSyncReleasePrHandoff:
+    @pytest.mark.unit
+    async def test_no_commits_ahead_completes_without_pr_or_monitor(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        validation = _RecordingValidation()
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="0\n")  # git rev-list --count
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
+            raise AssertionError("monitor must not run when there is nothing to sync")
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_monitor_factory=_monitor_factory,
+        )
+
+        await executor.execute(ws_id)
+
+        assert validation.calls == []
+        assert [c.args[:3] for c in fake.calls] == [
+            ["git", "fetch", "origin"],
+            ["git", "rev-list", "--count"],
+        ]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            no_change_events = [
+                e for e in ws.events if e.event_type == "workspace.release_pr_sync_no_changes"
+            ]
+            assert len(no_change_events) == 1
+            assert no_change_events[0].reason_code == "NO_CHANGES_TO_SYNC"
+            assert no_change_events[0].payload == {
+                "source_branch": "development",
+                "target_branch": "main",
+            }
+            assert ws.pr_url is None
+
+    @pytest.mark.unit
+    async def test_ahead_creates_release_pr_and_enters_monitoring(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        monitor_calls: list[str] = []
+        captured_auto_merge: list[bool] = []
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                del compose_project, compose_file
+                monitor_calls.append(workspace_id)
+
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="3\n")  # rev-list --count
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/321\n")  # gh pr create
+        fake.queue_result(returncode=0, stdout=_release_adoption_payload(number=321))  # gh pr view
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            create_task_attempt=True,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        def _monitor_factory(*_args: Any, **kwargs: Any) -> object:
+            workspace = _args[2] if len(_args) > 2 else None
+            if workspace is not None:
+                captured_auto_merge.append(bool(workspace.auto_merge))
+            return _Monitor()
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=_monitor_factory,
+        )
+
+        await executor.execute(ws_id)
+
+        assert monitor_calls == [ws_id]
+        assert captured_auto_merge == [False]
+        create_calls = [c for c in fake.calls if c.args[:3] == ["gh", "pr", "create"]]
+        assert len(create_calls) == 1
+        assert create_calls[0].args[create_calls[0].args.index("--base") + 1] == "main"
+        assert create_calls[0].args[create_calls[0].args.index("--head") + 1] == "development"
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.pr_url == "https://github.com/x/y/pull/321"
+            assert ws.pr_number == 321
+            assert ws.remote_push_branch == "development"
+            assert ws.monitor_last_commit_sha == "h" * 40
+            assert ws.base_commit == "b" * 40
+            assert ws.task_policy["release_sync"]["pr"]["number"] == 321
+            assert ws.task_policy["release_sync"]["pr"]["created"] is True
+            candidate = (
+                await s.execute(select(MergeCandidate).where(MergeCandidate.workspace_id == ws_id))
+            ).scalar_one()
+            assert candidate.status == "open"
+            assert candidate.pr_url == "https://github.com/x/y/pull/321"
+
+    @pytest.mark.unit
+    async def test_ahead_reuses_existing_open_release_pr(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        monitor_calls: list[str] = []
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                del compose_project, compose_file
+                monitor_calls.append(workspace_id)
+
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list --count
+        fake.queue_result(
+            returncode=0, stdout=_release_open_pr_list_payload(number=88)
+        )  # gh pr list
+        fake.queue_result(returncode=0, stdout=_release_adoption_payload(number=88))  # gh pr view
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            create_task_attempt=True,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            pr_monitor_factory=lambda *_args, **_kwargs: _Monitor(),
+        )
+
+        await executor.execute(ws_id)
+
+        assert monitor_calls == [ws_id]
+        assert all(c.args[:3] != ["gh", "pr", "create"] for c in fake.calls)
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.pr_number == 88
+            assert ws.task_policy["release_sync"]["pr"]["created"] is False
+
+    @pytest.mark.unit
+    async def test_invalid_repo_url_fails_before_git(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.repo_url = "not a github url"
+            await s.commit()
+
+        def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
+            raise AssertionError("monitor must not run when the repo URL is invalid")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.execute(ws_id)
+
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.events[-1].reason_code == "RELEASE_SYNC_REPO_INVALID"
+
+    @pytest.mark.unit
+    async def test_fetch_failure_fails_cleanly_before_monitor(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        fake.queue_result(returncode=1, stderr="network down")  # git fetch fails
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        def _monitor_factory(*_args: Any, **_kwargs: Any) -> object:
+            raise AssertionError("monitor must not run after a fetch failure")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "infrastructure_failure"
+            assert ws.events[-1].reason_code == "RELEASE_SYNC_FETCH_FAILED"
+
+    @pytest.mark.unit
+    async def test_no_op_skips_when_status_changes_mid_flight(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="0\n")  # rev-list -> no changes
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        executor = _make_executor(fake, factory, tmp_path)
+
+        async def _ensure_available(**_kwargs: Any) -> bool:
+            async with factory() as s:
+                ws = await WorkspaceRepository(s).get(ws_id)
+                assert ws is not None
+                ws.status = WorkspaceStatus.cancelled.value
+                await s.commit()
+            return True
+
+        monkeypatch.setattr(executor, "_ensure_worktree_available", _ensure_available)
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.cancelled.value
+            assert ws.events[-1].event_type == "workspace.stale_action_skipped"
+            assert ws.events[-1].payload["action"] == "sync_release_pr_handoff"
+
+    @pytest.mark.unit
+    async def test_monitoring_handoff_skips_when_status_changes_mid_flight(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        monitor_runs: list[str] = []
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list
+        fake.queue_result(returncode=0, stdout=_release_open_pr_list_payload(number=70))
+        fake.queue_result(returncode=0, stdout=_release_adoption_payload(number=70))
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            create_task_attempt=True,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        class _Monitor:
+            async def run(self, **_kwargs: Any) -> None:
+                monitor_runs.append(ws_id)
+
+        executor = _make_executor(
+            fake, factory, tmp_path, pr_monitor_factory=lambda *_a, **_k: _Monitor()
+        )
+
+        async def _ensure_available(**_kwargs: Any) -> bool:
+            async with factory() as s:
+                ws = await WorkspaceRepository(s).get(ws_id)
+                assert ws is not None
+                ws.status = WorkspaceStatus.cancelled.value
+                await s.commit()
+            return True
+
+        monkeypatch.setattr(executor, "_ensure_worktree_available", _ensure_available)
+
+        await executor.execute(ws_id)
+
+        assert monitor_runs == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.cancelled.value
+            assert ws.events[-1].payload["action"] == "sync_release_pr_handoff"
+
+    @pytest.mark.unit
+    async def test_recheck_prevents_monitor_run_after_handoff(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        monitor_runs: list[str] = []
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list
+        fake.queue_result(returncode=0, stdout="https://github.com/x/y/pull/321\n")  # create
+        fake.queue_result(returncode=0, stdout=_release_adoption_payload(number=321))  # view
+
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_release_pr",
+            auto_merge=False,
+            create_task_attempt=True,
+            task_policy=dict(_RELEASE_SYNC_POLICY),
+        )
+
+        class _Monitor:
+            async def run(self, **_kwargs: Any) -> None:
+                monitor_runs.append(ws_id)
+
+        executor = _make_executor(
+            fake, factory, tmp_path, pr_monitor_factory=lambda *_a, **_k: _Monitor()
+        )
+
+        async def _recheck_status(
+            workspace_id: str,
+            *,
+            expected: WorkspaceStatus,
+            action: str,
+            reason_code: str = "EXECUTOR_STALE_STATUS",
+        ) -> bool:
+            del workspace_id, expected, reason_code
+            return action != "run_pr_monitor"
+
+        monkeypatch.setattr(executor, "_recheck_status", _recheck_status)
+
+        await executor.execute(ws_id)
+
+        assert monitor_runs == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.events[-1].reason_code == "PR_MONITOR_ADOPTED"
+
+
+class TestReleaseSyncHelpers:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "task_policy, expected",
+        [
+            ({"release_sync": {"source_branch": "release/x"}}, "release/x"),
+            ({"release_sync": {}}, "development"),
+            ({}, "development"),
+        ],
+    )
+    def test_release_sync_source_branch(self, task_policy: dict[str, Any], expected: str) -> None:
+        ws = Workspace(
+            repo_url="git@github.com:x/y.git", branch_base="main", task_policy=task_policy
+        )
+        assert _release_sync_source_branch(ws) == expected
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "task_policy, branch_base, expected",
+        [
+            ({"release_sync": {"target_branch": "master"}}, "main", "master"),
+            ({}, "main", "main"),
+            ({}, "", "main"),
+        ],
+    )
+    def test_release_sync_target_branch(
+        self, task_policy: dict[str, Any], branch_base: str, expected: str
+    ) -> None:
+        ws = Workspace(
+            repo_url="git@github.com:x/y.git", branch_base=branch_base, task_policy=task_policy
+        )
+        assert _release_sync_target_branch(ws) == expected
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("task_policy", [None, {"release_sync": "not-a-dict"}, {}])
+    def test_with_release_sync_pr_metadata_handles_missing_block(self, task_policy: Any) -> None:
+        metadata = PullRequestAdoptionMetadata(
+            number=5,
+            head_ref="development",
+            head_repo_slug="x/y",
+            base_ref="main",
+            head_sha="h" * 40,
+            base_sha="b" * 40,
+            state="OPEN",
+            is_draft=False,
+            closed=False,
+            merged=False,
+            author="octocat",
+            url="https://github.com/x/y/pull/5",
+            title="Release",
+        )
+
+        policy = _with_release_sync_pr_metadata(task_policy, metadata=metadata, created=True)
+
+        assert policy["release_sync"]["pr"]["number"] == 5
+        assert policy["release_sync"]["pr"]["created"] is True

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -4849,6 +4849,46 @@ class TestTaskKindFailFast:
             assert "unsupported task kind" in (ws.failure_message or "")
             assert ws.events[-1].reason_code == "UNSUPPORTED_TASK_KIND"
 
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("task_kind", "message_fragment", "reason_code"),
+        [
+            ("monitor_release_pr", "deprecated", "DEPRECATED_TASK_KIND"),
+            ("totally_made_up", "unsupported task kind", "UNSUPPORTED_TASK_KIND"),
+        ],
+    )
+    async def test_resume_pr_monitor_fails_fast_on_unsupported_task_kind(
+        self,
+        task_kind: str,
+        message_fragment: str,
+        reason_code: str,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """A legacy deprecated/unsupported row already in ``monitoring_pr`` must
+        fail fast on the worker-restart resume path instead of being monitored
+        forever. The guard is shared with execute() but transitions from
+        ``monitoring_pr`` here, so the failure actually lands.
+        """
+        ws_id = await _seed_monitoring_pr(factory, task_kind=task_kind)
+
+        def _monitor_factory(*_args: Any) -> object:
+            raise AssertionError("resume must not build a monitor for unsupported kinds")
+
+        executor = _make_executor(fake, factory, tmp_path, pr_monitor_factory=_monitor_factory)
+
+        await executor.resume_pr_monitor(ws_id)
+
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "policy_failure"
+            assert message_fragment in (ws.failure_message or "")
+            assert ws.events[-1].reason_code == reason_code
+
 
 class TestSyncReleasePrHandoff:
     @pytest.mark.unit

--- a/tests/unit/control/test_executor_error_paths.py
+++ b/tests/unit/control/test_executor_error_paths.py
@@ -46,9 +46,10 @@ from awf.control.executor import (
     _validation_run_command_records,
     _with_release_sync_pr_metadata,
 )
-from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.enums import AgentRuntime, OperationStatus, OperationType, WorkspaceStatus
 from awf.db.models import MergeCandidate, Operation, TaskAttempt, Workspace, WorkspaceEvent
 from awf.db.repositories import (
+    OperationRepository,
     ResourceReservationRepository,
     TaskAttemptRepository,
     TaskRepository,
@@ -4888,6 +4889,59 @@ class TestTaskKindFailFast:
             assert ws.failure_reason == "policy_failure"
             assert message_fragment in (ws.failure_message or "")
             assert ws.events[-1].reason_code == reason_code
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("task_kind", "reason_code"),
+        [
+            ("monitor_release_pr", "DEPRECATED_TASK_KIND"),
+            ("totally_made_up", "UNSUPPORTED_TASK_KIND"),
+        ],
+    )
+    async def test_reject_unsupported_task_kind_finalizes_active_recovery(
+        self,
+        task_kind: str,
+        reason_code: str,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """A reclaimed workspace whose deprecated/unsupported kind is rejected
+        must also finalize any active validate/rebase recovery operation. This is
+        the worker-restart salvage of a stale ``running`` claim: failing the
+        workspace without closing the recovery row would strand it pending/running
+        forever. The fail-fast guard runs before recovery dispatch, so it owns the
+        cleanup itself.
+        """
+        ws_id = await _seed_ready(factory, task_kind=task_kind)
+        async with factory() as s:
+            op = await OperationRepository(s).create(
+                workspace_id=ws_id,
+                operation_type=OperationType.validate,
+                status=OperationStatus.running,
+                payload={"source": "worker_restart", "recovery_mode": "validate_only"},
+                idempotency_key=f"worker_restart:validate_only:{ws_id}",
+            )
+            op_id = op.id
+            await s.commit()
+
+        executor = _make_executor(fake, factory, tmp_path)
+
+        await executor.execute(ws_id)
+
+        assert fake.calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.failure_reason == "policy_failure"
+            assert ws.events[-1].reason_code == reason_code
+            op = await OperationRepository(s).get(op_id)
+            assert op is not None
+            assert op.status == OperationStatus.failed.value
+            assert op.error_code == reason_code
+            assert op.result == {"reason_code": reason_code}
+            assert op.finished_at is not None
 
 
 class TestSyncReleasePrHandoff:

--- a/tests/unit/control/test_executor_monitor_recovery.py
+++ b/tests/unit/control/test_executor_monitor_recovery.py
@@ -290,6 +290,7 @@ async def _seed_ready_workspace_with_recovery(
     operation_type: OperationType = OperationType.validate,
     resolved_profile: dict[str, Any] | None = None,
     recovery_payload_overrides: dict[str, Any] | None = None,
+    task_kind: str = "feature_branch_pr",
 ) -> str:
     """Insert a workspace already in ``ready`` with a pending `pr_monitor`
     validate operation — the shape the monitor's RECOVERY_DISPATCH path
@@ -306,6 +307,7 @@ async def _seed_ready_workspace_with_recovery(
             test_commands=["pytest -q"],
             requires_database=False,
             resolved_profile=resolved_profile,
+            task_kind=task_kind,
         )
         await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="X")
         ws.branch_name = f"awf/{ws.id}"
@@ -821,6 +823,76 @@ async def test_operator_api_validate_only_recovery_skips_full_agent_path(
     assert operator_ops[0].status == OperationStatus.succeeded.value
     assert isinstance(operator_ops[0].result, dict)
     assert "validation_run_id" in operator_ops[0].result
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("task_kind", "expected_reason_code", "message_fragment"),
+    [
+        ("monitor_release_pr", "DEPRECATED_TASK_KIND", "deprecated"),
+        ("totally_made_up", "UNSUPPORTED_TASK_KIND", "unsupported task kind"),
+    ],
+)
+async def test_unsupported_task_kind_with_active_recovery_still_fails_fast(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    task_kind: str,
+    expected_reason_code: str,
+    message_fragment: str,
+) -> None:
+    """Deprecated/unknown task kinds must fail fast even with an active
+    recovery.
+
+    The recovery branch in ``execute`` skips ``_dispatch_non_feature_task_kind``;
+    without the unconditional ``_reject_unsupported_task_kind`` guard a
+    ``monitor_release_pr`` or unknown kind that re-entered with a pending
+    validate-only recovery would resume the validation path instead of being
+    rejected — the "silently run as feature work" scenario PR #278 forbids.
+    """
+    executor = _make_executor(fake=fake, factory=factory, tmp_path=tmp_path)
+    ws_id = await _seed_ready_workspace_with_recovery(
+        factory,
+        source="worker_restart",
+        task_kind=task_kind,
+    )
+
+    # Queue results that WOULD drive the validation path so the test fails
+    # loudly (a ValidationRun would be created) if the guard is bypassed.
+    _queue_validation_head(fake, head="d" * 40)
+    fake.queue_result(returncode=0, stdout="tests ok")
+
+    await executor.execute(ws_id)
+
+    assert _all_adapter_args(fake) == []
+    assert _all_push_and_pr_create_calls(fake) == []
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
+        runs = await ValidationRunRepository(s).list_for_workspace(ws_id)
+        ops = await OperationRepository(s).list_all(workspace_id=ws_id)
+
+    assert ws is not None
+    assert ws.status == WorkspaceStatus.failed.value
+    assert ws.failure_reason == "policy_failure"
+    assert message_fragment in (ws.failure_message or "")
+    # The recovery validation path never ran.
+    assert runs == []
+    assert any(
+        event.event_type == "workspace.state_changed"
+        and event.reason_code == expected_reason_code
+        and event.old_state == WorkspaceStatus.running.value
+        and event.new_state == WorkspaceStatus.failed.value
+        for event in events
+    )
+    # The seeded recovery operation was never consumed/succeeded.
+    recovery_ops = [
+        op
+        for op in ops
+        if isinstance(op.payload, dict) and op.payload.get("source") == "worker_restart"
+    ]
+    assert len(recovery_ops) == 1
+    assert recovery_ops[0].status != OperationStatus.succeeded.value
 
 
 @pytest.mark.unit

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -1448,6 +1448,67 @@ class TestCreateWorkspace:
         assert ws.branch_base == "development"
 
     @pytest.mark.unit
+    async def test_create_workspace_sync_release_pr_omitted_base_defaults_to_main(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        payload = await _call(
+            mcp,
+            "awf_create_workspace",
+            {
+                "repo_url": "git@github.com:example/release-sync-default.git",
+                "task_kind": "sync_release_pr",
+                "task_title": "Release sync default target",
+                "task_prompt": "Open the standing release PR for the default target.",
+                "provider_readiness_override": True,
+                "provider_readiness_override_reason": "mcp release-sync default target regression",
+            },
+        )
+
+        assert isinstance(payload, dict)
+        async with factory() as session:
+            ws = await WorkspaceRepository(session).get(str(payload["workspace_id"]))
+
+        assert ws is not None
+        # Omitting base_branch for sync_release_pr must target main (development ->
+        # main), not the legacy development default that degenerates to
+        # development -> development and exits NO_CHANGES_TO_SYNC.
+        assert ws.branch_base == "main"
+        assert ws.task_policy["release_sync"] == {
+            "source_branch": "development",
+            "target_branch": "main",
+        }
+
+    @pytest.mark.unit
+    async def test_create_workspace_sync_release_pr_honors_explicit_base(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        payload = await _call(
+            mcp,
+            "awf_create_workspace",
+            {
+                "repo_url": "git@github.com:example/release-sync-explicit.git",
+                "base_branch": "release/2026.05",
+                "task_kind": "sync_release_pr",
+                "task_title": "Release sync explicit target",
+                "task_prompt": "Open the release PR against an explicit target branch.",
+                "provider_readiness_override": True,
+                "provider_readiness_override_reason": "mcp release-sync explicit target regression",
+            },
+        )
+
+        assert isinstance(payload, dict)
+        async with factory() as session:
+            ws = await WorkspaceRepository(session).get(str(payload["workspace_id"]))
+
+        assert ws is not None
+        assert ws.branch_base == "release/2026.05"
+        assert ws.task_policy["release_sync"]["target_branch"] == "release/2026.05"
+
+    @pytest.mark.unit
     async def test_create_workspace_accepts_matching_legacy_and_canonical_aliases(
         self,
         mcp,

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -1288,7 +1288,7 @@ class TestCreateWorkspace:
                 "base_branch": "main",
                 "task_title": "Add planner hook",
                 "task_prompt": "Implement the planner hook.",
-                "task_kind": "refactor_task",
+                "task_kind": "feature_branch_pr",
                 "agent": "claude_code",
                 "model": "claude-opus-4-7",
                 "effort": "xhigh",
@@ -1334,7 +1334,7 @@ class TestCreateWorkspace:
         assert ws.task_title == "Add planner hook"
         assert ws.task_prompt == "Implement the planner hook."
         assert ws.task_external_id == "AIRA-42"
-        assert ws.task_kind == "refactor_task"
+        assert ws.task_kind == "feature_branch_pr"
         assert ws.agent == "claude_code"
         assert ws.task_policy["agent_model"] == "claude-opus-4-7"
         assert ws.task_policy["agent_effort"] == "xhigh"

--- a/tests/unit/mcp/test_mcp_server.py
+++ b/tests/unit/mcp/test_mcp_server.py
@@ -1509,6 +1509,39 @@ class TestCreateWorkspace:
         assert ws.task_policy["release_sync"]["target_branch"] == "release/2026.05"
 
     @pytest.mark.unit
+    async def test_create_workspace_sync_release_pr_honors_explicit_source_branch(
+        self,
+        mcp,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:  # type: ignore[no-untyped-def]
+        payload = await _call(
+            mcp,
+            "awf_create_workspace",
+            {
+                "repo_url": "git@github.com:example/release-sync-source.git",
+                "base_branch": "main",
+                "source_branch": "release/staging",
+                "task_kind": "sync_release_pr",
+                "task_title": "Release sync explicit source",
+                "task_prompt": "Open the release PR from a non-default source branch.",
+                "provider_readiness_override": True,
+                "provider_readiness_override_reason": "mcp release-sync source override regression",
+            },
+        )
+
+        assert isinstance(payload, dict)
+        async with factory() as session:
+            ws = await WorkspaceRepository(session).get(str(payload["workspace_id"]))
+
+        assert ws is not None
+        # The MCP source_branch override must thread through to the release-sync
+        # policy so callers can sync a non-default branch, matching CLI/REST.
+        assert ws.task_policy["release_sync"] == {
+            "source_branch": "release/staging",
+            "target_branch": "main",
+        }
+
+    @pytest.mark.unit
     async def test_create_workspace_accepts_matching_legacy_and_canonical_aliases(
         self,
         mcp,

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -25,7 +25,7 @@ from awf.node.git_manager import (
 
 
 @pytest.mark.unit
-def test_github_pull_head_ref_pattern_defined_once() -> None:
+def test_github_pull_head_ref_pattern_matches_expected() -> None:
     pattern = git_manager._GITHUB_PULL_HEAD_REF
     assert pattern.match("refs/pull/278/head")
     assert pattern.match("refs/pull/0/head") is None

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -24,6 +24,13 @@ from awf.node.git_manager import (
 )
 
 
+@pytest.mark.unit
+def test_github_pull_head_ref_pattern_defined_once() -> None:
+    pattern = git_manager._GITHUB_PULL_HEAD_REF
+    assert pattern.match("refs/pull/278/head")
+    assert pattern.match("refs/pull/0/head") is None
+
+
 def _git(args: list[str], cwd: Path) -> None:
     """Run a synchronous git command for fixture setup; fail loudly on error."""
     subprocess.run(

--- a/tests/unit/node/test_provisioner.py
+++ b/tests/unit/node/test_provisioner.py
@@ -36,6 +36,7 @@ from awf.node.provisioner import (
     _egress_plan_destination_category,
     _positive_int,
     _provision_checkout_base_branch,
+    _provision_local_branch_name,
     _provision_remote_push_branch,
 )
 from awf.node.stack_launcher import ComposeStackLauncher
@@ -393,6 +394,52 @@ class TestSuccess:
 
         assert _provision_checkout_base_branch(ws) == "development"
         assert _provision_remote_push_branch(ws) == "awf/ws"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "task_policy, expected_source",
+        [
+            (
+                {"release_sync": {"source_branch": "release/next", "target_branch": "main"}},
+                "release/next",
+            ),
+            ({"release_sync": {"target_branch": "main"}}, "development"),
+            ({}, "development"),
+            ({"release_sync": "not-a-dict"}, "development"),
+            ({"release_sync": {"source_branch": " "}}, "development"),
+        ],
+    )
+    def test_sync_release_pr_checks_out_source_branch(
+        self,
+        task_policy: dict[str, Any],
+        expected_source: str,
+    ) -> None:
+        ws = Workspace(
+            repo_url="https://github.com/dimileeh/aira-web.git",
+            branch_base="main",
+            branch_name=None,
+            remote_push_branch=None,
+            task_kind="sync_release_pr",
+            task_policy=task_policy,
+        )
+
+        assert _provision_local_branch_name(ws, workspace_id="ws1", branch_prefix="awf") == (
+            "release-sync/ws1"
+        )
+        assert _provision_checkout_base_branch(ws) == expected_source
+        assert _provision_remote_push_branch(ws) == expected_source
+
+    @pytest.mark.unit
+    def test_feature_branch_pr_local_branch_uses_prefix(self) -> None:
+        ws = Workspace(
+            repo_url="https://github.com/dimileeh/aira-web.git",
+            branch_base="main",
+            task_kind="feature_branch_pr",
+            task_policy={},
+        )
+        assert (
+            _provision_local_branch_name(ws, workspace_id="ws1", branch_prefix="awf") == "awf/ws1"
+        )
 
     @pytest.mark.unit
     async def test_profile_secret_leases_are_issued_before_launch_and_mounted_after_success(

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -12,7 +12,7 @@ import json
 import pytest
 
 from awf.common.commands import FakeCommandRunner
-from awf.common.github_client import GitHubClient, RepoRef
+from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.runtime.release_pr_sync import (
     NO_CHANGES_REASON_CODE,
     ReleasePrSyncError,
@@ -333,6 +333,94 @@ class TestFindOrCreateReleasePr:
         assert exc.value.detail["expected_repo"] == "o/r"
         assert exc.value.detail["parsed_repo"] == "other/repo"
         # No gh pr view should run once the repo mismatch is detected.
+        assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
+
+    @pytest.mark.unit
+    async def test_adopts_pr_when_create_loses_race(self) -> None:
+        # The initial list finds no PR, but a concurrent sync run or a human
+        # opens one before `gh pr create` runs, so create fails on the
+        # duplicate. The re-check must adopt the now-existing same-repo PR
+        # instead of failing the workspace.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none yet
+        fake.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "development" into branch "main" already exists',
+        )  # gh pr create -> duplicate rejected
+        fake.queue_result(
+            returncode=0, stdout=_open_pr_list_payload(number=77)
+        )  # gh pr list (re-check)
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=77))  # gh pr view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert created is False
+        assert metadata.number == 77
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_create_failure_without_existing_pr_reraises(self) -> None:
+        # A create failure that is not a lost race (no PR appears on re-check)
+        # must surface the original gh error rather than being swallowed.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=1, stderr="HTTP 500 from GitHub")  # gh pr create -> fails
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list (re-check) -> still none
+        gh = GitHubClient(fake)
+
+        with pytest.raises(GitHubClientError) as exc:
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+            )
+
+        assert exc.value.operation == "gh pr create"
+        # No `gh pr view` runs when the create failure is genuine.
+        assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
+
+    @pytest.mark.unit
+    async def test_race_recheck_ignores_fork_collision(self) -> None:
+        # If create fails and the re-check only finds a fork PR sharing the head
+        # branch name, that fork must not be adopted; the original error
+        # re-raises rather than monitoring a fork PR.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=1, stderr="already exists")  # gh pr create -> fails
+        fake.queue_result(
+            returncode=0, stdout=_fork_open_pr_list_payload(number=555)
+        )  # gh pr list (re-check) -> only a fork PR
+        gh = GitHubClient(fake)
+
+        with pytest.raises(GitHubClientError):
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+            )
+
         assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
 
 

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -373,12 +373,45 @@ class TestFindOrCreateReleasePr:
         ]
 
     @pytest.mark.unit
-    async def test_create_failure_without_existing_pr_reraises(self) -> None:
-        # A create failure that is not a lost race (no PR appears on re-check)
-        # must surface the original gh error rather than being swallowed.
+    async def test_non_duplicate_create_failure_reraises_without_recheck(self) -> None:
+        # A create failure that is not a duplicate-PR rejection (auth, network,
+        # branch protection, HTTP 5xx) is not a lost race. It must surface the
+        # original gh error immediately, without a second `gh pr list` whose own
+        # failure could mask the real cause.
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
         fake.queue_result(returncode=1, stderr="HTTP 500 from GitHub")  # gh pr create -> fails
+        gh = GitHubClient(fake)
+
+        with pytest.raises(GitHubClientError) as exc:
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+            )
+
+        assert exc.value.operation == "gh pr create"
+        # Only the initial list + the failed create ran: no re-check, no view.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+        ]
+
+    @pytest.mark.unit
+    async def test_duplicate_signal_recheck_finds_nothing_reraises(self) -> None:
+        # The create fails with a duplicate-PR signal, so the re-check runs, but
+        # no same-repo PR materialises (e.g. the raced PR was closed). The
+        # original gh error must surface rather than being swallowed.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "development" into branch "main" already exists',
+        )  # gh pr create -> duplicate rejected
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list (re-check) -> still none
         gh = GitHubClient(fake)
 
@@ -394,8 +427,12 @@ class TestFindOrCreateReleasePr:
             )
 
         assert exc.value.operation == "gh pr create"
-        # No `gh pr view` runs when the create failure is genuine.
-        assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
+        # The duplicate signal triggers a re-check list, but no `gh pr view`.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+        ]
 
     @pytest.mark.unit
     async def test_race_recheck_ignores_fork_collision(self) -> None:

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -1,0 +1,298 @@
+"""Unit tests for ``awf.runtime.release_pr_sync``.
+
+``FakeCommandRunner`` returns canned ``git`` / ``gh`` output; the helpers parse
+it. Assertions cover ahead-count parsing, find-or-create branching, the no-op
+result, and error propagation.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import GitHubClient, RepoRef
+from awf.runtime.release_pr_sync import (
+    NO_CHANGES_REASON_CODE,
+    ReleasePrSyncError,
+    ReleasePrSyncNoOp,
+    ReleasePrSyncResult,
+    count_commits_ahead,
+    find_or_create_release_pr,
+    prepare_release_pr_sync,
+    release_pr_body,
+    release_pr_title,
+)
+
+_REPO = RepoRef(owner="o", name="r")
+
+
+def _adoption_payload(*, number: int = 321) -> str:
+    return json.dumps(
+        {
+            "number": number,
+            "headRefName": "development",
+            "headRepository": {"name": "r", "nameWithOwner": "o/r"},
+            "isCrossRepository": False,
+            "baseRefName": "main",
+            "headRefOid": "h" * 40,
+            "baseRefOid": "b" * 40,
+            "state": "OPEN",
+            "isDraft": False,
+            "author": {"login": "octocat"},
+            "url": f"https://github.com/o/r/pull/{number}",
+            "title": "Release",
+        }
+    )
+
+
+def _open_pr_list_payload(*, number: int = 321) -> str:
+    return json.dumps(
+        [
+            {
+                "number": number,
+                "url": f"https://github.com/o/r/pull/{number}",
+                "headRefName": "development",
+                "headRefOid": "h" * 40,
+                "headRepository": {"name": "r", "nameWithOwner": "o/r"},
+                "headRepositoryOwner": {"login": "o"},
+            }
+        ]
+    )
+
+
+class TestCountCommitsAhead:
+    @pytest.mark.unit
+    async def test_parses_positive_count(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)  # git fetch
+        fake.queue_result(returncode=0, stdout="3\n")  # git rev-list --count
+
+        count = await count_commits_ahead(
+            runner=fake,
+            cwd="/work",
+            source_branch="development",
+            target_branch="main",
+        )
+
+        assert count == 3
+        fetch_args = fake.calls[0].args
+        assert fetch_args[:3] == ["git", "fetch", "origin"]
+        assert "main" in fetch_args and "development" in fetch_args
+        assert fake.calls[0].cwd == "/work"
+        rev_args = fake.calls[1].args
+        assert rev_args[:3] == ["git", "rev-list", "--count"]
+        assert rev_args[-1] == "origin/main..origin/development"
+
+    @pytest.mark.unit
+    async def test_parses_zero_count(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="0\n")
+
+        count = await count_commits_ahead(
+            runner=fake, cwd="/work", source_branch="development", target_branch="main"
+        )
+
+        assert count == 0
+
+    @pytest.mark.unit
+    async def test_fetch_failure_raises(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=1, stderr="network down")
+
+        with pytest.raises(ReleasePrSyncError) as exc:
+            await count_commits_ahead(
+                runner=fake, cwd="/work", source_branch="development", target_branch="main"
+            )
+
+        assert exc.value.reason_code == "RELEASE_SYNC_FETCH_FAILED"
+        assert "network down" in exc.value.message
+
+    @pytest.mark.unit
+    async def test_rev_list_failure_raises(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=1, stderr="bad revision")
+
+        with pytest.raises(ReleasePrSyncError) as exc:
+            await count_commits_ahead(
+                runner=fake, cwd="/work", source_branch="development", target_branch="main"
+            )
+
+        assert exc.value.reason_code == "RELEASE_SYNC_REV_LIST_FAILED"
+
+    @pytest.mark.unit
+    async def test_rev_list_non_numeric_raises(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="not-a-number\n")
+
+        with pytest.raises(ReleasePrSyncError) as exc:
+            await count_commits_ahead(
+                runner=fake, cwd="/work", source_branch="development", target_branch="main"
+            )
+
+        assert exc.value.reason_code == "RELEASE_SYNC_REV_LIST_INVALID"
+
+
+class TestFindOrCreateReleasePr:
+    @pytest.mark.unit
+    async def test_reuses_existing_open_pr_without_create(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout=_open_pr_list_payload(number=99))  # gh pr list
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=99))  # gh pr view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert created is False
+        assert metadata.number == 99
+        # Only list + view ran; no `gh pr create`.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_creates_pr_when_none_exists(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")  # gh pr create
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # gh pr view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="Release: merge development into main",
+            body="b",
+        )
+
+        assert created is True
+        assert metadata.number == 321
+        create_args = fake.calls[1].args
+        assert create_args[:3] == ["gh", "pr", "create"]
+        assert create_args[create_args.index("--base") + 1] == "main"
+        assert create_args[create_args.index("--head") + 1] == "development"
+
+    @pytest.mark.unit
+    async def test_unparseable_create_url_raises(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")
+        fake.queue_result(returncode=0, stdout="not-a-url\n")
+        gh = GitHubClient(fake)
+
+        with pytest.raises(ReleasePrSyncError) as exc:
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+            )
+
+        assert exc.value.reason_code == "RELEASE_SYNC_PR_URL_INVALID"
+
+
+class TestPrepareReleasePrSync:
+    @pytest.mark.unit
+    async def test_no_commits_returns_noop(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)  # fetch
+        fake.queue_result(returncode=0, stdout="0\n")  # rev-list
+        gh = GitHubClient(fake)
+
+        outcome = await prepare_release_pr_sync(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            cwd="/work",
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert isinstance(outcome, ReleasePrSyncNoOp)
+        assert outcome.reason_code == NO_CHANGES_REASON_CODE
+        assert outcome.source_branch == "development"
+        assert outcome.target_branch == "main"
+        # No PR list/create/view calls beyond the two git calls.
+        assert len(fake.calls) == 2
+
+    @pytest.mark.unit
+    async def test_ahead_creates_pr_and_returns_result(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)  # fetch
+        fake.queue_result(returncode=0, stdout="4\n")  # rev-list
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")  # create
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # view
+        gh = GitHubClient(fake)
+
+        outcome = await prepare_release_pr_sync(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            cwd="/work",
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert isinstance(outcome, ReleasePrSyncResult)
+        assert outcome.created is True
+        assert outcome.commits_ahead == 4
+        assert outcome.metadata.number == 321
+        assert outcome.metadata.base_ref == "main"
+
+    @pytest.mark.unit
+    async def test_ahead_reuses_existing_pr(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0)  # fetch
+        fake.queue_result(returncode=0, stdout="2\n")  # rev-list
+        fake.queue_result(returncode=0, stdout=_open_pr_list_payload(number=88))  # gh pr list
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=88))  # view
+        gh = GitHubClient(fake)
+
+        outcome = await prepare_release_pr_sync(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            cwd="/work",
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert isinstance(outcome, ReleasePrSyncResult)
+        assert outcome.created is False
+        assert outcome.metadata.number == 88
+        assert all(c.args[:3] != ["gh", "pr", "create"] for c in fake.calls)
+
+
+class TestReleasePrText:
+    @pytest.mark.unit
+    def test_title_and_body_mention_branches(self) -> None:
+        title = release_pr_title(source_branch="development", target_branch="main")
+        body = release_pr_body(source_branch="development", target_branch="main")
+        assert "development" in title and "main" in title
+        assert "development" in body and "main" in body
+        assert "auto-merge disabled" in body

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -77,6 +77,33 @@ def _fork_open_pr_list_payload(*, number: int = 555) -> str:
     )
 
 
+def _fork_and_same_repo_pr_list_payload(
+    *, fork_number: int = 555, same_repo_number: int = 99
+) -> str:
+    # The fork PR is listed first so the test proves selection filters by repo
+    # identity rather than list order.
+    return json.dumps(
+        [
+            {
+                "number": fork_number,
+                "url": f"https://github.com/o/r/pull/{fork_number}",
+                "headRefName": "development",
+                "headRefOid": "f" * 40,
+                "headRepository": {"name": "r", "nameWithOwner": "fork/r"},
+                "headRepositoryOwner": {"login": "fork"},
+            },
+            {
+                "number": same_repo_number,
+                "url": f"https://github.com/o/r/pull/{same_repo_number}",
+                "headRefName": "development",
+                "headRefOid": "h" * 40,
+                "headRepository": {"name": "r", "nameWithOwner": "o/r"},
+                "headRepositoryOwner": {"login": "o"},
+            },
+        ]
+    )
+
+
 class TestCountCommitsAhead:
     @pytest.mark.unit
     async def test_parses_positive_count(self) -> None:
@@ -250,6 +277,38 @@ class TestFindOrCreateReleasePr:
             ["gh", "pr", "create"],
             ["gh", "pr", "view"],
         ]
+
+    @pytest.mark.unit
+    async def test_prefers_same_repo_pr_over_fork_collision(self) -> None:
+        # When `gh pr list` returns both a fork PR and a same-repo PR sharing
+        # the head branch, the same-repo PR must be adopted (no create).
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=_fork_and_same_repo_pr_list_payload(fork_number=555, same_repo_number=99),
+        )  # gh pr list
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=99))  # gh pr view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert created is False
+        assert metadata.number == 99
+        # Only list + view of the same-repo PR ran; the fork PR is never viewed
+        # and no `gh pr create` is issued.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "view"],
+        ]
+        assert fake.calls[1].args[:4] == ["gh", "pr", "view", "99"]
 
     @pytest.mark.unit
     async def test_created_url_for_other_repo_raises(self) -> None:

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -62,6 +62,21 @@ def _open_pr_list_payload(*, number: int = 321) -> str:
     )
 
 
+def _fork_open_pr_list_payload(*, number: int = 555) -> str:
+    return json.dumps(
+        [
+            {
+                "number": number,
+                "url": f"https://github.com/o/r/pull/{number}",
+                "headRefName": "development",
+                "headRefOid": "f" * 40,
+                "headRepository": {"name": "r", "nameWithOwner": "fork/r"},
+                "headRepositoryOwner": {"login": "fork"},
+            }
+        ]
+    )
+
+
 class TestCountCommitsAhead:
     @pytest.mark.unit
     async def test_parses_positive_count(self) -> None:
@@ -207,6 +222,59 @@ class TestFindOrCreateReleasePr:
             )
 
         assert exc.value.reason_code == "RELEASE_SYNC_PR_URL_INVALID"
+
+    @pytest.mark.unit
+    async def test_ignores_fork_pr_and_creates_in_repo(self) -> None:
+        # gh pr list can return a fork PR sharing the head branch name; it must
+        # not be adopted — a same-repo PR is created instead.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout=_fork_open_pr_list_payload(number=555))  # list
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")  # create
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert created is True
+        assert metadata.number == 321
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_created_url_for_other_repo_raises(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=0, stdout="https://github.com/other/repo/pull/7\n")  # create
+        gh = GitHubClient(fake)
+
+        with pytest.raises(ReleasePrSyncError) as exc:
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+            )
+
+        assert exc.value.reason_code == "RELEASE_SYNC_PR_REPO_MISMATCH"
+        assert exc.value.detail is not None
+        assert exc.value.detail["expected_repo"] == "o/r"
+        assert exc.value.detail["parsed_repo"] == "other/repo"
+        # No gh pr view should run once the repo mismatch is detected.
+        assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
 
 
 class TestPrepareReleasePrSync:

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -273,7 +273,11 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     default_monitor = created["executor_monitor_factory"](
         object(),
         WorkspaceProfile(name="default"),
-        SimpleNamespace(auto_merge=True, initial_review_grace_period_seconds=None),
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="feature_branch_pr",
+        ),
     )
     assert default_monitor is not None
     assert created["feature_monitor_kwargs"]["initial_review_grace_period_seconds"] == 900
@@ -299,7 +303,11 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     monitor = created["executor_monitor_factory"](
         object(),
         profile,
-        SimpleNamespace(auto_merge=True, initial_review_grace_period_seconds=None),
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="feature_branch_pr",
+        ),
     )
 
     assert monitor is not None
@@ -331,7 +339,11 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     manual_monitor = created["executor_monitor_factory"](
         object(),
         profile,
-        SimpleNamespace(auto_merge=False, initial_review_grace_period_seconds=12.5),
+        SimpleNamespace(
+            auto_merge=False,
+            initial_review_grace_period_seconds=12.5,
+            task_kind="feature_branch_pr",
+        ),
     )
 
     assert manual_monitor is not None
@@ -352,6 +364,24 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
         created["release_monitor_kwargs"]["merge_coordinator"]
         is created["feature_monitor_kwargs"]["merge_coordinator"]
     )
+
+    # Regression (PRRT_kwDOSJAM6s6EN6XO): a sync_release_pr workspace must get
+    # the human-gated release monitor even when its persisted auto_merge is True,
+    # so the never-auto-merge guarantee never hinges on that flag staying False.
+    created.pop("feature_monitor_kwargs", None)
+    created.pop("release_monitor_kwargs", None)
+    release_sync_monitor = created["executor_monitor_factory"](
+        object(),
+        profile,
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="sync_release_pr",
+        ),
+    )
+    assert release_sync_monitor is not None
+    assert "feature_monitor_kwargs" not in created
+    assert "release_monitor_kwargs" in created
 
 
 @pytest.mark.unit
@@ -494,7 +524,11 @@ def test_post_merge_reconciler_passes_workspace_id_to_exclude_open_candidate(
     created["pr_monitor_factory"](
         object(),
         WorkspaceProfile(name="default"),
-        SimpleNamespace(auto_merge=True, initial_review_grace_period_seconds=None),
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="feature_branch_pr",
+        ),
     )
     reconciler = created["reconciler"]
     _ = asyncio.run(
@@ -581,7 +615,11 @@ def test_build_worker_runtime_eagerly_uses_postgres_advisory_merge_coordinator_f
     created["pr_monitor_factory"](
         object(),
         WorkspaceProfile(name="default"),
-        SimpleNamespace(auto_merge=True, initial_review_grace_period_seconds=None),
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="feature_branch_pr",
+        ),
     )
 
     assert isinstance(

--- a/tests/unit/service/test_workspace_idempotency.py
+++ b/tests/unit/service/test_workspace_idempotency.py
@@ -69,12 +69,14 @@ def _v2_request(
     )
 
 
-def _release_sync_request(*, auto_merge: bool = True) -> WorkspaceCreateRequest:
+def _release_sync_request(
+    *, auto_merge: bool = True, source_branch: str = "development"
+) -> WorkspaceCreateRequest:
     return WorkspaceCreateRequest(
         repo={
             "url": "git@github.com:example/idempotency.git",
             "base_branch": "main",
-            "source_branch": "development",
+            "source_branch": source_branch,
         },
         task={
             "title": "Sync release PR",
@@ -639,6 +641,29 @@ async def test_create_release_sync_replay_matches_despite_forced_auto_merge_off(
     replayed = await service.create(request, idempotency_key=idempotency_key)
 
     assert replayed.id == created.id
+
+
+@pytest.mark.unit
+async def test_create_release_sync_replay_conflicts_when_source_branch_changes(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A sync_release_pr replay that changes repo.source_branch must conflict
+    rather than silently reusing the workspace, which would sync the wrong branch."""
+    service = WorkspaceService(factory)
+    idempotency_key = "service-create-v2-release-sync-source-branch"
+    request = _release_sync_request(source_branch="development")
+
+    created = await service.create(request, idempotency_key=idempotency_key)
+    assert created.id.startswith("ws_")
+
+    replayed = await service.create(request, idempotency_key=idempotency_key)
+    assert replayed.id == created.id
+
+    with pytest.raises(WorkspaceCreateIdempotencyConflictError):
+        await service.create(
+            _release_sync_request(source_branch="release-candidate"),
+            idempotency_key=idempotency_key,
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_idempotency.py
+++ b/tests/unit/service/test_workspace_idempotency.py
@@ -667,6 +667,31 @@ async def test_create_release_sync_replay_conflicts_when_source_branch_changes(
 
 
 @pytest.mark.unit
+async def test_create_release_sync_legacy_replay_allows_missing_source_branch(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A legacy sync_release_pr row created before the source_branch snapshot has
+    no recorded value; an identical default-branch replay must still match rather
+    than conflict, because such rows could only have synced the default branch."""
+    service = WorkspaceService(factory)
+    idempotency_key = "service-create-v2-release-sync-legacy-source-branch"
+    request = _release_sync_request(source_branch="development")
+
+    created = await service.create(request, idempotency_key=idempotency_key)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(created.id)
+        assert workspace is not None
+        task_policy = dict(workspace.task_policy)
+        task_policy.pop("release_sync", None)
+        workspace.task_policy = task_policy
+        await session.commit()
+
+    replayed = await service.create(request, idempotency_key=idempotency_key)
+
+    assert replayed.id == created.id
+
+
+@pytest.mark.unit
 async def test_create_auto_profile_legacy_replay_allows_missing_requested_tier(
     factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspace_idempotency.py
+++ b/tests/unit/service/test_workspace_idempotency.py
@@ -644,6 +644,30 @@ async def test_create_release_sync_replay_matches_despite_forced_auto_merge_off(
 
 
 @pytest.mark.unit
+async def test_create_release_sync_legacy_replay_allows_stored_auto_merge_true(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """A legacy sync_release_pr row written before auto_merge was forced off at
+    persistence snapshotted the raw request default (auto_merge=True). An identical
+    replay now resolves the effective auto_merge to False, so the matcher must skip
+    the comparison rather than conflict on an otherwise unchanged request."""
+    service = WorkspaceService(factory)
+    idempotency_key = "service-create-v2-release-sync-legacy-auto-merge"
+    request = _release_sync_request(auto_merge=True)
+
+    created = await service.create(request, idempotency_key=idempotency_key)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(created.id)
+        assert workspace is not None
+        workspace.auto_merge = True
+        await session.commit()
+
+    replayed = await service.create(request, idempotency_key=idempotency_key)
+
+    assert replayed.id == created.id
+
+
+@pytest.mark.unit
 async def test_create_release_sync_replay_conflicts_when_source_branch_changes(
     factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_workspace_idempotency.py
+++ b/tests/unit/service/test_workspace_idempotency.py
@@ -69,6 +69,29 @@ def _v2_request(
     )
 
 
+def _release_sync_request(*, auto_merge: bool = True) -> WorkspaceCreateRequest:
+    return WorkspaceCreateRequest(
+        repo={
+            "url": "git@github.com:example/idempotency.git",
+            "base_branch": "main",
+            "source_branch": "development",
+        },
+        task={
+            "title": "Sync release PR",
+            "prompt": "Exercise serialized idempotency lookup.",
+            "agent": "codex",
+            "kind": "sync_release_pr",
+            "auto_merge": auto_merge,
+        },
+        workspace={"profile_ref": "auto", "profile": None},
+        validation={"commands": ["pytest -q"], "requested_tier": 1},
+        preflight={
+            "provider_readiness_override": True,
+            "provider_readiness_override_reason": "idempotency serialization test fixture",
+        },
+    )
+
+
 def _record_idempotency_lock_order(
     monkeypatch: pytest.MonkeyPatch,
 ) -> list[tuple[str, str]]:
@@ -594,6 +617,28 @@ async def test_create_replay_conflicts_when_agent_effort_changes(
             request_with_xhigh_effort,
             idempotency_key=idempotency_key,
         )
+
+
+@pytest.mark.unit
+async def test_create_release_sync_replay_matches_despite_forced_auto_merge_off(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """Release-PR sync persists auto_merge=False; a same-payload replay (which
+    still carries the request default auto_merge=True) must match instead of
+    raising a spurious idempotency conflict."""
+    service = WorkspaceService(factory)
+    request = _release_sync_request(auto_merge=True)
+    idempotency_key = "service-create-v2-release-sync-auto-merge"
+
+    created = await service.create(request, idempotency_key=idempotency_key)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(created.id)
+        assert workspace is not None
+        assert workspace.auto_merge is False
+
+    replayed = await service.create(request, idempotency_key=idempotency_key)
+
+    assert replayed.id == created.id
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -944,11 +944,44 @@ async def test_retry_planning_scope_violation_discards_premature_work_and_replan
     assert retry_created[0].payload["salvage_policy"] == "explicit_salvage_required"
 
 
+async def _seed_failed_source_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    task_kind: str,
+) -> str:
+    """Persist a source workspace for a task kind that bypasses direct create.
+
+    ``sync_feature_pr`` is created through the PR-adoption flow (via
+    ``WorkspaceRepository.create``), not the public request path, so retry
+    coverage seeds the row the same way instead of building a rejected request.
+    """
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        source = await repo.create(
+            repo_url="git@github.com:example/retryable.git",
+            branch_base="development",
+            task_title="Retry flaky validation",
+            task_prompt="Fix the intermittent validation failure.",
+            task_external_id="TICKET-RETRY",
+            task_class="test_task",
+            owned_paths=["src/awf/retry/**"],
+            auto_merge=False,
+            initial_review_grace_period_seconds=30,
+            agent=AgentRuntime.codex.value,
+            profile_ref="python",
+            requested_profile={"source": "retry-test-profile"},
+            resolved_profile={"source": "retry-test-profile"},
+            test_commands=["uv run pytest tests/unit -q"],
+            task_kind=task_kind,
+        )
+        await session.commit()
+        return source.id
+
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("task_kind", "branch_name", "remote_push_branch"),
     [
-        ("monitor_release_pr", "release-monitor/ws_scope_old", "release/2026-05"),
         ("sync_release_pr", "release-sync/ws_scope_old", "development"),
         ("sync_feature_pr", "feature-sync/ws_scope_old", "contributors/fix-123"),
     ],
@@ -960,19 +993,22 @@ async def test_retry_planning_scope_violation_preserves_monitor_and_sync_remote_
     remote_push_branch: str,
 ) -> None:
     service = WorkspaceService(factory)
-    first = await service.create(_request(task_kind=task_kind))
+    if task_kind == "sync_release_pr":
+        first_id = (await service.create(_request(task_kind=task_kind))).id
+    else:
+        first_id = await _seed_failed_source_workspace(factory, task_kind=task_kind)
     await _mark_planning_scope_failed(
         factory,
-        first.id,
+        first_id,
         branch_name=branch_name,
         remote_push_branch=remote_push_branch,
     )
 
-    retry = await _retry_with_preflight_override(service, first.id)
+    retry = await _retry_with_preflight_override(service, first_id)
 
     async with factory() as session:
         repo = WorkspaceRepository(session)
-        original = await repo.get(first.id)
+        original = await repo.get(first_id)
         retried = await repo.get(retry.new_workspace_id)
 
     assert original is not None

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -49,6 +49,8 @@ from awf.service.workspaces import (
     WorkspaceRetryNotAllowedError,
     WorkspaceRetryNotFoundError,
     WorkspaceService,
+    _assert_supported_direct_create_task_kind,
+    _effective_auto_merge,
     _parse_memory_gb,
     owned_path_overlap_warning_payload,
     owned_path_overlap_warnings,
@@ -895,6 +897,91 @@ def test_v2_task_policy_and_profile_tier_helpers_cover_noop_and_updates() -> Non
     assert unchanged is profile
     assert changed.validation.requested_tier == 3
     assert profile.validation.requested_tier == 1
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("source_branch", "expected_source"),
+    [("release/cut", "release/cut"), (None, "development")],
+)
+def test_sync_release_pr_snapshot_records_release_sync_block(
+    source_branch: str | None,
+    expected_source: str,
+) -> None:
+    repo: dict[str, object] = {"url": "git@github.com:example/rel.git", "base_branch": "master"}
+    if source_branch is not None:
+        repo["source_branch"] = source_branch
+    request = WorkspaceCreateRequest(
+        repo=repo,
+        task={"title": "Release sync", "prompt": "p", "agent": "codex", "kind": "sync_release_pr"},
+        preflight={
+            "provider_readiness_override": True,
+            "provider_readiness_override_reason": "release sync fixture",
+        },
+    )
+
+    policy = workspace_create_task_policy_snapshot(request)
+
+    assert policy["release_sync"] == {
+        "source_branch": expected_source,
+        "target_branch": "master",
+    }
+
+
+@pytest.mark.unit
+def test_feature_branch_pr_snapshot_omits_release_sync_block() -> None:
+    request = WorkspaceCreateRequest(
+        repo={"url": "git@github.com:example/feat.git", "base_branch": "main"},
+        task={"title": "Feature", "prompt": "p", "agent": "codex", "kind": "feature_branch_pr"},
+        preflight={
+            "provider_readiness_override": True,
+            "provider_readiness_override_reason": "feature fixture",
+        },
+    )
+
+    policy = workspace_create_task_policy_snapshot(request)
+
+    assert "release_sync" not in policy
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("kind", "requested_auto_merge", "expected"),
+    [
+        ("sync_release_pr", True, False),
+        ("feature_branch_pr", True, True),
+        ("feature_branch_pr", False, False),
+    ],
+)
+def test_effective_auto_merge_forces_false_for_release_sync(
+    kind: str,
+    requested_auto_merge: bool,
+    expected: bool,
+) -> None:
+    request = WorkspaceCreateRequest(
+        repo={"url": "git@github.com:example/am.git", "base_branch": "main"},
+        task={
+            "title": "Auto merge",
+            "prompt": "p",
+            "agent": "codex",
+            "kind": kind,
+            "auto_merge": requested_auto_merge,
+        },
+        preflight={
+            "provider_readiness_override": True,
+            "provider_readiness_override_reason": "auto merge fixture",
+        },
+    )
+
+    assert _effective_auto_merge(request) is expected
+
+
+@pytest.mark.unit
+def test_assert_supported_direct_create_task_kind_guards_unsupported() -> None:
+    _assert_supported_direct_create_task_kind("feature_branch_pr")
+    _assert_supported_direct_create_task_kind("sync_release_pr")
+    with pytest.raises(ValueError, match="unsupported task kind"):
+        _assert_supported_direct_create_task_kind("sync_feature_pr")
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_2a4292d5b79747c7b93f881e` (agent: `claude_code`, model: `claude-opus-4-7`, effort: `xhigh`).

**External task ID**: hunter-report-release-sync-task-kind-2026-05-22

### Task
## Automatic AWF timeout salvage

AWF automatically captured the prior implementation diff from an agent run that timed out before it could finish. The retry workspace will restore that diff before the agent runs. Continue from the recovered implementation; do not restart from scratch unless the recovered code is unusable.

### Source reason
`AGENT_IDLE_TIMEOUT`

### Timeout message
post-agent git commit failed (exit=1): trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...........................................(no files to check)Skipped
check for added large files..............................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
ruff check...............................................................Passed
ruff format --check......................................................Failed
- hook id: awf-ruff-format-check
- exit code: 1

Would reformat: src/awf/node/provisioner.py
Would reformat: src/awf/runtime/release_pr_sync.py
Would reformat: tests/unit/api/test_schema_coverage_edges.py
Would reformat: tests/unit/control/t

### Salvaged implementation paths
- `docs/PLAN_PR_MONITOR.md`
- `docs/PLAN_RELEASE_PR_SYNC.md`
- `openapi.json`
- `skills/awf-scheduler/SKILL.md`
- `src/awf/api/schemas.py`
- `src/awf/cli/main.py`
- `src/awf/common/github_client.py`
- `src/awf/control/executor.py`
- `src/awf/control/worker.py`
- `src/awf/db/enums.py`
- `src/awf/mcp/server.py`
- `src/awf/node/git_manager.py`
- `src/awf/node/provisioner.py`
- `src/awf/runtime/pr_monitor.py`
- `src/awf/runtime/release_pr_sync.py`
- `src/awf/service/provider_recovery.py`
- `src/awf/service/workspaces.py`
- `tests/unit/api/test_schema_coverage_edges.py`
- `tests/unit/common/test_github_client.py`
- `tests/unit/control/test_executor_error_paths.py`
- ... and 5 more

### Original task
Implement the operator's updated resolution for the hunter-report release task-kind bug against development.

Product decision from operator:
- monitor_release_pr is redundant and should be removed/deprecated. AWF already has a generic PR adoption/monitoring path; monitoring an existing PR should work the same whether it is feature->development, branch->branch, or development->main/master. For release/manual PR monitoring, use existing PR adoption with auto_merge=false so build_release_pr_monitor is selected.
- sync_release_pr is legitimate and should become a real AWF task kind: AWF should create or update/reuse a development-to-main release PR, then monitor it with release/manual behavior and never auto-merge it.
- Also fix the minor hunter-report issue: remove the duplicate _GITHUB_PULL_HEAD_REF definition in src/awf/node/git_manager.py.

Required behavior:
1. Remove/deprecate monitor_release_pr as a public task kind.
   - Remove it from TaskKind and public docs where practical.
   - Update docs/comments that tell operators to create monitor_release_pr tasks; direct them to adopt/monitor an existing PR instead, using auto_merge=false for release/manual PRs.
   - For backward compatibility with legacy DB rows or stale clients that still say task_kind="monitor_release_pr", fail fast with a clear deprecated/unsupported message. Do not let it silently run as feature work.

2. Implement sync_release_pr as a real workflow.
   - A sync_release_pr workspace should not run the coding agent or create a feature PR.
   - It should check whether the configured source branch is ahead of the target branch. Default source branch is development. Default target branch is main; support master or an explicit configured target if the repo/profile/task policy already has a natural place for that. Prefer the simplest project-local, generic AWF design.
   - If there are no commits to sync, complete cleanly with a clear reason/event.
   - If an open release PR already exists for source->target, reuse it; do not create a duplicate.
   - If none exists, create the release PR source->target with a clear title/body.
   - Transition the workspace into monitoring_pr with the PR metadata recorded, using auto_merge=false/release monitor behavior.
   - Preserve the existing generic PR adoption monitor path for arbitrary existing PRs.
   - Keep this generic AWF core behavior; do not hard-code Aira-specific repositories.

3. Harden public task-kind admission.
   - REST/MCP workspace creation should reject arbitrary unknown task kinds.
   - Supported direct workspace task kinds after this change should include feature_branch_pr and sync_release_pr. Existing sync_feature_pr adoption/resume behavior must continue to work through the adoption flow.
   - Legacy unsupported/deprecated values must not fall through to feature-branch provisioning or execution.
   - Update CLI/API/MCP surfaces if task kind selection is missing or undocumented for workspace creation.

4. Remove the duplicate GitHub pull-head regex definition.
   - src/awf/node/git_manager.py should define _GITHUB_PULL_HEAD_REF only once.

Suggested starting points:
- docs/PLAN_RELEASE_PR_SYNC.md has useful historical design notes; adapt to the current service-backed architecture instead of resurrecting retired scripts.
- src/awf/runtime/release_pr_monitor.py already provides release/manual monitor behavior.
- src/awf/service/pr_monitor_adoption.py is the existing path for adopting arbitrary existing PRs.
- src/awf/service/worker.py chooses feature vs release monitor based on auto_merge; keep/direct release/manual monitoring through that generic mechanism.
- src/awf/control/executor.py and src/awf/node/provisioner.py are where unsafe task-kind fallthrough currently happens.

Testing expectations:
- Regression tests for rejecting unknown task kinds via REST/MCP.
- Regression tests that legacy monitor_release_pr does not fall through into feature work.
- Unit/integration-style coverage for sync_release_pr no-op when no commits are ahead, reuse existing open source->target PR, create a PR when needed, record PR metadata, and enter monitoring_pr with auto_merge=false/release monitor behavior.
- Existing sync_feature_pr adoption/monitor tests must keep passing.
- Duplicate regex cleanup can be covered by ordinary import/lint or a small assertion if useful.

Repository process requirements:
- Follow plans/PLAN_EXECUTION_PROTOCOL.md.
- Create plans/RELEASE_SYNC_TASK_KIND_PLAN.md before coding.
- Create plans/RELEASE_SYNC_TASK_KIND_VALIDATION.md after implementation.
- Keep changes scoped to this bug/workflow. Do not build a scheduler/cron system unless the current code already has an obvious lightweight hook; the core task-kind workflow is the priority.
- Do not add prompt-specific validation commands; rely on .awf/workspace.yml for validation.

Open a PR for the fix and let AWF monitor it.


---
Validation: 4 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release PR sync flow to create/reuse source→target release PRs (notification-only; never auto-merged).
  * CLI workspace create adds --task-kind and --source-branch; sync_release_pr defaults base to main and supports optional source_branch.
  * API accepts an optional source_branch and preserves release-sync policy for idempotent workspaces.

* **Bug Fixes**
  * Deprecated monitor_release_pr; deprecated/unsupported direct-create kinds are rejected and sync_release_pr forces auto-merge=false.

* **Documentation**
  * Updated release-PR guidance, adoption/verification steps, and task-kind docs.

* **Tests**
  * Extensive unit tests covering release-sync flows, CLI, validation, PR creation, and executor behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/278?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->