### PR TITLE
Report workspace LLM usage with pinned ccusage

### DIFF
--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -56,6 +56,7 @@ import {
   fallbackLifecycleStages,
   fallbackLlmUsage,
   formatDateTime,
+  formatUsageProvenance,
   lifecycleStages,
   relativeTime,
   pickWorkspaceLogStreams,
@@ -2302,7 +2303,7 @@ function UsageSummaryBlock({
           <Badge value="unavailable" />
         </div>
         <div className="mt-2 truncate text-[11px] text-slate-500">
-          {safeUsage.reason ?? "usage unavailable"}
+          {formatUsageProvenance(safeUsage.source, safeUsage.reason)}
         </div>
       </div>
     );
@@ -2337,7 +2338,7 @@ function UsageSummaryBlock({
         />
       </div>
       <div className="mt-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-slate-500">
-        {`${safeUsage.source}${safeUsage.reason ? ` / ${safeUsage.reason}` : ""}`}
+        {formatUsageProvenance(safeUsage.source, safeUsage.reason)}
         {pricingReason ? (
           <>
             <span className="text-slate-300">|</span>

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -2297,7 +2297,7 @@ function UsageSummaryBlock({
 
   if (safeUsage.status === "unavailable" || (safeUsage.input_tokens == null && safeUsage.output_tokens == null && safeUsage.total_tokens == null && safeUsage.cost_estimate == null)) {
     return (
-      <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+      <div data-testid="llm-usage" className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
         <div className="flex items-center justify-between gap-2">
           <span className="font-semibold text-slate-900">LLM usage</span>
           <Badge value="unavailable" />
@@ -2309,7 +2309,7 @@ function UsageSummaryBlock({
     );
   }
   return (
-    <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+    <div data-testid="llm-usage" className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
       <div className="flex items-center justify-between gap-2">
         <span className="font-semibold text-slate-900">LLM usage</span>
         <div className="flex items-center gap-1.5">

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -57,6 +57,27 @@ test("formatUsageProvenance maps ccusage source and reason codes to friendly lab
   assert.equal(formatUsageProvenance("none", "usage_not_reported"), "none / not reported");
 });
 
+test("formatUsageProvenance maps pricing cost-reason codes to friendly labels", () => {
+  assert.equal(
+    formatUsageProvenance("ccusage", "pricing_not_configured"),
+    "ccusage / pricing not configured",
+  );
+  assert.equal(formatUsageProvenance("ccusage", "pricing_stale"), "ccusage / pricing stale");
+  assert.equal(
+    formatUsageProvenance("ccusage", "pricing_rates_unavailable"),
+    "ccusage / pricing rates unavailable",
+  );
+  assert.equal(formatUsageProvenance("ccusage", "no_token_data"), "ccusage / no token data");
+  assert.equal(
+    formatUsageProvenance("ccusage", "negative_token_count"),
+    "ccusage / invalid token count",
+  );
+  assert.equal(
+    formatUsageProvenance("ccusage", "unsupported_pricing_unit"),
+    "ccusage / unsupported pricing unit",
+  );
+});
+
 test("formatUsageProvenance passes through unknown source and reason", () => {
   assert.equal(formatUsageProvenance("custom_src", "weird_reason"), "custom_src / weird_reason");
   assert.equal(formatUsageProvenance(undefined, undefined), "none");

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -5,6 +5,7 @@ import {
   fallbackLifecycleStages,
   fallbackLlmUsage,
   formatCostWithPricing,
+  formatUsageProvenance,
   pickWorkspaceLogStreams,
   renderLogEntries,
   toneFillClass,
@@ -46,6 +47,19 @@ test("fallbackLifecycleStages preserves active non-terminal status", () => {
   assert.equal(stages.running, "completed");
   assert.equal(stages.validating, "active");
   assert.equal(stages.pushing, "pending");
+});
+
+test("formatUsageProvenance maps ccusage source and reason codes to friendly labels", () => {
+  assert.equal(formatUsageProvenance("ccusage", null), "ccusage");
+  assert.equal(formatUsageProvenance("ccusage", "ccusage_no_records"), "ccusage / no usage recorded yet");
+  assert.equal(formatUsageProvenance("ccusage", "ccusage_timeout"), "ccusage / ccusage timed out");
+  assert.equal(formatUsageProvenance("operations", null), "operations");
+  assert.equal(formatUsageProvenance("none", "usage_not_reported"), "none / not reported");
+});
+
+test("formatUsageProvenance passes through unknown source and reason", () => {
+  assert.equal(formatUsageProvenance("custom_src", "weird_reason"), "custom_src / weird_reason");
+  assert.equal(formatUsageProvenance(undefined, undefined), "none");
 });
 
 test("fallbackLlmUsage protects legacy workspace payloads", () => {

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -76,6 +76,36 @@ export function fallbackLlmUsage(
   };
 }
 
+const USAGE_SOURCE_LABELS: Record<string, string> = {
+  ccusage: "ccusage",
+  operations: "operations",
+  none: "none",
+};
+
+const USAGE_REASON_LABELS: Record<string, string> = {
+  usage_not_reported: "not reported",
+  ccusage_source_unsupported: "provider not supported by ccusage",
+  ccusage_unavailable: "ccusage not installed",
+  ccusage_command_failed: "ccusage command failed",
+  ccusage_timeout: "ccusage timed out",
+  ccusage_invalid_json: "ccusage output unreadable",
+  ccusage_no_records: "no usage recorded yet",
+};
+
+// Friendly provenance line for the LLM usage block: maps the AWF usage source
+// and reason code to human-readable labels without redesigning the dashboard.
+export function formatUsageProvenance(
+  source: string | null | undefined,
+  reason: string | null | undefined,
+): string {
+  const sourceLabel = (source && USAGE_SOURCE_LABELS[source]) || source || "none";
+  if (!reason) {
+    return sourceLabel;
+  }
+  const reasonLabel = USAGE_REASON_LABELS[reason] ?? reason;
+  return `${sourceLabel} / ${reasonLabel}`;
+}
+
 export function formatCostWithPricing(
   cost: number | null,
   currency: string | null | undefined,

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -90,6 +90,14 @@ const USAGE_REASON_LABELS: Record<string, string> = {
   ccusage_timeout: "ccusage timed out",
   ccusage_invalid_json: "ccusage output unreadable",
   ccusage_no_records: "no usage recorded yet",
+  // compute_cost_estimate reason codes surfaced via usage_payload when AWF
+  // pricing can't derive a cost (workspace_observability.py).
+  pricing_not_configured: "pricing not configured",
+  pricing_stale: "pricing stale",
+  pricing_rates_unavailable: "pricing rates unavailable",
+  no_token_data: "no token data",
+  negative_token_count: "invalid token count",
+  unsupported_pricing_unit: "unsupported pricing unit",
 };
 
 // Friendly provenance line for the LLM usage block: maps the AWF usage source

--- a/apps/console/tests/dashboard-usage.spec.ts
+++ b/apps/console/tests/dashboard-usage.spec.ts
@@ -2,6 +2,28 @@ import { expect, type Page, test } from "@playwright/test";
 
 const now = "2026-05-02T12:00:00.000Z";
 
+type UsageKind = "available" | "unavailable" | "ccusage" | "ccusage_timeout";
+
+const WORKSPACE_DEFS: { id: string; title: string; usage: UsageKind }[] = [
+  { id: "ws_usage", title: "Usage Workspace", usage: "available" },
+  { id: "ws_no_usage", title: "No Usage Workspace", usage: "unavailable" },
+  { id: "ws_ccusage", title: "Ccusage Workspace", usage: "ccusage" },
+  { id: "ws_ccusage_timeout", title: "Ccusage Timeout Workspace", usage: "ccusage_timeout" },
+];
+
+function llmUsageFor(usage: UsageKind) {
+  switch (usage) {
+    case "available":
+      return { status: "available", input_tokens: 10, output_tokens: 20, total_tokens: 30, cost_estimate: 0.05, currency: "USD", source: "mock", reason: null };
+    case "ccusage":
+      return { status: "available", input_tokens: 111, output_tokens: 222, total_tokens: 333, cost_estimate: null, currency: null, source: "ccusage", reason: null };
+    case "ccusage_timeout":
+      return { status: "unavailable", input_tokens: null, output_tokens: null, total_tokens: null, cost_estimate: null, currency: null, source: "ccusage", reason: "ccusage_timeout" };
+    default:
+      return { status: "unavailable" };
+  }
+}
+
 test.beforeEach(async ({ page }) => {
   await mockAwfApi(page);
 });
@@ -47,6 +69,31 @@ test("dashboard hides llm usage metrics when unavailable", async ({ page }) => {
   await expect(page.getByText("Total")).not.toBeVisible();
 });
 
+test("dashboard renders ccusage-backed totals and source label", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  await page.getByText("Ccusage Workspace", { exact: true }).first().click();
+
+  const usageBlock = page.locator("section").filter({ hasText: "LLM usage" }).first();
+  await expect(usageBlock).toBeVisible();
+  await expect(usageBlock.getByText("333", { exact: true })).toBeVisible();
+  // The ccusage source is surfaced as a friendly provenance label.
+  await expect(usageBlock.getByText("ccusage", { exact: false })).toBeVisible();
+});
+
+test("dashboard renders ccusage unavailable reason", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  await page.getByText("Ccusage Timeout Workspace", { exact: true }).first().click();
+
+  await expect(page.getByText("LLM usage").first()).toBeVisible();
+  await expect(page.getByText("unavailable").first()).toBeVisible();
+  // Reason code is rendered through its friendly label.
+  await expect(page.getByText("ccusage timed out", { exact: false }).first()).toBeVisible();
+});
+
 async function waitForConsoleReady(page: Page) {
   await expect(page.locator("header").filter({ hasText: "AWF Console" })).toBeVisible();
   await expect(page.getByText("API: ok")).toBeVisible();
@@ -64,10 +111,7 @@ async function mockAwfApi(page: Page) {
     if (path === "/api/awf/workspaces/overview") {
       await fulfillJson(
         route,
-        listEnvelope([
-          workspaceOverview("ws_usage", "Usage Workspace", "available"),
-          workspaceOverview("ws_no_usage", "No Usage Workspace", "unavailable"),
-        ])
+        listEnvelope(WORKSPACE_DEFS.map((def) => workspaceOverview(def.id, def.title, def.usage)))
       );
       return;
     }
@@ -94,7 +138,10 @@ async function mockAwfApi(page: Page) {
       else if (path.endsWith("/events")) await fulfillJson(route, listEnvelope([]));
       else if (path.endsWith("/operations")) await fulfillJson(route, listEnvelope([]));
       else if (path.endsWith("/logs")) await fulfillJson(route, listEnvelope([]));
-      else await fulfillJson(route, workspaceOverview(id, id === "ws_usage" ? "Usage Workspace" : "No Usage Workspace", id === "ws_usage" ? "available" : "unavailable"));
+      else {
+        const def = WORKSPACE_DEFS.find((d) => d.id === id) ?? WORKSPACE_DEFS[1];
+        await fulfillJson(route, workspaceOverview(def.id, def.title, def.usage));
+      }
       return;
     }
     if (path.endsWith("/stream")) {
@@ -118,7 +165,7 @@ function listEnvelope<T>(items: T[]) {
   return { items, next_cursor: null, has_more: false };
 }
 
-function workspaceOverview(id: string, title: string, usageStatus: string) {
+function workspaceOverview(id: string, title: string, usage: UsageKind) {
   return {
     id,
     workspace_id: id,
@@ -137,7 +184,7 @@ function workspaceOverview(id: string, title: string, usageStatus: string) {
     created_at: now,
     updated_at: now,
     lifecycle: [],
-    llm_usage: usageStatus === "available" ? { status: "available", input_tokens: 10, output_tokens: 20, total_tokens: 30, cost_estimate: 0.05, currency: "USD", source: "mock", reason: null } : { status: "unavailable" },
+    llm_usage: llmUsageFor(usage),
     coordination_warnings: [],
   };
 }

--- a/apps/console/tests/dashboard-usage.spec.ts
+++ b/apps/console/tests/dashboard-usage.spec.ts
@@ -75,7 +75,10 @@ test("dashboard renders ccusage-backed totals and source label", async ({ page }
 
   await page.getByText("Ccusage Workspace", { exact: true }).first().click();
 
-  const usageBlock = page.locator("section").filter({ hasText: "LLM usage" }).first();
+  // Scope to the usage block itself: the surrounding details section also
+  // carries the workspace title/id/branch ("Ccusage Workspace", "ws_ccusage"),
+  // which would otherwise trip strict-mode on a substring match for "ccusage".
+  const usageBlock = page.getByTestId("llm-usage");
   await expect(usageBlock).toBeVisible();
   await expect(usageBlock.getByText("333", { exact: true })).toBeVisible();
   // The ccusage source is surfaced as a friendly provenance label.

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -132,7 +132,7 @@ RUN npm install -g --no-fund --no-audit \
     && claude --version || true \
     && gemini --version || true \
     && opencode --version || true \
-    && ccusage --version || true
+    && ccusage --version
 
 # ── Stage 6: Python tooling the agent may need inside the container ────────
 RUN python -m pip install --upgrade pip \

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -134,6 +134,15 @@ RUN npm install -g --no-fund --no-audit \
     && opencode --version || true \
     && ccusage --version
 
+# Neutral ccusage config consumed via ``--config`` by AWF's usage collector
+# (src/awf/service/usage_collection.py). The per-workspace auth copy seeds
+# ~/.claude from the host and does not strip a host ccusage.json, so pinning an
+# empty config keeps ccusage from auto-discovering a user/project config whose
+# since/until/project/breakdown defaults would silently filter per-run usage.
+RUN mkdir -p /opt/awf \
+    && printf '{}\n' > /opt/awf/ccusage-neutral.json \
+    && chmod 0644 /opt/awf/ccusage-neutral.json
+
 # ── Stage 6: Python tooling the agent may need inside the container ────────
 RUN python -m pip install --upgrade pip \
     && python -m pip install --no-cache-dir \

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -117,17 +117,22 @@ ARG CODEX_VERSION=0.130.0
 ARG CLAUDE_CODE_VERSION=2.1.143
 ARG GEMINI_VERSION=0.42.0
 ARG OPENCODE_VERSION=1.15.2
+# Usage collector. Pinned (not fetched via runtime npx/bunx) so AWF's
+# per-workspace usage sampler reads local provider usage files offline.
+ARG CCUSAGE_VERSION=20.0.3
 
 RUN npm install -g --no-fund --no-audit \
       @openai/codex@${CODEX_VERSION} \
       @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
       @google/gemini-cli@${GEMINI_VERSION} \
       opencode-ai@${OPENCODE_VERSION} \
+      ccusage@${CCUSAGE_VERSION} \
     && npm cache clean --force \
     && codex --version || true \
     && claude --version || true \
     && gemini --version || true \
-    && opencode --version || true
+    && opencode --version || true \
+    && ccusage --version || true
 
 # ── Stage 6: Python tooling the agent may need inside the container ────────
 RUN python -m pip install --upgrade pip \

--- a/plans/WORKSPACE_LLM_USAGE_COLLECTOR_PLAN.md
+++ b/plans/WORKSPACE_LLM_USAGE_COLLECTOR_PLAN.md
@@ -1,0 +1,120 @@
+# Workspace LLM Usage Collector Plan
+
+## Summary
+
+AWF console renders "LLM usage unavailable / usage_not_reported" because
+`workspace_usage_summary` only ever saw provider usage metadata that an
+operation happened to attach to its payload/result. No AWF component actively
+measured per-run LLM usage inside the workspace agent container.
+
+This plan adds an AWF-owned usage collector that samples `ccusage` from inside
+the workspace agent container while agent work runs, normalizes the output into
+safe numeric accounting data, persists a latest-wins snapshot under the AWF
+`work_dir`, and surfaces it through the existing observability/API payload so the
+console shows trusted live and final usage. The collector is generic across all
+currently supported AWF providers (`claude_code`, `codex`, `gemini`,
+`opencode`), keeps operation-usage aggregation as a compatibility fallback, and
+never persists raw JSONL, file paths, or credential-bearing files.
+
+It is wired around the single shared agent execution chokepoint
+(`AgentAdapter.run`) so normal workspace execution and PR-monitor/recovery agent
+runs are covered without duplicating provider-specific runner code.
+
+## Design (as built)
+
+### Runtime image
+- `docker/agent-runtime.Dockerfile` pins `ccusage@20.0.3` via the existing
+  `npm install -g` layer (no runtime `npx`/`bunx` network fetch), with a
+  `ccusage --version` smoke line.
+
+### Provider → ccusage source mapping
+- `usage_store.provider_ccusage_source` maps AWF `AgentRuntime` to a ccusage
+  per-source subcommand: `claude_code→claude`, `codex→codex`, `gemini→gemini`,
+  `opencode→opencode`. Any runtime not in the table has no source and reports
+  `ccusage_source_unsupported` (graceful, never a crash).
+
+### Collector (`service/usage_collection.CcusageCollector`)
+- Implements the `adapters.usage.UsageSampler` protocol (a leaf module depending
+  only on stdlib + `awf.db.enums`, so `adapters.base` can accept a sampler
+  without an adapter→service import cycle).
+- Invokes `ccusage <source> daily --json --offline` through the tracked compose
+  exec, with bounded wall + idle command timeouts.
+- Captures a baseline at run start, samples every 60 seconds while the agent run
+  is active, and takes a final sample on every exit path.
+- Reports baseline-subtracted deltas (clamped at zero) so copied host history
+  and prior runs cannot inflate per-run totals. The baseline is persisted in the
+  snapshot and reused across runs of the same workspace.
+
+### Finalization / outcome safety (`adapters/base.AgentAdapter.run`)
+- `run()` wraps a refactored `_run_agent_cli()` with `_start_usage_sampling` and
+  `_finalize_usage_sampling` in `try/except/finally`, mapping success /
+  `AgentRunError` (timeout vs failed) / `CancelledError` to a final status.
+- `finalize` uses `asyncio.shield` so the final sample completes even when the
+  agent task is being cancelled. Sampling errors are reason-coded or
+  swallowed-and-logged and never mask the agent outcome.
+
+### Persistence (`service/usage_store`)
+- Single latest-wins snapshot per workspace at
+  `<work_dir>/usage/<workspace_id>/snapshot.json`, written atomically (temp +
+  `replace`).
+- Stores only normalized numeric/accounting data plus safe metadata: provider,
+  ccusage source, model when available, status, phase, reason code, timestamps,
+  token counts, cost estimate, currency, and the baseline dict. No raw JSONL, no
+  file paths, no secret-bearing content.
+- The API reader and the worker writer normalize `work_dir` identically
+  (`.expanduser().resolve()`) so they always agree on the snapshot directory.
+
+### Claude/Gemini auth isolation (`node/auth_mounts`)
+- Per-workspace auth copies exclude provider usage-history directories via
+  `shutil.ignore_patterns` (`projects`, `todos`, `shell-snapshots`, `statsig`
+  for Claude; `tmp` for Gemini), so copied host history cannot be attributed to
+  the workspace run. Baseline/delta is the second line of defence.
+
+### Observability tiers (`service/workspace_observability.workspace_usage_summary`)
+1. ccusage snapshot with metrics → trusted live/final usage.
+2. Operation-usage aggregation → compatibility fallback (preserved).
+3. ccusage snapshot without metrics → surface its reason code.
+4. `usage_not_reported`.
+
+### Console (focused, no redesign)
+- `apps/console/lib/format.ts` adds `formatUsageProvenance(source, reason)` with
+  friendly source/reason label maps.
+- `apps/console/components/console-dashboard.tsx` uses it in both the unavailable
+  and available branches of `UsageSummaryBlock`.
+
+## Normalizer reason codes
+- `ccusage_source_unsupported`, `ccusage_unavailable`, `ccusage_command_failed`,
+  `ccusage_timeout`, `ccusage_invalid_json`, `ccusage_no_records`.
+- `normalize_ccusage_json` reads `totals` first, then sums `daily`, tolerates
+  missing fields and synthesizes totals, ignores boolean/non-numeric token
+  values, and returns an explicit reason on empty/invalid input.
+
+## Test Plan
+- Provider/source mapping for all supported runtimes (claude_code, codex,
+  gemini, opencode) and unknown-runtime → `None`.
+- Claude/Gemini auth isolation excludes host usage-history directories.
+- Baseline/delta excludes pre-run usage and reuses a persisted baseline across
+  runs; fresh capture when no prior baseline exists.
+- 60-second polling cadence while the run is active; live snapshots written
+  during the run.
+- Final sample runs in success, failure, timeout, and cancellation paths without
+  masking the agent outcome.
+- Parser/normalizer: valid totals/daily, empty/no-records, command failure,
+  timeout, malformed JSON → explicit reason codes.
+- Observability prefers ccusage snapshots, falls back to operation usage, and
+  surfaces snapshot reason codes; `work_dir` normalization parity.
+- Console renders available totals and friendly unavailable reason states.
+
+## Risks, Assumptions, Non-goals
+- **Risk:** the exact ccusage multi-source CLI surface (`<source> daily --json
+  --offline`) must hold for the pinned `20.0.3`; unsupported combinations
+  degrade to reason codes, not crashes. CLI-surface verification needs the built
+  runtime image (AWF/CI-owned at build time).
+- **Risk:** API reader and worker writer must share the same physical
+  `work_dir` volume, exactly as the existing `LogStore` already assumes.
+- **Assumption:** snapshots live under `<work_dir>/usage/<workspace_id>/`,
+  outside the repo, so they are never committed and need no `.gitignore` entry.
+- **Non-goals:** no dashboard redesign, no new public REST schema fields
+  (reuse `LlmUsageSummary`), no removal of operation-usage aggregation, no DB
+  migrations (snapshots are file-backed), and no persistence of raw JSONL or
+  secret-bearing files.

--- a/plans/WORKSPACE_LLM_USAGE_COLLECTOR_VALIDATION.md
+++ b/plans/WORKSPACE_LLM_USAGE_COLLECTOR_VALIDATION.md
@@ -1,0 +1,86 @@
+# Workspace LLM Usage Collector Validation
+
+## Context
+
+This workspace is a timeout-salvage continuation (source reason
+`AGENT_IDLE_TIMEOUT`). AWF restored the prior agent's diff; this run continued
+from the recovered, substantially-complete implementation. Per the AWF
+workspace contract, broad/coverage/e2e validation (full
+`pytest --cov-fail-under`, repo-wide ruff/mypy, `pre-commit`, the Playwright
+suite, and image builds) is owned by AWF + GitHub CI after the agent phase and
+was deliberately not run locally (the prior idle timeout is consistent with a
+long-running broad/coverage run). The checks below are focused on the changed
+files only.
+
+## Plan Alignment
+- Pinned `ccusage@20.0.3` in `docker/agent-runtime.Dockerfile` via `npm install
+  -g` with a `ccusage --version` smoke line (no runtime npx/bunx fetch).
+- Added `adapters/usage.py` (`UsageSampler`/`UsageSampleContext` leaf protocols),
+  `service/usage_store.py` (provider→source map, normalizer, baseline/delta,
+  durable latest-wins snapshot, reason codes), and
+  `service/usage_collection.py` (`CcusageCollector`: baseline capture, 60s loop,
+  shielded finalize, bounded timeouts).
+- Wired sampling into the shared chokepoint `AgentAdapter.run` and threaded
+  `usage_sampler` through `WorkspaceExecutor` (all three agent call sites) and
+  `build_worker_runtime`, covering normal execution and PR-monitor/recovery.
+- Excluded provider usage-history directories from per-workspace Claude/Gemini
+  auth copies in `node/auth_mounts.py`.
+- Tiered `workspace_usage_summary`: ccusage-with-metrics → operation fallback →
+  ccusage reason code → `usage_not_reported`; preserved operation aggregation.
+- Focused console change: `formatUsageProvenance` in `lib/format.ts`, used in
+  both branches of `UsageSummaryBlock`.
+- Hardened `usage_store._resolve_work_dir` to normalize the default `work_dir`
+  with `.expanduser().resolve()`, matching the worker's normalization so the API
+  reader and collector writer agree on the snapshot directory (G3).
+
+## Verification (focused)
+- `uv run --python 3.12 --extra dev pytest -q tests/unit/service/test_usage_store.py tests/unit/service/test_usage_collection.py tests/unit/adapters/test_base_usage_collection.py tests/unit/node/test_service_auth_mounts.py tests/unit/service/test_worker.py tests/unit/service/test_workspaces_observability.py`
+  - Result: passed, 212 tests.
+- TDD for G3: ran the new
+  `tests/unit/service/test_usage_store.py::test_read_latest_usage_snapshot_normalizes_user_home_work_dir`
+  against the unpatched `_resolve_work_dir` first — failed (reader returned
+  `None` for a `~/`-prefixed `work_dir`); after the one-line normalization it
+  passed.
+- `uv run --python 3.12 --extra dev pytest -q tests/unit/service/test_usage_store.py`
+  - Result: passed, 35 tests.
+- `uv run --python 3.12 --extra dev ruff check src/awf/adapters/usage.py src/awf/service/usage_store.py src/awf/service/usage_collection.py src/awf/adapters/base.py src/awf/control/executor.py src/awf/service/worker.py src/awf/node/auth_mounts.py src/awf/service/workspace_observability.py tests/unit/service/test_usage_store.py tests/unit/service/test_usage_collection.py tests/unit/adapters/test_base_usage_collection.py`
+  - Result: passed (All checks passed!).
+- `uv run --python 3.12 --extra dev mypy src/awf/adapters/usage.py src/awf/service/usage_store.py src/awf/service/usage_collection.py src/awf/adapters/base.py src/awf/service/worker.py src/awf/service/workspace_observability.py`
+  - Result: passed (no issues found in 6 source files).
+- `node --test lib/format.test.mjs` (run from `apps/console`)
+  - Result: passed, 15 tests.
+
+## Required-behavior → covering tests
+- Provider/source map (claude_code, codex, gemini, opencode):
+  `test_usage_store::test_provider_ccusage_source_maps_all_supported_runtimes`,
+  `test_usage_collection::test_ccusage_argv_per_provider`.
+- Claude/Gemini auth isolation excludes host history:
+  `test_service_auth_mounts::test_*_exclude_*_usage_history`.
+- Baseline/delta excludes pre-run usage; baseline reused:
+  `test_usage_collection::test_baseline_subtracted_from_final_sample`,
+  `::test_persisted_baseline_reused_across_runs`,
+  `::test_prior_snapshot_without_baseline_captures_fresh`.
+- 60s cadence while active:
+  `test_usage_collection::test_samples_at_sixty_second_interval_while_active`,
+  `::test_live_snapshots_written_during_run`.
+- Final sample in success/failure/timeout/cancellation, no outcome masking:
+  `test_base_usage_collection::test_sampler_finalized_*` and
+  `::test_sampler_*_does_not_mask_*`;
+  `test_usage_collection::test_finalize_completes_final_sample_under_cancellation`.
+- Parser reason codes (valid/empty/failure/timeout/malformed):
+  `test_usage_store::test_normalize_ccusage_json_*`,
+  `test_usage_collection::test_final_sample_reason_codes`.
+- Observability prefers ccusage, falls back to operations, `work_dir` parity:
+  `test_workspaces_observability::test_workspace_usage_summary_*`,
+  `test_usage_store::test_read_latest_usage_snapshot_normalizes_user_home_work_dir`.
+- Console renders totals + friendly unavailable reasons:
+  `format.test.mjs::formatUsageProvenance*`,
+  `dashboard-usage.spec.ts` ccusage cases.
+
+## Deferred to AWF + GitHub CI (not run locally)
+- Full `pytest --cov=awf --cov-report=term-missing --cov-fail-under` suite.
+- Repo-wide ruff/mypy and `pre-commit`.
+- Playwright e2e (`apps/console/tests/dashboard-usage.spec.ts`).
+- `docker build` of `docker/agent-runtime.Dockerfile` and runtime `ccusage`
+  CLI-surface smoke (`ccusage <source> daily --json --offline`), which requires
+  the built image.

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from awf.adapters.provider_failures import classify_provider_failure
+from awf.adapters.usage import UsageSampleContext, UsageSampler
 from awf.common.commands import (
     COMMAND_IDLE_TIMEOUT_REASON,
     COMMAND_TIMEOUT_REASON,
@@ -124,6 +125,7 @@ class AgentAdapter(ABC):
         log_store: LogStore | None = None,
         agent_wall_timeout_seconds: float = DEFAULT_AGENT_WALL_TIMEOUT_SECONDS,
         agent_idle_timeout_seconds: float = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
+        usage_sampler: UsageSampler | None = None,
     ) -> None:
         if agent_wall_timeout_seconds <= 0:
             raise ValueError("agent_wall_timeout_seconds must be positive")
@@ -135,6 +137,7 @@ class AgentAdapter(ABC):
         self._log_store = log_store
         self._agent_wall_timeout_seconds = agent_wall_timeout_seconds
         self._agent_idle_timeout_seconds = agent_idle_timeout_seconds
+        self._usage_sampler = usage_sampler
 
     @property
     @abstractmethod
@@ -205,6 +208,100 @@ class AgentAdapter(ABC):
             source=log_source,
             prompt_bytes=len(prompt_input),
         )
+        # Wrap the agent run with optional usage sampling. The sampler captures a
+        # baseline + periodic samples and is finalized in *every* exit path so the
+        # final usage sample is recorded on success, failure/timeout, and
+        # cancellation — never masking the agent outcome.
+        sampler_ctx = await self._start_usage_sampling(
+            compose_project=compose_project,
+            compose_file=compose_file,
+            workspace_id=workspace_id,
+        )
+        final_status = "failed"
+        try:
+            result = await self._run_agent_cli(
+                invocation=invocation,
+                args=args,
+                prompt_input=prompt_input,
+                model=model,
+                workspace_id=workspace_id,
+                log_source=log_source,
+                compose_project=compose_project,
+            )
+            final_status = "success"
+            return result
+        except AgentRunError as exc:
+            final_status = (
+                "timeout"
+                if exc.reason_code in {"AGENT_TIMEOUT", "AGENT_IDLE_TIMEOUT"}
+                else "failed"
+            )
+            raise
+        except asyncio.CancelledError:
+            final_status = "cancelled"
+            raise
+        finally:
+            await self._finalize_usage_sampling(
+                sampler_ctx, status=final_status, workspace_id=workspace_id
+            )
+
+    async def _start_usage_sampling(
+        self,
+        *,
+        compose_project: str,
+        compose_file: Path,
+        workspace_id: str | None,
+    ) -> UsageSampleContext | None:
+        if self._usage_sampler is None or workspace_id is None:
+            return None
+        try:
+            return await self._usage_sampler.start(
+                compose_project=compose_project,
+                compose_file=compose_file,
+                workspace_id=workspace_id,
+                provider=self.name,
+            )
+        except Exception:
+            _log.warning(
+                "usage.collect.error",
+                agent=self.name.value,
+                workspace_id=workspace_id,
+                phase="start",
+                exc_info=True,
+            )
+            return None
+
+    async def _finalize_usage_sampling(
+        self,
+        sampler_ctx: UsageSampleContext | None,
+        *,
+        status: str,
+        workspace_id: str | None,
+    ) -> None:
+        if sampler_ctx is None:
+            return
+        try:
+            await sampler_ctx.finalize(status=status)
+        except Exception:
+            _log.warning(
+                "usage.collect.error",
+                agent=self.name.value,
+                workspace_id=workspace_id,
+                phase="finalize",
+                exc_info=True,
+            )
+
+    async def _run_agent_cli(
+        self,
+        *,
+        invocation: Any,
+        args: list[str],
+        prompt_input: bytes,
+        model: str | None,
+        workspace_id: str | None,
+        log_source: str,
+        compose_project: str,
+    ) -> AgentRunResult:
         # Stream the prompt on stdin and close it explicitly. This avoids OS
         # argv length limits for large review comments while still preventing
         # CLIs from waiting forever for inherited interactive input.
@@ -352,6 +449,7 @@ def get_adapter(
     log_store: LogStore | None = None,
     agent_wall_timeout_seconds: float = DEFAULT_AGENT_WALL_TIMEOUT_SECONDS,
     agent_idle_timeout_seconds: float = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
+    usage_sampler: UsageSampler | None = None,
 ) -> AgentAdapter:
     """Instantiate the adapter for the given runtime.
 
@@ -369,6 +467,7 @@ def get_adapter(
         log_store=log_store,
         agent_wall_timeout_seconds=agent_wall_timeout_seconds,
         agent_idle_timeout_seconds=agent_idle_timeout_seconds,
+        usage_sampler=usage_sampler,
     )
 
 

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -232,14 +232,18 @@ class AgentAdapter(ABC):
         # Wrap the agent run with optional usage sampling. The sampler captures a
         # baseline + periodic samples and is finalized in *every* exit path so the
         # final usage sample is recorded on success, failure/timeout, and
-        # cancellation — never masking the agent outcome.
-        sampler_ctx = await self._start_usage_sampling(
-            compose_project=compose_project,
-            compose_file=compose_file,
-            workspace_id=workspace_id,
-        )
+        # cancellation — never masking the agent outcome. _start_usage_sampling
+        # stays *inside* the try: cancellation during baseline capture re-raises
+        # CancelledError (a BaseException its own except-Exception guard can't
+        # catch), so only the enclosing try/finally still reaches finalization.
+        sampler_ctx: UsageSampleContext | None = None
         final_status = "failed"
         try:
+            sampler_ctx = await self._start_usage_sampling(
+                compose_project=compose_project,
+                compose_file=compose_file,
+                workspace_id=workspace_id,
+            )
             result = await self._run_agent_cli(
                 invocation=invocation,
                 args=args,

--- a/src/awf/adapters/usage.py
+++ b/src/awf/adapters/usage.py
@@ -1,0 +1,42 @@
+"""Usage-sampling protocols shared by the agent adapter and collectors.
+
+This is a leaf module: it depends only on stdlib + ``awf.db.enums`` so the agent
+adapter (``awf.adapters.base``) can accept an optional usage sampler without
+importing any ``awf.service`` code (which would create an import cycle, since the
+service layer imports adapters). The concrete implementation lives in
+``awf.service.usage_collection``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from awf.db.enums import AgentRuntime
+
+
+class UsageSampleContext(Protocol):
+    """Handle for a single agent run's in-progress usage sampling."""
+
+    async def finalize(  # pragma: no cover - Protocol method declaration only.
+        self, *, status: str
+    ) -> None:
+        """Stop periodic sampling and record one final usage sample.
+
+        ``status`` is the agent run outcome (``"success"``/``"failed"``/
+        ``"timeout"``/``"cancelled"``). Implementations must never raise — the
+        agent outcome must not be masked by usage-collection errors.
+        """
+
+
+class UsageSampler(Protocol):
+    """Starts usage sampling for an agent run inside its workspace container."""
+
+    async def start(  # pragma: no cover - Protocol method declaration only.
+        self,
+        *,
+        compose_project: str,
+        compose_file: Path,
+        workspace_id: str,
+        provider: AgentRuntime,
+    ) -> UsageSampleContext: ...

--- a/src/awf/control/executor.py
+++ b/src/awf/control/executor.py
@@ -40,6 +40,7 @@ from awf.adapters.base import (
     get_adapter,
 )
 from awf.adapters.defaults import DEFAULT_AGENT_DEFAULTS, defaults_with_model_overrides
+from awf.adapters.usage import UsageSampler
 from awf.common.audit import redact_audit_text, redact_audit_value
 from awf.common.command_evidence import append_command_evidence
 from awf.common.commands import AsyncCommandRunner, CommandResult
@@ -1087,6 +1088,7 @@ class WorkspaceExecutor:
         pr_monitor: _MonitorRunnerProto | None = None,
         pr_monitor_factory: Callable[..., _MonitorRunnerProto] | None = None,
         log_store: LogStore | None = None,
+        usage_sampler: UsageSampler | None = None,
     ) -> None:
         """``pr_monitor`` and ``pr_monitor_factory`` are mutually exclusive
         optional hooks that wire the ``monitoring_pr`` stage:
@@ -1114,6 +1116,7 @@ class WorkspaceExecutor:
         self._pr_monitor = pr_monitor
         self._pr_monitor_factory = pr_monitor_factory
         self._log_store = log_store
+        self._usage_sampler = usage_sampler
 
     async def _record_executor_pr_audit_event(
         self,
@@ -1484,6 +1487,7 @@ class WorkspaceExecutor:
                     log_store=self._log_store,
                     agent_wall_timeout_seconds=self._config.agent_wall_timeout_seconds,
                     agent_idle_timeout_seconds=self._config.agent_idle_timeout_seconds,
+                    usage_sampler=self._usage_sampler,
                 )
                 profile = _profile_for_workspace(
                     workspace,
@@ -1740,6 +1744,7 @@ class WorkspaceExecutor:
                 log_store=self._log_store,
                 agent_wall_timeout_seconds=self._config.agent_wall_timeout_seconds,
                 agent_idle_timeout_seconds=self._config.agent_idle_timeout_seconds,
+                usage_sampler=self._usage_sampler,
             )
             profile = _profile_for_workspace(
                 ws,
@@ -3799,6 +3804,7 @@ class WorkspaceExecutor:
                     runner=self._runner,
                     defaults=adapter_defaults,
                     log_store=self._log_store,
+                    usage_sampler=self._usage_sampler,
                 )
                 profile = _profile_for_workspace(
                     ws,

--- a/src/awf/node/auth_mounts.py
+++ b/src/awf/node/auth_mounts.py
@@ -23,6 +23,13 @@ _GEMINI_TARGET = f"{_CONTAINER_HOME}/.gemini"
 _OPENCODE_TARGET = f"{_CONTAINER_HOME}/.config/opencode"
 _OLLAMA_TARGET = f"{_CONTAINER_HOME}/.ollama"
 _OLLAMA_AUTH_FILES = frozenset(("config.json", "id_ed25519", "id_ed25519.pub"))
+# Per-workspace Claude/Gemini auth copies must exclude historical usage/transcript
+# dirs. Otherwise ``ccusage`` (which reads these local files) would attribute the
+# host's prior usage to the workspace run; baseline/delta still guards totals, but
+# excluding the copy keeps the workspace from seeing unrelated host transcripts and
+# avoids copying potentially large history trees.
+_CLAUDE_USAGE_HISTORY_DIRS = ("projects", "todos", "shell-snapshots", "statsig")
+_GEMINI_USAGE_HISTORY_DIRS = ("tmp",)
 _LEGACY_PROVIDER_TARGETS: Mapping[str, frozenset[str]] = {
     "github": frozenset({_GH_CONFIG_TARGET}),
 }
@@ -287,7 +294,12 @@ def _prepare_isolated_claude_auth(
     if _CLAUDE_DIR_TARGET not in suppressed_targets and source_dir.is_dir():
         target_root.mkdir(parents=True, exist_ok=True)
         if not target_dir.exists():
-            shutil.copytree(source_dir, target_dir, ignore_dangling_symlinks=True)
+            shutil.copytree(
+                source_dir,
+                target_dir,
+                ignore=shutil.ignore_patterns(*_CLAUDE_USAGE_HISTORY_DIRS),
+                ignore_dangling_symlinks=True,
+            )
         mounts.append(
             AuthMount(
                 source=str(target_dir),
@@ -323,7 +335,11 @@ def _prepare_isolated_gemini_auth(*, host_home: Path, target_root: Path) -> tupl
 
     target_root.mkdir(parents=True, exist_ok=True)
     if not target_dir.exists():
-        shutil.copytree(source_dir, target_dir)
+        shutil.copytree(
+            source_dir,
+            target_dir,
+            ignore=shutil.ignore_patterns(*_GEMINI_USAGE_HISTORY_DIRS),
+        )
 
     return (
         AuthMount(

--- a/src/awf/service/tasks.py
+++ b/src/awf/service/tasks.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.schemas import (
@@ -14,7 +16,9 @@ from awf.api.schemas import (
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import MergeCandidate, TaskAttempt, Workspace
 from awf.db.repositories import TaskAttemptRepository, TaskRepository, WorkspaceRepository
+from awf.service.usage_store import read_latest_usage_snapshots
 from awf.service.workspace_observability import (
+    prefetched_usage_snapshots,
     workspace_identity_usage_payload,
     workspace_pricing_metadata,
 )
@@ -176,15 +180,19 @@ async def build_task_list_response(
     canonical_attempt_ids = await attempt_repo.list_canonical_ids_for_tasks(
         row.task_id for row in attempt_rows
     )
+    workspace_ids = [row.workspace_id for row in attempt_rows]
+    workspace_ids.extend(row.id for row in legacy_rows)
+    snapshots = await asyncio.to_thread(read_latest_usage_snapshots, workspace_ids)
     items: list[TaskResponse] = []
-    for row in attempt_rows:
-        items.append(
-            _task_from_attempt(
-                row,
-                canonical_attempt_id=canonical_attempt_ids.get(row.task_id),
+    with prefetched_usage_snapshots(snapshots):
+        for row in attempt_rows:
+            items.append(
+                _task_from_attempt(
+                    row,
+                    canonical_attempt_id=canonical_attempt_ids.get(row.task_id),
+                )
             )
-        )
-    items.extend(_task_from_workspace(row) for row in legacy_rows)
+        items.extend(_task_from_workspace(row) for row in legacy_rows)
     items.sort(key=lambda item: (item.created_at, item.workspace_id), reverse=True)
     return TaskListResponse(
         items=items[:limit],

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -34,6 +34,7 @@ from awf.common.logging import get_logger
 from awf.db.enums import AgentRuntime
 from awf.service.usage_store import (
     REASON_COMMAND_FAILED,
+    REASON_NO_RECORDS,
     REASON_SOURCE_UNSUPPORTED,
     REASON_TIMEOUT,
     REASON_UNAVAILABLE,
@@ -112,7 +113,7 @@ class CcusageCollector(UsageSampler):
             # Unsupported provider: record the reason once, no periodic loop.
             await ctx._safe_sample(phase="live", status="running")
             return ctx
-        ctx._baseline = await ctx._capture_baseline()
+        await ctx._capture_baseline()
         ctx._task = asyncio.create_task(ctx._run_loop())
         return ctx
 
@@ -137,6 +138,10 @@ class _CcusageSampleContext(UsageSampleContext):
         self._provider = provider
         self._source = source
         self._baseline: NormalizedUsage | None = None
+        # Set when baseline capture failed (vs. a fresh, legitimately empty one).
+        # While set, samples report unavailable instead of subtracting against a
+        # missing baseline and leaking copied host history into the totals.
+        self._baseline_unavailable_reason: str | None = None
         self._task: asyncio.Task[None] | None = None
         self._finalized = False
 
@@ -168,24 +173,38 @@ class _CcusageSampleContext(UsageSampleContext):
             await self._collector._clock.sleep(self._collector._interval_seconds)
             await self._safe_sample(phase="live", status="running")
 
-    async def _capture_baseline(self) -> NormalizedUsage | None:
+    async def _capture_baseline(self) -> None:
         prior = read_latest_usage_snapshot(self._workspace_id, work_dir=self._collector._work_dir)
         if prior is not None:
             reused = prior.baseline_usage()
             if reused is not None:
-                return reused
+                self._baseline = reused
+                return
         try:
-            usage, _reason, _model = await self._run_ccusage()
+            usage, reason, _model = await self._run_ccusage()
         except asyncio.CancelledError:
             raise
         except Exception:
+            # Unexpected runner failure: swallow-and-log so the agent outcome is
+            # never masked, but flag the baseline as unanchored so later samples
+            # don't subtract against nothing and leak copied host history.
             _log.warning(
                 "usage.collect.baseline_error",
                 workspace_id=self._workspace_id,
                 exc_info=True,
             )
-            return None
-        return usage
+            self._baseline_unavailable_reason = REASON_COMMAND_FAILED
+            return
+        if usage is not None:
+            self._baseline = usage
+            return
+        if reason == REASON_NO_RECORDS:
+            # Fresh workspace: ccusage ran cleanly with no prior host usage, so an
+            # empty baseline is correct and later totals are genuine workspace usage.
+            return
+        # ccusage failed for a classified reason (timeout / command error /
+        # unreadable output): we can't anchor a trustworthy baseline, so flag it.
+        self._baseline_unavailable_reason = reason or REASON_COMMAND_FAILED
 
     async def _safe_sample(self, *, phase: str, status: str) -> None:
         try:
@@ -217,6 +236,18 @@ class _CcusageSampleContext(UsageSampleContext):
                 phase=phase,
                 status_label="unavailable",
                 reason=reason,
+                metrics=NormalizedUsage(),
+                model=None,
+            )
+            return
+        if self._baseline_unavailable_reason is not None:
+            # We have a current reading but never anchored a baseline, so a delta
+            # would expose copied host history. Report unavailable with the
+            # baseline failure reason instead of an inflated total.
+            self._write(
+                phase=phase,
+                status_label="unavailable",
+                reason=self._baseline_unavailable_reason,
                 metrics=NormalizedUsage(),
                 model=None,
             )

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -209,6 +209,13 @@ class _CcusageSampleContext(UsageSampleContext):
             await pending
 
     async def _run_loop(self) -> None:
+        # ``interval_seconds`` (DEFAULT_SAMPLE_INTERVAL_SECONDS) is the sleep
+        # *between* samples, not a fixed wall-clock period: each iteration then
+        # runs _safe_sample, which can itself spend up to ``command_timeout_seconds``
+        # waiting on ccusage, so the effective period is interval + sample time
+        # (~80s worst case at the defaults). Sampling is a diagnostic, so this
+        # gap-based cadence (no drift correction back to a fixed clock) is
+        # intentional; tune the constant with that composition in mind.
         while True:
             await self._collector._clock.sleep(self._collector._interval_seconds)
             await self._safe_sample(phase="live", run_status="running")
@@ -423,7 +430,11 @@ class _CcusageSampleContext(UsageSampleContext):
         # (see ``_CCUSAGE_NEUTRAL_CONFIG_PATH``). A future pin that moves the provider
         # behind a flag (e.g. ``--source``) or renames/removes ``--config`` would make
         # this invocation degrade to REASON_COMMAND_FAILED, so re-verify the argument
-        # order and flags whenever the Dockerfile pin is bumped.
+        # order and flags whenever the Dockerfile pin is bumped. ``--offline`` is
+        # ccusage's global ``-O`` option and is accepted by every source subcommand,
+        # including ``opencode``, at the pinned 20.0.3 (verified: ``ccusage opencode
+        # daily --help`` lists ``-O, --offline`` and the full invocation exits 0), so
+        # it does not degrade opencode runs even though the docs page omits it.
         invocation = build_tracked_compose_exec(
             compose_project=self._compose_project,
             compose_file=self._compose_file,

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -150,6 +150,9 @@ class _CcusageSampleContext(UsageSampleContext):
         self._baseline_unavailable_reason: str | None = None
         self._task: asyncio.Task[None] | None = None
         self._finalized = False
+        # Most recent snapshot write, tracked so finalize() can drain an in-flight
+        # live write before issuing its own final write (see _write / _drain_pending_write).
+        self._pending_write: asyncio.Task[Path] | None = None
 
     async def finalize(self, *, status: str) -> None:
         if self._finalized:
@@ -164,6 +167,7 @@ class _CcusageSampleContext(UsageSampleContext):
 
     async def _finalize_inner(self, status: str) -> None:
         await self._cancel_loop()
+        await self._drain_pending_write()
         await self._safe_sample(phase="final", run_status=status)
 
     async def _cancel_loop(self) -> None:
@@ -173,6 +177,19 @@ class _CcusageSampleContext(UsageSampleContext):
         task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await task
+
+    async def _drain_pending_write(self) -> None:
+        # _cancel_loop only cancels the loop *task*; if it was awaiting a snapshot
+        # write, the thread-pool job is uncancellable and keeps running to its
+        # tmp.replace(target) rename. Wait for that write (kept reachable past the
+        # cancellation by the shield in _write) to land before finalize issues its
+        # own write, so a late live-write rename can't clobber the final snapshot
+        # under the store's latest-wins semantics.
+        pending = self._pending_write
+        if pending is None:
+            return
+        with contextlib.suppress(Exception):
+            await pending
 
     async def _run_loop(self) -> None:
         while True:
@@ -356,9 +373,17 @@ class _CcusageSampleContext(UsageSampleContext):
             currency=metrics.currency,
             baseline=self._baseline.as_baseline_dict() if self._baseline is not None else None,
         )
-        # Offload the blocking mkdir/write/replace off the event loop; finalize()
-        # shields its sample so the final write still completes under cancellation.
-        await asyncio.to_thread(write_usage_snapshot, snapshot, work_dir=self._collector._work_dir)
+        # Offload the blocking mkdir/write/replace off the event loop, tracking the
+        # write so finalize() can drain it. shield keeps the worker-thread job
+        # reachable when a loop cancellation interrupts this await: the await raises
+        # CancelledError but the thread keeps running to its tmp.replace(target)
+        # rename, and the tracked task lets _drain_pending_write order that rename
+        # before the final write. finalize() also shields its own sample so the
+        # final write still completes under outer cancellation.
+        self._pending_write = asyncio.create_task(
+            asyncio.to_thread(write_usage_snapshot, snapshot, work_dir=self._collector._work_dir)
+        )
+        await asyncio.shield(self._pending_write)
 
     async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
         # Expected ccusage CLI contract (pinned at 20.0.3 in

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -54,6 +54,11 @@ from awf.service.usage_store import (
 
 _log = get_logger(__name__)
 
+# Gap *between* samples, not a fixed wall-clock period: each loop iteration
+# sleeps this long and then runs ccusage (up to the command timeout below), so
+# the effective cadence is this value + sample time (~80s worst case at the
+# defaults). See ``_run_loop`` for the full rationale; callers/tests overriding
+# the interval should reason about sample frequency with that composition in mind.
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 60.0
 DEFAULT_CCUSAGE_COMMAND_TIMEOUT_SECONDS = 20.0
 

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -149,7 +149,7 @@ class _CcusageSampleContext(UsageSampleContext):
         if self._finalized:
             return
         self._finalized = True
-        final_task = asyncio.ensure_future(self._finalize_inner(status))
+        final_task = asyncio.create_task(self._finalize_inner(status))
         # Shield the final sample so it still completes if the agent run is being
         # cancelled (the await below may be cancelled repeatedly).
         while not final_task.done():

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -71,10 +71,13 @@ class _RealClock:
 def _is_missing_binary(result: CommandResult) -> bool:
     if result.returncode == 127:
         return True
-    # Only inspect stderr: a shell's "command not found" lands there, whereas
-    # ccusage's own stdout may legitimately contain "not found" for app-level
-    # reasons (e.g. "record not found"), which must stay REASON_COMMAND_FAILED.
-    return "not found" in result.stderr.lower()
+    # A real missing binary exits 127 (handled above); only treat stderr as a
+    # missing-binary signal for the exact phrases shells emit ("command not
+    # found" from bash, "no such file" from a failed exec/setsid). This keeps
+    # app-level errors that merely contain "not found" (e.g. ccusage
+    # "source not found") classified as REASON_COMMAND_FAILED.
+    stderr_lower = result.stderr.lower()
+    return "command not found" in stderr_lower or "no such file" in stderr_lower
 
 
 class CcusageCollector(UsageSampler):

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -175,7 +175,16 @@ class _CcusageSampleContext(UsageSampleContext):
 
     async def _capture_baseline(self) -> None:
         prior = read_latest_usage_snapshot(self._workspace_id, work_dir=self._collector._work_dir)
-        if prior is not None:
+        # Reuse a prior baseline only when it was anchored for the same
+        # provider/source. A workspace can switch agents in place (provider
+        # recovery fallback mutates Workspace.agent for the same workspace_id),
+        # and a baseline from the old provider would subtract against an
+        # unrelated ccusage source and skew the delta.
+        if (
+            prior is not None
+            and prior.provider == self._provider.value
+            and prior.ccusage_source == self._source
+        ):
             reused = prior.baseline_usage()
             if reused is not None:
                 self._baseline = reused

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -53,6 +53,21 @@ _log = get_logger(__name__)
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 60.0
 DEFAULT_CCUSAGE_COMMAND_TIMEOUT_SECONDS = 20.0
 
+# Neutral ccusage config baked into the agent-runtime image (see
+# docker/agent-runtime.Dockerfile). Passed via ``--config`` on every ccusage
+# invocation so the collector loads ONLY this empty config and ccusage skips
+# auto-discovery of ``.ccusage/ccusage.json`` (cwd), ``~/.claude/ccusage.json``
+# and ``~/.config/claude/ccusage.json``. The per-workspace auth copy seeds
+# ``~/.claude`` from the host (see ``_prepare_isolated_claude_auth``) and does
+# not strip a host ``ccusage.json``, so without this pin a host config's
+# ``since``/``until``/``project``/``breakdown``/``instances`` defaults (or
+# per-``daily`` overrides) would silently filter the sampler's reading to partial
+# totals or REASON_NO_RECORDS instead of full per-run usage. Pinning any path
+# bypasses discovery even when the file is absent (ccusage then applies no
+# config), so the isolation holds regardless; the baked empty file additionally
+# guards against a future pin that might reject a missing ``--config`` target.
+_CCUSAGE_NEUTRAL_CONFIG_PATH = "/opt/awf/ccusage-neutral.json"
+
 
 class _Clock(Protocol):
     def now(self) -> datetime: ...  # pragma: no cover - Protocol declaration only.
@@ -387,16 +402,27 @@ class _CcusageSampleContext(UsageSampleContext):
 
     async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
         # Expected ccusage CLI contract (pinned at 20.0.3 in
-        # docker/agent-runtime.Dockerfile): ``ccusage <source> daily --json --offline``,
-        # where ``<source>`` is a positional provider sub-command ("claude" /
-        # "codex" / "gemini" / "opencode"; see ``provider_ccusage_source``). A future
-        # pin that moves the provider behind a flag (e.g. ``--source``) would make
-        # this positional invocation degrade to REASON_COMMAND_FAILED, so re-verify
-        # this argument order whenever the Dockerfile pin is bumped.
+        # docker/agent-runtime.Dockerfile): ``ccusage <source> daily --json --offline
+        # --config <neutral>``, where ``<source>`` is a positional provider
+        # sub-command ("claude" / "codex" / "gemini" / "opencode"; see
+        # ``provider_ccusage_source``) and ``--config`` pins a neutral config so
+        # auto-discovered user/project ccusage configs can't filter per-run totals
+        # (see ``_CCUSAGE_NEUTRAL_CONFIG_PATH``). A future pin that moves the provider
+        # behind a flag (e.g. ``--source``) or renames/removes ``--config`` would make
+        # this invocation degrade to REASON_COMMAND_FAILED, so re-verify the argument
+        # order and flags whenever the Dockerfile pin is bumped.
         invocation = build_tracked_compose_exec(
             compose_project=self._compose_project,
             compose_file=self._compose_file,
-            cli_args=["ccusage", str(self._source), "daily", "--json", "--offline"],
+            cli_args=[
+                "ccusage",
+                str(self._source),
+                "daily",
+                "--json",
+                "--offline",
+                "--config",
+                _CCUSAGE_NEUTRAL_CONFIG_PATH,
+            ],
             source="usage",
             label="ccusage",
         )

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -71,8 +71,10 @@ class _RealClock:
 def _is_missing_binary(result: CommandResult) -> bool:
     if result.returncode == 127:
         return True
-    haystack = f"{result.stdout} {result.stderr}".lower()
-    return "not found" in haystack
+    # Only inspect stderr: a shell's "command not found" lands there, whereas
+    # ccusage's own stdout may legitimately contain "not found" for app-level
+    # reasons (e.g. "record not found"), which must stay REASON_COMMAND_FAILED.
+    return "not found" in result.stderr.lower()
 
 
 class CcusageCollector(UsageSampler):

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -230,7 +230,7 @@ class _CcusageSampleContext(UsageSampleContext):
 
     async def _sample_and_write(self, *, phase: str, run_status: str) -> None:
         if self._source is None:
-            self._write(
+            await self._write(
                 phase=phase,
                 run_status=run_status,
                 status_label="unavailable",
@@ -241,7 +241,7 @@ class _CcusageSampleContext(UsageSampleContext):
             return
         usage, reason, model = await self._run_ccusage()
         if usage is None:
-            self._write(
+            await self._write(
                 phase=phase,
                 run_status=run_status,
                 status_label="unavailable",
@@ -254,7 +254,7 @@ class _CcusageSampleContext(UsageSampleContext):
             # We have a current reading but never anchored a baseline, so a delta
             # would expose copied host history. Report unavailable with the
             # baseline failure reason instead of an inflated total.
-            self._write(
+            await self._write(
                 phase=phase,
                 run_status=run_status,
                 status_label="unavailable",
@@ -264,7 +264,7 @@ class _CcusageSampleContext(UsageSampleContext):
             )
             return
         delta = subtract_baseline(usage, self._baseline)
-        self._write(
+        await self._write(
             phase=phase,
             run_status=run_status,
             status_label="available",
@@ -273,7 +273,7 @@ class _CcusageSampleContext(UsageSampleContext):
             model=model,
         )
 
-    def _write(
+    async def _write(
         self,
         *,
         phase: str,
@@ -300,7 +300,9 @@ class _CcusageSampleContext(UsageSampleContext):
             currency=metrics.currency,
             baseline=self._baseline.as_baseline_dict() if self._baseline is not None else None,
         )
-        write_usage_snapshot(snapshot, work_dir=self._collector._work_dir)
+        # Offload the blocking mkdir/write/replace off the event loop; finalize()
+        # shields its sample so the final write still completes under cancellation.
+        await asyncio.to_thread(write_usage_snapshot, snapshot, work_dir=self._collector._work_dir)
 
     async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
         invocation = build_tracked_compose_exec(

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -114,7 +114,7 @@ class CcusageCollector(UsageSampler):
         )
         if source is None:
             # Unsupported provider: record the reason once, no periodic loop.
-            await ctx._safe_sample(phase="live", status="running")
+            await ctx._safe_sample(phase="live", run_status="running")
             return ctx
         await ctx._capture_baseline()
         ctx._task = asyncio.create_task(ctx._run_loop())
@@ -161,7 +161,7 @@ class _CcusageSampleContext(UsageSampleContext):
 
     async def _finalize_inner(self, status: str) -> None:
         await self._cancel_loop()
-        await self._safe_sample(phase="final", status=status)
+        await self._safe_sample(phase="final", run_status=status)
 
     async def _cancel_loop(self) -> None:
         task = self._task
@@ -174,7 +174,7 @@ class _CcusageSampleContext(UsageSampleContext):
     async def _run_loop(self) -> None:
         while True:
             await self._collector._clock.sleep(self._collector._interval_seconds)
-            await self._safe_sample(phase="live", status="running")
+            await self._safe_sample(phase="live", run_status="running")
 
     async def _capture_baseline(self) -> None:
         # Always capture a fresh reading at run start; never reuse a prior
@@ -211,9 +211,9 @@ class _CcusageSampleContext(UsageSampleContext):
         # unreadable output): we can't anchor a trustworthy baseline, so flag it.
         self._baseline_unavailable_reason = reason or REASON_COMMAND_FAILED
 
-    async def _safe_sample(self, *, phase: str, status: str) -> None:
+    async def _safe_sample(self, *, phase: str, run_status: str) -> None:
         try:
-            await self._sample_and_write(phase=phase)
+            await self._sample_and_write(phase=phase, run_status=run_status)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -221,14 +221,15 @@ class _CcusageSampleContext(UsageSampleContext):
                 "usage.collect.error",
                 workspace_id=self._workspace_id,
                 phase=phase,
-                status=status,
+                status=run_status,
                 exc_info=True,
             )
 
-    async def _sample_and_write(self, *, phase: str) -> None:
+    async def _sample_and_write(self, *, phase: str, run_status: str) -> None:
         if self._source is None:
             self._write(
                 phase=phase,
+                run_status=run_status,
                 status_label="unavailable",
                 reason=REASON_SOURCE_UNSUPPORTED,
                 metrics=NormalizedUsage(),
@@ -239,6 +240,7 @@ class _CcusageSampleContext(UsageSampleContext):
         if usage is None:
             self._write(
                 phase=phase,
+                run_status=run_status,
                 status_label="unavailable",
                 reason=reason,
                 metrics=NormalizedUsage(),
@@ -251,6 +253,7 @@ class _CcusageSampleContext(UsageSampleContext):
             # baseline failure reason instead of an inflated total.
             self._write(
                 phase=phase,
+                run_status=run_status,
                 status_label="unavailable",
                 reason=self._baseline_unavailable_reason,
                 metrics=NormalizedUsage(),
@@ -260,6 +263,7 @@ class _CcusageSampleContext(UsageSampleContext):
         delta = subtract_baseline(usage, self._baseline)
         self._write(
             phase=phase,
+            run_status=run_status,
             status_label="available",
             reason=None,
             metrics=delta,
@@ -270,6 +274,7 @@ class _CcusageSampleContext(UsageSampleContext):
         self,
         *,
         phase: str,
+        run_status: str,
         status_label: str,
         reason: str | None,
         metrics: NormalizedUsage,
@@ -280,6 +285,7 @@ class _CcusageSampleContext(UsageSampleContext):
             provider=self._provider.value,
             ccusage_source=self._source,
             status=status_label,
+            run_status=run_status,
             phase=phase,
             captured_at=self._collector._clock.now().isoformat(),
             reason=reason,

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -226,17 +226,28 @@ class _CcusageSampleContext(UsageSampleContext):
             raise
         except Exception:
             # Unexpected runner failure: swallow-and-log so the agent outcome is
-            # never masked, but flag the baseline as unanchored so later samples
-            # don't subtract against nothing and leak copied host history. Skip the
-            # start snapshot on this path: an unexpected exception leaves the
-            # sampler in an unknown state, so keep the existing swallow-and-log
-            # behavior rather than writing from a reading we never obtained.
+            # never masked, and flag the baseline as unanchored so later samples
+            # don't subtract against nothing and leak copied host history.
             _log.warning(
                 "usage.collect.baseline_error",
                 workspace_id=self._workspace_id,
                 exc_info=True,
             )
             self._baseline_unavailable_reason = REASON_COMMAND_FAILED
+            # Still seed an immediate unavailable snapshot, like the classified-
+            # failure path below. The reused workspace id means the prior run's
+            # snapshot.json is the latest record on disk; skipping the write would
+            # leave it reported as this run's usage until the first live tick (or
+            # indefinitely if sampling keeps failing). Persist zeros + the baseline
+            # failure reason — never the reading we failed to obtain — so usage
+            # state stays consistent with this run without leaking host history.
+            await self._safe_write_reading(
+                usage=None,
+                reason=REASON_COMMAND_FAILED,
+                model=None,
+                phase="live",
+                run_status="running",
+            )
             return
         if usage is not None:
             self._baseline = usage

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -189,13 +189,16 @@ class _CcusageSampleContext(UsageSampleContext):
         # baseline would let the prior run's tokens inflate this run's per-run
         # total; a fresh reading anchors the baseline at this run's true start.
         try:
-            usage, reason, _model = await self._run_ccusage()
+            usage, reason, model = await self._run_ccusage()
         except asyncio.CancelledError:
             raise
         except Exception:
             # Unexpected runner failure: swallow-and-log so the agent outcome is
             # never masked, but flag the baseline as unanchored so later samples
-            # don't subtract against nothing and leak copied host history.
+            # don't subtract against nothing and leak copied host history. Skip the
+            # start snapshot on this path: an unexpected exception leaves the
+            # sampler in an unknown state, so keep the existing swallow-and-log
+            # behavior rather than writing from a reading we never obtained.
             _log.warning(
                 "usage.collect.baseline_error",
                 workspace_id=self._workspace_id,
@@ -205,18 +208,55 @@ class _CcusageSampleContext(UsageSampleContext):
             return
         if usage is not None:
             self._baseline = usage
-            return
-        if reason == REASON_NO_RECORDS:
-            # Fresh workspace: ccusage ran cleanly with no prior host usage, so an
-            # empty baseline is correct and later totals are genuine workspace usage.
-            return
-        # ccusage failed for a classified reason (timeout / command error /
-        # unreadable output): we can't anchor a trustworthy baseline, so flag it.
-        self._baseline_unavailable_reason = reason or REASON_COMMAND_FAILED
+        elif reason != REASON_NO_RECORDS:
+            # ccusage failed for a classified reason (timeout / command error /
+            # unreadable output): we can't anchor a trustworthy baseline, so flag
+            # it. (REASON_NO_RECORDS is a fresh workspace: an empty baseline is
+            # correct and later totals are genuine workspace usage.)
+            self._baseline_unavailable_reason = reason or REASON_COMMAND_FAILED
+        # Seed an immediate "running" snapshot from this same baseline reading.
+        # The same workspace id is reused across retries/recovery, so the prior
+        # run's snapshot.json is still the latest record on disk; without this
+        # write it would stay latest until the first live sample (one interval
+        # away) or finalization, and workspace_usage_summary would report the old
+        # run's totals as this run's usage during that window. No extra ccusage
+        # exec: the start reading is, by definition, a zero delta against the
+        # baseline it just anchored (or an unavailable reason when it didn't).
+        await self._safe_write_reading(
+            usage=usage, reason=reason, model=model, phase="live", run_status="running"
+        )
 
     async def _safe_sample(self, *, phase: str, run_status: str) -> None:
         try:
             await self._sample_and_write(phase=phase, run_status=run_status)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "usage.collect.error",
+                workspace_id=self._workspace_id,
+                phase=phase,
+                status=run_status,
+                exc_info=True,
+            )
+
+    async def _safe_write_reading(
+        self,
+        *,
+        usage: NormalizedUsage | None,
+        reason: str | None,
+        model: str | None,
+        phase: str,
+        run_status: str,
+    ) -> None:
+        # Swallow-and-log wrapper for seeding the start snapshot from the baseline
+        # reading. A failed seed write must not mask the agent outcome nor abort
+        # the sampler (its caller runs on the agent start path), so it logs like
+        # _safe_sample rather than propagating.
+        try:
+            await self._write_reading(
+                usage=usage, reason=reason, model=model, phase=phase, run_status=run_status
+            )
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -240,6 +280,22 @@ class _CcusageSampleContext(UsageSampleContext):
             )
             return
         usage, reason, model = await self._run_ccusage()
+        await self._write_reading(
+            usage=usage, reason=reason, model=model, phase=phase, run_status=run_status
+        )
+
+    async def _write_reading(
+        self,
+        *,
+        usage: NormalizedUsage | None,
+        reason: str | None,
+        model: str | None,
+        phase: str,
+        run_status: str,
+    ) -> None:
+        # Persist one ccusage reading as a baseline-subtracted snapshot. Shared by
+        # the periodic/final samples (reading fetched via _run_ccusage) and the
+        # start-time seed snapshot (reading reused from _capture_baseline).
         if usage is None:
             await self._write(
                 phase=phase,

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -10,7 +10,9 @@ Design invariants:
 - Sampling never masks the agent outcome (all sample failures are reason-coded
   or swallowed-and-logged).
 - Reported totals are baseline-subtracted so copied host history can't inflate
-  them; the baseline is persisted and reused across runs of the same workspace.
+  them; a fresh baseline is captured at the start of each run (never reused from
+  a prior run, whose transcripts persist in the per-workspace auth copy) so
+  prior-run usage can't inflate this run's per-run total.
 - Only normalized numeric/accounting data is persisted (see ``usage_store``).
 """
 
@@ -42,7 +44,6 @@ from awf.service.usage_store import (
     UsageSnapshot,
     normalize_ccusage_json,
     provider_ccusage_source,
-    read_latest_usage_snapshot,
     subtract_baseline,
     write_usage_snapshot,
 )
@@ -174,21 +175,14 @@ class _CcusageSampleContext(UsageSampleContext):
             await self._safe_sample(phase="live", status="running")
 
     async def _capture_baseline(self) -> None:
-        prior = read_latest_usage_snapshot(self._workspace_id, work_dir=self._collector._work_dir)
-        # Reuse a prior baseline only when it was anchored for the same
-        # provider/source. A workspace can switch agents in place (provider
-        # recovery fallback mutates Workspace.agent for the same workspace_id),
-        # and a baseline from the old provider would subtract against an
-        # unrelated ccusage source and skew the delta.
-        if (
-            prior is not None
-            and prior.provider == self._provider.value
-            and prior.ccusage_source == self._source
-        ):
-            reused = prior.baseline_usage()
-            if reused is not None:
-                self._baseline = reused
-                return
+        # Always capture a fresh reading at run start; never reuse a prior
+        # snapshot's baseline. The per-workspace auth copy persists across
+        # retries and recovery runs (auth_mounts skips the copytree when the
+        # target dir already exists, and the copy is only GC'd once the
+        # workspace completes), so the previous run's transcripts are still on
+        # disk when the next run starts. Reusing the old start-of-prior-run
+        # baseline would let the prior run's tokens inflate this run's per-run
+        # total; a fresh reading anchors the baseline at this run's true start.
         try:
             usage, reason, _model = await self._run_ccusage()
         except asyncio.CancelledError:

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -1,0 +1,282 @@
+"""ccusage-backed implementation of the ``UsageSampler`` protocol.
+
+``CcusageCollector`` samples per-run LLM usage from inside a workspace's agent
+container by running a pinned ``ccusage`` with ``--json --offline``. It is wired
+into ``AgentAdapter.run`` (the single shared agent chokepoint) so both normal
+workspace execution and PR-monitor/recovery runs are covered without duplicating
+provider-specific runner code.
+
+Design invariants:
+- Sampling never masks the agent outcome (all sample failures are reason-coded
+  or swallowed-and-logged).
+- Reported totals are baseline-subtracted so copied host history can't inflate
+  them; the baseline is persisted and reused across runs of the same workspace.
+- Only normalized numeric/accounting data is persisted (see ``usage_store``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from awf.adapters.usage import UsageSampleContext, UsageSampler
+from awf.common.commands import (
+    COMMAND_IDLE_TIMEOUT_REASON,
+    COMMAND_TIMEOUT_REASON,
+    AsyncStreamingCommandRunner,
+    CommandResult,
+)
+from awf.common.compose_exec import build_tracked_compose_exec
+from awf.common.logging import get_logger
+from awf.db.enums import AgentRuntime
+from awf.service.usage_store import (
+    REASON_COMMAND_FAILED,
+    REASON_SOURCE_UNSUPPORTED,
+    REASON_TIMEOUT,
+    REASON_UNAVAILABLE,
+    NormalizedUsage,
+    UsageSnapshot,
+    normalize_ccusage_json,
+    provider_ccusage_source,
+    read_latest_usage_snapshot,
+    subtract_baseline,
+    write_usage_snapshot,
+)
+
+_log = get_logger(__name__)
+
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 60.0
+DEFAULT_CCUSAGE_COMMAND_TIMEOUT_SECONDS = 20.0
+
+
+class _Clock(Protocol):
+    def now(self) -> datetime: ...  # pragma: no cover - Protocol declaration only.
+
+    async def sleep(self, seconds: float) -> None: ...  # pragma: no cover - Protocol decl.
+
+
+class _RealClock:
+    def now(self) -> datetime:
+        return datetime.now(UTC)
+
+    async def sleep(self, seconds: float) -> None:
+        await asyncio.sleep(seconds)
+
+
+def _is_missing_binary(result: CommandResult) -> bool:
+    if result.returncode == 127:
+        return True
+    haystack = f"{result.stdout} {result.stderr}".lower()
+    return "not found" in haystack
+
+
+class CcusageCollector(UsageSampler):
+    """Samples ccusage usage inside the agent container every ``interval`` seconds."""
+
+    def __init__(
+        self,
+        *,
+        runner: AsyncStreamingCommandRunner,
+        work_dir: str | Path,
+        clock: _Clock | None = None,
+        interval_seconds: float = DEFAULT_SAMPLE_INTERVAL_SECONDS,
+        command_timeout_seconds: float = DEFAULT_CCUSAGE_COMMAND_TIMEOUT_SECONDS,
+    ) -> None:
+        self._runner = runner
+        self._work_dir = Path(work_dir)
+        self._clock = clock or _RealClock()
+        self._interval_seconds = interval_seconds
+        self._command_timeout_seconds = command_timeout_seconds
+
+    async def start(
+        self,
+        *,
+        compose_project: str,
+        compose_file: Path,
+        workspace_id: str,
+        provider: AgentRuntime,
+    ) -> _CcusageSampleContext:
+        source = provider_ccusage_source(provider)
+        ctx = _CcusageSampleContext(
+            collector=self,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            workspace_id=workspace_id,
+            provider=provider,
+            source=source,
+        )
+        if source is None:
+            # Unsupported provider: record the reason once, no periodic loop.
+            await ctx._safe_sample(phase="live", status="running")
+            return ctx
+        ctx._baseline = await ctx._capture_baseline()
+        ctx._task = asyncio.create_task(ctx._run_loop())
+        return ctx
+
+
+class _CcusageSampleContext(UsageSampleContext):
+    """Per-run sampling handle returned by ``CcusageCollector.start``."""
+
+    def __init__(
+        self,
+        *,
+        collector: CcusageCollector,
+        compose_project: str,
+        compose_file: Path,
+        workspace_id: str,
+        provider: AgentRuntime,
+        source: str | None,
+    ) -> None:
+        self._collector = collector
+        self._compose_project = compose_project
+        self._compose_file = compose_file
+        self._workspace_id = workspace_id
+        self._provider = provider
+        self._source = source
+        self._baseline: NormalizedUsage | None = None
+        self._task: asyncio.Task[None] | None = None
+        self._finalized = False
+
+    async def finalize(self, *, status: str) -> None:
+        if self._finalized:
+            return
+        self._finalized = True
+        final_task = asyncio.ensure_future(self._finalize_inner(status))
+        # Shield the final sample so it still completes if the agent run is being
+        # cancelled (the await below may be cancelled repeatedly).
+        while not final_task.done():
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.shield(final_task)
+
+    async def _finalize_inner(self, status: str) -> None:
+        await self._cancel_loop()
+        await self._safe_sample(phase="final", status=status)
+
+    async def _cancel_loop(self) -> None:
+        task = self._task
+        if task is None:
+            return
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    async def _run_loop(self) -> None:
+        while True:
+            await self._collector._clock.sleep(self._collector._interval_seconds)
+            await self._safe_sample(phase="live", status="running")
+
+    async def _capture_baseline(self) -> NormalizedUsage | None:
+        prior = read_latest_usage_snapshot(self._workspace_id, work_dir=self._collector._work_dir)
+        if prior is not None:
+            reused = prior.baseline_usage()
+            if reused is not None:
+                return reused
+        try:
+            usage, _reason, _model = await self._run_ccusage()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "usage.collect.baseline_error",
+                workspace_id=self._workspace_id,
+                exc_info=True,
+            )
+            return None
+        return usage
+
+    async def _safe_sample(self, *, phase: str, status: str) -> None:
+        try:
+            await self._sample_and_write(phase=phase)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "usage.collect.error",
+                workspace_id=self._workspace_id,
+                phase=phase,
+                status=status,
+                exc_info=True,
+            )
+
+    async def _sample_and_write(self, *, phase: str) -> None:
+        if self._source is None:
+            self._write(
+                phase=phase,
+                status_label="unavailable",
+                reason=REASON_SOURCE_UNSUPPORTED,
+                metrics=NormalizedUsage(),
+                model=None,
+            )
+            return
+        usage, reason, model = await self._run_ccusage()
+        if usage is None:
+            self._write(
+                phase=phase,
+                status_label="unavailable",
+                reason=reason,
+                metrics=NormalizedUsage(),
+                model=None,
+            )
+            return
+        delta = subtract_baseline(usage, self._baseline)
+        self._write(
+            phase=phase,
+            status_label="available",
+            reason=None,
+            metrics=delta,
+            model=model,
+        )
+
+    def _write(
+        self,
+        *,
+        phase: str,
+        status_label: str,
+        reason: str | None,
+        metrics: NormalizedUsage,
+        model: str | None,
+    ) -> None:
+        snapshot = UsageSnapshot(
+            workspace_id=self._workspace_id,
+            provider=self._provider.value,
+            ccusage_source=self._source,
+            status=status_label,
+            phase=phase,
+            captured_at=self._collector._clock.now().isoformat(),
+            reason=reason,
+            model=model,
+            input_tokens=metrics.input_tokens,
+            output_tokens=metrics.output_tokens,
+            total_tokens=metrics.total_tokens,
+            cost_estimate=metrics.cost_estimate,
+            currency=metrics.currency,
+            baseline=self._baseline.as_baseline_dict() if self._baseline is not None else None,
+        )
+        write_usage_snapshot(snapshot, work_dir=self._collector._work_dir)
+
+    async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
+        invocation = build_tracked_compose_exec(
+            compose_project=self._compose_project,
+            compose_file=self._compose_file,
+            cli_args=["ccusage", str(self._source), "daily", "--json", "--offline"],
+            source="usage",
+            label="ccusage",
+        )
+        result = await self._collector._runner.run_streaming(
+            invocation.args,
+            wall_timeout_seconds=self._collector._command_timeout_seconds,
+            idle_timeout_seconds=self._collector._command_timeout_seconds,
+        )
+        if result.reason_code in (COMMAND_TIMEOUT_REASON, COMMAND_IDLE_TIMEOUT_REASON):
+            return None, REASON_TIMEOUT, None
+        if not result.ok:
+            failure_reason = (
+                REASON_UNAVAILABLE if _is_missing_binary(result) else REASON_COMMAND_FAILED
+            )
+            return None, failure_reason, None
+        usage, reason = normalize_ccusage_json(result.stdout)
+        model = usage.model if usage is not None else None
+        return usage, reason, model

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -86,13 +86,15 @@ class _RealClock:
 def _is_missing_binary(result: CommandResult) -> bool:
     if result.returncode == 127:
         return True
-    # A real missing binary exits 127 (handled above); only treat stderr as a
-    # missing-binary signal for the exact phrases shells emit ("command not
-    # found" from bash, "no such file" from a failed exec/setsid). This keeps
-    # app-level errors that merely contain "not found" (e.g. ccusage
-    # "source not found") classified as REASON_COMMAND_FAILED.
-    stderr_lower = result.stderr.lower()
-    return "command not found" in stderr_lower or "no such file" in stderr_lower
+    # A real missing binary exits 127 (handled above): on this Debian image both
+    # the setsid (util-linux EXIT_NOTFOUND) and dash exec paths return 127 on
+    # ENOENT. Only treat stderr as a secondary missing-binary signal for the
+    # exact phrase shells emit ("command not found" from bash/sh). Avoid
+    # "no such file" here: ccusage (Node) emits ENOENT errors for missing
+    # config/data files (e.g. the --config neutral file) with that phrase in
+    # stderr, which would misclassify a present-but-failing binary as
+    # REASON_UNAVAILABLE ("ccusage not installed") instead of REASON_COMMAND_FAILED.
+    return "command not found" in result.stderr.lower()
 
 
 class CcusageCollector(UsageSampler):

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -31,7 +31,11 @@ from awf.common.commands import (
     AsyncStreamingCommandRunner,
     CommandResult,
 )
-from awf.common.compose_exec import build_tracked_compose_exec
+from awf.common.compose_exec import (
+    TrackedComposeExec,
+    build_tracked_compose_exec,
+    cleanup_compose_exec_invocation,
+)
 from awf.common.logging import get_logger
 from awf.db.enums import AgentRuntime
 from awf.service.usage_store import (
@@ -456,6 +460,7 @@ class _CcusageSampleContext(UsageSampleContext):
             idle_timeout_seconds=self._collector._command_timeout_seconds,
         )
         if result.reason_code in (COMMAND_TIMEOUT_REASON, COMMAND_IDLE_TIMEOUT_REASON):
+            await self._cleanup_timed_out_invocation(invocation)
             return None, REASON_TIMEOUT, None
         if not result.ok:
             failure_reason = (
@@ -465,3 +470,28 @@ class _CcusageSampleContext(UsageSampleContext):
         usage, reason = normalize_ccusage_json(result.stdout)
         model = usage.model if usage is not None else None
         return usage, reason, model
+
+    async def _cleanup_timed_out_invocation(self, invocation: TrackedComposeExec) -> None:
+        # On timeout, run_streaming kills the local compose client, but per the
+        # build_tracked_compose_exec contract that does not prove the in-container
+        # ccusage process tree is gone. Run targeted cleanup for this invocation so
+        # orphaned ccusage processes can't accumulate across repeated timeouts and
+        # degrade later samples (same pattern as AgentAdapter.run / validation). This
+        # is best-effort diagnostics: swallow-and-log any cleanup failure (it already
+        # logs an error internally) so the sample stays reason-coded as REASON_TIMEOUT
+        # and the agent outcome is never masked.
+        try:
+            await cleanup_compose_exec_invocation(
+                self._collector._runner,
+                invocation,
+                workspace_id=self._workspace_id,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            _log.warning(
+                "usage.collect.cleanup_error",
+                workspace_id=self._workspace_id,
+                invocation_id=invocation.invocation_id,
+                exc_info=True,
+            )

--- a/src/awf/service/usage_collection.py
+++ b/src/awf/service/usage_collection.py
@@ -305,6 +305,13 @@ class _CcusageSampleContext(UsageSampleContext):
         await asyncio.to_thread(write_usage_snapshot, snapshot, work_dir=self._collector._work_dir)
 
     async def _run_ccusage(self) -> tuple[NormalizedUsage | None, str | None, str | None]:
+        # Expected ccusage CLI contract (pinned at 20.0.3 in
+        # docker/agent-runtime.Dockerfile): ``ccusage <source> daily --json --offline``,
+        # where ``<source>`` is a positional provider sub-command ("claude" /
+        # "codex" / "gemini" / "opencode"; see ``provider_ccusage_source``). A future
+        # pin that moves the provider behind a flag (e.g. ``--source``) would make
+        # this positional invocation degrade to REASON_COMMAND_FAILED, so re-verify
+        # this argument order whenever the Dockerfile pin is bumped.
         invocation = build_tracked_compose_exec(
             compose_project=self._compose_project,
             compose_file=self._compose_file,

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -123,7 +123,9 @@ def _usage_from_record(record: dict[str, Any], *, model: str | None) -> Normaliz
     total_tokens = _first(record, _TOTAL_TOKEN_KEYS, _coerce_int)
     cost_estimate = _first(record, _COST_KEYS, _coerce_float)
     if total_tokens is None and (input_tokens is not None or output_tokens is not None):
-        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+        total_tokens = (input_tokens if input_tokens is not None else 0) + (
+            output_tokens if output_tokens is not None else 0
+        )
     if (
         input_tokens is None
         and output_tokens is None

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -1,0 +1,354 @@
+"""AWF-owned durable store for normalized workspace LLM usage snapshots.
+
+This module is intentionally dependency-light: it maps AWF agent runtimes to
+``ccusage`` sources, normalizes ``ccusage --json`` output into safe numeric
+accounting data, and reads/writes a single latest-wins snapshot per workspace
+under ``<work_dir>/usage/<workspace_id>/snapshot.json``.
+
+It never persists raw prompt JSONL, file paths, or credential-bearing content —
+only normalized token/cost numbers plus safe metadata (provider, source, model,
+status, reason codes, timestamps).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from awf.common.config import get_settings
+from awf.common.logging import get_logger
+from awf.db.enums import AgentRuntime
+
+_log = get_logger(__name__)
+
+SCHEMA_VERSION = 1
+SNAPSHOT_FILENAME = "snapshot.json"
+USAGE_SOURCE = "ccusage"
+
+# Reason codes surfaced when ccusage usage is missing or invalid.
+REASON_SOURCE_UNSUPPORTED = "ccusage_source_unsupported"
+REASON_UNAVAILABLE = "ccusage_unavailable"
+REASON_COMMAND_FAILED = "ccusage_command_failed"
+REASON_TIMEOUT = "ccusage_timeout"
+REASON_INVALID_JSON = "ccusage_invalid_json"
+REASON_NO_RECORDS = "ccusage_no_records"
+
+# AWF runtime -> ccusage per-source subcommand. Generic table; any runtime not
+# present here has no ccusage source and reports ``ccusage_source_unsupported``.
+_PROVIDER_CCUSAGE_SOURCE: dict[AgentRuntime, str] = {
+    AgentRuntime.claude_code: "claude",
+    AgentRuntime.codex: "codex",
+    AgentRuntime.gemini: "gemini",
+    AgentRuntime.opencode: "opencode",
+}
+
+_INPUT_TOKEN_KEYS = ("inputTokens", "input_tokens")
+_OUTPUT_TOKEN_KEYS = ("outputTokens", "output_tokens")
+_TOTAL_TOKEN_KEYS = ("totalTokens", "total_tokens")
+_COST_KEYS = ("totalCost", "costUSD", "cost", "cost_estimate")
+
+
+def provider_ccusage_source(runtime: AgentRuntime) -> str | None:
+    """Return the ccusage source subcommand for an AWF runtime, or ``None``."""
+
+    return _PROVIDER_CCUSAGE_SOURCE.get(runtime)
+
+
+@dataclass(frozen=True)
+class NormalizedUsage:
+    """Normalized token/cost accounting extracted from ccusage output."""
+
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    cost_estimate: float | None = None
+    currency: str | None = None
+    model: str | None = None
+
+    def as_baseline_dict(self) -> dict[str, Any]:
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_estimate": self.cost_estimate,
+            "currency": self.currency,
+            "model": self.model,
+        }
+
+    @classmethod
+    def from_baseline_dict(cls, data: dict[str, Any]) -> NormalizedUsage:
+        return cls(
+            input_tokens=data.get("input_tokens"),
+            output_tokens=data.get("output_tokens"),
+            total_tokens=data.get("total_tokens"),
+            cost_estimate=data.get("cost_estimate"),
+            currency=data.get("currency"),
+            model=data.get("model"),
+        )
+
+
+def _coerce_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _first(mapping: dict[str, Any], keys: tuple[str, ...], coerce: Any) -> Any:
+    for key in keys:
+        if key in mapping:
+            coerced = coerce(mapping[key])
+            if coerced is not None:
+                return coerced
+    return None
+
+
+def _usage_from_record(record: dict[str, Any], *, model: str | None) -> NormalizedUsage | None:
+    input_tokens = _first(record, _INPUT_TOKEN_KEYS, _coerce_int)
+    output_tokens = _first(record, _OUTPUT_TOKEN_KEYS, _coerce_int)
+    total_tokens = _first(record, _TOTAL_TOKEN_KEYS, _coerce_int)
+    cost_estimate = _first(record, _COST_KEYS, _coerce_float)
+    if total_tokens is None and (input_tokens is not None or output_tokens is not None):
+        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+    if (
+        input_tokens is None
+        and output_tokens is None
+        and total_tokens is None
+        and cost_estimate is None
+    ):
+        return None
+    return NormalizedUsage(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        cost_estimate=cost_estimate,
+        currency="USD" if cost_estimate is not None else None,
+        model=model,
+    )
+
+
+def _usage_from_daily(daily: list[Any], *, model: str | None) -> NormalizedUsage | None:
+    totals: dict[str, Any] = {}
+    seen = False
+    for entry in daily:
+        if not isinstance(entry, dict):
+            continue
+        usage = _usage_from_record(entry, model=model)
+        if usage is None:
+            continue
+        seen = True
+        totals["inputTokens"] = (totals.get("inputTokens", 0)) + (usage.input_tokens or 0)
+        totals["outputTokens"] = (totals.get("outputTokens", 0)) + (usage.output_tokens or 0)
+        totals["totalTokens"] = (totals.get("totalTokens", 0)) + (usage.total_tokens or 0)
+        if usage.cost_estimate is not None:
+            totals["totalCost"] = (totals.get("totalCost", 0.0)) + usage.cost_estimate
+    if not seen:
+        return None
+    return _usage_from_record(totals, model=model)
+
+
+def normalize_ccusage_json(raw: str) -> tuple[NormalizedUsage | None, str | None]:
+    """Parse ccusage ``--json`` output into ``NormalizedUsage`` or a reason code."""
+
+    text = raw.strip()
+    if not text:
+        return None, REASON_INVALID_JSON
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return None, REASON_INVALID_JSON
+    if not isinstance(data, dict):
+        return None, REASON_INVALID_JSON
+
+    model = data.get("model") if isinstance(data.get("model"), str) else None
+
+    totals = data.get("totals")
+    if isinstance(totals, dict):
+        usage = _usage_from_record(totals, model=model)
+        if usage is not None:
+            return usage, None
+
+    daily = data.get("daily")
+    if isinstance(daily, list):
+        usage = _usage_from_daily(daily, model=model)
+        if usage is not None:
+            return usage, None
+
+    return None, REASON_NO_RECORDS
+
+
+def _delta(current: int | None, baseline: int | None) -> int | None:
+    if current is None:
+        return None
+    if baseline is None:
+        return current
+    return max(0, current - baseline)
+
+
+def _delta_float(current: float | None, baseline: float | None) -> float | None:
+    if current is None:
+        return None
+    if baseline is None:
+        return current
+    return max(0.0, current - baseline)
+
+
+def subtract_baseline(
+    current: NormalizedUsage, baseline: NormalizedUsage | None
+) -> NormalizedUsage:
+    """Return ``current - baseline`` per field, clamped at zero.
+
+    When ``baseline`` is ``None`` the current reading is returned unchanged.
+    ``None`` fields in ``current`` stay ``None`` (unknown, not zero).
+    """
+
+    if baseline is None:
+        return current
+    return NormalizedUsage(
+        input_tokens=_delta(current.input_tokens, baseline.input_tokens),
+        output_tokens=_delta(current.output_tokens, baseline.output_tokens),
+        total_tokens=_delta(current.total_tokens, baseline.total_tokens),
+        cost_estimate=_delta_float(current.cost_estimate, baseline.cost_estimate),
+        currency=current.currency,
+        model=current.model,
+    )
+
+
+@dataclass(frozen=True)
+class UsageSnapshot:
+    """A normalized, latest-wins usage snapshot for one workspace run."""
+
+    workspace_id: str
+    provider: str
+    ccusage_source: str | None
+    status: str
+    phase: str
+    captured_at: str
+    reason: str | None = None
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    cost_estimate: float | None = None
+    currency: str | None = None
+    baseline: dict[str, Any] | None = None
+    schema_version: int = SCHEMA_VERSION
+    source: str = USAGE_SOURCE
+
+    @property
+    def has_metrics(self) -> bool:
+        return any(
+            value is not None
+            for value in (
+                self.input_tokens,
+                self.output_tokens,
+                self.total_tokens,
+                self.cost_estimate,
+            )
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "workspace_id": self.workspace_id,
+            "provider": self.provider,
+            "source": self.source,
+            "ccusage_source": self.ccusage_source,
+            "model": self.model,
+            "status": self.status,
+            "reason": self.reason,
+            "phase": self.phase,
+            "captured_at": self.captured_at,
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "total_tokens": self.total_tokens,
+            "cost_estimate": self.cost_estimate,
+            "currency": self.currency,
+            "baseline": self.baseline,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> UsageSnapshot:
+        return cls(
+            workspace_id=data["workspace_id"],
+            provider=data["provider"],
+            ccusage_source=data.get("ccusage_source"),
+            status=data["status"],
+            phase=data["phase"],
+            captured_at=data["captured_at"],
+            reason=data.get("reason"),
+            model=data.get("model"),
+            input_tokens=data.get("input_tokens"),
+            output_tokens=data.get("output_tokens"),
+            total_tokens=data.get("total_tokens"),
+            cost_estimate=data.get("cost_estimate"),
+            currency=data.get("currency"),
+            baseline=data.get("baseline"),
+            schema_version=data.get("schema_version", SCHEMA_VERSION),
+            source=data.get("source", USAGE_SOURCE),
+        )
+
+    def baseline_usage(self) -> NormalizedUsage | None:
+        if not isinstance(self.baseline, dict):
+            return None
+        return NormalizedUsage.from_baseline_dict(self.baseline)
+
+
+def workspace_usage_dir(work_dir: str | Path, workspace_id: str) -> Path:
+    """Return the AWF-owned usage directory for a workspace."""
+
+    return Path(work_dir) / "usage" / workspace_id
+
+
+def _resolve_work_dir(work_dir: str | Path | None) -> Path:
+    if work_dir is not None:
+        return Path(work_dir)
+    # Match the worker's work_dir normalization (build_worker_runtime applies
+    # .expanduser().resolve()) so the API reader and the collector writer agree
+    # on the snapshot directory even when settings.work_dir holds ~/ or a
+    # relative/symlinked path.
+    return Path(get_settings().work_dir).expanduser().resolve()
+
+
+def write_usage_snapshot(snapshot: UsageSnapshot, *, work_dir: str | Path) -> Path:
+    """Atomically write the latest snapshot for a workspace and return its path."""
+
+    usage_dir = workspace_usage_dir(work_dir, snapshot.workspace_id)
+    usage_dir.mkdir(parents=True, exist_ok=True)
+    target = usage_dir / SNAPSHOT_FILENAME
+    tmp = usage_dir / f"{SNAPSHOT_FILENAME}.{os.getpid()}.tmp"
+    tmp.write_text(json.dumps(snapshot.to_dict(), separators=(",", ":")))
+    tmp.replace(target)
+    return target
+
+
+def read_latest_usage_snapshot(
+    workspace_id: str | None, *, work_dir: str | Path | None = None
+) -> UsageSnapshot | None:
+    """Read the latest usage snapshot for a workspace, or ``None`` if absent/invalid."""
+
+    if not workspace_id:
+        return None
+    target = workspace_usage_dir(_resolve_work_dir(work_dir), workspace_id) / SNAPSHOT_FILENAME
+    try:
+        raw = target.read_text()
+    except OSError:
+        return None
+    try:
+        data = json.loads(raw)
+        return UsageSnapshot.from_dict(data)
+    except (json.JSONDecodeError, ValueError, KeyError, TypeError):
+        _log.warning("usage.snapshot.invalid", workspace_id=workspace_id)
+        return None

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -17,6 +17,7 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from awf.common.config import get_settings
 from awf.common.logging import get_logger
@@ -375,9 +376,18 @@ def write_usage_snapshot(snapshot: UsageSnapshot, *, work_dir: str | Path) -> Pa
     usage_dir = workspace_usage_dir(work_dir, snapshot.workspace_id)
     usage_dir.mkdir(parents=True, exist_ok=True)
     target = usage_dir / SNAPSHOT_FILENAME
-    tmp = usage_dir / f"{SNAPSHOT_FILENAME}.{os.getpid()}.tmp"
-    tmp.write_text(json.dumps(snapshot.to_dict(), separators=(",", ":")))
-    tmp.replace(target)
+    # A per-write unique suffix (not just the process-scoped PID) keeps the temp
+    # path distinct if two coroutines in the same worker process write a
+    # snapshot for the same workspace concurrently, so neither can overwrite the
+    # other's bytes before ``replace`` performs the atomic swap.
+    tmp = usage_dir / f"{SNAPSHOT_FILENAME}.{os.getpid()}.{uuid4().hex}.tmp"
+    try:
+        tmp.write_text(json.dumps(snapshot.to_dict(), separators=(",", ":")))
+        tmp.replace(target)
+    finally:
+        # ``replace`` consumes tmp on success; this clears a partial temp left by
+        # a failed write so the now-unique-named temps cannot accumulate.
+        tmp.unlink(missing_ok=True)
     return target
 
 

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -240,6 +240,12 @@ class UsageSnapshot:
     phase: str
     captured_at: str
     reason: str | None = None
+    # Agent run outcome (success/failed/timeout/cancelled/running) at the moment
+    # this sample was taken. Distinct from ``status`` (sample availability): a
+    # final snapshot after a timeout and one after success both carry
+    # ``status="available"``/``phase="final"``, so the run outcome is the only
+    # field that distinguishes them.
+    run_status: str | None = None
     model: str | None = None
     input_tokens: int | None = None
     output_tokens: int | None = None
@@ -271,6 +277,7 @@ class UsageSnapshot:
             "ccusage_source": self.ccusage_source,
             "model": self.model,
             "status": self.status,
+            "run_status": self.run_status,
             "reason": self.reason,
             "phase": self.phase,
             "captured_at": self.captured_at,
@@ -292,6 +299,7 @@ class UsageSnapshot:
             phase=data["phase"],
             captured_at=data["captured_at"],
             reason=data.get("reason"),
+            run_status=data.get("run_status"),
             model=data.get("model"),
             input_tokens=data.get("input_tokens"),
             output_tokens=data.get("output_tokens"),

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -229,6 +229,35 @@ def subtract_baseline(
     )
 
 
+# Strict typed accessors for deserializing a *persisted* snapshot. Unlike the
+# lenient ``_coerce_*`` helpers (which silently drop bad fields from untrusted
+# ccusage output), these raise ``TypeError`` on a wrong-typed field so a
+# corrupted snapshot file is rejected wholesale by ``read_latest_usage_snapshot``
+# rather than loaded as partially-bogus accounting data.
+def _require_str(value: Any) -> str | None:
+    if value is None or isinstance(value, str):
+        return value
+    raise TypeError("expected string or null")
+
+
+def _require_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise TypeError("expected int or null")
+    if isinstance(value, int):
+        return value
+    raise TypeError("expected int or null")
+
+
+def _require_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError("expected float or null")
+    return float(value)
+
+
 @dataclass(frozen=True)
 class UsageSnapshot:
     """A normalized, latest-wins usage snapshot for one workspace run."""
@@ -291,22 +320,25 @@ class UsageSnapshot:
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> UsageSnapshot:
+        baseline = data.get("baseline")
+        if baseline is not None and not isinstance(baseline, dict):
+            raise TypeError("baseline must be an object or null")
         return cls(
             workspace_id=data["workspace_id"],
             provider=data["provider"],
-            ccusage_source=data.get("ccusage_source"),
+            ccusage_source=_require_str(data.get("ccusage_source")),
             status=data["status"],
             phase=data["phase"],
             captured_at=data["captured_at"],
-            reason=data.get("reason"),
-            run_status=data.get("run_status"),
-            model=data.get("model"),
-            input_tokens=data.get("input_tokens"),
-            output_tokens=data.get("output_tokens"),
-            total_tokens=data.get("total_tokens"),
-            cost_estimate=data.get("cost_estimate"),
-            currency=data.get("currency"),
-            baseline=data.get("baseline"),
+            reason=_require_str(data.get("reason")),
+            run_status=_require_str(data.get("run_status")),
+            model=_require_str(data.get("model")),
+            input_tokens=_require_int(data.get("input_tokens")),
+            output_tokens=_require_int(data.get("output_tokens")),
+            total_tokens=_require_int(data.get("total_tokens")),
+            cost_estimate=_require_float(data.get("cost_estimate")),
+            currency=_require_str(data.get("currency")),
+            baseline=baseline,
             schema_version=data.get("schema_version", SCHEMA_VERSION),
             source=data.get("source", USAGE_SOURCE),
         )

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -167,7 +167,11 @@ def normalize_ccusage_json(raw: str) -> tuple[NormalizedUsage | None, str | None
 
     text = raw.strip()
     if not text:
-        return None, REASON_INVALID_JSON
+        # Callers only parse stdout after a clean (exit 0) ccusage run, so empty
+        # output means "ran fine, no records yet", not unreadable JSON. Reporting
+        # REASON_INVALID_JSON here would wrongly flag the run's baseline as
+        # unavailable (see _capture_baseline) for every later sample.
+        return None, REASON_NO_RECORDS
     try:
         data = json.loads(text)
     except (json.JSONDecodeError, ValueError):

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -409,3 +410,24 @@ def read_latest_usage_snapshot(
     except (json.JSONDecodeError, ValueError, KeyError, TypeError):
         _log.warning("usage.snapshot.invalid", workspace_id=workspace_id)
         return None
+
+
+def read_latest_usage_snapshots(
+    workspace_ids: Iterable[str | None], *, work_dir: str | Path | None = None
+) -> dict[str, UsageSnapshot | None]:
+    """Read the latest snapshot for several workspaces in one pass.
+
+    Designed to be offloaded to a worker thread (e.g. ``asyncio.to_thread``) so
+    list endpoints can take the per-workspace blocking file reads off the async
+    event loop. The work directory is resolved once and reused. Returns a map
+    keyed by workspace id (blank/``None`` ids and duplicates are skipped); each
+    value is the snapshot or ``None`` when absent/invalid.
+    """
+
+    resolved = _resolve_work_dir(work_dir)
+    snapshots: dict[str, UsageSnapshot | None] = {}
+    for workspace_id in workspace_ids:
+        if not workspace_id or workspace_id in snapshots:
+            continue
+        snapshots[workspace_id] = read_latest_usage_snapshot(workspace_id, work_dir=resolved)
+    return snapshots

--- a/src/awf/service/usage_store.py
+++ b/src/awf/service/usage_store.py
@@ -149,9 +149,12 @@ def _usage_from_daily(daily: list[Any], *, model: str | None) -> NormalizedUsage
         if usage is None:
             continue
         seen = True
-        totals["inputTokens"] = (totals.get("inputTokens", 0)) + (usage.input_tokens or 0)
-        totals["outputTokens"] = (totals.get("outputTokens", 0)) + (usage.output_tokens or 0)
-        totals["totalTokens"] = (totals.get("totalTokens", 0)) + (usage.total_tokens or 0)
+        if usage.input_tokens is not None:
+            totals["inputTokens"] = (totals.get("inputTokens", 0)) + usage.input_tokens
+        if usage.output_tokens is not None:
+            totals["outputTokens"] = (totals.get("outputTokens", 0)) + usage.output_tokens
+        if usage.total_tokens is not None:
+            totals["totalTokens"] = (totals.get("totalTokens", 0)) + usage.total_tokens
         if usage.cost_estimate is not None:
             totals["totalCost"] = (totals.get("totalCost", 0.0)) + usage.cost_estimate
     if not seen:

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -47,6 +47,7 @@ from awf.service.target_branch_monitor import (
     TargetBranchReconcileMonitor,
     reconcile_and_refresh_stale_candidates,
 )
+from awf.service.usage_collection import CcusageCollector
 
 _log = get_logger(__name__)
 
@@ -76,6 +77,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
     compose = ComposeManager(work_dir=work_dir, template_path=template)
     runtime_cleaner = WorkspaceCleaner(git=git, compose=compose)
     runner = AsyncioSubprocessRunner()
+    usage_collector = CcusageCollector(runner=runner, work_dir=work_dir)
     log_store = LogStore(root=work_dir / "logs", session_factory=session_factory)
     merge_coordinator = _merge_coordinator_for_database_url(settings.database_url, engine=engine)
     validation = ValidationRunner(
@@ -200,6 +202,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         ),
         pr_monitor_factory=_pr_monitor_factory,
         log_store=log_store,
+        usage_sampler=usage_collector,
     )
     worker = ControlWorker(
         session_factory=session_factory,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -37,6 +37,7 @@ from awf.service.provider_recovery import (
     ProviderRecoveryStateView,
     provider_recovery_state_for_workspace,
 )
+from awf.service.usage_store import USAGE_SOURCE, read_latest_usage_snapshot
 
 AgentIdentitySource = Literal["task_policy", "default", "unavailable"]
 LifecycleStageStatus = Literal["pending", "active", "completed", "terminal_skipped"]
@@ -556,6 +557,58 @@ def workspace_lifecycle_summary(
 
 
 def workspace_usage_summary(workspace: Workspace) -> LlmUsageSummary:
+    """Resolve usage for a workspace, preferring ccusage snapshots.
+
+    Tiers (highest precedence first):
+    1. A ccusage snapshot with metrics → trusted live/final usage.
+    2. Operation-provided usage aggregation → compatibility fallback.
+    3. A ccusage snapshot without metrics → surface its reason code so the
+       console can show *why* usage is unavailable.
+    4. ``usage_not_reported``.
+    """
+
+    snapshot = read_latest_usage_snapshot(getattr(workspace, "id", None))
+    if snapshot is not None and snapshot.has_metrics:
+        return LlmUsageSummary(
+            input_tokens=snapshot.input_tokens,
+            output_tokens=snapshot.output_tokens,
+            total_tokens=snapshot.total_tokens,
+            cost_estimate=snapshot.cost_estimate,
+            currency=snapshot.currency,
+            status="available",
+            source=USAGE_SOURCE,
+            reason=snapshot.reason,
+        )
+
+    operations_summary = _operations_usage_summary(workspace)
+    if operations_summary is not None:
+        return operations_summary
+
+    if snapshot is not None:
+        return LlmUsageSummary(
+            input_tokens=None,
+            output_tokens=None,
+            total_tokens=None,
+            cost_estimate=None,
+            currency=None,
+            status="unavailable",
+            source=USAGE_SOURCE,
+            reason=snapshot.reason or "usage_not_reported",
+        )
+
+    return LlmUsageSummary(
+        input_tokens=None,
+        output_tokens=None,
+        total_tokens=None,
+        cost_estimate=None,
+        currency=None,
+        status="unavailable",
+        source="none",
+        reason="usage_not_reported",
+    )
+
+
+def _operations_usage_summary(workspace: Workspace) -> LlmUsageSummary | None:
     input_tokens = None
     output_tokens = None
     total_tokens = None
@@ -630,16 +683,7 @@ def workspace_usage_summary(workspace: Workspace) -> LlmUsageSummary:
         and total_tokens is None
         and cost_estimate is None
     ):
-        return LlmUsageSummary(
-            input_tokens=None,
-            output_tokens=None,
-            total_tokens=None,
-            cost_estimate=None,
-            currency=None,
-            status="unavailable",
-            source="none",
-            reason="usage_not_reported",
-        )
+        return None
 
     return LlmUsageSummary(
         input_tokens=input_tokens,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import binascii
 import json
 import re
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Literal, Protocol, TypedDict, cast
@@ -37,7 +40,12 @@ from awf.service.provider_recovery import (
     ProviderRecoveryStateView,
     provider_recovery_state_for_workspace,
 )
-from awf.service.usage_store import USAGE_SOURCE, read_latest_usage_snapshot
+from awf.service.usage_store import (
+    USAGE_SOURCE,
+    UsageSnapshot,
+    read_latest_usage_snapshot,
+    read_latest_usage_snapshots,
+)
 
 AgentIdentitySource = Literal["task_policy", "default", "unavailable"]
 LifecycleStageStatus = Literal["pending", "active", "completed", "terminal_skipped"]
@@ -265,8 +273,11 @@ async def list_workspace_overview_response(
     )
     page_rows = rows[:limit]
     has_more = len(rows) > limit
+    snapshots = await asyncio.to_thread(read_latest_usage_snapshots, [ws.id for ws in page_rows])
+    with prefetched_usage_snapshots(snapshots):
+        items = [_workspace_overview_item(ws) for ws in page_rows]
     return WorkspaceOverviewListResponse(
-        items=[_workspace_overview_item(ws) for ws in page_rows],
+        items=items,
         next_cursor=_encode_overview_cursor(page_rows[-1]) if has_more and page_rows else None,
         has_more=has_more,
         limit=limit,
@@ -556,6 +567,43 @@ def workspace_lifecycle_summary(
     return summaries
 
 
+# Request-scoped map of pre-read usage snapshots keyed by workspace id. List
+# endpoints populate it (off the event loop) so the synchronous projection below
+# does not block the loop with one file read per workspace; see
+# ``prefetched_usage_snapshots``.
+_PREFETCHED_USAGE_SNAPSHOTS: ContextVar[Mapping[str, UsageSnapshot | None] | None] = ContextVar(
+    "awf_prefetched_usage_snapshots", default=None
+)
+
+
+@contextmanager
+def prefetched_usage_snapshots(
+    snapshots: Mapping[str, UsageSnapshot | None],
+) -> Iterator[None]:
+    """Scope a request-local map of pre-read usage snapshots for this task.
+
+    ``workspace_usage_summary`` consults this map first, so a list endpoint can
+    read every workspace's snapshot once in a worker thread (keeping the
+    blocking file I/O off the async event loop) instead of doing a synchronous
+    read per workspace on the loop. Outside this scope, or for an id absent from
+    the map, the summary falls back to a direct disk read — the map is a pure
+    optimization, never a correctness dependency.
+    """
+
+    token = _PREFETCHED_USAGE_SNAPSHOTS.set(snapshots)
+    try:
+        yield
+    finally:
+        _PREFETCHED_USAGE_SNAPSHOTS.reset(token)
+
+
+def _resolve_usage_snapshot(workspace_id: str | None) -> UsageSnapshot | None:
+    prefetched = _PREFETCHED_USAGE_SNAPSHOTS.get()
+    if prefetched is not None and workspace_id is not None and workspace_id in prefetched:
+        return prefetched[workspace_id]
+    return read_latest_usage_snapshot(workspace_id)
+
+
 def workspace_usage_summary(workspace: Workspace) -> LlmUsageSummary:
     """Resolve usage for a workspace, preferring ccusage snapshots.
 
@@ -567,7 +615,7 @@ def workspace_usage_summary(workspace: Workspace) -> LlmUsageSummary:
     4. ``usage_not_reported``.
     """
 
-    snapshot = read_latest_usage_snapshot(getattr(workspace, "id", None))
+    snapshot = _resolve_usage_snapshot(getattr(workspace, "id", None))
     if snapshot is not None and snapshot.has_metrics:
         return LlmUsageSummary(
             input_tokens=snapshot.input_tokens,

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -598,6 +598,24 @@ def prefetched_usage_snapshots(
 
 
 def _resolve_usage_snapshot(workspace_id: str | None) -> UsageSnapshot | None:
+    """Resolve a workspace's usage snapshot, preferring a prefetched read.
+
+    Two tiers:
+    1. The request-scoped ``prefetched_usage_snapshots`` map, when this id is
+       present in it.
+    2. A direct ``read_latest_usage_snapshot`` read (a blocking ``Path.read_text``).
+
+    Tier 2 is reachable on the event loop, by design. Callers that resolve a
+    single workspace take this one bounded latest-wins read inline rather than
+    set up a prefetch context: ``GET /workspaces/{id}`` (``_get_workspace_response``
+    → ``workspace_response``), the websocket initial snapshot (``ws._send_initial_state``),
+    and ``WorkspaceService.get``/``create``. The prefetch exists only to spare
+    *multi-row* projections one blocking read per row, so any latency-sensitive
+    caller that fans out over many workspaces must read snapshots in a worker
+    thread and wrap the projection in ``prefetched_usage_snapshots`` (as the task
+    list and workspace overview endpoints do) instead of relying on this fallback.
+    """
+
     prefetched = _PREFETCHED_USAGE_SNAPSHOTS.get()
     if prefetched is not None and workspace_id is not None and workspace_id in prefetched:
         return prefetched[workspace_id]

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -869,7 +869,14 @@ def lifecycle_payload(
 def usage_payload(workspace: Workspace) -> LlmUsagePayload:
     usage = workspace_usage_summary(workspace)
     pricing = workspace_pricing_metadata(workspace)
-    cost, reason = compute_cost_estimate(usage, pricing)
+    cost, cost_reason = compute_cost_estimate(usage, pricing)
+    if cost is None and usage.cost_estimate is not None:
+        # AWF pricing metadata could not derive a cost (commonly: pricing not
+        # configured), but the usage source already reported one — e.g. ccusage's
+        # locally-recorded billing total. Surface that figure instead of dropping
+        # it behind a pricing_* reason that would otherwise force cost_estimate=null.
+        cost = usage.cost_estimate
+        cost_reason = None
     return {
         "input_tokens": usage.input_tokens,
         "output_tokens": usage.output_tokens,
@@ -878,7 +885,7 @@ def usage_payload(workspace: Workspace) -> LlmUsagePayload:
         "currency": usage.currency or (pricing.currency if pricing is not None else None),
         "status": "available" if cost is not None else usage.status,
         "source": usage.source,
-        "reason": usage.reason or reason,
+        "reason": usage.reason or cost_reason,
     }
 
 

--- a/tests/unit/adapters/test_base_usage_collection.py
+++ b/tests/unit/adapters/test_base_usage_collection.py
@@ -1,0 +1,229 @@
+"""Tests for usage-sampling wiring in ``AgentAdapter.run``.
+
+The adapter must drive the injected ``UsageSampler`` so the final sample is
+recorded in every exit path (success, failure, timeout, cancellation) without
+ever masking the agent outcome.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from awf.adapters.base import AgentRunError
+from awf.adapters.codex import CodexAdapter
+from awf.common.commands import COMMAND_TIMEOUT_REASON, CommandResult
+from awf.db.enums import AgentRuntime
+
+_COMPOSE_FILE = Path("/fake/compose.yml")
+
+
+class _RecordingContext:
+    def __init__(self, events: list[str], *, finalize_error: Exception | None = None) -> None:
+        self._events = events
+        self._finalize_error = finalize_error
+
+    async def finalize(self, *, status: str) -> None:
+        self._events.append(f"finalize:{status}")
+        if self._finalize_error is not None:
+            raise self._finalize_error
+
+
+class _RecordingSampler:
+    def __init__(
+        self,
+        events: list[str],
+        *,
+        start_error: Exception | None = None,
+        finalize_error: Exception | None = None,
+    ) -> None:
+        self._events = events
+        self._start_error = start_error
+        self._finalize_error = finalize_error
+        self.start_kwargs: dict[str, Any] | None = None
+
+    async def start(self, **kwargs: Any) -> _RecordingContext:
+        self._events.append("start")
+        self.start_kwargs = kwargs
+        if self._start_error is not None:
+            raise self._start_error
+        return _RecordingContext(self._events, finalize_error=self._finalize_error)
+
+
+class _EventRunner:
+    def __init__(self, events: list[str], *, result: CommandResult, cancel: bool = False) -> None:
+        self._events = events
+        self._result = result
+        self._cancel = cancel
+        self.calls: list[list[str]] = []
+
+    async def run(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        # Targeted cleanup on timeout/cancellation funnels through here.
+        self._events.append("cleanup")
+        self.calls.append(list(args))
+        return CommandResult(returncode=0, stdout="cleanup ok", stderr="")
+
+    async def run_streaming(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        self._events.append("agent")
+        if self._cancel:
+            raise asyncio.CancelledError
+        return self._result
+
+
+@pytest.mark.unit
+async def test_sampler_started_before_agent_and_finalized_on_success() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events)
+    runner = _EventRunner(events, result=CommandResult(returncode=0, stdout="ok", stderr=""))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    result = await adapter.run(
+        compose_project="proj",
+        compose_file=_COMPOSE_FILE,
+        prompt="do work",
+        workspace_id="ws_ok",
+    )
+
+    assert result.ok
+    assert events == ["start", "agent", "finalize:success"]
+    assert sampler.start_kwargs is not None
+    assert sampler.start_kwargs["provider"] is AgentRuntime.codex
+    assert sampler.start_kwargs["compose_project"] == "proj"
+    assert sampler.start_kwargs["workspace_id"] == "ws_ok"
+
+
+@pytest.mark.unit
+async def test_sampler_finalized_failed_on_agent_error() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events)
+    runner = _EventRunner(events, result=CommandResult(returncode=1, stdout="", stderr="boom"))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    with pytest.raises(AgentRunError):
+        await adapter.run(
+            compose_project="proj",
+            compose_file=_COMPOSE_FILE,
+            prompt="do work",
+            workspace_id="ws_fail",
+        )
+
+    assert events[-1] == "finalize:failed"
+
+
+@pytest.mark.unit
+async def test_sampler_finalized_timeout_on_agent_timeout() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events)
+    runner = _EventRunner(
+        events,
+        result=CommandResult(
+            returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON
+        ),
+    )
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    with pytest.raises(AgentRunError) as excinfo:
+        await adapter.run(
+            compose_project="proj",
+            compose_file=_COMPOSE_FILE,
+            prompt="do work",
+            workspace_id="ws_timeout",
+        )
+
+    assert excinfo.value.reason_code == "AGENT_TIMEOUT"
+    assert events[-1] == "finalize:timeout"
+
+
+@pytest.mark.unit
+async def test_sampler_finalized_cancelled_on_cancellation() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events)
+    runner = _EventRunner(
+        events, result=CommandResult(returncode=0, stdout="", stderr=""), cancel=True
+    )
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.run(
+            compose_project="proj",
+            compose_file=_COMPOSE_FILE,
+            prompt="do work",
+            workspace_id="ws_cancel",
+        )
+
+    assert events[-1] == "finalize:cancelled"
+
+
+@pytest.mark.unit
+async def test_sampler_start_error_does_not_mask_result() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events, start_error=RuntimeError("sampler down"))
+    runner = _EventRunner(events, result=CommandResult(returncode=0, stdout="ok", stderr=""))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    result = await adapter.run(
+        compose_project="proj",
+        compose_file=_COMPOSE_FILE,
+        prompt="do work",
+        workspace_id="ws_start_err",
+    )
+
+    assert result.ok
+    # start failed -> no context -> no finalize event, agent still ran.
+    assert events == ["start", "agent"]
+
+
+@pytest.mark.unit
+async def test_sampler_finalize_error_does_not_mask_agent_error() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events, finalize_error=RuntimeError("finalize down"))
+    runner = _EventRunner(events, result=CommandResult(returncode=1, stdout="", stderr="boom"))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    # The agent failure must surface even though finalize raised.
+    with pytest.raises(AgentRunError):
+        await adapter.run(
+            compose_project="proj",
+            compose_file=_COMPOSE_FILE,
+            prompt="do work",
+            workspace_id="ws_fin_err",
+        )
+    assert events[-1] == "finalize:failed"
+
+
+@pytest.mark.unit
+async def test_no_sampler_runs_agent_without_sampling() -> None:
+    events: list[str] = []
+    runner = _EventRunner(events, result=CommandResult(returncode=0, stdout="ok", stderr=""))
+    adapter = CodexAdapter(runner=runner)
+
+    result = await adapter.run(
+        compose_project="proj",
+        compose_file=_COMPOSE_FILE,
+        prompt="do work",
+        workspace_id="ws_none",
+    )
+
+    assert result.ok
+    assert events == ["agent"]
+
+
+@pytest.mark.unit
+async def test_sampler_skipped_without_workspace_id() -> None:
+    events: list[str] = []
+    sampler = _RecordingSampler(events)
+    runner = _EventRunner(events, result=CommandResult(returncode=0, stdout="ok", stderr=""))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    result = await adapter.run(
+        compose_project="proj",
+        compose_file=_COMPOSE_FILE,
+        prompt="do work",
+    )
+
+    assert result.ok
+    # No workspace_id -> sampler is not started.
+    assert events == ["agent"]

--- a/tests/unit/adapters/test_base_usage_collection.py
+++ b/tests/unit/adapters/test_base_usage_collection.py
@@ -177,6 +177,43 @@ async def test_sampler_start_error_does_not_mask_result() -> None:
 
 
 @pytest.mark.unit
+async def test_finalization_reached_when_start_cancelled() -> None:
+    # Cancellation during baseline capture makes CcusageCollector.start re-raise
+    # CancelledError. Since that is a BaseException (not caught by
+    # _start_usage_sampling's except-Exception guard), the call must sit inside
+    # the run try/finally so the cancelled exit path still reaches finalization
+    # (a no-op for the missing context) instead of escaping the guard.
+    events: list[str] = []
+    sampler = _RecordingSampler(events, start_error=asyncio.CancelledError())
+    runner = _EventRunner(events, result=CommandResult(returncode=0, stdout="ok", stderr=""))
+    adapter = CodexAdapter(runner=runner, usage_sampler=sampler)
+
+    finalize_calls: list[tuple[Any, str]] = []
+    original_finalize = adapter._finalize_usage_sampling
+
+    async def _recording_finalize(
+        sampler_ctx: Any, *, status: str, workspace_id: str | None
+    ) -> None:
+        finalize_calls.append((sampler_ctx, status))
+        await original_finalize(sampler_ctx, status=status, workspace_id=workspace_id)
+
+    adapter._finalize_usage_sampling = _recording_finalize  # type: ignore[method-assign]
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter.run(
+            compose_project="proj",
+            compose_file=_COMPOSE_FILE,
+            prompt="do work",
+            workspace_id="ws_cancel_start",
+        )
+
+    # start() raised before the agent ran, yet finalization still ran — with no
+    # context (None) and the cancelled status.
+    assert events == ["start"]
+    assert finalize_calls == [(None, "cancelled")]
+
+
+@pytest.mark.unit
 async def test_sampler_finalize_error_does_not_mask_agent_error() -> None:
     events: list[str] = []
     sampler = _RecordingSampler(events, finalize_error=RuntimeError("finalize down"))

--- a/tests/unit/api/test_egress_audit.py
+++ b/tests/unit/api/test_egress_audit.py
@@ -258,7 +258,7 @@ async def test_readyz_includes_egress_audit_check(
 
     try:
         resp = await client.get("/readyz")
-        assert resp.status_code == 200
+        assert resp.status_code == 200, resp.json()
         body = resp.json()
 
         checks = body.get("checks", {})

--- a/tests/unit/node/test_service_auth_mounts.py
+++ b/tests/unit/node/test_service_auth_mounts.py
@@ -228,6 +228,57 @@ def test_service_auth_mounts_preserve_existing_workspace_codex_home(tmp_path: Pa
 
 
 @pytest.mark.unit
+def test_service_auth_mounts_exclude_claude_usage_history(tmp_path: Path) -> None:
+    host_home = tmp_path / "host-home"
+    host_claude = host_home / ".claude"
+    (host_claude / "projects" / "repo").mkdir(parents=True)
+    (host_claude / "projects" / "repo" / "session.jsonl").write_text('{"usage": "historical"}\n')
+    (host_claude / "todos").mkdir()
+    (host_claude / "todos" / "x.json").write_text("{}\n")
+    (host_claude / "shell-snapshots").mkdir()
+    (host_claude / "statsig").mkdir()
+    (host_claude / "settings.json").write_text('{"theme": "dark"}\n')
+    work_dir = tmp_path / "work"
+
+    mounts = resolve_service_auth_mounts(
+        host_home=host_home,
+        work_dir=work_dir,
+        workspace_id="ws_auth",
+        host_env={},
+    )
+
+    claude_home = Path({m.target: m for m in mounts}["/home/agent/.claude"].source)
+    # Auth survives the copy, but the historical usage/transcript dirs do not —
+    # so ccusage cannot attribute host history to this workspace run.
+    assert (claude_home / "settings.json").read_text() == '{"theme": "dark"}\n'
+    assert not (claude_home / "projects").exists()
+    assert not (claude_home / "todos").exists()
+    assert not (claude_home / "shell-snapshots").exists()
+    assert not (claude_home / "statsig").exists()
+
+
+@pytest.mark.unit
+def test_service_auth_mounts_exclude_gemini_usage_history(tmp_path: Path) -> None:
+    host_home = tmp_path / "host-home"
+    host_gemini = host_home / ".gemini"
+    (host_gemini / "tmp" / "session").mkdir(parents=True)
+    (host_gemini / "tmp" / "session" / "logs.json").write_text('[{"tokens": 999}]\n')
+    (host_gemini / "settings.json").write_text('{"selectedAuthType": "oauth"}\n')
+    work_dir = tmp_path / "work"
+
+    mounts = resolve_service_auth_mounts(
+        host_home=host_home,
+        work_dir=work_dir,
+        workspace_id="ws_auth",
+        host_env={},
+    )
+
+    gemini_home = Path({m.target: m for m in mounts}["/home/agent/.gemini"].source)
+    assert (gemini_home / "settings.json").read_text() == '{"selectedAuthType": "oauth"}\n'
+    assert not (gemini_home / "tmp").exists()
+
+
+@pytest.mark.unit
 def test_service_auth_mounts_preserve_existing_workspace_claude_auth(tmp_path: Path) -> None:
     host_home = tmp_path / "host-home"
     host_claude = host_home / ".claude"

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -83,7 +83,10 @@ async def _wait_for(predicate: Callable[[], bool], *, tries: int = 200) -> None:
     for _ in range(tries):
         if predicate():
             return
-        await asyncio.sleep(0)
+        # Real (tiny) delay, not sleep(0): snapshot writes now run via
+        # asyncio.to_thread, so the poll must yield enough wall-time for the
+        # worker thread to complete and post its result back to the loop.
+        await asyncio.sleep(0.001)
     raise AssertionError("condition not reached")
 
 
@@ -369,7 +372,9 @@ async def test_live_snapshots_written_during_run(tmp_path: Path) -> None:
     )
     await _wait_for(lambda: len(clock.sleeps) == 1)
     clock.tick()
-    await _wait_for(lambda: len(runner.calls) == 2)
+    # The write trails the ccusage call (it now runs via asyncio.to_thread), so
+    # wait on the observable snapshot landing rather than the runner call count.
+    await _wait_for(lambda: read_latest_usage_snapshot("ws_live", work_dir=tmp_path) is not None)
 
     snap = read_latest_usage_snapshot("ws_live", work_dir=tmp_path)
     assert snap is not None

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -217,6 +217,55 @@ async def test_prior_snapshot_without_baseline_captures_fresh(tmp_path: Path) ->
 
 
 @pytest.mark.unit
+async def test_failed_baseline_does_not_leak_host_usage(tmp_path: Path) -> None:
+    # Baseline capture times out, then the final read succeeds with a large total
+    # that includes copied host history. Without a trustworthy baseline we must
+    # report unavailable rather than subtracting against nothing and leaking it.
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON)
+    runner.queue_result(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 999}}))
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_baseline_fail",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_baseline_fail", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+    assert snap.status == "unavailable"
+    assert snap.reason == "ccusage_timeout"  # baseline failure reason, not "available"
+    assert snap.total_tokens is None  # host total is NOT leaked as workspace usage
+
+
+@pytest.mark.unit
+async def test_fresh_workspace_no_records_baseline_reports_full_usage(tmp_path: Path) -> None:
+    # ccusage runs cleanly at baseline but the fresh workspace has no prior usage,
+    # so the later total is genuine workspace usage and must be reported in full.
+    runner = _ccusage_runner(
+        json.dumps({}),  # baseline: valid JSON, no usage records (fresh)
+        json.dumps({"totals": {"totalTokens": 12}}),  # final: real workspace usage
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_fresh",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_fresh", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.status == "available"
+    assert snap.total_tokens == 12  # full usage; no host history to subtract
+    assert snap.baseline is None  # nothing anchored, so the next run recaptures
+
+
+@pytest.mark.unit
 async def test_samples_at_sixty_second_interval_while_active(tmp_path: Path) -> None:
     clock = FakeClock()
     runner = _ccusage_runner(*[json.dumps({"totals": {"totalTokens": 1}})] * 8)

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -390,7 +390,7 @@ async def test_live_snapshots_written_during_run(tmp_path: Path) -> None:
         (CommandResult(returncode=2, stdout="", stderr="boom"), "ccusage_command_failed"),
         (CommandResult(returncode=127, stdout="", stderr=""), "ccusage_unavailable"),
         (
-            CommandResult(returncode=1, stdout="", stderr="sh: ccusage: not found"),
+            CommandResult(returncode=1, stdout="", stderr="sh: ccusage: command not found"),
             "ccusage_unavailable",
         ),
         (CommandResult(returncode=0, stdout="garbage{", stderr=""), "ccusage_invalid_json"),
@@ -575,8 +575,21 @@ async def test_sampler_errors_are_swallowed(tmp_path: Path) -> None:
     ("result", "expected"),
     [
         (CommandResult(returncode=127, stdout="", stderr=""), True),
-        (CommandResult(returncode=1, stdout="", stderr="ccusage: not found"), True),
+        # Exact shell phrases for a missing executable count even on a non-127 exit.
+        (CommandResult(returncode=1, stdout="", stderr="bash: ccusage: command not found"), True),
+        (
+            CommandResult(
+                returncode=1,
+                stdout="",
+                stderr="setsid: failed to execute ccusage: No such file or directory",
+            ),
+            True,
+        ),
         (CommandResult(returncode=1, stdout="", stderr="boom"), False),
+        # A bare "<x> not found" on stderr is an app-level error (e.g. ccusage
+        # "source not found"), not a missing binary — a real missing binary
+        # exits 127 (covered above).
+        (CommandResult(returncode=1, stdout="", stderr="source not found"), False),
         # App-level "not found" in stdout (non-127, clean stderr) is a command
         # failure, not a missing binary.
         (CommandResult(returncode=1, stdout="usage record not found", stderr=""), False),

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -577,6 +577,9 @@ async def test_sampler_errors_are_swallowed(tmp_path: Path) -> None:
         (CommandResult(returncode=127, stdout="", stderr=""), True),
         (CommandResult(returncode=1, stdout="", stderr="ccusage: not found"), True),
         (CommandResult(returncode=1, stdout="", stderr="boom"), False),
+        # App-level "not found" in stdout (non-127, clean stderr) is a command
+        # failure, not a missing binary.
+        (CommandResult(returncode=1, stdout="usage record not found", stderr=""), False),
     ],
 )
 def test_is_missing_binary(result: CommandResult, expected: bool) -> None:

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -293,6 +293,9 @@ async def test_failed_baseline_does_not_leak_host_usage(tmp_path: Path) -> None:
     # report unavailable rather than subtracting against nothing and leaking it.
     runner = FakeCommandRunner()
     runner.queue_result(returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON)
+    # The baseline timeout triggers targeted compose-exec cleanup, which issues a
+    # runner.run() that consumes the next FIFO slot (shared with run_streaming).
+    runner.queue_result(returncode=0, stdout="awf cleanup: absent")
     runner.queue_result(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 999}}))
     collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
     ctx = await collector.start(
@@ -309,6 +312,37 @@ async def test_failed_baseline_does_not_leak_host_usage(tmp_path: Path) -> None:
     assert snap.status == "unavailable"
     assert snap.reason == "ccusage_timeout"  # baseline failure reason, not "available"
     assert snap.total_tokens is None  # host total is NOT leaked as workspace usage
+
+
+@pytest.mark.unit
+async def test_timeout_runs_targeted_compose_exec_cleanup(tmp_path: Path) -> None:
+    # A timed-out ccusage exec only kills the local compose client; per the
+    # build_tracked_compose_exec contract the in-container process tree may survive.
+    # The collector must run targeted cleanup for the timed-out invocation so
+    # orphaned ccusage processes can't accumulate across repeated timeouts. The
+    # sample still stays reason-coded as ccusage_timeout.
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 1}}))  # baseline
+    runner.queue_result(returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON)
+    runner.queue_result(returncode=0, stdout="awf cleanup: killed")  # targeted cleanup run()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_timeout_cleanup",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="failed")
+
+    snap = read_latest_usage_snapshot("ws_timeout_cleanup", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+    assert snap.status == "unavailable"
+    assert snap.reason == "ccusage_timeout"  # cleanup failure must not change reason coding
+    # Exactly one targeted cleanup exec was issued for the timed-out invocation
+    # (the cleanup argv carries the awf-cleanup marker).
+    cleanup_calls = [call for call in runner.calls if "awf-cleanup" in call.args]
+    assert len(cleanup_calls) == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -768,15 +768,20 @@ async def test_sampler_errors_are_swallowed(tmp_path: Path) -> None:
     ("result", "expected"),
     [
         (CommandResult(returncode=127, stdout="", stderr=""), True),
-        # Exact shell phrases for a missing executable count even on a non-127 exit.
+        # The exact "command not found" shell phrase counts even on a non-127 exit.
         (CommandResult(returncode=1, stdout="", stderr="bash: ccusage: command not found"), True),
+        # A non-127 "no such file" is NOT a missing binary: a real missing binary
+        # exits 127 (covered above), whereas ccusage (Node) emits this phrase for
+        # ENOENT on a missing config/data file while the binary is present, so it
+        # must stay REASON_COMMAND_FAILED rather than REASON_UNAVAILABLE.
         (
             CommandResult(
                 returncode=1,
                 stdout="",
-                stderr="setsid: failed to execute ccusage: No such file or directory",
+                stderr="Error: ENOENT: no such file or directory, open "
+                "'/opt/awf/ccusage-neutral.json'",
             ),
-            True,
+            False,
         ),
         (CommandResult(returncode=1, stdout="", stderr="boom"), False),
         # A bare "<x> not found" on stderr is an app-level error (e.g. ccusage

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -1,0 +1,498 @@
+"""Unit tests for the ccusage usage collector (no real docker, no real CLI)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from awf.common.commands import COMMAND_TIMEOUT_REASON, CommandResult, FakeCommandRunner
+from awf.db.enums import AgentRuntime
+from awf.service import usage_collection
+from awf.service.usage_collection import CcusageCollector, _is_missing_binary, _RealClock
+from awf.service.usage_store import (
+    UsageSnapshot,
+    read_latest_usage_snapshot,
+    write_usage_snapshot,
+)
+
+_COMPOSE_FILE = Path("/fake/compose.yml")
+
+
+class FakeClock:
+    """Deterministic clock: ``sleep`` blocks until the test calls ``tick``."""
+
+    def __init__(self) -> None:
+        self.sleeps: list[float] = []
+        self._gate: asyncio.Queue[None] = asyncio.Queue()
+        self._t = datetime(2026, 5, 22, tzinfo=UTC)
+
+    def now(self) -> datetime:
+        return self._t
+
+    async def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        await self._gate.get()
+        self._t += timedelta(seconds=seconds)
+
+    def tick(self) -> None:
+        self._gate.put_nowait(None)
+
+
+class _BlockingRunner:
+    """``run_streaming`` records the call then blocks until ``release`` is set."""
+
+    def __init__(self, result: CommandResult) -> None:
+        self.calls: list[list[str]] = []
+        self.release = asyncio.Event()
+        self._result = result
+
+    async def run(self, args: list[str], **_kwargs: Any) -> CommandResult:  # pragma: no cover
+        raise AssertionError("run() should not be called")
+
+    async def run_streaming(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        self.calls.append(list(args))
+        await self.release.wait()
+        return self._result
+
+
+class _RaisingRunner:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    async def run(self, args: list[str], **_kwargs: Any) -> CommandResult:  # pragma: no cover
+        raise RuntimeError("boom")
+
+    async def run_streaming(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        self.calls.append(list(args))
+        raise RuntimeError("boom")
+
+
+async def _wait_for(predicate: Callable[[], bool], *, tries: int = 200) -> None:
+    for _ in range(tries):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition not reached")
+
+
+def _ccusage_runner(*stdouts: str) -> FakeCommandRunner:
+    runner = FakeCommandRunner()
+    for stdout in stdouts:
+        runner.queue_result(returncode=0, stdout=stdout)
+    return runner
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("provider", "source"),
+    [
+        (AgentRuntime.claude_code, "claude"),
+        (AgentRuntime.codex, "codex"),
+        (AgentRuntime.gemini, "gemini"),
+        (AgentRuntime.opencode, "opencode"),
+    ],
+)
+async def test_ccusage_argv_per_provider(
+    tmp_path: Path, provider: AgentRuntime, source: str
+) -> None:
+    runner = FakeCommandRunner()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="proj",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_argv",
+        provider=provider,
+    )
+    await ctx.finalize(status="success")
+
+    args = runner.calls[0].args
+    assert args[:2] == ["docker", "compose"]
+    assert "-p" in args and "proj" in args
+    assert "agent" in args
+    assert args[-5:] == ["ccusage", source, "daily", "--json", "--offline"]
+
+
+@pytest.mark.unit
+async def test_baseline_subtracted_from_final_sample(tmp_path: Path) -> None:
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 5, "inputTokens": 3, "outputTokens": 2}}),
+        json.dumps({"totals": {"totalTokens": 8, "inputTokens": 5, "outputTokens": 3}}),
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_delta",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_delta", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+    assert snap.status == "available"
+    assert snap.total_tokens == 3  # 8 - 5 baseline
+    assert snap.input_tokens == 2
+    assert snap.output_tokens == 1
+    assert snap.baseline == {
+        "input_tokens": 3,
+        "output_tokens": 2,
+        "total_tokens": 5,
+        "cost_estimate": None,
+        "currency": None,
+        "model": None,
+    }
+
+
+@pytest.mark.unit
+async def test_persisted_baseline_reused_across_runs(tmp_path: Path) -> None:
+    # A prior snapshot already anchored a baseline for this workspace.
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_reuse",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            baseline={"total_tokens": 100},
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _ccusage_runner(json.dumps({"totals": {"totalTokens": 130}}))
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_reuse",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_reuse", work_dir=tmp_path)
+    assert snap is not None
+    # delta uses the *persisted* baseline (100), not a fresh one: 130 - 100 = 30.
+    assert snap.total_tokens == 30
+    # The final sample was the only ccusage call (baseline reused, no extra call).
+    assert len(runner.calls) == 1
+
+
+@pytest.mark.unit
+async def test_prior_snapshot_without_baseline_captures_fresh(tmp_path: Path) -> None:
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_nobase",
+            provider="claude_code",
+            ccusage_source=None,
+            status="unavailable",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            reason="ccusage_source_unsupported",
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 10}}),
+        json.dumps({"totals": {"totalTokens": 17}}),
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_nobase",
+        provider=AgentRuntime.claude_code,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_nobase", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.total_tokens == 7  # fresh baseline 10, final 17
+    assert len(runner.calls) == 2
+
+
+@pytest.mark.unit
+async def test_samples_at_sixty_second_interval_while_active(tmp_path: Path) -> None:
+    clock = FakeClock()
+    runner = _ccusage_runner(*[json.dumps({"totals": {"totalTokens": 1}})] * 8)
+    collector = CcusageCollector(
+        runner=runner, work_dir=tmp_path, clock=clock, interval_seconds=60.0
+    )
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_cadence",
+        provider=AgentRuntime.codex,
+    )
+    assert len(runner.calls) == 1  # baseline at start
+
+    await _wait_for(lambda: len(clock.sleeps) == 1)
+    clock.tick()
+    await _wait_for(lambda: len(runner.calls) == 2)  # first live sample
+
+    await _wait_for(lambda: len(clock.sleeps) == 2)
+    clock.tick()
+    await _wait_for(lambda: len(runner.calls) == 3)  # second live sample
+
+    await _wait_for(lambda: len(clock.sleeps) == 3)
+    await ctx.finalize(status="success")
+    await _wait_for(lambda: len(runner.calls) == 4)  # final sample
+
+    assert clock.sleeps == [60.0, 60.0, 60.0]
+    snap = read_latest_usage_snapshot("ws_cadence", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+
+
+@pytest.mark.unit
+async def test_live_snapshots_written_during_run(tmp_path: Path) -> None:
+    clock = FakeClock()
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 2}}),  # baseline
+        json.dumps({"totals": {"totalTokens": 9}}),  # live sample
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_live",
+        provider=AgentRuntime.codex,
+    )
+    await _wait_for(lambda: len(clock.sleeps) == 1)
+    clock.tick()
+    await _wait_for(lambda: len(runner.calls) == 2)
+
+    snap = read_latest_usage_snapshot("ws_live", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "live"
+    assert snap.total_tokens == 7  # 9 - 2 baseline
+
+    await ctx.finalize(status="success")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("result", "expected_reason"),
+    [
+        (
+            CommandResult(returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON),
+            "ccusage_timeout",
+        ),
+        (CommandResult(returncode=2, stdout="", stderr="boom"), "ccusage_command_failed"),
+        (CommandResult(returncode=127, stdout="", stderr=""), "ccusage_unavailable"),
+        (
+            CommandResult(returncode=1, stdout="", stderr="sh: ccusage: not found"),
+            "ccusage_unavailable",
+        ),
+        (CommandResult(returncode=0, stdout="garbage{", stderr=""), "ccusage_invalid_json"),
+        (CommandResult(returncode=0, stdout="{}", stderr=""), "ccusage_no_records"),
+    ],
+)
+async def test_final_sample_reason_codes(
+    tmp_path: Path, result: CommandResult, expected_reason: str
+) -> None:
+    runner = FakeCommandRunner()
+    # Baseline reads a clean total; the final read returns the failure-shaped result.
+    runner.queue_result(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 1}}))
+    runner._queued.append(result)  # noqa: SLF001 - intentional canned final result
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_reason",
+        provider=AgentRuntime.gemini,
+    )
+    await ctx.finalize(status="failed")
+
+    snap = read_latest_usage_snapshot("ws_reason", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+    assert snap.status == "unavailable"
+    assert snap.reason == expected_reason
+
+
+@pytest.mark.unit
+async def test_unsupported_provider_records_reason_without_running_ccusage(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(usage_collection, "provider_ccusage_source", lambda _provider: None)
+    runner = FakeCommandRunner()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_unsupported",
+        provider=AgentRuntime.codex,
+    )
+    assert runner.calls == []  # no ccusage invocation for an unsupported source
+    live = read_latest_usage_snapshot("ws_unsupported", work_dir=tmp_path)
+    assert live is not None
+    assert live.reason == "ccusage_source_unsupported"
+    assert live.status == "unavailable"
+    assert live.ccusage_source is None
+
+    await ctx.finalize(status="success")
+    final = read_latest_usage_snapshot("ws_unsupported", work_dir=tmp_path)
+    assert final is not None
+    assert final.phase == "final"
+    assert final.reason == "ccusage_source_unsupported"
+    assert runner.calls == []
+
+
+@pytest.mark.unit
+async def test_finalize_is_idempotent(tmp_path: Path) -> None:
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 1}}),
+        json.dumps({"totals": {"totalTokens": 4}}),
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_idem",
+        provider=AgentRuntime.opencode,
+    )
+    await ctx.finalize(status="success")
+    calls_after_first = len(runner.calls)
+    await ctx.finalize(status="success")
+    assert len(runner.calls) == calls_after_first  # second finalize is a no-op
+
+
+@pytest.mark.unit
+async def test_finalize_completes_final_sample_under_cancellation(tmp_path: Path) -> None:
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_cancel",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            baseline={"total_tokens": 10},
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _BlockingRunner(
+        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 50}}), stderr="")
+    )
+    clock = FakeClock()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_cancel",
+        provider=AgentRuntime.claude_code,
+    )
+    assert runner.calls == []  # baseline reused from prior snapshot
+
+    await _wait_for(lambda: len(clock.sleeps) == 1)  # live loop parked on sleep
+    finalize_task = asyncio.ensure_future(ctx.finalize(status="cancelled"))
+    await _wait_for(lambda: len(runner.calls) == 1)  # final sample blocked in run_streaming
+
+    finalize_task.cancel()  # cancel the agent run mid-finalize
+    for _ in range(5):
+        await asyncio.sleep(0)
+    runner.release.set()  # let the shielded final sample complete
+    await finalize_task
+
+    snap = read_latest_usage_snapshot("ws_cancel", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.phase == "final"
+    assert snap.total_tokens == 40  # 50 - 10 baseline
+
+
+@pytest.mark.unit
+async def test_baseline_cancellation_propagates(tmp_path: Path) -> None:
+    runner = _BlockingRunner(
+        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 1}}), stderr="")
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    start_task = asyncio.ensure_future(
+        collector.start(
+            compose_project="p",
+            compose_file=_COMPOSE_FILE,
+            workspace_id="ws_bcancel",
+            provider=AgentRuntime.claude_code,
+        )
+    )
+    await _wait_for(lambda: len(runner.calls) == 1)  # baseline blocked in run_streaming
+    start_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await start_task
+
+
+@pytest.mark.unit
+async def test_live_sample_cancellation_propagates(tmp_path: Path) -> None:
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_lcancel",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            baseline={"total_tokens": 1},
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _BlockingRunner(
+        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 9}}), stderr="")
+    )
+    clock = FakeClock()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_lcancel",
+        provider=AgentRuntime.claude_code,
+    )
+    await _wait_for(lambda: len(clock.sleeps) == 1)  # parked on sleep
+    clock.tick()
+    await _wait_for(lambda: len(runner.calls) == 1)  # live sample blocked in run_streaming
+
+    assert ctx._task is not None
+    ctx._task.cancel()  # cancellation must propagate, not be swallowed
+    with pytest.raises(asyncio.CancelledError):
+        await ctx._task
+
+
+@pytest.mark.unit
+async def test_sampler_errors_are_swallowed(tmp_path: Path) -> None:
+    runner = _RaisingRunner()
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_raise",
+        provider=AgentRuntime.claude_code,
+    )
+    # Neither the baseline error nor the final-sample error propagates.
+    await ctx.finalize(status="failed")
+    assert read_latest_usage_snapshot("ws_raise", work_dir=tmp_path) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("result", "expected"),
+    [
+        (CommandResult(returncode=127, stdout="", stderr=""), True),
+        (CommandResult(returncode=1, stdout="", stderr="ccusage: not found"), True),
+        (CommandResult(returncode=1, stdout="", stderr="boom"), False),
+    ],
+)
+def test_is_missing_binary(result: CommandResult, expected: bool) -> None:
+    assert _is_missing_binary(result) is expected
+
+
+@pytest.mark.unit
+async def test_real_clock_defaults(tmp_path: Path) -> None:
+    # Constructing without a clock uses the real clock.
+    collector = CcusageCollector(runner=FakeCommandRunner(), work_dir=tmp_path)
+    assert isinstance(collector._clock, _RealClock)
+    assert isinstance(collector._clock.now(), datetime)
+    await collector._clock.sleep(0)

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -125,7 +125,18 @@ async def test_ccusage_argv_per_provider(
     assert args[:2] == ["docker", "compose"]
     assert "-p" in args and "proj" in args
     assert "agent" in args
-    assert args[-5:] == ["ccusage", source, "daily", "--json", "--offline"]
+    # ``--config`` pins a neutral config (baked into the agent-runtime image) so
+    # ccusage skips auto-discovery of user/project ccusage configs that could
+    # otherwise filter per-run totals. The literal path must match the Dockerfile.
+    assert args[-7:] == [
+        "ccusage",
+        source,
+        "daily",
+        "--json",
+        "--offline",
+        "--config",
+        "/opt/awf/ccusage-neutral.json",
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -370,11 +370,25 @@ async def test_live_snapshots_written_during_run(tmp_path: Path) -> None:
         workspace_id="ws_live",
         provider=AgentRuntime.codex,
     )
+    # start() seeds an immediate zero-delta "running" snapshot from the baseline
+    # reading (so a reused workspace id can't surface a prior run's totals before
+    # the first live sample). It lands synchronously, before the first tick.
+    seed = read_latest_usage_snapshot("ws_live", work_dir=tmp_path)
+    assert seed is not None
+    assert seed.phase == "live"
+    assert seed.total_tokens == 0  # baseline 2 - baseline 2
+
     await _wait_for(lambda: len(clock.sleeps) == 1)
     clock.tick()
-    # The write trails the ccusage call (it now runs via asyncio.to_thread), so
-    # wait on the observable snapshot landing rather than the runner call count.
-    await _wait_for(lambda: read_latest_usage_snapshot("ws_live", work_dir=tmp_path) is not None)
+    # The write trails the ccusage call (it now runs via asyncio.to_thread), and
+    # the seed is already on disk, so wait on the live *delta* landing rather than
+    # mere snapshot presence.
+    await _wait_for(
+        lambda: (
+            (snap := read_latest_usage_snapshot("ws_live", work_dir=tmp_path)) is not None
+            and snap.total_tokens == 7
+        )
+    )
 
     snap = read_latest_usage_snapshot("ws_live", work_dir=tmp_path)
     assert snap is not None
@@ -382,6 +396,88 @@ async def test_live_snapshots_written_during_run(tmp_path: Path) -> None:
     assert snap.total_tokens == 7  # 9 - 2 baseline
 
     await ctx.finalize(status="success")
+
+
+@pytest.mark.unit
+async def test_start_seeds_running_snapshot_over_prior_run(tmp_path: Path) -> None:
+    # A prior run left a final snapshot with metrics for this workspace id, which
+    # retries/recovery reuse. At start — before the first live sample — the
+    # collector must overwrite it with a fresh zero-delta "running" snapshot so
+    # workspace_usage_summary can't keep reporting the prior run's 500-token total
+    # as this run's usage during the pre-first-sample window.
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_seed",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            run_status="success",
+            captured_at="2026-05-22T00:00:00+00:00",
+            input_tokens=300,
+            output_tokens=200,
+            total_tokens=500,
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _ccusage_runner(json.dumps({"totals": {"totalTokens": 120}}))  # fresh baseline only
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_seed",
+        provider=AgentRuntime.claude_code,
+    )
+
+    # No live tick yet: the seed has already replaced the prior snapshot on disk.
+    seed = read_latest_usage_snapshot("ws_seed", work_dir=tmp_path)
+    assert seed is not None
+    assert seed.phase == "live"
+    assert seed.run_status == "running"
+    assert seed.status == "available"
+    assert seed.total_tokens == 0  # baseline 120 - baseline 120, not the prior 500
+    assert len(runner.calls) == 1  # only the baseline exec; the seed reuses it
+
+    await ctx.finalize(status="cancelled")
+
+
+@pytest.mark.unit
+async def test_start_seed_clears_stale_metrics_when_baseline_unavailable(tmp_path: Path) -> None:
+    # Same reused-id scenario, but the run-start baseline read times out, so no
+    # trustworthy baseline is anchored. The seed must still overwrite the prior
+    # run's metrics — reporting unavailable with the baseline reason rather than
+    # leaving the stale 500-token total as this run's usage.
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_seed_fail",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            total_tokens=500,
+        ),
+        work_dir=tmp_path,
+    )
+    runner = FakeCommandRunner()
+    runner.queue_result(returncode=124, stdout="", stderr="", reason_code=COMMAND_TIMEOUT_REASON)
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_seed_fail",
+        provider=AgentRuntime.claude_code,
+    )
+
+    seed = read_latest_usage_snapshot("ws_seed_fail", work_dir=tmp_path)
+    assert seed is not None
+    assert seed.phase == "live"
+    assert seed.run_status == "running"
+    assert seed.status == "unavailable"
+    assert seed.reason == "ccusage_timeout"  # baseline failure reason, not "available"
+    assert seed.total_tokens is None  # prior run's 500 cleared, not reported
+
+    await ctx.finalize(status="failed")
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -749,7 +749,18 @@ async def test_sampler_errors_are_swallowed(tmp_path: Path) -> None:
     )
     # Neither the baseline error nor the final-sample error propagates.
     await ctx.finalize(status="failed")
-    assert read_latest_usage_snapshot("ws_raise", work_dir=tmp_path) is None
+    # The baseline read raised before anchoring a baseline, but the start path
+    # still seeds an unavailable snapshot so a reused workspace id's prior-run
+    # snapshot.json can't be reported as this run's usage during the window before
+    # the first live tick. The final-sample error is swallowed (no later write),
+    # so this seed stays the latest record on disk.
+    seed = read_latest_usage_snapshot("ws_raise", work_dir=tmp_path)
+    assert seed is not None
+    assert seed.phase == "live"
+    assert seed.run_status == "running"
+    assert seed.status == "unavailable"
+    assert seed.reason == "ccusage_command_failed"  # baseline failure, not a reading
+    assert seed.total_tokens is None  # no prior-run metrics reported as this run's
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
@@ -604,6 +605,75 @@ async def test_finalize_completes_final_sample_under_cancellation(tmp_path: Path
     assert snap is not None
     assert snap.phase == "final"
     assert snap.total_tokens == 40  # 50 - 10 baseline
+
+
+@pytest.mark.unit
+async def test_final_write_drains_inflight_live_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A live-sample snapshot write runs in a worker thread that can't be
+    # cancelled. If finalize cancelled the loop and raced ahead to its own final
+    # write while that live write was still mid-rename, the two renames would race
+    # and a late live rename could clobber the final snapshot (the store is
+    # latest-wins). finalize must instead drain the in-flight live write first, so
+    # the final write is never even started until the live write has landed.
+    real_write = usage_collection.write_usage_snapshot
+    block_live = threading.Event()  # enabled once the start-time seed write is done
+    live_entered = threading.Event()  # worker signals it is blocked mid live write
+    release_live = threading.Event()  # test releases the blocked live write
+    final_started = threading.Event()  # worker signals the final write has begun
+
+    def instrumented_write(snapshot: UsageSnapshot, *, work_dir: Path) -> Path:
+        if snapshot.phase == "live" and block_live.is_set():
+            live_entered.set()
+            release_live.wait()
+        if snapshot.phase == "final":
+            final_started.set()
+        return real_write(snapshot, work_dir=work_dir)
+
+    monkeypatch.setattr(usage_collection, "write_usage_snapshot", instrumented_write)
+
+    clock = FakeClock()
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 2}}),  # baseline (+ start-time seed write)
+        json.dumps({"totals": {"totalTokens": 9}}),  # live sample
+        json.dumps({"totals": {"totalTokens": 12}}),  # final sample
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_drain",
+        provider=AgentRuntime.claude_code,
+    )
+
+    # The seed write already landed during start(); only block the live sample.
+    block_live.set()
+    await _wait_for(lambda: len(clock.sleeps) == 1)
+    clock.tick()
+    await _wait_for(live_entered.is_set)  # live write is now blocked in its worker thread
+
+    finalize_task = asyncio.ensure_future(ctx.finalize(status="success"))
+    await _wait_for(lambda: ctx._task is not None and ctx._task.done())  # loop cancelled
+
+    # The default executor has many workers, so without draining the final write
+    # would run on its own thread and race the blocked live write's rename. Give
+    # finalize ample yields: the final write must not start while the live write
+    # is still in flight (each sleep lets finalize/the worker threads progress).
+    for _ in range(50):
+        await asyncio.sleep(0.002)
+        assert not final_started.is_set(), "final write started before the live write drained"
+    assert not finalize_task.done()  # blocked draining the in-flight live write
+
+    release_live.set()  # let the in-flight live write finish its rename
+    await finalize_task
+
+    snap = read_latest_usage_snapshot("ws_drain", work_dir=tmp_path)
+    assert snap is not None
+    # The final write ran only after the live write landed, so it wins latest-wins.
+    assert snap.phase == "final"
+    assert snap.run_status == "success"
+    assert snap.total_tokens == 10  # final 12 - baseline 2
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -45,18 +45,24 @@ class FakeClock:
 
 
 class _BlockingRunner:
-    """``run_streaming`` records the call then blocks until ``release`` is set."""
+    """``run_streaming`` records each call. The first calls return the matching
+    ``passthrough`` result immediately (e.g. the run-start baseline read); every
+    later call blocks until ``release`` is set."""
 
-    def __init__(self, result: CommandResult) -> None:
+    def __init__(self, result: CommandResult, *, passthrough: Sequence[CommandResult] = ()) -> None:
         self.calls: list[list[str]] = []
         self.release = asyncio.Event()
         self._result = result
+        self._passthrough = tuple(passthrough)
 
     async def run(self, args: list[str], **_kwargs: Any) -> CommandResult:  # pragma: no cover
         raise AssertionError("run() should not be called")
 
     async def run_streaming(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        index = len(self.calls)
         self.calls.append(list(args))
+        if index < len(self._passthrough):
+            return self._passthrough[index]
         await self.release.wait()
         return self._result
 
@@ -151,8 +157,15 @@ async def test_baseline_subtracted_from_final_sample(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-async def test_persisted_baseline_reused_across_runs(tmp_path: Path) -> None:
-    # A prior snapshot already anchored a baseline for this workspace.
+async def test_prior_baseline_not_reused_fresh_capture_each_run(tmp_path: Path) -> None:
+    # A prior snapshot anchored a baseline for this workspace, but it must NOT be
+    # reused. The per-workspace auth copy persists across retries/recovery runs
+    # (auth_mounts skips the copy when the target dir exists; GC only runs on
+    # workspace completion), so the prior run's transcripts are still on disk and
+    # ccusage at this run's start already reflects them. Here the persisted
+    # baseline is 100 but the on-disk reading at run start is 120 (the prior run
+    # added 20). Reusing 100 would report 130-100=30, inflating this run's total
+    # by the prior run's usage; a fresh baseline (120) reports the true 130-120=10.
     write_usage_snapshot(
         UsageSnapshot(
             workspace_id="ws_reuse",
@@ -165,7 +178,10 @@ async def test_persisted_baseline_reused_across_runs(tmp_path: Path) -> None:
         ),
         work_dir=tmp_path,
     )
-    runner = _ccusage_runner(json.dumps({"totals": {"totalTokens": 130}}))
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 120}}),  # fresh baseline at run start
+        json.dumps({"totals": {"totalTokens": 130}}),  # final
+    )
     collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
     ctx = await collector.start(
         compose_project="p",
@@ -177,10 +193,10 @@ async def test_persisted_baseline_reused_across_runs(tmp_path: Path) -> None:
 
     snap = read_latest_usage_snapshot("ws_reuse", work_dir=tmp_path)
     assert snap is not None
-    # delta uses the *persisted* baseline (100), not a fresh one: 130 - 100 = 30.
-    assert snap.total_tokens == 30
-    # The final sample was the only ccusage call (baseline reused, no extra call).
-    assert len(runner.calls) == 1
+    # Fresh baseline (120) captured at run start, NOT the persisted 100: 130-120=10.
+    assert snap.total_tokens == 10
+    # Two ccusage calls: fresh baseline + final (no reuse short-circuit).
+    assert len(runner.calls) == 2
 
 
 @pytest.mark.unit
@@ -453,20 +469,15 @@ async def test_finalize_is_idempotent(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 async def test_finalize_completes_final_sample_under_cancellation(tmp_path: Path) -> None:
-    write_usage_snapshot(
-        UsageSnapshot(
-            workspace_id="ws_cancel",
-            provider="claude_code",
-            ccusage_source="claude",
-            status="available",
-            phase="final",
-            captured_at="2026-05-22T00:00:00+00:00",
-            baseline={"total_tokens": 10},
-        ),
-        work_dir=tmp_path,
-    )
+    # Baseline is read fresh at run start (passthrough, totalTokens=10); the final
+    # sample (totalTokens=50) blocks in run_streaming so we can cancel mid-finalize.
     runner = _BlockingRunner(
-        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 50}}), stderr="")
+        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 50}}), stderr=""),
+        passthrough=[
+            CommandResult(
+                returncode=0, stdout=json.dumps({"totals": {"totalTokens": 10}}), stderr=""
+            )
+        ],
     )
     clock = FakeClock()
     collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
@@ -476,11 +487,11 @@ async def test_finalize_completes_final_sample_under_cancellation(tmp_path: Path
         workspace_id="ws_cancel",
         provider=AgentRuntime.claude_code,
     )
-    assert runner.calls == []  # baseline reused from prior snapshot
+    assert len(runner.calls) == 1  # fresh baseline captured at run start
 
     await _wait_for(lambda: len(clock.sleeps) == 1)  # live loop parked on sleep
     finalize_task = asyncio.ensure_future(ctx.finalize(status="cancelled"))
-    await _wait_for(lambda: len(runner.calls) == 1)  # final sample blocked in run_streaming
+    await _wait_for(lambda: len(runner.calls) == 2)  # final sample blocked in run_streaming
 
     finalize_task.cancel()  # cancel the agent run mid-finalize
     for _ in range(5):
@@ -516,20 +527,15 @@ async def test_baseline_cancellation_propagates(tmp_path: Path) -> None:
 
 @pytest.mark.unit
 async def test_live_sample_cancellation_propagates(tmp_path: Path) -> None:
-    write_usage_snapshot(
-        UsageSnapshot(
-            workspace_id="ws_lcancel",
-            provider="claude_code",
-            ccusage_source="claude",
-            status="available",
-            phase="final",
-            captured_at="2026-05-22T00:00:00+00:00",
-            baseline={"total_tokens": 1},
-        ),
-        work_dir=tmp_path,
-    )
+    # Baseline is read fresh at run start (passthrough); the live sample blocks in
+    # run_streaming so we can cancel it and assert the cancellation propagates.
     runner = _BlockingRunner(
-        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 9}}), stderr="")
+        CommandResult(returncode=0, stdout=json.dumps({"totals": {"totalTokens": 9}}), stderr=""),
+        passthrough=[
+            CommandResult(
+                returncode=0, stdout=json.dumps({"totals": {"totalTokens": 1}}), stderr=""
+            )
+        ],
     )
     clock = FakeClock()
     collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=clock)
@@ -541,7 +547,7 @@ async def test_live_sample_cancellation_propagates(tmp_path: Path) -> None:
     )
     await _wait_for(lambda: len(clock.sleeps) == 1)  # parked on sleep
     clock.tick()
-    await _wait_for(lambda: len(runner.calls) == 1)  # live sample blocked in run_streaming
+    await _wait_for(lambda: len(runner.calls) == 2)  # live sample blocked in run_streaming
 
     assert ctx._task is not None
     ctx._task.cancel()  # cancellation must propagate, not be swallowed

--- a/tests/unit/service/test_usage_collection.py
+++ b/tests/unit/service/test_usage_collection.py
@@ -184,6 +184,45 @@ async def test_persisted_baseline_reused_across_runs(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+async def test_baseline_not_reused_when_provider_changed(tmp_path: Path) -> None:
+    # A workspace can switch agents in place (provider recovery fallback), so a
+    # prior baseline anchored for a different provider/source must not be reused:
+    # subtracting it against an unrelated ccusage source would skew the delta.
+    write_usage_snapshot(
+        UsageSnapshot(
+            workspace_id="ws_switch",
+            provider="claude_code",
+            ccusage_source="claude",
+            status="available",
+            phase="final",
+            captured_at="2026-05-22T00:00:00+00:00",
+            baseline={"total_tokens": 100},
+        ),
+        work_dir=tmp_path,
+    )
+    runner = _ccusage_runner(
+        json.dumps({"totals": {"totalTokens": 10}}),  # fresh codex baseline
+        json.dumps({"totals": {"totalTokens": 17}}),  # codex final
+    )
+    collector = CcusageCollector(runner=runner, work_dir=tmp_path, clock=FakeClock())
+    ctx = await collector.start(
+        compose_project="p",
+        compose_file=_COMPOSE_FILE,
+        workspace_id="ws_switch",
+        provider=AgentRuntime.codex,
+    )
+    await ctx.finalize(status="success")
+
+    snap = read_latest_usage_snapshot("ws_switch", work_dir=tmp_path)
+    assert snap is not None
+    assert snap.provider == "codex"
+    assert snap.ccusage_source == "codex"
+    # Stale claude baseline (100) ignored; a fresh codex baseline (10) is captured.
+    assert snap.total_tokens == 7  # fresh baseline 10, final 17
+    assert len(runner.calls) == 2  # fresh baseline + final, not a single reused call
+
+
+@pytest.mark.unit
 async def test_prior_snapshot_without_baseline_captures_fresh(tmp_path: Path) -> None:
     write_usage_snapshot(
         UsageSnapshot(

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -134,7 +134,7 @@ def test_normalize_ccusage_json_extracts_model_when_present() -> None:
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("raw", ["", "   ", "not-json{", "[1, 2, 3]"])
+@pytest.mark.parametrize("raw", ["not-json{", "[1, 2, 3]"])
 def test_normalize_ccusage_json_invalid_returns_invalid_json(raw: str) -> None:
     usage, reason = normalize_ccusage_json(raw)
     assert usage is None
@@ -145,6 +145,9 @@ def test_normalize_ccusage_json_invalid_returns_invalid_json(raw: str) -> None:
 @pytest.mark.parametrize(
     "raw",
     [
+        # Empty / whitespace-only output from an exit-0 run is "no records yet".
+        "",
+        "   ",
         json.dumps({}),
         json.dumps({"daily": []}),
         json.dumps({"totals": {}}),

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -375,6 +375,34 @@ def test_write_snapshot_is_atomic_overwrite(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_write_snapshot_cleans_up_temp_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The per-write unique temp suffix (added so concurrent same-process writers
+    # cannot collide) must not leak: a write that fails before the atomic
+    # replace has to remove its partial temp instead of orphaning it.
+    snapshot = UsageSnapshot(
+        workspace_id="ws_fail",
+        provider="claude_code",
+        ccusage_source="claude",
+        status="available",
+        phase="final",
+        captured_at="2026-05-22T01:02:03+00:00",
+        total_tokens=7,
+    )
+
+    def boom(self: Path, target: Path) -> None:
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(Path, "replace", boom)
+    with pytest.raises(OSError, match="replace failed"):
+        write_usage_snapshot(snapshot, work_dir=tmp_path)
+
+    usage_dir = workspace_usage_dir(tmp_path, "ws_fail")
+    assert list(usage_dir.iterdir()) == []
+
+
+@pytest.mark.unit
 def test_snapshot_serialization_contains_only_safe_keys(tmp_path: Path) -> None:
     snapshot = UsageSnapshot(
         workspace_id="ws_safe",

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -198,6 +198,27 @@ def test_normalize_ccusage_json_daily_skips_noise_entries() -> None:
 
 
 @pytest.mark.unit
+def test_normalize_ccusage_json_daily_preserves_unknown_token_field() -> None:
+    # When no daily entry reports a token field, the aggregate must stay
+    # ``None`` (unknown) rather than collapsing to a misleading ``0``.
+    raw = json.dumps(
+        {
+            "daily": [
+                {"outputTokens": 5},
+                {"outputTokens": 7},
+            ]
+        }
+    )
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens is None
+    assert usage.output_tokens == 12
+    assert usage.total_tokens == 12
+    assert usage.cost_estimate is None
+
+
+@pytest.mark.unit
 def test_normalized_usage_baseline_dict_round_trip() -> None:
     usage = NormalizedUsage(
         input_tokens=1, output_tokens=2, total_tokens=3, cost_estimate=0.4, currency="USD"

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -1,0 +1,441 @@
+"""Unit tests for the AWF-owned usage snapshot store and ccusage normalizer."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from awf.db.enums import AgentRuntime
+from awf.service import usage_store
+from awf.service.usage_store import (
+    REASON_INVALID_JSON,
+    REASON_NO_RECORDS,
+    SCHEMA_VERSION,
+    NormalizedUsage,
+    UsageSnapshot,
+    normalize_ccusage_json,
+    provider_ccusage_source,
+    read_latest_usage_snapshot,
+    subtract_baseline,
+    workspace_usage_dir,
+    write_usage_snapshot,
+)
+
+_ALLOWED_SNAPSHOT_KEYS = {
+    "schema_version",
+    "workspace_id",
+    "provider",
+    "source",
+    "ccusage_source",
+    "model",
+    "status",
+    "reason",
+    "phase",
+    "captured_at",
+    "input_tokens",
+    "output_tokens",
+    "total_tokens",
+    "cost_estimate",
+    "currency",
+    "baseline",
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("runtime", "expected"),
+    [
+        (AgentRuntime.claude_code, "claude"),
+        (AgentRuntime.codex, "codex"),
+        (AgentRuntime.gemini, "gemini"),
+        (AgentRuntime.opencode, "opencode"),
+    ],
+)
+def test_provider_ccusage_source_maps_all_supported_runtimes(
+    runtime: AgentRuntime, expected: str
+) -> None:
+    assert provider_ccusage_source(runtime) == expected
+
+
+@pytest.mark.unit
+def test_provider_ccusage_source_unknown_returns_none() -> None:
+    assert provider_ccusage_source("mystery") is None  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_reads_totals() -> None:
+    raw = json.dumps(
+        {
+            "totals": {
+                "inputTokens": 100,
+                "outputTokens": 40,
+                "totalTokens": 140,
+                "totalCost": 0.25,
+            }
+        }
+    )
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage == NormalizedUsage(
+        input_tokens=100,
+        output_tokens=40,
+        total_tokens=140,
+        cost_estimate=0.25,
+        currency="USD",
+        model=None,
+    )
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_sums_daily_when_no_totals() -> None:
+    raw = json.dumps(
+        {
+            "daily": [
+                {"inputTokens": 10, "outputTokens": 5, "totalTokens": 15, "totalCost": 0.01},
+                {"inputTokens": 20, "outputTokens": 10, "totalTokens": 30, "totalCost": 0.02},
+            ]
+        }
+    )
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens == 30
+    assert usage.output_tokens == 15
+    assert usage.total_tokens == 45
+    assert usage.cost_estimate is not None
+    assert abs(usage.cost_estimate - 0.03) < 1e-9
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_tolerates_missing_fields_and_synthesizes_total() -> None:
+    raw = json.dumps({"totals": {"inputTokens": 100}})
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens == 100
+    assert usage.output_tokens is None
+    # total synthesized from the available token counts
+    assert usage.total_tokens == 100
+    assert usage.cost_estimate is None
+    assert usage.currency is None
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_extracts_model_when_present() -> None:
+    raw = json.dumps({"model": "claude-opus", "totals": {"totalTokens": 7}})
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.model == "claude-opus"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("raw", ["", "   ", "not-json{", "[1, 2, 3]"])
+def test_normalize_ccusage_json_invalid_returns_invalid_json(raw: str) -> None:
+    usage, reason = normalize_ccusage_json(raw)
+    assert usage is None
+    assert reason == REASON_INVALID_JSON
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "raw",
+    [
+        json.dumps({}),
+        json.dumps({"daily": []}),
+        json.dumps({"totals": {}}),
+        json.dumps({"totals": {"note": "no numbers"}, "daily": []}),
+    ],
+)
+def test_normalize_ccusage_json_no_records(raw: str) -> None:
+    usage, reason = normalize_ccusage_json(raw)
+    assert usage is None
+    assert reason == REASON_NO_RECORDS
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_ignores_bool_token_values() -> None:
+    # JSON booleans must not be treated as integer token counts.
+    raw = json.dumps({"totals": {"inputTokens": True, "outputTokens": 5, "totalCost": True}})
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens is None
+    assert usage.output_tokens == 5
+    assert usage.cost_estimate is None
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_ignores_non_numeric_token_values() -> None:
+    raw = json.dumps({"totals": {"inputTokens": "abc", "outputTokens": 5, "totalCost": "free"}})
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens is None
+    assert usage.output_tokens == 5
+    assert usage.cost_estimate is None
+
+
+@pytest.mark.unit
+def test_normalize_ccusage_json_daily_skips_noise_entries() -> None:
+    raw = json.dumps(
+        {
+            "daily": [
+                "not-a-dict",
+                {"note": "no numbers here"},
+                {"inputTokens": 4, "outputTokens": 1, "totalTokens": 5},
+            ]
+        }
+    )
+    usage, reason = normalize_ccusage_json(raw)
+    assert reason is None
+    assert usage is not None
+    assert usage.input_tokens == 4
+    assert usage.total_tokens == 5
+
+
+@pytest.mark.unit
+def test_normalized_usage_baseline_dict_round_trip() -> None:
+    usage = NormalizedUsage(
+        input_tokens=1, output_tokens=2, total_tokens=3, cost_estimate=0.4, currency="USD"
+    )
+    assert NormalizedUsage.from_baseline_dict(usage.as_baseline_dict()) == usage
+
+
+@pytest.mark.unit
+def test_snapshot_baseline_usage_helper() -> None:
+    snapshot = UsageSnapshot(
+        workspace_id="ws",
+        provider="codex",
+        ccusage_source="codex",
+        status="available",
+        phase="live",
+        captured_at="2026-05-22T00:00:00+00:00",
+        baseline={"total_tokens": 7},
+    )
+    baseline = snapshot.baseline_usage()
+    assert baseline is not None
+    assert baseline.total_tokens == 7
+    # No baseline dict -> None.
+    assert (
+        UsageSnapshot(
+            workspace_id="ws",
+            provider="codex",
+            ccusage_source="codex",
+            status="available",
+            phase="live",
+            captured_at="2026-05-22T00:00:00+00:00",
+        ).baseline_usage()
+        is None
+    )
+
+
+@pytest.mark.unit
+def test_subtract_baseline_with_partial_baseline_fields() -> None:
+    current = NormalizedUsage(input_tokens=10, total_tokens=10, cost_estimate=0.5)
+    baseline = NormalizedUsage(input_tokens=4)  # only input has a baseline value
+    delta = subtract_baseline(current, baseline)
+    assert delta.input_tokens == 6
+    # baseline missing for these -> current passes through unchanged
+    assert delta.total_tokens == 10
+    assert delta.cost_estimate == 0.5
+
+
+@pytest.mark.unit
+def test_subtract_baseline_clamps_to_non_negative() -> None:
+    current = NormalizedUsage(
+        input_tokens=150, output_tokens=60, total_tokens=210, cost_estimate=0.30, currency="USD"
+    )
+    baseline = NormalizedUsage(
+        input_tokens=100, output_tokens=80, total_tokens=180, cost_estimate=0.25, currency="USD"
+    )
+    delta = subtract_baseline(current, baseline)
+    assert delta.input_tokens == 50
+    # baseline larger than current -> clamped to 0, never negative
+    assert delta.output_tokens == 0
+    assert delta.total_tokens == 30
+    assert delta.cost_estimate is not None
+    assert abs(delta.cost_estimate - 0.05) < 1e-9
+    assert delta.currency == "USD"
+
+
+@pytest.mark.unit
+def test_subtract_baseline_none_returns_current() -> None:
+    current = NormalizedUsage(input_tokens=10, total_tokens=10)
+    assert subtract_baseline(current, None) == current
+
+
+@pytest.mark.unit
+def test_subtract_baseline_preserves_none_current_fields() -> None:
+    current = NormalizedUsage(input_tokens=None, total_tokens=5)
+    baseline = NormalizedUsage(input_tokens=3, total_tokens=2)
+    delta = subtract_baseline(current, baseline)
+    assert delta.input_tokens is None
+    assert delta.total_tokens == 3
+
+
+@pytest.mark.unit
+def test_usage_snapshot_has_metrics() -> None:
+    assert UsageSnapshot(
+        workspace_id="ws",
+        provider="claude_code",
+        ccusage_source="claude",
+        status="available",
+        phase="final",
+        captured_at="2026-05-22T00:00:00+00:00",
+        total_tokens=5,
+    ).has_metrics
+    assert not UsageSnapshot(
+        workspace_id="ws",
+        provider="claude_code",
+        ccusage_source="claude",
+        status="unavailable",
+        phase="final",
+        captured_at="2026-05-22T00:00:00+00:00",
+        reason="ccusage_no_records",
+    ).has_metrics
+
+
+@pytest.mark.unit
+def test_write_and_read_snapshot_round_trip(tmp_path: Path) -> None:
+    snapshot = UsageSnapshot(
+        workspace_id="ws_round",
+        provider="codex",
+        ccusage_source="codex",
+        status="available",
+        phase="live",
+        captured_at="2026-05-22T01:02:03+00:00",
+        model="gpt-5",
+        input_tokens=12,
+        output_tokens=8,
+        total_tokens=20,
+        cost_estimate=0.02,
+        currency="USD",
+        baseline={"total_tokens": 4},
+    )
+    path = write_usage_snapshot(snapshot, work_dir=tmp_path)
+    assert path == workspace_usage_dir(tmp_path, "ws_round") / "snapshot.json"
+
+    loaded = read_latest_usage_snapshot("ws_round", work_dir=tmp_path)
+    assert loaded == snapshot
+    assert loaded is not None
+    assert loaded.schema_version == SCHEMA_VERSION
+
+
+@pytest.mark.unit
+def test_write_snapshot_is_atomic_overwrite(tmp_path: Path) -> None:
+    base = {
+        "workspace_id": "ws_over",
+        "provider": "gemini",
+        "ccusage_source": "gemini",
+        "status": "available",
+        "captured_at": "2026-05-22T01:02:03+00:00",
+    }
+    write_usage_snapshot(UsageSnapshot(phase="live", total_tokens=5, **base), work_dir=tmp_path)
+    write_usage_snapshot(UsageSnapshot(phase="final", total_tokens=9, **base), work_dir=tmp_path)
+    loaded = read_latest_usage_snapshot("ws_over", work_dir=tmp_path)
+    assert loaded is not None
+    assert loaded.phase == "final"
+    assert loaded.total_tokens == 9
+    # No leftover temp files in the usage dir.
+    usage_dir = workspace_usage_dir(tmp_path, "ws_over")
+    assert [p.name for p in usage_dir.iterdir()] == ["snapshot.json"]
+
+
+@pytest.mark.unit
+def test_snapshot_serialization_contains_only_safe_keys(tmp_path: Path) -> None:
+    snapshot = UsageSnapshot(
+        workspace_id="ws_safe",
+        provider="claude_code",
+        ccusage_source="claude",
+        status="available",
+        phase="final",
+        captured_at="2026-05-22T01:02:03+00:00",
+        total_tokens=10,
+        baseline={"total_tokens": 1},
+    )
+    path = write_usage_snapshot(snapshot, work_dir=tmp_path)
+    payload = json.loads(path.read_text())
+    assert set(payload) == _ALLOWED_SNAPSHOT_KEYS
+    # No raw transcript paths or jsonl references leak into the durable record.
+    text = path.read_text()
+    assert ".jsonl" not in text
+    assert "/home/" not in text
+    assert "projects" not in text
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshot_missing_returns_none(tmp_path: Path) -> None:
+    assert read_latest_usage_snapshot("ws_absent", work_dir=tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshot_none_workspace_returns_none(tmp_path: Path) -> None:
+    assert read_latest_usage_snapshot(None, work_dir=tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshot_malformed_file_returns_none(tmp_path: Path) -> None:
+    usage_dir = workspace_usage_dir(tmp_path, "ws_bad")
+    usage_dir.mkdir(parents=True)
+    (usage_dir / "snapshot.json").write_text("{not json")
+    assert read_latest_usage_snapshot("ws_bad", work_dir=tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshot_defaults_to_settings_work_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        usage_store,
+        "get_settings",
+        lambda: SimpleNamespace(work_dir=str(tmp_path)),
+    )
+    snapshot = UsageSnapshot(
+        workspace_id="ws_default",
+        provider="opencode",
+        ccusage_source="opencode",
+        status="available",
+        phase="final",
+        captured_at="2026-05-22T01:02:03+00:00",
+        total_tokens=3,
+    )
+    write_usage_snapshot(snapshot, work_dir=tmp_path)
+    loaded = read_latest_usage_snapshot("ws_default")
+    assert loaded == snapshot
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshot_normalizes_user_home_work_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The worker normalizes settings.work_dir with .expanduser().resolve()
+    # before the collector writes snapshots. The reader's default path must
+    # normalize identically; otherwise the API reads a different directory than
+    # the worker wrote and silently falls back to usage_not_reported.
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    work_dir_setting = "~/awf-work"
+    writer_work_dir = Path(work_dir_setting).expanduser().resolve()
+    monkeypatch.setattr(
+        usage_store,
+        "get_settings",
+        lambda: SimpleNamespace(work_dir=work_dir_setting),
+    )
+    snapshot = UsageSnapshot(
+        workspace_id="ws_tilde",
+        provider="claude_code",
+        ccusage_source="claude",
+        status="available",
+        phase="final",
+        captured_at="2026-05-22T01:02:03+00:00",
+        total_tokens=11,
+    )
+    write_usage_snapshot(snapshot, work_dir=writer_work_dir)
+
+    loaded = read_latest_usage_snapshot("ws_tilde")
+    assert loaded == snapshot

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -19,6 +19,7 @@ from awf.service.usage_store import (
     normalize_ccusage_json,
     provider_ccusage_source,
     read_latest_usage_snapshot,
+    read_latest_usage_snapshots,
     subtract_baseline,
     workspace_usage_dir,
     write_usage_snapshot,
@@ -422,6 +423,34 @@ def test_snapshot_serialization_contains_only_safe_keys(tmp_path: Path) -> None:
     assert ".jsonl" not in text
     assert "/home/" not in text
     assert "projects" not in text
+
+
+@pytest.mark.unit
+def test_read_latest_usage_snapshots_batch(tmp_path: Path) -> None:
+    base = {
+        "provider": "claude_code",
+        "ccusage_source": "claude",
+        "status": "available",
+        "phase": "final",
+        "captured_at": "2026-05-22T01:02:03+00:00",
+    }
+    write_usage_snapshot(
+        UsageSnapshot(workspace_id="ws_a", total_tokens=3, **base), work_dir=tmp_path
+    )
+    write_usage_snapshot(
+        UsageSnapshot(workspace_id="ws_b", total_tokens=7, **base), work_dir=tmp_path
+    )
+
+    # Blank/None ids are skipped and duplicates collapse to a single read.
+    result = read_latest_usage_snapshots(
+        ["ws_a", "ws_b", "ws_missing", None, "", "ws_a"], work_dir=tmp_path
+    )
+
+    assert set(result) == {"ws_a", "ws_b", "ws_missing"}
+    assert result["ws_a"] is not None and result["ws_a"].total_tokens == 3
+    assert result["ws_b"] is not None and result["ws_b"].total_tokens == 7
+    # An absent workspace is present in the map as None (read once, off-thread).
+    assert result["ws_missing"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -32,6 +32,7 @@ _ALLOWED_SNAPSHOT_KEYS = {
     "ccusage_source",
     "model",
     "status",
+    "run_status",
     "reason",
     "phase",
     "captured_at",

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -328,8 +328,9 @@ def test_write_and_read_snapshot_round_trip(tmp_path: Path) -> None:
         provider="codex",
         ccusage_source="codex",
         status="available",
-        phase="live",
+        phase="final",
         captured_at="2026-05-22T01:02:03+00:00",
+        run_status="timeout",
         model="gpt-5",
         input_tokens=12,
         output_tokens=8,
@@ -345,6 +346,9 @@ def test_write_and_read_snapshot_round_trip(tmp_path: Path) -> None:
     assert loaded == snapshot
     assert loaded is not None
     assert loaded.schema_version == SCHEMA_VERSION
+    # A concrete run_status must survive the write/read round-trip so accidental
+    # drops or misspellings of the field are caught.
+    assert loaded.run_status == "timeout"
 
 
 @pytest.mark.unit
@@ -405,6 +409,38 @@ def test_read_latest_usage_snapshot_malformed_file_returns_none(tmp_path: Path) 
     usage_dir.mkdir(parents=True)
     (usage_dir / "snapshot.json").write_text("{not json")
     assert read_latest_usage_snapshot("ws_bad", work_dir=tmp_path) is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "bad_field",
+    [
+        {"run_status": {}},
+        {"model": 5},
+        {"currency": ["USD"]},
+        {"total_tokens": "5"},
+        {"input_tokens": True},
+        {"cost_estimate": "free"},
+        {"baseline": []},
+    ],
+)
+def test_read_latest_usage_snapshot_rejects_malformed_field_types(
+    tmp_path: Path, bad_field: dict[str, object]
+) -> None:
+    # Valid JSON but a wrong-typed field must reject the whole snapshot (fall
+    # back to None) rather than leaking bogus accounting data downstream.
+    payload: dict[str, object] = {
+        "workspace_id": "ws_typed",
+        "provider": "codex",
+        "status": "available",
+        "phase": "final",
+        "captured_at": "2026-05-22T01:02:03+00:00",
+        **bad_field,
+    }
+    usage_dir = workspace_usage_dir(tmp_path, "ws_typed")
+    usage_dir.mkdir(parents=True)
+    (usage_dir / "snapshot.json").write_text(json.dumps(payload))
+    assert read_latest_usage_snapshot("ws_typed", work_dir=tmp_path) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -160,6 +160,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
             config: object,
             pr_monitor_factory: object,
             log_store: object,
+            usage_sampler: object = None,
         ) -> None:
             created["executor"] = self
             created["executor_session_factory"] = session_factory
@@ -170,6 +171,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
             created["executor_config"] = config
             created["executor_monitor_factory"] = pr_monitor_factory
             created["executor_log_store"] = log_store
+            created["executor_usage_sampler"] = usage_sampler
 
     class _ControlWorker:
         def __init__(
@@ -258,6 +260,9 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["stack_auth_mount_resolver"].workspace_owner_gid == 1000
     assert created["stack_secret_lease_resolver"].__class__ is _LocalSecretLeaseMountResolver
     assert created["executor_log_store"] is created["validation_log_store"]
+    assert created["executor_usage_sampler"].__class__ is worker_mod.CcusageCollector
+    assert created["executor_usage_sampler"]._runner is created["executor_runner"]
+    assert created["executor_usage_sampler"]._work_dir == work_dir
     assert created["log_root"] == work_dir / "logs"
     assert created["validation_artifacts_dir"] == work_dir / "artifacts"
     assert created["executor_config"].worktrees_root == work_dir / "git" / "worktrees"

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -2072,6 +2072,124 @@ def test_workspace_usage_summary_is_explicitly_unavailable_without_adapter_usage
     assert usage.reason == "usage_not_reported"
 
 
+def _usage_snapshot(**overrides: object) -> object:
+    from awf.service.usage_store import UsageSnapshot
+
+    base: dict[str, object] = {
+        "workspace_id": "ws_snap",
+        "provider": "claude_code",
+        "ccusage_source": "claude",
+        "status": "available",
+        "phase": "final",
+        "captured_at": "2026-05-22T00:00:00+00:00",
+    }
+    base.update(overrides)
+    return UsageSnapshot(**base)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_prefers_ccusage_snapshot_with_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _usage_snapshot(
+        input_tokens=10, output_tokens=20, total_tokens=30, cost_estimate=0.05, currency="USD"
+    )
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: snapshot
+    )
+    # Operation usage exists, but the ccusage snapshot takes precedence.
+    workspace = SimpleNamespace(
+        id="ws_snap",
+        operations=[SimpleNamespace(result={"usage": {"total_tokens": 999}})],
+    )
+    usage = workspace_usage_summary(workspace)
+
+    assert usage.source == "ccusage"
+    assert usage.status == "available"
+    assert usage.total_tokens == 30
+    assert usage.input_tokens == 10
+    assert usage.reason is None
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_surfaces_ccusage_unavailable_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _usage_snapshot(status="unavailable", reason="ccusage_no_records")
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: snapshot
+    )
+    usage = workspace_usage_summary(SimpleNamespace(id="ws_snap", operations=[]))
+
+    assert usage.source == "ccusage"
+    assert usage.status == "unavailable"
+    assert usage.reason == "ccusage_no_records"
+    assert usage.total_tokens is None
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_ccusage_unavailable_defaults_reason(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _usage_snapshot(status="unavailable", reason=None)
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: snapshot
+    )
+    usage = workspace_usage_summary(SimpleNamespace(id="ws_snap", operations=[]))
+
+    assert usage.source == "ccusage"
+    assert usage.reason == "usage_not_reported"
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_falls_back_to_operations_when_ccusage_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    snapshot = _usage_snapshot(status="unavailable", reason="ccusage_timeout")
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: snapshot
+    )
+    workspace = SimpleNamespace(
+        id="ws_snap",
+        operations=[SimpleNamespace(result={"usage": {"input_tokens": 7, "total_tokens": 7}})],
+    )
+    usage = workspace_usage_summary(workspace)
+
+    # Operation usage is a real metric; it wins over a metric-less ccusage snapshot.
+    assert usage.source == "operations"
+    assert usage.input_tokens == 7
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_operations_when_no_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: None
+    )
+    workspace = SimpleNamespace(
+        id="ws_snap",
+        operations=[SimpleNamespace(result={"usage": {"total_tokens": 5}})],
+    )
+    usage = workspace_usage_summary(workspace)
+
+    assert usage.source == "operations"
+    assert usage.total_tokens == 5
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_usage_not_reported_when_nothing_available(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: None
+    )
+    usage = workspace_usage_summary(SimpleNamespace(id="ws_snap", operations=[]))
+
+    assert usage.source == "none"
+    assert usage.reason == "usage_not_reported"
+
+
 class TestWorkspacePricingMetadata:
     @pytest.mark.unit
     def test_returns_none_when_no_pricing_stanza(self) -> None:

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -3045,6 +3045,81 @@ def test_usage_payload_preserves_usage_not_reported_when_pricing_absent() -> Non
 
 
 @pytest.mark.unit
+def test_usage_payload_surfaces_reported_cost_when_pricing_absent() -> None:
+    from awf.service.workspace_observability import LlmUsageSummary, usage_payload
+
+    # A ccusage snapshot reported a locally-recorded cost, but no AWF pricing
+    # metadata is configured (the common case). The reported cost must not be
+    # dropped behind a pricing_not_configured reason.
+    usage = LlmUsageSummary(
+        input_tokens=10,
+        output_tokens=20,
+        total_tokens=30,
+        cost_estimate=0.05,
+        currency="USD",
+        status="available",
+        source="ccusage",
+        reason=None,
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "awf.service.workspace_observability.workspace_usage_summary",
+            lambda _: usage,
+        )
+        mp.setattr(
+            "awf.service.workspace_observability.workspace_pricing_metadata",
+            lambda _: None,
+        )
+        result = usage_payload(SimpleNamespace(id="ws_test"))
+    assert result["cost_estimate"] == pytest.approx(0.05)
+    assert result["currency"] == "USD"
+    assert result["status"] == "available"
+    assert result["reason"] is None
+    assert result["source"] == "ccusage"
+
+
+@pytest.mark.unit
+def test_usage_payload_prefers_configured_pricing_over_reported_cost() -> None:
+    from awf.profiles.pricing import PricingMetadata
+    from awf.service.workspace_observability import LlmUsageSummary, usage_payload
+
+    # When AWF pricing metadata is configured and yields a cost, that
+    # operator-defined figure stays authoritative over the reported one.
+    usage = LlmUsageSummary(
+        input_tokens=1000,
+        output_tokens=500,
+        total_tokens=1500,
+        cost_estimate=0.05,
+        currency="USD",
+        status="available",
+        source="ccusage",
+        reason=None,
+    )
+    pricing = PricingMetadata(
+        provider="openai",
+        model="gpt-4",
+        currency="USD",
+        unit="per_1000_tokens",
+        price_per_unit=0.03,
+        timestamp=datetime.now(UTC),
+    )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "awf.service.workspace_observability.workspace_usage_summary",
+            lambda _: usage,
+        )
+        mp.setattr(
+            "awf.service.workspace_observability.workspace_pricing_metadata",
+            lambda _: pricing,
+        )
+        result = usage_payload(SimpleNamespace(id="ws_test"))
+    assert result["cost_estimate"] == pytest.approx(0.045)
+    assert result["status"] == "available"
+
+
+@pytest.mark.unit
 def test_workspace_usage_summary_safely_ignores_malformed_usage() -> None:
     workspace = SimpleNamespace(
         id="ws_usage",

--- a/tests/unit/service/test_workspaces_observability.py
+++ b/tests/unit/service/test_workspaces_observability.py
@@ -2190,6 +2190,62 @@ def test_workspace_usage_summary_usage_not_reported_when_nothing_available(
     assert usage.reason == "usage_not_reported"
 
 
+@pytest.mark.unit
+def test_workspace_usage_summary_uses_prefetched_snapshot_without_disk_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # When a list endpoint has pre-read snapshots off-thread, the summary must
+    # consult that map and not block the event loop with a per-workspace read.
+    def _fail_disk_read(_workspace_id: object) -> object:
+        raise AssertionError("read_latest_usage_snapshot must not run when id is prefetched")
+
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", _fail_disk_read
+    )
+    snapshot = _usage_snapshot(workspace_id="ws_pf", total_tokens=42)
+    with workspace_observability_module.prefetched_usage_snapshots({"ws_pf": snapshot}):
+        usage = workspace_usage_summary(SimpleNamespace(id="ws_pf", operations=[]))
+
+    assert usage.source == "ccusage"
+    assert usage.total_tokens == 42
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_prefetched_none_skips_disk_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A prefetched ``None`` (snapshot already read off-thread as absent/invalid)
+    # is honored as "no snapshot" without a redundant disk read.
+    def _fail_disk_read(_workspace_id: object) -> object:
+        raise AssertionError("read_latest_usage_snapshot must not run when id is prefetched")
+
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", _fail_disk_read
+    )
+    with workspace_observability_module.prefetched_usage_snapshots({"ws_pf": None}):
+        usage = workspace_usage_summary(SimpleNamespace(id="ws_pf", operations=[]))
+
+    assert usage.source == "none"
+    assert usage.reason == "usage_not_reported"
+
+
+@pytest.mark.unit
+def test_workspace_usage_summary_falls_back_to_disk_when_id_absent_from_prefetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # An id missing from the prefetch map is distinct from a cached ``None``: it
+    # must still fall back to a direct read rather than be treated as absent.
+    snapshot = _usage_snapshot(workspace_id="ws_other", total_tokens=9)
+    monkeypatch.setattr(
+        workspace_observability_module, "read_latest_usage_snapshot", lambda _id: snapshot
+    )
+    with workspace_observability_module.prefetched_usage_snapshots({"ws_present": None}):
+        usage = workspace_usage_summary(SimpleNamespace(id="ws_other", operations=[]))
+
+    assert usage.source == "ccusage"
+    assert usage.total_tokens == 9
+
+
 class TestWorkspacePricingMetadata:
     @pytest.mark.unit
     def test_returns_none_when_no_pricing_stanza(self) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_983f7e6969124e52b77c53e4` (agent: `claude_code`, model: `claude-opus-4-7`, effort: `xhigh`).


### Task
## Automatic AWF timeout salvage

AWF automatically captured the prior implementation diff from an agent run that timed out before it could finish. The retry workspace will restore that diff before the agent runs. Continue from the recovered implementation; do not restart from scratch unless the recovered code is unusable.

### Source reason
`AGENT_IDLE_TIMEOUT`

### Timeout message
post-agent git add failed (exit=1): The following paths are ignored by one of your .gitignore files:
apps/console/lib
hint: Use -f if you really want to add them.
hint: Turn this message off by running
hint: "git config advice.addIgnoredFile false"; agent CLI exited 124 (AGENT_IDLE_TIMEOUT); continuing to salvage any uncommitted work

### Salvaged implementation paths
- `apps/console/components/console-dashboard.tsx`
- `apps/console/lib/format.test.mjs`
- `apps/console/lib/format.ts`
- `apps/console/tests/dashboard-usage.spec.ts`
- `docker/agent-runtime.Dockerfile`
- `src/awf/adapters/base.py`
- `src/awf/adapters/usage.py`
- `src/awf/control/executor.py`
- `src/awf/node/auth_mounts.py`
- `src/awf/service/usage_collection.py`
- `src/awf/service/usage_store.py`
- `src/awf/service/worker.py`
- `src/awf/service/workspace_observability.py`
- `tests/unit/adapters/test_base_usage_collection.py`
- `tests/unit/node/test_service_auth_mounts.py`
- `tests/unit/service/test_usage_collection.py`
- `tests/unit/service/test_usage_store.py`
- `tests/unit/service/test_worker.py`
- `tests/unit/service/test_workspaces_observability.py`

### Original task
Implement workspace LLM usage reporting via pinned ccusage.

Context:
- AWF currently renders "LLM usage unavailable usage_not_reported" because workspace_usage_summary only sees provider usage metadata already attached to operations.
- ccusage can read local usage files for supported coding assistants and can emit JSON. Use it as the collection source inside AWF agent containers.
- AWF currently supports these agent providers: claude_code, codex, gemini, and opencode. The implementation must be generic enough to report usage for workspaces launched with any currently supported provider, not only Claude.

Required scope:
1. Create plans/WORKSPACE_LLM_USAGE_COLLECTOR_PLAN.md before coding and plans/WORKSPACE_LLM_USAGE_COLLECTOR_VALIDATION.md after implementation.
2. Install/pin ccusage in the agent runtime image, not via runtime npx/bunx network fetches.
3. Add an AWF-owned usage collector that samples from inside the workspace agent container every 60 seconds while agent work is running and also takes a final sample at job end, including failure/cancellation paths.
4. Integrate collection around the shared agent execution path so normal workspace execution and PR monitor/recovery agent runs are covered without duplicating provider-specific runner code.
5. Map AWF providers to ccusage sources for claude_code, codex, gemini, and opencode. Use offline/local-file behavior where supported, bounded command timeouts, and clear reason codes on missing or invalid data.
6. Fix the Claude isolation trap: current per-workspace Claude auth copying can include historical host .claude/projects usage. Prevent copied host history from contaminating workspace usage, or establish a reliable baseline/delta so reported totals are only for the workspace run.
7. Persist normalized usage snapshots/deltas in an AWF-owned durable path and expose them through the existing workspace observability/API payload so the console usage section shows trusted live and final usage instead of usage_not_reported.
8. Do not persist raw prompt JSONL or secret-bearing usage files. Store only normalized numeric/accounting data plus safe metadata such as provider/source, model when available, timestamps, status, and reason codes.
9. Preserve existing operation-provided usage aggregation as a compatibility fallback.
10. Keep the console change focused: render available ccusage-backed totals/final status and meaningful unavailable reasons without redesigning the dashboard.

Tests expected:
- Provider/source mapping for all currently supported AWF providers: claude_code, codex, gemini, opencode.
- Claude auth isolation or baseline/delta prevents historical host project usage from being counted.
- Polling cadence samples at the intended 60-second interval while the agent run is active.
- Final sampling runs in success, failure, timeout, and cancellation paths without masking the original agent outcome.
- Parser/normalizer handles valid ccusage JSON, empty/no-record output, command failure, timeout, and malformed JSON with explicit reason codes.
- Workspace observability/API returns ccusage-backed totals and still falls back to operation usage when no ccusage snapshots exist.
- Console renders available usage and unavailable reason states correctly.

Constraints:
- Do not add explicit validation commands to this AWF task request; rely on .awf/workspace.yml for validation.
- Keep AWF core generic; do not hard-code Aira-specific assumptions.
- Keep changes scoped and TDD-oriented. Add regression tests for every behavior change.
- Use auto_merge=true because the base branch is development.


---
Validation: 4 profile command(s) passed inside the workspace container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live workspace LLM usage snapshots with baseline-subtracted totals and human-readable provenance/reason labels in the dashboard (including timeout/unavailable reasons).
  * Console/dashboard shows ccusage-backed totals and clear provenance labels; unsupported/timeouts surface friendly reasons.

* **Documentation**
  * Added plans for workspace LLM usage collection and validation.

* **Bug Fixes / Privacy**
  * Host LLM history excluded from workspace auth mounts to avoid leaking past usage.

* **Tests**
  * Expanded unit and e2e coverage for sampling, snapshot store, provenance formatting, dashboard rendering, auth-mounts, and runtime wiring.

* **Chores**
  * Runtime tooling updated to install a pinned ccusage CLI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->