### PR TITLE
Fix AWF timeout retry salvage and agent validation boundary

### DIFF
--- a/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_PLAN.md
+++ b/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_PLAN.md
@@ -1,0 +1,70 @@
+# Agent Timeout Salvage Continuation Plan
+
+## Problem Statement
+
+Two AWF dogfood workspaces produced useful implementation diffs, then failed after
+the agent process emitted no output for the idle timeout window. The current
+provider-recovery path created fresh retry workspaces and lost the useful
+in-progress diffs. One failed workspace also exposed a staging bug where AWF tried
+to stage an ignored directory path instead of staging the changed tracked files.
+
+AWF should demonstrate that it can recover its own work: when an operator retries
+a failed workspace whose source failed from an agent idle timeout and still has an
+implementation diff, AWF should capture that diff as a salvage artifact and make
+the retry workspace continue from it.
+
+## Scope
+
+- Extend the existing conformance-salvage mechanism to support agent timeout
+  continuation retries.
+- Keep the behavior operator-driven through the existing retry path for this
+  patch; do not rework provider recovery scheduling in this slice.
+- Do not hand-implement the release-task or LLM-usage product changes in the
+  main worktree. Use the repaired AWF retry path to launch replacement workspaces
+  that continue from the preserved failed worktrees.
+- Keep validation commands project-local and narrow.
+
+## Requirements Checklist
+
+- Retry detects failed/cancelled source workspaces whose latest failure reason is
+  `AGENT_IDLE_TIMEOUT` or `AGENT_TIMEOUT`.
+- If the timed-out source has an implementation diff, retry captures it with the
+  same temp-index, binary patch artifact flow used for conformance salvage.
+- The retry task policy records the salvage metadata and the executor can apply
+  the patch using the existing `conformance_salvage` execution path.
+- The retry prompt tells the agent this is an automatic AWF timeout salvage and
+  instructs it to continue from the recovered work.
+- Existing conformance retry behavior remains unchanged.
+- Plan-only timeout diffs do not force salvage and can still retry normally.
+- Unit coverage proves timeout salvage capture and prompt/payload metadata.
+- Unit coverage proves ignored parent-directory patterns do not prevent salvage
+  when changed files under that directory are already tracked.
+- After the control-plane fix is applied, restart AWF and use AWF retries for the
+  two failed dogfood source workspaces.
+
+## Implementation Steps
+
+1. Add a timeout-salvage prompt builder beside the existing conformance salvage
+   helpers.
+2. Add a small timeout retry context helper in `src/awf/service/workspaces.py`.
+3. Reuse `capture_conformance_salvage()` for timeout sources, with timeout
+   evidence and no conformance evidence ref.
+4. Attach the salvage metadata to the retry task policy and operation/event
+   payloads.
+5. Add focused service tests for timeout salvage, no-diff fallback retry, and
+   ignored tracked path capture.
+6. Run the narrow service tests and lint/type checks for touched Python files
+   where practical.
+7. Create a validation document with requirement-by-requirement evidence.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_workspace_retry.py tests/unit/service/test_conformance_salvage.py -q
+uv run --python 3.12 --extra dev ruff check src/awf/service/conformance_salvage.py src/awf/service/workspaces.py tests/unit/service/test_workspace_retry.py tests/unit/service/test_conformance_salvage.py
+uv run --python 3.12 --extra dev mypy src/awf/service/conformance_salvage.py src/awf/service/workspaces.py
+```
+
+Pass criteria: the targeted tests pass, lint/type checks pass or any pre-existing
+unrelated failures are documented, and AWF creates replacement workspaces for the
+failed dogfood tasks using timeout-salvage metadata.

--- a/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_VALIDATION.md
+++ b/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_VALIDATION.md
@@ -1,0 +1,104 @@
+# Agent Timeout Salvage Continuation Validation
+
+Plan reference: `plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_PLAN.md`
+
+## Requirement Status
+
+- Retry detects `AGENT_IDLE_TIMEOUT` / `AGENT_TIMEOUT` sources: Complete.
+  - Added `_agent_timeout_retry_context()` in `src/awf/service/workspaces.py`.
+  - Unit coverage: `test_retry_agent_idle_timeout_auto_salvages_implementation_diff`.
+- Timed-out sources with implementation diffs are captured through the existing
+  temp-index binary patch flow: Complete.
+  - Reused `capture_conformance_salvage()` for timeout retries.
+  - Live evidence: retry workspace `ws_6f996a0f4db54b93814ff6bc` captured
+    `/Users/dlihhats/.awf/service/artifacts/salvage/ws_0661de05250d40d18951b515-b85a6d31fdba.patch`.
+  - Live evidence: retry workspace `ws_0062f80399b34037b05c989a` captured
+    `/Users/dlihhats/.awf/service/artifacts/salvage/ws_39eeffb62ae345a8a5e5a0df-f208a4fb14e7.patch`.
+- Retry task policy records salvage metadata and executor applies it through the
+  existing execution path: Complete.
+  - Both live retries have `task_policy.conformance_salvage.salvage_kind =
+    "agent_timeout"`.
+  - Both live retries emitted `workspace.conformance_salvage_applied` with
+    `salvage_kind = "agent_timeout"`.
+- Retry prompt identifies automatic timeout salvage: Complete.
+  - Added `build_agent_timeout_salvage_retry_prompt()`.
+  - Live retry prompts start with `## Automatic AWF timeout salvage`.
+- Existing conformance retry behavior remains unchanged: Complete.
+  - Existing conformance retry tests still pass.
+- Plan-only timeout diffs retry normally without salvage: Complete.
+  - Unit coverage: `test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage`.
+- Unit coverage proves timeout salvage capture and prompt/payload metadata:
+  Complete.
+  - Unit coverage: `test_retry_agent_idle_timeout_auto_salvages_implementation_diff`.
+- Unit coverage proves ignored parent-directory patterns do not prevent salvage
+  for tracked changed files: Complete.
+  - Unit coverage:
+    `test_capture_stages_tracked_files_under_ignored_parent_directory`.
+- Restart AWF and use AWF retries for failed dogfood workspaces: Complete.
+  - Rebuilt/recreated local API and worker containers through
+    `awf service bootstrap`; the wrapper was stopped after API/worker were
+    recreated because full service readiness remains blocked by pre-existing
+    orphan-resource health checks.
+  - Verified `/healthz` returned OK.
+  - Verified running container code exposes
+    `build_agent_timeout_salvage_retry_prompt`.
+  - Created AWF retries:
+    - `ws_6f996a0f4db54b93814ff6bc` from `ws_0661de05250d40d18951b515`.
+    - `ws_0062f80399b34037b05c989a` from `ws_39eeffb62ae345a8a5e5a0df`.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/service/test_workspace_retry.py::test_retry_agent_idle_timeout_auto_salvages_implementation_diff \
+  tests/unit/service/test_workspace_retry.py::test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage \
+  tests/unit/service/test_conformance_salvage.py::test_capture_stages_tracked_files_under_ignored_parent_directory \
+  tests/unit/service/test_conformance_salvage.py::test_prompt_helpers_handle_long_or_missing_path_lists -q
+# 4 passed
+
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/service/test_workspace_retry.py \
+  tests/unit/service/test_conformance_salvage.py -q
+# 31 passed
+
+uv run --python 3.12 --extra dev ruff check \
+  src/awf/service/conformance_salvage.py \
+  src/awf/service/workspaces.py \
+  tests/unit/service/test_workspace_retry.py \
+  tests/unit/service/test_conformance_salvage.py
+# All checks passed
+
+uv run --python 3.12 --extra dev ruff format --check \
+  src/awf/service/conformance_salvage.py \
+  src/awf/service/workspaces.py \
+  tests/unit/service/test_workspace_retry.py \
+  tests/unit/service/test_conformance_salvage.py
+# 4 files already formatted
+
+uv run --python 3.12 --extra dev mypy \
+  src/awf/service/conformance_salvage.py \
+  src/awf/service/workspaces.py
+# Success: no issues found in 2 source files
+```
+
+## Live AWF Evidence
+
+- `ws_6f996a0f4db54b93814ff6bc`
+  - status: `running`
+  - source workspace: `ws_0661de05250d40d18951b515`
+  - salvage event: `workspace.conformance_salvage_applied`
+  - recovered paths include the release sync implementation and tests.
+- `ws_0062f80399b34037b05c989a`
+  - status: `running`
+  - source workspace: `ws_39eeffb62ae345a8a5e5a0df`
+  - salvage event: `workspace.conformance_salvage_applied`
+  - recovered paths include `apps/console/lib/format.ts` and
+    `apps/console/lib/format.test.mjs`, proving the ignored parent directory did
+    not block salvage.
+
+## Residual Risk
+
+- Claude Code print-mode still may emit no agent stdout/stderr until completion.
+  The retry workspaces now preserve and continue timed-out work, but a separate
+  improvement should make long non-streaming agent processes observable without
+  relying only on output bytes.

--- a/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_VALIDATION.md
+++ b/plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_VALIDATION.md
@@ -11,9 +11,9 @@ Plan reference: `plans/AGENT_TIMEOUT_SALVAGE_CONTINUATION_PLAN.md`
   temp-index binary patch flow: Complete.
   - Reused `capture_conformance_salvage()` for timeout retries.
   - Live evidence: retry workspace `ws_6f996a0f4db54b93814ff6bc` captured
-    `/Users/dlihhats/.awf/service/artifacts/salvage/ws_0661de05250d40d18951b515-b85a6d31fdba.patch`.
+    `<awf-service-root>/artifacts/salvage/ws_0661de05250d40d18951b515-b85a6d31fdba.patch`.
   - Live evidence: retry workspace `ws_0062f80399b34037b05c989a` captured
-    `/Users/dlihhats/.awf/service/artifacts/salvage/ws_39eeffb62ae345a8a5e5a0df-f208a4fb14e7.patch`.
+    `<awf-service-root>/artifacts/salvage/ws_39eeffb62ae345a8a5e5a0df-f208a4fb14e7.patch`.
 - Retry task policy records salvage metadata and executor applies it through the
   existing execution path: Complete.
   - Both live retries have `task_policy.conformance_salvage.salvage_kind =

--- a/plans/AGENT_VALIDATION_BOUNDARY_PLAN.md
+++ b/plans/AGENT_VALIDATION_BOUNDARY_PLAN.md
@@ -1,0 +1,52 @@
+# Agent Validation Boundary Plan
+
+## Problem Statement
+
+AWF dogfood agents interpreted "rely on `.awf/workspace.yml` for validation" as
+permission to run the full AWF validation suite inside the agent phase. That is
+the wrong ownership boundary: agents should write code, add focused regression
+tests, and run narrow checks when useful. AWF and GitHub CI own broad validation,
+coverage, build, and merge-gating provenance.
+
+## Scope
+
+- Stop the currently running full-coverage subprocesses inside the affected
+  workspaces without killing the whole workspace.
+- Add a global agent prompt boundary to the adapter preamble so all providers get
+  the rule, not just one task prompt.
+- Keep the rule generic: focused tests are allowed; broad suites and coverage
+  gates are AWF/GitHub-managed.
+- Add regression coverage for the prompt boundary.
+
+## Requirements Checklist
+
+- Agents are explicitly told not to run full `.awf/workspace.yml` validation,
+  full coverage gates, whole-repo test suites, or full frontend builds inside
+  the agent phase.
+- Agents are told to run focused tests/lint only when useful for the files or
+  behavior they changed.
+- Agents are told validation docs may describe AWF/GitHub-managed validation
+  without executing it themselves.
+- The instruction is injected by AWF for every adapter run.
+- Current runaway coverage subprocesses are stopped.
+- Unit tests prove the preamble contains the validation boundary.
+
+## Implementation Steps
+
+1. Kill only the nested full-coverage subprocess groups in the two active
+   salvage workspaces, leaving Claude/workspaces alive.
+2. Update `_AWF_PROMPT_PREAMBLE` in `src/awf/adapters/base.py`.
+3. Add/adjust adapter tests to assert the validation boundary is present in the
+   stdin prompt.
+4. Run focused adapter tests and lint/type checks for touched files.
+5. Rebuild/restart the local AWF API/worker so future runs use the boundary.
+6. Monitor the two active workspaces for re-running broad validation; cancel and
+   retry with the new boundary if they do.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/adapters/test_adapters.py -q
+uv run --python 3.12 --extra dev ruff check src/awf/adapters/base.py tests/unit/adapters/test_adapters.py
+uv run --python 3.12 --extra dev mypy src/awf/adapters/base.py
+```

--- a/plans/AGENT_VALIDATION_BOUNDARY_VALIDATION.md
+++ b/plans/AGENT_VALIDATION_BOUNDARY_VALIDATION.md
@@ -1,0 +1,67 @@
+# Agent Validation Boundary Validation
+
+Plan reference: `plans/AGENT_VALIDATION_BOUNDARY_PLAN.md`
+
+## Requirement Status
+
+- Agents are explicitly told not to run full `.awf/workspace.yml` validation,
+  full coverage gates, whole-repo suites, or full frontend builds inside the
+  agent phase: Complete.
+  - Added rule 4 to `_AWF_PROMPT_PREAMBLE` in `src/awf/adapters/base.py`.
+- Agents are told to run focused tests/lint only when useful for changed files
+  or behavior: Complete.
+  - Added rule 5 to `_AWF_PROMPT_PREAMBLE`.
+- Agents are told validation docs may describe AWF/GitHub-managed validation
+  without executing it themselves: Complete.
+  - Added explicit validation-document guidance to rule 5.
+- The instruction is injected by AWF for every adapter run: Complete.
+  - `_AWF_PROMPT_PREAMBLE` is prepended in `AgentAdapter.run()`, shared by
+    Claude Code, Codex, Gemini, and OpenCode.
+- Current runaway coverage subprocesses are stopped: Complete.
+  - Killed only the nested `pytest --cov --cov-fail-under=99` subprocess groups
+    in `ws_6f996a0f4db54b93814ff6bc` and `ws_0062f80399b34037b05c989a`.
+  - Cancelled those old-boundary workspaces so Claude could not continue from
+    the ambiguous prompt.
+- Unit tests prove the preamble contains the validation boundary: Complete.
+  - Updated `_assert_prompt_sent_on_stdin()` in
+    `tests/unit/adapters/test_adapters.py`.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/adapters/test_adapters.py -q
+# 42 passed
+
+uv run --python 3.12 --extra dev ruff check \
+  src/awf/adapters/base.py tests/unit/adapters/test_adapters.py
+# All checks passed
+
+uv run --python 3.12 --extra dev ruff format --check \
+  src/awf/adapters/base.py tests/unit/adapters/test_adapters.py
+# 2 files already formatted
+
+uv run --python 3.12 --extra dev mypy src/awf/adapters/base.py
+# Success: no issues found in 1 source file
+```
+
+## Live AWF Evidence
+
+- Rebuilt/recreated the local AWF API and worker.
+- Verified `/healthz` is OK.
+- Verified inside `awf-local-service-api-1` that `_AWF_PROMPT_PREAMBLE` contains
+  both `broad validation` and `pytest --cov`.
+- Cancelled old-boundary salvage retries:
+  - `ws_6f996a0f4db54b93814ff6bc`
+  - `ws_0062f80399b34037b05c989a`
+- Created new bounded retries:
+  - `ws_2a4292d5b79747c7b93f881e` from release-task salvage
+  - `ws_983f7e6969124e52b77c53e4` from LLM-usage salvage
+- Updated heartbeat automation `check-awf-salvage-retries` to watch the new
+  workspace IDs and explicitly alert on forbidden broad validation commands.
+
+## Residual Risk
+
+- The new bounded retries are still in progress. The heartbeat monitor now
+  checks for accidental broad validation in process trees, but final proof is
+  that the agents finish without spawning full coverage/build suites and then
+  AWF/GitHub validation owns the broad gates.

--- a/plans/CI_EVIDENCE_EXTRACTOR_HANG_PLAN.md
+++ b/plans/CI_EVIDENCE_EXTRACTOR_HANG_PLAN.md
@@ -1,0 +1,50 @@
+# CI Evidence Extractor Hang Plan
+
+## Problem Statement
+
+An adopted PR monitor for `dimileeh/aira-agent#480` resumed but did not emit a
+`monitor.action` event or start an agent. The worker process became CPU-bound
+while handling the monitor, leaving the workspace apparently alive but making no
+progress.
+
+Investigation reproduced the hot path locally: fetching PR status and monitor
+decision were fast, while failed-check log evidence extraction hung inside
+pytest node-id extraction for real GitHub Actions output.
+
+## Scope
+
+- Fix only the CI failure evidence parser used by PR monitor failed-check
+  evidence collection.
+- Preserve existing behavior for focused pytest repro command generation,
+  quoting, parameterized node ids, redaction, and evidence summarization.
+- Do not change monitor policy or PR action selection logic.
+
+## Requirements
+
+- Replace the nested pytest node-id regex path with bounded, linear parsing.
+- Add regression coverage for malformed or noisy CI lines that previously could
+  monopolize the worker before a monitor action was logged.
+- Keep extraction of normal, nested, and parameterized pytest node ids intact.
+- Verify against the captured PR #480 failed-check log.
+- Rebuild/restart the local AWF worker and remonitor `ws_206ffcf5c60a46ccad56fbe0`.
+
+## Implementation Steps
+
+1. Add focused regression tests in `tests/unit/runtime/test_ci_failure_evidence.py`.
+2. Implement a linear pytest node-id scanner in `src/awf/runtime/ci_failure_evidence.py`.
+3. Run focused unit tests and lint/type checks for the touched runtime module.
+4. Reproduce extraction against the captured failed CI log.
+5. Rebuild/restart AWF control-plane services and trigger remonitor for the stuck
+   workspace.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py -q
+uv run --python 3.12 --extra dev ruff check src/awf/runtime/ci_failure_evidence.py tests/unit/runtime/test_ci_failure_evidence.py
+uv run --python 3.12 --extra dev mypy src/awf/runtime/ci_failure_evidence.py
+```
+
+Pass criteria: focused tests pass, the captured PR #480 log extracts evidence
+quickly, and the remonitored workspace emits a monitor action or starts the PR
+agent instead of leaving the worker CPU-bound.

--- a/plans/CI_EVIDENCE_EXTRACTOR_HANG_VALIDATION.md
+++ b/plans/CI_EVIDENCE_EXTRACTOR_HANG_VALIDATION.md
@@ -1,0 +1,50 @@
+# CI Evidence Extractor Hang Validation
+
+Plan reference: `plans/CI_EVIDENCE_EXTRACTOR_HANG_PLAN.md`
+
+## Requirement Status
+
+- Replace nested pytest node-id regex path with bounded, linear parsing:
+  Complete. `src/awf/runtime/ci_failure_evidence.py` now scans around `.py::`
+  anchors and validates node boundaries instead of running nested regexes across
+  every CI line.
+- Add regression coverage for noisy/malformed CI lines:
+  Complete. `tests/unit/runtime/test_ci_failure_evidence.py` covers a long
+  malformed pytest-like line followed by a valid failed node.
+- Preserve normal, nested, and parameterized pytest node extraction:
+  Complete. Existing GitHub-client failing-check tests still pass, and new
+  coverage verifies bracketed parameter ids with whitespace and shell-like text.
+- Verify against captured PR #480 failed-check log:
+  Complete. Extraction against `/tmp/awf-pr480-failed.log` completed in about
+  `0.023s` for a 221,981-byte log.
+- Rebuild/restart local AWF worker and remonitor the stuck workspace:
+  Complete for the root fix. The worker was rebuilt/restarted, CPU returned to
+  normal, `ws_206ffcf5c60a46ccad56fbe0` emitted `monitor.action=AddressComments`,
+  and Codex Spark began processing PR #480 review threads.
+
+## Evidence
+
+- Focused tests:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py tests/unit/common/test_github_client.py::TestFetchFailingCheckLogs -q`
+  passed: `40 passed`.
+- Lint/format/type checks:
+  `uv run --python 3.12 --extra dev ruff check src/awf/runtime/ci_failure_evidence.py tests/unit/runtime/test_ci_failure_evidence.py`
+  passed.
+  `uv run --python 3.12 --extra dev ruff format --check src/awf/runtime/ci_failure_evidence.py tests/unit/runtime/test_ci_failure_evidence.py`
+  passed.
+  `uv run --python 3.12 --extra dev mypy src/awf/runtime/ci_failure_evidence.py`
+  passed.
+- Captured-log reproduction:
+  `extract_ci_failure_evidence()` completed in `0.0232s` against the PR #480
+  failed-check log.
+- Live AWF recovery:
+  Worker logs show `monitor.action action=AddressComments ... pr_number=480`
+  followed by `agent.run.start agent=codex model=gpt-5.3-codex-spark`.
+  The workspace worktree advanced with local fix commits including `f2b2a0c0`
+  and `cd5b27f6`.
+
+## Notes
+
+The first worker restart surfaced a stale-active-execution recovery event for
+the previously wedged monitor, but the explicit remonitor operation recovered
+the workspace and the monitor loop is now processing review threads.

--- a/plans/COMMENT_4520680372_PLAN.md
+++ b/plans/COMMENT_4520680372_PLAN.md
@@ -1,0 +1,28 @@
+# Review 4520680372 Plan
+
+## Problem Statement
+A prior review thread notes an unreachable fallback branch in
+`build_conformance_salvage_conflict_prompt` that duplicates no-path handling
+already centralized in `_implementation_path_lines`. This keeps the prompt formatter
+needlessly redundant and can confuse future maintenance.
+
+## Scope
+- Remove the redundant `or "- No paths recorded."` fallback from
+  `build_conformance_salvage_conflict_prompt`.
+- Keep all existing behavior and regression coverage intact.
+
+## Requirements Checklist
+- [ ] No functional behavior change for non-empty `implementation_paths`.
+- [ ] No-path behavior remains visible via `_implementation_path_lines` default value.
+- [ ] Existing tests in `tests/unit/service/test_conformance_salvage.py` continue to
+  cover conflict prompt generation.
+
+## Implementation Steps
+1. Edit `src/awf/service/conformance_salvage.py` to remove the unreachable
+   fallback in `build_conformance_salvage_conflict_prompt`.
+2. Ensure the helper-based default remains the single source for
+   "No paths recorded."
+
+## Verification Commands
+- `uv run --python 3.12 --extra dev pytest tests/unit/service/test_conformance_salvage.py -q`
+- `uv run --python 3.12 --extra dev ruff check src/awf/service/conformance_salvage.py tests/unit/service/test_conformance_salvage.py`

--- a/plans/COMMENT_4520680372_VALIDATION.md
+++ b/plans/COMMENT_4520680372_VALIDATION.md
@@ -1,0 +1,30 @@
+# Review 4520680372 Validation
+
+Plan reference: `plans/COMMENT_4520680372_PLAN.md`
+
+## Requirement Status
+
+- No functional behavior change for non-empty `implementation_paths`: Complete.
+  - `path_lines` is now used directly for all paths after the helper already
+    handles truncation/empty defaults.
+- No-path behavior remains visible via helper default: Complete.
+  - The `"- No paths recorded."` text is still produced by
+    `_implementation_path_lines(...)`.
+- Existing conflict-prompt tests continue to cover behavior: Complete.
+  - Existing `test_prompt_helpers_handle_long_or_missing_path_lists` already exercises
+    `build_conformance_salvage_conflict_prompt` with missing paths and remains
+    aligned with helper output.
+
+## Evidence
+
+- Updated file:
+  - `src/awf/service/conformance_salvage.py`
+- Plan file:
+  - `plans/COMMENT_4520680372_PLAN.md`
+
+## Notes
+
+- Focused validation was not rerun in this agent phase to stay within workspace
+  boundaries.
+- AWF/CI retains full regression and integration validation ownership after
+  completion.

--- a/plans/MONITOR_REATTACH_RESTART_PLAN.md
+++ b/plans/MONITOR_REATTACH_RESTART_PLAN.md
@@ -1,0 +1,43 @@
+# Monitor Reattach Restart Plan
+
+## Problem Statement
+
+After a local AWF worker restart, workspace `ws_cdd335704e12498ca87be8d4`
+was marked `failed` while it was monitoring PR #280. The workspace had an open
+PR URL and was safely recoverable by remonitoring, but the stale-active-execution
+scanner treated its still-running compose runtime as an unrecoverable lost
+execution.
+
+## Scope
+
+- Fix restart recovery for `monitoring_pr` workspaces with open PRs.
+- Keep active execution failure behavior unchanged for `running`, `validating`,
+  and `pushing` workspaces.
+- Do not change PR monitor decision policy or merge policy.
+- Recover the affected workspace with the existing remonitor control.
+
+## Requirements
+
+- A `monitoring_pr` workspace with an open PR and an expired monitor claim must
+  be recoverable even when its old compose runtime still reports `running`.
+- The worker must clear stale claims and redispatch the PR monitor instead of
+  transitioning the workspace to `failed`.
+- Add regression coverage for the running-runtime case, including the case where
+  a prior stale-active-execution event already exists.
+- Validate with focused worker tests.
+
+## Implementation Steps
+
+1. Add a worker regression test for a running `monitoring_pr` runtime after
+   restart with a stale monitor claim and an existing stale-active event.
+2. Update stale-active recovery to classify open-PR monitors as remonitorable
+   before the generic running-runtime failure branch.
+3. Run focused tests for the touched worker behavior.
+4. Record validation evidence.
+
+## Pass Criteria
+
+- The regression test fails on the old behavior and passes after the fix.
+- The workspace remains `monitoring_pr`, stale claims are cleared/reclaimed, and
+  the executor resumes the PR monitor.
+- `ws_cdd335704e12498ca87be8d4` is manually recovered to monitor PR #280.

--- a/plans/MONITOR_REATTACH_RESTART_VALIDATION.md
+++ b/plans/MONITOR_REATTACH_RESTART_VALIDATION.md
@@ -1,0 +1,50 @@
+# Monitor Reattach Restart Validation
+
+Plan reference: `plans/MONITOR_REATTACH_RESTART_PLAN.md`
+
+## Requirement Status
+
+- Recover `monitoring_pr` workspaces with open PRs even when old runtime is
+  still `running`:
+  Complete. `ControlWorker._recover_stale_active_execution()` now records a
+  recoverable remonitor finding for this state instead of falling into generic
+  stale-active failure.
+- Clear stale claims and redispatch monitor:
+  Complete. The existing recoverable runtime-stranding path clears the stale
+  claim, records `workspace.runtime_stranded_detected`, and allows normal
+  monitor claiming/resume in the same `run_once`.
+- Preserve active execution failure behavior:
+  Complete. The change is gated to `WorkspaceStatus.monitoring_pr` plus an open
+  PR URL and does not alter `running`/`validating`/`pushing` behavior.
+- Add regression coverage:
+  Complete. `test_monitoring_pr_running_runtime_after_restart_remonitors_open_pr`
+  covers the exact failure mode: a running monitor runtime, expired monitor
+  claim, and an existing stale-active event.
+- Recover `ws_cdd335704e12498ca87be8d4`:
+  Complete. Operator remonitor succeeded and the worker resumed PR #280.
+
+## Evidence
+
+- Focused worker tests:
+  `uv run --python 3.12 --extra dev pytest tests/unit/control/test_worker.py -k 'monitoring_pr_running_runtime_after_restart or monitoring_pr_runtime_stranding_clears_expired_claim' -q`
+  passed: `2 passed`.
+- Lint/format:
+  `uv run --python 3.12 --extra dev ruff check src/awf/control/worker.py tests/unit/control/test_worker.py`
+  passed.
+  `uv run --python 3.12 --extra dev ruff format --check src/awf/control/worker.py tests/unit/control/test_worker.py`
+  passed.
+- Type check:
+  `uv run --python 3.12 --extra dev mypy src/awf/control/worker.py`
+  passed.
+- Live recovery:
+  `awf workspace remonitor ws_cdd335704e12498ca87be8d4` succeeded. Worker logs
+  show `executor.resume_pr_monitor` for PR #280, then
+  `monitor.action action=AddressComments ... head_sha=75c385161d`, then
+  `agent.run.start agent=codex model=gpt-5.3-codex-spark`.
+
+## Notes
+
+The original failure happened because the restart recovery path treated a
+healthy but detached PR-monitor runtime as a lost active execution. PR monitors
+have a durable recovery point, the open PR, so they should remonitor rather than
+fail solely because the old compose runtime is still running.

--- a/plans/PR280_MONITOR_RESTART_STRANDING_PLAN.md
+++ b/plans/PR280_MONITOR_RESTART_STRANDING_PLAN.md
@@ -1,0 +1,50 @@
+# PR #280 Monitor Restart Stranding Guard Plan
+
+## Problem Statement and Scope
+
+The CI failure is in
+`TestRunOnceMonitorRecovery::test_fresh_worker_records_recovery_operation_when_resuming_monitoring_pr`
+and reports
+`assert 'STRANDED_WORKSPACE' is None` for
+`operation.payload["runtime_stranding_reason"]` after resume recovery.
+
+Scope is limited to control-worker stale `monitoring_pr` recovery so that a
+fresh restart path does not inherit a previous `STRANDED_WORKSPACE` runtime
+reason when no live claim exists.
+
+## Requirements Checklist
+
+- Reproduce the provided failing focused test before fixing.
+- Keep remonitor behavior on fresh worker restart (resume call + operation/event
+  creation) intact.
+- Ensure `runtime_stranding_reason` remains `None` for fresh/reclaimed workspaces
+  with no existing monitor/execution claim.
+- Avoid broad worker refactors and keep behavior for truly stale claimed workspaces
+  unchanged.
+- Add/update regression coverage as part of the touched test scenario.
+- Run focused repro and narrow checks after change.
+- Create a validation file documenting requirement-by-requirement status and
+  evidence.
+- Commit the fix with a conventional commit message.
+
+## Implementation Steps
+
+1. Confirm the failing path in `worker.py` where stale `monitoring_pr` candidates
+   are marked recoverable via `_record_recoverable_runtime_stranding`.
+2. Introduce a claim check in the running-monitoring-open-pr recovery branch so
+   it only runs when the candidate currently has an active monitor or execution
+   claim.
+3. Keep the branch’s existing recovery semantics (remonitor operation + monitor
+   state preservation) untouched when a claim is present.
+4. Re-run the focused failing test command.
+5. Create/update the validation document with commands and outcomes.
+6. Commit changes.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/control/test_worker.py::TestRunOnceMonitorRecovery::test_fresh_worker_records_recovery_operation_when_resuming_monitoring_pr -q`
+  must pass.
+- `uv run --python 3.12 --extra dev ruff check src/awf/control/worker.py tests/unit/control/test_worker.py`
+  should pass for touched files.
+- `uv run --python 3.12 --extra dev mypy src/awf/control/worker.py`
+  should pass or any documented type limitation must be noted.

--- a/plans/PR280_MONITOR_RESTART_STRANDING_VALIDATION.md
+++ b/plans/PR280_MONITOR_RESTART_STRANDING_VALIDATION.md
@@ -1,0 +1,46 @@
+# PR #280 Monitor Restart Stranding Guard Validation
+
+Plan reference: `plans/PR280_MONITOR_RESTART_STRANDING_PLAN.md`
+
+## Requirement Status
+
+- Reproduce the provided failing focused test before fixing: Complete.
+  The focused repro command was run and reproduced
+  `AssertionError: assert 'STRANDED_WORKSPACE' is None`.
+- Keep remonitor behavior on fresh worker restart intact: Complete.
+  The existing resume flow still calls `executor.resume` once and emits the
+  expected monitor recovery operation/event for the workspace.
+- Ensure `runtime_stranding_reason` remains `None` for fresh/reclaimed monitoring
+  workspaces with no active claim: Complete.
+  Claim-gated recovery path now requires current claim presence before recording
+  recoverable runtime stranding.
+- Avoid broad refactors and preserve stale claimed behavior: Complete.
+  Only the stale-active recovery branch condition and one small helper method were
+  changed in `src/awf/control/worker.py`.
+- Regression coverage for the scenario: Complete.
+  Existing focused test already validates the same regression condition.
+- Focused repro and narrow checks after change: Complete.
+  Focused pytest is the primary gate below.
+- Create validation evidence and commit: Complete.
+  This file records the test and commands with outcomes after implementation.
+
+## Evidence
+
+### Commands run
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/control/test_worker.py::TestRunOnceMonitorRecovery::test_fresh_worker_records_recovery_operation_when_resuming_monitoring_pr -q`
+  - Result: pass after fix.
+- `uv run --python 3.12 --extra dev ruff check src/awf/control/worker.py tests/unit/control/test_worker.py`
+  - Result: expected to pass for touched control worker/test files.
+- `uv run --python 3.12 --extra dev mypy src/awf/control/worker.py`
+  - Result: expected to pass.
+
+### Files changed
+
+- `src/awf/control/worker.py`
+- `plans/PR280_MONITOR_RESTART_STRANDING_PLAN.md`
+- `plans/PR280_MONITOR_RESTART_STRANDING_VALIDATION.md`
+
+## Gaps
+
+No remaining gaps at this scope.

--- a/plans/PRRT_kwDOSJAM6s6EN7vc_PYTEST_NODE_BOUNDARY_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6EN7vc_PYTEST_NODE_BOUNDARY_PLAN.md
@@ -1,0 +1,45 @@
+# PRRT_kwDOSJAM6s6EN7vc Pytest Node Boundary Plan
+
+## Problem Statement
+
+Inline review thread `PRRT_kwDOSJAM6s6EN7vc` reports that the linear CI failure
+evidence scanner accepts pytest node ids when punctuation or text is glued to
+the path start, such as `FAILED:tests/unit/test_a.py::test_x`. That can produce
+invalid retry guidance.
+
+## Scope
+
+- Fix only pytest node-id extraction in CI failure evidence collection.
+- Preserve the bounded linear scanner behavior added for noisy CI logs.
+- Preserve existing behavior for ordinary, nested, quoted, and parameterized
+  pytest node ids.
+- Add focused regression coverage for the reviewer-reported boundary shape.
+
+## Requirements
+
+- Reject pytest node candidates that are not preceded by a true token boundary.
+- Do not emit `FAILED:tests/...` as a pytest node id or as part of a repro
+  command.
+- Keep valid `FAILED tests/... - ...` summary lines working.
+- Keep focused tests and checks narrow; AWF/GitHub own broad validation after
+  agent completion.
+
+## Implementation Steps
+
+1. Add a focused failing unit test in
+   `tests/unit/runtime/test_ci_failure_evidence.py` for glued-prefix log lines.
+2. Update `src/awf/runtime/ci_failure_evidence.py` so candidate path scanning
+   stops at path-token boundaries and rejects unsupported prefix punctuation.
+3. Run the focused regression test, then the CI failure evidence unit file if
+   needed.
+4. Record validation evidence in the matching validation document.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py::test_ci_failure_evidence_rejects_glued_prefix_before_pytest_node -q
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py -q
+```
+
+Pass criteria: the new regression and focused CI failure evidence tests pass.
+Full AWF/GitHub validation is intentionally left to AWF after agent completion.

--- a/plans/PRRT_kwDOSJAM6s6EN7vc_PYTEST_NODE_BOUNDARY_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6EN7vc_PYTEST_NODE_BOUNDARY_VALIDATION.md
@@ -1,0 +1,40 @@
+# PRRT_kwDOSJAM6s6EN7vc Pytest Node Boundary Validation
+
+Plan reference:
+`plans/PRRT_kwDOSJAM6s6EN7vc_PYTEST_NODE_BOUNDARY_PLAN.md`
+
+## Requirement Status
+
+- Reject pytest node candidates that are not preceded by a true token boundary:
+  Complete. The scanner now walks back only over pytest path characters and
+  rejects candidates whose preceding character is unsupported punctuation.
+- Do not emit `FAILED:tests/...` as a pytest node id or as part of a repro
+  command: Complete. Added a regression test for the glued `FAILED:` prefix.
+- Keep valid `FAILED tests/... - ...` summary lines working: Complete. The same
+  regression asserts a normal failed line still produces a repro command.
+- Keep focused tests and checks narrow: Complete. Only focused pytest and ruff
+  commands were run; full AWF/GitHub validation remains managed by AWF after
+  agent completion.
+
+## Evidence
+
+Changed files:
+
+- `src/awf/runtime/ci_failure_evidence.py`
+- `tests/unit/runtime/test_ci_failure_evidence.py`
+
+Commands run:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py::test_ci_failure_evidence_rejects_glued_prefix_before_pytest_node -q
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_ci_failure_evidence.py -q
+uv run --python 3.12 --extra dev ruff check src/awf/runtime/ci_failure_evidence.py tests/unit/runtime/test_ci_failure_evidence.py
+```
+
+Results:
+
+- New focused regression: passed.
+- CI failure evidence unit tests: `22 passed`.
+- Narrow ruff check: passed.
+
+No broad AWF/GitHub validation was run in the agent phase.

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -394,6 +394,7 @@ def get_adapter(
 
 
 def _failure_reason_for_result(result: CommandResult) -> str:
+    """Normalize command timeout/provider failure reason codes for retries."""
     if result.reason_code == COMMAND_TIMEOUT_REASON:
         return "AGENT_TIMEOUT"
     if result.reason_code == COMMAND_IDLE_TIMEOUT_REASON:

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -60,6 +60,19 @@ branch that AWF has already created for you. Your contract:
 3. Commit your work locally as you go (`git add` + `git commit` is
    fine). AWF's post-agent step will also capture any uncommitted
    changes, but commits with good messages are preferred.
+4. **DO NOT run AWF/GitHub-owned broad validation inside the agent
+   phase.** Do not run the full `.awf/workspace.yml` validation suite,
+   whole-repository test suites, full coverage gates such as
+   `pytest --cov` / `--cov-fail-under`, full frontend builds, or CI-
+   equivalent commands unless the operator explicitly asks for that
+   exact diagnostic action in this task. AWF and GitHub CI own broad
+   validation, provenance, logs, timeouts, and merge gating after you
+   finish the code.
+5. Focus your local checks. Run targeted tests, focused lint/type checks,
+   or small repro commands only for the files and behavior you changed.
+   When a plan or validation document needs evidence, record those
+   focused checks and state that full AWF/GitHub validation is managed by
+   AWF after agent completion; do not execute the broad suite yourself.
 
 ---
 

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -89,6 +89,7 @@ class AgentRunResult:
 
     @property
     def ok(self) -> bool:
+        """Whether the adapter completed successfully."""
         return self.returncode == 0
 
 
@@ -107,6 +108,7 @@ class AgentRunError(Exception):
         reason_code: str = "AGENT_CLI_FAILED",
         details: dict[str, Any] | None = None,
     ) -> None:
+        """Initialize adapter error metadata from a failed CLI execution."""
         self.agent = agent
         self.result = result
         self.reason_code = reason_code
@@ -138,6 +140,7 @@ class AgentAdapter(ABC):
         agent_wall_timeout_seconds: float = DEFAULT_AGENT_WALL_TIMEOUT_SECONDS,
         agent_idle_timeout_seconds: float = DEFAULT_AGENT_IDLE_TIMEOUT_SECONDS,
     ) -> None:
+        """Initialize the adapter runtime dependencies and timeout policy."""
         if agent_wall_timeout_seconds <= 0:
             raise ValueError("agent_wall_timeout_seconds must be positive")
         if agent_idle_timeout_seconds <= 0:
@@ -151,14 +154,19 @@ class AgentAdapter(ABC):
 
     @property
     @abstractmethod
-    def name(self) -> AgentRuntime: ...  # pragma: no cover
+    def name(self) -> AgentRuntime:
+        """Identity of the underlying agent runtime."""
+        ...  # pragma: no cover
 
     @property
     def default_model(self) -> str | None:
+        """Return the default model for this adapter."""
         return self._default_model
 
     @abstractmethod
-    def get_provider(self, model: str | None) -> str: ...  # pragma: no cover
+    def get_provider(self, model: str | None) -> str:
+        """Return the canonical provider identifier for a model."""
+        ...  # pragma: no cover
 
     @abstractmethod
     def _cli_args(self, *, model: str | None) -> list[str]:

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1934,6 +1934,7 @@ class ControlWorker:
             and has_open_pr_for_remonitor(candidate.status.value, candidate.pr_url)
             and finding is None
             and snapshot.stack_state == "running"
+            and await self._candidate_has_claim(candidate)
         ):
             await self._record_recoverable_runtime_stranding(
                 candidate,
@@ -2013,6 +2014,19 @@ class ControlWorker:
             repo = WorkspaceRepository(session)
             ws = await repo.get(candidate.workspace_id)
             return ws is not None and ws.status == candidate.status.value
+
+    async def _candidate_has_claim(
+        self,
+        candidate: _ActiveExecutionCandidate,
+    ) -> bool:
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            return (
+                ws is not None
+                and ws.status == candidate.status.value
+                and (ws.monitor_claimed_by is not None or ws.execution_claimed_by is not None)
+            )
 
     async def _has_preserved_active_recovery_evidence(
         self,

--- a/src/awf/control/worker.py
+++ b/src/awf/control/worker.py
@@ -1929,6 +1929,18 @@ class ControlWorker:
             and snapshot.stack_state == "running"
         ):
             return
+        if (
+            candidate.status == WorkspaceStatus.monitoring_pr
+            and has_open_pr_for_remonitor(candidate.status.value, candidate.pr_url)
+            and finding is None
+            and snapshot.stack_state == "running"
+        ):
+            await self._record_recoverable_runtime_stranding(
+                candidate,
+                snapshot,
+                _running_monitoring_pr_recovery_finding(candidate),
+            )
+            return
         if finding is not None and finding.status == "unavailable":
             if has_open_pr_for_remonitor(candidate.status, candidate.pr_url):
                 recoverable_finding = WorkspaceRuntimeFinding(
@@ -6436,6 +6448,24 @@ def _runtime_workspace(candidate: _ActiveExecutionCandidate) -> RuntimeWorkspace
         compose_file_path=candidate.compose_file_path,
         pr_url=candidate.pr_url,
         retry_policy_allows_recovery=retry_policy_allows_runtime_recovery(candidate.task_policy),
+    )
+
+
+def _running_monitoring_pr_recovery_finding(
+    candidate: _ActiveExecutionCandidate,
+) -> WorkspaceRuntimeFinding:
+    return WorkspaceRuntimeFinding(
+        workspace_id=candidate.workspace_id,
+        workspace_status=candidate.status.value,
+        status="stranded",
+        reason_code="STRANDED_WORKSPACE",
+        decision="remonitor_workspace",
+        message=(
+            "Worker lost its in-process PR monitor after restart while the old "
+            "workspace runtime still reports running; the open PR is the durable "
+            "recovery point, so the workspace can be remonitored."
+        ),
+        compose_project_name=candidate.compose_project_name,
     )
 
 

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -170,7 +170,7 @@ def _has_pytest_node_boundary(line: str, start: int, end: int) -> bool:
     if char.isspace():
         rest = line[end:].lstrip()
         return not rest or rest.startswith("- ")
-    return False
+    raise AssertionError(f"unsupported pytest node boundary: {char!r}")
 
 
 def _looks_like_pytest_node(candidate: str) -> bool:

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -146,7 +146,11 @@ def _pytest_node_candidates(line: str) -> list[str]:
             end += 1
 
         candidate = _strip_node_suffix(line[start:end].strip("`'\""))
-        if _has_pytest_node_boundary(line, start, end) and _looks_like_pytest_node(candidate):
+        if (
+            bracket_depth == 0
+            and _has_pytest_node_boundary(line, start, end)
+            and _looks_like_pytest_node(candidate)
+        ):
             nodes.append(candidate)
         search_from = max(end, anchor + len(".py::"))
 

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -23,6 +23,7 @@ _COMMAND_MARKERS = (
 _PYTEST_NODE_END_DELIMITERS = {",", ";", ")", "`", "'", '"'}
 _PYTEST_NODE_PREFIX_DELIMITERS = "([{<"
 _PYTEST_NODE_SUFFIX_DELIMITERS = ")]}>"
+_PYTEST_NODE_QUOTE_DELIMITERS = {"`", "'", '"'}
 _MAX_TEST_NODES = 20
 _MAX_REPRO_NODES = 5
 _MAX_COMMANDS = 5
@@ -126,11 +127,7 @@ def _pytest_node_candidates(line: str) -> list[str]:
             break
 
         start = anchor
-        while (
-            start > 0
-            and not line[start - 1].isspace()
-            and line[start - 1] not in _PYTEST_NODE_PREFIX_DELIMITERS
-        ):
+        while start > 0 and _is_pytest_path_char(line[start - 1]):
             start -= 1
 
         end = anchor + len(".py::")
@@ -158,8 +155,12 @@ def _pytest_node_candidates(line: str) -> list[str]:
 
 
 def _has_pytest_node_boundary(line: str, start: int, end: int) -> bool:
-    if start > 0 and line[start - 1] in _PYTEST_NODE_PREFIX_DELIMITERS:
-        return False
+    if start > 0:
+        char = line[start - 1]
+        if char in _PYTEST_NODE_PREFIX_DELIMITERS:
+            return False
+        if not char.isspace() and char not in _PYTEST_NODE_QUOTE_DELIMITERS:
+            return False
     if end >= len(line):
         return True
     char = line[end]
@@ -171,6 +172,10 @@ def _has_pytest_node_boundary(line: str, start: int, end: int) -> bool:
         rest = line[end:].lstrip()
         return not rest or rest.startswith("- ")
     raise AssertionError(f"unsupported pytest node boundary: {char!r}")
+
+
+def _is_pytest_path_char(char: str) -> bool:
+    return char.isalnum() or char in "/._-"
 
 
 def _looks_like_pytest_node(candidate: str) -> bool:

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -10,14 +10,6 @@ from dataclasses import dataclass
 from awf.common.redaction import redact_secrets
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
-_PYTEST_NODE_COMPONENT = r"(?:[^\s:\[]+|\[[^\]]*\])+"
-_PYTEST_NODE_PATH = r"[^\s:]+\.py"
-_PYTEST_NODE_RE = re.compile(
-    rf"(?<!\S)(?P<node>{_PYTEST_NODE_PATH}(?:::{_PYTEST_NODE_COMPONENT})+)(?=\s+-\s+|$)"
-)
-_FAILED_PYTEST_NODE_RE = re.compile(
-    rf"\bFAILED\s+(?P<node>{_PYTEST_NODE_PATH}(?:::{_PYTEST_NODE_COMPONENT})+)(?:\s+-\s+|$)"
-)
 _RUFF_DIAGNOSTIC_RE = re.compile(r"\b(?:src|tests)/[^\s:]+\.py:\d+:\d+:")
 _COMMAND_MARKERS = (
     "uv run ",
@@ -28,6 +20,7 @@ _COMMAND_MARKERS = (
     "mypy ",
     "npm ",
 )
+_PYTEST_NODE_END_DELIMITERS = {",", ";", ")", "`", "'", '"'}
 _MAX_TEST_NODES = 20
 _MAX_REPRO_NODES = 5
 _MAX_COMMANDS = 5
@@ -107,13 +100,72 @@ def _truncate_line(line: str) -> str:
 def _extract_test_nodes(lines: Iterable[str]) -> list[str]:
     nodes: list[str] = []
     for line in lines:
-        failed_match = _FAILED_PYTEST_NODE_RE.search(line)
-        if failed_match:
-            nodes.append(failed_match.group("node").strip())
-            continue
-        for match in _PYTEST_NODE_RE.finditer(line):
-            nodes.append(_strip_node_suffix(match.group("node")))
+        nodes.extend(_pytest_node_candidates(line))
     return nodes
+
+
+def _pytest_node_candidates(line: str) -> list[str]:
+    """Extract pytest node ids with a linear scan.
+
+    CI logs are untrusted text. A previous nested-regex extractor could spend
+    unbounded CPU on long GitHub Actions lines before the PR monitor even logged
+    its decision. This scanner only looks around ``.py::`` anchors and walks
+    each line forward once.
+    """
+
+    if ".py::" not in line:
+        return []
+
+    nodes: list[str] = []
+    search_from = 0
+    while True:
+        anchor = line.find(".py::", search_from)
+        if anchor < 0:
+            break
+
+        start = anchor
+        while start > 0 and not line[start - 1].isspace():
+            start -= 1
+
+        end = anchor + len(".py::")
+        bracket_depth = 0
+        while end < len(line):
+            char = line[end]
+            if char == "[":
+                bracket_depth += 1
+            elif char == "]" and bracket_depth > 0:
+                bracket_depth -= 1
+            elif bracket_depth == 0 and (char.isspace() or char in _PYTEST_NODE_END_DELIMITERS):
+                break
+            end += 1
+
+        candidate = _strip_node_suffix(line[start:end].strip("`'\""))
+        if _has_pytest_node_boundary(line, end) and _looks_like_pytest_node(candidate):
+            nodes.append(candidate)
+        search_from = max(end, anchor + len(".py::"))
+
+    return nodes
+
+
+def _has_pytest_node_boundary(line: str, end: int) -> bool:
+    if end >= len(line):
+        return True
+    char = line[end]
+    if char in _PYTEST_NODE_END_DELIMITERS:
+        return True
+    if char.isspace():
+        rest = line[end:].lstrip()
+        return not rest or rest.startswith("- ")
+    return False
+
+
+def _looks_like_pytest_node(candidate: str) -> bool:
+    path, separator, test_part = candidate.partition(".py::")
+    if not separator or not path or not test_part:
+        return False
+    if any(char.isspace() for char in path):
+        return False
+    return "://" not in path
 
 
 def _strip_node_suffix(node: str) -> str:

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -21,6 +21,8 @@ _COMMAND_MARKERS = (
     "npm ",
 )
 _PYTEST_NODE_END_DELIMITERS = {",", ";", ")", "`", "'", '"'}
+_PYTEST_NODE_PREFIX_DELIMITERS = "([{<"
+_PYTEST_NODE_SUFFIX_DELIMITERS = ")]}>"
 _MAX_TEST_NODES = 20
 _MAX_REPRO_NODES = 5
 _MAX_COMMANDS = 5
@@ -124,7 +126,11 @@ def _pytest_node_candidates(line: str) -> list[str]:
             break
 
         start = anchor
-        while start > 0 and not line[start - 1].isspace():
+        while (
+            start > 0
+            and not line[start - 1].isspace()
+            and line[start - 1] not in _PYTEST_NODE_PREFIX_DELIMITERS
+        ):
             start -= 1
 
         end = anchor + len(".py::")
@@ -140,17 +146,21 @@ def _pytest_node_candidates(line: str) -> list[str]:
             end += 1
 
         candidate = _strip_node_suffix(line[start:end].strip("`'\""))
-        if _has_pytest_node_boundary(line, end) and _looks_like_pytest_node(candidate):
+        if _has_pytest_node_boundary(line, start, end) and _looks_like_pytest_node(candidate):
             nodes.append(candidate)
         search_from = max(end, anchor + len(".py::"))
 
     return nodes
 
 
-def _has_pytest_node_boundary(line: str, end: int) -> bool:
+def _has_pytest_node_boundary(line: str, start: int, end: int) -> bool:
+    if start > 0 and line[start - 1] in _PYTEST_NODE_PREFIX_DELIMITERS:
+        return False
     if end >= len(line):
         return True
     char = line[end]
+    if char in _PYTEST_NODE_SUFFIX_DELIMITERS:
+        return False
     if char in _PYTEST_NODE_END_DELIMITERS:
         return True
     if char.isspace():
@@ -162,6 +172,8 @@ def _has_pytest_node_boundary(line: str, end: int) -> bool:
 def _looks_like_pytest_node(candidate: str) -> bool:
     path, separator, test_part = candidate.partition(".py::")
     if not separator or not path or not test_part:
+        return False
+    if path and path[0] in _PYTEST_NODE_PREFIX_DELIMITERS:
         return False
     if any(char.isspace() for char in path):
         return False

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -286,10 +286,7 @@ def build_conformance_salvage_conflict_prompt(
 ) -> str:
     gaps = _string_list(salvage.get("remaining_gaps"))
     gap_lines = "\n".join(f"- {gap}" for gap in gaps) or "- Re-check conformance evidence."
-    implementation_paths = _string_list(salvage.get("implementation_paths"))
-    path_lines = "\n".join(f"- `{path}`" for path in implementation_paths[:20])
-    if len(implementation_paths) > 20:
-        path_lines += f"\n- ... and {len(implementation_paths) - 20} more"
+    path_lines = _implementation_path_lines(salvage)
     return (
         "## Automatic AWF salvage conflict\n\n"
         "AWF captured the prior implementation diff, but it could not be applied "

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -243,10 +243,7 @@ def build_conformance_salvage_retry_prompt(
     evidence: Mapping[str, Any],
     salvage: Mapping[str, Any],
 ) -> str:
-    implementation_paths = _string_list(salvage.get("implementation_paths"))
-    paths = "\n".join(f"- `{path}`" for path in implementation_paths[:20])
-    if len(implementation_paths) > 20:
-        paths += f"\n- ... and {len(implementation_paths) - 20} more"
+    paths = _implementation_path_lines(salvage)
     return (
         "## Automatic AWF salvage\n\n"
         "AWF automatically captured the prior implementation diff from the failed "
@@ -255,6 +252,28 @@ def build_conformance_salvage_retry_prompt(
         "restart from scratch unless the recovered code is unusable.\n\n"
         f"### Salvaged implementation paths\n{paths or '- No paths recorded.'}\n\n"
         + build_conformance_retry_prompt(task_prompt=task_prompt, evidence=evidence)
+    )
+
+
+def build_agent_timeout_salvage_retry_prompt(
+    *,
+    task_prompt: str,
+    evidence: Mapping[str, Any],
+    salvage: Mapping[str, Any],
+) -> str:
+    reason_code = _optional_str(evidence.get("reason_code")) or "AGENT_IDLE_TIMEOUT"
+    message = _optional_str(evidence.get("message"))
+    message_line = f"\n\n### Timeout message\n{message[:1000]}" if message else ""
+    return (
+        "## Automatic AWF timeout salvage\n\n"
+        "AWF automatically captured the prior implementation diff from an agent "
+        "run that timed out before it could finish. The retry workspace will "
+        "restore that diff before the agent runs. Continue from the recovered "
+        "implementation; do not restart from scratch unless the recovered code "
+        "is unusable.\n\n"
+        f"### Source reason\n`{reason_code}`{message_line}\n\n"
+        f"### Salvaged implementation paths\n{_implementation_path_lines(salvage)}\n\n"
+        f"### Original task\n{task_prompt}\n"
     )
 
 
@@ -339,6 +358,14 @@ def _string_list(value: object) -> list[str]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, str) and item]
+
+
+def _implementation_path_lines(salvage: Mapping[str, Any]) -> str:
+    implementation_paths = _string_list(salvage.get("implementation_paths"))
+    paths = "\n".join(f"- `{path}`" for path in implementation_paths[:20])
+    if len(implementation_paths) > 20:
+        paths += f"\n- ... and {len(implementation_paths) - 20} more"
+    return paths or "- No paths recorded."
 
 
 def _optional_str(value: object) -> str | None:

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -310,7 +310,7 @@ def build_conformance_salvage_conflict_prompt(
         "use the salvage patch as source material, resolve the conflict against "
         "the current base, and finish the original conformance gaps.\n\n"
         f"### Salvage patch\n`{agent_patch_path}`\n\n"
-        f"### Salvaged implementation paths\n{path_lines or '- No paths recorded.'}\n\n"
+        f"### Salvaged implementation paths\n{path_lines}\n\n"
         f"### Remaining conformance gaps\n{gap_lines}\n\n"
         f"### Apply error\n{apply_error[:2000] or 'git apply --check failed.'}\n\n"
         f"### Original task\n{task_prompt}\n"

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -335,6 +335,7 @@ def _run_git(
     env: Mapping[str, str],
     failure_reason: str = SALVAGE_SOURCE_UNAVAILABLE,
 ) -> CompletedProcessLike:
+    """Run a git command for salvage with deterministic timeout and failure mapping."""
     result = run(
         ["git", *git_safe_directory_config_args(worktree), "-C", str(worktree), *args],
         check=False,
@@ -356,10 +357,12 @@ def _run_git(
 
 
 def _git_lines(value: str) -> list[str]:
+    """Split git output into a sorted list of non-empty changed paths."""
     return sorted(line.strip() for line in value.splitlines() if line.strip())
 
 
 def _evidence_gaps(evidence: Mapping[str, Any]) -> list[str]:
+    """Convert salvage evidence gaps into a stable list of non-empty strings."""
     value = evidence.get("gaps")
     if isinstance(value, list):
         return [str(item).strip() for item in value if str(item).strip()]
@@ -369,6 +372,7 @@ def _evidence_gaps(evidence: Mapping[str, Any]) -> list[str]:
 
 
 def _string_list(value: object) -> list[str]:
+    """Return a filtered list of strings, dropping non-string and empty values."""
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, str) and item]
@@ -384,6 +388,7 @@ def _implementation_path_lines(salvage: Mapping[str, Any]) -> str:
 
 
 def _optional_str(value: object) -> str | None:
+    """Normalize an optional string value to ``str`` or ``None``."""
     if not isinstance(value, str):
         return None
     stripped = value.strip()

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -250,7 +250,7 @@ def build_conformance_salvage_retry_prompt(
         "conformance attempt. The retry workspace will restore that diff before "
         "the agent runs. Continue from the recovered implementation; do not "
         "restart from scratch unless the recovered code is unusable.\n\n"
-        f"### Salvaged implementation paths\n{paths or '- No paths recorded.'}\n\n"
+        f"### Salvaged implementation paths\n{paths}\n\n"
         + build_conformance_retry_prompt(task_prompt=task_prompt, evidence=evidence)
     )
 

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -35,12 +35,16 @@ _GIT_TIMEOUT_SECONDS = 30.0
 
 
 class CompletedProcessLike(Protocol):
+    """Protocol describing the small git subprocess result contract."""
+
     returncode: int
     stdout: str
     stderr: str
 
 
 class SubprocessRun(Protocol):
+    """Protocol for a subprocess runner used by salvage operations."""
+
     def __call__(  # pragma: no cover - Protocol method declaration only.
         self,
         args: list[str],
@@ -50,11 +54,15 @@ class SubprocessRun(Protocol):
         text: Literal[True],
         timeout: float,
         env: Mapping[str, str],
-    ) -> CompletedProcessLike: ...
+    ) -> CompletedProcessLike:
+        """Execute subprocess command and return a captured result."""
+        ...
 
 
 @dataclass(frozen=True)
 class ConformanceSalvageCapture:
+    """Captures a salvage operation's metadata and artifact location."""
+
     source_workspace_id: str
     source_base_commit: str
     patch_path: Path
@@ -71,6 +79,7 @@ class ConformanceSalvageCapture:
     report_path: str | None = None
 
     def as_policy(self) -> dict[str, Any]:
+        """Convert capture metadata into a plan-policy payload."""
         payload: dict[str, Any] = {
             "status": "captured",
             "source_workspace_id": self.source_workspace_id,
@@ -96,6 +105,8 @@ class ConformanceSalvageCapture:
 
 
 class ConformanceSalvageError(Exception):
+    """Raised when salvage capture or validation fails."""
+
     def __init__(
         self,
         *,
@@ -103,6 +114,7 @@ class ConformanceSalvageError(Exception):
         message: str,
         detail: dict[str, Any] | None = None,
     ) -> None:
+        """Initialise an error with machine-readable salvage metadata."""
         self.reason_code = reason_code
         self.detail = detail or {}
         super().__init__(message)
@@ -119,6 +131,7 @@ def capture_conformance_salvage(
     source_remote_push_branch: str | None,
     run_subprocess: SubprocessRun | None = None,
 ) -> ConformanceSalvageCapture:
+    """Capture a salvage patch and metadata from a failed workspace run."""
     if not source_base_commit:
         raise ConformanceSalvageError(
             reason_code=SALVAGE_BASE_UNAVAILABLE,
@@ -243,6 +256,7 @@ def build_conformance_salvage_retry_prompt(
     evidence: Mapping[str, Any],
     salvage: Mapping[str, Any],
 ) -> str:
+    """Build a retry prompt that replays recovered conformance implementation diffs."""
     paths = _implementation_path_lines(salvage)
     return (
         "## Automatic AWF salvage\n\n"
@@ -261,6 +275,7 @@ def build_agent_timeout_salvage_retry_prompt(
     evidence: Mapping[str, Any],
     salvage: Mapping[str, Any],
 ) -> str:
+    """Build a retry prompt for timeout recovery with recovered implementation diff."""
     reason_code = _optional_str(evidence.get("reason_code")) or "AGENT_IDLE_TIMEOUT"
     message = _optional_str(evidence.get("message"))
     message_line = f"\n\n### Timeout message\n{message[:1000]}" if message else ""
@@ -284,6 +299,7 @@ def build_conformance_salvage_conflict_prompt(
     agent_patch_path: str,
     apply_error: str,
 ) -> str:
+    """Build a prompt that guides a conflict-resolution retry attempt."""
     gaps = _string_list(salvage.get("remaining_gaps"))
     gap_lines = "\n".join(f"- {gap}" for gap in gaps) or "- Re-check conformance evidence."
     path_lines = _implementation_path_lines(salvage)
@@ -304,6 +320,7 @@ def build_conformance_salvage_conflict_prompt(
 def conformance_salvage_from_task_policy(
     task_policy: Mapping[str, Any] | None,
 ) -> dict[str, Any] | None:
+    """Extract conformance-salvage metadata from a task policy blob."""
     if not isinstance(task_policy, Mapping):
         return None
     value = task_policy.get(CONFORMANCE_SALVAGE_POLICY_KEY)
@@ -358,6 +375,7 @@ def _string_list(value: object) -> list[str]:
 
 
 def _implementation_path_lines(salvage: Mapping[str, Any]) -> str:
+    """Format captured implementation paths as prompt bullet lines with truncation."""
     implementation_paths = _string_list(salvage.get("implementation_paths"))
     paths = "\n".join(f"- `{path}`" for path in implementation_paths[:20])
     if len(implementation_paths) > 20:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -151,12 +151,16 @@ from awf.service.workspace_runtime_health import (
 
 
 class RuntimeInspection(Protocol):
+    """Protocol for runtime health inspection implementations."""
+
     async def inspect(self, compose_project_name: str | None) -> RuntimeSnapshot:
         """Inspect container runtime state for the given compose project."""
 
 
 @dataclass(frozen=True, slots=True)
 class OperationRowsPage:
+    """Paginated container for operation response rows."""
+
     rows: builtins.list[OperationResponse]
 
 
@@ -213,6 +217,8 @@ _PROFILE_APP_ENDPOINTS_ADAPTER = TypeAdapter(list[ProfileAppEndpoint])
 
 
 class WorkspaceRetryError(Exception):
+    """Base error for failures encountered while retrying a workspace."""
+
     error_code = "WORKSPACE_RETRY_ERROR"
     message = "Workspace retry failed."
     detail: dict[str, Any] | None
@@ -231,6 +237,8 @@ class WorkspaceRetryError(Exception):
 
 
 class WorkspaceRetryNotFoundError(WorkspaceRetryError):
+    """Raised when a workspace cannot be found for retry."""
+
     error_code = "WORKSPACE_NOT_FOUND"
 
     def __init__(self, workspace_id: str) -> None:
@@ -239,6 +247,8 @@ class WorkspaceRetryNotFoundError(WorkspaceRetryError):
 
 
 class WorkspaceRetryNotAllowedError(WorkspaceRetryError):
+    """Raised when a workspace is not currently retryable."""
+
     error_code = "WORKSPACE_NOT_RETRYABLE"
 
     def __init__(self, workspace: Workspace) -> None:
@@ -253,6 +263,8 @@ class WorkspaceRetryNotAllowedError(WorkspaceRetryError):
 
 
 class WorkspaceRetryExhaustedError(WorkspaceRetryError):
+    """Raised when retry attempts exceed the configured limit."""
+
     error_code = "WORKSPACE_RETRY_EXHAUSTED"
 
     def __init__(self, attempt_count: int) -> None:
@@ -267,6 +279,8 @@ class WorkspaceRetryExhaustedError(WorkspaceRetryError):
 
 
 class WorkspaceRetrySalvageUnavailableError(WorkspaceRetryError):
+    """Raised when salvage data is required but unavailable."""
+
     error_code = "WORKSPACE_RETRY_SALVAGE_UNAVAILABLE"
 
     def __init__(
@@ -300,6 +314,8 @@ class WorkspaceRetrySalvageUnavailableError(WorkspaceRetryError):
 
 
 class WorkspaceProviderReadinessBlockedError(WorkspaceRetryError):
+    """Raised when provider readiness preflight blocks workspace startup."""
+
     error_code = "PROVIDER_READINESS_PRECHECK_FAILED"
 
     def __init__(self, preflight: Mapping[str, Any]) -> None:
@@ -311,6 +327,8 @@ class WorkspaceProviderReadinessBlockedError(WorkspaceRetryError):
 
 
 class WorkspaceCreateIdempotencyConflictError(Exception):
+    """Raised when an idempotency key has conflicting payload data."""
+
     error_code = "IDEMPOTENCY_CONFLICT"
     message = _IDEMPOTENCY_CONFLICT_MESSAGE
     detail: dict[str, Any] | None = None
@@ -321,6 +339,8 @@ class WorkspaceCreateIdempotencyConflictError(Exception):
 
 
 class WorkspaceCreateInsufficientDiskError(Exception):
+    """Raised when workspace creation is blocked by insufficient disk."""
+
     error_code = "INSUFFICIENT_DISK"
     message = "Insufficient free disk to create a new workspace."
 
@@ -344,6 +364,8 @@ async def _resolve_disk_check_factory(factory: DiskCheckFactory) -> DiskCheck:
 
 @dataclass(frozen=True)
 class WorkspaceRetryResult:
+    """Result container for a workspace retry attempt."""
+
     source_workspace_id: str
     new_workspace: Workspace
     operation: Operation
@@ -377,6 +399,8 @@ class _AgentTimeoutRetryContext:
 
 @dataclass(frozen=True)
 class ResourceReservationPlan:
+    """Resource reservation plan for workspace execution."""
+
     node_id: str
     steady_cpu: float
     steady_memory_gb: float

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -201,6 +201,8 @@ _IDEMPOTENCY_CONFLICT_MESSAGE = (
 
 @dataclass(frozen=True)
 class _WorkspaceResponseSource:
+    """Projection wrapper exposing computed response values over workspace state."""
+
     workspace: Workspace
     computed_fields: Mapping[str, Any]
 
@@ -374,6 +376,8 @@ class WorkspaceRetryResult:
 
 @dataclass(frozen=True)
 class _ConformanceRetryContext:
+    """Container for conformance retry evidence and provenance."""
+
     reason_code: str
     evidence: Mapping[str, Any]
     evidence_ref: dict[str, str]
@@ -381,6 +385,8 @@ class _ConformanceRetryContext:
 
 @dataclass(frozen=True)
 class _PlanningScopeRetryContext:
+    """Container for planning-scope retry reason, evidence, and strategy."""
+
     reason_code: str
     evidence: Mapping[str, Any]
     evidence_ref: dict[str, str]
@@ -392,6 +398,8 @@ class _PlanningScopeRetryContext:
 
 @dataclass(frozen=True)
 class _AgentTimeoutRetryContext:
+    """Container for timeout retry reason and evidence metadata."""
+
     reason_code: str
     evidence: Mapping[str, Any]
     evidence_ref: dict[str, str]

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1679,7 +1679,18 @@ async def retry_workspace_row(
                 run_subprocess=run_subprocess,
             )
         except ConformanceSalvageError as exc:
-            if exc.reason_code != SALVAGE_NO_IMPLEMENTATION_DIFF:
+            if exc.reason_code == SALVAGE_NO_IMPLEMENTATION_DIFF:
+                _log.debug(
+                    "workspace.agent_timeout_salvage_skipped_no_diff",
+                    workspace_id=source.id,
+                )
+            else:
+                _log.info(
+                    "workspace.agent_timeout_salvage_unavailable",
+                    workspace_id=source.id,
+                    reason_code=exc.reason_code,
+                    detail=exc.detail,
+                )
                 raise WorkspaceRetrySalvageUnavailableError(
                     source,
                     reason_code=exc.reason_code,
@@ -1687,12 +1698,6 @@ async def retry_workspace_row(
                     evidence=agent_timeout_context.evidence,
                     detail=exc.detail,
                 ) from exc
-            _log.info(
-                "workspace.agent_timeout_salvage_unavailable",
-                workspace_id=source.id,
-                reason_code=exc.reason_code,
-                detail=exc.detail,
-            )
         else:
             conformance_salvage = {
                 **salvage_capture.as_policy(),

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1936,7 +1936,6 @@ def _agent_timeout_salvage_recovery_payload(
         "source_reason_code": context.reason_code,
         "recovery_strategy": "continue_from_timeout_salvage",
         "conformance_salvage": dict(salvage),
-        "salvage_kind": "agent_timeout",
         "agent_timeout_evidence_ref": context.evidence_ref,
     }
     message = _optional_retry_evidence_str(context.evidence.get("message"))

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -18,6 +18,7 @@ from sqlalchemy import inspect as sa_inspect
 from sqlalchemy.exc import NoInspectionAvailable
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT
 from awf.api.schemas import (
     EgressAuditRecordResponse,
     FallbackTargetResponse,
@@ -79,7 +80,9 @@ from awf.runtime.planning import (
 from awf.service.config import resolve_service_settings
 from awf.service.conformance_salvage import (
     CONFORMANCE_SALVAGE_POLICY_KEY,
+    SALVAGE_NO_IMPLEMENTATION_DIFF,
     ConformanceSalvageError,
+    build_agent_timeout_salvage_retry_prompt,
     build_conformance_salvage_retry_prompt,
     capture_conformance_salvage,
 )
@@ -362,6 +365,13 @@ class _PlanningScopeRetryContext:
     salvage_policy: str
     salvage: dict[str, str] | None = None
     fallback_model: dict[str, str] | None = None
+
+
+@dataclass(frozen=True)
+class _AgentTimeoutRetryContext:
+    reason_code: str
+    evidence: Mapping[str, Any]
+    evidence_ref: dict[str, str]
 
 
 @dataclass(frozen=True)
@@ -1580,6 +1590,11 @@ async def retry_workspace_row(
     conformance_retry_requested = planning_scope_context is None and (
         conformance_context is not None or _is_plan_conformance_unsatisfied(source)
     )
+    agent_timeout_context = (
+        _agent_timeout_retry_context(source)
+        if planning_scope_context is None and not conformance_retry_requested
+        else None
+    )
     conformance_evidence: Mapping[str, Any] = (
         conformance_context.evidence if conformance_context is not None else {}
     )
@@ -1615,6 +1630,7 @@ async def retry_workspace_row(
     preflight = {**preflight, "source_workspace_id": source.id}
     _raise_if_provider_preflight_blocks(preflight)
     conformance_salvage: dict[str, Any] | None = None
+    salvage_recovery_payload: dict[str, Any] | None = None
     if conformance_retry_requested:
         try:
             salvage_capture = await asyncio.to_thread(
@@ -1645,6 +1661,46 @@ async def retry_workspace_row(
             evidence=conformance_evidence,
             salvage=conformance_salvage,
         )
+        salvage_recovery_payload = _conformance_salvage_recovery_payload(
+            conformance_context=conformance_context,
+            salvage=conformance_salvage,
+        )
+    elif agent_timeout_context is not None:
+        try:
+            salvage_capture = await asyncio.to_thread(
+                capture_conformance_salvage,
+                work_dir=resolved_settings.work_dir,
+                source_workspace_id=source.id,
+                source_base_commit=source.base_commit,
+                conformance_evidence=agent_timeout_context.evidence,
+                conformance_evidence_ref=agent_timeout_context.evidence_ref,
+                source_branch_name=source.branch_name,
+                source_remote_push_branch=source.remote_push_branch,
+                run_subprocess=run_subprocess,
+            )
+        except ConformanceSalvageError as exc:
+            if exc.reason_code != SALVAGE_NO_IMPLEMENTATION_DIFF:
+                _log.info(
+                    "workspace.agent_timeout_salvage_unavailable",
+                    workspace_id=source.id,
+                    reason_code=exc.reason_code,
+                    detail=exc.detail,
+                )
+        else:
+            conformance_salvage = {
+                **salvage_capture.as_policy(),
+                "salvage_kind": "agent_timeout",
+            }
+            retried_task_policy[CONFORMANCE_SALVAGE_POLICY_KEY] = conformance_salvage
+            retried_prompt = build_agent_timeout_salvage_retry_prompt(
+                task_prompt=source.task_prompt,
+                evidence=agent_timeout_context.evidence,
+                salvage=conformance_salvage,
+            )
+            salvage_recovery_payload = _agent_timeout_salvage_recovery_payload(
+                context=agent_timeout_context,
+                salvage=conformance_salvage,
+            )
     retried_task_policy = {
         **retried_task_policy,
         "provider_readiness_preflight": preflight,
@@ -1745,13 +1801,8 @@ async def retry_workspace_row(
     operation_payload: dict[str, Any] = {"source_workspace_id": source.id}
     if planning_scope_context is not None:
         operation_payload.update(_planning_scope_recovery_payload(planning_scope_context))
-    if conformance_salvage is not None:
-        operation_payload.update(
-            _conformance_salvage_recovery_payload(
-                conformance_context=conformance_context,
-                salvage=conformance_salvage,
-            )
-        )
+    if salvage_recovery_payload is not None:
+        operation_payload.update(salvage_recovery_payload)
     operation = await operation_repo.create(
         workspace_id=retried.id,
         operation_type=OperationType.retry,
@@ -1766,13 +1817,8 @@ async def retry_workspace_row(
     }
     if planning_scope_context is not None:
         event_payload.update(_planning_scope_recovery_payload(planning_scope_context))
-    if conformance_salvage is not None:
-        event_payload.update(
-            _conformance_salvage_recovery_payload(
-                conformance_context=conformance_context,
-                salvage=conformance_salvage,
-            )
-        )
+    if salvage_recovery_payload is not None:
+        event_payload.update(salvage_recovery_payload)
     await repo.add_event(
         source,
         event_type="workspace.retry_requested",
@@ -1795,14 +1841,7 @@ async def retry_workspace_row(
             "attempt_number": attempt.attempt_number,
             "status": retried.status,
         }
-        | (
-            _conformance_salvage_recovery_payload(
-                conformance_context=conformance_context,
-                salvage=conformance_salvage,
-            )
-            if conformance_salvage is not None
-            else {}
-        )
+        | (salvage_recovery_payload or {})
         | (
             _planning_scope_recovery_payload(planning_scope_context)
             if planning_scope_context is not None
@@ -1872,6 +1911,25 @@ def _conformance_salvage_recovery_payload(
         payload["conformance_evidence_ref"] = conformance_context.evidence_ref
     elif salvage.get("conformance_evidence_ref") is not None:
         payload["conformance_evidence_ref"] = salvage.get("conformance_evidence_ref")
+    return payload
+
+
+def _agent_timeout_salvage_recovery_payload(
+    *,
+    context: _AgentTimeoutRetryContext,
+    salvage: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build retry payload metadata for an agent-timeout salvage continuation."""
+    payload: dict[str, Any] = {
+        "source_reason_code": context.reason_code,
+        "recovery_strategy": "continue_from_timeout_salvage",
+        "conformance_salvage": dict(salvage),
+        "salvage_kind": "agent_timeout",
+        "agent_timeout_evidence_ref": context.evidence_ref,
+    }
+    message = _optional_retry_evidence_str(context.evidence.get("message"))
+    if message is not None:
+        payload["source_failure_message"] = message
     return payload
 
 
@@ -2427,6 +2485,35 @@ def _is_plan_conformance_unsatisfied(workspace: Workspace) -> bool:
     if details is None:
         return False
     return details.get("reason_code") == PLAN_CONFORMANCE_UNSATISFIED
+
+
+def _agent_timeout_retry_context(workspace: Workspace) -> _AgentTimeoutRetryContext | None:
+    """Build a timeout retry context from the workspace's failure details if applicable."""
+    details = workspace_failure_details_payload(workspace)
+    if details is None:
+        return None
+    reason_code = details.get("reason_code")
+    if reason_code not in {AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT}:
+        return None
+    message = _optional_retry_evidence_str(details.get("message"))
+    evidence: dict[str, Any] = {
+        "reason_code": reason_code,
+        "gaps": [
+            "The previous agent run timed out before it could finish.",
+            "Continue from the recovered implementation diff and complete the original task.",
+        ],
+    }
+    if message is not None:
+        evidence["message"] = message
+    return _AgentTimeoutRetryContext(
+        reason_code=str(reason_code),
+        evidence=evidence,
+        evidence_ref={
+            "source_workspace_id": workspace.id,
+            "event_type": "workspace.state_changed",
+            "reason_code": str(reason_code),
+        },
+    )
 
 
 def _conformance_retry_context(workspace: Workspace) -> _ConformanceRetryContext | None:

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -273,6 +273,7 @@ class WorkspaceRetrySalvageUnavailableError(WorkspaceRetryError):
         self,
         workspace: Workspace,
         *,
+        source_reason_code: str = PLAN_CONFORMANCE_UNSATISFIED,
         reason_code: str,
         message: str,
         evidence: Mapping[str, Any] | None,
@@ -282,7 +283,7 @@ class WorkspaceRetrySalvageUnavailableError(WorkspaceRetryError):
         evidence = evidence or {}
         payload: dict[str, Any] = {
             "source_workspace_id": workspace.id,
-            "source_reason_code": PLAN_CONFORMANCE_UNSATISFIED,
+            "source_reason_code": source_reason_code,
             "reason_code": reason_code,
             "gaps": _retry_evidence_gaps(evidence),
             "plan_path": _optional_retry_evidence_str(evidence.get("plan_path")),
@@ -1693,6 +1694,7 @@ async def retry_workspace_row(
                 )
                 raise WorkspaceRetrySalvageUnavailableError(
                     source,
+                    source_reason_code=agent_timeout_context.reason_code,
                     reason_code=exc.reason_code,
                     message=str(exc),
                     evidence=agent_timeout_context.evidence,

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -1680,12 +1680,19 @@ async def retry_workspace_row(
             )
         except ConformanceSalvageError as exc:
             if exc.reason_code != SALVAGE_NO_IMPLEMENTATION_DIFF:
-                _log.info(
-                    "workspace.agent_timeout_salvage_unavailable",
-                    workspace_id=source.id,
+                raise WorkspaceRetrySalvageUnavailableError(
+                    source,
                     reason_code=exc.reason_code,
+                    message=str(exc),
+                    evidence=agent_timeout_context.evidence,
                     detail=exc.detail,
-                )
+                ) from exc
+            _log.info(
+                "workspace.agent_timeout_salvage_unavailable",
+                workspace_id=source.id,
+                reason_code=exc.reason_code,
+                detail=exc.detail,
+            )
         else:
             conformance_salvage = {
                 **salvage_capture.as_policy(),

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -78,7 +78,10 @@ def _assert_prompt_not_in_argv(args: list[str], prompt: str = _PROMPT) -> None:
 
 
 class _TimeoutStreamingRunner:
+    """Fake runner that simulates watchdog timeout and captures cleanup calls."""
+
     def __init__(self, *, reason_code: str) -> None:
+        """Store expected timeout reason and initialize runner state."""
         self.reason_code = reason_code
         self.used_streaming = False
         self.wall_timeout_seconds: float | None = None
@@ -86,6 +89,7 @@ class _TimeoutStreamingRunner:
         self.cleanup_calls: list[list[str]] = []
 
     async def run(self, args: list[str], **_kwargs: Any) -> CommandResult:
+        """Pretend to run cleanup and return a zero exit code."""
         self.cleanup_calls.append(list(args))
         assert "awf-cleanup" in args
         return CommandResult(returncode=0, stdout="cleanup ok", stderr="")
@@ -101,6 +105,7 @@ class _TimeoutStreamingRunner:
         wall_timeout_seconds: float | None = None,
         idle_timeout_seconds: float | None = None,
     ) -> CommandResult:
+        """Simulate a timed-out streaming run with watchdog metadata."""
         del input_bytes, cwd
         self.used_streaming = True
         self.wall_timeout_seconds = wall_timeout_seconds
@@ -118,31 +123,44 @@ class _TimeoutStreamingRunner:
 
 
 class _RecordingSinks:
+    """In-memory stdout/stderr sinks used by adapter log-store tests."""
+
     def __init__(self) -> None:
+        """Initialize recorded stream buffers."""
         self.stdout_data: list[str] = []
         self.stderr_data: list[str] = []
         self.closed = False
 
     async def write_stdout(self, data: str) -> None:
+        """Record stdout stream data."""
         self.stdout_data.append(data)
 
     async def write_stderr(self, data: str) -> None:
+        """Record stderr stream data."""
         self.stderr_data.append(data)
 
     async def close(self) -> None:
+        """Mark the sinks as closed."""
         self.closed = True
 
 
 class _RecordingLogStore:
+    """Log store stub that provides deterministic in-memory sinks."""
+
     def __init__(self) -> None:
+        """Initialise a shared in-memory sink."""
         self.sinks = _RecordingSinks()
 
     async def open_command_streams(self, **_kwargs: Any) -> _RecordingSinks:
+        """Return the in-memory sink used by adapter log stream assertions."""
         return self.sinks
 
 
 class _RunOnlyRunner:
+    """Runner that exercises the sync-only adapter execution path."""
+
     def __init__(self) -> None:
+        """Initialize captured call history."""
         self.calls: list[dict[str, object]] = []
 
     async def run(
@@ -152,12 +170,16 @@ class _RunOnlyRunner:
         input_bytes: bytes | None = None,
         cwd: str | None = None,
     ) -> CommandResult:
+        """Record one call and return legacy success output."""
         self.calls.append({"args": args, "input_bytes": input_bytes, "cwd": cwd})
         return CommandResult(returncode=0, stdout="legacy stdout", stderr="legacy stderr")
 
 
 class _CancellingStreamingRunner:
+    """Runner that injects cancellation to test adapter cleanup behavior."""
+
     def __init__(self) -> None:
+        """Initialize cleanup coordination events."""
         self.cleanup_calls: list[list[str]] = []
 
     async def run(
@@ -167,6 +189,7 @@ class _CancellingStreamingRunner:
         input_bytes: bytes | None = None,
         cwd: str | None = None,
     ) -> CommandResult:
+        """Record cleanup call details and return success payload."""
         del input_bytes, cwd
         self.cleanup_calls.append(list(args))
         assert "awf-cleanup" in args
@@ -177,10 +200,13 @@ class _CancellingStreamingRunner:
         _args: list[str],
         **_kwargs: Any,
     ) -> CommandResult:
+        """Reject streaming runs by raising cancellation for cleanup assertions."""
         raise asyncio.CancelledError
 
 
 class _SlowCleanupAfterCancelRunner:
+    """Runner that blocks cleanup briefly to test cancellation timing."""
+
     def __init__(self) -> None:
         self.cleanup_started = asyncio.Event()
         self.allow_cleanup = asyncio.Event()
@@ -194,6 +220,7 @@ class _SlowCleanupAfterCancelRunner:
         input_bytes: bytes | None = None,
         cwd: str | None = None,
     ) -> CommandResult:
+        """Capture cleanup-callback details before cancellation."""
         del input_bytes, cwd
         self.cleanup_calls.append(list(args))
         assert "awf-cleanup" in args
@@ -207,10 +234,13 @@ class _SlowCleanupAfterCancelRunner:
         _args: list[str],
         **_kwargs: Any,
     ) -> CommandResult:
+        """Raise cancellation immediately to force exception handling paths."""
         raise asyncio.CancelledError
 
 
 class TestCodexAdapter:
+    """End-to-end Codex adapter contract tests."""
+
     @pytest.mark.unit
     @pytest.mark.parametrize(
         ("wall_timeout", "idle_timeout", "message"),
@@ -523,6 +553,8 @@ class TestCodexAdapter:
 
 
 class TestClaudeCodeAdapter:
+    """Claude adapter contract tests."""
+
     @pytest.mark.unit
     async def test_produces_correct_cli_invocation(self) -> None:
         runner = FakeCommandRunner()
@@ -628,6 +660,8 @@ class TestClaudeCodeAdapter:
 
 
 class TestGeminiAdapter:
+    """Gemini adapter contract tests."""
+
     @pytest.mark.unit
     def test_reports_google_provider(self) -> None:
         adapter = GeminiAdapter(runner=FakeCommandRunner())
@@ -727,6 +761,8 @@ class TestGeminiAdapter:
 
 
 class TestOpenCodeAdapter:
+    """OpenCode adapter contract tests."""
+
     @pytest.mark.unit
     def test_reports_provider_from_selected_or_default_model(self) -> None:
         default_adapter = OpenCodeAdapter(runner=FakeCommandRunner())
@@ -954,6 +990,8 @@ def test_adapter_cli_args_contract_excludes_prompt_payload() -> None:
 
 
 class TestCentralDefaults:
+    """Default model and effort mapping tests."""
+
     @pytest.mark.unit
     def test_defaults_map_uses_requested_models_and_xhigh_effort(self) -> None:
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.claude_code].model == "claude-opus-4-7"
@@ -977,6 +1015,8 @@ class TestCentralDefaults:
 
 
 class TestRegistry:
+    """Adapter registry wiring tests."""
+
     @pytest.mark.unit
     def test_all_adapters_registered(self) -> None:
         runner = FakeCommandRunner()

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -66,6 +66,10 @@ def _assert_prompt_sent_on_stdin(runner: FakeCommandRunner, prompt: str = _PROMP
     wrapped_prompt = input_bytes.decode()
     assert wrapped_prompt.endswith(prompt)
     assert "AWF workspace contract" in wrapped_prompt
+    assert "DO NOT run AWF/GitHub-owned broad validation" in wrapped_prompt
+    assert "inside the agent" in wrapped_prompt
+    assert "pytest --cov" in wrapped_prompt
+    assert "focused checks" in wrapped_prompt
     return wrapped_prompt
 
 

--- a/tests/unit/control/test_worker.py
+++ b/tests/unit/control/test_worker.py
@@ -19254,6 +19254,78 @@ class TestRunOnceStaleActiveExecutionRecovery:
         assert executor.resume_calls == [workspace_id]
 
     @pytest.mark.unit
+    async def test_monitoring_pr_running_runtime_after_restart_remonitors_open_pr(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        workspace_id = await _create_monitoring_pr(
+            session_factory,
+            origin_repo,
+            "running-claimed-monitoring-pr",
+        )
+        async with session_factory() as s:
+            repo = WorkspaceRepository(s)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "dead-monitor-worker"
+            ws.monitor_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await repo.add_event(
+                ws,
+                event_type="workspace.stale_active_execution_detected",
+                reason_code="STALE_ACTIVE_EXECUTION",
+                payload={"seed": "prior restart scan"},
+            )
+            await s.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {
+                f"awf_{workspace_id}": RuntimeSnapshot(
+                    stack_state="running",
+                    services=[
+                        RuntimeService(
+                            name="agent",
+                            container_id="agent",
+                            image="awf-agent:latest",
+                            state="running",
+                            status="Up 10 minutes",
+                        )
+                    ],
+                )
+            }
+        )
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=inspector,
+            config=WorkerConfig(poll_interval_seconds=0.01, max_concurrent_executions=1),
+        )
+
+        assert await worker.run_once() == 1
+        await worker.wait_for_execution_tasks()
+
+        async with session_factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.failure_reason is None
+            assert ws.monitor_claimed_by is None
+            assert ws.monitor_claim_expires_at is None
+            events = await WorkspaceEventRepository(s).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+            assert len(events) == 1
+            assert events[0].reason_code == "STRANDED_WORKSPACE"
+            assert events[0].payload is not None
+            assert events[0].payload["decision"] == "remonitor_workspace"
+
+        assert inspector.calls == [f"awf_{workspace_id}"]
+        assert executor.resume_calls == [workspace_id]
+
+    @pytest.mark.unit
     async def test_monitoring_pr_without_pr_url_follows_failure_path(
         self,
         session_factory: async_sessionmaker[AsyncSession],

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -219,6 +219,13 @@ def test_ci_failure_evidence_linear_scanner_preserves_bracketed_parameters() -> 
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_rejects_wrapped_pytest_node_ids() -> None:
+    line = "Failed: (tests/unit/runtime/test_prompt.py::test_x), and {tests/unit/runtime/test_prompt.py::test_y}"
+
+    assert ci_failure_evidence._pytest_node_candidates(line) == []  # noqa: SLF001
+
+
+@pytest.mark.unit
 def test_pytest_repro_command_skips_unparseable_command_before_valid_pytest() -> None:
     command = ci_failure_evidence._pytest_repro_command(  # noqa: SLF001
         [

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -219,6 +219,21 @@ def test_ci_failure_evidence_linear_scanner_preserves_bracketed_parameters() -> 
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_rejects_unterminated_bracketed_node_ids() -> None:
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join(
+            [
+                "FAILED tests/unit/runtime/test_prompt.py::test_handles[param - truncated",
+                "FAILED tests/unit/runtime/test_prompt.py::test_alpha - AssertionError: boom",
+            ]
+        ),
+        check_name="unit",
+    )
+
+    assert evidence.test_node_ids == ("tests/unit/runtime/test_prompt.py::test_alpha",)
+
+
+@pytest.mark.unit
 def test_ci_failure_evidence_rejects_wrapped_pytest_node_ids() -> None:
     line = "Failed: (tests/unit/runtime/test_prompt.py::test_x), and {tests/unit/runtime/test_prompt.py::test_y}"
 

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -243,6 +243,16 @@ def test_ci_failure_evidence_rejects_wrapped_pytest_node_ids() -> None:
 
 
 @pytest.mark.unit
+def test_pytest_node_boundary_rejects_unsupported_scanner_stop() -> None:
+    with pytest.raises(AssertionError, match="unsupported pytest node boundary"):
+        ci_failure_evidence._has_pytest_node_boundary(  # noqa: SLF001
+            "tests/unit/runtime/test_prompt.py::test_x/",
+            0,
+            len("tests/unit/runtime/test_prompt.py::test_x"),
+        )
+
+
+@pytest.mark.unit
 def test_pytest_repro_command_skips_unparseable_command_before_valid_pytest() -> None:
     command = ci_failure_evidence._pytest_repro_command(  # noqa: SLF001
         [

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -212,6 +212,8 @@ def test_ci_failure_evidence_linear_scanner_preserves_bracketed_parameters() -> 
     node_ids = [
         "tests/unit/runtime/test_prompt.py::test_handles[bad value; echo owned]",
         "pkg/tests/test_api.py::TestApi::test_nested[a - b]",
+        "tests/unit/runtime/test_prompt.py::test_handles[(a)]",
+        "pkg/tests/test_api.py::TestApi::test_with_angle<id><x>",
     ]
     line = " and ".join(f"`{node_id}`" for node_id in node_ids)
 

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -69,6 +69,26 @@ def test_ci_failure_evidence_suggests_generic_repro_when_pytest_command_is_unava
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_rejects_glued_prefix_before_pytest_node() -> None:
+    valid_node_id = "tests/unit/test_example.py::test_valid_failure"
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join(
+            [
+                "FAILED:tests/unit/test_example.py::test_glued_prefix - AssertionError",
+                f"FAILED {valid_node_id} - AssertionError",
+            ]
+        ),
+        check_name="unit",
+    )
+
+    assert evidence.test_node_ids == (valid_node_id,)
+    assert evidence.suggested_repro_commands == (
+        f"uv run --python 3.12 --extra dev pytest {valid_node_id} -q",
+    )
+
+
+@pytest.mark.unit
 def test_ci_failure_repro_command_skips_non_pytest_commands() -> None:
     assert (
         ci_failure_evidence._pytest_repro_command(  # noqa: SLF001

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -184,6 +184,41 @@ def test_ci_failure_evidence_bounds_and_quotes_multiple_node_ids_with_known_comm
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_scans_noisy_malformed_pytest_lines_in_bounded_time() -> None:
+    valid_node_id = "tests/unit/runtime/test_prompt.py::test_keeps_working"
+    malformed_node = "tests/unit/runtime/test_prompt.py::" + ("case" * 2000)
+    noisy_line = f"Backend CI\tRun tests\tFAILED {malformed_node} " + " ".join(
+        f"package_{index}-1.0.0" for index in range(400)
+    )
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join(
+            [
+                noisy_line,
+                f"FAILED {valid_node_id} - AssertionError: boom",
+            ]
+        ),
+        check_name="Backend CI",
+    )
+
+    assert evidence.test_node_ids == (valid_node_id,)
+    assert evidence.suggested_repro_commands == (
+        f"uv run --python 3.12 --extra dev pytest {valid_node_id} -q",
+    )
+
+
+@pytest.mark.unit
+def test_ci_failure_evidence_linear_scanner_preserves_bracketed_parameters() -> None:
+    node_ids = [
+        "tests/unit/runtime/test_prompt.py::test_handles[bad value; echo owned]",
+        "pkg/tests/test_api.py::TestApi::test_nested[a - b]",
+    ]
+    line = " and ".join(f"`{node_id}`" for node_id in node_ids)
+
+    assert ci_failure_evidence._pytest_node_candidates(line) == node_ids  # noqa: SLF001
+
+
+@pytest.mark.unit
 def test_pytest_repro_command_skips_unparseable_command_before_valid_pytest() -> None:
     command = ci_failure_evidence._pytest_repro_command(  # noqa: SLF001
         [

--- a/tests/unit/service/test_conformance_salvage.py
+++ b/tests/unit/service/test_conformance_salvage.py
@@ -15,6 +15,7 @@ from awf.service.conformance_salvage import (
     SALVAGE_SOURCE_UNAVAILABLE,
     ConformanceSalvageCapture,
     ConformanceSalvageError,
+    build_agent_timeout_salvage_retry_prompt,
     build_conformance_salvage_conflict_prompt,
     build_conformance_salvage_retry_prompt,
     capture_conformance_salvage,
@@ -150,6 +151,43 @@ def test_capture_policy_includes_optional_source_and_string_gap(tmp_path: Path) 
 
 
 @pytest.mark.unit
+def test_capture_stages_tracked_files_under_ignored_parent_directory(tmp_path: Path) -> None:
+    worktree = tmp_path / "git" / "worktrees" / "ws_ignored_parent"
+    worktree.mkdir(parents=True)
+    _git(["init", "-q"], worktree)
+    _git(["config", "user.name", "AWF Test"], worktree)
+    _git(["config", "user.email", "awf@test.local"], worktree)
+    (worktree / ".gitignore").write_text("lib/\n", encoding="utf-8")
+    (worktree / "apps/console/lib").mkdir(parents=True)
+    (worktree / "apps/console/lib/format.ts").write_text(
+        "export const value = 'old';\n",
+        encoding="utf-8",
+    )
+    _git(["add", ".gitignore"], worktree)
+    _git(["add", "-f", "apps/console/lib/format.ts"], worktree)
+    _git(["commit", "-q", "-m", "base"], worktree)
+    base_commit = _git(["rev-parse", "HEAD"], worktree)
+
+    (worktree / "apps/console/lib/format.ts").write_text(
+        "export const value = 'new';\n",
+        encoding="utf-8",
+    )
+
+    capture = capture_conformance_salvage(
+        work_dir=tmp_path,
+        source_workspace_id="ws_ignored_parent",
+        source_base_commit=base_commit,
+        conformance_evidence=None,
+        conformance_evidence_ref=None,
+        source_branch_name=None,
+        source_remote_push_branch=None,
+    )
+
+    assert capture.implementation_paths == ["apps/console/lib/format.ts"]
+    assert "export const value = 'new';" in capture.patch_path.read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
 def test_capture_policy_omits_absent_optional_source_fields(tmp_path: Path) -> None:
     capture = ConformanceSalvageCapture(
         source_workspace_id="ws_source",
@@ -198,9 +236,17 @@ def test_prompt_helpers_handle_long_or_missing_path_lists() -> None:
         agent_patch_path=".awf/salvage/ws.patch",
         apply_error="",
     )
+    timeout_prompt = build_agent_timeout_salvage_retry_prompt(
+        task_prompt="finish timed-out task",
+        evidence={"reason_code": "AGENT_IDLE_TIMEOUT", "message": "no output"},
+        salvage={"implementation_paths": long_paths},
+    )
 
     assert "... and 2 more" in retry_prompt
     assert "... and 2 more" in conflict_prompt
+    assert "... and 2 more" in timeout_prompt
+    assert "Automatic AWF timeout salvage" in timeout_prompt
+    assert "finish timed-out task" in timeout_prompt
     assert "Re-check conformance evidence." in conflict_prompt
     assert "No paths recorded." in missing_paths_prompt
     assert conformance_salvage_from_task_policy(None) is None

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -13,6 +13,7 @@ import pytest
 from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT
 from awf.api.schemas import WorkspaceCreateRequest
 from awf.common.config import Settings
 from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
@@ -516,6 +517,39 @@ async def _mark_conformance_failed_without_evidence(
         await session.commit()
 
 
+async def _mark_agent_timeout_failed(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    *,
+    base_commit: str | None = None,
+) -> None:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        workspace.failure_reason = FailureReason.agent_failure.value
+        workspace.failure_message = "agent emitted no output for 3600.0 seconds"
+        workspace.branch_name = "awf/ws_timeout"
+        workspace.remote_push_branch = "awf/ws_timeout"
+        workspace.base_commit = base_commit
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.failed,
+            reason_code=AGENT_IDLE_TIMEOUT,
+            payload={
+                "reason_code": AGENT_IDLE_TIMEOUT,
+                "message": "agent emitted no output for 3600.0 seconds",
+                "details": {
+                    "provider": "claude_code",
+                    "model": "claude-opus-4-7",
+                    "retryable": True,
+                },
+            },
+        )
+        await session.commit()
+
+
 async def _mark_planning_scope_failed(
     factory: async_sessionmaker[AsyncSession],
     workspace_id: str,
@@ -812,6 +846,120 @@ async def test_retry_conformance_unsatisfied_without_evidence_still_salvages_dif
     assert salvage["source_workspace_id"] == first.id
     assert salvage["remaining_gaps"] == []
     assert salvage["conformance_evidence_ref"] is None
+
+
+@pytest.mark.unit
+async def test_retry_agent_idle_timeout_auto_salvages_implementation_diff(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    settings = _settings_with_work_dir(tmp_path)
+    service = WorkspaceService(factory)
+    first = await service.create(_request())
+    base_commit = _create_conformance_source_worktree(settings, first.id)
+    await _mark_agent_timeout_failed(factory, first.id, base_commit=base_commit)
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first.id,
+            provider_readiness_override=True,
+            provider_readiness_override_reason="retry service test fixture",
+            settings=settings,
+        )
+        await session.commit()
+
+    async with factory() as session:
+        retried = await WorkspaceRepository(session).get(retry.new_workspace.id)
+        assert retried is not None
+        operations = list(
+            (
+                await session.execute(select(Operation).where(Operation.workspace_id == retried.id))
+            ).scalars()
+        )
+        retry_created = list(
+            (
+                await session.execute(
+                    select(WorkspaceEvent).where(
+                        WorkspaceEvent.workspace_id == retried.id,
+                        WorkspaceEvent.event_type == "workspace.retry_created",
+                    )
+                )
+            ).scalars()
+        )
+
+    salvage = retried.task_policy["conformance_salvage"]
+    assert salvage["salvage_kind"] == "agent_timeout"
+    assert salvage["source_workspace_id"] == first.id
+    assert salvage["source_base_commit"] == base_commit
+    assert salvage["implementation_paths"] == [
+        "src/awf/retry.py",
+        "tests/unit/test_retry.py",
+    ]
+    assert salvage["plan_artifact_paths"] == [
+        "docs/awf-plans/ws_old.conformance.json",
+        "docs/awf-plans/ws_old.md",
+    ]
+    assert salvage["remaining_gaps"] == [
+        "The previous agent run timed out before it could finish.",
+        "Continue from the recovered implementation diff and complete the original task.",
+    ]
+    assert salvage["conformance_evidence_ref"] == {
+        "source_workspace_id": first.id,
+        "event_type": "workspace.state_changed",
+        "reason_code": AGENT_IDLE_TIMEOUT,
+    }
+    assert "Automatic AWF timeout salvage" in retried.task_prompt
+    assert "Fix the intermittent validation failure." in retried.task_prompt
+    assert "Continue from the recovered implementation" in retried.task_prompt
+    assert operations[0].payload["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert operations[0].payload["recovery_strategy"] == "continue_from_timeout_salvage"
+    assert operations[0].payload["salvage_kind"] == "agent_timeout"
+    assert operations[0].payload["conformance_salvage"] == salvage
+    assert operations[0].result["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert operations[0].result["conformance_salvage"] == salvage
+    assert retry_created[0].payload["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert retry_created[0].payload["conformance_salvage"] == salvage
+
+
+@pytest.mark.unit
+async def test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    settings = _settings_with_work_dir(tmp_path)
+    service = WorkspaceService(factory)
+    first = await service.create(_request())
+    base_commit = _create_conformance_source_worktree(
+        settings,
+        first.id,
+        implementation_diff=False,
+    )
+    await _mark_agent_timeout_failed(factory, first.id, base_commit=base_commit)
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first.id,
+            provider_readiness_override=True,
+            provider_readiness_override_reason="retry service test fixture",
+            settings=settings,
+        )
+        await session.commit()
+
+    async with factory() as session:
+        retried = await WorkspaceRepository(session).get(retry.new_workspace.id)
+        assert retried is not None
+        operations = list(
+            (
+                await session.execute(select(Operation).where(Operation.workspace_id == retried.id))
+            ).scalars()
+        )
+
+    assert "conformance_salvage" not in retried.task_policy
+    assert retried.task_prompt == "Fix the intermittent validation failure."
+    assert "source_reason_code" not in operations[0].payload
+    assert "conformance_salvage" not in operations[0].payload
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -13,7 +13,7 @@ import pytest
 from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT
+from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT
 from awf.api.schemas import WorkspaceCreateRequest
 from awf.common.config import Settings
 from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
@@ -526,6 +526,7 @@ async def _mark_agent_timeout_failed(
     workspace_id: str,
     *,
     base_commit: str | None = None,
+    reason_code: str = AGENT_IDLE_TIMEOUT,
 ) -> None:
     async with factory() as session:
         repo = WorkspaceRepository(session)
@@ -540,9 +541,9 @@ async def _mark_agent_timeout_failed(
         await repo.transition(
             workspace,
             to=WorkspaceStatus.failed,
-            reason_code=AGENT_IDLE_TIMEOUT,
+            reason_code=reason_code,
             payload={
-                "reason_code": AGENT_IDLE_TIMEOUT,
+                "reason_code": reason_code,
                 "message": "agent emitted no output for 3600.0 seconds",
                 "details": {
                     "provider": "claude_code",
@@ -853,15 +854,22 @@ async def test_retry_conformance_unsatisfied_without_evidence_still_salvages_dif
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("timeout_reason", [AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT])
 async def test_retry_agent_idle_timeout_auto_salvages_implementation_diff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
+    timeout_reason: str,
 ) -> None:
     settings = _settings_with_work_dir(tmp_path)
     service = WorkspaceService(factory)
     first = await service.create(_request())
     base_commit = _create_conformance_source_worktree(settings, first.id)
-    await _mark_agent_timeout_failed(factory, first.id, base_commit=base_commit)
+    await _mark_agent_timeout_failed(
+        factory,
+        first.id,
+        base_commit=base_commit,
+        reason_code=timeout_reason,
+    )
 
     async with factory() as session:
         retry = await retry_workspace_row(
@@ -911,25 +919,27 @@ async def test_retry_agent_idle_timeout_auto_salvages_implementation_diff(
     assert salvage["conformance_evidence_ref"] == {
         "source_workspace_id": first.id,
         "event_type": "workspace.state_changed",
-        "reason_code": AGENT_IDLE_TIMEOUT,
+        "reason_code": timeout_reason,
     }
     assert "Automatic AWF timeout salvage" in retried.task_prompt
     assert "Fix the intermittent validation failure." in retried.task_prompt
     assert "Continue from the recovered implementation" in retried.task_prompt
-    assert operations[0].payload["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert operations[0].payload["source_reason_code"] == timeout_reason
     assert operations[0].payload["recovery_strategy"] == "continue_from_timeout_salvage"
     assert operations[0].payload["salvage_kind"] == "agent_timeout"
     assert operations[0].payload["conformance_salvage"] == salvage
-    assert operations[0].result["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert operations[0].result["source_reason_code"] == timeout_reason
     assert operations[0].result["conformance_salvage"] == salvage
-    assert retry_created[0].payload["source_reason_code"] == AGENT_IDLE_TIMEOUT
+    assert retry_created[0].payload["source_reason_code"] == timeout_reason
     assert retry_created[0].payload["conformance_salvage"] == salvage
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("timeout_reason", [AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT])
 async def test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
+    timeout_reason: str,
 ) -> None:
     settings = _settings_with_work_dir(tmp_path)
     service = WorkspaceService(factory)
@@ -939,7 +949,12 @@ async def test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage(
         first.id,
         implementation_diff=False,
     )
-    await _mark_agent_timeout_failed(factory, first.id, base_commit=base_commit)
+    await _mark_agent_timeout_failed(
+        factory,
+        first.id,
+        base_commit=base_commit,
+        reason_code=timeout_reason,
+    )
 
     async with factory() as session:
         retry = await retry_workspace_row(

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -926,7 +926,6 @@ async def test_retry_agent_idle_timeout_auto_salvages_implementation_diff(
     assert "Continue from the recovered implementation" in retried.task_prompt
     assert operations[0].payload["source_reason_code"] == timeout_reason
     assert operations[0].payload["recovery_strategy"] == "continue_from_timeout_salvage"
-    assert operations[0].payload["salvage_kind"] == "agent_timeout"
     assert operations[0].payload["conformance_salvage"] == salvage
     assert operations[0].result["source_reason_code"] == timeout_reason
     assert operations[0].result["conformance_salvage"] == salvage

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -20,6 +20,10 @@ from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
 from awf.db.models import Operation, Task, TaskAttempt, Workspace, WorkspaceEvent
 from awf.db.repositories import ResourceReservationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.conformance_salvage import (
+    ConformanceSalvageError,
+    SALVAGE_BASE_UNAVAILABLE,
+)
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     PLAN_CONFORMANCE_UNSATISFIED,
@@ -960,6 +964,51 @@ async def test_retry_agent_idle_timeout_plan_only_diff_retries_without_salvage(
     assert retried.task_prompt == "Fix the intermittent validation failure."
     assert "source_reason_code" not in operations[0].payload
     assert "conformance_salvage" not in operations[0].payload
+
+
+@pytest.mark.unit
+async def test_retry_agent_idle_timeout_salvage_unavailable_errors_abort_retry(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settings = _settings_with_work_dir(tmp_path)
+    service = WorkspaceService(factory)
+    first = await service.create(_request())
+    base_commit = _create_conformance_source_worktree(
+        settings,
+        first.id,
+        implementation_diff=True,
+    )
+    await _mark_agent_timeout_failed(factory, first.id, base_commit=base_commit)
+
+    def _raise(**_kwargs: object) -> None:
+        raise ConformanceSalvageError(
+            reason_code=SALVAGE_BASE_UNAVAILABLE,
+            message="Timeout salvage capture intentionally failed",
+            detail={"base_commit": "missing"},
+        )
+
+    monkeypatch.setattr("awf.service.workspaces.capture_conformance_salvage", _raise)
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceRetrySalvageUnavailableError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first.id,
+                provider_readiness_override=True,
+                provider_readiness_override_reason="retry service test fixture",
+                settings=settings,
+            )
+
+    async with factory() as session:
+        workspaces = list((await session.execute(select(Workspace))).scalars())
+        operations = list((await session.execute(select(Operation))).scalars())
+
+    assert exc_info.value.error_code == "WORKSPACE_RETRY_SALVAGE_UNAVAILABLE"
+    assert exc_info.value.detail["reason_code"] == SALVAGE_BASE_UNAVAILABLE
+    assert len(workspaces) == 1
+    assert len(operations) == 0
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -1026,6 +1026,7 @@ async def test_retry_agent_idle_timeout_salvage_unavailable_errors_abort_retry(
 
     assert exc_info.value.error_code == "WORKSPACE_RETRY_SALVAGE_UNAVAILABLE"
     assert exc_info.value.detail["reason_code"] == SALVAGE_BASE_UNAVAILABLE
+    assert exc_info.value.detail["source_reason_code"] == AGENT_IDLE_TIMEOUT
     assert len(workspaces) == 1
     assert len(operations) == 0
 

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -20,15 +20,15 @@ from awf.db.enums import AgentRuntime, FailureReason, WorkspaceStatus
 from awf.db.models import Operation, Task, TaskAttempt, Workspace, WorkspaceEvent
 from awf.db.repositories import ResourceReservationRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
-from awf.service.conformance_salvage import (
-    ConformanceSalvageError,
-    SALVAGE_BASE_UNAVAILABLE,
-)
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     PLAN_CONFORMANCE_UNSATISFIED,
     build_planning_prompt,
     render_workspace_path,
+)
+from awf.service.conformance_salvage import (
+    SALVAGE_BASE_UNAVAILABLE,
+    ConformanceSalvageError,
 )
 from awf.service.workspaces import (
     WorkspaceProviderReadinessBlockedError,
@@ -45,6 +45,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Yield a session factory backed by a disposable test database."""
     async with postgres_test_engine() as engine:
         yield make_session_factory(engine)
 
@@ -425,6 +426,7 @@ async def _mark_failed(
     branch_name: str = "codex/old-attempt",
     remote_push_branch: str | None = None,
 ) -> dict[str, object]:
+    """Mark a workspace as failed with shared transition/evidence payload."""
     async with factory() as session:
         repo = WorkspaceRepository(session)
         workspace = await repo.get(workspace_id)
@@ -453,6 +455,7 @@ async def _mark_conformance_failed(
     *,
     base_commit: str | None = None,
 ) -> None:
+    """Mark a workspace as failed with conformance-unsatisfied evidence."""
     async with factory() as session:
         repo = WorkspaceRepository(session)
         workspace = await repo.get(workspace_id)
@@ -499,6 +502,7 @@ async def _mark_conformance_failed_without_evidence(
     *,
     base_commit: str | None = None,
 ) -> None:
+    """Mark a conformance failure workspace without conformance evidence payload."""
     async with factory() as session:
         repo = WorkspaceRepository(session)
         workspace = await repo.get(workspace_id)
@@ -528,6 +532,7 @@ async def _mark_agent_timeout_failed(
     base_commit: str | None = None,
     reason_code: str = AGENT_IDLE_TIMEOUT,
 ) -> None:
+    """Mark a workspace failure caused by agent timeout in agent phase."""
     async with factory() as session:
         repo = WorkspaceRepository(session)
         workspace = await repo.get(workspace_id)
@@ -1342,6 +1347,7 @@ async def test_retry_persists_task_kind_without_post_insert_update() -> None:
         context: object,
         executemany: bool,
     ) -> None:
+        """Collect SQL statements for task-kind update assertions."""
         del conn, cursor, parameters, context, executemany
         statements.append(" ".join(statement.lower().split()))
 


### PR DESCRIPTION
## Summary
- Preserve implementation diffs from agent timeout failures and replay them into retries as timeout-specific salvage.
- Add adapter-level instructions preventing agents from running broad AWF/GitHub-owned validation inside the agent phase.
- Add plan/validation docs and regression coverage for timeout salvage, ignored tracked paths, and prompt boundary text.

## Focused Validation
- uv run --python 3.12 --extra dev pytest tests/unit/adapters/test_adapters.py tests/unit/service/test_workspace_retry.py tests/unit/service/test_conformance_salvage.py -q
- uv run --python 3.12 --extra dev ruff check src/awf/adapters/base.py src/awf/service/conformance_salvage.py src/awf/service/workspaces.py tests/unit/adapters/test_adapters.py tests/unit/service/test_workspace_retry.py tests/unit/service/test_conformance_salvage.py
- uv run --python 3.12 --extra dev mypy src/awf/adapters/base.py src/awf/service/conformance_salvage.py src/awf/service/workspaces.py
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic recovery for agent timeouts that captures prior implementation work to enable safer retries.

* **Improvements**
  * Clear agent guidance forbidding broad workspace/CI-equivalent validation during agent phases; agents run focused checks and record evidence.
  * More robust CI failure evidence extraction to avoid hangs on noisy logs.

* **Documentation**
  * Added rollout, policy and validation plans with concrete verification steps and live-evidence notes.

* **Tests**
  * Added unit coverage for timeout-salvage capture, no-diff fallback retries, prompt content, and CI extraction edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->