### PR TITLE
Guided awf init project onboarding

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -78,15 +78,16 @@ If bootstrap or first-run health checks fail, use the
 before continuing with provider or workspace-level work.
 
 After it reports success, export `AWF_GITHUB_TOKEN` so the worker can create
-PRs and use `awf init <path>` to inspect a project repository (see
-[Project Onboarding](PROJECT_ONBOARDING.md) for the project-mode
+PRs and use `awf init <path>` to create or inspect a project repository's
+`.awf/workspace.yml` (see [Project Onboarding](PROJECT_ONBOARDING.md) for the project-mode
 walkthrough and per-provider copy-paste prompts). The two `awf init` shapes are
 explicit:
 
 - `awf init` — bootstrap AWF on this machine (Docker, state dir,
   `docker/compose/.env` or `.env`, service stack).
-- `awf init <path>` — run local onboarding readiness checks for a project
-  checkout.
+- `awf init <path>` — run local project onboarding. Interactive terminals get
+  a short guided profile setup; automation can use
+  `awf init <path> --write-profile --yes` to write detected defaults.
 
 Subsequent sections describe the contributor/development setup; a fresh
 machine only needs the steps above plus a coding-agent credential.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -2,8 +2,8 @@
 
 This page is the copy-paste contract for making an existing repository usable
 with AWF without launching a workspace. The first pass should inspect the repo,
-draft `.awf/workspace.yml`, show gaps, and stop. Humans or agents can then edit
-the draft and decide when to submit a real workspace request.
+draft or write `.awf/workspace.yml`, show gaps, and stop. Humans or agents can
+then edit the draft and decide when to submit a real workspace request.
 
 ## First-run operator command
 
@@ -14,14 +14,16 @@ the draft and decide when to submit a real workspace request.
   from `.env.example`, and starts or validates the local Postgres + migrate
   + API + worker stack. Use this once per machine before running any
   workspace-related commands.
-- `awf init <path>` — the project-onboarding readiness pass described on
-  this page. It inspects a checked-out repository, runs local readiness
-  checks (without calling the AWF API), and prints plain-language next
-  steps that point to profile-edit and smoke-workspace workflows.
+- `awf init <path>` — the project-onboarding pass described on this page. It
+  inspects a checked-out repository, runs local readiness checks without
+  calling the AWF API, and creates or previews `.awf/workspace.yml`. Interactive
+  terminals get a short guided setup when no profile exists; automation can use
+  `--write-profile --yes` to write detected defaults.
 
 ```bash
 awf init                          # one-time local service bootstrap
-awf init .                        # project-onboarding readiness for ./.
+awf init .                        # guided project onboarding for ./.
+awf init . --write-profile --yes  # silent profile write with detected defaults
 awf init . --include-smoke-request
 ```
 
@@ -36,9 +38,9 @@ open a PR, or start project services. Start with:
 
 `awf init .`
 `awf profile preview .`
-`awf profile init . --write`
+`awf init . --write-profile --yes`
 
-or use `awf profile init . --include-smoke-request` for a local copy-paste smoke request
+or use `awf init . --include-smoke-request` for a local copy-paste smoke request
 payload (local-only, no submission). Keep secrets as
 profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -53,11 +55,10 @@ generic for any repository and do not contain project-specific assumptions.
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo.
-2. Run `awf profile init . --write` to generate `.awf/workspace.yml`.
-3. Run `awf profile preview .` to preview the resolved profile.
-4. Run `awf profile init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+2. Run `awf profile preview .` to preview the resolved profile.
+3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -67,11 +68,10 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 I will inspect this repository for AWF onboarding. I will not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo.
-2. Run `awf profile init . --write` to generate `.awf/workspace.yml`.
-3. Run `awf profile preview .` to preview the resolved profile.
-4. Run `awf profile init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+2. Run `awf profile preview .` to preview the resolved profile.
+3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -81,11 +81,10 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Analyze this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo.
-2. Run `awf profile init . --write` to generate `.awf/workspace.yml`.
-3. Run `awf profile preview .` to preview the resolved profile.
-4. Run `awf profile init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+2. Run `awf profile preview .` to preview the resolved profile.
+3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -95,11 +94,10 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Use `opencode run` to inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo.
-2. Run `awf profile init . --write` to generate `.awf/workspace.yml`.
-3. Run `awf profile preview .` to preview the resolved profile.
-4. Run `awf profile init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+2. Run `awf profile preview .` to preview the resolved profile.
+3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -109,11 +107,10 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Inspect this repository for AWF onboarding via your OpenClaw runtime. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo.
-2. Run `awf profile init . --write` to generate `.awf/workspace.yml`.
-3. Run `awf profile preview .` to preview the resolved profile.
-4. Run `awf profile init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+2. Run `awf profile preview .` to preview the resolved profile.
+3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -129,23 +126,25 @@ awf profile preview .
 Write a draft profile:
 
 ```bash
-awf profile init . --write
+awf init . --write-profile --yes
 ```
 
 Overwrite an existing draft intentionally:
 
 ```bash
-awf profile init . --write --force
+awf init . --write-profile --yes --force
 ```
 
 Include an example request body without launching it:
 
 ```bash
-awf profile init . --include-smoke-request
+awf init . --include-smoke-request
 ```
 
-The command is local filesystem work. It does not call the AWF API, create a
-workspace, start Docker, push branches, or open a PR.
+`awf profile init` remains available as a lower-level preview/write command for
+scripts and expert workflows. Both onboarding commands are local filesystem
+work: they do not call the AWF API, create a workspace, start Docker, push
+branches, or open a PR.
 
 Generated onboarding profiles use `security.egress.mode: restricted` by
 default. Keep that default for new projects unless the repository needs
@@ -154,7 +153,7 @@ intentional unrestricted internet access and should be visible in review.
 
 ## Templates
 
-`awf profile init` currently drafts these small templates:
+`awf init <path>` and `awf profile init` currently draft these small templates:
 
 - `generic`: fallback profile when no known project shape is detected.
 - `python`: `pyproject.toml`, `requirements.txt`, `uv.lock`, or `pytest.ini`;
@@ -192,8 +191,8 @@ about unknowns.
 
 ## Optional smoke request
 
-`--include-smoke-request` prints a v2 request-shaped payload with the draft
-profile inlined:
+`--include-smoke-request` prints a workspace request-shaped payload with the
+draft profile inlined:
 
 ```json
 {

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -36,9 +36,8 @@ operator:
 Inspect this repository for AWF onboarding. Do not launch a workspace, push,
 open a PR, or start project services. Start with:
 
-`awf init .`
-`awf profile preview .`
 `awf init . --write-profile --yes`
+`awf profile preview .`
 
 or use `awf init . --include-smoke-request` for a local copy-paste smoke request
 payload (local-only, no submission). Keep secrets as
@@ -55,7 +54,7 @@ generic for any repository and do not contain project-specific assumptions.
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 2. Run `awf profile preview .` to preview the resolved profile.
 3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
 4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
@@ -68,7 +67,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 I will inspect this repository for AWF onboarding. I will not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 2. Run `awf profile preview .` to preview the resolved profile.
 3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
 4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
@@ -81,7 +80,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Analyze this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 2. Run `awf profile preview .` to preview the resolved profile.
 3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
 4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
@@ -94,7 +93,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Use `opencode run` to inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 2. Run `awf profile preview .` to preview the resolved profile.
 3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
 4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
@@ -107,7 +106,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Inspect this repository for AWF onboarding via your OpenClaw runtime. Do not launch a workspace yet.
 
-1. Run `awf init .` to inspect the repo and generate `.awf/workspace.yml`.
+1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 2. Run `awf profile preview .` to preview the resolved profile.
 3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
 4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -73,10 +73,12 @@ awf smoke run --mocked-local --format pretty
 ```
 
 If `.awf/workspace.yml` already exists, `awf init .` validates local readiness
-and points you at preview/smoke commands. If no profile exists, create one with:
+and points you at preview/smoke commands. If no profile exists, interactive
+terminals guide you through a short setup. For automation, write detected
+defaults without prompting:
 
 ```bash
-awf profile init . --write
+awf init . --write-profile --yes
 ```
 
 ## When Something Fails

--- a/plans/GUIDED_AWF_INIT_ONBOARDING_PLAN.md
+++ b/plans/GUIDED_AWF_INIT_ONBOARDING_PLAN.md
@@ -1,0 +1,41 @@
+# Guided AWF Init Onboarding Plan
+
+## Problem
+
+`awf init <repo>` currently performs a read-only readiness preview and points users
+to `awf profile init <repo> --write` to create `.awf/workspace.yml`. Fresh-project
+onboarding should instead be centered on `awf init <repo>` with guided interactive
+setup and silent automation-friendly profile creation.
+
+## Requirements
+
+- Extend `awf init <repo>` with guided and silent project profile creation.
+- Keep `awf init` without a path as the existing local service bootstrap.
+- Support `--guided/--no-guided`, `--write-profile`, `--yes`, `--template`, and
+  `--force` in project mode.
+- Only auto-prompt in interactive pretty output when no profile exists.
+- Ensure `--format json` never prompts and returns structured preview/write state.
+- Allow `.awf/workspace.yml` creation even when local service/doctor checks fail,
+  while still surfacing those failures as warnings.
+- Keep `awf profile init` supported as a lower-level expert command.
+- Update public docs to make `awf init .` the primary onboarding path and remove
+  stale v2 request language.
+
+## Implementation Steps
+
+1. Add/adjust CLI tests for silent write, JSON no-prompt, existing profile force
+   behavior, unhealthy local checks, and guided input.
+2. Add a small onboarding helper that can re-render a preview after applying
+   egress and validation-command choices through the typed profile model.
+3. Extend `awf init` project-mode flags and route only path-mode flags to project
+   onboarding.
+4. Update project onboarding output for preview/write/guided modes and preserve
+   no-path bootstrap behavior.
+5. Update Quickstart, Getting Started, Project Onboarding, and docs tests for the
+   canonical `awf init .` flow.
+
+## Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py tests/unit/cli/test_profile_init.py tests/unit/docs -q`
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py src/awf/profiles/onboarding.py tests/unit/cli/test_init.py tests/unit/cli/test_profile_init.py tests/unit/docs`
+- `uv run --python 3.12 --extra dev mypy src/awf`

--- a/plans/GUIDED_AWF_INIT_ONBOARDING_VALIDATION.md
+++ b/plans/GUIDED_AWF_INIT_ONBOARDING_VALIDATION.md
@@ -1,0 +1,37 @@
+# Guided AWF Init Onboarding Validation
+
+Plan: `plans/GUIDED_AWF_INIT_ONBOARDING_PLAN.md`
+
+## Requirement Status
+
+- Extend `awf init <repo>` with guided and silent profile creation: Complete.
+- Preserve no-path `awf init` service bootstrap: Complete.
+- Add `--guided/--no-guided`, `--write-profile`, `--yes`, `--template`, and
+  `--force`: Complete.
+- Auto-prompt only for interactive pretty output when no profile exists:
+  Complete.
+- Keep `--format json` non-interactive and structured: Complete.
+- Allow profile creation while local service/doctor checks are unhealthy:
+  Complete.
+- Keep `awf profile init` supported: Complete.
+- Update public onboarding docs and remove stale v2 request language: Complete.
+
+## Evidence
+
+- Updated `src/awf/cli/main.py` for project-mode init flags, JSON output,
+  guided prompts, non-blocking local check warnings, and write/force handling.
+- Updated `src/awf/profiles/onboarding.py` with typed preview customization
+  for guided egress and validation-command choices.
+- Added CLI/docs regression coverage in `tests/unit/cli/test_init.py` and
+  `tests/unit/docs/test_public_docs_status.py`.
+- Updated `docs/QUICKSTART.md`, `docs/GETTING_STARTED.md`, and
+  `docs/PROJECT_ONBOARDING.md`.
+
+## Verification Commands
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py tests/unit/cli/test_profile_init.py tests/unit/docs -q`
+  - Result: `168 passed`
+- `uv run --python 3.12 --extra dev ruff check src/awf tests`
+  - Result: passed
+- `uv run --python 3.12 --extra dev mypy src/awf`
+  - Result: passed

--- a/plans/PR283_REVIEW_COMMENT_4524755400_PLAN.md
+++ b/plans/PR283_REVIEW_COMMENT_4524755400_PLAN.md
@@ -1,0 +1,32 @@
+# PR 283 Review Comment 4524755400 Plan
+
+## Problem
+
+Greptile's review-level PR comment identified two UX gaps in `awf init <path>`:
+guided mode only accepts one validation command, and `--yes` is accepted without
+`--write-profile` even though it only approves non-interactive profile writes.
+
+## Scope
+
+- Keep the fix limited to project-onboarding CLI behavior and focused unit tests.
+- Do not change AWF branch, push, or broad validation ownership.
+- Treat existing tests as policy evidence and preserve current onboarding behavior
+  except where the review feedback identifies a gap.
+
+## Requirements
+
+- Reject `awf init <path> --yes` when `--write-profile` is not also supplied.
+- Keep `awf init <path> --write-profile --yes` working.
+- Let guided onboarding collect more than one validation command.
+- Preserve the guided write confirmation as the final prompt.
+- Record focused verification only; AWF/GitHub will run broad validation later.
+
+## Implementation Steps
+
+1. Add focused CLI regression tests for the invalid `--yes` combination and
+   repeated guided validation-command input.
+2. Run the new focused tests to confirm the current failure where practical.
+3. Add the smallest CLI changes to reject orphan `--yes` and loop for additional
+   guided validation commands.
+4. Re-run the focused CLI tests and a narrow lint check for touched files.
+5. Document validation evidence in a matching validation file.

--- a/plans/PR283_REVIEW_COMMENT_4524755400_VALIDATION.md
+++ b/plans/PR283_REVIEW_COMMENT_4524755400_VALIDATION.md
@@ -1,0 +1,34 @@
+# PR 283 Review Comment 4524755400 Validation
+
+Plan: `plans/PR283_REVIEW_COMMENT_4524755400_PLAN.md`
+
+## Requirement Status
+
+- Reject `awf init <path> --yes` without `--write-profile`: Complete.
+- Keep `awf init <path> --write-profile --yes` working: Complete.
+- Let guided onboarding collect more than one validation command: Complete.
+- Preserve guided write confirmation as the final prompt: Complete.
+- Record focused verification only: Complete.
+
+## Evidence
+
+- Updated `src/awf/cli/main.py` to fail fast when `--yes` is supplied without
+  `--write-profile` in project-onboarding mode.
+- Updated guided validation-command prompting in `src/awf/cli/main.py` to accept
+  repeated commands before the final profile-write confirmation.
+- Added focused regressions in `tests/unit/cli/test_init.py` for orphan `--yes`
+  and multi-command guided validation input.
+
+## Focused Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py::test_init_yes_requires_write_profile tests/unit/cli/test_init.py::test_init_guided_writes_answers_into_workspace_yml tests/unit/cli/test_init.py::test_init_guided_accepts_multiple_validation_commands -q`
+  - Initial result before implementation: failed as expected.
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py::test_init_yes_requires_write_profile tests/unit/cli/test_init.py::test_init_write_profile_yes_creates_default_workspace_yml tests/unit/cli/test_init.py::test_init_guided_writes_answers_into_workspace_yml tests/unit/cli/test_init.py::test_init_guided_accepts_multiple_validation_commands tests/unit/cli/test_init.py::test_init_write_profile_guided_declined_confirmation_does_not_write -q`
+  - Result after implementation: `5 passed`.
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Result: passed.
+- `uv run --python 3.12 --extra dev ruff format --check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Result: passed.
+
+Full AWF/GitHub validation remains owned by AWF after agent completion per the
+workspace contract.

--- a/plans/PRRT_kwDOSJAM6s6ESXeu_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6ESXeu_PLAN.md
@@ -1,0 +1,39 @@
+# PRRT_kwDOSJAM6s6ESXeu Plan
+
+## Problem Statement And Scope
+
+The PR review reports that `awf init <path>` no longer catches unexpected
+failures from `preview_project_onboarding`, causing repository inspection errors
+such as `OSError` to surface as raw tracebacks instead of a friendly CLI error.
+
+Scope is limited to restoring the friendly error handling for project
+onboarding preview construction and adding a focused regression test.
+
+## Requirements Checklist
+
+- [ ] Preserve `ValueError` handling as a usage error with exit code 2.
+- [ ] Convert unexpected preview construction failures to a friendly error with
+      exit code 1.
+- [ ] Prevent raw tracebacks in the CLI output for this path.
+- [ ] Add a focused regression test for an unexpected preview failure.
+- [ ] Run only focused validation owned by this change; AWF/GitHub own broad
+      validation after agent completion.
+
+## Implementation Steps
+
+1. Add a CLI unit test that stubs local prerequisites and makes
+   `preview_project_onboarding` raise `OSError`.
+2. Confirm the new regression fails against the current code.
+3. Add the generic exception guard around preview construction in
+   `src/awf/cli/main.py`.
+4. Re-run the focused regression test and a narrow lint check on touched files.
+5. Record validation evidence in a matching validation document.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k unexpected_preview`
+  - Passes after implementation.
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Passes after implementation.
+
+Full AWF/GitHub validation is intentionally not run during the agent phase.

--- a/plans/PRRT_kwDOSJAM6s6ESXeu_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6ESXeu_VALIDATION.md
@@ -1,0 +1,43 @@
+# PRRT_kwDOSJAM6s6ESXeu Validation
+
+Plan reference: `plans/PRRT_kwDOSJAM6s6ESXeu_PLAN.md`
+
+## Requirement Status
+
+- Preserve `ValueError` handling as a usage error with exit code 2:
+  Complete. The existing `except ValueError` branch remains unchanged before
+  the generic exception guard.
+- Convert unexpected preview construction failures to a friendly error with
+  exit code 1:
+  Complete. `src/awf/cli/main.py` now catches unexpected exceptions from
+  `preview_project_onboarding`, prints a concise onboarding-preview error, and
+  exits with code 1.
+- Prevent raw tracebacks in the CLI output for this path:
+  Complete. The new regression asserts no `Traceback` appears when preview
+  construction raises `OSError`.
+- Add a focused regression test for an unexpected preview failure:
+  Complete. `tests/unit/cli/test_init.py` covers an `OSError` from preview
+  construction.
+- Run only focused validation owned by this change:
+  Complete. Full AWF/GitHub validation was not run during the agent phase and is
+  managed by AWF after agent completion.
+
+## Evidence
+
+- Failing-before-fix command:
+  `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k unexpected_preview`
+  - Failed because the CLI output was empty and the original `OSError`
+    propagated.
+- Passing-after-fix command:
+  `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k unexpected_preview`
+  - Passed: `1 passed, 135 deselected`.
+- Focused format command:
+  `uv run --python 3.12 --extra dev ruff format tests/unit/cli/test_init.py`
+  - Passed after reformatting the touched test file.
+- Focused lint command:
+  `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Passed: `All checks passed!`
+
+## Remaining Gaps
+
+None.

--- a/plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_PLAN.md
@@ -1,0 +1,41 @@
+# PRRT_kwDOSJAM6s6ES_2h Guided Preview Exception Plan
+
+## Problem Statement And Scope
+
+The PR review reports that guided `awf init <path>` catches unexpected preview
+construction failures for the initial preview, but not when the user changes
+the template and the guided prompt rebuilds the preview. That can expose raw
+tracebacks for repository inspection errors such as unreadable project files.
+
+Scope is limited to the guided template-change preview rebuild in
+`src/awf/cli/main.py` and a focused regression test in
+`tests/unit/cli/test_init.py`.
+
+## Requirements Checklist
+
+- [ ] Preserve unsupported-template validation before preview rebuild.
+- [ ] Preserve `ValueError` preview failures as usage errors with exit code 2.
+- [ ] Convert unexpected preview rebuild failures to a friendly error with exit
+      code 1.
+- [ ] Prevent raw tracebacks in CLI output for the guided template-change path.
+- [ ] Run only focused validation for the touched CLI behavior; AWF/GitHub own
+      broad validation after agent completion.
+
+## Implementation Steps
+
+1. Add a failing focused unit test for guided template change when
+   `preview_factory` raises `OSError`.
+2. Confirm the new regression fails against the current code.
+3. Add matching `ValueError` and generic exception guards around the guided
+   preview rebuild.
+4. Re-run the focused regression test and a narrow lint check on touched files.
+5. Record validation evidence in a matching validation document.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k guided_template_change_preview_failure`
+  - Fails before the fix and passes after implementation.
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Passes after implementation.
+
+Full AWF/GitHub validation is intentionally not run during the agent phase.

--- a/plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_VALIDATION.md
@@ -1,0 +1,53 @@
+# PRRT_kwDOSJAM6s6ES_2h Guided Preview Exception Validation
+
+Plan reference:
+`plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_PLAN.md`
+
+## Requirement Status
+
+- Complete: Preserve unsupported-template validation before preview rebuild.
+  - Existing validation still rejects a template choice that is not in
+    `supported_templates` before calling `preview_factory`.
+- Complete: Preserve `ValueError` preview failures as usage errors with exit
+  code 2.
+  - Added parameterized coverage for `ValueError` from guided template-change
+    preview rebuild.
+- Complete: Convert unexpected preview rebuild failures to a friendly error
+  with exit code 1.
+  - Added the same generic exception guard used by the initial preview path.
+- Complete: Prevent raw tracebacks in CLI output for the guided template-change
+  path.
+  - Regression test asserts no `Traceback` text is emitted for either failure
+    class.
+- Complete: Run only focused validation for the touched CLI behavior.
+  - Full AWF/GitHub validation was not run during the agent phase; AWF/GitHub
+    own broad validation after completion.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/cli/main.py`
+- `tests/unit/cli/test_init.py`
+- `plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_PLAN.md`
+- `plans/PRRT_kwDOSJAM6s6ES_2h_GUIDED_PREVIEW_EXCEPTION_VALIDATION.md`
+
+Focused checks:
+
+- Before implementation:
+  - `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k guided_template_change_preview_failure`
+  - Result: failed because `ValueError` and `OSError` from `preview_factory`
+    propagated out of `_prompt_project_onboarding_choices`.
+- After implementation:
+  - `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k guided_template_change_preview_failure`
+  - Result: passed, `2 passed, 136 deselected`.
+  - `uv run --python 3.12 --extra dev ruff format tests/unit/cli/test_init.py`
+  - Result: passed, reformatted one touched test file.
+  - `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k guided_template_change_preview_failure`
+  - Result: passed, `2 passed, 136 deselected`.
+  - `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Result: passed.
+
+## Remaining Gaps
+
+None.

--- a/plans/REVIEW_4350229871_SECRET_ASSERTION_PLAN.md
+++ b/plans/REVIEW_4350229871_SECRET_ASSERTION_PLAN.md
@@ -1,0 +1,38 @@
+# Review 4350229871 Secret Assertion Plan
+
+## Problem Statement and Scope
+
+CodeRabbit review comment `4350229871` reported one still-valid outside-diff
+test reliability issue: `tests/unit/cli/test_init.py` asserts that the generic
+substring `"root"` is absent from CLI output after a non-UTF-8 env overlay
+merge failure. That can fail for unrelated output containing `root`.
+
+Other review items in the supplied review-level summary are already addressed
+in the current branch: project onboarding docs use `awf init . --write-profile
+--yes`, guided init rejects non-interactive stdio, guided decline does not write
+the profile, and explicit empty validation command lists clear validation
+commands through `clear_validation_commands()`.
+
+## Requirements Checklist
+
+- Replace the fragile generic `"root"` output assertion with a targeted secret
+  leak assertion for the exact fixture value.
+- Preserve existing regression coverage and assertions around the merge failure.
+- Keep changes scoped to the affected test plus required plan/validation docs.
+- Run only focused validation for the affected behavior; leave broad AWF/GitHub
+  validation to the AWF post-agent workflow.
+
+## Implementation Steps
+
+1. Update the affected assertion in `tests/unit/cli/test_init.py` to check that
+   `AWF_API_TOKEN=root` is not leaked.
+2. Run the single affected unit test.
+3. Record validation evidence in the matching validation document.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k test_init_without_path_json_marks_non_utf8_env_overlay_merge_failed`
+  - Passes with the updated targeted assertion.
+
+Full repository validation, coverage gates, and CI-equivalent checks are owned
+by AWF/GitHub after agent completion for this repair cycle.

--- a/plans/REVIEW_4350229871_SECRET_ASSERTION_VALIDATION.md
+++ b/plans/REVIEW_4350229871_SECRET_ASSERTION_VALIDATION.md
@@ -1,0 +1,32 @@
+# Review 4350229871 Secret Assertion Validation
+
+Plan reference: `plans/REVIEW_4350229871_SECRET_ASSERTION_PLAN.md`
+
+## Requirement Status
+
+- Complete: Replaced the fragile generic `"root"` output assertion with a
+  targeted assertion that `AWF_API_TOKEN=root` is not leaked.
+- Complete: Preserved the existing merge-failure regression assertions in
+  `tests/unit/cli/test_init.py`.
+- Complete: Kept changes scoped to the affected test plus required
+  plan/validation docs.
+- Complete: Ran only focused validation for the affected behavior.
+
+## Evidence
+
+Files changed:
+
+- `tests/unit/cli/test_init.py`
+- `plans/REVIEW_4350229871_SECRET_ASSERTION_PLAN.md`
+- `plans/REVIEW_4350229871_SECRET_ASSERTION_VALIDATION.md`
+
+Focused validation:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k test_init_without_path_json_marks_non_utf8_env_overlay_merge_failed
+```
+
+Result: passed, `1 passed, 135 deselected`.
+
+Full AWF/GitHub validation, coverage gates, and CI-equivalent checks are
+managed by AWF after agent completion for this repair cycle.

--- a/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md
+++ b/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md
@@ -1,0 +1,36 @@
+# Review 4524723975 Docstring Coverage Plan
+
+## Problem Statement
+
+CodeRabbit's review-level pre-merge check reported low docstring coverage for PR
+#283 and requested docstrings for missing functions. The PR's guided onboarding
+changes added a focused cluster of `awf init <path>` CLI helpers in
+`src/awf/cli/main.py` without docstrings.
+
+## Scope
+
+- Add concise docstrings to the new project-onboarding CLI helper functions.
+- Keep runtime behavior, command output, validation flow, and tests unchanged.
+- Avoid broad AWF/GitHub-owned validation; run only targeted local checks.
+
+## Requirements Checklist
+
+- [ ] `_run_init_project_onboarding` documents the two-stage local readiness and
+      profile-preview/write flow.
+- [ ] Guided prompting, JSON payload, next-step, pretty-output, and existing
+      profile helper functions have concise docstrings.
+- [ ] No behavior changes beyond docstrings.
+- [ ] Targeted lint passes for the touched CLI module.
+
+## Implementation Steps
+
+1. Add docstrings to the undocumented onboarding helper functions in
+   `src/awf/cli/main.py`.
+2. Inspect the diff to confirm the change is documentation-only.
+3. Run `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py`.
+
+## Verification Commands
+
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py`
+
+Full AWF/GitHub validation remains owned by the post-agent workflow and CI.

--- a/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md
+++ b/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md
@@ -2,9 +2,9 @@
 
 ## Problem Statement
 
-CodeRabbit's review-level pre-merge check reported low docstring coverage for PR
-#283 and requested docstrings for missing functions. The PR's guided onboarding
-changes added a focused cluster of `awf init <path>` CLI helpers in
+CodeRabbit's review-level pre-merge check reported low docstring coverage for
+PR `#283` and requested docstrings for missing functions. The PR's guided
+onboarding changes added a focused cluster of `awf init <path>` CLI helpers in
 `src/awf/cli/main.py` without docstrings.
 
 ## Scope

--- a/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_VALIDATION.md
+++ b/plans/REVIEW_4524723975_DOCSTRING_COVERAGE_VALIDATION.md
@@ -1,0 +1,32 @@
+# Review 4524723975 Docstring Coverage Validation
+
+Plan reference: `plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md`
+
+## Requirement Status
+
+- `_run_init_project_onboarding` documents the two-stage local readiness and
+  profile-preview/write flow: `Complete`.
+- Guided prompting, JSON payload, next-step, pretty-output, and existing profile
+  helper functions have concise docstrings: `Complete`.
+- No behavior changes beyond docstrings: `Complete`.
+- Targeted lint passes for the touched CLI module: `Complete`.
+
+## Evidence
+
+- Changed files:
+  - `src/awf/cli/main.py`
+  - `plans/REVIEW_4524723975_DOCSTRING_COVERAGE_PLAN.md`
+  - `plans/REVIEW_4524723975_DOCSTRING_COVERAGE_VALIDATION.md`
+- Verification:
+  - `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py` passed.
+  - AST inspection confirmed the focused onboarding helper cluster now has
+    docstrings, including nested service-status collector helpers.
+
+## Notes
+
+Full AWF/GitHub validation and any broad docstring-coverage gate are managed by
+the post-agent workflow and CI per the workspace contract.
+
+The default commit hook attempted broad `ruff` and `mypy` checks and AWF blocked
+them during the agent phase; the final commit uses the targeted lint evidence
+above instead.

--- a/plans/REVIEW_PRRT_VALIDATION_COMMAND_CLEAR_PLAN.md
+++ b/plans/REVIEW_PRRT_VALIDATION_COMMAND_CLEAR_PLAN.md
@@ -1,0 +1,43 @@
+# Review PRRT_kwDOSJAM6s6ESXPh Validation Command Clear Plan
+
+## Problem Statement and Scope
+
+The onboarding customization path ignores an explicit empty `validation_commands`
+sequence because it only calls `WorkspaceProfile.with_validation_commands` when
+the cleaned command list is non-empty. Review feedback asks that an explicit
+empty or all-whitespace list clear detected validation commands.
+
+Scope is limited to onboarding profile customization and directly related model
+helper behavior. Existing append semantics for
+`WorkspaceProfile.with_validation_commands([])` remain unchanged because tests
+and request-resolution behavior treat it as a no-op.
+
+## Requirements Checklist
+
+- Add an explicit profile operation that clears validation commands.
+- Make `customize_project_onboarding_preview(..., validation_commands=[])` and
+  all-whitespace sequences clear existing validation commands.
+- Preserve `validation_commands=None` as no override.
+- Preserve guided CLI behavior so absence of user-entered validation commands
+  does not accidentally clear already detected commands.
+- Add focused regression tests for model clear behavior, onboarding explicit
+  clear behavior, and guided CLI no-override behavior.
+
+## Implementation Steps
+
+1. Add `WorkspaceProfile.clear_validation_commands()`.
+2. Update onboarding customization to call the clear method when an explicit
+   sequence cleans to empty.
+3. Update guided CLI prompt plumbing to pass `None` when there is no validation
+   override.
+4. Add targeted unit coverage in profile and CLI tests.
+
+## Verification Commands
+
+Focused checks only:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_profiles.py -q -k 'validation_commands'`
+- `uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_project_onboarding.py -q -k 'validation_commands or customization'`
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k 'guided_egress_choices_follow_model_enum'`
+
+Full AWF/GitHub validation is intentionally not run during this agent phase.

--- a/plans/REVIEW_PRRT_VALIDATION_COMMAND_CLEAR_VALIDATION.md
+++ b/plans/REVIEW_PRRT_VALIDATION_COMMAND_CLEAR_VALIDATION.md
@@ -1,0 +1,41 @@
+# Review PRRT_kwDOSJAM6s6ESXPh Validation Command Clear Validation
+
+Plan reference: `plans/REVIEW_PRRT_VALIDATION_COMMAND_CLEAR_PLAN.md`
+
+## Requirement Status
+
+- Complete: Added `WorkspaceProfile.clear_validation_commands()` as an explicit
+  clear operation while preserving empty append no-op behavior.
+- Complete: `customize_project_onboarding_preview` clears validation commands
+  when passed an explicit empty or all-whitespace `validation_commands`
+  sequence.
+- Complete: `validation_commands=None` remains a no-override path.
+- Complete: Guided CLI passes `None` when the user does not enter a validation
+  override, avoiding accidental clearing of detected commands.
+- Complete: Added focused regression coverage for profile clearing, onboarding
+  explicit clear behavior, and guided CLI no-override plumbing.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/profiles/models.py`
+- `src/awf/profiles/onboarding.py`
+- `src/awf/cli/main.py`
+- `tests/unit/profiles/test_profiles.py`
+- `tests/unit/profiles/test_project_onboarding.py`
+- `tests/unit/cli/test_init.py`
+
+Focused commands run:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_profiles.py -q -k 'validation_commands'`
+  - Result: `3 passed, 122 deselected`
+- `uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_project_onboarding.py -q -k 'validation_commands or customization'`
+  - Result: `3 passed, 43 deselected`
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k 'guided_egress_choices_follow_model_enum'`
+  - Result: `1 passed, 134 deselected`
+- `uv run --python 3.12 --extra dev ruff check src/awf/profiles/models.py src/awf/profiles/onboarding.py src/awf/cli/main.py tests/unit/profiles/test_profiles.py tests/unit/profiles/test_project_onboarding.py tests/unit/cli/test_init.py`
+  - Result: `All checks passed!`
+
+Full AWF/GitHub validation was not run in this agent phase; AWF owns broad
+validation and merge-gating after completion.

--- a/plans/REVIEW_PRRT_kwDOSJAM6s6ESXPf_GUIDED_WRITE_CONFIRMATION_PLAN.md
+++ b/plans/REVIEW_PRRT_kwDOSJAM6s6ESXPf_GUIDED_WRITE_CONFIRMATION_PLAN.md
@@ -1,0 +1,36 @@
+# Review PRRT_kwDOSJAM6s6ESXPf Guided Write Confirmation Plan
+
+## Problem
+
+The PR review reports that `awf init <path> --write-profile --guided` writes
+`.awf/workspace.yml` even when the user declines the guided write confirmation.
+That would make an interactive "no" answer ineffective and mutate files
+unexpectedly.
+
+## Scope
+
+- Verify and fix only the guided project-onboarding write decision in
+  `src/awf/cli/main.py`.
+- Add a focused regression test in `tests/unit/cli/test_init.py`.
+- Do not run broad AWF/GitHub-owned validation; AWF handles that after agent
+  completion.
+
+## Requirements
+
+- `--write-profile --guided` must honor a final guided write answer of "no".
+- Non-guided `--write-profile --yes` must continue to write.
+- Guided writes still occur when the guided confirmation is accepted.
+- The change must be covered by a targeted unit test.
+
+## Implementation Steps
+
+1. Add a failing unit test for `--write-profile --guided` with a declined write
+   confirmation.
+2. Change the project-onboarding write decision so guided mode uses the final
+   guided confirmation.
+3. Run only focused tests and lint for the touched behavior/files.
+
+## Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k "guided or write_profile"`
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`

--- a/plans/REVIEW_PRRT_kwDOSJAM6s6ESXPf_GUIDED_WRITE_CONFIRMATION_VALIDATION.md
+++ b/plans/REVIEW_PRRT_kwDOSJAM6s6ESXPf_GUIDED_WRITE_CONFIRMATION_VALIDATION.md
@@ -1,0 +1,33 @@
+# Review PRRT_kwDOSJAM6s6ESXPf Guided Write Confirmation Validation
+
+Plan: `plans/REVIEW_PRRT_kwDOSJAM6s6ESXPf_GUIDED_WRITE_CONFIRMATION_PLAN.md`
+
+## Requirement Status
+
+- `--write-profile --guided` honors a final guided write answer of "no":
+  Complete.
+- Non-guided `--write-profile --yes` continues to write: Complete.
+- Guided writes still occur when the guided confirmation is accepted: Complete.
+- The change is covered by a targeted unit test: Complete.
+
+## Evidence
+
+- Updated `src/awf/cli/main.py` so guided mode uses the final guided write
+  confirmation for the write decision.
+- Added
+  `tests/unit/cli/test_init.py::test_init_write_profile_guided_declined_confirmation_does_not_write`
+  to cover the PR thread's reported mutation path.
+- Confirmed the new test failed before the implementation change:
+  `1 failed, 134 deselected`.
+
+## Verification Commands
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k "write_profile_guided_declined_confirmation"`
+  - Result: `1 passed, 134 deselected`
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k "guided or write_profile"`
+  - Result: `9 passed, 126 deselected`
+- `uv run --python 3.12 --extra dev ruff check src/awf/cli/main.py tests/unit/cli/test_init.py`
+  - Result: passed
+
+Broad AWF/GitHub-owned validation was not run inside the agent phase; AWF owns
+that after completion.

--- a/plans/REVIEW_PRRT_kwDOSJAM6s6ES_u_PROFILE_MARKERS_PLAN.md
+++ b/plans/REVIEW_PRRT_kwDOSJAM6s6ES_u_PROFILE_MARKERS_PLAN.md
@@ -1,0 +1,38 @@
+# Review PRRT_kwDOSJAM6s6ES_u Profile Markers Plan
+
+## Problem Statement
+
+The PR review thread reports that `awf init <path> --write-profile --yes` only
+blocks writes when `.awf/workspace.yml` already exists, while profile discovery
+also treats `.awf/workspace.yaml`, `awf.workspace.yml`, and
+`awf.workspace.yaml` as existing project profiles. Writing the canonical profile
+beside one of those alternate markers can change profile precedence without an
+explicit `--force`.
+
+## Requirements
+
+- Add a regression test proving `awf init <path> --write-profile --yes` refuses
+  to create `.awf/workspace.yml` when an alternate supported profile marker
+  already exists.
+- Preserve `--force` as the explicit opt-in for writing the canonical profile
+  in that situation.
+- Reuse the shared profile marker path list so write behavior stays aligned
+  with discovery.
+- Keep validation focused to the changed behavior; full AWF/GitHub validation is
+  handled after agent completion.
+
+## Implementation Steps
+
+1. Add the focused CLI regression test in `tests/unit/cli/test_init.py`.
+2. Run that test and confirm it fails against the current implementation.
+3. Update `write_workspace_profile` to check all supported profile marker paths
+   before writing when `force` is false.
+4. Re-run the focused regression and any immediately adjacent focused test that
+   proves normal forced overwrite behavior.
+5. Commit the plan, code, tests, and validation evidence locally.
+
+## Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k 'alternate_profile_marker or existing_profile_requires_force'`
+- Pass criteria: the alternate-marker case blocks without `--force`, allows with
+  `--force`, and existing canonical overwrite behavior remains covered.

--- a/plans/REVIEW_PRRT_kwDOSJAM6s6ES_u_PROFILE_MARKERS_VALIDATION.md
+++ b/plans/REVIEW_PRRT_kwDOSJAM6s6ES_u_PROFILE_MARKERS_VALIDATION.md
@@ -1,0 +1,35 @@
+# Review PRRT_kwDOSJAM6s6ES_u Profile Markers Validation
+
+Plan reference: `plans/REVIEW_PRRT_kwDOSJAM6s6ES_u_PROFILE_MARKERS_PLAN.md`
+
+## Requirement Status
+
+- Complete: Added a regression test proving `awf init <path> --write-profile --yes`
+  refuses to create `.awf/workspace.yml` when `.awf/workspace.yaml` already
+  exists.
+- Complete: Preserved `--force` as the explicit opt-in; the regression asserts
+  forced write creates the canonical profile while leaving the alternate marker
+  in place.
+- Complete: Updated `write_workspace_profile` to consult the shared
+  `PROFILE_MARKER_PATHS` list before writing.
+- Complete: Kept validation focused. Full AWF/GitHub validation is managed by
+  AWF after agent completion.
+
+## Evidence
+
+- Initial failing regression:
+  `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k 'alternate_profile_marker'`
+  failed because `awf init` wrote `.awf/workspace.yml` beside
+  `.awf/workspace.yaml`.
+- Passing targeted CLI regression:
+  `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py -q -k 'alternate_profile_marker or existing_profile_requires_force'`
+  passed with `2 passed, 137 deselected`.
+- Passing adjacent shared-writer checks:
+  `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_profile_init.py -q -k 'write_creates or refuses_to_overwrite'`
+  passed with `2 passed, 2 deselected`.
+- Focused lint:
+  `uv run --python 3.12 --extra dev ruff check src/awf/profiles/onboarding.py tests/unit/cli/test_init.py`
+  passed.
+- Focused format check:
+  `uv run --python 3.12 --extra dev ruff format --check src/awf/profiles/onboarding.py tests/unit/cli/test_init.py`
+  passed.

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -826,6 +826,14 @@ def _run_init_project_onboarding(
             err=True,
         )
         raise typer.Exit(code=2)
+    stdio_is_interactive = _stdio_is_interactive()
+    if guided is True and not stdio_is_interactive:
+        typer.echo(
+            "error: --guided requires an interactive terminal; use "
+            "--write-profile --yes for non-interactive writes.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
     service_status: dict[str, object]
     doctor_report: DoctorReport | None
@@ -915,7 +923,7 @@ def _run_init_project_onboarding(
         and fmt == OutputFormat.pretty
         and existing_profile_path is None
         and not write_profile
-        and _stdio_is_interactive()
+        and stdio_is_interactive
     )
     effective_guided = guided is True or auto_guided
 

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -939,7 +939,7 @@ def _run_init_project_onboarding(
             customize_preview=customize_project_onboarding_preview,
         )
 
-    should_write = write_profile or guided_wants_write
+    should_write = guided_wants_write if effective_guided else write_profile
     written_path: Path | None = None
     if should_write:
         try:

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -790,6 +790,7 @@ def _run_init_project_onboarding(
     force: bool,
     fmt: OutputFormat,
 ) -> None:
+    """Run repository onboarding checks and optionally write the workspace profile."""
     from awf.profiles.models import EgressMode
     from awf.profiles.onboarding import (
         customize_project_onboarding_preview,
@@ -844,6 +845,7 @@ def _run_init_project_onboarding(
         service_name = getattr(settings, "service_name", "unknown")
 
         async def _collect_reports() -> tuple[dict[str, object], DoctorReport | None, str | None]:
+            """Collect service status and doctor diagnostics with one shared status read."""
             service_status_task = asyncio.create_task(
                 collect_service_status(
                     settings,
@@ -859,6 +861,7 @@ def _run_init_project_onboarding(
                 provider_environ: Mapping[str, str] | None = None,
                 **_kwargs: object,
             ) -> dict[str, object]:
+                """Serve the in-flight service status result to doctor diagnostics."""
                 _ = settings, strict_providers, provider_environ, _kwargs
                 return await service_status_task
 
@@ -981,6 +984,7 @@ def _run_init_project_onboarding(
 
 
 def _stdio_is_interactive() -> bool:
+    """Return whether both stdin and stdout are attached to an interactive TTY."""
     stdin_isatty = getattr(sys.stdin, "isatty", lambda: False)
     stdout_isatty = getattr(sys.stdout, "isatty", lambda: False)
     return bool(stdin_isatty() and stdout_isatty())
@@ -996,6 +1000,7 @@ def _prompt_project_onboarding_choices(
     preview_factory: Any,
     customize_preview: Any,
 ) -> tuple[Any, bool]:
+    """Prompt for template, egress, validation, and profile-write onboarding choices."""
     typer.echo("AWF init: guided project profile setup")
     typer.echo(f"Detected template: {preview.draft.template}")
     template_choice = typer.prompt("Template", default=preview.draft.template).strip()
@@ -1065,6 +1070,7 @@ def _init_project_onboarding_payload(
     guided: bool,
     mode: str,
 ) -> dict[str, object]:
+    """Build the structured project-onboarding payload for pretty and JSON output."""
     payload = cast(dict[str, object], preview.to_dict())
     profile_exists = existing_profile_path is not None or written_path is not None
     payload.update(
@@ -1094,6 +1100,7 @@ def _init_project_next_steps(
     existing_profile_path: Path | None,
     written_path: Path | None,
 ) -> list[str]:
+    """Return context-aware follow-up commands for the onboarding result."""
     if written_path is not None:
         return [
             "Run `awf profile preview <path> --profile auto --format pretty` to inspect profile resolution.",
@@ -1119,6 +1126,7 @@ def _emit_init_project_onboarding_pretty(
     doctor_pretty: str,
     include_smoke_request: bool,
 ) -> None:
+    """Render the human-readable project-onboarding readiness report."""
     typer.echo("AWF init: local onboarding readiness check")
     typer.echo(f"  repository: {preview.path}")
     typer.echo(f"  detected profile template: {preview.draft.template}")
@@ -1156,6 +1164,7 @@ def _emit_init_project_onboarding_pretty(
 
 
 def _existing_project_profile_path(repository: Path) -> Path | None:
+    """Return the first supported project-local AWF profile path if one exists."""
     for relative_path in _PROJECT_PROFILE_MARKER_PATHS:
         candidate = repository / relative_path
         if candidate.is_file():

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -1012,11 +1012,18 @@ def _prompt_project_onboarding_choices(
         )
         raise typer.Exit(code=2)
     if template_choice != preview.draft.template:
-        preview = preview_factory(
-            repository,
-            template=template_choice,
-            include_smoke_request=include_smoke_request,
-        )
+        try:
+            preview = preview_factory(
+                repository,
+                template=template_choice,
+                include_smoke_request=include_smoke_request,
+            )
+        except ValueError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=2) from exc
+        except Exception as exc:
+            typer.echo(f"error: could not build onboarding preview: {exc}", err=True)
+            raise typer.Exit(code=1) from exc
 
     egress_mode = (
         typer.prompt(

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -1057,12 +1057,13 @@ def _init_project_onboarding_payload(
     mode: str,
 ) -> dict[str, object]:
     payload = cast(dict[str, object], preview.to_dict())
+    profile_exists = existing_profile_path is not None or written_path is not None
     payload.update(
         {
             "mode": mode,
             "guided": guided,
             "selected_template": preview.draft.template,
-            "profile_exists": existing_profile_path is not None,
+            "profile_exists": profile_exists,
             "service_status": service_status,
             "doctor_status": doctor_status,
             "local_checks_ready": local_checks_ready,

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -911,6 +911,9 @@ def _run_init_project_onboarding(
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
+    except Exception as exc:
+        typer.echo(f"error: could not build onboarding preview: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
 
     doctor_status = (
         getattr(doctor_report, "status", "fail") if doctor_report is not None else "fail"

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -1002,7 +1002,14 @@ def _prompt_project_onboarding_choices(
             include_smoke_request=include_smoke_request,
         )
 
-    egress_mode = typer.prompt("Egress mode", default="restricted").strip().lower()
+    egress_mode = (
+        typer.prompt(
+            "Egress mode",
+            default=egress_mode_type.restricted.value,
+        )
+        .strip()
+        .lower()
+    )
     supported_egress = {mode.value for mode in egress_mode_type}
     if egress_mode not in supported_egress:
         typer.echo(

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -820,6 +820,12 @@ def _run_init_project_onboarding(
     if fmt == OutputFormat.json and guided is True:
         typer.echo("error: --guided cannot be used with --format json.", err=True)
         raise typer.Exit(code=2)
+    if yes and not write_profile:
+        typer.echo(
+            "error: --yes requires --write-profile to approve a non-interactive profile write.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
     if write_profile and not yes and guided is not True:
         typer.echo(
             "error: --write-profile requires --yes for non-interactive writes "
@@ -1053,9 +1059,12 @@ def _prompt_project_onboarding_choices(
         "Add a validation command now?",
         default=False,
     ):
-        validation_command = typer.prompt("Validation command").strip()
-        if validation_command:
-            validation_commands.append(validation_command)
+        while True:
+            validation_command = typer.prompt("Validation command").strip()
+            if validation_command:
+                validation_commands.append(validation_command)
+            if not typer.confirm("Add another validation command?", default=False):
+                break
 
     preview = customize_preview(
         preview,

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -642,6 +642,34 @@ def init(
         "--include-smoke-request",
         help="Include a smoke-workspace request payload (does not submit).",
     ),
+    guided: bool | None = typer.Option(
+        None,
+        "--guided/--no-guided",
+        help=(
+            "Project onboarding: prompt for a short first-run profile setup. "
+            "Defaults to guided only for interactive pretty output when no profile exists."
+        ),
+    ),
+    write_profile: bool = typer.Option(
+        False,
+        "--write-profile",
+        help="Project onboarding: write .awf/workspace.yml from the detected profile.",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        help="Project onboarding: approve non-interactive profile writes.",
+    ),
+    template: str = typer.Option(
+        "auto",
+        "--template",
+        help="Project onboarding: template override or auto.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help="Project onboarding: overwrite an existing .awf/workspace.yml when writing.",
+    ),
     write_env: bool = typer.Option(
         True,
         "--write-env/--no-write-env",
@@ -681,11 +709,31 @@ def init(
     ),
 ) -> None:
     """Bootstrap the local AWF service or run project-onboarding checks."""
+    ctx = click.get_current_context()
+
+    def _explicit(name: str) -> bool:
+        """Return whether an option was explicitly supplied."""
+        return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
+
     if path is None:
+        project_only_flags: list[str] = []
         if include_smoke_request:
+            project_only_flags.append("--include-smoke-request")
+        if _explicit("guided"):
+            project_only_flags.append("--guided" if guided else "--no-guided")
+        if _explicit("write_profile"):
+            project_only_flags.append("--write-profile")
+        if _explicit("yes"):
+            project_only_flags.append("--yes")
+        if _explicit("template"):
+            project_only_flags.append("--template")
+        if _explicit("force"):
+            project_only_flags.append("--force")
+        if project_only_flags:
             typer.echo(
-                "error: onboarding-only flag --include-smoke-request requires a "
-                "project path; pass `awf init <path> --include-smoke-request`.",
+                "error: project-onboarding flag(s) "
+                f"{', '.join(project_only_flags)} require a project path; pass "
+                "`awf init <path>`.",
                 err=True,
             )
             raise typer.Exit(code=2)
@@ -699,12 +747,6 @@ def init(
         )
         return
 
-    ctx = click.get_current_context()
-
-    def _explicit(name: str) -> bool:
-        """Return whether a bootstrap-only option was explicitly supplied."""
-        return ctx.get_parameter_source(name) == ParameterSource.COMMANDLINE
-
     bootstrap_only_flags: list[str] = []
     if _explicit("skip_agent_runtime_build"):
         bootstrap_only_flags.append("--skip-agent-runtime-build")
@@ -716,8 +758,6 @@ def init(
         bootstrap_only_flags.append("--poll-interval-seconds")
     if _explicit("write_env"):
         bootstrap_only_flags.append("--write-env" if write_env else "--no-write-env")
-    if _explicit("fmt"):
-        bootstrap_only_flags.append("--format")
     if bootstrap_only_flags:
         typer.echo(
             "error: bootstrap-only flag(s) "
@@ -730,6 +770,12 @@ def init(
     _run_init_project_onboarding(
         path,
         include_smoke_request=include_smoke_request,
+        guided=guided,
+        write_profile=write_profile,
+        yes=yes,
+        template=template,
+        force=force,
+        fmt=fmt,
     )
 
 
@@ -737,8 +783,20 @@ def _run_init_project_onboarding(
     path: Path,
     *,
     include_smoke_request: bool,
+    guided: bool | None,
+    write_profile: bool,
+    yes: bool,
+    template: str,
+    force: bool,
+    fmt: OutputFormat,
 ) -> None:
-    from awf.profiles.onboarding import preview_project_onboarding
+    from awf.profiles.models import EgressMode
+    from awf.profiles.onboarding import (
+        customize_project_onboarding_preview,
+        preview_project_onboarding,
+        supported_onboarding_templates,
+        write_workspace_profile,
+    )
     from awf.service.config import (
         ServiceSettings,
         local_service_environ,
@@ -758,13 +816,26 @@ def _run_init_project_onboarding(
         raise typer.Exit(code=2)
 
     existing_profile_path = _existing_project_profile_path(repository)
+    if fmt == OutputFormat.json and guided is True:
+        typer.echo("error: --guided cannot be used with --format json.", err=True)
+        raise typer.Exit(code=2)
+    if write_profile and not yes and guided is not True:
+        typer.echo(
+            "error: --write-profile requires --yes for non-interactive writes "
+            "or --guided for an interactive confirmation.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
+    service_status: dict[str, object]
+    doctor_report: DoctorReport | None
+    doctor_error: str | None = None
     try:
         settings = resolve_service_settings()
         service_env = local_service_environ()
         service_name = getattr(settings, "service_name", "unknown")
 
-        async def _collect_reports() -> tuple[dict[str, object], DoctorReport]:
+        async def _collect_reports() -> tuple[dict[str, object], DoctorReport | None, str | None]:
             service_status_task = asyncio.create_task(
                 collect_service_status(
                     settings,
@@ -816,33 +887,241 @@ def _run_init_project_onboarding(
             else:
                 service_status = service_status_result
             if isinstance(doctor_report, BaseException):
-                raise doctor_report
+                return service_status, None, str(doctor_report)
 
-            return service_status, doctor_report
+            return service_status, doctor_report, None
 
-        service_status, doctor_report = asyncio.run(_collect_reports())
+        service_status, doctor_report, doctor_error = asyncio.run(_collect_reports())
+    except Exception as exc:
+        service_status = {
+            "service": "awf",
+            "status": "fail",
+            "checks": {},
+            "agent_readiness": {"status": "fail"},
+            "detail": str(exc),
+        }
+        doctor_report = None
+        doctor_error = str(exc)
+
+    try:
         preview = preview_project_onboarding(
             repository,
+            template=template,
             include_smoke_request=include_smoke_request,
         )
     except ValueError as exc:
         typer.echo(f"error: {exc}", err=True)
         raise typer.Exit(code=2) from exc
-    except Exception as exc:
-        typer.echo(f"error: could not collect local checks: {exc}", err=True)
-        raise typer.Exit(code=1) from exc
 
-    doctor_status = getattr(doctor_report, "status", "unknown")
+    doctor_status = (
+        getattr(doctor_report, "status", "fail") if doctor_report is not None else "fail"
+    )
     service_ok = service_status.get("status") == "ok"
     doctor_ok = doctor_status != "fail"
+    local_checks_ready = service_ok and doctor_ok
+    auto_guided = (
+        guided is None
+        and fmt == OutputFormat.pretty
+        and existing_profile_path is None
+        and not write_profile
+        and _stdio_is_interactive()
+    )
+    effective_guided = guided is True or auto_guided
 
+    guided_wants_write = False
+    if effective_guided:
+        preview, guided_wants_write = _prompt_project_onboarding_choices(
+            repository,
+            preview=preview,
+            include_smoke_request=include_smoke_request,
+            supported_templates=supported_onboarding_templates(),
+            egress_mode_type=EgressMode,
+            preview_factory=preview_project_onboarding,
+            customize_preview=customize_project_onboarding_preview,
+        )
+
+    should_write = write_profile or guided_wants_write
+    written_path: Path | None = None
+    if should_write:
+        try:
+            written_path = write_workspace_profile(preview, force=force)
+        except FileExistsError as exc:
+            typer.echo(f"error: {exc}", err=True)
+            raise typer.Exit(code=1) from None
+
+    mode = "guided" if effective_guided else "write" if should_write else "preview"
+    payload = _init_project_onboarding_payload(
+        preview=preview,
+        existing_profile_path=existing_profile_path,
+        written_path=written_path,
+        service_status=service_status,
+        doctor_status=str(doctor_status),
+        local_checks_ready=local_checks_ready,
+        guided=effective_guided,
+        mode=mode,
+    )
+
+    if fmt == OutputFormat.json:
+        _emit(payload, fmt)
+        return
+
+    doctor_pretty = (
+        render_doctor_pretty(doctor_report)
+        if doctor_report is not None
+        else f"AWF doctor: fail\n  detail: {doctor_error or 'doctor report unavailable'}\n"
+    )
+    _emit_init_project_onboarding_pretty(
+        preview=preview,
+        payload=payload,
+        doctor_pretty=doctor_pretty,
+        include_smoke_request=include_smoke_request,
+    )
+
+
+def _stdio_is_interactive() -> bool:
+    stdin_isatty = getattr(sys.stdin, "isatty", lambda: False)
+    stdout_isatty = getattr(sys.stdout, "isatty", lambda: False)
+    return bool(stdin_isatty() and stdout_isatty())
+
+
+def _prompt_project_onboarding_choices(
+    repository: Path,
+    *,
+    preview: Any,
+    include_smoke_request: bool,
+    supported_templates: tuple[str, ...],
+    egress_mode_type: Any,
+    preview_factory: Any,
+    customize_preview: Any,
+) -> tuple[Any, bool]:
+    typer.echo("AWF init: guided project profile setup")
+    typer.echo(f"Detected template: {preview.draft.template}")
+    template_choice = typer.prompt("Template", default=preview.draft.template).strip()
+    if template_choice not in supported_templates:
+        typer.echo(
+            "error: unsupported onboarding template "
+            f"{template_choice!r}; choose one of {', '.join(supported_templates)}.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    if template_choice != preview.draft.template:
+        preview = preview_factory(
+            repository,
+            template=template_choice,
+            include_smoke_request=include_smoke_request,
+        )
+
+    egress_mode = typer.prompt("Egress mode", default="restricted").strip().lower()
+    supported_egress = {"restricted", "open", "offline"}
+    if egress_mode not in supported_egress:
+        typer.echo(
+            "error: unsupported egress mode "
+            f"{egress_mode!r}; choose one of {', '.join(sorted(supported_egress))}.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
+    open_explanation = None
+    if egress_mode == "open":
+        open_explanation = typer.prompt(
+            "Open egress explanation",
+            default="Project setup or validation needs internet access.",
+        ).strip()
+
+    validation_commands: list[str] = []
+    if not preview.draft.profile.phases.validate_commands and typer.confirm(
+        "Add a validation command now?",
+        default=False,
+    ):
+        validation_command = typer.prompt("Validation command").strip()
+        if validation_command:
+            validation_commands.append(validation_command)
+
+    preview = customize_preview(
+        preview,
+        egress_mode=egress_mode_type(egress_mode),
+        open_explanation=open_explanation,
+        validation_commands=validation_commands,
+    )
+    return preview, typer.confirm("Write .awf/workspace.yml?", default=True)
+
+
+def _init_project_onboarding_payload(
+    *,
+    preview: Any,
+    existing_profile_path: Path | None,
+    written_path: Path | None,
+    service_status: dict[str, object],
+    doctor_status: str,
+    local_checks_ready: bool,
+    guided: bool,
+    mode: str,
+) -> dict[str, object]:
+    payload = cast(dict[str, object], preview.to_dict())
+    payload.update(
+        {
+            "mode": mode,
+            "guided": guided,
+            "selected_template": preview.draft.template,
+            "profile_exists": existing_profile_path is not None,
+            "service_status": service_status,
+            "doctor_status": doctor_status,
+            "local_checks_ready": local_checks_ready,
+            "next_steps": _init_project_next_steps(
+                existing_profile_path=existing_profile_path,
+                written_path=written_path,
+            ),
+        }
+    )
+    if existing_profile_path is not None:
+        payload["existing_profile_path"] = str(existing_profile_path)
+    if written_path is not None:
+        payload["written_path"] = str(written_path)
+    return payload
+
+
+def _init_project_next_steps(
+    *,
+    existing_profile_path: Path | None,
+    written_path: Path | None,
+) -> list[str]:
+    if written_path is not None:
+        return [
+            "Run `awf profile preview <path> --profile auto --format pretty` to inspect profile resolution.",
+            "Run `awf smoke run --mocked-local --format pretty` for a local DX proof.",
+        ]
+    if existing_profile_path is not None:
+        return [
+            f"AWF profile already exists: {existing_profile_path}",
+            "Run `awf profile preview <path> --profile auto --format pretty` to inspect profile resolution.",
+            "Run `awf smoke run --mocked-local --format pretty` for a local DX proof.",
+        ]
+    return [
+        "Run `awf init <path> --write-profile --yes` to create `.awf/workspace.yml` with detected defaults.",
+        "Run `awf init <path> --guided` for a short interactive setup.",
+        "Run `awf profile preview <path> --profile <name> --format pretty` to inspect profile resolution.",
+    ]
+
+
+def _emit_init_project_onboarding_pretty(
+    *,
+    preview: Any,
+    payload: Mapping[str, object],
+    doctor_pretty: str,
+    include_smoke_request: bool,
+) -> None:
     typer.echo("AWF init: local onboarding readiness check")
-    typer.echo(f"  repository: {repository}")
+    typer.echo(f"  repository: {preview.path}")
     typer.echo(f"  detected profile template: {preview.draft.template}")
+    service_status = _mapping_value(payload.get("service_status"))
     typer.echo(f"  service status: {service_status.get('status', 'unknown')}")
-    typer.echo(f"  doctor status: {doctor_status}")
+    typer.echo(f"  doctor status: {payload.get('doctor_status', 'unknown')}")
     typer.echo("")
-    typer.echo(render_doctor_pretty(doctor_report), nl=False)
+    typer.echo(doctor_pretty, nl=False)
+
+    written_path = payload.get("written_path")
+    if written_path:
+        typer.echo("")
+        typer.echo(f"Wrote AWF profile: {written_path}")
 
     if include_smoke_request and preview.smoke_request is not None:
         typer.echo("")
@@ -851,31 +1130,19 @@ def _run_init_project_onboarding(
 
     typer.echo("")
     typer.echo("Suggested next steps:")
-    if existing_profile_path is not None:
-        typer.echo(f"  - AWF profile already exists: {existing_profile_path}")
-        typer.echo(
-            "  - Run `awf profile preview <path> --profile auto --format pretty` "
-            "to inspect profile resolution."
-        )
-        typer.echo("  - Run `awf smoke run --mocked-local --format pretty` for a local DX proof.")
-    else:
-        typer.echo("  - Run `awf profile init <path> --write` to create `.awf/workspace.yml`.")
-        typer.echo(
-            "  - Run `awf profile preview <path> --profile <name> --format pretty` "
-            "to inspect profile resolution."
-        )
+    for step in _list_value(payload.get("next_steps")):
+        typer.echo(f"  - {step}")
     typer.echo(
         "  - Optional: generate a smoke workspace request locally with "
         "`awf init <path> --include-smoke-request`; this prints the payload inline and does "
         "not submit a workspace."
     )
 
-    if not service_ok or not doctor_ok:
+    if not bool(payload.get("local_checks_ready")):
         typer.echo(
-            "\nLocal prerequisites are not fully ready yet; fix the issues above before "
-            "creating or retrying workspaces."
+            "\nLocal prerequisites are not fully ready yet; profile onboarding can "
+            "continue, but fix the issues above before creating or retrying workspaces."
         )
-        raise typer.Exit(code=1)
 
 
 def _existing_project_profile_path(repository: Path) -> Path | None:

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -1046,7 +1046,7 @@ def _prompt_project_onboarding_choices(
         preview,
         egress_mode=egress_mode_type(egress_mode),
         open_explanation=open_explanation,
-        validation_commands=validation_commands,
+        validation_commands=validation_commands or None,
     )
     return preview, typer.confirm("Write .awf/workspace.yml?", default=True)
 

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -852,16 +852,7 @@ def _run_init_project_onboarding(
                 **_kwargs: object,
             ) -> dict[str, object]:
                 _ = settings, strict_providers, provider_environ, _kwargs
-                try:
-                    return await service_status_task
-                except Exception as exc:
-                    return {
-                        "service": service_name,
-                        "status": "fail",
-                        "checks": {},
-                        "agent_readiness": {"status": "fail"},
-                        "detail": str(exc),
-                    }
+                return await service_status_task
 
             service_status_result, doctor_report = await asyncio.gather(
                 service_status_task,

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -1003,7 +1003,7 @@ def _prompt_project_onboarding_choices(
         )
 
     egress_mode = typer.prompt("Egress mode", default="restricted").strip().lower()
-    supported_egress = {"restricted", "open", "offline"}
+    supported_egress = {mode.value for mode in egress_mode_type}
     if egress_mode not in supported_egress:
         typer.echo(
             "error: unsupported egress mode "

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -774,6 +774,13 @@ class WorkspaceProfile(BaseModel):
             update={"phases": self.phases.model_copy(update={"validate_commands": phase_commands})},
         )
 
+    def clear_validation_commands(self) -> WorkspaceProfile:
+        """Return a copy with validation commands removed."""
+        return self.model_copy(
+            deep=True,
+            update={"phases": self.phases.model_copy(update={"validate_commands": []})},
+        )
+
 
 def _normalized_endpoint_env_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]+", "_", name).strip("_").upper()

--- a/src/awf/profiles/onboarding.py
+++ b/src/awf/profiles/onboarding.py
@@ -287,6 +287,73 @@ def preview_project_onboarding(
     )
 
 
+def supported_onboarding_templates() -> tuple[str, ...]:
+    """Return supported project onboarding template names."""
+    return tuple(sorted(_SUPPORTED_TEMPLATES))
+
+
+def customize_project_onboarding_preview(
+    preview: ProjectOnboardingPreview,
+    *,
+    egress_mode: str | EgressMode | None = None,
+    open_explanation: str | None = None,
+    validation_commands: Sequence[str] | None = None,
+) -> ProjectOnboardingPreview:
+    """Return a preview with safe first-run profile choices applied."""
+    profile = preview.draft.profile.model_copy(deep=True)
+
+    if egress_mode is not None:
+        selected_mode = EgressMode(egress_mode)
+        if selected_mode == EgressMode.restricted:
+            egress = profile.security.egress.model_copy(
+                update={
+                    "mode": selected_mode,
+                    "allowlist_templates": list(_DEFAULT_RESTRICTED_ALLOWLIST_TEMPLATES),
+                    "open_explanation": None,
+                }
+            )
+        else:
+            egress = profile.security.egress.model_copy(
+                update={
+                    "mode": selected_mode,
+                    "allowlist_templates": [],
+                    "open_explanation": open_explanation
+                    if selected_mode == EgressMode.open
+                    else None,
+                }
+            )
+        profile = profile.model_copy(
+            update={"security": profile.security.model_copy(update={"egress": egress})}
+        )
+
+    if validation_commands is not None:
+        clean_commands = [command.strip() for command in validation_commands if command.strip()]
+        if clean_commands:
+            profile = profile.with_validation_commands(clean_commands)
+
+    diagnostics = _diagnostics_for(
+        preview.inspection,
+        profile=profile,
+        template=preview.draft.template,
+    )
+    draft = DraftProfile(
+        template=preview.draft.template,
+        profile=profile,
+        yaml=_profile_yaml(profile),
+        diagnostics=diagnostics,
+    )
+    smoke_request = (
+        _smoke_request(preview.path, profile) if preview.smoke_request is not None else None
+    )
+    return ProjectOnboardingPreview(
+        path=preview.path,
+        inspection=preview.inspection,
+        draft=draft,
+        diagnostics=diagnostics,
+        smoke_request=smoke_request,
+    )
+
+
 def preview_workspace_profile(
     project: Path,
     resolution: ProfileResolution,

--- a/src/awf/profiles/onboarding.py
+++ b/src/awf/profiles/onboarding.py
@@ -330,6 +330,8 @@ def customize_project_onboarding_preview(
         clean_commands = [command.strip() for command in validation_commands if command.strip()]
         if clean_commands:
             profile = profile.with_validation_commands(clean_commands)
+        else:
+            profile = profile.clear_validation_commands()
 
     diagnostics = _diagnostics_for(
         preview.inspection,

--- a/src/awf/profiles/onboarding.py
+++ b/src/awf/profiles/onboarding.py
@@ -418,11 +418,23 @@ def preview_workspace_profile(
 def write_workspace_profile(preview: ProjectOnboardingPreview, force: bool = False) -> Path:
     """Write the previewed draft to ``.awf/workspace.yml``."""
     profile_path = preview.path / ".awf" / "workspace.yml"
-    if profile_path.exists() and not force:
-        raise FileExistsError(f"{profile_path} already exists; pass --force to overwrite")
+    existing_profile_path = _existing_workspace_profile_path(preview.path)
+    if existing_profile_path is None and profile_path.exists():
+        existing_profile_path = profile_path
+    if existing_profile_path is not None and not force:
+        raise FileExistsError(f"{existing_profile_path} already exists; pass --force to overwrite")
     profile_path.parent.mkdir(parents=True, exist_ok=True)
     profile_path.write_text(preview.draft.yaml, encoding="utf-8")
     return profile_path
+
+
+def _existing_workspace_profile_path(project: Path) -> Path | None:
+    """Return the first supported workspace profile marker path on disk."""
+    for relative_path in PROFILE_MARKER_PATHS:
+        candidate = project / relative_path
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _profile_for_template(inspection: ProjectInspection, template: str) -> WorkspaceProfile:

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -3501,7 +3501,7 @@ def test_init_without_path_json_marks_non_utf8_env_overlay_merge_failed(
         "message": "env seeding merge requires UTF-8 dotenv files",
     }
     assert not (compose / ".env").exists()
-    assert "root" not in result.output
+    assert "AWF_API_TOKEN=root" not in result.output
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -412,6 +412,24 @@ def test_init_guided_writes_answers_into_workspace_yml(
 
 
 @pytest.mark.unit
+def test_init_write_profile_guided_declined_confirmation_does_not_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+    monkeypatch.setattr("awf.cli.main._stdio_is_interactive", lambda: True)
+
+    result = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--guided"],
+        input="\n\n\nn\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert not (tmp_path / ".awf" / "workspace.yml").exists()
+    assert "Wrote AWF profile" not in result.output
+
+
+@pytest.mark.unit
 def test_init_guided_egress_choices_follow_model_enum(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -369,10 +369,31 @@ def test_init_write_profile_requires_yes_when_not_guided(
 
 
 @pytest.mark.unit
+def test_init_guided_requires_interactive_stdio(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    monkeypatch.setattr("awf.cli.main._stdio_is_interactive", lambda: False)
+    monkeypatch.setattr(
+        "awf.cli.main._prompt_project_onboarding_choices",
+        MagicMock(side_effect=AssertionError("should not prompt without a TTY")),
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--guided"])
+
+    assert result.exit_code == 2, result.output
+    assert "--guided requires an interactive terminal" in result.output
+    assert "--yes" in result.output
+    assert not (tmp_path / ".awf" / "workspace.yml").exists()
+
+
+@pytest.mark.unit
 def test_init_guided_writes_answers_into_workspace_yml(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _stub_local_prerequisites(monkeypatch)
+    monkeypatch.setattr("awf.cli.main._stdio_is_interactive", lambda: True)
 
     result = _runner.invoke(
         app,

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -566,6 +566,32 @@ def test_init_write_profile_existing_profile_requires_force(
 
 
 @pytest.mark.unit
+def test_init_write_profile_alternate_profile_marker_requires_force(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+    alternate_profile_path = tmp_path / ".awf" / "workspace.yaml"
+    alternate_profile_path.parent.mkdir()
+    alternate_profile_path.write_text("version: 1\nname: existing\n", encoding="utf-8")
+    canonical_profile_path = tmp_path / ".awf" / "workspace.yml"
+
+    blocked = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes"],
+    )
+    forced = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes", "--force"],
+    )
+
+    assert blocked.exit_code == 1, blocked.output
+    assert f"{alternate_profile_path} already exists" in blocked.output
+    assert forced.exit_code == 0, forced.output
+    assert canonical_profile_path.is_file()
+    assert alternate_profile_path.is_file()
+
+
+@pytest.mark.unit
 def test_init_json_mode_never_prompts_and_reports_structured_state(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -9,6 +9,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+import yaml
 from typer.testing import CliRunner
 
 from awf.cli.main import app
@@ -257,14 +258,28 @@ def _stub_local_prerequisites(
 
         def _preview_project_onboarding(_path: Path, **_kwargs: object) -> object:
             return SimpleNamespace(
+                path=_path,
                 draft=SimpleNamespace(template="generic"),
                 smoke_request={"dummy": "payload"},
+                to_dict=lambda: {
+                    "path": str(_path),
+                    "draft": {"template": "generic"},
+                    "diagnostics": {},
+                },
             )
 
         monkeypatch.setattr(
             "awf.profiles.onboarding.preview_project_onboarding",
             _preview_project_onboarding,
         )
+
+
+def _read_written_profile(project: Path) -> dict[str, Any]:
+    raw = yaml.safe_load((project / ".awf" / "workspace.yml").read_text(encoding="utf-8"))
+    assert isinstance(raw, dict)
+    awf_profile = raw.get("awf")
+    assert isinstance(awf_profile, dict)
+    return awf_profile
 
 
 @pytest.mark.unit
@@ -298,6 +313,119 @@ def test_init_is_safe_by_default_and_idempotent(
     assert result_first.exit_code == 0, result_first.output
     assert result_second.exit_code == 0, result_second.output
     assert not (tmp_path / ".awf" / "workspace.yml").exists()
+
+
+@pytest.mark.unit
+def test_init_write_profile_yes_creates_default_workspace_yml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from awf.profiles.models import WorkspaceProfile
+
+    _stub_local_prerequisites(monkeypatch)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--write-profile", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    profile = _read_written_profile(tmp_path)
+    WorkspaceProfile.model_validate(profile)
+    assert profile["name"] == "generic"
+    assert profile["security"]["egress"]["mode"] == "restricted"
+    assert "Wrote AWF profile" in result.output
+
+
+@pytest.mark.unit
+def test_init_write_profile_requires_yes_when_not_guided(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--write-profile"])
+
+    assert result.exit_code == 2, result.output
+    assert "--write-profile" in result.output
+    assert "--yes" in result.output
+    assert not (tmp_path / ".awf" / "workspace.yml").exists()
+
+
+@pytest.mark.unit
+def test_init_guided_writes_answers_into_workspace_yml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    result = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--guided"],
+        input="\nopen\nNeeds package registry and model-provider access.\ny\npytest -q\ny\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    profile = _read_written_profile(tmp_path)
+    assert profile["security"]["egress"]["mode"] == "open"
+    assert (
+        profile["security"]["egress"]["open_explanation"]
+        == "Needs package registry and model-provider access."
+    )
+    assert profile["phases"]["validate"] == [{"command": "pytest -q", "required": True}]
+
+
+@pytest.mark.unit
+def test_init_write_profile_existing_profile_requires_force(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+    profile_path = tmp_path / ".awf" / "workspace.yml"
+    profile_path.parent.mkdir()
+    profile_path.write_text("original: true\n", encoding="utf-8")
+
+    blocked = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes"],
+    )
+    overwritten = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes", "--force"],
+    )
+
+    assert blocked.exit_code == 1, blocked.output
+    assert "already exists" in blocked.output
+    assert overwritten.exit_code == 0, overwritten.output
+    assert _read_written_profile(tmp_path)["name"] == "generic"
+
+
+@pytest.mark.unit
+def test_init_json_mode_never_prompts_and_reports_structured_state(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["path"] == str(tmp_path.resolve())
+    assert payload["profile_exists"] is False
+    assert payload["guided"] is False
+    assert payload["mode"] == "preview"
+    assert payload["service_status"]["status"] == "ok"
+    assert payload["doctor_status"] == "ok"
+    assert "written_path" not in payload
+    assert "prompt" not in result.output.lower()
+    assert not (tmp_path / ".awf" / "workspace.yml").exists()
+
+
+@pytest.mark.unit
+def test_init_write_profile_continues_when_local_checks_are_unhealthy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch, service_status="fail", doctor_status="fail")
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--write-profile", "--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / ".awf" / "workspace.yml").exists()
+    assert "Local prerequisites are not fully ready" in result.output
+    assert "Wrote AWF profile" in result.output
 
 
 @pytest.mark.unit
@@ -346,7 +474,7 @@ def test_init_prints_clear_next_steps(tmp_path: Path, monkeypatch: pytest.Monkey
     result = _runner.invoke(app, ["init", str(tmp_path)])
 
     assert result.exit_code == 0, result.output
-    assert "awf profile init" in result.output
+    assert "awf init <path> --write-profile --yes" in result.output
     assert "awf profile preview" in result.output
     assert "--include-smoke-request" in result.output
 
@@ -439,7 +567,7 @@ def test_init_continues_when_service_status_probe_raises(
 
     result = _runner.invoke(app, ["init", str(tmp_path)])
 
-    assert result.exit_code == 1, result.output
+    assert result.exit_code == 0, result.output
     assert calls["status"] == 1
     assert calls["doctor"] == 1
     assert "service status: fail" in result.output
@@ -559,7 +687,7 @@ def test_init_reports_local_prerequisite_failures_without_api_calls(
 
     result = _runner.invoke(app, ["init", str(tmp_path)])
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0, result.output
     assert "Local prerequisites are not fully ready" in result.output
     assert "AWF doctor: fail" in result.output
 
@@ -3609,7 +3737,7 @@ def test_init_with_path_keeps_existing_project_onboarding_behavior(
 
     assert result.exit_code == 0, result.output
     assert "AWF init: local onboarding readiness check" in result.output
-    assert "awf profile init" in result.output
+    assert "awf init <path> --write-profile --yes" in result.output
 
 
 @pytest.mark.unit
@@ -3667,7 +3795,7 @@ def test_init_with_path_rejects_no_write_env_flag(
 
 
 @pytest.mark.unit
-def test_init_with_path_rejects_format_json_flag(
+def test_init_with_path_accepts_format_json_flag(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     _stub_local_prerequisites(monkeypatch)
@@ -3677,11 +3805,10 @@ def test_init_with_path_rejects_format_json_flag(
         ["init", str(tmp_path), "--format", "json"],
     )
 
-    output = result.output
-    assert result.exit_code == 2
-    assert "--format" in output
-    assert "without a project path" in output or "no path" in output
-    assert "Traceback" not in output
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "preview"
+    assert payload["profile_exists"] is False
 
 
 @pytest.mark.unit
@@ -3696,7 +3823,6 @@ def test_init_with_path_rejects_explicit_default_bootstrap_flags(
         (["--timeout-seconds", "180"], "--timeout-seconds"),
         (["--poll-interval-seconds", "2"], "--poll-interval-seconds"),
         (["--write-env"], "--write-env"),
-        (["--format", "pretty"], "--format"),
     ]
     for extra, expected_flag in cases:
         result = _runner.invoke(app, ["init", str(tmp_path), *extra])

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -397,7 +397,7 @@ def test_init_guided_egress_choices_follow_model_enum(
     from awf.cli import main as cli_main
 
     class CustomEgressMode(StrEnum):
-        restricted = "restricted"
+        restricted = "private-default"
         private = "private"
 
     preview = SimpleNamespace(
@@ -407,9 +407,14 @@ def test_init_guided_egress_choices_follow_model_enum(
         )
     )
     captured: dict[str, object] = {}
+    prompt_defaults: list[object] = []
     prompt_answers = iter(["generic", "private"])
 
-    monkeypatch.setattr("awf.cli.main.typer.prompt", lambda *_args, **_kwargs: next(prompt_answers))
+    def prompt(_label: str, **kwargs: object) -> str:
+        prompt_defaults.append(kwargs.get("default"))
+        return next(prompt_answers)
+
+    monkeypatch.setattr("awf.cli.main.typer.prompt", prompt)
     monkeypatch.setattr("awf.cli.main.typer.confirm", lambda *_args, **_kwargs: False)
 
     def customize_preview(received_preview: object, **kwargs: object) -> object:
@@ -428,6 +433,7 @@ def test_init_guided_egress_choices_follow_model_enum(
 
     assert result is preview
     assert wants_write is False
+    assert prompt_defaults == ["generic", CustomEgressMode.restricted.value]
     assert captured["egress_mode"] == CustomEgressMode.private
 
 

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -10,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+import typer
 import yaml
 from typer.testing import CliRunner
 
@@ -475,6 +476,69 @@ def test_init_guided_egress_choices_follow_model_enum(
     assert prompt_defaults == ["generic", CustomEgressMode.restricted.value]
     assert captured["egress_mode"] == CustomEgressMode.private
     assert captured["validation_commands"] is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("preview_error", "expected_code", "expected_message"),
+    (
+        (
+            ValueError("unsupported onboarding template: python"),
+            2,
+            "error: unsupported onboarding template: python",
+        ),
+        (
+            OSError("permission denied reading pyproject.toml"),
+            1,
+            "error: could not build onboarding preview: permission denied reading pyproject.toml",
+        ),
+    ),
+)
+def test_init_guided_template_change_preview_failure_is_reported_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    preview_error: Exception,
+    expected_code: int,
+    expected_message: str,
+) -> None:
+    from awf.cli import main as cli_main
+    from awf.profiles.models import EgressMode
+
+    preview = SimpleNamespace(
+        draft=SimpleNamespace(
+            template="generic",
+            profile=SimpleNamespace(phases=SimpleNamespace(validate_commands=[])),
+        )
+    )
+
+    def _raise_preview_failure(_path: Path, **_kwargs: object) -> object:
+        raise preview_error
+
+    monkeypatch.setattr("awf.cli.main.typer.prompt", lambda *_args, **_kwargs: "python")
+    monkeypatch.setattr(
+        "awf.cli.main.typer.confirm",
+        MagicMock(side_effect=AssertionError("should not continue after preview failure")),
+    )
+
+    with pytest.raises(typer.Exit) as exc_info:
+        cli_main._prompt_project_onboarding_choices(  # noqa: SLF001
+            tmp_path,
+            preview=preview,
+            include_smoke_request=False,
+            supported_templates=("generic", "python"),
+            egress_mode_type=EgressMode,
+            preview_factory=_raise_preview_failure,
+            customize_preview=MagicMock(
+                side_effect=AssertionError("should not customize a failed preview")
+            ),
+        )
+
+    captured = capsys.readouterr()
+    assert exc_info.value.exit_code == expected_code
+    assert expected_message in captured.err
+    assert "Traceback" not in captured.out
+    assert "Traceback" not in captured.err
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -370,6 +370,16 @@ def test_init_write_profile_requires_yes_when_not_guided(
 
 
 @pytest.mark.unit
+def test_init_yes_requires_write_profile(tmp_path: Path) -> None:
+    result = _runner.invoke(app, ["init", str(tmp_path), "--yes"])
+
+    assert result.exit_code == 2, result.output
+    assert "--yes" in result.output
+    assert "--write-profile" in result.output
+    assert not (tmp_path / ".awf" / "workspace.yml").exists()
+
+
+@pytest.mark.unit
 def test_init_guided_requires_interactive_stdio(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -399,7 +409,7 @@ def test_init_guided_writes_answers_into_workspace_yml(
     result = _runner.invoke(
         app,
         ["init", str(tmp_path), "--guided"],
-        input="\nopen\nNeeds package registry and model-provider access.\ny\npytest -q\ny\n",
+        input="\nopen\nNeeds package registry and model-provider access.\ny\npytest -q\nn\ny\n",
     )
 
     assert result.exit_code == 0, result.output
@@ -410,6 +420,27 @@ def test_init_guided_writes_answers_into_workspace_yml(
         == "Needs package registry and model-provider access."
     )
     assert profile["phases"]["validate"] == [{"command": "pytest -q", "required": True}]
+
+
+@pytest.mark.unit
+def test_init_guided_accepts_multiple_validation_commands(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+    monkeypatch.setattr("awf.cli.main._stdio_is_interactive", lambda: True)
+
+    result = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--guided"],
+        input="\n\ny\nmake lint\ny\npytest -q\nn\ny\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    profile = _read_written_profile(tmp_path)
+    assert profile["phases"]["validate"] == [
+        {"command": "make lint", "required": True},
+        {"command": "pytest -q", "required": True},
+    ]
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -596,6 +596,45 @@ def test_init_continues_when_service_status_probe_raises(
 
 
 @pytest.mark.unit
+def test_init_cached_service_status_lets_doctor_handle_probe_exceptions(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"status": 0, "doctor": 0, "status_collector_raised": 0}
+
+    async def _collect_service_status(_settings: object, **_kwargs: object) -> dict[str, object]:
+        calls["status"] += 1
+        raise RuntimeError("service probe is unavailable")
+
+    async def _collect_doctor_report(
+        _settings: object,
+        **kwargs: object,
+    ) -> object:
+        calls["doctor"] += 1
+        status_collector = kwargs["status_collector"]
+        with pytest.raises(RuntimeError, match="service probe is unavailable"):
+            await status_collector(_settings, strict_providers=frozenset(), provider_environ={})
+        calls["status_collector_raised"] += 1
+        return SimpleNamespace(status="fail", diagnostics=())
+
+    monkeypatch.setattr("awf.service.config.resolve_service_settings", lambda: object())
+    monkeypatch.setattr("awf.service.status.collect_service_status", _collect_service_status)
+    monkeypatch.setattr("awf.service.doctor.collect_doctor_report", _collect_doctor_report)
+    monkeypatch.setattr(
+        "awf.service.doctor.render_doctor_pretty",
+        lambda report: f"AWF doctor: {getattr(report, 'status', 'unknown')}\n",
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == {"status": 1, "doctor": 1, "status_collector_raised": 1}
+    assert "service status: fail" in result.output
+    assert "AWF doctor: fail" in result.output
+    assert "Local prerequisites are not fully ready yet" in result.output
+
+
+@pytest.mark.unit
 def test_init_uses_cached_service_status_for_doctor_report(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -474,6 +474,7 @@ def test_init_guided_egress_choices_follow_model_enum(
     assert wants_write is False
     assert prompt_defaults == ["generic", CustomEgressMode.restricted.value]
     assert captured["egress_mode"] == CustomEgressMode.private
+    assert captured["validation_commands"] is None
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -518,7 +518,7 @@ def test_init_json_mode_never_prompts_and_reports_structured_state(
     assert payload["service_status"]["status"] == "ok"
     assert payload["doctor_status"] == "ok"
     assert "written_path" not in payload
-    assert "prompt" not in result.output.lower()
+    assert "prompt" not in payload
     assert not (tmp_path / ".awf" / "workspace.yml").exists()
 
 

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -334,6 +334,26 @@ def test_init_write_profile_yes_creates_default_workspace_yml(
 
 
 @pytest.mark.unit
+def test_init_write_profile_json_reports_profile_exists_after_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    result = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes", "--format", "json"],
+    )
+
+    written_path = tmp_path / ".awf" / "workspace.yml"
+    assert result.exit_code == 0, result.output
+    assert written_path.exists()
+    payload = json.loads(result.output)
+    assert payload["mode"] == "write"
+    assert payload["written_path"] == str(written_path)
+    assert payload["profile_exists"] is True
+
+
+@pytest.mark.unit
 def test_init_write_profile_requires_yes_when_not_guided(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from enum import StrEnum
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -387,6 +388,47 @@ def test_init_guided_writes_answers_into_workspace_yml(
         == "Needs package registry and model-provider access."
     )
     assert profile["phases"]["validate"] == [{"command": "pytest -q", "required": True}]
+
+
+@pytest.mark.unit
+def test_init_guided_egress_choices_follow_model_enum(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from awf.cli import main as cli_main
+
+    class CustomEgressMode(StrEnum):
+        restricted = "restricted"
+        private = "private"
+
+    preview = SimpleNamespace(
+        draft=SimpleNamespace(
+            template="generic",
+            profile=SimpleNamespace(phases=SimpleNamespace(validate_commands=["pytest -q"])),
+        )
+    )
+    captured: dict[str, object] = {}
+    prompt_answers = iter(["generic", "private"])
+
+    monkeypatch.setattr("awf.cli.main.typer.prompt", lambda *_args, **_kwargs: next(prompt_answers))
+    monkeypatch.setattr("awf.cli.main.typer.confirm", lambda *_args, **_kwargs: False)
+
+    def customize_preview(received_preview: object, **kwargs: object) -> object:
+        captured.update(kwargs)
+        return received_preview
+
+    result, wants_write = cli_main._prompt_project_onboarding_choices(  # noqa: SLF001
+        tmp_path,
+        preview=preview,
+        include_smoke_request=False,
+        supported_templates=("generic",),
+        egress_mode_type=CustomEgressMode,
+        preview_factory=lambda *_args, **_kwargs: preview,
+        customize_preview=customize_preview,
+    )
+
+    assert result is preview
+    assert wants_write is False
+    assert captured["egress_mode"] == CustomEgressMode.private
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init.py
+++ b/tests/unit/cli/test_init.py
@@ -576,6 +576,29 @@ def test_init_invalid_project_path_is_reported_without_service_checks(
 
 
 @pytest.mark.unit
+def test_init_reports_unexpected_preview_failure_without_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_local_prerequisites(monkeypatch)
+
+    def _raise_preview_failure(_path: Path, **_kwargs: object) -> object:
+        raise OSError("permission denied reading pyproject.toml")
+
+    monkeypatch.setattr(
+        "awf.profiles.onboarding.preview_project_onboarding",
+        _raise_preview_failure,
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path)])
+
+    assert result.exit_code == 1, result.output
+    assert (
+        "error: could not build onboarding preview: permission denied reading pyproject.toml"
+    ) in result.output
+    assert "Traceback" not in result.output
+
+
+@pytest.mark.unit
 def test_init_prints_clear_next_steps(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     _stub_local_prerequisites(monkeypatch)
 

--- a/tests/unit/docs/test_public_docs_status.py
+++ b/tests/unit/docs/test_public_docs_status.py
@@ -108,6 +108,18 @@ def test_quickstart_is_canonical_and_not_a_stub() -> None:
     assert "[Quickstart](QUICKSTART.md)" in start_here_text
 
 
+def test_project_onboarding_docs_make_awf_init_primary() -> None:
+    quickstart_text = (REPO_ROOT / "docs" / "QUICKSTART.md").read_text(encoding="utf-8")
+    getting_started_text = (REPO_ROOT / "docs" / "GETTING_STARTED.md").read_text(encoding="utf-8")
+    onboarding_text = (REPO_ROOT / "docs" / "PROJECT_ONBOARDING.md").read_text(encoding="utf-8")
+
+    assert "awf init . --write-profile --yes" in quickstart_text
+    assert "awf init <path> --write-profile --yes" in getting_started_text
+    assert "awf init . --write-profile --yes" in onboarding_text
+    assert "v2 request-shaped" not in onboarding_text
+    assert "awf profile init . --write" not in quickstart_text
+
+
 def test_changelog_and_upgrade_guide_are_discoverable() -> None:
     readme_text = README_PATH.read_text(encoding="utf-8")
 

--- a/tests/unit/profiles/test_profiles.py
+++ b/tests/unit/profiles/test_profiles.py
@@ -1353,6 +1353,20 @@ def test_workspace_profile_with_validation_commands_returns_self_for_empty_overr
 
 
 @pytest.mark.unit
+def test_workspace_profile_clear_validation_commands_removes_existing_commands() -> None:
+    profile = WorkspaceProfile(name="generic", phases={"validate": ["pytest -q", "ruff check"]})
+
+    result = profile.clear_validation_commands()
+
+    assert result is not profile
+    assert result.phases.validate_commands == []
+    assert [command.command for command in profile.phases.validate_commands] == [
+        "pytest -q",
+        "ruff check",
+    ]
+
+
+@pytest.mark.unit
 def test_unknown_profile_ref_raises_resolution_error(tmp_path: Path) -> None:
     with pytest.raises(ProfileResolutionError, match="unknown workspace profile_ref"):
         ProfileResolver().resolve(worktree_path=tmp_path, profile_ref="missing-profile")

--- a/tests/unit/profiles/test_project_onboarding.py
+++ b/tests/unit/profiles/test_project_onboarding.py
@@ -24,6 +24,7 @@ from awf.profiles.onboarding import (
     _compose_web_port_scheme,
     _diagnostics_for,
     _profile_for_template,
+    customize_project_onboarding_preview,
     draft_workspace_profile,
     inspect_project,
     preview_project_onboarding,
@@ -96,6 +97,43 @@ def test_detects_python_template_and_generates_valid_profile(tmp_path: Path) -> 
     assert draft.profile.name == "python"
     assert [command.command for command in draft.profile.phases.validate_commands] == ["pytest -q"]
     assert WorkspaceProfile.model_validate(draft.profile.model_dump(mode="json")) == draft.profile
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("validation_commands", [[], ["  ", "\t"]])
+def test_customize_preview_empty_validation_commands_clear_detected_commands(
+    tmp_path: Path,
+    validation_commands: list[str],
+) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "app"\n', encoding="utf-8")
+    preview = preview_project_onboarding(tmp_path, include_smoke_request=True)
+
+    customized = customize_project_onboarding_preview(
+        preview,
+        validation_commands=validation_commands,
+    )
+
+    assert customized.draft.profile.phases.validate_commands == []
+    assert customized.smoke_request is not None
+    assert customized.smoke_request["validation"] == {"commands": [], "requested_tier": 1}
+    assert "No validation command was detected; add lint, test, or build commands." in (
+        customized.diagnostics.missing_validation_commands
+    )
+
+
+@pytest.mark.unit
+def test_customize_onboarding_preview_none_validation_commands_preserves_detected_commands(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "app"\n', encoding="utf-8")
+    preview = preview_project_onboarding(tmp_path)
+
+    customized = customize_project_onboarding_preview(preview, validation_commands=None)
+
+    assert [command.command for command in customized.draft.profile.phases.validate_commands] == [
+        "pytest -q"
+    ]
+    assert customized.diagnostics.missing_validation_commands == ()
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- make `awf init <repo>` the canonical project onboarding path
- add guided and silent `.awf/workspace.yml` writing with typed profile customization
- keep project onboarding usable when local service/doctor checks are unhealthy
- update public docs away from `awf profile init --write` as the primary path

## Validation
- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_init.py tests/unit/cli/test_profile_init.py tests/unit/docs -q`
- `uv run --python 3.12 --extra dev ruff check src/awf tests`
- `uv run --python 3.12 --extra dev mypy src/awf`

## Notes
- `awf profile init` remains supported as a lower-level expert command.
- MCP-guided onboarding is intentionally left for a later slice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Guided and non-interactive project onboarding via a unified `awf init <path>` flow with template selection, profile writing, and optional smoke-request preview.
  * Flags for guided mode, non-interactive write confirmation, template selection, and forced overwrite; structured JSON output for automation.

* **Bug Fixes**
  * Prevent accidental profile overwrites when alternate profile markers exist.
  * Respect final guided-write confirmation; improved friendly CLI error messaging (no raw tracebacks).

* **Improvements**
  * Better local readiness checks and clearer next-step suggestions when prerequisites are unhealthy.

* **Documentation**
  * Updated onboarding, quickstart, and getting-started guides to make `awf init` the primary workflow.

* **Tests**
  * Expanded unit tests covering onboarding flows, write behavior, JSON output, and validation-command handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->