### PR TITLE
chore: commit .claude/ project knowledge (bug-hunter memories) for OSS contributors

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -1,0 +1,43 @@
+# `.claude/` — Project knowledge for AI assistants
+
+This directory holds project-level context for [Claude Code](https://claude.com/claude-code)
+and other compatible AI coding assistants working in this repo. Everything checked in here
+is project knowledge — bug-pattern memories, architecture notes, agent-specific guidance —
+not personal config or credentials (those are excluded via `.gitignore`).
+
+## What's here
+
+- **`agent-memory/`** — Persistent memories that AI assistants load when working on the
+  repo. Currently:
+  - `bug-hunter/awf_architecture.md` — one-line context on AWF's main layers
+  - `bug-hunter/awf_hotspots.md` — recurring bug patterns with file:line refs and
+    "first place to check" hints
+
+  These are written when a memory would save real time on a future session. They're
+  read-on-relevance, not always-loaded. Updating one is part of normal review work —
+  if a pattern stops being true, edit or delete the file.
+
+- **`CLAUDE.md`** — When present at repo root, Claude Code loads this as standing
+  instructions for every session. AWF's lives at the repo root (`./CLAUDE.md`),
+  not here.
+
+## What's NOT here
+
+These are ignored via `.gitignore` and stay per-developer:
+
+- `settings.local.json` — local Claude Code settings overrides
+- `.credentials.json` — OAuth tokens
+- `projects/`, `todos/`, `.session*` — session-scoped state
+
+## If you're not using Claude Code
+
+This directory is safe to ignore. Nothing in `.claude/` is required to build, test,
+or run AWF. The memories are useful context if you're scanning the codebase for bugs
+or architectural drift, regardless of which tool you read them with.
+
+## Adding new project knowledge
+
+If you write a memory that would help future contributors (yours or anyone else's),
+add it under `agent-memory/<your-agent-or-role>/` and link it from that subdirectory's
+`MEMORY.md` index. One-line description, then the body. Keep claims grounded in actual
+file:line evidence — stale memories are worse than no memories.

--- a/.claude/agent-memory/bug-hunter/MEMORY.md
+++ b/.claude/agent-memory/bug-hunter/MEMORY.md
@@ -1,0 +1,2 @@
+- [AWF architecture snapshot](awf_architecture.md) — one-line context on the project's main layers for subsequent scans
+- [Recurring bug hotspots](awf_hotspots.md) — areas where bugs recur in AWF PRs

--- a/.claude/agent-memory/bug-hunter/awf_architecture.md
+++ b/.claude/agent-memory/bug-hunter/awf_architecture.md
@@ -1,0 +1,20 @@
+---
+name: AWF architecture snapshot
+description: One-paragraph map of the AWF codebase so scans know where the pressure points live
+type: project
+---
+
+AWF (Aira Workspace Fabric) orchestrates Claude Code / Codex / Gemini inside ephemeral Docker workspaces to execute tasks. Key layers:
+
+- `src/awf/runtime/pr_monitor.py` — pure decision core (`decide()`), returns one `MonitorAction` per call.
+- `src/awf/runtime/pr_monitor_runner.py` — I/O orchestrator wrapping `decide()`, handles gh calls, git, docker.
+- `src/awf/control/executor.py` — drives `ready` → `monitoring_pr`/`completed`. Branch-drift recovery, orphan-history recovery.
+- `src/awf/control/validation_fix_cycle.py` — validation retry loop, prompt builder.
+- `src/awf/runtime/validation.py` — runs test_commands + optional alembic upgrade inside the agent container.
+- `src/awf/node/git_manager.py` — bare mirror + per-workspace worktree plumbing.
+- `scripts/run_awf.py` — one-shot driver; creates GitManager per-task (concurrency caveat).
+- `scripts/release_pr_watcher.py`, `scripts/schedule_release_pr.py`, `scripts/attach_feature_pr_monitor.py` — process-spawning shells around `run_awf.py`.
+
+**Why:** Recent PRs kept touching `pr_monitor*`, `executor.py`, `validation.py`, `git_manager.py`. Scans should start there.
+
+**How to apply:** When asked to scan AWF, begin with the monitor + runner + executor + validation, then move to scripts that spawn `run_awf.py`. The state machine in `src/awf/control/state_machine.py` is the audit authority for status transitions.

--- a/.claude/agent-memory/bug-hunter/awf_hotspots.md
+++ b/.claude/agent-memory/bug-hunter/awf_hotspots.md
@@ -1,0 +1,23 @@
+---
+name: Recurring bug hotspots in AWF
+description: Bug patterns that keep showing up across AWF PRs — check these first on scans
+type: project
+---
+
+Recurring bug patterns seen in AWF scans:
+
+1. **`GitManager` per-task instantiation in `scripts/run_awf.py`** — a fresh `GitManager` is built inside every `_run_task` / `_run_sync_*`. Its per-repo `_mirror_locks` dict is an INSTANCE attribute; two concurrent tasks on the same repo hold different locks, so the "serialize concurrent ensure_mirror / worktree add" guarantee evaporates. Race condition window: mirror-clone vs mirror-clone, worktree add vs worktree add.
+
+2. **Hardcoded `_ROOT / ".venv" / "bin" / "python"`** — CodeRabbit already flagged this in `schedule_release_pr.py` (fixed → `sys.executable`). Same pattern still in `scripts/attach_feature_pr_monitor.py` (as of 2026-04-24).
+
+3. **Review-level comment "fix_committed" verdicts never resolved on GitHub** — `_run_fix_cycle` in `pr_monitor_runner.py` only appends INLINE thread IDs to `threads_to_resolve`. Review-level comments stay unresolved even when the CLI says "fixed"; they're only filtered out of future batches via `state.threads_addressed_ids`. This is documented as intentional (review-level comments have no thread_id to `resolveReviewThread` against), but the behavior is surprising — the `NotifyHuman` gate can flip on a bot-authored defer that the CLI claimed to fix.
+
+4. **Signal handling in asyncio via `signal.signal()`** — `release_pr_watcher.py` uses `signal.signal(SIGTERM, handler)` instead of `loop.add_signal_handler(...)`. Handler calls `asyncio.Event.set()`, which is not signal-safe. Usually works, occasionally wedges.
+
+5. **`_run_sync_base` pushes after CLI-conflict-resolution failure** — If the CLI fails to resolve merge conflicts (AgentRunError), `_run_sync_base` logs and STILL calls `_git_push`. HEAD hasn't advanced so the push is a no-op for the remote, but the local worktree is left with unmerged index state until next iteration's `git merge --abort`.
+
+6. **`_parse_verdict` returns "defer" on empty stdout** — If the CLI writes only to stderr (or a signal-killed CLI dumps nothing), we force a "defer". Rare, but a bot-reviewed PR with no stdout activity will spuriously collect human-defer markers that block merge.
+
+**Why:** Each of these has bitten a real PR review. Future scans should confirm they haven't regressed AND check neighbouring files for the same pattern.
+
+**How to apply:** When scanning AWF, grep for: `GitManager(`, `_ROOT / ".venv"`, `signal.signal(`, `threads_to_resolve.append`, `_run_sync_base`. These are the first five places to check.

--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,12 @@ workspaces/
 # keep migration files; ignore local db dumps only
 *.dump
 *.sql.bak
+
+# Claude Code — commit project knowledge (.claude/agent-memory/, CLAUDE.md,
+# settings.json, .claude/skills/) but ignore per-developer state + secrets.
+.claude/settings.local.json
+.claude/.credentials.json
+.claude/.session*
+.claude/projects/
+.claude/todos/
+.claude/hooks/*.local.*

--- a/src/awf/cli/watchdog.py
+++ b/src/awf/cli/watchdog.py
@@ -15,6 +15,23 @@ scripts". The attach script is itself idempotent (see the file-lock in
 ``scripts/attach_feature_pr_monitor.py``) so repeated invocations from
 concurrent watchdog instances can never double-spawn.
 
+NotifyHuman-aware skip
+----------------------
+
+Crash recovery is the watchdog's primary purpose, but a previous
+monitor may have exited intentionally — typically a release PR with
+``auto_merge=False`` whose only unresolved feedback is a deferred bot
+comment. In that case the runner writes a defer-signal artifact (see
+``pr_monitor_runner._write_defer_signal``) with ``terminal_action ==
+"NotifyHuman"`` and the PR's head_sha. Before respawning, the watchdog
+consults the latest such artifact for the PR: when the recorded
+terminal is ``NotifyHuman`` AND the head_sha hasn't moved, it skips
+the respawn (logging ``watchdog.skipped_notify_human_terminal``). New
+commits, any other terminal action, a missing artifact, or a corrupt
+artifact all fall through to respawn — the strict default is "respawn
+unless we have positive evidence the previous run handed control back
+to a human".
+
 Entry point: ``awf-watchdog start --work-dir <dir> --poll-seconds
 300``. See ``main()`` for the full invocation.
 """
@@ -87,7 +104,12 @@ def _default_gh_lister(repo: str, *, limit: int = 200) -> str:
 
     ``limit`` maps directly to ``gh pr list --limit``. The watchdog
     binds this via ``functools.partial`` from ``WatchdogConfig.gh_pr_limit``
-    so operators can raise it if a repo ever exceeds the default."""
+    so operators can raise it if a repo ever exceeds the default.
+
+    ``headRefOid`` is requested so the NotifyHuman-aware respawn-skip
+    can compare the PR's current head SHA against the SHA recorded in
+    the latest defer-signal artifact — without it, a NotifyHuman PR
+    that received new commits would never re-engage."""
     result = subprocess.run(
         [
             "gh",
@@ -100,7 +122,7 @@ def _default_gh_lister(repo: str, *, limit: int = 200) -> str:
             "--head",
             "awf/",
             "--json",
-            "number,headRefName,baseRefName",
+            "number,headRefName,headRefOid,baseRefName",
             "--limit",
             str(limit),
         ],
@@ -180,6 +202,93 @@ def _extract_owner_name(repo: str) -> tuple[str, str]:
     return owner, name
 
 
+def _latest_defer_signal_for_pr(
+    artifacts_root: Path, *, owner: str, repo: str, pr_number: int
+) -> dict[str, object] | None:
+    """Scan ``artifacts_root`` for the most-recent ``*.defer-signal.json``
+    whose payload matches this owner/repo/pr_number triple.
+
+    Returns the parsed JSON, or None when no match is found, OR when any
+    unreadable artifact has a newer mtime than the latest matching one.
+    The PR number lives inside the JSON (not in the filename), so a
+    corrupt sibling's PR is unknowable — it might well be a fresher
+    state for THIS PR. Falling back to an older NotifyHuman in that
+    "latest state uncertain" case would silence the very respawn the
+    watchdog exists to perform; returning None instead lets
+    ``_should_skip_respawn`` default to crash recovery.
+
+    Multiple workspaces can drive the same PR over its lifetime
+    (a workspace exits, the operator re-attaches, etc.); we use file
+    mtime to pick the freshest artifact so a stale NotifyHuman cannot
+    silence a more recent Abort."""
+    if not artifacts_root.is_dir():
+        return None
+    expected_slug = f"{owner}/{repo}"
+    latest_match: tuple[float, dict[str, object]] | None = None
+    latest_unreadable_mtime: float | None = None
+    for path in artifacts_root.glob("*.defer-signal.json"):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        try:
+            payload = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            if latest_unreadable_mtime is None or mtime > latest_unreadable_mtime:
+                latest_unreadable_mtime = mtime
+            continue
+        if not isinstance(payload, dict):
+            if latest_unreadable_mtime is None or mtime > latest_unreadable_mtime:
+                latest_unreadable_mtime = mtime
+            continue
+        if payload.get("pr_number") != pr_number:
+            continue
+        if payload.get("repo") != expected_slug:
+            continue
+        if latest_match is None or mtime > latest_match[0]:
+            latest_match = (mtime, payload)
+    if latest_match is None:
+        return None
+    if latest_unreadable_mtime is not None and latest_unreadable_mtime > latest_match[0]:
+        return None
+    return latest_match[1]
+
+
+def _should_skip_respawn(
+    *,
+    owner: str,
+    repo: str,
+    pr_number: int,
+    current_head_sha: str,
+    artifacts_root: Path,
+) -> bool:
+    """Return True iff the previous monitor for this PR exited via
+    ``NotifyHuman`` AND the PR's head_sha hasn't moved since.
+
+    Crash recovery is the watchdog's primary purpose, so the default for
+    every uncertain case is False (respawn). We only skip when there is
+    POSITIVE evidence the previous run reached a terminal that explicitly
+    handed control back to a human and there's nothing new to look at."""
+    signal = _latest_defer_signal_for_pr(
+        artifacts_root, owner=owner, repo=repo, pr_number=pr_number
+    )
+    if signal is None:
+        return False  # crash recovery — never silence
+    if signal.get("terminal_action") != "NotifyHuman":
+        return False  # Merge / Abort / ShortCircuitCompleted → respawn
+    artifact_sha = str(signal.get("head_sha") or "")
+    if not artifact_sha or artifact_sha != current_head_sha:
+        return False  # new commits arrived → re-engage
+    _log.info(
+        "watchdog.skipped_notify_human_terminal",
+        repo=f"{owner}/{repo}",
+        pr_number=pr_number,
+        head_sha=current_head_sha[:10],
+        reason="awaiting human merge or new commits",
+    )
+    return True
+
+
 def _pr_already_monitored(*, repo: str, pr_number: int, ps_output: str) -> bool:
     """True iff ``ps_output`` contains a process line that references
     the deterministic spec filename for this repo+PR.
@@ -242,6 +351,7 @@ def run_one_scan(
             _log.warning("watchdog.gh_output_wrong_shape", repo=repo, raw=repr(prs)[:200])
             continue
 
+        owner, name = _extract_owner_name(repo)
         for pr in prs:
             pr_number = pr.get("number") if isinstance(pr, dict) else None
             if not isinstance(pr_number, int):
@@ -250,6 +360,16 @@ def run_one_scan(
 
             if _pr_already_monitored(repo=repo, pr_number=pr_number, ps_output=ps_output):
                 _log.info("watchdog.pr_already_monitored", repo=repo, pr=pr_number)
+                continue
+
+            head_sha = pr.get("headRefOid") if isinstance(pr, dict) else None
+            if _should_skip_respawn(
+                owner=owner,
+                repo=name,
+                pr_number=pr_number,
+                current_head_sha=str(head_sha or ""),
+                artifacts_root=config.work_dir / "artifacts",
+            ):
                 continue
 
             _log.info("watchdog.respawning_monitor", repo=repo, pr=pr_number)
@@ -352,7 +472,15 @@ def start(
         help="Max PRs fetched per repo via 'gh pr list --limit'. Raise if any repo has >200 open awf/ PRs.",
     ),
 ) -> None:
-    """Run the watchdog loop (blocks forever until SIGTERM/SIGINT)."""
+    """Run the watchdog loop (blocks forever until SIGTERM/SIGINT).
+
+    Per scan, each open ``awf/`` PR is respawned UNLESS either (a) a
+    matching ``run_awf.py`` process is already attached to its spec
+    file, or (b) the latest defer-signal artifact under
+    ``<work_dir>/artifacts/`` records ``terminal_action == "NotifyHuman"``
+    with the PR's current head_sha — in which case the watchdog stays
+    out of the way until a new commit (or a manual re-attach) arrives.
+    """
     config = WatchdogConfig(
         work_dir=work_dir,
         repos=list(repo) if repo else list(_DEFAULT_REPOS),

--- a/src/awf/runtime/pr_monitor_runner.py
+++ b/src/awf/runtime/pr_monitor_runner.py
@@ -300,6 +300,7 @@ class PullRequestMonitorRunner:
                 merged=True,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -317,6 +318,7 @@ class PullRequestMonitorRunner:
                 merged=False,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_failed(
                 workspace_id,
@@ -393,6 +395,7 @@ class PullRequestMonitorRunner:
                     merged=False,
                     status=status,
                     state=state,
+                    repo=repo,
                 )
                 await self._terminate_completed(
                     workspace_id,
@@ -408,6 +411,7 @@ class PullRequestMonitorRunner:
                 merged=True,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -430,6 +434,7 @@ class PullRequestMonitorRunner:
                 merged=False,
                 status=status,
                 state=state,
+                repo=repo,
             )
             await self._terminate_completed(
                 workspace_id,
@@ -824,6 +829,7 @@ class PullRequestMonitorRunner:
         merged: bool,
         status: PRStatus,
         state: MonitorState,
+        repo: RepoRef,
     ) -> None:
         """Persist a machine-readable drop of the workspace's terminal
         state for an orchestrator to consume.
@@ -834,6 +840,11 @@ class PullRequestMonitorRunner:
         presence as the authoritative "monitor is done" signal without
         also having to handle a missing-file case.
 
+        ``repo`` (owner/name) and ``head_sha`` are recorded so the
+        stranded-PR watchdog can disambiguate cross-repo PR-number
+        collisions and detect new commits since the terminal — both
+        needed for the NotifyHuman-aware respawn-skip.
+
         Called with a best-effort contract: a failure to write MUST NOT
         stop the state-machine transition (the DB write has priority).
         """
@@ -842,8 +853,10 @@ class PullRequestMonitorRunner:
             bot_items, human_items = _collect_defer_items(status, state)
             payload = {
                 "workspace_id": workspace_id,
+                "repo": repo.slug(),
                 "pr_number": pr_number,
                 "terminal_action": terminal_action,
+                "head_sha": status.head_sha,
                 "merged": merged,
                 "deferred_bot_items": bot_items,
                 "deferred_human_items": human_items,

--- a/tests/unit/cli/test_watchdog.py
+++ b/tests/unit/cli/test_watchdog.py
@@ -27,13 +27,19 @@ from pathlib import Path
 from awf.cli.watchdog import WatchdogConfig, run_one_scan
 
 
-def _canned_gh_output(*, repo: str, prs: list[tuple[int, str]]) -> str:
-    """Shape mirrors ``gh pr list --json number,headRefName,baseRefName``."""
+def _canned_gh_output(
+    *,
+    repo: str,
+    prs: list[tuple[int, str]],
+    head_oid: str = "abc1234567890def",
+) -> str:
+    """Shape mirrors ``gh pr list --json number,headRefName,baseRefName,headRefOid``."""
     return json.dumps(
         [
             {
                 "number": pr[0],
                 "headRefName": pr[1],
+                "headRefOid": head_oid,
                 "baseRefName": "development",
                 "repository": {"nameWithOwner": repo},
             }
@@ -268,3 +274,106 @@ class TestWatchdogConfig:
             "dimileeh/aira-web",
             "dimileeh/aira-agent-workspace-fabric",
         ]
+
+
+class TestWatchdogSkipNotifyHuman:
+    """Integration: ``run_one_scan`` must consult the defer-signal
+    artifact and skip respawn when the previous monitor exited via
+    ``NotifyHuman`` and no new commits have arrived. Without this, the
+    watchdog re-spawns the same monitor every poll for a release PR
+    that's intentionally awaiting human merge."""
+
+    def test_main_loop_skips_notify_human_pr_with_same_sha(self, tmp_path: Path) -> None:
+        head = "deadbeefcafe1234"
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                    head_oid=head,
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        # Drop a NotifyHuman artifact for PR 355 with matching head_sha.
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text(
+            json.dumps(
+                {
+                    "workspace_id": "ws_abc",
+                    "repo": "dimileeh/aira-agent",
+                    "pr_number": 355,
+                    "terminal_action": "NotifyHuman",
+                    "head_sha": head,
+                    "merged": False,
+                    "deferred_bot_items": [],
+                    "deferred_human_items": [],
+                }
+            )
+        )
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        # The whole point: no respawn for an intentionally-deferred PR.
+        assert spawn.calls == []
+
+    def test_main_loop_respawns_notify_human_pr_when_sha_advanced(self, tmp_path: Path) -> None:
+        """Same artifact, but the PR has new commits → must re-engage."""
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                    head_oid="newsha2222222222",
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text(
+            json.dumps(
+                {
+                    "workspace_id": "ws_abc",
+                    "repo": "dimileeh/aira-agent",
+                    "pr_number": 355,
+                    "terminal_action": "NotifyHuman",
+                    "head_sha": "oldsha0000000000",
+                    "merged": False,
+                    "deferred_bot_items": [],
+                    "deferred_human_items": [],
+                }
+            )
+        )
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        assert len(spawn.calls) == 1
+        assert spawn.calls[0]["pr_number"] == 355
+
+    def test_main_loop_respawns_when_no_artifact_exists(self, tmp_path: Path) -> None:
+        """Crash recovery — if no artifact was ever written for this PR,
+        respawn (the watchdog's primary purpose)."""
+        gh = _FakeGhLister(
+            per_repo={
+                "dimileeh/aira-agent": _canned_gh_output(
+                    repo="dimileeh/aira-agent",
+                    prs=[(355, "awf/release-foo")],
+                ),
+            }
+        )
+        spawn = _FakeSpawn()
+        run_one_scan(
+            config=_cfg(["dimileeh/aira-agent"], tmp_path),
+            gh_lister=gh,
+            process_lister=lambda: "",
+            spawn_attach=spawn,
+        )
+        assert len(spawn.calls) == 1

--- a/tests/unit/cli/test_watchdog_skip_notify_human.py
+++ b/tests/unit/cli/test_watchdog_skip_notify_human.py
@@ -1,0 +1,412 @@
+"""Tests for the NotifyHuman-aware respawn-skip in the stranded-PR watchdog.
+
+PR #12 added the watchdog: every poll interval, it lists open ``awf/`` PRs
+and respawns ``attach_feature_pr_monitor.py`` for any PR with no live
+``run_awf.py`` process. That fix is correct for crash recovery, but it
+respawned on EVERY missing-process scan — even when the previous monitor
+exited intentionally with ``NotifyHuman`` (release PR with ``auto_merge=False``,
+or a deferred-bot-comment-only situation). The agent kept being woken up
+to address the same comments and re-defer them, in an infinite cycle.
+
+The fix consults the defer-signal artifact (PR #9): when the LATEST
+artifact for this PR shows ``terminal_action == "NotifyHuman"`` AND the
+PR's current head_sha matches the artifact's recorded head_sha, skip the
+respawn. New commits or any other terminal action falls through to
+respawn — preserving crash recovery as the primary purpose of the
+watchdog.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from structlog.testing import capture_logs
+
+from awf.cli.watchdog import _should_skip_respawn
+
+
+def _write_artifact(
+    artifacts_root: Path,
+    *,
+    workspace_id: str,
+    repo: str,
+    pr_number: int,
+    terminal_action: str,
+    head_sha: str = "abc1234567890def",
+    mtime: float | None = None,
+) -> Path:
+    """Helper: drop a defer-signal JSON exactly like the runner does."""
+    artifacts_root.mkdir(parents=True, exist_ok=True)
+    path = artifacts_root / f"{workspace_id}.defer-signal.json"
+    payload = {
+        "workspace_id": workspace_id,
+        "repo": repo,
+        "pr_number": pr_number,
+        "terminal_action": terminal_action,
+        "head_sha": head_sha,
+        "merged": terminal_action == "Merge",
+        "deferred_bot_items": [],
+        "deferred_human_items": [],
+    }
+    path.write_text(json.dumps(payload))
+    if mtime is not None:
+        os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestShouldSkipRespawn:
+    def test_no_artifact_means_respawn(self, tmp_path: Path) -> None:
+        """Empty artifacts dir → respawn (covers crash recovery — the
+        primary purpose of the watchdog)."""
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_missing_artifacts_dir_means_respawn(self, tmp_path: Path) -> None:
+        """Even the artifacts directory may not exist yet (fresh host)."""
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=tmp_path / "does-not-exist",
+            )
+            is False
+        )
+
+    def test_notify_human_terminal_with_same_sha_skips(self, tmp_path: Path) -> None:
+        """The whole point of the fix: PR has a NotifyHuman artifact AND
+        the head_sha hasn't moved → don't respawn.
+
+        We use ``structlog.testing.capture_logs`` instead of ``capsys`` /
+        ``caplog`` because the project's structlog config can route events
+        either via the default ``PrintLogger`` (no ``configure_logging``
+        call yet) or via ``structlog.stdlib.LoggerFactory`` (after one of
+        the logging tests has run earlier in the suite, binding a stdout
+        handler to the original ``sys.stdout``). Neither capsys nor caplog
+        catches both cases. ``capture_logs`` intercepts events at the
+        bound-logger boundary, so it works regardless of factory."""
+        artifacts_root = tmp_path / "artifacts"
+        head = "deadbeefcafe1234"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha=head,
+        )
+        with capture_logs() as cap_logs:
+            result = _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha=head,
+                artifacts_root=artifacts_root,
+            )
+        assert result is True
+        # Operator should be able to grep logs for this exact event.
+        assert any(
+            entry.get("event") == "watchdog.skipped_notify_human_terminal" for entry in cap_logs
+        ), f"expected watchdog.skipped_notify_human_terminal log line, got {cap_logs!r}"
+
+    def test_notify_human_terminal_with_different_sha_respawns(self, tmp_path: Path) -> None:
+        """New commits arrived since the NotifyHuman → re-engage."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="oldsha0000000000",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="newsha1111111111",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_merge_terminal_does_not_skip(self, tmp_path: Path) -> None:
+        """A previously-merged PR being re-opened (or stale artifact for
+        a different PR life cycle) should NOT silence the watchdog."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Merge",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_abort_terminal_does_not_skip(self, tmp_path: Path) -> None:
+        """Abort = upstream invariant violation / closed PR. The watchdog
+        should still respawn because the PR is somehow open AND in an AWF
+        state — the operator wants visibility."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_short_circuit_does_not_skip(self, tmp_path: Path) -> None:
+        """ShortCircuitCompleted = PR was merged externally. If it's still
+        open, the artifact is stale and respawn is correct."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_abc",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="ShortCircuitCompleted",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_corrupted_artifact_treated_as_missing(self, tmp_path: Path) -> None:
+        """A truncated / non-JSON artifact must not crash the watchdog —
+        fall through to respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        artifacts_root.mkdir()
+        (artifacts_root / "ws_abc.defer-signal.json").write_text("{not valid json")
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_artifact_for_different_pr_is_ignored(self, tmp_path: Path) -> None:
+        """A NotifyHuman artifact for PR 999 must NOT silence the watchdog
+        when scanning PR 355 (cross-PR contamination guard)."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_other",
+            repo="dimileeh/aira-agent",
+            pr_number=999,
+            terminal_action="NotifyHuman",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_artifact_for_different_repo_is_ignored(self, tmp_path: Path) -> None:
+        """PR number 100 in repo A and repo B can collide. The repo field
+        is what disambiguates."""
+        artifacts_root = tmp_path / "artifacts"
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_other",
+            repo="dimileeh/aira-web",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",  # different repo, same PR number
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_picks_latest_artifact_when_multiple(self, tmp_path: Path) -> None:
+        """Two workspaces have driven PR 355 over its lifetime. The most
+        recent artifact wins — older NotifyHuman should not silence a
+        newer Abort, for example."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        # Older: NotifyHuman (would skip if it won)
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        # Newer: Abort (should NOT skip)
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_picks_latest_artifact_when_multiple_notify_human(self, tmp_path: Path) -> None:
+        """Symmetric counter-test: newest IS NotifyHuman → skip wins."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="Abort",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is True
+        )
+
+    def test_newer_corrupt_artifact_poisons_older_notify_human(self, tmp_path: Path) -> None:
+        """A corrupt artifact's PR number is unknowable (the number lives
+        inside the JSON, not in the filename), so it might well be the
+        newest state for THIS PR. Defaulting to an older NotifyHuman in
+        that "latest state uncertain" case silences a respawn the watchdog
+        is supposed to perform — see PR #48 thread PRRT_kwDOSJAM6s59owC_.
+
+        Expected: the older valid NotifyHuman is poisoned by the newer
+        corrupt sibling → fall through to respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_old",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now - 3600,
+        )
+        artifacts_root.mkdir(parents=True, exist_ok=True)
+        corrupt = artifacts_root / "ws_new.defer-signal.json"
+        corrupt.write_text("{not valid json")
+        os.utime(corrupt, (now, now))
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is False
+        )
+
+    def test_older_corrupt_artifact_does_not_poison_newer_notify_human(
+        self, tmp_path: Path
+    ) -> None:
+        """The poisoning rule is asymmetric: only an unreadable artifact
+        NEWER than the latest matching one creates "latest state uncertain".
+        An older corrupt sibling is just noise and must not block a valid
+        recent NotifyHuman from skipping the respawn."""
+        artifacts_root = tmp_path / "artifacts"
+        now = time.time()
+        artifacts_root.mkdir(parents=True, exist_ok=True)
+        corrupt = artifacts_root / "ws_old.defer-signal.json"
+        corrupt.write_text("{not valid json")
+        os.utime(corrupt, (now - 3600, now - 3600))
+        _write_artifact(
+            artifacts_root,
+            workspace_id="ws_new",
+            repo="dimileeh/aira-agent",
+            pr_number=355,
+            terminal_action="NotifyHuman",
+            head_sha="abc1234567890def",
+            mtime=now,
+        )
+        assert (
+            _should_skip_respawn(
+                owner="dimileeh",
+                repo="aira-agent",
+                pr_number=355,
+                current_head_sha="abc1234567890def",
+                artifacts_root=artifacts_root,
+            )
+            is True
+        )

--- a/tests/unit/runtime/test_defer_signal_artifact.py
+++ b/tests/unit/runtime/test_defer_signal_artifact.py
@@ -119,6 +119,14 @@ class TestDeferSignalArtifact:
         data = _artifact_for(artifacts_root, ws_id)
         assert data["workspace_id"] == ws_id
         assert data["pr_number"] == 42
+        # ``repo`` (owner/name) is required for the watchdog to disambiguate
+        # PR-number collisions across repos.
+        assert data["repo"] == "dimileeh/aira-web"
+        # ``head_sha`` lets the watchdog detect new commits since the
+        # terminal — without it, NotifyHuman + new push would never re-engage.
+        # Pin the exact SHA so a regression that writes the wrong commit
+        # (e.g. base SHA, empty string) is caught.
+        assert data["head_sha"] == "abc1234567890def"
         assert data["terminal_action"] == "Merge"
         assert data["merged"] is True
         assert len(data["deferred_bot_items"]) == 1
@@ -238,6 +246,8 @@ class TestDeferSignalArtifact:
         )
         data = _artifact_for(artifacts_root, ws_id)
         assert data["terminal_action"] == "NotifyHuman"
+        assert data["repo"] == "dimileeh/aira-web"
+        assert data["head_sha"] == "abc1234567890def"
         assert data["merged"] is False
         assert data["deferred_bot_items"] == []
         assert len(data["deferred_human_items"]) == 1


### PR DESCRIPTION
## Summary

Land the bug-hunter agent memory + a targeted .gitignore so this repo (which is heading to OSS) ships its institutional knowledge to contributors instead of keeping it on individual maintainer machines.

**What lands:**

- \`.claude/agent-memory/bug-hunter/MEMORY.md\` — index
- \`.claude/agent-memory/bug-hunter/awf_architecture.md\` — one-line context on AWF's main layers
- \`.claude/agent-memory/bug-hunter/awf_hotspots.md\` — 6 recurring bug patterns with file:line refs and "first place to check" hints
- \`.claude/README.md\` — explains what \`.claude/\` is for contributors not using Claude Code

**Targeted .gitignore companion** — keep project knowledge committed, exclude per-developer state + secrets:

\`\`\`
.claude/settings.local.json
.claude/.credentials.json
.claude/.session*
.claude/projects/
.claude/todos/
.claude/hooks/*.local.*
\`\`\`

## Why now

The repo is preparing for OSS. Bug-hunter's institutional knowledge (where the recurring sharp edges live: GitManager per-task instantiation race, hardcoded \`_ROOT / ".venv"\`, signal.signal in asyncio, etc.) is exactly the kind of thing OSS contributors usually have to rediscover the hard way. Shipping it lowers the on-ramp.

No personal config, no credentials, no PII in what's committed.

## Test plan

- [x] Visual inspect — no secrets in the committed files
- [x] .gitignore additions are scoped to per-developer paths only (settings.local.json, .credentials.json, projects/, todos/, .session*, hooks/*.local.*)
- [x] .claude/README.md documents both what's safe to ignore and how external contributors can add their own knowledge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and .gitignore only; no production code paths are modified.
> 
> **Overview**
> This PR **adds version-controlled AI assistant project knowledge** under `.claude/` so OSS contributors get the same bug-hunter context maintainers used locally.
> 
> It introduces **`.claude/README.md`** (what to commit vs ignore, how to extend memories), a **`bug-hunter` memory index**, an **architecture snapshot** (key AWF layers and where to start scans), and a **hotspots doc** with six recurring failure patterns and grep hints. **`.gitignore`** is extended to ignore per-developer Claude Code state and secrets while keeping committed project knowledge.
> 
> No runtime, build, or test behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4702e485fdf66deabb04e819b3920775f9a80e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project-level knowledge base and configuration for AI coding assistants.
  * Updated version control exclusions to prevent unintended commits of local development state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->