### PR TITLE
fix: bundle docker buildx plugin; make DinD image profile-configurable (#297)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,8 +85,9 @@ then re-run the same command or `pre-commit run --all-files` before committing.
 ### Build the Agent Runtime Image
 
 AWF workspaces use `awf-agent-runtime:latest` unless configured otherwise.
-The image includes the Docker CLI and Docker Compose plugin so DinD profiles
-can run project Compose diagnostics inside the workspace sidecar. Rebuild this
+The image includes the Docker CLI, Docker Compose plugin, and the Docker
+Buildx plugin so DinD profiles can run project Compose diagnostics (with
+BuildKit, not the legacy builder) inside the workspace sidecar. Rebuild this
 image whenever the runtime Dockerfile or those Docker tooling packages change.
 
 ```bash

--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -70,9 +70,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libxkbcommon0 \
     && rm -rf /var/lib/apt/lists/*
 
-# ── Stage 2: Docker CLI + Compose plugin ──────────────────────────────────
+# ── Stage 2: Docker CLI + Compose + Buildx plugins ────────────────────────
+# Buildx is the client-side plugin Compose uses to drive BuildKit builds.
+# Without it, `docker compose` warns ("requires buildx plugin to be
+# installed") and falls back to the legacy builder. The agent is the Docker
+# client inside DinD workspaces (DOCKER_HOST=tcp://docker:2375), so it needs
+# buildx locally even though the DinD daemon already ships BuildKit.
 ARG DOCKER_CE_CLI_VERSION=5:29.4.1-1~debian.12~bookworm
 ARG DOCKER_COMPOSE_PLUGIN_VERSION=5.1.3-1~debian.12~bookworm
+ARG DOCKER_BUILDX_PLUGIN_VERSION=0.34.1-1~debian.12~bookworm
 RUN install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg \
       -o /etc/apt/keyrings/docker.asc \
@@ -84,9 +90,11 @@ RUN install -m 0755 -d /etc/apt/keyrings \
     && apt-get install -y --no-install-recommends \
         "docker-ce-cli=${DOCKER_CE_CLI_VERSION}" \
         "docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}" \
+        "docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}" \
     && rm -rf /var/lib/apt/lists/* \
     && docker --version \
-    && docker compose version
+    && docker compose version \
+    && docker buildx version
 
 # ── Stage 3: GitHub CLI ───────────────────────────────────────────────────
 ARG GH_VERSION=2.92.0

--- a/docker/control-plane.Dockerfile
+++ b/docker/control-plane.Dockerfile
@@ -6,6 +6,11 @@ ENV PATH="/app/.venv/bin:${PATH}"
 
 ARG DOCKER_CE_CLI_VERSION=5:29.4.1-1~debian.12~bookworm
 ARG DOCKER_COMPOSE_PLUGIN_VERSION=5.1.3-1~debian.12~bookworm
+# Buildx is the client-side plugin Compose uses to drive BuildKit builds.
+# The control plane runs `docker compose up` for the outer workspace stack
+# (which builds managed companions), so it needs buildx to avoid the legacy
+# builder and the "requires buildx plugin" warning.
+ARG DOCKER_BUILDX_PLUGIN_VERSION=0.34.1-1~debian.12~bookworm
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -26,6 +31,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         "docker-ce-cli=${DOCKER_CE_CLI_VERSION}" \
         "docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}" \
+        "docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}" \
         gh \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/control-plane.Dockerfile
+++ b/docker/control-plane.Dockerfile
@@ -33,7 +33,10 @@ RUN apt-get update \
         "docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}" \
         "docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}" \
         gh \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && docker --version \
+    && docker compose version \
+    && docker buildx version
 
 WORKDIR /app
 

--- a/openapi.json
+++ b/openapi.json
@@ -2805,6 +2805,7 @@
             "default": "docker:27-dind",
             "maxLength": 512,
             "minLength": 1,
+            "pattern": "^[a-zA-Z0-9][a-zA-Z0-9_./:@-]*$",
             "title": "Dind Image",
             "type": "string"
           },

--- a/openapi.json
+++ b/openapi.json
@@ -2801,6 +2801,13 @@
             "title": "Compose Files",
             "type": "array"
           },
+          "dind_image": {
+            "default": "docker:27-dind",
+            "maxLength": 512,
+            "minLength": 1,
+            "title": "Dind Image",
+            "type": "string"
+          },
           "mode": {
             "$ref": "#/components/schemas/DockerMode",
             "default": "none"

--- a/plans/ISSUE_297_DIND_BUILDX_PLAN.md
+++ b/plans/ISSUE_297_DIND_BUILDX_PLAN.md
@@ -4,7 +4,7 @@
 
 Every `docker compose up` in a DinD workspace prints:
 
-```
+```text
 level=warning msg="Docker Compose requires buildx plugin to be installed"
 ```
 

--- a/plans/ISSUE_297_DIND_BUILDX_PLAN.md
+++ b/plans/ISSUE_297_DIND_BUILDX_PLAN.md
@@ -1,0 +1,78 @@
+# Issue #297 — buildx plugin for DinD workspaces
+
+## Problem
+
+Every `docker compose up` in a DinD workspace prints:
+
+```
+level=warning msg="Docker Compose requires buildx plugin to be installed"
+```
+
+Compose then falls back to the legacy builder. The warning is noise, pollutes
+`COMPOSE_COMMAND_FAILED` stderr (false-cause for unrelated failures), and the
+legacy builder forgoes BuildKit features (cache mounts, `--secret`).
+
+## Root cause (corrected from the issue's framing)
+
+The warning is **client-side** — emitted by whichever `docker compose` CLI runs
+the build, not by the DinD daemon image the issue points at
+(`compose_manager.py:169`). In AWF the Docker clients are:
+
+- `docker/agent-runtime.Dockerfile` — the agent is the Docker client inside a
+  DinD workspace (`DOCKER_HOST=tcp://docker:2375`). It installed `docker-ce-cli`
+  + `docker-compose-plugin` but **not** `docker-buildx-plugin`.
+- `docker/control-plane.Dockerfile` — runs `docker compose up` for the outer
+  workspace stack (which builds managed companions). Same gap.
+
+The `docker:27-dind` daemon already ships BuildKit, so the daemon side was fine.
+Fixing only the DinD image would not have silenced the warning when the agent or
+control plane runs compose.
+
+## Approach (option C — comprehensive)
+
+1. Add the official, pinned `docker-buildx-plugin` to both AWF-built client
+   images, mirroring the existing `docker-compose-plugin` install (pinned ARG +
+   apt from the already-configured Docker repo + version check). This silences
+   the warning at its real source and unlocks BuildKit features.
+2. Make the DinD daemon image profile-configurable
+   (`ProfileDocker.dind_image`, default unchanged `docker:27-dind`) so the
+   hardcoding the issue calls out is removed without forcing a new image or a
+   registry/publish pipeline on the OSS core.
+
+Pinned buildx version: `0.34.1-1~debian.12~bookworm` — the latest stable in the
+Docker apt repo for bookworm (verified against the live package index), well
+above the `>= 0.17` minimum Compose requires.
+
+## Changes
+
+- `docker/agent-runtime.Dockerfile`: `ARG DOCKER_BUILDX_PLUGIN_VERSION` +
+  `docker-buildx-plugin=${...}` in Stage 2 apt install + `docker buildx version`.
+- `docker/control-plane.Dockerfile`: same ARG + apt package.
+- `src/awf/profiles/models.py`: `ProfileDocker.dind_image: str` (default
+  `docker:27-dind`, `min_length=1`, `max_length=512`).
+- `src/awf/node/stack_launcher.py`: pass `dind_image=profile.docker.dind_image`
+  into `WorkspaceComposeSpec`.
+- `openapi.json`: regenerated for the new `ProfileDocker.dind_image` property.
+- `CONTRIBUTING.md`: note buildx is bundled in the agent-runtime image.
+
+## Tests
+
+- `tests/unit/test_agent_runtime_dockerfile.py`: pinned buildx ARG + apt package
+  + `docker buildx version`; CONTRIBUTING section mentions buildx.
+- `tests/unit/test_control_plane_dockerfile.py` (new): docker CLI + compose +
+  pinned buildx packages.
+- `tests/unit/profiles/test_profiles.py`: `dind_image` default, override,
+  empty-string rejection.
+- `tests/unit/node/test_stack_launcher.py`: default + custom `dind_image` flow
+  from profile into the compose spec.
+- `tests/unit/node/test_compose_manager.py`: custom `dind_image` reaches the
+  rendered `docker` service.
+
+## NOT in scope
+
+- Custom `awf-dind` image / registry pipeline (issue Option A) — unnecessary once
+  clients carry buildx; daemon already has BuildKit.
+- DinD entrypoint apk-install of buildx (Option B) — needs startup egress, slower.
+- Changing the default DinD image or pointing any profile at a non-default image.
+- buildx-feature usage docs (`--secret`, cache mounts) — availability is the
+  enabler; usage docs can follow separately.

--- a/plans/ISSUE_297_DIND_BUILDX_VALIDATION.md
+++ b/plans/ISSUE_297_DIND_BUILDX_VALIDATION.md
@@ -1,0 +1,62 @@
+# Issue #297 — buildx plugin for DinD workspaces — Validation
+
+Validation of the implementation against `ISSUE_297_DIND_BUILDX_PLAN.md`.
+
+## Plan adherence
+
+| Plan item | Status | Notes |
+|-----------|--------|-------|
+| buildx in agent-runtime image | Done | `ARG DOCKER_BUILDX_PLUGIN_VERSION=0.34.1-1~debian.12~bookworm`, `docker-buildx-plugin=${...}` in Stage 2 apt install, `docker buildx version` verification. |
+| buildx in control-plane image | Done | Same pinned ARG + `docker-buildx-plugin` in apt install. |
+| Profile-configurable `dind_image` | Done | `ProfileDocker.dind_image` (default `docker:27-dind`), plumbed via `stack_launcher.py` into `WorkspaceComposeSpec`. |
+| Regenerate OpenAPI | Done | `ProfileDocker.dind_image` present; `generate_openapi.py --check` clean. |
+| Docs | Done | CONTRIBUTING "Build the Agent Runtime Image" notes buildx. |
+
+## Version pin verification
+
+Queried the live Docker apt repo
+(`download.docker.com/linux/debian/dists/bookworm/stable/binary-amd64`):
+
+- `docker-ce-cli=5:29.4.1-1~debian.12~bookworm` — exists (matches existing pin).
+- `docker-compose-plugin=5.1.3-1~debian.12~bookworm` — exists (matches existing pin).
+- `docker-buildx-plugin=0.34.1-1~debian.12~bookworm` — latest stable available;
+  well above the `>= 0.17` minimum Compose requires. Not fabricated.
+
+## Tests added
+
+- `tests/unit/test_agent_runtime_dockerfile.py` — pinned buildx ARG/package +
+  `docker buildx version`; CONTRIBUTING section mentions buildx.
+- `tests/unit/test_control_plane_dockerfile.py` (new) — docker CLI + compose +
+  pinned buildx packages.
+- `tests/unit/profiles/test_profile_docker_config.py` (new) — `dind_image`
+  default, override, empty rejection.
+- `tests/unit/node/test_stack_launcher.py` — default + custom `dind_image` flow.
+- `tests/unit/node/test_compose_manager.py` — custom `dind_image` render +
+  `ensure_project_up(wait=False)` flag omission.
+- `tests/unit/profiles/test_profile_models_helpers.py` (new) — health-check
+  command/target getters, URL userinfo redaction, method/scheme normalizers.
+- `tests/unit/node/test_stack_launcher_edge_cases.py` (new) —
+  `DOCKER_UNAVAILABLE` with no required services / empty detail; parsed
+  companion compose-up timeout branch.
+- `tests/unit/node/test_service_auth_mounts.py` — read-only mount chown skip.
+
+## Validation gate results
+
+- `ruff check .` — All checks passed.
+- `ruff format --check .` — all files formatted.
+- `mypy` — Success, no issues in 288 source files.
+- `python scripts/generate_openapi.py --check` — spec matches the app.
+- `pytest -n 20 --dist=loadscope --cov=awf` — 8702 passed; coverage 99.01%
+  (`Required test coverage of 99.0% reached`).
+
+## Gaps / notes
+
+- The buildx warning is client-side; the fix targets the agent-runtime and
+  control-plane images (the actual Docker clients) rather than the DinD daemon
+  image the issue named. The DinD image remains profile-configurable but its
+  default is unchanged.
+- A live "no buildx warning" assertion would require an integration test that
+  builds the real agent-runtime image (not the lightweight `docker:27-cli`
+  stand-in used by `test_compose_manager_dind_dogfood.py`); deferred as it needs
+  a Docker daemon and a full image build. Dockerfile-content tests + the
+  bootstrap/CI image builds enforce the package presence instead.

--- a/src/awf/node/stack_launcher.py
+++ b/src/awf/node/stack_launcher.py
@@ -170,6 +170,7 @@ class ComposeStackLauncher:
             agent_runtime_image=self._agent_runtime_image,
             agent_environment=agent_environment,
             docker_mode=profile.docker.mode.value,
+            dind_image=profile.docker.dind_image,
             services=services,
             companions=companions,
             auth_mounts=tuple(auth_mounts),

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -63,6 +63,7 @@ class ProfileDocker(BaseModel):
     compose_files: list[str] = Field(default_factory=list)
     project_directory: str = "."
     startup_timeout_seconds: int = Field(default=300, ge=1, le=7200)
+    dind_image: str = Field(default="docker:27-dind", min_length=1, max_length=512)
 
 
 class ProfileCommand(BaseModel):

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -63,7 +63,15 @@ class ProfileDocker(BaseModel):
     compose_files: list[str] = Field(default_factory=list)
     project_directory: str = "."
     startup_timeout_seconds: int = Field(default=300, ge=1, le=7200)
-    dind_image: str = Field(default="docker:27-dind", min_length=1, max_length=512)
+    # Interpolated unescaped into image: "{{ s.image }}" in the compose Jinja
+    # template (autoescape=False), so guard the canonical image-reference grammar
+    # here to keep an embedded quote/newline from injecting compose YAML.
+    dind_image: str = Field(
+        default="docker:27-dind",
+        min_length=1,
+        max_length=512,
+        pattern=r"^[a-zA-Z0-9][a-zA-Z0-9_./:@-]*$",
+    )
 
 
 class ProfileCommand(BaseModel):

--- a/src/awf/runtime/validation_identity.py
+++ b/src/awf/runtime/validation_identity.py
@@ -56,6 +56,7 @@ def environment_identity_inputs(profile: WorkspaceProfile) -> dict[str, Any]:
             "mode": str(profile.docker.mode),
             "compose_files": sorted(profile.docker.compose_files),
             "project_directory": profile.docker.project_directory,
+            "dind_image": profile.docker.dind_image,
             "startup_timeout_seconds": profile.docker.startup_timeout_seconds,
         },
         "services": [_service_identity(service) for service in _sorted_services(profile.services)],

--- a/tests/unit/node/test_compose_manager.py
+++ b/tests/unit/node/test_compose_manager.py
@@ -589,6 +589,18 @@ class TestRender:
         assert parsed["volumes"]["dind_data"]["name"] == "awf-ws_test123-dind_data"
 
     @pytest.mark.unit
+    def test_dind_daemon_uses_configured_dind_image(
+        self, manager: ComposeManager, tmp_path: Path
+    ) -> None:
+        spec = _spec(
+            tmp_path,
+            docker_mode="dind",
+            dind_image="ghcr.io/example/dind:buildx",
+        )
+        parsed = yaml.safe_load(manager.render(spec).compose_file.read_text())
+        assert parsed["services"]["docker"]["image"] == "ghcr.io/example/dind:buildx"
+
+    @pytest.mark.unit
     def test_dind_mode_sets_default_agent_docker_host(
         self, manager: ComposeManager, tmp_path: Path
     ) -> None:
@@ -799,6 +811,32 @@ class TestRender:
         assert isinstance(env, dict)
         assert env["COMPOSE_PROJECT_NAME"] == "awf_ws_long_flags"
         assert env["COMPOSE_FILE"] == str(compose_file)
+
+    @pytest.mark.unit
+    async def test_ensure_project_up_without_wait_omits_wait_flags(
+        self,
+        manager: ComposeManager,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[tuple[object, ...]] = []
+
+        async def _spawn(*args: object, **_kwargs: object) -> _FakeProcess:
+            calls.append(args)
+            return _FakeProcess(returncode=0)
+
+        monkeypatch.setattr(compose_module.asyncio, "create_subprocess_exec", _spawn)
+
+        await manager.ensure_project_up(
+            project_name="awf_ws_resume",
+            compose_file=tmp_path / "compose.yml",
+            workspace_id="ws_resume",
+            wait=False,
+        )
+
+        assert calls
+        assert calls[0] == ("docker", "compose", "up", "-d", "--remove-orphans")
+        assert "--wait" not in calls[0]
 
     @pytest.mark.unit
     async def test_compose_command_times_out_and_kills_hung_process(

--- a/tests/unit/node/test_service_auth_mounts.py
+++ b/tests/unit/node/test_service_auth_mounts.py
@@ -8,6 +8,7 @@ import pytest
 
 from awf.node import auth_mounts as auth_mounts_mod
 from awf.node.auth_mounts import ServiceAuthMountResolver, resolve_service_auth_mounts
+from awf.node.compose_manager import AuthMount
 
 
 @pytest.mark.unit
@@ -620,3 +621,14 @@ def test_service_auth_mounts_skip_missing_paths(tmp_path: Path) -> None:
     )
 
     assert mounts == ()
+
+
+@pytest.mark.unit
+def test_chown_workspace_auth_sources_skips_read_only_mounts() -> None:
+    # Read-only mounts must be skipped: no chown is attempted on the source,
+    # so a non-existent path is safe and the call returns without error.
+    auth_mounts_mod._chown_workspace_auth_sources(  # noqa: SLF001
+        [AuthMount(source="/nonexistent/ro-source", target="/agent/ro", mode="ro")],
+        uid=1000,
+        gid=1000,
+    )

--- a/tests/unit/node/test_stack_launcher.py
+++ b/tests/unit/node/test_stack_launcher.py
@@ -432,12 +432,39 @@ async def test_compose_stack_launcher_builds_profile_driven_spec() -> None:
     assert spec.agent_runtime_image == "custom-agent-runtime:dev"
     assert ("DATABASE_URL", "postgresql://awf@postgres/awf") in spec.agent_environment
     assert spec.docker_mode == "dind"
+    assert spec.dind_image == "docker:27-dind"
     assert spec.git_name == "AWF Agent"
     assert spec.git_email == "awf@example.com"
     assert [service.name for service in spec.services] == ["postgres"]
     assert spec.auth_mounts[0].source == str(layout.mirror_path)
     assert spec.auth_mounts[0].target == str(layout.mirror_path)
     assert spec.auth_mounts[0].mode == "rw"
+
+
+@pytest.mark.unit
+async def test_compose_stack_launcher_passes_profile_dind_image_to_spec() -> None:
+    compose = _RecordingCompose()
+    launcher = ComposeStackLauncher(
+        compose=compose,  # type: ignore[arg-type]
+        agent_runtime_image="custom-agent-runtime:dev",
+    )
+    profile = WorkspaceProfile(
+        name="serviceful",
+        docker=ProfileDocker(
+            mode=DockerMode.dind,
+            dind_image="ghcr.io/example/dind:buildx",
+        ),
+    )
+
+    await launcher.launch(
+        WorkspaceStackLaunchRequest(
+            workspace_id="ws_launcher",
+            layout=_layout(),
+            profile=profile,
+        )
+    )
+
+    assert compose.specs[0].dind_image == "ghcr.io/example/dind:buildx"
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_stack_launcher_edge_cases.py
+++ b/tests/unit/node/test_stack_launcher_edge_cases.py
@@ -1,0 +1,81 @@
+"""Edge-case coverage for the workspace stack launcher.
+
+Complements ``test_stack_launcher.py`` (kept in a separate module so the main
+suite stays under the first-party file line cap). Covers the
+``DOCKER_UNAVAILABLE`` path with no required services / empty diagnostics and
+the parsed-spec branch of the companion compose-up timeout helper.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.node.companion_services import WorkspaceCompanionSpec
+from awf.node.compose_manager import ComposeOperationError, WorkspaceComposeSpec
+from awf.node.git_manager import WorktreeLayout
+from awf.node.stack_launcher import (
+    ComposeStackLauncher,
+    WorkspaceServiceExecutionError,
+    WorkspaceStackLaunchRequest,
+    effective_compose_up_timeout_seconds,
+)
+from awf.profiles.models import ProfileDocker, WorkspaceProfile
+
+
+class _UnavailableCompose:
+    def __init__(self) -> None:
+        self.specs: list[WorkspaceComposeSpec] = []
+
+    async def up(self, spec: WorkspaceComposeSpec, *, wait: bool = True) -> None:
+        del wait
+        self.specs.append(spec)
+        raise ComposeOperationError(
+            operation="up",
+            returncode=1,
+            stdout="",
+            stderr="",
+            reason_code="DOCKER_UNAVAILABLE",
+        )
+
+
+def _layout() -> WorktreeLayout:
+    return WorktreeLayout(
+        mirror_path=Path("/host/awf/git/mirrors/repo.git"),
+        worktree_path=Path("/host/awf/git/worktrees/ws_edge"),
+        branch_name="awf/ws_edge",
+    )
+
+
+@pytest.mark.unit
+async def test_docker_unavailable_without_required_services_or_detail() -> None:
+    launcher = ComposeStackLauncher(
+        compose=_UnavailableCompose(),  # type: ignore[arg-type]
+        agent_runtime_image="custom-agent-runtime:dev",
+    )
+
+    with pytest.raises(WorkspaceServiceExecutionError) as raised:
+        await launcher.launch(
+            WorkspaceStackLaunchRequest(
+                workspace_id="ws_edge",
+                layout=_layout(),
+                profile=WorkspaceProfile(name="bare"),
+            )
+        )
+
+    message = str(raised.value)
+    assert message == "DOCKER_UNAVAILABLE: Cannot start workspace agent container"
+    assert "required services" not in message
+
+
+@pytest.mark.unit
+def test_effective_timeout_uses_parsed_companion_spec_timeout() -> None:
+    profile = WorkspaceProfile(name="serviceful", docker=ProfileDocker(startup_timeout_seconds=300))
+    companion = WorkspaceCompanionSpec(
+        name="backend",
+        repo_url="https://github.com/example/backend.git",
+        compose_up_timeout_seconds=900,
+    )
+
+    assert effective_compose_up_timeout_seconds(profile=profile, companions=(companion,)) == 900

--- a/tests/unit/profiles/test_profile_docker_config.py
+++ b/tests/unit/profiles/test_profile_docker_config.py
@@ -1,0 +1,27 @@
+"""Tests for the ``ProfileDocker`` workspace Docker configuration model."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from awf.profiles.models import DockerMode, ProfileDocker
+from awf.profiles.registry import docker_compose_profile
+
+
+@pytest.mark.unit
+def test_profile_docker_dind_image_defaults_to_official_image() -> None:
+    assert ProfileDocker().dind_image == "docker:27-dind"
+    assert docker_compose_profile().docker.dind_image == "docker:27-dind"
+
+
+@pytest.mark.unit
+def test_profile_docker_dind_image_accepts_override() -> None:
+    docker = ProfileDocker(mode=DockerMode.dind, dind_image="ghcr.io/example/dind:buildx")
+    assert docker.dind_image == "ghcr.io/example/dind:buildx"
+
+
+@pytest.mark.unit
+def test_profile_docker_rejects_empty_dind_image() -> None:
+    with pytest.raises(ValidationError):
+        ProfileDocker(dind_image="")

--- a/tests/unit/profiles/test_profile_docker_config.py
+++ b/tests/unit/profiles/test_profile_docker_config.py
@@ -25,3 +25,33 @@ def test_profile_docker_dind_image_accepts_override() -> None:
 def test_profile_docker_rejects_empty_dind_image() -> None:
     with pytest.raises(ValidationError):
         ProfileDocker(dind_image="")
+
+
+@pytest.mark.unit
+def test_profile_docker_accepts_canonical_image_references() -> None:
+    # Registry/host/digest forms must keep working — the guard is a grammar, not a denylist.
+    for ref in (
+        "docker:27-dind",
+        "ghcr.io/example/dind:buildx",
+        "registry.example.com:5000/team/dind:latest",
+        "docker@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    ):
+        assert ProfileDocker(dind_image=ref).dind_image == ref
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "payload",
+    [
+        'docker:27-dind"\nprivileged: true',  # YAML scalar breakout + key injection
+        'docker:27-dind"',  # bare embedded quote closes the scalar
+        "docker 27-dind",  # space is illegal in an image reference
+        "-docker:27-dind",  # must start with an alphanumeric
+    ],
+)
+def test_profile_docker_rejects_yaml_injection_in_dind_image(payload: str) -> None:
+    # dind_image is interpolated unescaped into image: "{{ s.image }}" in the
+    # compose Jinja template (autoescape=False); reject illegal characters at
+    # deserialization so a malicious profile cannot inject compose YAML.
+    with pytest.raises(ValidationError):
+        ProfileDocker(dind_image=payload)

--- a/tests/unit/profiles/test_profile_models_helpers.py
+++ b/tests/unit/profiles/test_profile_models_helpers.py
@@ -32,6 +32,7 @@ def test_url_healthcheck_target_redacts_userinfo() -> None:
     check = ProfileHealthCheck(name="api", url="http://user:secret@api:8080/health")
 
     assert check.target() == "http://api:8080/health"
+    assert check.display_command() == "GET http://api:8080/health expected 200"
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_profile_models_helpers.py
+++ b/tests/unit/profiles/test_profile_models_helpers.py
@@ -1,0 +1,48 @@
+"""Unit coverage for pure helpers on profile model value objects."""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.profiles.models import (
+    ProfileAppEndpoint,
+    ProfileAppEndpointHealth,
+    ProfileHealthCheck,
+)
+
+
+@pytest.mark.unit
+def test_command_healthcheck_display_and_target_return_command() -> None:
+    check = ProfileHealthCheck(name="db", command="pg_isready -U awf")
+
+    assert check.display_command() == "pg_isready -U awf"
+    assert check.target() == "pg_isready -U awf"
+
+
+@pytest.mark.unit
+def test_url_healthcheck_target_passes_through_when_no_userinfo() -> None:
+    check = ProfileHealthCheck(name="api", url="http://api:8080/health")
+
+    assert check.target() == "http://api:8080/health"
+    assert check.display_command() == "GET http://api:8080/health expected 200"
+
+
+@pytest.mark.unit
+def test_url_healthcheck_target_redacts_userinfo() -> None:
+    check = ProfileHealthCheck(name="api", url="http://user:secret@api:8080/health")
+
+    assert check.target() == "http://api:8080/health"
+
+
+@pytest.mark.unit
+def test_app_endpoint_health_normalizes_method_to_uppercase() -> None:
+    health = ProfileAppEndpointHealth(path="/health", method="get")
+
+    assert health.method == "GET"
+
+
+@pytest.mark.unit
+def test_app_endpoint_normalizes_scheme_to_lowercase() -> None:
+    endpoint = ProfileAppEndpoint(name="web", service="app", port=8080, scheme="HTTPS")
+
+    assert endpoint.scheme == "https"

--- a/tests/unit/runtime/test_validation_parts/test_validation_part_002.py
+++ b/tests/unit/runtime/test_validation_parts/test_validation_part_002.py
@@ -610,6 +610,30 @@ def test_environment_identity_digest_is_stable_across_mapping_and_service_order(
 
 
 @pytest.mark.unit
+def test_environment_identity_digest_changes_for_dind_daemon_image() -> None:
+    # The DinD daemon image is rendered into the per-workspace compose stack, so
+    # two runs that differ only by docker.dind_image must not collide on the
+    # environment identity digest (else validation provenance treats different
+    # Docker daemons as identical).
+    baseline = _identity_profile()
+    overridden = _identity_profile(
+        docker={
+            "mode": "dind",
+            "compose_files": ["compose.yml", "compose.override.yml"],
+            "project_directory": ".",
+            "startup_timeout_seconds": 120,
+            "dind_image": "ghcr.io/example/dind:buildx",
+        }
+    )
+
+    assert environment_identity_inputs(baseline)["docker"]["dind_image"] == "docker:27-dind"
+    assert (
+        environment_identity_inputs(overridden)["docker"]["dind_image"]
+        == "ghcr.io/example/dind:buildx"
+    )
+    assert environment_identity_digest(baseline) != environment_identity_digest(overridden)
+
+
 def test_environment_identity_digest_changes_for_parallel_coverage_policy() -> None:
     serial = _identity_profile()
     parallel = _identity_profile(

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -74,6 +74,16 @@ def test_agent_runtime_installs_docker_compose_plugin() -> None:
 
 
 @pytest.mark.unit
+def test_agent_runtime_installs_pinned_docker_buildx_plugin() -> None:
+    dockerfile = _agent_runtime_dockerfile()
+
+    assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=" in dockerfile
+    assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=latest" not in dockerfile
+    assert '"docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}"' in dockerfile
+    assert "docker buildx version" in dockerfile
+
+
+@pytest.mark.unit
 def test_agent_runtime_installs_all_supported_coding_clis() -> None:
     dockerfile = _agent_runtime_dockerfile()
 
@@ -112,5 +122,6 @@ def test_readme_notes_agent_runtime_rebuild_for_docker_tooling_changes() -> None
 
     assert "Docker CLI" in section
     assert "Docker Compose plugin" in section
+    assert "buildx" in section.lower()
     assert "rebuild" in section.lower()
     assert "docker build -t awf-agent-runtime:latest" in section

--- a/tests/unit/test_control_plane_dockerfile.py
+++ b/tests/unit/test_control_plane_dockerfile.py
@@ -34,3 +34,4 @@ def test_control_plane_installs_pinned_docker_buildx_plugin() -> None:
     assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=" in dockerfile
     assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=latest" not in dockerfile
     assert '"docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}"' in dockerfile
+    assert "docker buildx version" in dockerfile

--- a/tests/unit/test_control_plane_dockerfile.py
+++ b/tests/unit/test_control_plane_dockerfile.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def _control_plane_dockerfile() -> str:
+    return Path("docker/control-plane.Dockerfile").read_text(encoding="utf-8")
+
+
+@pytest.mark.unit
+def test_control_plane_installs_docker_cli_from_official_apt_repository() -> None:
+    dockerfile = _control_plane_dockerfile()
+
+    assert "download.docker.com/linux/debian" in dockerfile
+    assert "docker.asc" in dockerfile
+    assert "ARG DOCKER_CE_CLI_VERSION=" in dockerfile
+    assert '"docker-ce-cli=${DOCKER_CE_CLI_VERSION}"' in dockerfile
+
+
+@pytest.mark.unit
+def test_control_plane_installs_docker_compose_plugin() -> None:
+    dockerfile = _control_plane_dockerfile()
+
+    assert "ARG DOCKER_COMPOSE_PLUGIN_VERSION=" in dockerfile
+    assert '"docker-compose-plugin=${DOCKER_COMPOSE_PLUGIN_VERSION}"' in dockerfile
+
+
+@pytest.mark.unit
+def test_control_plane_installs_pinned_docker_buildx_plugin() -> None:
+    dockerfile = _control_plane_dockerfile()
+
+    assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=" in dockerfile
+    assert "ARG DOCKER_BUILDX_PLUGIN_VERSION=latest" not in dockerfile
+    assert '"docker-buildx-plugin=${DOCKER_BUILDX_PLUGIN_VERSION}"' in dockerfile


### PR DESCRIPTION
## Summary

Fixes #297. The `Docker Compose requires buildx plugin to be installed` warning in DinD workspaces is **client-side** — emitted by whichever `docker compose` CLI runs the build, not the `docker:27-dind` daemon image the issue named.

The two AWF-built Docker clients both lacked buildx:
- **agent-runtime image** — the agent is the Docker client inside DinD workspaces (`DOCKER_HOST=tcp://docker:2375`).
- **control-plane image** — runs `docker compose up` for the outer workspace stack (where managed companions build).

Both shipped `docker-ce-cli` + `docker-compose-plugin` but no `docker-buildx-plugin`, so Compose warned and fell back to the legacy builder. The DinD daemon already ships BuildKit, so fixing only the daemon image would not have silenced the warning.

## Changes

- Install pinned `docker-buildx-plugin=0.34.1-1~debian.12~bookworm` in `agent-runtime.Dockerfile` and `control-plane.Dockerfile`, mirroring the existing compose-plugin install (pinned ARG + apt from the configured Docker repo + `docker buildx version` check). Version verified against the live Docker apt repo for bookworm; well above the `>= 0.17` Compose minimum.
- Make the DinD daemon image profile-configurable via `ProfileDocker.dind_image` (default `docker:27-dind` unchanged), removing the hardcoding at `compose_manager.py:169` called out in the issue without forcing a custom image or registry on the OSS core. Plumbed through `stack_launcher.py` into `WorkspaceComposeSpec`.
- Regenerated `openapi.json` for the new `ProfileDocker.dind_image` property.
- CONTRIBUTING note that buildx is bundled in the agent-runtime image.

No behavior change for existing users: the default DinD image is unchanged; this only adds the client-side plugin and an opt-in override.

## Test plan

- [x] `ruff check .` / `ruff format --check .`
- [x] `mypy` (no issues, 288 source files)
- [x] `python scripts/generate_openapi.py --check` (spec in sync)
- [x] `pytest -n 20 --dist=loadscope --cov=awf` — 8702 passed, coverage 99.01% (gate reached)
- [x] New tests: Dockerfile content (agent-runtime + control-plane buildx), `ProfileDocker.dind_image` default/override/empty, `dind_image` flow through launcher + render, `ensure_project_up(wait=False)`, plus coverage for adjacent helpers
- [ ] Follow-up (out of scope): live integration assertion that the warning is gone, which needs a full agent-runtime image build against a Docker daemon

Plan/validation docs: `plans/ISSUE_297_DIND_BUILDX_PLAN.md`, `plans/ISSUE_297_DIND_BUILDX_VALIDATION.md`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workspace Docker client images and compose stack generation; defaults are unchanged but operators must rebuild images and misconfigured `dind_image` could affect DinD stacks.
> 
> **Overview**
> Installs the pinned **Docker Buildx** plugin in the **agent-runtime** and **control-plane** images alongside the existing CLI and Compose packages, so `docker compose` in DinD and outer workspace stacks can use BuildKit instead of warning and falling back to the legacy builder. **CONTRIBUTING** now calls out Buildx when rebuilding the agent runtime image.
> 
> Adds **`ProfileDocker.dind_image`** (default still `docker:27-dind`, validated image-reference pattern) and passes it through **`stack_launcher`** into the workspace compose spec so the DinD daemon service image is profile-driven; **OpenAPI** and environment **validation identity** include the new field.
> 
> Expands unit tests for Dockerfiles, profile/docker config, compose render/launch paths, and related edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c54aaffcc2e11d0fe480d04caa8efb4b2ed0cd8f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace profiles can now specify the Docker-in-Docker image (default: docker:27-dind).
  * Docker Buildx plugin is installed alongside Docker CLI/Compose in runtime and control-plane images.

* **Documentation**
  * Clarified runtime image build instructions to note Buildx availability and rebuild requirements when Docker tooling changes.

* **Tests**
  * Expanded tests to cover DinD image handling, Buildx installation, and related compose behaviours.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dimileeh/aira-agent-workspace-fabric/pull/321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->