### PR TITLE
T04 - Add setup dry-run system checks

### DIFF
--- a/docs/awf-plans/ws_04dcade26c1b4caba84bc5bb.md
+++ b/docs/awf-plans/ws_04dcade26c1b4caba84bc5bb.md
@@ -1,0 +1,493 @@
+# T04 — `awf setup --dry-run` System Checks And Readiness Payload Plan
+
+## Planning Context
+
+This planning artifact is constrained to
+`docs/awf-plans/ws_04dcade26c1b4caba84bc5bb.md` by the AWF planning-phase prompt.
+No implementation files are modified during planning.
+
+Per `AGENTS.md` and `plans/PLAN_EXECUTION_PROTOCOL.md`, the **implementation
+phase** must additionally create:
+
+- `plans/T04_SETUP_DRY_RUN_PLAN.md` (mirror of this plan) before coding, and
+- `plans/T04_SETUP_DRY_RUN_VALIDATION.md` after implementation
+  (requirement-by-requirement `Complete | Partial | Missing` with evidence).
+
+Source inputs reviewed:
+
+- `TODO/awf-full-installer-first-run-setup-backlog.md` (task **T04** card,
+  conflict flags, critical failure-mode table).
+- T01 wiring: `src/awf/cli/main.py` (registers `setup`/`start` commands),
+  `src/awf/cli/setup_commands.py` (current placeholder).
+- T02 config/asset model: `src/awf/host_setup/config.py`,
+  `src/awf/host_setup/source_assets.py`.
+- T03 error contract + rendering: `src/awf/host_setup/rendering.py`,
+  `src/awf/service/doctor/reasons.py`, `docs/REASON_CATALOG.md`,
+  `tests/unit/service/test_host_setup_rendering.py`,
+  `tests/unit/cli/test_setup_commands.py`, `tests/unit/cli/test_first_run_command_imports.py`.
+- Reusable system probes: `src/awf/service/doctor/__init__.py` (Docker/port/socket
+  probes, redaction), `src/awf/service/disk.py` (`check_disk_space`),
+  `src/awf/service/local_capacity.py` (`docker info` capacity parse),
+  `src/awf/service/provider_readiness.py` (`PROVIDER_NAMES`),
+  `src/awf/common/config.py` (`DEFAULT_MIN_FREE_DISK_BYTES`).
+
+T01, T02, and T03 are treated as **merged and available**; their behavior is
+reused, not reimplemented. The reason codes T04 needs already exist in
+`_REASON_TEXT` and `docs/REASON_CATALOG.md`
+(`SETUP_READINESS_FAILED`, `SETUP_PROVIDER_UNKNOWN`, `INTERACTIVE_INPUT_REQUIRED`,
+`SOURCE_CHECKOUT_INVALID`, `HOST_SETUP_CONFIG_*`, `DOCKER_CLI_NOT_FOUND`,
+`DOCKER_DAEMON_UNREACHABLE`, `INSUFFICIENT_DISK`), so **no new reason codes and
+no `docs/REASON_CATALOG.md` edits are expected**.
+
+## Objective
+
+Implement only **T04**: turn the reserved `awf setup` placeholder into the
+one-time machine setup wizard *shell* that runs **local-first, bounded host
+system checks** and emits a reason-coded **readiness payload** in `pretty` and
+`json` form, **without starting Core and without writing secrets**.
+
+The deliverable is `awf setup --dry-run` plus the parser/flag surface that later
+slices (T06 credentials, T07 provider orchestration, T08 client config) build
+on. Non-dry-run runs may write **safe, non-secret config only**.
+
+## Scope (in)
+
+- `awf setup` command shell with these flags:
+  - `--provider PROVIDER` (repeatable), `--dry-run`, `--non-interactive`,
+    `--allow-plain-secrets`, `--source-checkout PATH`, `--format json|pretty`.
+- Host system checks (no Core start): Docker CLI, Docker daemon, Docker Compose,
+  Git, `gh`, Python/runtime floor, ports (API host port + Postgres), disk,
+  shell/PATH reachability, and local capacity.
+- A structured readiness payload built from the T03 `FirstRunPayload` contract.
+- Safe config persistence (non-secret only) when **not** in `--dry-run`.
+
+## Out of scope / Non-goals (owned elsewhere)
+
+- Credential storage backends (keyring/env/plain-file) — **T06**. T04 only
+  *accepts and forwards* the `--allow-plain-secrets` consent flag; it never
+  stores a secret and never makes plain-file the default.
+- Provider setup orchestration / probing real provider auth — **T07**. T04 only
+  *validates and forwards* the `--provider` selector as a recheck scope.
+- Claude/Codex client config writers and `--client` flag — **T08**.
+- `awf start` startup wrapper — **T05** (T04 only references it as the next
+  command).
+- New reason codes or `docs/REASON_CATALOG.md` changes (already present from T03).
+- Starting Core / `awf service bootstrap` invocation of any kind.
+
+## Intended Files And Modules To Touch (implementation phase)
+
+Process artifacts:
+
+- `plans/T04_SETUP_DRY_RUN_PLAN.md` (new)
+- `plans/T04_SETUP_DRY_RUN_VALIDATION.md` (new, post-implementation)
+
+New runtime module:
+
+- `src/awf/host_setup/system_checks.py` (new)
+  - Pure, dependency-injected host readiness checks returning structured results.
+
+Edited runtime modules:
+
+- `src/awf/host_setup/rendering.py`
+  - Add a readiness payload builder that turns a system-checks report (plus
+    provider/consent/source context) into a `FirstRunPayload`. Keeps rendering
+    integration in the T03 module per the backlog "Modules touched" list.
+- `src/awf/cli/setup_commands.py`
+  - Replace the placeholder with the real wizard shell: flag parsing, provider
+    selector validation, source-checkout validation, system-check dispatch,
+    readiness rendering, safe config write (non-dry-run only), exit codes.
+- `src/awf/cli/main.py`
+  - Update the registered `setup` command `help=` string to drop "Reserved
+    before full setup checks land" and describe the real flags. (Small, scoped;
+    the `start` command help is left untouched — that is T05.)
+- `src/awf/host_setup/__init__.py`
+  - Export the new `system_checks` symbols and the new rendering builder, and add
+    them to `__all__`.
+
+Tests (written first — see TDD section):
+
+- `tests/unit/cli/test_setup_commands.py` (rewritten for real behavior)
+- `tests/unit/service/test_host_setup_system_checks.py` (new)
+- `tests/unit/service/test_host_setup_rendering.py` (extended for the builder)
+
+Existing `tests/unit/cli/test_first_run_command_imports.py` must keep passing
+(no payload construction at import time — all payload building stays inside
+functions).
+
+## Design
+
+### 1. `host_setup/system_checks.py` (new)
+
+Provider-neutral, **local-first and bounded** host checks. No Core startup, no
+network beyond bounded local socket probes and bounded `docker` subprocess calls.
+
+Result types (frozen `pydantic` models, mirroring the T03 strict/immutable base
+or simple frozen dataclasses — match the surrounding `host_setup` pydantic
+style):
+
+- `SystemCheck`: `id`, `label`, `status` (`ok|warn|fail|skipped`), `reason`
+  (stable string), `message`, `fix`, `docs_link`, `metadata` (secret-free).
+- `SystemChecksReport`: `checks: tuple[SystemCheck, ...]`, derived
+  `status` (`ok|warn|fail`), `blockers` (fail checks), `warnings` (warn checks),
+  optional `capacity` metadata. Includes `to_dict()` for JSON/detail embedding.
+
+Orchestrator:
+
+```text
+run_system_checks(
+    *,
+    host_port: int,                 # from HostSetupConfig.api.host_port
+    work_dir: str,                  # from HostSetupConfig.work_dir (expanduser'd)
+    min_free_bytes: int = DEFAULT_MIN_FREE_DISK_BYTES,
+    # injectable probes (real defaults) for deterministic tests:
+    which: Callable[[str], str | None] = shutil.which,
+    run_subprocess: SubprocessRun = <bounded subprocess.run>,
+    socket_connector: SocketConnector = <socket.create_connection>,
+    disk_usage: DiskUsage | None = None,           # -> check_disk_space
+    environ: Mapping[str, str] = os.environ,
+    python_version: tuple[int, int] = sys.version_info[:2],
+    docker_host: str | None = None,
+) -> SystemChecksReport
+```
+
+Check inventory and severity:
+
+| id | probe | blocker? | reused reason / source |
+| --- | --- | --- | --- |
+| `docker_cli` | `which("docker")` | **fail** if missing | `DOCKER_CLI_NOT_FOUND` |
+| `docker_daemon` | `docker info --format {{json .}}` (bounded) | **fail** if non-zero / timeout / unreachable | `DOCKER_DAEMON_UNREACHABLE` |
+| `docker_compose` | `docker compose version --short` (bounded) | **fail** if missing/non-zero | setup-local reason `COMPOSE_*` in report detail |
+| `git` | `which("git")` | **fail** if missing | setup-local reason in report detail |
+| `gh` | `which("gh")` | warn only (env ref token is an alternative; GitHub is T07) | setup-local reason |
+| `python_runtime` | `python_version >= (3, 12)` | **fail** if below floor | setup-local reason |
+| `port_api` | `socket_connector((host, host_port))` | warn if **in use** (may be a running AWF); ok if refused | setup-local reason |
+| `port_db` | `socket_connector((host, 5432))` | warn if in use; ok if refused | setup-local reason |
+| `disk` | `check_disk_space(work_dir, min_free_bytes=...)` | **fail** if insufficient | `INSUFFICIENT_DISK` / `SUFFICIENT_DISK` |
+| `shell_path` | `which("awf")` | warn if not on PATH (PATH hint in fix) | setup-local reason |
+| `capacity` | parse `NCPU`/`MemTotal` from the **same** `docker info` JSON | warn if unknown/low; never blocker | setup-local reason |
+
+Notes:
+
+- **Capacity reuses the single `docker info` call** from `docker_daemon` (parse
+  `NCPU`/`MemTotal` like `local_capacity._positive_float`/`_bytes_to_gib`), so we
+  avoid a second subprocess and avoid constructing full `Settings`.
+- Per-check `reason` strings that are *not* in the doctor catalog are carried
+  only inside the structured report (NOT via `error_code=` and NOT through
+  `first_run_issue_from_reason_code`), so the `test_catalog_coverage` guard is not
+  tripped. The **top-level** payload reason code is always a documented one.
+- All subprocess calls use a bounded timeout (~5s, matching doctor); timeouts and
+  `FileNotFoundError`/`OSError` are caught specifically and converted to `fail`
+  results — never bare `except Exception` swallowing, per AGENTS.md.
+- `metadata` is kept secret-free by construction (versions, ports, byte counts,
+  booleans only); no env values are copied in.
+
+### 2. `host_setup/rendering.py` (extend)
+
+Add a builder, e.g. `first_run_setup_readiness_payload(...)`:
+
+```text
+first_run_setup_readiness_payload(
+    report: SystemChecksReport,
+    *,
+    command: str = "awf setup",
+    dry_run: bool,
+    providers: tuple[str, ...],          # validated recheck scope ([] = all)
+    allow_plain_secrets: bool,
+    source_checkout_root: str | None,
+) -> FirstRunPayload
+```
+
+- `details` mapping (JSON-safe, redacted by existing `render_first_run_json`):
+  `dry_run`, `providers`, `provider_scope` (`"all"` vs `"targeted recheck"`),
+  `allow_plain_secrets`, `source_checkout`, `capacity`, and a `checks` list with
+  per-check `id/status/reason/message/fix/docs_link`, plus `blockers`/`warnings`.
+- Status mapping → payload:
+  - `report.status == "fail"` → `first_run_failure_payload(reason_code=
+    SETUP_READINESS_FAILED, status="blocked", details=..., next_steps=...)`.
+  - `report.status == "warn"` → `first_run_warning_payload(reason_code=
+    SETUP_READINESS_FAILED, ...)` **or** a success-with-warnings payload; chosen
+    so warnings render but the command still succeeds (exit 0). (Decision: warn →
+    success payload carrying warnings in details + a `warning`-severity note, so
+    non-blocking advisories do not fail the command. Finalized in tests.)
+  - `report.status == "ok"` → `first_run_success_payload(...)`.
+- `next_steps`: on success/warn → the next command (`awf start`); on failure →
+  the de-duplicated blocker `fix` actions followed by
+  `Re-run awf setup --dry-run`. Satisfies "next actions" for Docker failures and
+  "status, blockers, warnings, docs links, and next command" in pretty output.
+- Reuses existing redaction (`render_first_run_json` →
+  `redact_first_run_value`), so provider refs / token-shaped values never render.
+
+This keeps `rendering.py` one-directional: it may import `system_checks`;
+`system_checks` must **not** import `rendering` (no cycle).
+
+### 3. `cli/setup_commands.py` (rewrite)
+
+`setup_command` signature (Typer), mirroring the repeatable-option pattern
+already used by `init` (`provider: list[str] = typer.Option([], "--provider")`):
+
+```text
+setup_command(
+    provider: list[str]      = Option([], "--provider"),     # repeatable
+    dry_run: bool            = Option(False, "--dry-run"),
+    non_interactive: bool    = Option(False, "--non-interactive"),
+    allow_plain_secrets: bool= Option(False, "--allow-plain-secrets"),
+    source_checkout: Path|None = Option(None, "--source-checkout"),
+    fmt: OutputFormat        = Option(OutputFormat.pretty, "--format"),
+)
+```
+
+Control flow:
+
+1. **Provider validation** — normalize + de-duplicate selectors (order-stable),
+   validate against the known setup-provider set
+   (`github, codex, claude_code, gemini, opencode`; `docker` is a *system check*,
+   not a provider). Unknown → emit `SETUP_PROVIDER_UNKNOWN` failure, **exit 2**
+   (usage error, consistent with `_emit_init_migration_error`). No system checks
+   run on this path → "no silent fallback to all-provider setup".
+2. **Config read** — `read_host_setup_config()`; on `HostSetupConfigError`
+   surface `exc.reason_code` (`HOST_SETUP_CONFIG_CORRUPT|SECRET_VALUE`) failure.
+3. **Source-checkout** — if `--source-checkout` given, `validate_source_checkout`;
+   on `SourceCheckoutError` emit failure with `exc.reason_code`
+   (`SOURCE_CHECKOUT_INVALID`) + `missing_markers`, **exit 1**.
+4. **Interactive guard** — if `--non-interactive` **and** a `--provider` is
+   selected **and** not `--dry-run` (i.e. setup would begin provider
+   configuration that needs prompt input deferred to T06/T07), emit
+   `INTERACTIVE_INPUT_REQUIRED`, **exit 1**. (See assumption A4.)
+5. **System checks** — `run_system_checks(host_port=config.api.host_port,
+   work_dir=config.work_dir, ...)`.
+6. **Build payload** — `first_run_setup_readiness_payload(report, dry_run=...,
+   providers=..., allow_plain_secrets=..., source_checkout_root=...)`.
+7. **Safe config write** — **only when not `--dry-run` and not blocked**: merge
+   safe, non-secret fields into the existing config and `write_host_setup_config`
+   (e.g. record verified `source_checkout` metadata, `consent.plain_file_secrets`
+   from `--allow-plain-secrets`, `consent.source_checkout_assets`). Never writes
+   secrets; the config schema already rejects secret payloads.
+8. **Emit + exit**:
+   - JSON: `_emit(render_first_run_json(payload), fmt)` → stdout (scripting).
+   - Pretty success/warn → `typer.echo(render_first_run_pretty(payload))` stdout,
+     **exit 0**.
+   - Pretty failure/blocked → `typer.echo(..., err=True)` stderr, **exit 1**.
+
+Exit-code contract: `0` ready / warnings-only; `1` readiness blocked, source
+invalid, config error, interactive-required; `2` unknown provider (usage).
+
+`main.py`: update `app.command("setup", help=...)` to describe the real command
+(keep the "Prepare this machine for AWF" lead used by the help test).
+
+### Reuse map
+
+| Need | Reused from |
+| --- | --- |
+| Payload models, redaction, pretty/json render | `host_setup.rendering` (T03) |
+| Reason text/remediation lookup | `doctor.reasons.reason_text_for_code` via T03 helpers |
+| Config read/write, secret rejection, consent fields | `host_setup.config` (T02) |
+| Source-checkout validation + reason codes | `host_setup.source_assets` (T02) |
+| Disk free-space check | `service.disk.check_disk_space` |
+| Docker capacity parse pattern | `service.local_capacity` |
+| Provider name vocabulary | `service.provider_readiness.PROVIDER_NAMES` |
+| Bounded subprocess / socket protocols | mirror `service.doctor.models` |
+| Disk threshold default | `common.config.DEFAULT_MIN_FREE_DISK_BYTES` |
+
+## Tests To Write First (TDD)
+
+Write/adjust these failing tests before implementation. Markers: `@pytest.mark.unit`.
+
+### `tests/unit/service/test_host_setup_system_checks.py` (new — fixture-driven)
+
+Inject fake `which`, `run_subprocess`, `socket_connector`, `disk_usage`,
+`environ`, `python_version` so no Docker/network is required.
+
+1. `test_all_checks_pass_with_healthy_fakes` → report `status == "ok"`, empty
+   blockers, capacity populated from fake `docker info`.
+2. `test_docker_cli_missing_is_blocker` → `which("docker")` None → `fail`,
+   reason `DOCKER_CLI_NOT_FOUND`, present in `blockers`.
+3. `test_docker_daemon_unreachable_is_blocker` → `docker info` returncode≠0 →
+   `fail` `DOCKER_DAEMON_UNREACHABLE`.
+4. `test_docker_compose_missing_is_blocker`.
+5. `test_git_missing_is_blocker`.
+6. `test_gh_missing_is_warning_not_blocker`.
+7. `test_python_below_floor_is_blocker` (`python_version=(3, 11)`).
+8. `test_api_port_in_use_is_warning` / `test_ports_free_are_ok` (socket connect
+   succeeds → warn; raises `OSError` → ok).
+9. `test_disk_below_threshold_is_blocker` (fake `disk_usage` free < threshold →
+   `INSUFFICIENT_DISK`).
+10. `test_capacity_unavailable_is_warning_only` (docker down → capacity unknown,
+    but capacity itself never a blocker).
+11. `test_shell_path_awf_not_found_is_warning` with PATH hint in `fix`.
+12. `test_report_status_rollup` (fail > warn > ok precedence).
+13. `test_subprocess_timeout_is_handled` (`TimeoutExpired` → `fail`, bounded, no
+    crash, no bare-Exception swallow).
+14. `test_checks_do_not_start_core` (no `compose ... up`/bootstrap invocation;
+    assert only allowed bounded commands are called via the fake runner).
+15. `test_metadata_is_secret_free` (token-shaped env value never appears in
+    `report.to_dict()`).
+
+### `tests/unit/service/test_host_setup_rendering.py` (extend)
+
+16. `test_setup_readiness_payload_success` → `status == "success"`, `details`
+    has `dry_run`, `providers`, `provider_scope`, `checks`, capacity; next
+    command present.
+17. `test_setup_readiness_payload_blocked` → `reason_code == SETUP_READINESS_FAILED`,
+    `status == "blocked"`, blockers + per-check `docs_link` rendered in pretty,
+    `next_steps` include blocker fixes + `awf setup --dry-run`.
+18. `test_setup_readiness_payload_warning_succeeds` (warn-only report → exit-0
+    style success payload carrying warnings).
+19. `test_setup_readiness_payload_redacts_provider_refs` (a provider-ref/token in
+    details is redacted by `render_first_run_json`).
+
+### `tests/unit/cli/test_setup_commands.py` (rewrite for real behavior)
+
+CLI tests monkeypatch `awf.cli.setup_commands.run_system_checks` (crafted
+report) and config IO (`read_host_setup_config` / `write_host_setup_config`
+spies) for determinism.
+
+20. `test_setup_help_describes_real_first_run_surface` (help shows "Prepare this
+    machine", `--dry-run`, `--provider`; no "Reserved" language; no `Traceback`).
+21. `test_setup_dry_run_ready_success` (healthy report → exit 0, JSON status
+    `success`, next command present).
+22. `test_setup_dry_run_does_not_write_config_or_secrets` (write spy **not**
+    called; if a real tmp config path is used, file absent afterward).
+23. `test_setup_dry_run_docker_blocker_readiness_failure` (docker-fail report →
+    exit 1, `reason_code == SETUP_READINESS_FAILED`, blockers list docker, next
+    actions present, pretty on stderr / stdout empty).
+24. `test_setup_provider_selector_forwarded` (`--provider github` → details
+    `providers == ["github"]`, `provider_scope == "targeted recheck"`).
+25. `test_setup_repeated_provider_selectors_deduped`
+    (`--provider github --provider github` → `["github"]`).
+26. `test_setup_multiple_providers_forwarded`
+    (`--provider github --provider codex` → both, order-stable).
+27. `test_setup_unknown_provider_rejected` (`--provider nope` → exit 2,
+    `reason_code == SETUP_PROVIDER_UNKNOWN`, `run_system_checks` **not** called).
+28. `test_setup_allow_plain_secrets_forwarded_not_default`
+    (with flag → details `allow_plain_secrets is True`; without → `False`).
+29. `test_setup_source_checkout_valid_dry_run` (`--source-checkout <repo root>` →
+    success, details `source_checkout` populated; uses `validate_source_checkout`).
+30. `test_setup_source_checkout_invalid` (bad path → exit 1,
+    `reason_code == SOURCE_CHECKOUT_INVALID`, `missing_markers` present).
+31. `test_setup_non_interactive_provider_requires_input`
+    (`--non-interactive --provider github` no `--dry-run` → exit 1,
+    `reason_code == INTERACTIVE_INPUT_REQUIRED`).
+32. `test_setup_non_dry_run_writes_safe_config` (healthy report, not dry-run →
+    write spy called with a `HostSetupConfig` carrying no secret values; consent/
+    source recorded).
+33. `test_setup_config_corrupt_surfaces_reason` (`read_host_setup_config` raises
+    `HostSetupConfigError(HOST_SETUP_CONFIG_CORRUPT)` → failure payload with that
+    reason).
+34. `test_setup_json_and_pretty_shapes` (JSON keys stable; pretty contains
+    `Status:`, blockers, warnings, `Docs:`, `Next:`).
+
+Keep `tests/unit/cli/test_first_run_command_imports.py` green (no import-time
+payload construction).
+
+## Implementation Steps (ordered)
+
+1. Add the failing tests above (service, then rendering, then CLI).
+2. Implement `host_setup/system_checks.py` (result models + injectable
+   `run_system_checks`); make service tests green.
+3. Add `first_run_setup_readiness_payload(...)` to `rendering.py`; make rendering
+   tests green.
+4. Rewrite `cli/setup_commands.py` for real dispatch; update `main.py` help;
+   export new symbols from `host_setup/__init__.py`; make CLI tests green.
+5. Create `plans/T04_SETUP_DRY_RUN_PLAN.md` (mirror) and, after green,
+   `plans/T04_SETUP_DRY_RUN_VALIDATION.md`.
+6. Run focused validation (below); iterate on any `Partial`/`Missing` gap.
+
+## Validation Commands And Pass Criteria
+
+Focused, per the AWF agent contract (AWF/GitHub own the broad suite):
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/cli/test_setup_commands.py \
+  tests/unit/cli/test_first_run_command_imports.py \
+  tests/unit/service/test_host_setup_system_checks.py \
+  tests/unit/service/test_host_setup_rendering.py \
+  tests/unit/docs/test_catalog_coverage.py \
+  tests/unit/service/test_doctor_reasons.py -q
+```
+
+Manual source-lane spot check (acceptance: works under `uv run`):
+
+```bash
+uv run --python 3.12 --extra dev awf setup --dry-run --format json
+uv run --python 3.12 --extra dev awf setup --dry-run --source-checkout .
+uv run --python 3.12 --extra dev awf setup --provider github --dry-run
+```
+
+Pass criteria:
+
+- ruff + mypy clean on touched files.
+- All listed test modules pass; catalog-coverage test still passes (no new codes).
+- `awf setup --dry-run` performs zero config writes and never starts Core.
+- Each T04 acceptance criterion maps to at least one passing test (table below).
+- Coverage on new lines kept at/above the repo target (broad coverage gate owned
+  by AWF/CI after the agent phase).
+
+## Acceptance-Criteria Traceability
+
+| Acceptance criterion | Covered by |
+| --- | --- |
+| `--dry-run` never writes secrets / never starts Core | #22, #14, no bootstrap call |
+| `--provider github --dry-run` accepts + forwards selector | #24 |
+| `--allow-plain-secrets` accepted + forwarded, not default | #28 |
+| Unknown provider → reason-coded diagnostic, no all-provider fallback | #27 |
+| Missing/stopped Docker → readiness failure with next actions | #23, #2, #3, #17 |
+| Source-checkout dry-run works from checkout & `uv run ... --source-checkout .` | #29, manual spot check |
+| Pretty output: status, blockers, warnings, docs links, next command | #34, #17 |
+| Non-interactive secret-needed → `INTERACTIVE_INPUT_REQUIRED` | #31 |
+
+## Risks, Assumptions, Open Decisions
+
+Assumptions (finalize/adjust in tests during implementation):
+
+- **A1 — Port semantics:** an *occupied* API/Postgres port is a **warning**
+  (AWF may already be running), not a hard blocker; a *refused* connection is
+  `ok`. Avoids false negatives when Core is up.
+- **A2 — `gh` and `shell_path` are warnings**, not blockers: GitHub auth can use
+  an env-ref token (T07), and `awf` may legitimately run via `uv run` without a
+  global PATH entry.
+- **A3 — Provider set** for `--provider` is the credential-bearing providers
+  (`github, codex, claude_code, gemini, opencode`); `docker` is excluded (it is a
+  system check). Aliases (e.g. `openai`→`codex`) are out of scope unless a test
+  demands them.
+- **A4 — Interactive guard trigger:** since T04 does not capture credentials,
+  `INTERACTIVE_INPUT_REQUIRED` is raised when `--non-interactive` + a `--provider`
+  selection + not `--dry-run` would begin provider configuration deferred to
+  T06/T07. The backlog phrases this as "if this path is touched", giving latitude.
+- **A5 — Safe config write** happens only when not `--dry-run` and not blocked,
+  recording non-secret fields (source-checkout metadata, consent flags) merged
+  into existing config; never secrets.
+- **A6 — Disk threshold** reuses `DEFAULT_MIN_FREE_DISK_BYTES` (10 GiB),
+  overridable via the injected parameter for tests.
+- **A7 — Capacity** is derived from the single `docker info` JSON used for the
+  daemon check (no extra subprocess, no full `Settings`).
+
+Risks / mitigations:
+
+- **Existing placeholder tests change.** `tests/unit/cli/test_setup_commands.py`
+  is rewritten (placeholder → real behavior); `AWF_SETUP_PLACEHOLDER` stays in
+  the catalog/`rendering` constants (used by tooling) but is no longer emitted by
+  the command.
+- **Import cycle risk** (`rendering` ↔ `system_checks`). Mitigation: strictly
+  one-directional (`rendering` imports `system_checks`); verified by import test.
+- **Catalog-coverage guard** could trip on stray reason strings. Mitigation:
+  per-check reasons live only in the structured report (no `error_code=`, not in
+  `_REASON_TEXT`); top-level payloads use only documented codes.
+- **No bare-`except`** per AGENTS.md: subprocess/socket failures catch specific
+  exceptions (`FileNotFoundError`, `OSError`, `subprocess.TimeoutExpired`,
+  `json.JSONDecodeError`) and map to `fail`/`skipped` with preserved reasons.
+- **Determinism / boundedness** (perf review note): all checks are local-first
+  with ~5s bounded subprocess and short socket timeouts; tests inject fakes.
+
+## Definition Of Done
+
+- New/edited modules implemented; all listed tests pass; ruff + mypy clean on
+  touched files; catalog-coverage and doctor-reason tests still pass.
+- `awf setup --dry-run` runs host checks, emits readiness payload in json/pretty,
+  writes nothing, starts nothing.
+- `plans/T04_SETUP_DRY_RUN_PLAN.md` and
+  `plans/T04_SETUP_DRY_RUN_VALIDATION.md` exist with per-requirement status.
+- Changes scoped to setup CLI, host setup system checks, rendering integration,
+  and tests; no work belonging to T05–T08 is implemented.

--- a/plans/T04_SETUP_DRY_RUN_PLAN.md
+++ b/plans/T04_SETUP_DRY_RUN_PLAN.md
@@ -1,0 +1,134 @@
+# T04 `awf setup --dry-run` System Checks And Readiness Payload — Implementation Plan
+
+## Context
+
+T04 turns the reserved `awf setup` placeholder into the one-time machine setup
+wizard *shell*. It runs local-first, bounded host system checks and emits a
+reason-coded readiness payload (pretty + json) **without starting Core and
+without writing secrets**. It depends on T01 (CLI grammar), T02 (host setup
+config + source-checkout asset model), and T03 (first-run error contract +
+rendering helpers), all merged on `development`.
+
+The authoritative planning artifact is
+`docs/awf-plans/ws_04dcade26c1b4caba84bc5bb.md`; this file mirrors it for the
+`plans/` protocol (`AGENTS.md`, `plans/PLAN_EXECUTION_PROTOCOL.md`).
+
+## Goal
+
+Deliver `awf setup --dry-run` plus the flag surface later slices build on
+(`--provider` repeatable, `--dry-run`, `--non-interactive`,
+`--allow-plain-secrets`, `--source-checkout PATH`, `--format json|pretty`).
+Non-dry-run, non-blocked runs may persist **safe, non-secret config only**.
+
+## Scope (in)
+
+- `host_setup/system_checks.py` (new): pure, dependency-injected host readiness
+  checks (`SystemCheck`, `SystemChecksReport`, `run_system_checks`).
+- `host_setup/rendering.py` (extend): `first_run_setup_readiness_payload(...)`
+  builder turning a report + provider/consent/source context into a
+  `FirstRunPayload`.
+- `cli/setup_commands.py` (rewrite): real wizard shell — flag parse, provider
+  validation, source-checkout validation, interactive guard, system-check
+  dispatch, readiness rendering, safe config write (non-dry-run only), exit
+  codes.
+- `cli/main.py` (help text), `host_setup/__init__.py` (exports).
+
+## Out of scope (owned elsewhere)
+
+- Credential storage backends (T06): T04 only forwards `--allow-plain-secrets`.
+- Provider setup orchestration / real auth probing (T07): T04 only validates and
+  forwards the `--provider` selector.
+- Client config writers / `--client` (T08).
+- `awf start` wrapper (T05) — referenced only as the next command.
+- New reason codes / `docs/REASON_CATALOG.md` edits (already present from T03).
+- Starting Core / `awf service bootstrap` of any kind.
+
+## Checks (local-first, bounded; no Core start)
+
+| id | probe | severity | reason |
+| --- | --- | --- | --- |
+| docker_cli | `which("docker")` | fail if missing | `DOCKER_CLI_NOT_FOUND` |
+| docker_daemon | `docker info --format {{json .}}` (5s) | fail if non-zero/timeout/unreachable | `DOCKER_DAEMON_UNREACHABLE` |
+| docker_compose | `docker compose version --short` (5s) | fail if missing/non-zero | `COMPOSE_NOT_AVAILABLE` (report-local) |
+| git | `which("git")` | fail if missing | `GIT_NOT_FOUND` (report-local) |
+| gh | `which("gh")` | warn only | `GH_NOT_FOUND` (report-local) |
+| python_runtime | `version >= (3, 12)` | fail if below | `PYTHON_RUNTIME_BELOW_FLOOR` (report-local) |
+| port_api | connect (host, api_port) | warn if in use; ok if refused | report-local |
+| port_db | connect (host, 5432) | warn if in use; ok if refused | report-local |
+| disk | `check_disk_space(work_dir, ...)` | fail if insufficient | `INSUFFICIENT_DISK`/`SUFFICIENT_DISK` |
+| shell_path | `which("awf")` | warn if missing | `AWF_NOT_ON_PATH` (report-local) |
+| capacity | parse NCPU/MemTotal from the same `docker info` JSON | never blocker (warn if unknown) | report-local |
+
+Notes: capacity reuses the single `docker info` call; report-local reasons live
+only in the structured report (never via `error_code=` and never added to
+`FIRST_RUN_*` tuples), so `test_catalog_coverage` is not tripped. Subprocess and
+socket failures catch specific exceptions
+(`FileNotFoundError`, `OSError`, `subprocess.TimeoutExpired`,
+`json.JSONDecodeError`) → `fail`/`warn`, never bare `except`. Metadata is
+secret-free by construction.
+
+## Readiness payload builder
+
+`first_run_setup_readiness_payload(report, *, command="awf setup", dry_run,
+providers, allow_plain_secrets, source_checkout_root)`:
+
+- details: `dry_run`, `providers`, `provider_scope` (`all` vs `targeted recheck`),
+  `allow_plain_secrets`, optional `source_checkout`, optional `capacity`,
+  `checks` (per-check id/status/reason/message/fix/docs_link), `blockers`,
+  `warnings`.
+- status mapping: `fail` → `first_run_failure_payload(SETUP_READINESS_FAILED,
+  status="blocked")` with next_steps = deduped blocker fixes + re-run; `warn` →
+  success payload carrying a warning-severity note + warnings in details (exit
+  0); `ok` → `first_run_success_payload`. Success/warn next command = `awf start`.
+- redaction is inherited from `render_first_run_json`.
+
+## CLI control flow + exit codes
+
+1. Provider validation (normalize/dedup, order-stable; set =
+   `github, codex, claude_code, gemini, opencode`; `claude` → `claude_code`).
+   Unknown → `SETUP_PROVIDER_UNKNOWN`, **exit 2**, no system checks run.
+2. `read_host_setup_config()`; `HostSetupConfigError` → `exc.reason_code` failure,
+   exit 1.
+3. `--source-checkout` → `validate_source_checkout`; `SourceCheckoutError` →
+   `exc.reason_code` (+ missing_markers), exit 1.
+4. Interactive guard: `--non-interactive` + `--provider` + not `--dry-run` →
+   `INTERACTIVE_INPUT_REQUIRED`, exit 1.
+5. `run_system_checks(host_port=config.api.host_port, work_dir=config.work_dir)`.
+6. Build readiness payload.
+7. Safe config write only when not `--dry-run` and not blocked (consent flags +
+   verified source metadata; never secrets).
+8. Emit: JSON → stdout; pretty success/warn → stdout exit 0; pretty
+   failure/blocked → stderr exit 1.
+
+## TDD test plan
+
+- `tests/unit/service/test_host_setup_system_checks.py` (new): healthy pass,
+  docker cli/daemon/compose blockers, git blocker, gh warning, python floor,
+  port in-use warning / free ok, disk insufficient blocker, capacity warn-only,
+  shell_path warn, status rollup, subprocess timeout handled, no-Core-start
+  command allowlist, metadata secret-free.
+- `tests/unit/service/test_host_setup_rendering.py` (extend): readiness success,
+  blocked (blockers + docs links + next_steps), warning-succeeds, redaction.
+- `tests/unit/cli/test_setup_commands.py` (rewrite): help, dry-run success,
+  dry-run no write, docker blocker readiness failure, provider forwarded /
+  deduped / multiple, unknown provider exit 2, allow-plain-secrets forwarded,
+  source-checkout valid / invalid, non-interactive provider requires input,
+  non-dry-run writes safe config, config corrupt surfaces reason, json/pretty
+  shapes.
+- Keep `tests/unit/cli/test_first_run_command_imports.py` green.
+
+## Validation commands
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/cli/test_setup_commands.py \
+  tests/unit/cli/test_first_run_command_imports.py \
+  tests/unit/service/test_host_setup_system_checks.py \
+  tests/unit/service/test_host_setup_rendering.py \
+  tests/unit/docs/test_catalog_coverage.py \
+  tests/unit/service/test_doctor_reasons.py -q
+```
+
+Broad coverage/CI validation is owned by AWF/GitHub after the agent phase.

--- a/plans/T04_SETUP_DRY_RUN_VALIDATION.md
+++ b/plans/T04_SETUP_DRY_RUN_VALIDATION.md
@@ -1,0 +1,43 @@
+# T04 Setup Dry-Run Validation
+
+Workspace: `ws_04dcade26c1b4caba84bc5bb`
+
+## Result
+
+The failed T04 workspace was salvaged after its validation-fix pass left the
+implementation staged but uncommitted. The original validation failure was caused by
+the workspace validation command targeting
+`tests/unit/service/test_host_setup_system_checks.py` before that file existed in the
+committed workspace head. The validation repair created that test file and the T04
+implementation, but its commit failed on `ruff format --check`.
+
+## Commands
+
+```bash
+uv run --python 3.12 --extra dev ruff format src/awf/cli/main.py src/awf/cli/setup_commands.py src/awf/host_setup/__init__.py src/awf/host_setup/rendering.py src/awf/host_setup/system_checks.py tests/unit/cli/test_setup_commands.py tests/unit/service/test_host_setup_rendering.py tests/unit/service/test_host_setup_system_checks.py
+```
+
+Result: passed; three files were reformatted.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_setup_commands.py tests/unit/cli/test_first_run_command_imports.py tests/unit/service/test_host_setup_system_checks.py tests/unit/service/test_host_setup_rendering.py tests/unit/docs/test_catalog_coverage.py tests/unit/service/test_doctor_reasons.py -q
+```
+
+Result: passed, `96 passed in 2.52s`.
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+```
+
+Result: passed.
+
+```bash
+uv run --python 3.12 --extra dev mypy src/awf
+```
+
+Result: passed, `Success: no issues found in 289 source files`.
+
+## Notes
+
+Full AWF and GitHub validation, including the repository coverage gate, remains owned
+by the AWF validation and PR monitor flow after the recovered implementation is pushed.

--- a/src/awf/cli/main.py
+++ b/src/awf/cli/main.py
@@ -91,9 +91,10 @@ app.add_typer(smoke_app, name="smoke")
 app.command(
     "setup",
     help=(
-        "Prepare this machine for AWF first-run use. "
-        "Reserved before full setup checks land. "
-        "Current runnable path: awf service bootstrap, then awf init <path>."
+        "Prepare this machine for AWF first-run use: run bounded host readiness "
+        "checks and emit a reason-coded readiness report. Use --dry-run to inspect "
+        "readiness without writing config or starting Core; --provider scopes a "
+        "targeted recheck. Next: awf start."
     ),
 )(setup_command)
 app.command(

--- a/src/awf/cli/setup_commands.py
+++ b/src/awf/cli/setup_commands.py
@@ -1,39 +1,84 @@
-"""First-run host setup CLI placeholder."""
+"""First-run host setup wizard shell for ``awf setup``.
+
+This command runs bounded, local-first host readiness checks and emits a
+reason-coded readiness payload. It never starts AWF Core and never writes
+secrets. Non-dry-run, non-blocked runs may persist safe, non-secret config only
+(consent flags and verified source-checkout metadata).
+"""
 
 from __future__ import annotations
+
+from pathlib import Path
+from typing import NoReturn
 
 import typer
 
 from awf.cli.common import OutputFormat, _emit
+from awf.host_setup.config import (
+    HostSetupConfig,
+    HostSetupConfigError,
+    read_host_setup_config,
+    write_host_setup_config,
+)
 from awf.host_setup.rendering import (
-    AWF_SETUP_PLACEHOLDER,
+    INTERACTIVE_INPUT_REQUIRED,
+    SETUP_PROVIDER_UNKNOWN,
     FirstRunPayload,
     first_run_failure_payload,
+    first_run_setup_readiness_payload,
     render_first_run_json,
     render_first_run_pretty,
 )
-
-SETUP_PLACEHOLDER_REASON = AWF_SETUP_PLACEHOLDER
-
-_SETUP_PLACEHOLDER_SUMMARY = "awf setup is reserved; host setup checks land in a later setup slice."
-_SETUP_PLACEHOLDER_NEXT_STEPS = (
-    "Run awf service bootstrap for current local Core startup.",
-    "Run awf init <path> to onboard a project repository.",
+from awf.host_setup.source_assets import (
+    SourceCheckoutError,
+    VerifiedSourceCheckout,
+    validate_source_checkout,
 )
+from awf.host_setup.system_checks import run_system_checks
 
+_SETUP_COMMAND = "awf setup"
 
-def _setup_placeholder_payload() -> FirstRunPayload:
-    """Build the reserved setup command first-run placeholder payload."""
-    return first_run_failure_payload(
-        command="awf setup",
-        reason_code=SETUP_PLACEHOLDER_REASON,
-        summary=_SETUP_PLACEHOLDER_SUMMARY,
-        status="blocked",
-        next_steps=_SETUP_PLACEHOLDER_NEXT_STEPS,
-    )
+# Credential-bearing providers a setup recheck can target. ``docker`` is a host
+# system check, not a provider; ``claude`` is accepted as an alias.
+_SETUP_PROVIDER_NAMES: tuple[str, ...] = (
+    "github",
+    "codex",
+    "claude_code",
+    "gemini",
+    "opencode",
+)
+_PROVIDER_ALIASES: dict[str, str] = {"claude": "claude_code"}
 
 
 def setup_command(
+    provider: list[str] = typer.Option(
+        [],
+        "--provider",
+        help=(
+            "Provider to scope a targeted recheck (repeatable). Omit to evaluate all "
+            "configured providers."
+        ),
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Run host readiness checks without writing config or starting Core.",
+    ),
+    non_interactive: bool = typer.Option(
+        False,
+        "--non-interactive",
+        help="Fail instead of prompting when interactive input would be required.",
+    ),
+    allow_plain_secrets: bool = typer.Option(
+        False,
+        "--allow-plain-secrets",
+        help="Consent to plain-file secret storage for later credential setup slices.",
+    ),
+    source_checkout: Path | None = typer.Option(
+        None,
+        "--source-checkout",
+        help="Path to an AWF source checkout to validate for first-run assets.",
+    ),
     fmt: OutputFormat = typer.Option(
         OutputFormat.pretty,
         "--format",
@@ -41,9 +86,154 @@ def setup_command(
     ),
 ) -> None:
     """Prepare this machine for AWF first-run use."""
-    payload = _setup_placeholder_payload()
+    providers, unknown = _normalize_setup_providers(provider)
+    if unknown:
+        _emit_first_run(_unknown_provider_payload(unknown), fmt, exit_code=2)
+
+    try:
+        config = read_host_setup_config()
+    except HostSetupConfigError as exc:
+        _emit_first_run(_config_error_payload(exc), fmt, exit_code=1)
+
+    verified_source: VerifiedSourceCheckout | None = None
+    if source_checkout is not None:
+        try:
+            verified_source = validate_source_checkout(source_checkout)
+        except SourceCheckoutError as exc:
+            _emit_first_run(_source_checkout_error_payload(exc), fmt, exit_code=1)
+
+    if non_interactive and providers and not dry_run:
+        _emit_first_run(_interactive_required_payload(providers), fmt, exit_code=1)
+
+    report = run_system_checks(host_port=config.api.host_port, work_dir=config.work_dir)
+    payload = first_run_setup_readiness_payload(
+        report,
+        command=_SETUP_COMMAND,
+        dry_run=dry_run,
+        providers=providers,
+        allow_plain_secrets=allow_plain_secrets,
+        source_checkout_root=str(verified_source.root) if verified_source is not None else None,
+    )
+
+    blocked = report.status == "fail"
+    if not dry_run and not blocked:
+        _write_safe_setup_config(
+            config,
+            allow_plain_secrets=allow_plain_secrets,
+            verified_source=verified_source,
+        )
+
+    _emit_first_run(payload, fmt, exit_code=1 if blocked else 0)
+
+
+def _normalize_setup_providers(values: list[str]) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Return ``(validated providers, unknown selectors)``; order-stable and deduped."""
+    providers: list[str] = []
+    unknown: list[str] = []
+    for raw in values:
+        name = raw.strip().lower().replace("-", "_")
+        name = _PROVIDER_ALIASES.get(name, name)
+        if not name:
+            continue
+        if name not in _SETUP_PROVIDER_NAMES:
+            if raw not in unknown:
+                unknown.append(raw)
+            continue
+        if name not in providers:
+            providers.append(name)
+    return tuple(providers), tuple(unknown)
+
+
+def _unknown_provider_payload(unknown: tuple[str, ...]) -> FirstRunPayload:
+    """Build the usage-error payload for unsupported ``--provider`` selectors."""
+    return first_run_failure_payload(
+        command=_SETUP_COMMAND,
+        reason_code=SETUP_PROVIDER_UNKNOWN,
+        summary="AWF setup was asked to configure an unsupported provider.",
+        status="failed",
+        details={
+            "unknown_providers": list(unknown),
+            "supported_providers": list(_SETUP_PROVIDER_NAMES),
+        },
+        next_steps=(
+            "Use a supported provider name, or omit --provider to evaluate all providers.",
+        ),
+    )
+
+
+def _config_error_payload(exc: HostSetupConfigError) -> FirstRunPayload:
+    """Build a failure payload from a reason-coded host setup config error."""
+    return first_run_failure_payload(
+        command=_SETUP_COMMAND,
+        reason_code=exc.reason_code,
+        summary=exc.message,
+        status="failed",
+        details=dict(exc.details) or None,
+    )
+
+
+def _source_checkout_error_payload(exc: SourceCheckoutError) -> FirstRunPayload:
+    """Build a failure payload from a reason-coded source-checkout error."""
+    details: dict[str, object] = {"root": str(exc.root)}
+    if exc.missing_markers:
+        details["missing_markers"] = list(exc.missing_markers)
+    details.update(exc.details)
+    return first_run_failure_payload(
+        command=_SETUP_COMMAND,
+        reason_code=exc.reason_code,
+        summary=exc.message,
+        status="failed",
+        details=details,
+    )
+
+
+def _interactive_required_payload(providers: tuple[str, ...]) -> FirstRunPayload:
+    """Build the failure payload for non-interactive runs that need input."""
+    return first_run_failure_payload(
+        command=_SETUP_COMMAND,
+        reason_code=INTERACTIVE_INPUT_REQUIRED,
+        summary="AWF setup needs interactive input that is unavailable in this run.",
+        status="failed",
+        details={
+            "providers": list(providers),
+            "non_interactive": True,
+            "dry_run": False,
+        },
+        next_steps=(
+            "Re-run interactively, supply safe env/keychain references, or add --dry-run.",
+        ),
+    )
+
+
+def _write_safe_setup_config(
+    config: HostSetupConfig,
+    *,
+    allow_plain_secrets: bool,
+    verified_source: VerifiedSourceCheckout | None,
+) -> None:
+    """Persist non-secret consent flags and verified source metadata only."""
+    consent = config.consent.model_copy(
+        update={
+            "plain_file_secrets": config.consent.plain_file_secrets or allow_plain_secrets,
+            "source_checkout_assets": (
+                config.consent.source_checkout_assets or verified_source is not None
+            ),
+        }
+    )
+    updates: dict[str, object] = {"consent": consent}
+    if verified_source is not None:
+        updates["source_checkout"] = verified_source.to_metadata()
+    write_host_setup_config(config.model_copy(update=updates))
+
+
+def _emit_first_run(payload: FirstRunPayload, fmt: OutputFormat, *, exit_code: int) -> NoReturn:
+    """Emit a first-run payload and exit with the given code.
+
+    JSON always goes to stdout for scripting. Pretty success (exit 0) goes to
+    stdout; pretty failures go to stderr.
+    """
     if fmt == OutputFormat.json:
         _emit(render_first_run_json(payload), fmt)
     else:
-        typer.echo(render_first_run_pretty(payload), err=True)
-    raise typer.Exit(code=1)
+        typer.echo(render_first_run_pretty(payload), err=exit_code != 0)
+    raise typer.Exit(code=exit_code)

--- a/src/awf/host_setup/__init__.py
+++ b/src/awf/host_setup/__init__.py
@@ -53,6 +53,7 @@ from awf.host_setup.rendering import (
     first_run_failure_payload,
     first_run_issue_from_reason_code,
     first_run_remediation_from_reason_code,
+    first_run_setup_readiness_payload,
     first_run_success_payload,
     first_run_warning_payload,
     redact_first_run_value,
@@ -71,6 +72,11 @@ from awf.host_setup.source_assets import (
     VerifiedSourceCheckout,
     validate_source_checkout,
     verified_source_from_metadata,
+)
+from awf.host_setup.system_checks import (
+    SystemCheck,
+    SystemChecksReport,
+    run_system_checks,
 )
 
 __all__ = [
@@ -126,17 +132,21 @@ __all__ = [
     "SourceCheckoutAssetPaths",
     "SourceCheckoutError",
     "SourceCheckoutMarker",
+    "SystemCheck",
+    "SystemChecksReport",
     "VerifiedSourceCheckout",
     "default_host_setup_config_path",
     "first_run_failure_payload",
     "first_run_issue_from_reason_code",
     "first_run_remediation_from_reason_code",
+    "first_run_setup_readiness_payload",
     "first_run_success_payload",
     "first_run_warning_payload",
     "read_host_setup_config",
     "redact_first_run_value",
     "render_first_run_json",
     "render_first_run_pretty",
+    "run_system_checks",
     "validate_source_checkout",
     "verified_source_from_metadata",
     "write_host_setup_config",

--- a/src/awf/host_setup/rendering.py
+++ b/src/awf/host_setup/rendering.py
@@ -26,6 +26,7 @@ from awf.host_setup.source_assets import (
     SOURCE_CHECKOUT_ASSETS_STALE,
     SOURCE_CHECKOUT_INVALID,
 )
+from awf.host_setup.system_checks import SystemChecksReport
 from awf.service.doctor.reasons import reason_text_for_code
 
 AWF_SETUP_PLACEHOLDER = "AWF_SETUP_PLACEHOLDER"
@@ -311,6 +312,90 @@ def first_run_failure_payload(
         issues=(issue,),
         next_steps=next_steps,
     )
+
+
+def first_run_setup_readiness_payload(
+    report: SystemChecksReport,
+    *,
+    command: str = "awf setup",
+    dry_run: bool,
+    providers: tuple[str, ...],
+    allow_plain_secrets: bool,
+    source_checkout_root: str | None,
+) -> FirstRunPayload:
+    """Build a first-run readiness payload from a host system-checks report.
+
+    A failing report becomes a blocked failure payload keyed on
+    ``SETUP_READINESS_FAILED`` whose ``next_steps`` are the de-duplicated blocker
+    fixes plus a re-run instruction. An ``ok``/``warn`` report becomes a success
+    payload (exit 0); warnings ride along in ``details`` so they render without
+    failing the command. The next command on success is ``awf start``.
+    """
+    details = _setup_readiness_details(
+        report,
+        dry_run=dry_run,
+        providers=providers,
+        allow_plain_secrets=allow_plain_secrets,
+        source_checkout_root=source_checkout_root,
+    )
+    if report.status == "fail":
+        return first_run_failure_payload(
+            command=command,
+            reason_code=SETUP_READINESS_FAILED,
+            summary="AWF setup found one or more machine readiness blockers.",
+            status="blocked",
+            details=details,
+            next_steps=_setup_blocker_next_steps(report),
+        )
+    summary = (
+        "AWF setup machine readiness checks passed."
+        if report.status == "ok"
+        else "AWF setup machine readiness checks passed with warnings."
+    )
+    return first_run_success_payload(
+        command=command,
+        summary=summary,
+        details=details,
+        next_steps=("Run awf start to launch local AWF Core.",),
+    )
+
+
+def _setup_readiness_details(
+    report: SystemChecksReport,
+    *,
+    dry_run: bool,
+    providers: tuple[str, ...],
+    allow_plain_secrets: bool,
+    source_checkout_root: str | None,
+) -> dict[str, Any]:
+    """Build the JSON-safe readiness details mapping (redacted at render time)."""
+    # The consent boolean is reported under a redaction-safe key. Any detail key
+    # containing "secret"/"token" has its value scrubbed by render_first_run_json,
+    # which would hide this non-sensitive opt-in decision from operators.
+    details: dict[str, Any] = {
+        "dry_run": dry_run,
+        "providers": list(providers),
+        "provider_scope": "targeted recheck" if providers else "all",
+        "allow_plain_file_credentials": allow_plain_secrets,
+        "checks": [check.to_dict() for check in report.checks],
+        "blockers": [check.id for check in report.blockers],
+        "warnings": [check.id for check in report.warnings],
+    }
+    if source_checkout_root is not None:
+        details["source_checkout"] = source_checkout_root
+    if report.capacity is not None:
+        details["capacity"] = dict(report.capacity)
+    return details
+
+
+def _setup_blocker_next_steps(report: SystemChecksReport) -> tuple[str, ...]:
+    """Return de-duplicated blocker fixes followed by a re-run instruction."""
+    steps: list[str] = []
+    for check in report.blockers:
+        if check.fix and check.fix not in steps:
+            steps.append(check.fix)
+    steps.append("Re-run awf setup --dry-run after resolving the blockers above.")
+    return tuple(steps)
 
 
 def render_first_run_json(payload: FirstRunPayload) -> dict[str, Any]:
@@ -645,6 +730,7 @@ __all__ = [
     "first_run_failure_payload",
     "first_run_issue_from_reason_code",
     "first_run_remediation_from_reason_code",
+    "first_run_setup_readiness_payload",
     "first_run_success_payload",
     "first_run_warning_payload",
     "redact_first_run_value",

--- a/src/awf/host_setup/system_checks.py
+++ b/src/awf/host_setup/system_checks.py
@@ -1,0 +1,641 @@
+"""Local-first, bounded host readiness checks for ``awf setup``.
+
+These checks are provider-neutral and never start AWF Core. Every probe is
+dependency-injected so tests run without Docker, sockets, or a real filesystem.
+Subprocess and socket failures catch specific exceptions and map to ``fail`` /
+``warn`` results rather than swallowing errors behind a bare ``except``.
+
+Per-check ``reason`` strings that are not part of the documented doctor reason
+catalog live only inside the structured report; they are never emitted through
+``error_code=`` and never added to the first-run reason tuples, so the catalog
+coverage guard is not tripped. The documented codes the report does reuse
+(``DOCKER_CLI_NOT_FOUND``, ``DOCKER_DAEMON_UNREACHABLE``, ``INSUFFICIENT_DISK``,
+``SUFFICIENT_DISK``) already exist in the catalog.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+from collections.abc import Callable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Literal
+
+from awf.common.config import DEFAULT_MIN_FREE_DISK_BYTES
+from awf.service.disk import DiskUsage, check_disk_space
+from awf.service.doctor.models import CompletedProcessLike, SocketConnector, SubprocessRun
+from awf.service.doctor.reasons import reason_text_for_code
+
+SystemCheckStatus = Literal["ok", "warn", "fail", "skipped"]
+SystemChecksStatus = Literal["ok", "warn", "fail"]
+
+PYTHON_RUNTIME_FLOOR: tuple[int, int] = (3, 12)
+_DEFAULT_HOST = "127.0.0.1"
+_DEFAULT_DB_PORT = 5432
+_SUBPROCESS_TIMEOUT_SECONDS = 5.0
+_SOCKET_TIMEOUT_SECONDS = 0.5
+_BYTES_PER_GIB = 1024**3
+
+# Report-local reason strings. These are intentionally NOT in the doctor reason
+# catalog and are only ever carried in the structured report's ``reason`` field.
+_DOCKER_CLI_OK = "DOCKER_CLI_AVAILABLE"
+_DOCKER_DAEMON_OK = "DOCKER_DAEMON_REACHABLE"
+_DOCKER_DAEMON_SKIPPED = "DOCKER_DAEMON_CHECK_SKIPPED"
+_COMPOSE_OK = "COMPOSE_AVAILABLE"
+_COMPOSE_MISSING = "COMPOSE_NOT_AVAILABLE"
+_COMPOSE_SKIPPED = "COMPOSE_CHECK_SKIPPED"
+_GIT_OK = "GIT_AVAILABLE"
+_GIT_MISSING = "GIT_NOT_FOUND"
+_GH_OK = "GH_AVAILABLE"
+_GH_MISSING = "GH_NOT_FOUND"
+_PYTHON_OK = "PYTHON_RUNTIME_OK"
+_PYTHON_BELOW_FLOOR = "PYTHON_RUNTIME_BELOW_FLOOR"
+_PORT_AVAILABLE = "PORT_AVAILABLE"
+_PORT_IN_USE = "PORT_IN_USE"
+_AWF_ON_PATH = "AWF_ON_PATH"
+_AWF_NOT_ON_PATH = "AWF_NOT_ON_PATH"
+_CAPACITY_DETECTED = "CAPACITY_DETECTED"
+_CAPACITY_UNKNOWN = "CAPACITY_UNKNOWN"
+
+# Documented doctor reason codes the report reuses verbatim.
+_DOCKER_CLI_NOT_FOUND = "DOCKER_CLI_NOT_FOUND"
+_DOCKER_DAEMON_UNREACHABLE = "DOCKER_DAEMON_UNREACHABLE"
+
+
+@dataclass(frozen=True, kw_only=True)
+class SystemCheck:
+    """One bounded host readiness check with stable, secret-free fields."""
+
+    id: str
+    label: str
+    status: SystemCheckStatus
+    reason: str
+    message: str
+    fix: str | None = None
+    docs_link: str | None = None
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe, secret-free representation of the check."""
+        payload: dict[str, object] = {
+            "id": self.id,
+            "status": self.status,
+            "reason": self.reason,
+            "message": self.message,
+        }
+        if self.fix is not None:
+            payload["fix"] = self.fix
+        if self.docs_link is not None:
+            payload["docs_link"] = self.docs_link
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(frozen=True, kw_only=True)
+class SystemChecksReport:
+    """Aggregated host readiness checks with a derived blocking status."""
+
+    checks: tuple[SystemCheck, ...]
+    capacity: Mapping[str, object] | None = None
+
+    @property
+    def status(self) -> SystemChecksStatus:
+        """Return ``fail`` if any check blocks, ``warn`` if any advises, else ``ok``."""
+        if any(check.status == "fail" for check in self.checks):
+            return "fail"
+        if any(check.status == "warn" for check in self.checks):
+            return "warn"
+        return "ok"
+
+    @property
+    def blockers(self) -> tuple[SystemCheck, ...]:
+        """Return the checks that block readiness."""
+        return tuple(check for check in self.checks if check.status == "fail")
+
+    @property
+    def warnings(self) -> tuple[SystemCheck, ...]:
+        """Return the non-blocking advisory checks."""
+        return tuple(check for check in self.checks if check.status == "warn")
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe, secret-free report representation."""
+        payload: dict[str, object] = {
+            "status": self.status,
+            "checks": [check.to_dict() for check in self.checks],
+            "blockers": [check.id for check in self.blockers],
+            "warnings": [check.id for check in self.warnings],
+        }
+        if self.capacity is not None:
+            payload["capacity"] = dict(self.capacity)
+        return payload
+
+
+def run_system_checks(
+    *,
+    host_port: int,
+    work_dir: str,
+    host: str = _DEFAULT_HOST,
+    min_free_bytes: int = DEFAULT_MIN_FREE_DISK_BYTES,
+    which: Callable[[str], str | None] = shutil.which,
+    run_subprocess: SubprocessRun | None = None,
+    socket_connector: SocketConnector | None = None,
+    disk_usage: DiskUsage | None = None,
+    environ: Mapping[str, str] | None = None,
+    python_version: tuple[int, int] = sys.version_info[:2],
+    docker_host: str | None = None,
+) -> SystemChecksReport:
+    """Run bounded host readiness checks without starting AWF Core.
+
+    All probes are injectable so the suite is deterministic and never touches
+    Docker, the network, or a real work directory in tests.
+    """
+    resolved_run = run_subprocess or _run_subprocess
+    resolved_connect = socket_connector or _default_socket_connector
+    env = dict(os.environ if environ is None else environ)
+    if docker_host:
+        env["DOCKER_HOST"] = docker_host
+
+    docker_cli_path = which("docker")
+    docker_cli_check = _docker_cli_check(docker_cli_path)
+    docker_info_payload, docker_daemon_check = _docker_daemon_check(
+        cli_present=docker_cli_path is not None,
+        run_subprocess=resolved_run,
+        env=env,
+    )
+    compose_check = _docker_compose_check(
+        cli_present=docker_cli_path is not None,
+        run_subprocess=resolved_run,
+        env=env,
+    )
+    capacity = _parse_capacity(docker_info_payload)
+
+    checks: tuple[SystemCheck, ...] = (
+        docker_cli_check,
+        docker_daemon_check,
+        compose_check,
+        _which_check(
+            check_id="git",
+            label="Git CLI",
+            executable="git",
+            which=which,
+            ok_reason=_GIT_OK,
+            missing_reason=_GIT_MISSING,
+            missing_status="fail",
+            missing_message="Git was not found on PATH; AWF needs git to manage worktrees.",
+            missing_fix="Install git and ensure it is on PATH.",
+        ),
+        _which_check(
+            check_id="gh",
+            label="GitHub CLI",
+            executable="gh",
+            which=which,
+            ok_reason=_GH_OK,
+            missing_reason=_GH_MISSING,
+            missing_status="warn",
+            missing_message=(
+                "GitHub CLI was not found. AWF can use an env-ref token instead, so "
+                "this is advisory."
+            ),
+            missing_fix="Install gh, or supply a GitHub token via env reference during provider setup.",
+        ),
+        _python_runtime_check(python_version),
+        _port_check(
+            check_id="port_api",
+            label="AWF API port",
+            host=host,
+            port=host_port,
+            socket_connector=resolved_connect,
+        ),
+        _port_check(
+            check_id="port_db",
+            label="Postgres port",
+            host=host,
+            port=_DEFAULT_DB_PORT,
+            socket_connector=resolved_connect,
+        ),
+        _disk_check(work_dir=work_dir, min_free_bytes=min_free_bytes, disk_usage=disk_usage),
+        _which_check(
+            check_id="shell_path",
+            label="awf on PATH",
+            executable="awf",
+            which=which,
+            ok_reason=_AWF_ON_PATH,
+            missing_reason=_AWF_NOT_ON_PATH,
+            missing_status="warn",
+            missing_message=(
+                "The awf entry point was not found on PATH. This is fine when running "
+                "via `uv run awf`."
+            ),
+            missing_fix="Add the AWF install location to PATH, or invoke AWF via `uv run awf`.",
+        ),
+        _capacity_check(capacity),
+    )
+    return SystemChecksReport(checks=checks, capacity=capacity)
+
+
+def _docker_cli_check(docker_cli_path: str | None) -> SystemCheck:
+    """Return the Docker CLI availability check."""
+    if docker_cli_path is not None:
+        return SystemCheck(
+            id="docker_cli",
+            label="Docker CLI",
+            status="ok",
+            reason=_DOCKER_CLI_OK,
+            message="Docker CLI is available on PATH.",
+            metadata={"present": True},
+        )
+    return SystemCheck(
+        id="docker_cli",
+        label="Docker CLI",
+        status="fail",
+        reason=_DOCKER_CLI_NOT_FOUND,
+        message="Docker CLI was not found on PATH.",
+        fix=_catalog_action(_DOCKER_CLI_NOT_FOUND),
+        docs_link=_docs_link_for(_DOCKER_CLI_NOT_FOUND),
+        metadata={"present": False},
+    )
+
+
+def _docker_daemon_check(
+    *,
+    cli_present: bool,
+    run_subprocess: SubprocessRun,
+    env: Mapping[str, str],
+) -> tuple[Mapping[str, object] | None, SystemCheck]:
+    """Probe the Docker daemon once and return the parsed ``docker info`` payload."""
+    if not cli_present:
+        return None, SystemCheck(
+            id="docker_daemon",
+            label="Docker daemon",
+            status="skipped",
+            reason=_DOCKER_DAEMON_SKIPPED,
+            message="Docker CLI is missing, so the daemon check was skipped.",
+        )
+
+    completed, error_detail = _run_bounded(
+        run_subprocess,
+        ["docker", "info", "--format", "{{json .}}"],
+        env=env,
+    )
+    if completed is None:
+        return None, SystemCheck(
+            id="docker_daemon",
+            label="Docker daemon",
+            status="fail",
+            reason=_DOCKER_DAEMON_UNREACHABLE,
+            message="Docker is installed but the daemon could not be reached.",
+            fix=_catalog_action(_DOCKER_DAEMON_UNREACHABLE),
+            docs_link=_docs_link_for(_DOCKER_DAEMON_UNREACHABLE),
+            metadata={"probe": error_detail},
+        )
+    if completed.returncode != 0:
+        return None, SystemCheck(
+            id="docker_daemon",
+            label="Docker daemon",
+            status="fail",
+            reason=_DOCKER_DAEMON_UNREACHABLE,
+            message="Docker is installed but the daemon reported it is not reachable.",
+            fix=_catalog_action(_DOCKER_DAEMON_UNREACHABLE),
+            docs_link=_docs_link_for(_DOCKER_DAEMON_UNREACHABLE),
+            metadata={"returncode": completed.returncode},
+        )
+
+    payload = _parse_docker_info(completed.stdout)
+    return payload, SystemCheck(
+        id="docker_daemon",
+        label="Docker daemon",
+        status="ok",
+        reason=_DOCKER_DAEMON_OK,
+        message="Docker daemon is reachable.",
+        metadata={"reachable": True},
+    )
+
+
+def _docker_compose_check(
+    *,
+    cli_present: bool,
+    run_subprocess: SubprocessRun,
+    env: Mapping[str, str],
+) -> SystemCheck:
+    """Probe ``docker compose`` plugin availability."""
+    if not cli_present:
+        return SystemCheck(
+            id="docker_compose",
+            label="Docker Compose",
+            status="skipped",
+            reason=_COMPOSE_SKIPPED,
+            message="Docker CLI is missing, so the Compose check was skipped.",
+        )
+
+    completed, _ = _run_bounded(
+        run_subprocess,
+        ["docker", "compose", "version", "--short"],
+        env=env,
+    )
+    if completed is None or completed.returncode != 0:
+        return SystemCheck(
+            id="docker_compose",
+            label="Docker Compose",
+            status="fail",
+            reason=_COMPOSE_MISSING,
+            message="The docker compose plugin is not available.",
+            fix="Install the Docker Compose v2 plugin (bundled with Docker Desktop).",
+            metadata={"available": False},
+        )
+    version = (completed.stdout or "").strip()
+    metadata: dict[str, object] = {"available": True}
+    if version:
+        metadata["version"] = version
+    return SystemCheck(
+        id="docker_compose",
+        label="Docker Compose",
+        status="ok",
+        reason=_COMPOSE_OK,
+        message="The docker compose plugin is available.",
+        metadata=metadata,
+    )
+
+
+def _which_check(
+    *,
+    check_id: str,
+    label: str,
+    executable: str,
+    which: Callable[[str], str | None],
+    ok_reason: str,
+    missing_reason: str,
+    missing_status: SystemCheckStatus,
+    missing_message: str,
+    missing_fix: str,
+) -> SystemCheck:
+    """Return a presence-on-PATH check for a required or advisory executable."""
+    if which(executable) is not None:
+        return SystemCheck(
+            id=check_id,
+            label=label,
+            status="ok",
+            reason=ok_reason,
+            message=f"{executable} is available on PATH.",
+            metadata={"present": True},
+        )
+    return SystemCheck(
+        id=check_id,
+        label=label,
+        status=missing_status,
+        reason=missing_reason,
+        message=missing_message,
+        fix=missing_fix,
+        metadata={"present": False},
+    )
+
+
+def _python_runtime_check(python_version: tuple[int, int]) -> SystemCheck:
+    """Return the interpreter floor check."""
+    detected = f"{python_version[0]}.{python_version[1]}"
+    required = f"{PYTHON_RUNTIME_FLOOR[0]}.{PYTHON_RUNTIME_FLOOR[1]}"
+    metadata: dict[str, object] = {"detected": detected, "required": required}
+    if python_version >= PYTHON_RUNTIME_FLOOR:
+        return SystemCheck(
+            id="python_runtime",
+            label="Python runtime",
+            status="ok",
+            reason=_PYTHON_OK,
+            message=f"Python {detected} meets the {required} floor.",
+            metadata=metadata,
+        )
+    return SystemCheck(
+        id="python_runtime",
+        label="Python runtime",
+        status="fail",
+        reason=_PYTHON_BELOW_FLOOR,
+        message=f"Python {detected} is below the required {required} floor.",
+        fix=f"Install Python {required} or newer and re-run AWF under it.",
+        metadata=metadata,
+    )
+
+
+def _port_check(
+    *,
+    check_id: str,
+    label: str,
+    host: str,
+    port: int,
+    socket_connector: SocketConnector,
+) -> SystemCheck:
+    """Return a non-blocking port-occupancy check.
+
+    An occupied port is a warning (AWF may already be running); a refused
+    connection means the port is free.
+    """
+    metadata: dict[str, object] = {"host": host, "port": port}
+    try:
+        connection = socket_connector((host, port), _SOCKET_TIMEOUT_SECONDS)
+    except OSError:
+        return SystemCheck(
+            id=check_id,
+            label=label,
+            status="ok",
+            reason=_PORT_AVAILABLE,
+            message=f"{label} {port} is free.",
+            metadata={**metadata, "in_use": False},
+        )
+    with suppress(OSError):
+        connection.close()
+    return SystemCheck(
+        id=check_id,
+        label=label,
+        status="warn",
+        reason=_PORT_IN_USE,
+        message=f"{label} {port} is already in use; AWF may already be running.",
+        fix=f"Stop the process using port {port}, or reconfigure the AWF port.",
+        metadata={**metadata, "in_use": True},
+    )
+
+
+def _disk_check(
+    *,
+    work_dir: str,
+    min_free_bytes: int,
+    disk_usage: DiskUsage | None,
+) -> SystemCheck:
+    """Return the free-disk check for the AWF work directory."""
+    # check_disk_space expands ``~`` and walks to the nearest existing parent.
+    result = check_disk_space(
+        work_dir,
+        min_free_bytes=min_free_bytes,
+        disk_usage=disk_usage,
+    )
+    metadata: dict[str, object] = {
+        "free_bytes": result.free_bytes,
+        "threshold_bytes": result.threshold_bytes,
+        "percent_free": result.percent_free,
+    }
+    if result.ok:
+        return SystemCheck(
+            id="disk",
+            label="Free disk",
+            status="ok",
+            reason=result.reason,
+            message="Free disk meets the configured AWF threshold.",
+            metadata=metadata,
+        )
+    return SystemCheck(
+        id="disk",
+        label="Free disk",
+        status="fail",
+        reason=result.reason,
+        message=result.detail or "Free disk is below the configured AWF threshold.",
+        fix=_catalog_action(result.reason)
+        or "Free disk before creating workspaces, or lower the configured threshold.",
+        docs_link=_docs_link_for(result.reason),
+        metadata=metadata,
+    )
+
+
+def _capacity_check(capacity: Mapping[str, object] | None) -> SystemCheck:
+    """Return a never-blocking capacity check derived from ``docker info``."""
+    if capacity is None:
+        return SystemCheck(
+            id="capacity",
+            label="Local capacity",
+            status="warn",
+            reason=_CAPACITY_UNKNOWN,
+            message="Local Docker capacity could not be determined.",
+            fix="Start Docker to let AWF size local workspace capacity.",
+        )
+    return SystemCheck(
+        id="capacity",
+        label="Local capacity",
+        status="ok",
+        reason=_CAPACITY_DETECTED,
+        message="Local Docker capacity was detected.",
+        metadata=dict(capacity),
+    )
+
+
+def _run_bounded(
+    run_subprocess: SubprocessRun,
+    args: list[str],
+    *,
+    env: Mapping[str, str],
+) -> tuple[CompletedProcessLike | None, str]:
+    """Run a bounded subprocess, mapping known failures to ``(None, detail)``.
+
+    Returns the completed process on success, or ``None`` with a short,
+    secret-free detail string when the command could not run to completion.
+    """
+    try:
+        completed = run_subprocess(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            env=env,
+        )
+    except FileNotFoundError:
+        return None, "command_not_found"
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+    except OSError as exc:
+        return None, type(exc).__name__
+    return completed, "ok"
+
+
+def _parse_docker_info(stdout: str | None) -> Mapping[str, object] | None:
+    """Parse ``docker info`` JSON, tolerating malformed output."""
+    if not stdout:
+        return None
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, Mapping) else None
+
+
+def _parse_capacity(payload: Mapping[str, object] | None) -> dict[str, object] | None:
+    """Parse CPU/memory capacity from a ``docker info`` payload."""
+    if payload is None:
+        return None
+    cpu_cores = _positive_float(payload.get("NCPU"))
+    memory_gb = _bytes_to_gib(payload.get("MemTotal"))
+    if cpu_cores is None and memory_gb is None:
+        return None
+    capacity: dict[str, object] = {}
+    if cpu_cores is not None:
+        capacity["cpu_cores"] = cpu_cores
+    if memory_gb is not None:
+        capacity["memory_gb"] = memory_gb
+    return capacity
+
+
+def _positive_float(value: object) -> float | None:
+    """Return a positive float for a docker info numeric field, else ``None``."""
+    if value is None or isinstance(value, bool) or not isinstance(value, (str, int, float)):
+        return None
+    try:
+        number = float(value)
+    except ValueError:
+        return None
+    return number if number > 0 else None
+
+
+def _bytes_to_gib(value: object) -> float | None:
+    """Convert a byte count to rounded GiB, else ``None``."""
+    number = _positive_float(value)
+    if number is None:
+        return None
+    return round(number / _BYTES_PER_GIB, 3)
+
+
+def _catalog_action(reason_code: str) -> str | None:
+    """Return the documented remediation action for a catalog reason code."""
+    reason = reason_text_for_code(reason_code)
+    return reason.action if reason is not None else None
+
+
+def _docs_link_for(reason_code: str) -> str | None:
+    """Return the documented docs link for a catalog reason code."""
+    reason = reason_text_for_code(reason_code)
+    return reason.docs_link if reason is not None else None
+
+
+def _run_subprocess(
+    args: list[str],
+    *,
+    check: bool,
+    capture_output: bool,
+    text: Literal[True],
+    timeout: float,
+    env: Mapping[str, str],
+) -> subprocess.CompletedProcess[str]:
+    """Default bounded subprocess runner used when no fake is injected."""
+    return subprocess.run(
+        args,
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        timeout=timeout,
+        env=env,
+    )
+
+
+def _default_socket_connector(address: tuple[str, int], timeout: float) -> socket.socket:
+    """Default socket connector used when no fake is injected."""
+    return socket.create_connection(address, timeout=timeout)
+
+
+__all__ = [
+    "PYTHON_RUNTIME_FLOOR",
+    "SystemCheck",
+    "SystemCheckStatus",
+    "SystemChecksReport",
+    "SystemChecksStatus",
+    "run_system_checks",
+]

--- a/tests/unit/cli/test_setup_commands.py
+++ b/tests/unit/cli/test_setup_commands.py
@@ -1,69 +1,321 @@
-"""CLI coverage for the reserved ``awf setup`` first-run surface."""
+"""CLI coverage for the ``awf setup`` first-run wizard shell."""
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import click
 import pytest
 from typer.testing import CliRunner
 
+import awf.cli.setup_commands as setup_commands
 from awf.cli.main import app
+from awf.host_setup.config import HostSetupConfig, HostSetupConfigError
+from awf.host_setup.source_assets import (
+    SOURCE_CHECKOUT_INVALID,
+    validate_source_checkout,
+)
+from awf.host_setup.system_checks import SystemCheck, SystemChecksReport
 
 _runner = CliRunner()
 
 
+def _report(*checks: SystemCheck) -> SystemChecksReport:
+    return SystemChecksReport(checks=checks)
+
+
+def _healthy_report() -> SystemChecksReport:
+    return _report(
+        SystemCheck(
+            id="docker_cli",
+            label="Docker CLI",
+            status="ok",
+            reason="DOCKER_CLI_AVAILABLE",
+            message="ok",
+        ),
+        SystemCheck(id="git", label="Git CLI", status="ok", reason="GIT_AVAILABLE", message="ok"),
+    )
+
+
+def _docker_blocked_report() -> SystemChecksReport:
+    return _report(
+        SystemCheck(
+            id="docker_cli",
+            label="Docker CLI",
+            status="fail",
+            reason="DOCKER_CLI_NOT_FOUND",
+            message="Docker CLI was not found on PATH.",
+            fix="Install Docker Desktop or make the docker CLI available.",
+            docs_link="https://docs.docker.com/get-docker/",
+        ),
+        SystemCheck(id="git", label="Git CLI", status="ok", reason="GIT_AVAILABLE", message="ok"),
+    )
+
+
+@pytest.fixture
+def patched_setup(monkeypatch: pytest.MonkeyPatch) -> dict[str, object]:
+    """Patch config IO + system checks so the command is deterministic."""
+    state: dict[str, object] = {
+        "report": _healthy_report(),
+        "writes": [],
+        "system_check_calls": 0,
+    }
+
+    def _fake_run_system_checks(**_kwargs: object) -> SystemChecksReport:
+        state["system_check_calls"] = int(state["system_check_calls"]) + 1  # type: ignore[call-overload]
+        return state["report"]  # type: ignore[return-value]
+
+    def _fake_read() -> HostSetupConfig:
+        return HostSetupConfig()
+
+    def _fake_write(config: HostSetupConfig, **_kwargs: object) -> None:
+        writes = state["writes"]
+        assert isinstance(writes, list)
+        writes.append(config)
+
+    monkeypatch.setattr(setup_commands, "run_system_checks", _fake_run_system_checks)
+    monkeypatch.setattr(setup_commands, "read_host_setup_config", _fake_read)
+    monkeypatch.setattr(setup_commands, "write_host_setup_config", _fake_write)
+    return state
+
+
 @pytest.mark.unit
-def test_setup_help_describes_first_run_surface() -> None:
-    """Verify setup help points operators at the current first-run paths."""
-    result = _runner.invoke(app, ["setup", "--help"], env={"COLUMNS": "180"})
+def test_setup_help_describes_real_first_run_surface() -> None:
+    """Verify setup help advertises the real wizard surface, not a placeholder."""
+    result = _runner.invoke(app, ["setup", "--help"], env={"COLUMNS": "200"})
     visible_help = click.unstyle(result.output)
 
     assert result.exit_code == 0, result.output
     assert "Prepare this machine for AWF" in visible_help
-    assert "awf service bootstrap" in visible_help
-    assert "awf init <path>" in visible_help
+    assert "--dry-run" in visible_help
+    assert "--provider" in visible_help
+    assert "Reserved" not in visible_help
     assert "Traceback" not in visible_help
 
 
 @pytest.mark.unit
-def test_setup_placeholder_pretty_has_stable_reason_code() -> None:
-    """Verify pretty setup placeholder output includes stable guidance."""
-    result = _runner.invoke(app, ["setup"])
+def test_setup_dry_run_ready_success(patched_setup: dict[str, object]) -> None:
+    """Verify a healthy dry-run reports success and the next command."""
+    result = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
 
-    assert result.exit_code == 1
-    assert result.stdout == ""
-    assert "Status: blocked" in result.stderr
-    assert "Command: awf setup" in result.stderr
-    assert "AWF_SETUP_PLACEHOLDER" in result.stderr
-    assert "Problem:" in result.stderr
-    assert "Cause:" in result.stderr
-    assert "Fix:" in result.stderr
-    assert "Docs:" in result.stderr
-    assert "awf service bootstrap" in result.stderr
-    assert "awf init <path>" in result.stderr
-    assert "Traceback" not in result.stderr
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["status"] == "success"
+    assert payload["details"]["dry_run"] is True
+    assert any("awf start" in step for step in payload["next_steps"])
 
 
 @pytest.mark.unit
-def test_setup_placeholder_json_has_stable_shape() -> None:
-    """Verify JSON setup placeholder output has the stable first-run shape."""
-    result = _runner.invoke(app, ["setup", "--format", "json"])
+def test_setup_dry_run_does_not_write_config_or_secrets(patched_setup: dict[str, object]) -> None:
+    """Verify a dry-run never persists config."""
+    result = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert patched_setup["writes"] == []
+
+
+@pytest.mark.unit
+def test_setup_dry_run_docker_blocker_readiness_failure(patched_setup: dict[str, object]) -> None:
+    """Verify a docker blocker yields a reason-coded readiness failure."""
+    patched_setup["report"] = _docker_blocked_report()
+    result = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
 
     assert result.exit_code == 1
     payload = json.loads(result.output)
     assert payload["status"] == "blocked"
-    assert payload["reason_code"] == "AWF_SETUP_PLACEHOLDER"
-    assert payload["command"] == "awf setup"
-    assert payload["summary"] == (
-        "awf setup is reserved; host setup checks land in a later setup slice."
+    assert payload["reason_code"] == "SETUP_READINESS_FAILED"
+    assert "docker_cli" in payload["issues"][0]["details"]["blockers"]
+    assert payload["next_steps"]
+
+
+@pytest.mark.unit
+def test_setup_docker_blocker_pretty_goes_to_stderr(patched_setup: dict[str, object]) -> None:
+    """Verify blocked pretty output goes to stderr with an empty stdout."""
+    patched_setup["report"] = _docker_blocked_report()
+    result = _runner.invoke(app, ["setup", "--dry-run"])
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "Status: blocked" in result.stderr
+    assert "Docs:" in result.stderr
+    assert "Next:" in result.stderr
+
+
+@pytest.mark.unit
+def test_setup_provider_selector_forwarded(patched_setup: dict[str, object]) -> None:
+    """Verify a single provider selector becomes a targeted recheck scope."""
+    result = _runner.invoke(app, ["setup", "--dry-run", "--provider", "github", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    details = json.loads(result.output)["details"]
+    assert details["providers"] == ["github"]
+    assert details["provider_scope"] == "targeted recheck"
+
+
+@pytest.mark.unit
+def test_setup_repeated_provider_selectors_deduped(patched_setup: dict[str, object]) -> None:
+    """Verify repeated provider selectors are de-duplicated."""
+    result = _runner.invoke(
+        app,
+        ["setup", "--dry-run", "--provider", "github", "--provider", "github", "--format", "json"],
     )
-    assert payload["next_steps"] == [
-        "Run awf service bootstrap for current local Core startup.",
-        "Run awf init <path> to onboard a project repository.",
-    ]
-    assert payload["issues"][0]["reason_code"] == "AWF_SETUP_PLACEHOLDER"
-    assert payload["issues"][0]["remediation"]["problem"]
-    assert payload["issues"][0]["remediation"]["cause"]
-    assert payload["issues"][0]["remediation"]["fix"]
-    assert payload["issues"][0]["remediation"]["docs_link"]
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["details"]["providers"] == ["github"]
+
+
+@pytest.mark.unit
+def test_setup_multiple_providers_forwarded(patched_setup: dict[str, object]) -> None:
+    """Verify multiple provider selectors are forwarded order-stable."""
+    result = _runner.invoke(
+        app,
+        ["setup", "--dry-run", "--provider", "github", "--provider", "codex", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["details"]["providers"] == ["github", "codex"]
+
+
+@pytest.mark.unit
+def test_setup_claude_alias_normalized(patched_setup: dict[str, object]) -> None:
+    """Verify the ``claude`` alias normalizes to ``claude_code``."""
+    result = _runner.invoke(app, ["setup", "--dry-run", "--provider", "claude", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output)["details"]["providers"] == ["claude_code"]
+
+
+@pytest.mark.unit
+def test_setup_unknown_provider_rejected(patched_setup: dict[str, object]) -> None:
+    """Verify an unknown provider is a usage error that skips system checks."""
+    result = _runner.invoke(app, ["setup", "--dry-run", "--provider", "nope", "--format", "json"])
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["reason_code"] == "SETUP_PROVIDER_UNKNOWN"
+    assert payload["issues"][0]["details"]["unknown_providers"] == ["nope"]
+    assert patched_setup["system_check_calls"] == 0
+
+
+@pytest.mark.unit
+def test_setup_allow_plain_secrets_forwarded_not_default(patched_setup: dict[str, object]) -> None:
+    """Verify the plain-secret consent flag is forwarded and defaults off."""
+    with_flag = _runner.invoke(
+        app, ["setup", "--dry-run", "--allow-plain-secrets", "--format", "json"]
+    )
+    without_flag = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
+
+    assert with_flag.exit_code == 0, with_flag.output
+    assert json.loads(with_flag.output)["details"]["allow_plain_file_credentials"] is True
+    assert json.loads(without_flag.output)["details"]["allow_plain_file_credentials"] is False
+
+
+@pytest.mark.unit
+def test_setup_source_checkout_valid_dry_run(patched_setup: dict[str, object]) -> None:
+    """Verify a valid source checkout is recorded in readiness details."""
+    repo_root = str(Path(__file__).resolve().parents[3])
+    result = _runner.invoke(
+        app,
+        ["setup", "--dry-run", "--source-checkout", repo_root, "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    details = json.loads(result.output)["details"]
+    # validate_source_checkout resolves the canonical root before recording it.
+    assert details["source_checkout"] == str(validate_source_checkout(repo_root).root)
+
+
+@pytest.mark.unit
+def test_setup_source_checkout_invalid(
+    patched_setup: dict[str, object],
+    tmp_path: Path,
+) -> None:
+    """Verify an invalid source checkout surfaces the reason and missing markers."""
+    result = _runner.invoke(
+        app,
+        ["setup", "--dry-run", "--source-checkout", str(tmp_path), "--format", "json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["reason_code"] == SOURCE_CHECKOUT_INVALID
+    assert payload["issues"][0]["details"]["missing_markers"]
+
+
+@pytest.mark.unit
+def test_setup_non_interactive_provider_requires_input(patched_setup: dict[str, object]) -> None:
+    """Verify non-interactive provider setup without dry-run requires input."""
+    result = _runner.invoke(
+        app,
+        ["setup", "--non-interactive", "--provider", "github", "--format", "json"],
+    )
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["reason_code"] == "INTERACTIVE_INPUT_REQUIRED"
+    assert patched_setup["system_check_calls"] == 0
+
+
+@pytest.mark.unit
+def test_setup_non_dry_run_writes_safe_config(patched_setup: dict[str, object]) -> None:
+    """Verify a healthy non-dry-run persists safe, non-secret config."""
+    result = _runner.invoke(app, ["setup", "--allow-plain-secrets", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    writes = patched_setup["writes"]
+    assert isinstance(writes, list) and len(writes) == 1
+    written = writes[0]
+    assert isinstance(written, HostSetupConfig)
+    assert written.consent.plain_file_secrets is True
+    # No secret values are persisted (model would reject them on write anyway).
+    assert "secret" not in json.dumps(written.model_dump(mode="json")).replace(
+        "plain_file_secrets", ""
+    )
+
+
+@pytest.mark.unit
+def test_setup_config_corrupt_surfaces_reason(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify a corrupt host setup config surfaces its reason code."""
+
+    def _raise() -> HostSetupConfig:
+        raise HostSetupConfigError(
+            reason_code="HOST_SETUP_CONFIG_CORRUPT",
+            message="Host setup config is corrupt or unsupported.",
+            path=Path("~/.awf/config.yml"),
+            details={"error_type": "non_mapping_yaml"},
+        )
+
+    calls = {"system": 0}
+
+    def _fake_run_system_checks(**_kwargs: object) -> SystemChecksReport:
+        calls["system"] += 1
+        return _healthy_report()
+
+    monkeypatch.setattr(setup_commands, "read_host_setup_config", _raise)
+    monkeypatch.setattr(setup_commands, "run_system_checks", _fake_run_system_checks)
+
+    result = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["reason_code"] == "HOST_SETUP_CONFIG_CORRUPT"
+    assert calls["system"] == 0
+
+
+@pytest.mark.unit
+def test_setup_json_and_pretty_shapes(patched_setup: dict[str, object]) -> None:
+    """Verify JSON keys are stable and pretty output renders the key sections."""
+    patched_setup["report"] = _docker_blocked_report()
+    json_result = _runner.invoke(app, ["setup", "--dry-run", "--format", "json"])
+    pretty_result = _runner.invoke(app, ["setup", "--dry-run"])
+
+    payload = json.loads(json_result.output)
+    assert set(payload) >= {"status", "command", "summary", "reason_code", "issues", "next_steps"}
+    assert payload["command"] == "awf setup"
+
+    stderr = pretty_result.stderr
+    assert "Status: blocked" in stderr
+    assert "Docs:" in stderr
+    assert "Next:" in stderr
+    assert "docker_cli" in stderr

--- a/tests/unit/service/test_host_setup_rendering.py
+++ b/tests/unit/service/test_host_setup_rendering.py
@@ -18,12 +18,14 @@ from awf.host_setup.rendering import (
     first_run_failure_payload,
     first_run_issue_from_reason_code,
     first_run_remediation_from_reason_code,
+    first_run_setup_readiness_payload,
     first_run_success_payload,
     first_run_warning_payload,
     redact_first_run_value,
     render_first_run_json,
     render_first_run_pretty,
 )
+from awf.host_setup.system_checks import SystemCheck, SystemChecksReport
 
 
 @pytest.mark.unit
@@ -1127,3 +1129,130 @@ def test_first_run_redaction_does_not_double_redact_provider_ref_assignments() -
         "message": "TOKEN=[redacted]",
         "nested": ("API_KEY=[redacted]",),
     }
+
+
+def _readiness_check(
+    *,
+    check_id: str,
+    status: str,
+    reason: str,
+    fix: str | None = None,
+    docs_link: str | None = None,
+) -> SystemCheck:
+    return SystemCheck(
+        id=check_id,
+        label=check_id,
+        status=status,  # type: ignore[arg-type]
+        reason=reason,
+        message=f"{check_id} {status}",
+        fix=fix,
+        docs_link=docs_link,
+    )
+
+
+@pytest.mark.unit
+def test_setup_readiness_payload_success() -> None:
+    """Verify an ok report becomes an exit-0 success payload with details."""
+    report = SystemChecksReport(
+        checks=(
+            _readiness_check(check_id="docker_cli", status="ok", reason="DOCKER_CLI_AVAILABLE"),
+        ),
+        capacity={"cpu_cores": 8.0, "memory_gb": 16.0},
+    )
+
+    payload = first_run_setup_readiness_payload(
+        report,
+        dry_run=True,
+        providers=("github",),
+        allow_plain_secrets=False,
+        source_checkout_root="/repo",
+    )
+    rendered = render_first_run_json(payload)
+
+    assert payload.status == "success"
+    assert rendered["details"]["dry_run"] is True
+    assert rendered["details"]["providers"] == ["github"]
+    assert rendered["details"]["provider_scope"] == "targeted recheck"
+    assert rendered["details"]["capacity"] == {"cpu_cores": 8.0, "memory_gb": 16.0}
+    assert rendered["details"]["source_checkout"] == "/repo"
+    assert any("awf start" in step for step in rendered["next_steps"])
+
+
+@pytest.mark.unit
+def test_setup_readiness_payload_blocked() -> None:
+    """Verify a failing report becomes a blocked payload with blocker fixes."""
+    report = SystemChecksReport(
+        checks=(
+            _readiness_check(
+                check_id="docker_cli",
+                status="fail",
+                reason="DOCKER_CLI_NOT_FOUND",
+                fix="Install Docker Desktop.",
+                docs_link="https://docs.docker.com/get-docker/",
+            ),
+            _readiness_check(check_id="gh", status="warn", reason="GH_NOT_FOUND"),
+        ),
+    )
+
+    payload = first_run_setup_readiness_payload(
+        report,
+        dry_run=True,
+        providers=(),
+        allow_plain_secrets=False,
+        source_checkout_root=None,
+    )
+    pretty = render_first_run_pretty(payload)
+
+    assert payload.status == "blocked"
+    assert payload.reason_code == "SETUP_READINESS_FAILED"
+    assert "Install Docker Desktop." in payload.next_steps
+    assert any("Re-run awf setup --dry-run" in step for step in payload.next_steps)
+    assert "https://docs.docker.com/get-docker/" in pretty
+    assert "docker_cli" in pretty
+
+
+@pytest.mark.unit
+def test_setup_readiness_payload_warning_succeeds() -> None:
+    """Verify a warn-only report succeeds (exit 0) while carrying warnings."""
+    report = SystemChecksReport(
+        checks=(
+            _readiness_check(check_id="docker_cli", status="ok", reason="DOCKER_CLI_AVAILABLE"),
+            _readiness_check(check_id="gh", status="warn", reason="GH_NOT_FOUND"),
+        ),
+    )
+
+    payload = first_run_setup_readiness_payload(
+        report,
+        dry_run=False,
+        providers=(),
+        allow_plain_secrets=False,
+        source_checkout_root=None,
+    )
+    rendered = render_first_run_json(payload)
+
+    assert payload.status == "success"
+    assert "warnings" in rendered["details"]
+    assert rendered["details"]["warnings"] == ["gh"]
+    assert "warnings" in payload.summary.lower()
+
+
+@pytest.mark.unit
+def test_setup_readiness_payload_redacts_provider_refs() -> None:
+    """Verify token-shaped check content is redacted by render_first_run_json."""
+    report = SystemChecksReport(
+        checks=(
+            _readiness_check(check_id="docker_cli", status="ok", reason="DOCKER_CLI_AVAILABLE"),
+        ),
+    )
+    payload = first_run_setup_readiness_payload(
+        report,
+        dry_run=True,
+        providers=("env://OPENAI_API_KEY",),
+        allow_plain_secrets=False,
+        source_checkout_root=None,
+    )
+
+    rendered = render_first_run_json(payload)
+
+    assert "env://OPENAI_API_KEY" not in json.dumps(rendered)
+    assert "[redacted]" in json.dumps(rendered)

--- a/tests/unit/service/test_host_setup_system_checks.py
+++ b/tests/unit/service/test_host_setup_system_checks.py
@@ -1,0 +1,326 @@
+"""Unit coverage for bounded host readiness checks used by ``awf setup``."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Callable, Mapping
+
+import pytest
+
+from awf.host_setup.system_checks import (
+    SystemCheck,
+    SystemChecksReport,
+    run_system_checks,
+)
+
+_HEALTHY_DOCKER_INFO = json.dumps({"NCPU": 8, "MemTotal": 17179869184})
+_PRESENT_EXECUTABLES = frozenset({"docker", "git", "gh", "awf"})
+
+
+class _FakeProc:
+    """Minimal completed-process stand-in for injected subprocess fakes."""
+
+    def __init__(self, *, returncode: int = 0, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class _FakeSocket:
+    """Socket stand-in that records that it was closed."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AmpleUsage:
+    total = 100 * 1024**3
+    used = 10 * 1024**3
+    free = 90 * 1024**3
+
+
+class _StarvedUsage:
+    total = 100 * 1024**3
+    used = 99 * 1024**3
+    free = 1 * 1024**3
+
+
+def _healthy_which(
+    executables: frozenset[str] = _PRESENT_EXECUTABLES,
+) -> Callable[[str], str | None]:
+    def _which(name: str) -> str | None:
+        return f"/usr/bin/{name}" if name in executables else None
+
+    return _which
+
+
+def _docker_runner(
+    *,
+    docker_info: _FakeProc | Exception | None = None,
+    compose: _FakeProc | Exception | None = None,
+    calls: list[list[str]] | None = None,
+) -> Callable[..., _FakeProc]:
+    info_result = docker_info if docker_info is not None else _FakeProc(stdout=_HEALTHY_DOCKER_INFO)
+    compose_result = compose if compose is not None else _FakeProc(stdout="2.27.0\n")
+
+    def _run(
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: float,
+        env: Mapping[str, str],
+    ) -> _FakeProc:
+        if calls is not None:
+            calls.append(list(args))
+        if args[:2] == ["docker", "info"]:
+            if isinstance(info_result, Exception):
+                raise info_result
+            return info_result
+        if args[:3] == ["docker", "compose", "version"]:
+            if isinstance(compose_result, Exception):
+                raise compose_result
+            return compose_result
+        raise AssertionError(f"unexpected command: {args}")
+
+    return _run
+
+
+def _refused_connector(address: tuple[str, int], timeout: float) -> _FakeSocket:
+    raise OSError("connection refused")
+
+
+def _build_report(**overrides: object) -> SystemChecksReport:
+    """Run checks with healthy fakes, overriding individual dependencies."""
+    kwargs: dict[str, object] = {
+        "host_port": 8000,
+        "work_dir": "/tmp/awf-work",
+        "which": _healthy_which(),
+        "run_subprocess": _docker_runner(),
+        "socket_connector": _refused_connector,
+        "disk_usage": lambda _path: _AmpleUsage(),
+        "environ": {},
+        "python_version": (3, 12),
+    }
+    kwargs.update(overrides)
+    return run_system_checks(**kwargs)  # type: ignore[arg-type]
+
+
+def _check(report: SystemChecksReport, check_id: str) -> SystemCheck:
+    return next(check for check in report.checks if check.id == check_id)
+
+
+@pytest.mark.unit
+def test_all_checks_pass_with_healthy_fakes() -> None:
+    """Verify a healthy host reports ``ok`` with populated capacity."""
+    report = _build_report()
+
+    assert report.status == "ok"
+    assert report.blockers == ()
+    assert report.warnings == ()
+    assert report.capacity == {"cpu_cores": 8.0, "memory_gb": 16.0}
+    assert _check(report, "capacity").status == "ok"
+
+
+@pytest.mark.unit
+def test_docker_cli_missing_is_blocker() -> None:
+    """Verify a missing Docker CLI is a reason-coded blocker."""
+    report = _build_report(which=_healthy_which(_PRESENT_EXECUTABLES - {"docker"}))
+
+    docker_cli = _check(report, "docker_cli")
+    assert docker_cli.status == "fail"
+    assert docker_cli.reason == "DOCKER_CLI_NOT_FOUND"
+    assert report.status == "fail"
+    assert "docker_cli" in [check.id for check in report.blockers]
+    # With no CLI, the daemon and compose probes are skipped, not run.
+    assert _check(report, "docker_daemon").status == "skipped"
+    assert _check(report, "docker_compose").status == "skipped"
+
+
+@pytest.mark.unit
+def test_docker_daemon_unreachable_is_blocker() -> None:
+    """Verify a non-zero ``docker info`` is a daemon-unreachable blocker."""
+    report = _build_report(
+        run_subprocess=_docker_runner(docker_info=_FakeProc(returncode=1, stderr="no daemon"))
+    )
+
+    daemon = _check(report, "docker_daemon")
+    assert daemon.status == "fail"
+    assert daemon.reason == "DOCKER_DAEMON_UNREACHABLE"
+    assert daemon.docs_link is not None
+    assert report.status == "fail"
+
+
+@pytest.mark.unit
+def test_docker_compose_missing_is_blocker() -> None:
+    """Verify a failing ``docker compose version`` is a blocker."""
+    report = _build_report(
+        run_subprocess=_docker_runner(compose=_FakeProc(returncode=1, stderr="no plugin"))
+    )
+
+    compose = _check(report, "docker_compose")
+    assert compose.status == "fail"
+    assert compose.reason == "COMPOSE_NOT_AVAILABLE"
+    assert report.status == "fail"
+
+
+@pytest.mark.unit
+def test_git_missing_is_blocker() -> None:
+    """Verify a missing git CLI blocks readiness."""
+    report = _build_report(which=_healthy_which(_PRESENT_EXECUTABLES - {"git"}))
+
+    git = _check(report, "git")
+    assert git.status == "fail"
+    assert git.reason == "GIT_NOT_FOUND"
+    assert report.status == "fail"
+
+
+@pytest.mark.unit
+def test_gh_missing_is_warning_not_blocker() -> None:
+    """Verify a missing gh CLI is advisory, not blocking."""
+    report = _build_report(which=_healthy_which(_PRESENT_EXECUTABLES - {"gh"}))
+
+    gh = _check(report, "gh")
+    assert gh.status == "warn"
+    assert gh.reason == "GH_NOT_FOUND"
+    assert "gh" in [check.id for check in report.warnings]
+    assert report.status == "warn"
+
+
+@pytest.mark.unit
+def test_python_below_floor_is_blocker() -> None:
+    """Verify an interpreter below the floor blocks readiness."""
+    report = _build_report(python_version=(3, 11))
+
+    runtime = _check(report, "python_runtime")
+    assert runtime.status == "fail"
+    assert runtime.reason == "PYTHON_RUNTIME_BELOW_FLOOR"
+    assert runtime.metadata["detected"] == "3.11"
+    assert runtime.metadata["required"] == "3.12"
+    assert report.status == "fail"
+
+
+@pytest.mark.unit
+def test_api_port_in_use_is_warning() -> None:
+    """Verify an occupied port is a warning, not a blocker."""
+    sockets: list[_FakeSocket] = []
+
+    def _in_use(address: tuple[str, int], timeout: float) -> _FakeSocket:
+        connection = _FakeSocket()
+        sockets.append(connection)
+        return connection
+
+    report = _build_report(socket_connector=_in_use)
+
+    api_port = _check(report, "port_api")
+    assert api_port.status == "warn"
+    assert api_port.reason == "PORT_IN_USE"
+    assert api_port.metadata["port"] == 8000
+    # The probe socket is always closed to avoid leaking descriptors.
+    assert all(connection.closed for connection in sockets)
+    assert report.status == "warn"
+
+
+@pytest.mark.unit
+def test_ports_free_are_ok() -> None:
+    """Verify a refused connection means the port is free."""
+    report = _build_report(socket_connector=_refused_connector)
+
+    assert _check(report, "port_api").status == "ok"
+    assert _check(report, "port_api").reason == "PORT_AVAILABLE"
+    assert _check(report, "port_db").status == "ok"
+
+
+@pytest.mark.unit
+def test_disk_below_threshold_is_blocker() -> None:
+    """Verify insufficient free disk is a reason-coded blocker."""
+    report = _build_report(disk_usage=lambda _path: _StarvedUsage())
+
+    disk = _check(report, "disk")
+    assert disk.status == "fail"
+    assert disk.reason == "INSUFFICIENT_DISK"
+    assert report.status == "fail"
+
+
+@pytest.mark.unit
+def test_capacity_unavailable_is_warning_only() -> None:
+    """Verify missing capacity warns without ever blocking."""
+    report = _build_report(run_subprocess=_docker_runner(docker_info=_FakeProc(stdout="{}")))
+
+    capacity = _check(report, "capacity")
+    assert capacity.status == "warn"
+    assert capacity.reason == "CAPACITY_UNKNOWN"
+    assert report.capacity is None
+    # The daemon answered, so it is not a blocker.
+    assert _check(report, "docker_daemon").status == "ok"
+    assert "capacity" not in [check.id for check in report.blockers]
+
+
+@pytest.mark.unit
+def test_shell_path_awf_not_found_is_warning() -> None:
+    """Verify a missing awf entry point warns with a PATH hint."""
+    report = _build_report(which=_healthy_which(_PRESENT_EXECUTABLES - {"awf"}))
+
+    shell_path = _check(report, "shell_path")
+    assert shell_path.status == "warn"
+    assert shell_path.reason == "AWF_NOT_ON_PATH"
+    assert shell_path.fix is not None and "PATH" in shell_path.fix
+    assert report.status == "warn"
+
+
+@pytest.mark.unit
+def test_report_status_rollup() -> None:
+    """Verify report status follows fail > warn > ok precedence."""
+    ok_check = SystemCheck(id="a", label="A", status="ok", reason="A_OK", message="ok")
+    warn_check = SystemCheck(id="b", label="B", status="warn", reason="B_WARN", message="warn")
+    fail_check = SystemCheck(id="c", label="C", status="fail", reason="C_FAIL", message="fail")
+
+    assert SystemChecksReport(checks=(ok_check,)).status == "ok"
+    assert SystemChecksReport(checks=(ok_check, warn_check)).status == "warn"
+    assert SystemChecksReport(checks=(ok_check, warn_check, fail_check)).status == "fail"
+    assert SystemChecksReport(checks=(ok_check, warn_check, fail_check)).blockers == (fail_check,)
+    assert SystemChecksReport(checks=(ok_check, warn_check, fail_check)).warnings == (warn_check,)
+
+
+@pytest.mark.unit
+def test_subprocess_timeout_is_handled() -> None:
+    """Verify a bounded subprocess timeout maps to a fail, not a crash."""
+    timeout = subprocess.TimeoutExpired(cmd=["docker", "info"], timeout=5.0)
+    report = _build_report(run_subprocess=_docker_runner(docker_info=timeout))
+
+    daemon = _check(report, "docker_daemon")
+    assert daemon.status == "fail"
+    assert daemon.reason == "DOCKER_DAEMON_UNREACHABLE"
+    assert daemon.metadata.get("probe") == "timeout"
+
+
+@pytest.mark.unit
+def test_checks_do_not_start_core() -> None:
+    """Verify only bounded read-only probes are invoked (no Core startup)."""
+    calls: list[list[str]] = []
+    report = _build_report(run_subprocess=_docker_runner(calls=calls))
+
+    assert report.status == "ok"
+    assert calls == [
+        ["docker", "info", "--format", "{{json .}}"],
+        ["docker", "compose", "version", "--short"],
+    ]
+    flattened = {token for call in calls for token in call}
+    assert "up" not in flattened
+    assert "bootstrap" not in flattened
+    assert "run" not in flattened
+
+
+@pytest.mark.unit
+def test_metadata_is_secret_free() -> None:
+    """Verify host environment secrets never leak into the report payload."""
+    token = "ghp_abcdefghijklmnopqrstuvwx1234567890"
+    report = _build_report(environ={"GH_TOKEN": token, "AWF_GITHUB_TOKEN": token})
+
+    serialized = json.dumps(report.to_dict())
+    assert token not in serialized


### PR DESCRIPTION
## Summary
- add `awf setup --dry-run` system readiness checks without starting Core
- add readiness rendering and setup CLI dispatch for provider selectors, source checkout, non-interactive, and safe config updates
- add focused CLI, rendering, and system-check tests plus validation artifact

## Validation
- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_setup_commands.py tests/unit/cli/test_first_run_command_imports.py tests/unit/service/test_host_setup_system_checks.py tests/unit/service/test_host_setup_rendering.py tests/unit/docs/test_catalog_coverage.py tests/unit/service/test_doctor_reasons.py -q`
- `uv run --python 3.12 --extra dev ruff check src/awf tests`
- `uv run --python 3.12 --extra dev mypy src/awf`

Recovered from failed AWF workspace `ws_04dcade26c1b4caba84bc5bb` after validation-fix work was left staged by a ruff-format pre-commit failure.