### PR TITLE
feat(console): control-room design system refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,10 @@ npm --prefix apps/console run test:browser     # Playwright browser smoke
 Pre-commit hooks (`awf-ruff-check`, `awf-ruff-format-check`, `awf-mypy`) run these **without
 auto-fixing** — fix manually, then re-run or `pre-commit run --all-files`.
 
+**Console design system:** read `apps/console/DESIGN.md` before any console UI work. It is the
+source of truth for typography (IBM Plex), the semantic color tokens, status glyphs, density, and
+the Status/Diagnosis/Action layout. Do not hardcode palette values or convey status by color alone.
+
 **Running the control plane locally** (Postgres + one-shot Alembic `migrate` + API + worker, all
 in Docker Compose):
 

--- a/apps/console/.gitignore
+++ b/apps/console/.gitignore
@@ -7,3 +7,6 @@ next-env.d.ts
 *.tsbuildinfo
 playwright-report/
 test-results/
+
+# Local design-system specimen (sign-off preview, not shipped)
+design-preview.html

--- a/apps/console/DESIGN.md
+++ b/apps/console/DESIGN.md
@@ -1,0 +1,109 @@
+# Design System — AWF Console
+
+Authored via a design consultation (`/gstack-design-consultation`). This is the source of truth
+for the console's look and feel. Read it before any UI change; do not hardcode palette values and
+never convey status by color alone.
+
+## Product Context
+
+- **What this is:** local operator control room for Agent Workspace Fabric — monitoring fleets of
+  AI coding agents across isolated workspaces (lifecycle, validation freshness, merge queue,
+  capacity, failures, live logs).
+- **Who it is for:** operators triaging many concurrent agent workspaces.
+- **Project type:** real-time monitoring / observability console (Next.js 16, React 19, Tailwind v4).
+- **Peers:** Grafana, Datadog, Temporal Web, k9s/Lens.
+
+## Memorable Thing
+
+A serious, trustworthy control room. Calm, dense, information-first, never flashy.
+
+## Aesthetic Direction
+
+- Industrial / high-performance HMI (ISA-101 inspired). Decoration does no work; type, spacing,
+  surface elevation, and semantic color do.
+- No gradients, glow, or imagery. Sharp, precise, instrument-grade.
+
+## Principles
+
+- **Three layers:** Status (is the fleet ok? <5s glance, 5–7 KPIs, top-left priority) → Diagnosis
+  (why?) → Action (what do I do?). Progressive disclosure: detail lives in the inspector drawer.
+- **Semantic color carries meaning, never decoration**; never color-alone — pair every status with
+  a glyph + label (`statusGlyph`/`toneGlyph` in `lib/format.ts`).
+- **Dim/flag stale data** so operators never act on outdated readings (`data-awf-stale`).
+- WCAG 2.2 AA baseline; keep high-contrast + large-font + reduced-motion modes.
+
+## Typography
+
+- UI/body: **IBM Plex Sans** (self-hosted via `next/font`, `--font-plex-sans`).
+- Mono (IDs, SHAs, logs, numerics): **IBM Plex Mono** (`--font-plex-mono`, `.mono`).
+- All metrics use `font-variant-numeric: tabular-nums` (`.mono`, `.tnum`, `.kpi-value`).
+- Root font-size 100% (112.5% in large-font mode). Dense scale: labels 10–11px caps
+  (`.label-caps`), body 12–14px, KPI values 22px (`.kpi-value`), titles 16px.
+
+## Color (semantic tokens — one source of truth in `app/globals.css`)
+
+Every theme (light / dark / high-contrast, ×2) re-declares the same variables; Tailwind utilities
+are generated from them via `@theme inline` (`bg-surface`, `text-fg-muted`, `border-line`,
+`text-info`, `bg-pr-soft`, …). Legacy aliases (`--background`, `--panel`, `--border`, …) are kept
+so existing arbitrary-value utilities resolve against the same palette.
+
+Roles: `canvas`, `surface`, `surface-2`, `elevated`; `fg`, `fg-strong`, `fg-muted`, `fg-faint`;
+`line`, `line-strong`; `accent` (+soft); status `info`/`healthy`/`attention`/`danger`/`pr`/`idle`,
+each with `main` / `soft` / `border` / `text`.
+
+Status uses vivid, solid tints (not faint overlays) so green/blue/amber/red read clearly. Each
+status keeps `main` (dots/sparklines/values) + `soft` (chip fill) + `border` + `text`.
+
+Dark (default-quality, calm low-glare canvas; vivid status):
+
+- canvas `#0b0e14`, surface `#111722`, surface-2 `#161d2b`, elevated `#1b2433`
+- fg `rgb(226 232 240)` (desaturated, not pure white), muted 66%, faint 42%
+- line `rgb(226 232 240 / 14%)`, line-strong 28%
+- accent `#5b9dff` · info/`running`/`monitoring_pr` blue `#5b9dff` (soft `#102b47`) ·
+  healthy/`completed` green `#34d399` (soft `#0d2f24`) · attention/`cancelled` amber `#f4c86a`
+  (soft `#322507`) · danger/`failed` red `#fb8b83` (soft `#3a1111`) · idle `#8896a8`
+
+Light: canvas `#f5f7fa`, surface `#fff`, surface-2 `#eef2f7`; fg `#16202b`, muted `#5a6675`;
+accent/info `#2f6fe0` · healthy `#15875a` · attention `#9a6400` · danger `#c0392f`.
+
+High-contrast: per-role overrides (yellow accent on dark, etc.) — preserve existing behavior.
+
+## Status Glyphs (color + glyph + label)
+
+`running ●` · `requested/ready ◷` · `monitoring_pr ◆` · `completed ✓` · `failed/destroyed ✕` ·
+`cancelled ⊘` · `destroying ◌` · `stale/attention ⚠`. Source: `statusGlyph` in `lib/format.ts`.
+
+## Spacing & Radius
+
+Base 4px (Tailwind scale). Radius: controls/chips `--radius-control` 4px, panels
+`--radius-panel` 8px, pills/dots full.
+
+## Layout (Status → Diagnosis → Action)
+
+- **Top (Status):** `TopBar` (`<header>` with brand, API/Stream pills, refresh, preferences) plus
+  the `FleetHealthStrip` KPI band.
+- **Section nav:** `SectionNav` is a sticky jump bar shown **only on narrow screens** (`xl:hidden`),
+  where panels stack into one column. Wide screens lay panels out side by side and need none.
+- **Main (Diagnosis):** workspace list + capacity / merge-queue / failure panels.
+- **Inspector drawer (Action):** operator controls, lifecycle rail, validation freshness, logs.
+
+## Motion
+
+Minimal-functional. ~120ms ease-out transitions; the only "alive" motion is the live-stream pulse.
+Respect `prefers-reduced-motion` (already enforced globally).
+
+## Components
+
+`KpiStat` · `Badge` / `StatusDot` (glyph + color + label) · `Panel` (elevation + stale state) ·
+`Fact` · `Chip` / `QueueChip` · `LifecycleRail`.
+
+## Decisions Log
+
+- 2026-06 Initial system via `/gstack-design-consultation`. System-default theme with dark-first
+  quality, IBM Plex, semantic tokens replacing hardcoded slate hex, three-layer IA.
+- 2026-06 Revision: vivid solid status tints (green completed / amber cancelled / red failed /
+  blue running + monitoring_pr); `monitoring_pr` stays blue with a distinct `◆` glyph rather than
+  a separate hue. Section navigation is a narrow-screen-only sticky jump bar (the wide layout shows
+  panels side by side and needs none).
+- 2026-06 Removed KPI/capacity sparklines (sparse client-side history made them noisy) and the
+  comfortable/compact density toggle (negligible visual effect).

--- a/apps/console/DESIGN.md
+++ b/apps/console/DESIGN.md
@@ -94,7 +94,7 @@ Respect `prefers-reduced-motion` (already enforced globally).
 
 ## Components
 
-`KpiStat` · `Badge` / `StatusDot` (glyph + color + label) · `Panel` (elevation + stale state) ·
+`KpiStat` · `Badge` (glyph + color + label) · `Panel` (elevation + stale state) ·
 `Fact` · `Chip` / `QueueChip` · `LifecycleRail`.
 
 ## Decisions Log

--- a/apps/console/DESIGN.md
+++ b/apps/console/DESIGN.md
@@ -28,7 +28,7 @@ A serious, trustworthy control room. Calm, dense, information-first, never flash
 - **Three layers:** Status (is the fleet ok? <5s glance, 5–7 KPIs, top-left priority) → Diagnosis
   (why?) → Action (what do I do?). Progressive disclosure: detail lives in the inspector drawer.
 - **Semantic color carries meaning, never decoration**; never color-alone — pair every status with
-  a glyph + label (`statusGlyph`/`toneGlyph` in `lib/format.ts`).
+  a glyph + label (`statusGlyph` in `lib/format.ts`).
 - **Dim/flag stale data** so operators never act on outdated readings (`data-awf-stale`).
 - WCAG 2.2 AA baseline; keep high-contrast + large-font + reduced-motion modes.
 

--- a/apps/console/app/globals.css
+++ b/apps/console/app/globals.css
@@ -1,48 +1,189 @@
 @import "tailwindcss";
 
+/*
+ * AWF Console design tokens — "control room".
+ * One source of truth: every theme (light / dark / high-contrast) re-declares
+ * the same semantic variables; utilities below reference them via @theme inline.
+ * Legacy aliases (--background, --panel, --border, ...) are kept so existing
+ * Tailwind arbitrary-value utilities keep resolving against the same palette.
+ */
+
+@theme inline {
+  --font-sans: var(--font-plex-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  --font-mono: var(--font-plex-mono), "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo,
+    ui-monospace, monospace;
+
+  --color-canvas: var(--canvas);
+  --color-surface: var(--surface);
+  --color-surface-2: var(--surface-2);
+  --color-elevated: var(--elevated);
+  --color-line: var(--line);
+  --color-line-strong: var(--line-strong);
+  --color-fg: var(--fg);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-faint: var(--fg-faint);
+  --color-fg-strong: var(--fg-strong);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+
+  --color-info: var(--info);
+  --color-info-soft: var(--info-soft);
+  --color-info-border: var(--info-border);
+  --color-info-text: var(--info-text);
+
+  --color-healthy: var(--healthy);
+  --color-healthy-soft: var(--healthy-soft);
+  --color-healthy-border: var(--healthy-border);
+  --color-healthy-text: var(--healthy-text);
+
+  --color-attention: var(--attention);
+  --color-attention-soft: var(--attention-soft);
+  --color-attention-border: var(--attention-border);
+  --color-attention-text: var(--attention-text);
+
+  --color-danger: var(--danger);
+  --color-danger-soft: var(--danger-soft);
+  --color-danger-border: var(--danger-border);
+  --color-danger-text: var(--danger-text);
+
+  --color-pr: var(--pr);
+  --color-pr-soft: var(--pr-soft);
+  --color-pr-border: var(--pr-border);
+  --color-pr-text: var(--pr-text);
+
+  --color-idle: var(--idle);
+  --color-idle-soft: var(--idle-soft);
+  --color-idle-border: var(--idle-border);
+  --color-idle-text: var(--idle-text);
+
+  --radius-control: 4px;
+  --radius-panel: 8px;
+}
+
 :root {
   color-scheme: light;
   font-size: 100%;
-  --background: #f7f8fa;
-  --foreground: #17202b;
-  --panel: #ffffff;
-  --panel-muted: #f0f3f6;
-  --border: #d7dde5;
-  --border-strong: #aeb8c5;
-  --muted: #5e6a78;
-  --muted-strong: #3f4a56;
-  --accent: #1677ff;
+
+  /* control-room neutrals */
+  --canvas: #f5f7fa;
+  --surface: #ffffff;
+  --surface-2: #eef2f7;
+  --elevated: #ffffff;
+  --line: #d7dde5;
+  --line-strong: #aeb8c5;
+  --fg: #16202b;
+  --fg-strong: #2b3744;
+  --fg-muted: #5a6675;
+  --fg-faint: #8593a3;
+  --accent: #2f6fe0;
   --accent-soft: #e7f1ff;
-  --success: #148f63;
-  --warning: #a76100;
-  --danger: #c24135;
-  --terminal: #101722;
-  --terminal-foreground: #f1f5f9;
-  --focus-ring: #1677ff;
-  --focus-shadow: rgb(22 119 255 / 18%);
+
+  /* semantic status — main / soft / border / text */
+  --info: #2f6fe0;
+  --info-soft: #e7f1ff;
+  --info-border: #b9d2f7;
+  --info-text: #14478f;
+
+  --healthy: #15875a;
+  --healthy-soft: #e3f5ec;
+  --healthy-border: #a7dcc3;
+  --healthy-text: #0d5f3f;
+
+  --attention: #9a6400;
+  --attention-soft: #fdf3e0;
+  --attention-border: #f0d9a8;
+  --attention-text: #7a4f00;
+
+  --danger: #c0392f;
+  --danger-soft: #fdecea;
+  --danger-border: #f3b9b3;
+  --danger-text: #8f2820;
+
+  --pr: #2f6fe0;
+  --pr-soft: #e7f1ff;
+  --pr-border: #b9d2f7;
+  --pr-text: #14478f;
+
+  --idle: #64748b;
+  --idle-soft: #eef2f7;
+  --idle-border: #d7dde5;
+  --idle-text: #475569;
+
+  --terminal: #0b1220;
+  --terminal-foreground: #e7edf6;
+
+  --focus-ring: #2f6fe0;
+  --focus-shadow: rgb(47 111 224 / 18%);
   --focus-width: 2px;
   --selection: #cfe3ff;
   --scrollbar-thumb: #c7d0dc;
   --scrollbar-thumb-hover: #9aa8b8;
+
+  /* legacy aliases kept for existing arbitrary-value utilities */
+  --background: var(--canvas);
+  --foreground: var(--fg);
+  --panel: var(--surface);
+  --panel-muted: var(--surface-2);
+  --border: var(--line);
+  --border-strong: var(--line-strong);
+  --muted: var(--fg-muted);
+  --muted-strong: var(--fg-strong);
+  --success: var(--healthy);
+  --warning: var(--attention);
+  --danger-legacy: var(--danger);
 }
 
 :root[data-awf-theme="dark"] {
   color-scheme: dark;
-  --background: #0b1118;
-  --foreground: #e7edf6;
-  --panel: #101823;
-  --panel-muted: #162231;
-  --border: #273649;
-  --border-strong: #5a6d84;
-  --muted: #a8b4c4;
-  --muted-strong: #d3dce8;
-  --accent: #7db7ff;
-  --accent-soft: #102b47;
-  --success: #6ee7a8;
-  --warning: #f4c86a;
+
+  --canvas: #0b0e14;
+  --surface: #111722;
+  --surface-2: #161d2b;
+  --elevated: #1b2433;
+  --line: rgb(226 232 240 / 14%);
+  --line-strong: rgb(226 232 240 / 28%);
+  --fg: rgb(226 232 240);
+  --fg-strong: rgb(226 232 240 / 85%);
+  --fg-muted: rgb(226 232 240 / 66%);
+  --fg-faint: rgb(226 232 240 / 42%);
+  --accent: #5b9dff;
+  --accent-soft: rgb(91 157 255 / 16%);
+
+  /* solid, saturated dark tints so status reads vividly (not washed-out overlays) */
+  --info: #5b9dff;
+  --info-soft: #102b47;
+  --info-border: #3b82c4;
+  --info-text: #bfdbfe;
+
+  --healthy: #34d399;
+  --healthy-soft: #0d2f24;
+  --healthy-border: #24845f;
+  --healthy-text: #b7f7d4;
+
+  --attention: #f4c86a;
+  --attention-soft: #322507;
+  --attention-border: #946a1d;
+  --attention-text: #fde68a;
+
   --danger: #fb8b83;
-  --terminal: #050a12;
+  --danger-soft: #3a1111;
+  --danger-border: #a34444;
+  --danger-text: #fecaca;
+
+  --pr: #5b9dff;
+  --pr-soft: #102b47;
+  --pr-border: #3b82c4;
+  --pr-text: #bfdbfe;
+
+  --idle: #8896a8;
+  --idle-soft: #1b2433;
+  --idle-border: rgb(226 232 240 / 16%);
+  --idle-text: #c1cbd8;
+
+  --terminal: #05080e;
   --terminal-foreground: #e7edf6;
+
   --focus-ring: #8bc2ff;
   --focus-shadow: rgb(125 183 255 / 28%);
   --selection: #214f7a;
@@ -51,31 +192,58 @@
 }
 
 :root[data-awf-contrast="high"] {
-  --foreground: #07111f;
-  --border: #6b7280;
-  --border-strong: #111827;
-  --muted: #273241;
-  --muted-strong: #111827;
+  --fg: #07111f;
+  --fg-strong: #111827;
+  --fg-muted: #273241;
+  --fg-faint: #3f4a56;
+  --line: #6b7280;
+  --line-strong: #111827;
   --accent: #0046b8;
+  --info: #0046b8;
+  --info-border: #0046b8;
+  --info-text: #07111f;
+  --healthy-border: #0d5f3f;
+  --healthy-text: #07111f;
+  --attention-border: #7a4f00;
+  --attention-text: #2b1a00;
+  --danger-border: #8f2820;
+  --danger-text: #4a0f0a;
+  --pr-border: #4a2599;
+  --pr-text: #2c0f6b;
   --focus-ring: #003cff;
   --focus-shadow: rgb(0 60 255 / 28%);
   --focus-width: 3px;
 }
 
 :root[data-awf-theme="dark"][data-awf-contrast="high"] {
-  --background: #000000;
-  --foreground: #ffffff;
-  --panel: #060a10;
-  --panel-muted: #101721;
-  --border: #9ca3af;
-  --border-strong: #ffffff;
-  --muted: #f3f4f6;
-  --muted-strong: #ffffff;
+  --canvas: #000000;
+  --surface: #060a10;
+  --surface-2: #101721;
+  --elevated: #141c28;
+  --line: #9ca3af;
+  --line-strong: #ffffff;
+  --fg: #ffffff;
+  --fg-strong: #ffffff;
+  --fg-muted: #f3f4f6;
+  --fg-faint: #d1d5db;
   --accent: #facc15;
-  --accent-soft: #302b06;
-  --success: #86efac;
-  --warning: #fde68a;
+  --accent-soft: rgb(250 204 21 / 18%);
+  --info: #facc15;
+  --info-soft: rgb(250 204 21 / 18%);
+  --info-border: #facc15;
+  --info-text: #fde68a;
+  --healthy: #86efac;
+  --healthy-text: #bbf7d0;
+  --healthy-border: #86efac;
+  --attention: #fde68a;
+  --attention-text: #fef3c7;
+  --attention-border: #fde68a;
   --danger: #fca5a5;
+  --danger-text: #fecaca;
+  --danger-border: #fca5a5;
+  --pr: #e9d5ff;
+  --pr-text: #f3e8ff;
+  --pr-border: #e9d5ff;
   --terminal: #000000;
   --terminal-foreground: #ffffff;
   --focus-ring: #facc15;
@@ -97,10 +265,9 @@ html,
 body {
   min-height: 100%;
   margin: 0;
-  background: var(--background);
-  color: var(--foreground);
-  font-family:
-    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--canvas);
+  color: var(--fg);
+  font-family: var(--font-sans);
   letter-spacing: 0;
 }
 
@@ -134,8 +301,94 @@ textarea:focus-visible,
 pre,
 code,
 .mono {
-  font-family:
-    "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo, ui-monospace, monospace;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+/* numeric alignment for metrics, counts, costs, capacity readouts */
+.tnum {
+  font-variant-numeric: tabular-nums;
+}
+
+/* type-scale helpers (control-room) */
+.label-caps {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+.kpi-value {
+  font-size: 22px;
+  line-height: 1.1;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Status tones as explicit classes rather than Tailwind-generated utilities.
+ * These are composed at runtime in lib/format.ts, which Tailwind's content
+ * scanner does not reliably pick up — defining them here guarantees they ship,
+ * while staying theme-reactive through the tokens. Border width/radius come
+ * from utility classes already on the element.
+ */
+.tone-neutral {
+  border-color: var(--line);
+  background-color: var(--surface-2);
+  color: var(--fg-muted);
+}
+.tone-info {
+  border-color: var(--info-border);
+  background-color: var(--info-soft);
+  color: var(--info-text);
+}
+.tone-good {
+  border-color: var(--healthy-border);
+  background-color: var(--healthy-soft);
+  color: var(--healthy-text);
+}
+.tone-warn {
+  border-color: var(--attention-border);
+  background-color: var(--attention-soft);
+  color: var(--attention-text);
+}
+.tone-bad {
+  border-color: var(--danger-border);
+  background-color: var(--danger-soft);
+  color: var(--danger-text);
+}
+
+.tone-text-neutral {
+  color: var(--idle);
+}
+.tone-text-info {
+  color: var(--info);
+}
+.tone-text-good {
+  color: var(--healthy);
+}
+.tone-text-warn {
+  color: var(--attention);
+}
+.tone-text-bad {
+  color: var(--danger);
+}
+
+.tone-fill-neutral {
+  background-color: var(--idle);
+}
+.tone-fill-info {
+  background-color: var(--info);
+}
+.tone-fill-good {
+  background-color: var(--healthy);
+}
+.tone-fill-warn {
+  background-color: var(--attention);
+}
+.tone-fill-bad {
+  background-color: var(--danger);
 }
 
 ::selection {
@@ -163,24 +416,30 @@ code,
   background-clip: padding-box;
 }
 
+/*
+ * Compatibility bridge: existing components style chrome with hardcoded slate/
+ * tint utilities. These map them onto the semantic tokens so every theme stays
+ * in lockstep with the single token source above. New components should prefer
+ * the semantic utilities (bg-surface, text-fg-muted, border-line, ...).
+ */
 [data-awf-theme="dark"] .bg-white {
-  background-color: var(--panel) !important;
+  background-color: var(--surface) !important;
 }
 
 [data-awf-theme="dark"] .bg-white\/70 {
-  background-color: rgb(16 24 35 / 82%) !important;
+  background-color: color-mix(in srgb, var(--surface) 82%, transparent) !important;
 }
 
 [data-awf-theme="dark"] .bg-slate-50 {
-  background-color: var(--panel-muted) !important;
+  background-color: var(--surface-2) !important;
 }
 
 [data-awf-theme="dark"] .bg-slate-100 {
-  background-color: #202e40 !important;
+  background-color: var(--elevated) !important;
 }
 
 [data-awf-theme="dark"] .bg-slate-200 {
-  background-color: #304057 !important;
+  background-color: var(--line-strong) !important;
 }
 
 [data-awf-theme="dark"] .bg-slate-900,
@@ -195,28 +454,28 @@ code,
 
 [data-awf-theme="dark"] .border-slate-100,
 [data-awf-theme="dark"] .border-slate-200 {
-  border-color: var(--border) !important;
+  border-color: var(--line) !important;
 }
 
 [data-awf-theme="dark"] .border-slate-300 {
-  border-color: var(--border-strong) !important;
+  border-color: var(--line-strong) !important;
 }
 
 [data-awf-theme="dark"] .text-slate-950,
 [data-awf-theme="dark"] .text-slate-900,
 [data-awf-theme="dark"] .text-slate-800 {
-  color: var(--foreground) !important;
+  color: var(--fg) !important;
 }
 
 [data-awf-theme="dark"] .text-slate-700,
 [data-awf-theme="dark"] .text-slate-600 {
-  color: var(--muted-strong) !important;
+  color: var(--fg-strong) !important;
 }
 
 [data-awf-theme="dark"] .text-slate-500,
 [data-awf-theme="dark"] .text-slate-400,
 [data-awf-theme="dark"] .text-slate-300 {
-  color: var(--muted) !important;
+  color: var(--fg-muted) !important;
 }
 
 [data-awf-theme="dark"] .text-slate-100 {
@@ -225,75 +484,84 @@ code,
 
 [data-awf-theme="dark"] .hover\:bg-white:hover,
 [data-awf-theme="dark"] .hover\:bg-slate-50:hover {
-  background-color: #1c2a3a !important;
+  background-color: var(--elevated) !important;
 }
 
 [data-awf-theme="dark"] .bg-blue-50 {
-  background-color: #102b47 !important;
+  background-color: var(--info-soft) !important;
 }
 
+[data-awf-theme="dark"] .bg-blue-100 {
+  background-color: var(--info-soft) !important;
+}
+
+[data-awf-theme="dark"] .border-blue-100,
 [data-awf-theme="dark"] .border-blue-200,
 [data-awf-theme="dark"] .border-blue-300,
 [data-awf-theme="dark"] .border-blue-400 {
-  border-color: #3b82c4 !important;
+  border-color: var(--info-border) !important;
 }
 
 [data-awf-theme="dark"] .text-blue-700,
-[data-awf-theme="dark"] .text-blue-800 {
-  color: #bfdbfe !important;
+[data-awf-theme="dark"] .text-blue-800,
+[data-awf-theme="dark"] .text-blue-900,
+[data-awf-theme="dark"] .text-blue-950 {
+  color: var(--info-text) !important;
 }
 
-[data-awf-theme="dark"] .bg-emerald-50 {
-  background-color: #0d2f24 !important;
+[data-awf-theme="dark"] .bg-emerald-50,
+[data-awf-theme="dark"] .bg-emerald-100 {
+  background-color: var(--healthy-soft) !important;
 }
 
 [data-awf-theme="dark"] .border-emerald-200 {
-  border-color: #24845f !important;
+  border-color: var(--healthy-border) !important;
 }
 
 [data-awf-theme="dark"] .text-emerald-700,
 [data-awf-theme="dark"] .text-emerald-800,
 [data-awf-theme="dark"] .text-emerald-900 {
-  color: #b7f7d4 !important;
+  color: var(--healthy-text) !important;
 }
 
-[data-awf-theme="dark"] .bg-amber-50 {
-  background-color: #322507 !important;
+[data-awf-theme="dark"] .bg-amber-50,
+[data-awf-theme="dark"] .bg-amber-100 {
+  background-color: var(--attention-soft) !important;
 }
 
 [data-awf-theme="dark"] .border-amber-100,
 [data-awf-theme="dark"] .border-amber-200,
 [data-awf-theme="dark"] .border-amber-300 {
-  border-color: #946a1d !important;
+  border-color: var(--attention-border) !important;
 }
 
 [data-awf-theme="dark"] .text-amber-700,
 [data-awf-theme="dark"] .text-amber-800,
 [data-awf-theme="dark"] .text-amber-900,
 [data-awf-theme="dark"] .text-amber-950 {
-  color: #fde68a !important;
+  color: var(--attention-text) !important;
 }
 
 [data-awf-theme="dark"] .bg-red-50 {
-  background-color: #3a1111 !important;
+  background-color: var(--danger-soft) !important;
 }
 
 [data-awf-theme="dark"] .border-red-200 {
-  border-color: #a34444 !important;
+  border-color: var(--danger-border) !important;
 }
 
 [data-awf-theme="dark"] .text-red-700,
 [data-awf-theme="dark"] .text-red-800,
 [data-awf-theme="dark"] .text-red-900,
 [data-awf-theme="dark"] .text-red-950 {
-  color: #fecaca !important;
+  color: var(--danger-text) !important;
 }
 
 [data-awf-theme="dark"] table,
 [data-awf-theme="dark"] tr,
 [data-awf-theme="dark"] td,
 [data-awf-theme="dark"] th {
-  border-color: var(--border) !important;
+  border-color: var(--line) !important;
 }
 
 [data-awf-theme="dark"] pre.bg-\[var\(--terminal\)\] {
@@ -311,7 +579,7 @@ code,
 [data-awf-contrast="high"] .border-amber-200,
 [data-awf-contrast="high"] .border-amber-300,
 [data-awf-contrast="high"] .border-red-200 {
-  border-color: var(--border-strong) !important;
+  border-color: var(--line-strong) !important;
 }
 
 [data-awf-contrast="high"] .text-slate-500,
@@ -330,7 +598,7 @@ code,
 [data-awf-contrast="high"] .text-red-800,
 [data-awf-contrast="high"] .text-red-900,
 [data-awf-contrast="high"] .text-red-950 {
-  color: var(--foreground) !important;
+  color: var(--fg) !important;
 }
 
 [data-awf-contrast="high"] .bg-slate-50,
@@ -338,7 +606,18 @@ code,
 [data-awf-contrast="high"] .bg-emerald-50,
 [data-awf-contrast="high"] .bg-amber-50,
 [data-awf-contrast="high"] .bg-red-50 {
-  background-color: var(--panel-muted) !important;
+  background-color: var(--surface-2) !important;
+}
+
+/*
+ * Stale data — ISA-101: never let operators act on outdated readings. When a
+ * surface is flagged stale, desaturate and dim it slightly and show a marker
+ * in the panel header rendered in React.
+ */
+[data-awf-stale="true"] {
+  filter: saturate(0.65);
+  opacity: 0.82;
+  transition: opacity 120ms ease-out, filter 120ms ease-out;
 }
 
 @media (forced-colors: active) {

--- a/apps/console/app/globals.css
+++ b/apps/console/app/globals.css
@@ -9,9 +9,9 @@
  */
 
 @theme inline {
-  --font-sans: var(--font-plex-sans), ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+  --font-sans: "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
-  --font-mono: var(--font-plex-mono), "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo,
+  --font-mono: "IBM Plex Mono", "SFMono-Regular", "SF Mono", Consolas, "Liberation Mono", Menlo,
     ui-monospace, monospace;
 
   --color-canvas: var(--canvas);

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -1,24 +1,18 @@
 import type { Metadata, Viewport } from "next";
-import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
+// Self-hosted IBM Plex (vendored via @fontsource) so builds never depend on
+// reaching Google Fonts — important for egress-restricted/offline environments.
+import "@fontsource/ibm-plex-sans/400.css";
+import "@fontsource/ibm-plex-sans/500.css";
+import "@fontsource/ibm-plex-sans/600.css";
+import "@fontsource/ibm-plex-sans/700.css";
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/500.css";
+import "@fontsource/ibm-plex-mono/600.css";
 import {
   DEFAULT_OPERATOR_PREFERENCES,
   OPERATOR_PREFERENCES_STORAGE_KEY,
 } from "@/lib/operator-preferences";
 import "./globals.css";
-
-const plexSans = IBM_Plex_Sans({
-  subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
-  variable: "--font-plex-sans",
-  display: "swap",
-});
-
-const plexMono = IBM_Plex_Mono({
-  subsets: ["latin"],
-  weight: ["400", "500", "600"],
-  variable: "--font-plex-mono",
-  display: "swap",
-});
 
 export const metadata: Metadata = {
   title: "AWF Console",
@@ -70,7 +64,6 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${plexSans.variable} ${plexMono.variable}`}
       data-awf-theme={DEFAULT_OPERATOR_PREFERENCES.theme}
       data-awf-theme-mode={DEFAULT_OPERATOR_PREFERENCES.theme}
       data-awf-contrast={DEFAULT_OPERATOR_PREFERENCES.contrast}

--- a/apps/console/app/layout.tsx
+++ b/apps/console/app/layout.tsx
@@ -1,9 +1,24 @@
 import type { Metadata, Viewport } from "next";
+import { IBM_Plex_Mono, IBM_Plex_Sans } from "next/font/google";
 import {
   DEFAULT_OPERATOR_PREFERENCES,
   OPERATOR_PREFERENCES_STORAGE_KEY,
 } from "@/lib/operator-preferences";
 import "./globals.css";
+
+const plexSans = IBM_Plex_Sans({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-plex-sans",
+  display: "swap",
+});
+
+const plexMono = IBM_Plex_Mono({
+  subsets: ["latin"],
+  weight: ["400", "500", "600"],
+  variable: "--font-plex-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "AWF Console",
@@ -55,6 +70,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
+      className={`${plexSans.variable} ${plexMono.variable}`}
       data-awf-theme={DEFAULT_OPERATOR_PREFERENCES.theme}
       data-awf-theme-mode={DEFAULT_OPERATOR_PREFERENCES.theme}
       data-awf-contrast={DEFAULT_OPERATOR_PREFERENCES.contrast}

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -337,6 +337,8 @@ export function MergeQueuePanel({
       title="Merge Queue"
       icon={<GitPullRequest size={16} aria-hidden />}
       stale={stale}
+      fill
+      className="2xl:h-full"
       action={
         <span className="rounded-[var(--radius-control)] border border-line bg-surface-2 px-2.5 py-1 text-[11px] text-fg-muted">
           {summary}
@@ -350,7 +352,7 @@ export function MergeQueuePanel({
       ) : !hasSnapshot ? (
         <MutedLine>No PR-backed merge candidates are queued.</MutedLine>
       ) : (
-        <div className="grid gap-2">
+        <div className="flex min-h-0 flex-1 flex-col gap-2">
           {error ? (
             <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
               Showing last merge queue snapshot. Refresh failed: {error}
@@ -361,7 +363,7 @@ export function MergeQueuePanel({
               Showing first {items.length} merge candidates. More are queued.
             </div>
           ) : null}
-          <div className="grid max-h-[460px] gap-2 overflow-auto pr-1">
+          <div className="grid max-h-[460px] min-h-0 gap-2 overflow-auto pr-1 2xl:max-h-none 2xl:flex-1">
             {items.map((item, index) => {
               const rowKey = item.candidate_id ?? item.workspace_id;
               const expanded = expandedRows.has(rowKey);

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -26,9 +26,11 @@ compactId,
 fallbackLifecycleStages,
 formatDateTime,
 relativeTime,
+statusGlyph,
 statusTone,
 toneClass,
-toneFillClass
+toneFillClass,
+toneTextClass
 } from "@/lib/format";
 import {
 formatRequiredNextAction,
@@ -84,11 +86,13 @@ type CapacityUnit,
 export function ResourceCapacityPanel({
   saturation,
   error,
+  stale = false,
   workspaceSummary,
   workspaceSummaryError,
 }: {
   saturation: ResourceSaturationSummary | null;
   error: string | null;
+  stale?: boolean;
   workspaceSummary: WorkspaceReliabilitySummary | null;
   workspaceSummaryError: string | null;
 }) {
@@ -114,7 +118,7 @@ export function ResourceCapacityPanel({
     : "";
 
   return (
-    <Panel title="Resource / Runtime Capacity" icon={<Server size={16} aria-hidden />}>
+    <Panel title="Resource / Runtime Capacity" icon={<Server size={16} aria-hidden />} stale={stale}>
       {!saturation ? (
         <MutedLine>{error ? `Unable to load capacity: ${error}` : "Capacity snapshot loading."}</MutedLine>
       ) : (
@@ -309,11 +313,13 @@ export function MergeQueuePanel({
   hasMore,
   status,
   error,
+  stale = false,
 }: {
   items: MergeQueueItem[];
   hasMore: boolean;
   status: MergeQueueStatus;
   error: string | null;
+  stale?: boolean;
 }) {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const hasSnapshot = items.length > 0;
@@ -330,8 +336,9 @@ export function MergeQueuePanel({
     <Panel
       title="Merge Queue"
       icon={<GitPullRequest size={16} aria-hidden />}
+      stale={stale}
       action={
-        <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] text-slate-600">
+        <span className="rounded-[var(--radius-control)] border border-line bg-surface-2 px-2.5 py-1 text-[11px] text-fg-muted">
           {summary}
         </span>
       }
@@ -581,9 +588,9 @@ export function QueueDatum({
   tone?: ReturnType<typeof statusTone>;
 }) {
   return (
-    <div className={`min-w-0 rounded-md border px-2 py-1.5 ${tone ? toneClass(tone) : "border-slate-200 bg-slate-50"}`}>
-      <div className="text-[10px] font-medium text-slate-500">{label}</div>
-      <div className={`${mono ? "mono" : ""} truncate text-[11px] text-slate-900`}>{value}</div>
+    <div className={`min-w-0 rounded-[var(--radius-control)] border px-2 py-1.5 ${tone ? toneClass(tone) : "border-line bg-surface-2"}`}>
+      <div className="label-caps">{label}</div>
+      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] text-fg`}>{value}</div>
     </div>
   );
 }
@@ -604,11 +611,11 @@ export function QueueChip({
   return (
     <div
       title={detail ? `${label}: ${value} (${detail})` : `${label}: ${value}`}
-      className={`min-w-0 rounded-md border px-2 py-1 ${toneClass(tone)}`}
+      className={`min-w-0 rounded-[var(--radius-control)] border px-2 py-1 ${toneClass(tone)}`}
     >
-      <div className="text-[10px] font-medium text-slate-500">{label}</div>
-      <div className={`${mono ? "mono" : ""} truncate text-[11px] font-medium text-slate-900`}>{value}</div>
-      {detail ? <div className="truncate text-[10px] text-slate-500">{detail}</div> : null}
+      <div className="label-caps">{label}</div>
+      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] font-medium text-fg`}>{value}</div>
+      {detail ? <div className="truncate text-[10px] text-fg-faint">{detail}</div> : null}
     </div>
   );
 }
@@ -771,25 +778,33 @@ export function satisfiedTierTone(label: string): ReturnType<typeof statusTone> 
 }
 
 export function StatusCountStrip({ counts }: { counts: ResourceSaturationSummary["workspace_counts"] }) {
-  const items: [string, number][] = [
-    ["requested", counts.requested],
-    ["provisioning", counts.provisioning],
-    ["ready", counts.ready],
-    ["running", counts.running],
-    ["validating", counts.validating],
-    ["pushing", counts.pushing],
-    ["pr", counts.monitoring_pr],
-    ["destroying", counts.destroying],
+  const items: [string, string, number][] = [
+    ["requested", "requested", counts.requested],
+    ["provisioning", "provisioning", counts.provisioning],
+    ["ready", "ready", counts.ready],
+    ["running", "running", counts.running],
+    ["validating", "validating", counts.validating],
+    ["pushing", "pushing", counts.pushing],
+    ["pr", "monitoring_pr", counts.monitoring_pr],
+    ["destroying", "destroying", counts.destroying],
   ];
 
   return (
     <div className="grid grid-cols-2 gap-1 text-xs sm:grid-cols-4 xl:grid-cols-8">
-      {items.map(([label, value]) => (
-        <div key={label} className="min-w-0 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5">
-          <div className="truncate text-[10px] font-medium text-slate-500">{label}</div>
-          <div className="mono text-sm text-slate-950">{value}</div>
-        </div>
-      ))}
+      {items.map(([label, status, value]) => {
+        const tone = statusTone(status);
+        return (
+          <div key={label} className="min-w-0 rounded-[var(--radius-control)] border border-line bg-surface-2 px-2 py-1.5">
+            <div className="label-caps flex items-center gap-1 truncate">
+              <span aria-hidden className={toneTextClass(tone)}>
+                {statusGlyph(status)}
+              </span>
+              {label}
+            </div>
+            <div className={`mono text-sm ${value > 0 ? toneTextClass(tone) : "text-fg"}`}>{value}</div>
+          </div>
+        );
+      })}
     </div>
   );
 }
@@ -801,17 +816,17 @@ export function LaneMeter({ label, lane }: { label: string; lane: ConcurrencyLan
   const limitLabel = hasFiniteLimit ? `${lane.in_use}/${lane.limit}` : `${lane.in_use} active`;
 
   return (
-    <div className="rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
+    <div className="rounded-[var(--radius-control)] border border-line bg-surface-2 px-3 py-2 text-xs">
       <div className="flex items-center justify-between gap-2">
-        <span className="font-semibold text-slate-900">{label}</span>
-        <span className={saturated ? "font-semibold text-amber-800" : "text-slate-600"}>
+        <span className="font-semibold text-fg">{label}</span>
+        <span className={`tnum ${saturated ? "font-semibold text-attention-text" : "text-fg-muted"}`}>
           {hasFiniteLimit ? `${limitLabel} in use` : `${limitLabel} / no limit`}
         </span>
       </div>
-      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200">
-        <div className={saturated ? "h-full bg-amber-500" : "h-full bg-blue-500"} style={{ width: `${fill}%` }} />
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-line">
+        <div className={saturated ? "h-full bg-attention" : "h-full bg-info"} style={{ width: `${fill}%` }} />
       </div>
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-slate-600">
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-fg-muted">
         <span>{lane.queued} queued</span>
         <span>{lane.available} available</span>
       </div>
@@ -835,18 +850,18 @@ export function ResourceDimensionMeter({
   const tone = safeDimension.reason_code ? (safeDimension.reason_code.endsWith("_UNKNOWN") ? "warn" : "bad") : "good";
 
   return (
-    <div className={`rounded-md border px-3 py-2 text-xs ${toneClass(tone)}`}>
+    <div className={`rounded-[var(--radius-control)] border px-3 py-2 text-xs ${toneClass(tone)}`}>
       <div className="flex items-center justify-between gap-2">
-        <span className="font-semibold text-slate-900">{label}</span>
-        <span className="mono text-slate-700">
+        <span className="font-semibold text-fg">{label}</span>
+        <span className="mono text-fg-strong">
           {formatCapacityValue(safeDimension.reserved, unit)}
           {hasLimit ? ` / ${formatCapacityValue(limit, unit)}` : " / unknown"}
         </span>
       </div>
-      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-white/70">
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-line">
         <div className={`h-full ${toneFillClass(tone)}`} style={{ width: `${fill}%` }} />
       </div>
-      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-slate-700">
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-fg-strong">
         <span>{formatCapacityValue(safeDimension.available, unit)} available</span>
         <span>{formatCapacityValue(safeDimension.available_after_next_default, unit)} after next</span>
       </div>
@@ -871,32 +886,40 @@ export function LifecycleRail({
     <Panel title="Lifecycle" icon={<GitPullRequest size={16} aria-hidden />}>
       <div className="grid gap-2 md:grid-cols-4 xl:grid-cols-8">
         {stages.map((stage) => {
+          const isActive = stage.status === "active";
+          const isPr = stage.stage === "monitoring_pr";
+          const cellTone =
+            stage.status === "completed"
+              ? "good"
+              : isActive
+                ? "info"
+                : stage.status === "terminal_skipped"
+                  ? "warn"
+                  : "neutral";
           return (
             <div
               key={stage.stage}
-              className={`min-h-16 rounded-md border p-2 ${
-                stage.status === "active"
-                  ? "border-blue-300 bg-blue-50"
-                  : stage.status === "completed"
-                    ? "border-emerald-200 bg-emerald-50"
-                    : stage.status === "terminal_skipped"
-                      ? "border-amber-200 bg-amber-50"
-                      : "border-slate-200 bg-white"
+              className={`min-h-16 rounded-[var(--radius-control)] border p-2 ${
+                stage.status === "pending" ? "border-line bg-surface" : toneClass(cellTone)
               }`}
             >
-              <div className="flex items-center gap-1.5">
+              <div className="flex items-center gap-1.5 text-fg">
                 {stage.status === "completed" ? (
-                  <CheckCircle2 size={14} className="text-emerald-700" aria-hidden />
-                ) : stage.status === "active" ? (
-                  <CircleDot size={14} className="text-blue-700" aria-hidden />
+                  <CheckCircle2 size={14} className="text-healthy" aria-hidden />
+                ) : isActive ? (
+                  isPr ? (
+                    <GitPullRequest size={14} className="text-info" aria-hidden />
+                  ) : (
+                    <CircleDot size={14} className="text-info" aria-hidden />
+                  )
                 ) : stage.status === "terminal_skipped" ? (
-                  <AlertCircle size={14} className="text-amber-700" aria-hidden />
+                  <AlertCircle size={14} className="text-attention" aria-hidden />
                 ) : (
-                  <Clock3 size={14} className="text-slate-400" aria-hidden />
+                  <Clock3 size={14} className="text-fg-faint" aria-hidden />
                 )}
                 <span className="truncate text-xs font-medium">{stage.stage}</span>
               </div>
-              <div className="mt-2 grid gap-1 text-[11px] text-slate-600">
+              <div className="mt-2 grid gap-1 text-[11px] text-fg-muted">
                 <div className="truncate">start {formatDateTime(stage.started_at)}</div>
                 <div className="truncate">
                   end {stage.status === "active" ? "active" : formatDateTime(stage.ended_at)}
@@ -908,7 +931,7 @@ export function LifecycleRail({
         })}
       </div>
       {terminal ? (
-        <div className="mt-3 inline-flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+        <div className="mt-3 inline-flex items-center gap-2 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-3 py-2 text-xs text-attention-text">
           <AlertCircle size={14} aria-hidden />
           Terminal state: {status}
         </div>

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -122,7 +122,12 @@ export function ResourceCapacityPanel({
     : "";
 
   return (
-    <Panel title="Resource / Runtime Capacity" icon={<Server size={16} aria-hidden />} stale={stale}>
+    <Panel
+      title="Resource / Runtime Capacity"
+      icon={<Server size={16} aria-hidden />}
+      stale={stale || summaryStale}
+      dimBody={false}
+    >
       {!saturation ? (
         <MutedLine>{error ? `Unable to load capacity: ${error}` : "Capacity snapshot loading."}</MutedLine>
       ) : (
@@ -137,6 +142,23 @@ export function ResourceCapacityPanel({
               Unable to load workspace reliability metrics: {workspaceSummaryError}
             </div>
           ) : null}
+          {/* Reliability-summary facts dim with the summary feed only — kept out
+              of the saturation region so a stale saturation snapshot can't fade
+              freshly-refreshed Stuck / Reason coverage. */}
+          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+            <Fact
+              label="Stuck"
+              value={workspaceSummary ? `${workspaceSummary.stuck_count} workspaces` : "—"}
+              stale={summaryStale}
+            />
+            <Fact
+              label="Reason Coverage"
+              value={workspaceSummary ? `${coverage}% (${totalReason} tracked)` : "—"}
+              stale={summaryStale}
+            />
+          </div>
+          {/* Saturation-driven content dims with the saturation feed. */}
+          <div data-awf-stale={stale ? "true" : undefined} className="grid gap-3">
           <div className="rounded-md border border-blue-100 bg-blue-50 px-3 py-2 text-xs text-blue-950">
             <div className="flex flex-wrap items-center justify-between gap-2">
               <span className="font-semibold">Scheduler capacity source</span>
@@ -148,16 +170,6 @@ export function ResourceCapacityPanel({
           </div>
           <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
             <Fact label="Active" value={`${saturation.workspace_counts.active_total} workspaces`} />
-            <Fact
-              label="Stuck"
-              value={workspaceSummary ? `${workspaceSummary.stuck_count} workspaces` : "—"}
-              stale={summaryStale}
-            />
-            <Fact
-              label="Reason Coverage"
-              value={workspaceSummary ? `${coverage}% (${totalReason} tracked)` : "—"}
-              stale={summaryStale}
-            />
             <Fact
               label="Reserved runtime CPU"
               value={`${formatScalar(saturation.reserved_resources.steady_cpu)} steady / ${formatScalar(
@@ -262,6 +274,7 @@ export function ResourceCapacityPanel({
           </div>
           <div className="text-[11px] text-slate-500">
             generated {relativeTime(saturation.generated_at)}
+          </div>
           </div>
         </div>
       )}

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -592,7 +592,9 @@ export function QueueDatum({
   return (
     <div className={`min-w-0 rounded-[var(--radius-control)] border px-2 py-1.5 ${tone ? toneClass(tone) : "border-line bg-surface-2"}`}>
       <div className="label-caps">{label}</div>
-      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] text-fg`}>{value}</div>
+      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] ${tone && tone !== "neutral" ? "" : "text-fg"}`}>
+        {value}
+      </div>
     </div>
   );
 }
@@ -616,7 +618,9 @@ export function QueueChip({
       className={`min-w-0 rounded-[var(--radius-control)] border px-2 py-1 ${toneClass(tone)}`}
     >
       <div className="label-caps">{label}</div>
-      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] font-medium text-fg`}>{value}</div>
+      <div className={`${mono ? "mono" : "tnum"} truncate text-[11px] font-medium ${tone && tone !== "neutral" ? "" : "text-fg"}`}>
+        {value}
+      </div>
       {detail ? <div className="truncate text-[10px] text-fg-faint">{detail}</div> : null}
     </div>
   );
@@ -905,7 +909,7 @@ export function LifecycleRail({
                 stage.status === "pending" ? "border-line bg-surface" : toneClass(cellTone)
               }`}
             >
-              <div className="flex items-center gap-1.5 text-fg">
+              <div className="flex items-center gap-1.5">
                 {stage.status === "completed" ? (
                   <CheckCircle2 size={14} className="text-healthy" aria-hidden />
                 ) : isActive ? (

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -87,12 +87,16 @@ export function ResourceCapacityPanel({
   saturation,
   error,
   stale = false,
+  summaryStale = false,
   workspaceSummary,
   workspaceSummaryError,
 }: {
   saturation: ResourceSaturationSummary | null;
   error: string | null;
   stale?: boolean;
+  // Reliability-summary fields (Stuck, Reason coverage) come from a separate
+  // feed and dim independently of the saturation-driven panel staleness.
+  summaryStale?: boolean;
   workspaceSummary: WorkspaceReliabilitySummary | null;
   workspaceSummaryError: string | null;
 }) {
@@ -147,10 +151,12 @@ export function ResourceCapacityPanel({
             <Fact
               label="Stuck"
               value={workspaceSummary ? `${workspaceSummary.stuck_count} workspaces` : "—"}
+              stale={summaryStale}
             />
             <Fact
               label="Reason Coverage"
               value={workspaceSummary ? `${coverage}% (${totalReason} tracked)` : "—"}
+              stale={summaryStale}
             />
             <Fact
               label="Reserved runtime CPU"

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -259,10 +259,21 @@ export type FleetKpi = {
 
 // Status layer (ISA-101 three-layer model): a single-glance fleet HUD answering
 // "is the fleet ok?" — the 5-7 KPIs an operator scans first, most critical first.
-export function FleetHealthStrip({ kpis }: { kpis: FleetKpi[] }) {
+// When the feed is stale the KPI values are dimmed, but the warning above them
+// stays at full opacity so the cue is never lost.
+export function FleetHealthStrip({ kpis, stale = false }: { kpis: FleetKpi[]; stale?: boolean }) {
   return (
     <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
+      {stale ? (
+        <div className="mb-2 inline-flex items-center gap-1 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-2 py-0.5 text-[11px] font-medium text-attention-text">
+          <span aria-hidden>⚠</span>
+          showing last snapshot — live data may be stale
+        </div>
+      ) : null}
+      <div
+        data-awf-stale={stale ? "true" : undefined}
+        className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8"
+      >
         {kpis.map((kpi) => (
           <KpiStat
             key={kpi.id}

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -255,25 +255,24 @@ export type FleetKpi = {
   tone?: StatusTone;
   suffix?: string;
   hint?: string;
+  stale?: boolean;
 };
 
 // Status layer (ISA-101 three-layer model): a single-glance fleet HUD answering
 // "is the fleet ok?" — the 5-7 KPIs an operator scans first, most critical first.
-// When the feed is stale the KPI values are dimmed, but the warning above them
-// stays at full opacity so the cue is never lost.
-export function FleetHealthStrip({ kpis, stale = false }: { kpis: FleetKpi[]; stale?: boolean }) {
+// KPIs dim per source (saturation vs reliability summary) so only the actually
+// stale values fade, while the warning above stays at full opacity.
+export function FleetHealthStrip({ kpis }: { kpis: FleetKpi[] }) {
+  const anyStale = kpis.some((kpi) => kpi.stale);
   return (
     <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">
-      {stale ? (
+      {anyStale ? (
         <div className="mb-2 inline-flex items-center gap-1 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-2 py-0.5 text-[11px] font-medium text-attention-text">
           <span aria-hidden>⚠</span>
-          showing last snapshot — live data may be stale
+          some values show the last snapshot — live data may be stale
         </div>
       ) : null}
-      <div
-        data-awf-stale={stale ? "true" : undefined}
-        className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8"
-      >
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
         {kpis.map((kpi) => (
           <KpiStat
             key={kpi.id}
@@ -282,6 +281,7 @@ export function FleetHealthStrip({ kpis, stale = false }: { kpis: FleetKpi[]; st
             tone={kpi.tone}
             suffix={kpi.suffix}
             hint={kpi.hint}
+            stale={kpi.stale}
           />
         ))}
       </div>

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -3,6 +3,7 @@
 import {
 Activity,
 AlertCircle,
+AlertTriangle,
 ArrowDown,
 ArrowUp,
 Bot,
@@ -12,8 +13,10 @@ ChevronDown,
 ChevronUp,
 Contrast,
 FileText,
+GitPullRequest,
 HeartPulse,
 ListFilter,
+ListTree,
 Loader2,
 Maximize2,
 Monitor,
@@ -21,6 +24,7 @@ Moon,
 Radio,
 RefreshCw,
 Search,
+Server,
 Sun,
 Terminal,
 Type,
@@ -45,7 +49,8 @@ formatUsageProvenance,
 lifecycleStages,
 pricingAvailabilityReason,
 relativeTime,
-toneClass
+toneClass,
+type StatusTone
 } from "@/lib/format";
 import {
 requiredNextActionTone,
@@ -73,6 +78,7 @@ import {
 Badge,
 ExternalAnchor,
 Fact,
+KpiStat,
 OperatorActionState,
 Panel,
 RetryActionState,
@@ -239,6 +245,71 @@ export function StatePill({
       {icon}
       {label}: {state}
     </span>
+  );
+}
+
+export type FleetKpi = {
+  id: string;
+  label: string;
+  value: string | number;
+  tone?: StatusTone;
+  suffix?: string;
+  hint?: string;
+};
+
+// Status layer (ISA-101 three-layer model): a single-glance fleet HUD answering
+// "is the fleet ok?" — the 5-7 KPIs an operator scans first, most critical first.
+export function FleetHealthStrip({ kpis }: { kpis: FleetKpi[] }) {
+  return (
+    <div className="border-b border-line bg-canvas px-4 py-3" aria-label="Fleet health">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
+        {kpis.map((kpi) => (
+          <KpiStat
+            key={kpi.id}
+            label={kpi.label}
+            value={kpi.value}
+            tone={kpi.tone}
+            suffix={kpi.suffix}
+            hint={kpi.hint}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const NAV_ITEMS: { id: string; label: string; icon: typeof ListTree }[] = [
+  { id: "awf-workspaces", label: "Workspaces", icon: ListTree },
+  { id: "awf-capacity", label: "Capacity", icon: Server },
+  { id: "awf-merge-queue", label: "Merge queue", icon: GitPullRequest },
+  { id: "awf-failures", label: "Failures", icon: AlertTriangle },
+];
+
+// Section jump-nav. On wide screens the panels sit side by side and need no
+// navigation; on narrow screens they stack into one tall column, so this sticky
+// bar (narrow-only) lets operators jump straight to a section.
+export function SectionNav() {
+  const go = (id: string) => document.getElementById(id)?.scrollIntoView({ block: "start" });
+  return (
+    <nav
+      aria-label="Jump to section"
+      className="sticky top-0 z-30 flex gap-2 overflow-x-auto border-b border-line bg-canvas px-4 py-2 xl:hidden"
+    >
+      {NAV_ITEMS.map((item) => {
+        const Icon = item.icon;
+        return (
+          <button
+            key={item.id}
+            type="button"
+            onClick={() => go(item.id)}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-[var(--radius-control)] border border-line bg-surface px-2.5 py-1 text-[11px] font-medium text-fg-muted transition hover:bg-surface-2 hover:text-fg"
+          >
+            <Icon size={13} aria-hidden />
+            {item.label}
+          </button>
+        );
+      })}
+    </nav>
   );
 }
 

--- a/apps/console/components/console-dashboard-security.tsx
+++ b/apps/console/components/console-dashboard-security.tsx
@@ -241,10 +241,12 @@ export function FailureAnalysisPanel({
   summary,
   status,
   error,
+  stale = false,
 }: {
   summary: FailureSummaryResponse | null;
   status: "loading" | "success" | "error" | "unavailable";
   error: string | null;
+  stale?: boolean;
 }) {
   if (status === "unavailable") {
     return (
@@ -261,6 +263,7 @@ export function FailureAnalysisPanel({
     <Panel
       title="Failure Analysis"
       icon={<Activity size={16} aria-hidden />}
+      stale={stale}
       action={
         <span className="rounded-md border border-slate-200 bg-slate-50 px-2.5 py-1 text-[11px] text-slate-600">
           {isLoading && !summary ? "loading" : isError && !summary ? "error" : `${summary?.total_failures ?? 0} failures in window`}

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -367,15 +367,20 @@ export function KpiStat({
   tone,
   suffix,
   hint,
+  stale = false,
 }: {
   label: string;
   value: string | number;
   tone?: StatusTone;
   suffix?: string;
   hint?: string;
+  stale?: boolean;
 }) {
   return (
-    <div className="min-w-0 rounded-[var(--radius-panel)] border border-line bg-surface px-3 py-2">
+    <div
+      data-awf-stale={stale ? "true" : undefined}
+      className="min-w-0 rounded-[var(--radius-panel)] border border-line bg-surface px-3 py-2"
+    >
       <div className="label-caps truncate">{label}</div>
       <div className={`kpi-value mt-0.5 truncate ${tone ? toneTextClass(tone) : "text-fg"}`}>
         {value}

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -359,18 +359,6 @@ export function Badge({ value }: { value: string }) {
   );
 }
 
-export function StatusDot({ status, label }: { status: string; label?: string }) {
-  const tone = statusTone(status);
-  return (
-    <span className="inline-flex items-center gap-1.5">
-      <span aria-hidden className={`text-[11px] leading-none ${toneTextClass(tone)}`}>
-        {statusGlyph(status)}
-      </span>
-      {label ? <span className="truncate">{label}</span> : null}
-    </span>
-  );
-}
-
 // Single-glance KPI for the Status layer: a big tabular value with optional
 // tone color and a contextual hint.
 export function KpiStat({

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -6,8 +6,11 @@ import { createContext,useContext } from "react";
 import { omitUndefined } from "@/lib/api-payload";
 import {
 bytes,
+statusGlyph,
 statusTone,
-toneClass
+toneClass,
+toneTextClass,
+type StatusTone
 } from "@/lib/format";
 import type { OperatorPreferences,ResolvedOperatorTheme } from "@/lib/operator-preferences";
 import {
@@ -270,24 +273,46 @@ export function Panel({
   title,
   icon,
   action,
+  stale = false,
+  staleLabel = "stale",
   children,
 }: {
   title: string;
   icon: React.ReactNode;
   action?: React.ReactNode;
+  stale?: boolean;
+  staleLabel?: string;
   children: React.ReactNode;
 }) {
   const variant = useContext(PanelContext);
   const isGhost = variant === "ghost";
 
   return (
-    <section className={`min-w-0 w-full max-w-full ${isGhost ? "" : "rounded-md border border-[var(--border)] bg-white"}`}>
-      <div className={`flex min-h-11 min-w-0 flex-wrap items-center justify-between gap-3 border-slate-100 ${isGhost ? "px-1 py-2" : "px-3 py-2 border-b"}`}>
-        <h2 className="flex items-center gap-2 text-sm font-semibold">
+    <section
+      data-awf-stale={stale ? "true" : undefined}
+      className={`min-w-0 w-full max-w-full ${isGhost ? "" : "rounded-[var(--radius-panel)] border border-line bg-surface"}`}
+    >
+      <div
+        className={`flex min-h-11 min-w-0 flex-wrap items-center justify-between gap-3 ${
+          isGhost ? "px-1 py-2" : "border-b border-line px-3 py-2"
+        }`}
+      >
+        <h2 className="flex items-center gap-2 text-sm font-semibold text-fg">
           {icon}
           {title}
         </h2>
-        {action}
+        <div className="flex min-w-0 items-center gap-2">
+          {stale ? (
+            <span
+              title="Data may be stale — last refresh failed or stream disconnected"
+              className="inline-flex items-center gap-1 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-1.5 py-0.5 text-[10px] font-medium text-attention-text"
+            >
+              <span aria-hidden>⚠</span>
+              {staleLabel}
+            </span>
+          ) : null}
+          {action}
+        </div>
       </div>
       <div className={`min-w-0 ${isGhost ? "py-3" : "p-3"}`}>{children}</div>
     </section>
@@ -296,22 +321,68 @@ export function Panel({
 
 export function Fact({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
   return (
-    <div className="min-w-0 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
-      <div className="text-[11px] font-medium text-slate-500">{label}</div>
-      <div className={`${mono ? "mono" : ""} truncate text-sm text-slate-950`}>{value}</div>
+    <div className="min-w-0 rounded-[var(--radius-control)] border border-line bg-surface-2 px-3 py-2">
+      <div className="label-caps">{label}</div>
+      <div className={`${mono ? "mono" : "tnum"} truncate text-sm text-fg`}>{value}</div>
     </div>
   );
 }
 
+// Status as color + glyph + label (never color alone). Keeps the `Badge` name
+// so existing call sites are unchanged; the rendered status text stays a
+// distinct node so text-based selectors still match exactly.
 export function Badge({ value }: { value: string }) {
+  const tone = statusTone(value);
   return (
     <span
-      className={`inline-flex h-6 shrink-0 items-center rounded-md border px-2 text-[11px] font-medium ${toneClass(
-        statusTone(value),
+      className={`inline-flex h-6 shrink-0 items-center gap-1 rounded-[var(--radius-control)] border px-2 text-[11px] font-medium ${toneClass(
+        tone,
       )}`}
     >
-      {value}
+      <span aria-hidden className="text-[10px] leading-none">
+        {statusGlyph(value)}
+      </span>
+      <span>{value}</span>
     </span>
+  );
+}
+
+export function StatusDot({ status, label }: { status: string; label?: string }) {
+  const tone = statusTone(status);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <span aria-hidden className={`text-[11px] leading-none ${toneTextClass(tone)}`}>
+        {statusGlyph(status)}
+      </span>
+      {label ? <span className="truncate">{label}</span> : null}
+    </span>
+  );
+}
+
+// Single-glance KPI for the Status layer: a big tabular value with optional
+// tone color and a contextual hint.
+export function KpiStat({
+  label,
+  value,
+  tone,
+  suffix,
+  hint,
+}: {
+  label: string;
+  value: string | number;
+  tone?: StatusTone;
+  suffix?: string;
+  hint?: string;
+}) {
+  return (
+    <div className="min-w-0 rounded-[var(--radius-panel)] border border-line bg-surface px-3 py-2">
+      <div className="label-caps truncate">{label}</div>
+      <div className={`kpi-value mt-0.5 truncate ${tone ? toneTextClass(tone) : "text-fg"}`}>
+        {value}
+        {suffix ? <span className="ml-0.5 text-sm font-normal text-fg-faint">{suffix}</span> : null}
+      </div>
+      {hint ? <div className="mt-0.5 truncate text-[11px] text-fg-muted">{hint}</div> : null}
+    </div>
   );
 }
 
@@ -466,6 +537,23 @@ export function formatPercent(value: number): string {
     return "0%";
   }
   return `${value.toFixed(1)}%`;
+}
+
+// Single fleet-capacity headline: the worst utilization across peak CPU, peak
+// memory, and execution concurrency, clamped to 0-100.
+export function capacityUtilizationPct(saturation: ResourceSaturationSummary): number {
+  let pct = 0;
+  const dims = [saturation.allocated_capacity.peak_cpu, saturation.allocated_capacity.peak_memory_gb];
+  for (const dimension of dims) {
+    if (dimension.limit && dimension.limit > 0) {
+      pct = Math.max(pct, (dimension.reserved / dimension.limit) * 100);
+    }
+  }
+  const execution = saturation.concurrency.execution;
+  if (execution.limit > 0) {
+    pct = Math.max(pct, (execution.in_use / execution.limit) * 100);
+  }
+  return Math.min(100, Math.max(0, Math.round(pct)));
 }
 
 export async function apiGet<T>(path: string): Promise<ApiEnvelope<T>> {

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -331,9 +331,22 @@ export function Panel({
   );
 }
 
-export function Fact({ label, value, mono = false }: { label: string; value: string; mono?: boolean }) {
+export function Fact({
+  label,
+  value,
+  mono = false,
+  stale = false,
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+  stale?: boolean;
+}) {
   return (
-    <div className="min-w-0 rounded-[var(--radius-control)] border border-line bg-surface-2 px-3 py-2">
+    <div
+      data-awf-stale={stale ? "true" : undefined}
+      className="min-w-0 rounded-[var(--radius-control)] border border-line bg-surface-2 px-3 py-2"
+    >
       <div className="label-caps">{label}</div>
       <div className={`${mono ? "mono" : "tnum"} truncate text-sm text-fg`}>{value}</div>
     </div>

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -551,23 +551,6 @@ export function formatPercent(value: number): string {
   return `${value.toFixed(1)}%`;
 }
 
-// Single fleet-capacity headline: the worst utilization across peak CPU, peak
-// memory, and execution concurrency, clamped to 0-100.
-export function capacityUtilizationPct(saturation: ResourceSaturationSummary): number {
-  let pct = 0;
-  const dims = [saturation.allocated_capacity.peak_cpu, saturation.allocated_capacity.peak_memory_gb];
-  for (const dimension of dims) {
-    if (dimension.limit && dimension.limit > 0) {
-      pct = Math.max(pct, (dimension.reserved / dimension.limit) * 100);
-    }
-  }
-  const execution = saturation.concurrency.execution;
-  if (execution.limit > 0) {
-    pct = Math.max(pct, (execution.in_use / execution.limit) * 100);
-  }
-  return Math.min(100, Math.max(0, Math.round(pct)));
-}
-
 export async function apiGet<T>(path: string): Promise<ApiEnvelope<T>> {
   try {
     const response = await fetch(path, { cache: "no-store" });

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -276,6 +276,7 @@ export function Panel({
   stale = false,
   staleLabel = "stale",
   fill = false,
+  dimBody = true,
   className = "",
   children,
 }: {
@@ -287,6 +288,9 @@ export function Panel({
   // When true the panel is a flex column so a scrollable child can grow to
   // fill the panel height (used where a grid column is stretched to a sibling).
   fill?: boolean;
+  // When false the body is not dimmed on stale (the header badge still shows);
+  // used by panels that dim their content regions individually per data source.
+  dimBody?: boolean;
   className?: string;
   children: React.ReactNode;
 }) {
@@ -320,9 +324,10 @@ export function Panel({
         </div>
       </div>
       {/* Only the body dims when stale (data-awf-stale) so the header's stale
-          warning badge keeps full opacity. */}
+          warning badge keeps full opacity. Panels that mix data sources set
+          dimBody={false} and dim their content regions individually instead. */}
       <div
-        data-awf-stale={stale ? "true" : undefined}
+        data-awf-stale={stale && dimBody ? "true" : undefined}
         className={`min-w-0 ${fill ? "flex min-h-0 flex-1 flex-col " : ""}${isGhost ? "py-3" : "p-3"}`}
       >
         {children}

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -275,6 +275,8 @@ export function Panel({
   action,
   stale = false,
   staleLabel = "stale",
+  fill = false,
+  className = "",
   children,
 }: {
   title: string;
@@ -282,6 +284,10 @@ export function Panel({
   action?: React.ReactNode;
   stale?: boolean;
   staleLabel?: string;
+  // When true the panel is a flex column so a scrollable child can grow to
+  // fill the panel height (used where a grid column is stretched to a sibling).
+  fill?: boolean;
+  className?: string;
   children: React.ReactNode;
 }) {
   const variant = useContext(PanelContext);
@@ -290,7 +296,7 @@ export function Panel({
   return (
     <section
       data-awf-stale={stale ? "true" : undefined}
-      className={`min-w-0 w-full max-w-full ${isGhost ? "" : "rounded-[var(--radius-panel)] border border-line bg-surface"}`}
+      className={`min-w-0 w-full max-w-full ${fill ? "flex min-h-0 flex-col " : ""}${isGhost ? "" : "rounded-[var(--radius-panel)] border border-line bg-surface"} ${className}`}
     >
       <div
         className={`flex min-h-11 min-w-0 flex-wrap items-center justify-between gap-3 ${
@@ -314,7 +320,9 @@ export function Panel({
           {action}
         </div>
       </div>
-      <div className={`min-w-0 ${isGhost ? "py-3" : "p-3"}`}>{children}</div>
+      <div className={`min-w-0 ${fill ? "flex min-h-0 flex-1 flex-col " : ""}${isGhost ? "py-3" : "p-3"}`}>
+        {children}
+      </div>
     </section>
   );
 }

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -295,7 +295,6 @@ export function Panel({
 
   return (
     <section
-      data-awf-stale={stale ? "true" : undefined}
       className={`min-w-0 w-full max-w-full ${fill ? "flex min-h-0 flex-col " : ""}${isGhost ? "" : "rounded-[var(--radius-panel)] border border-line bg-surface"} ${className}`}
     >
       <div
@@ -310,7 +309,7 @@ export function Panel({
         <div className="flex min-w-0 items-center gap-2">
           {stale ? (
             <span
-              title="Data may be stale — last refresh failed or stream disconnected"
+              title="Showing the last snapshot — live data may be stale"
               className="inline-flex items-center gap-1 rounded-[var(--radius-control)] border border-attention-border bg-attention-soft px-1.5 py-0.5 text-[10px] font-medium text-attention-text"
             >
               <span aria-hidden>⚠</span>
@@ -320,7 +319,12 @@ export function Panel({
           {action}
         </div>
       </div>
-      <div className={`min-w-0 ${fill ? "flex min-h-0 flex-1 flex-col " : ""}${isGhost ? "py-3" : "p-3"}`}>
+      {/* Only the body dims when stale (data-awf-stale) so the header's stale
+          warning badge keeps full opacity. */}
+      <div
+        data-awf-stale={stale ? "true" : undefined}
+        className={`min-w-0 ${fill ? "flex min-h-0 flex-1 flex-col " : ""}${isGhost ? "py-3" : "p-3"}`}
+      >
         {children}
       </div>
     </section>

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -12,7 +12,7 @@ useTransition,
 } from "react";
 import { WorkspaceInspector } from "./workspace-inspector";
 
-import { compactDuration,fallbackLlmUsage,pickWorkspaceLogStreams } from "@/lib/format";
+import { capacityUtilizationPct,compactDuration,fallbackLlmUsage,pickWorkspaceLogStreams } from "@/lib/format";
 import type { OperatorPreferences,ResolvedOperatorTheme } from "@/lib/operator-preferences";
 import {
 DEFAULT_OPERATOR_PREFERENCES,
@@ -68,7 +68,6 @@ PanelContext,
 apiGet,
 apiPost,
 applyOperatorPreferenceAttributes,
-capacityUtilizationPct,
 compareLogEntries,
 compareWorkspaceDates,
 emptyDetail,

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -12,7 +12,7 @@ useTransition,
 } from "react";
 import { WorkspaceInspector } from "./workspace-inspector";
 
-import { fallbackLlmUsage,pickWorkspaceLogStreams } from "@/lib/format";
+import { compactDuration,fallbackLlmUsage,pickWorkspaceLogStreams } from "@/lib/format";
 import type { OperatorPreferences,ResolvedOperatorTheme } from "@/lib/operator-preferences";
 import {
 DEFAULT_OPERATOR_PREFERENCES,
@@ -52,7 +52,7 @@ RuntimePanel,
 terminalLifecycleSourceStage,
 } from "./console-dashboard-capacity";
 import { LogsPanel,MultiWorkspaceLogsFullscreen } from "./console-dashboard-logs";
-import { TaskDetailsModal,TopBar,WorkspaceFilters,WorkspaceList,WorkspaceSelectionToolbar,WorkspaceSummary } from "./console-dashboard-overview";
+import { type FleetKpi,FleetHealthStrip,SectionNav,TaskDetailsModal,TopBar,WorkspaceFilters,WorkspaceList,WorkspaceSelectionToolbar,WorkspaceSummary } from "./console-dashboard-overview";
 import { FailureAnalysisPanel,SecretsLeasesPanel,SecurityEgressPanel } from "./console-dashboard-security";
 import {
 type DetailState,
@@ -68,6 +68,7 @@ PanelContext,
 apiGet,
 apiPost,
 applyOperatorPreferenceAttributes,
+capacityUtilizationPct,
 compareLogEntries,
 compareWorkspaceDates,
 emptyDetail,
@@ -794,6 +795,62 @@ const searchParams = useSearchParams();
     [overview, taskDetailsWorkspaceId],
   );
 
+  const fleetKpis = useMemo<FleetKpi[]>(() => {
+    const counts = resourceSaturation?.workspace_counts;
+    const capacity = resourceSaturation ? capacityUtilizationPct(resourceSaturation) : null;
+    const queued = resourceSaturation?.capacity_queue.queued_workspace_count ?? 0;
+    const oldestWait = resourceSaturation?.capacity_queue.oldest_wait_seconds ?? null;
+    // Windowed reliability counts (default 24h) — actionable, unlike the
+    // ever-growing cumulative failed total.
+    const windowHours = workspaceSummary?.since_hours ?? 24;
+    const windowHint = `last ${windowHours}h`;
+    const completed = workspaceSummary?.completed_count;
+    const cancelled = workspaceSummary?.cancelled_count;
+    const failed = workspaceSummary?.failed_count;
+    return [
+      { id: "active", label: "Active", value: counts?.active_total ?? 0 },
+      { id: "running", label: "Running", value: counts?.running ?? 0, tone: "info" },
+      { id: "monitoring_pr", label: "Monitoring PR", value: counts?.monitoring_pr ?? 0, tone: "info" },
+      {
+        id: "queued",
+        label: "Queued",
+        value: queued,
+        tone: queued > 0 ? "warn" : undefined,
+        hint: oldestWait != null ? `oldest ${compactDuration(oldestWait)}` : "awaiting capacity",
+      },
+      {
+        id: "completed",
+        label: "Completed",
+        value: completed ?? "—",
+        tone: completed != null ? "good" : undefined,
+        hint: windowHint,
+      },
+      {
+        id: "cancelled",
+        label: "Cancelled",
+        value: cancelled ?? "—",
+        tone: cancelled ? "warn" : undefined,
+        hint: windowHint,
+      },
+      {
+        id: "failed",
+        label: "Failed",
+        value: failed ?? "—",
+        tone: failed ? "bad" : undefined,
+        hint: windowHint,
+      },
+      {
+        id: "capacity",
+        label: "Capacity",
+        value: capacity ?? "—",
+        suffix: capacity != null ? "%" : undefined,
+        tone: capacity != null ? (capacity >= 90 ? "bad" : capacity >= 75 ? "warn" : "info") : undefined,
+      },
+    ];
+  }, [resourceSaturation, workspaceSummary]);
+
+  const dataStale = apiState === "error";
+
   return (
     <main className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-[var(--background)] text-[var(--foreground)]">
       <TopBar
@@ -814,8 +871,14 @@ const searchParams = useSearchParams();
         isPending={isPending}
       />
 
+      <FleetHealthStrip kpis={fleetKpis} />
+      <SectionNav />
+
       <div className="grid min-h-[calc(100vh-57px)] w-full max-w-full grid-cols-1 overflow-x-hidden border-t border-[var(--border)] xl:grid-cols-[440px_minmax(0,1fr)] 2xl:grid-cols-[500px_minmax(0,1fr)]">
-        <aside className="min-w-0 border-b border-[var(--border)] bg-white xl:border-r xl:border-b-0">
+        <aside
+          id="awf-workspaces"
+          className="min-w-0 border-b border-[var(--border)] bg-white xl:border-r xl:border-b-0"
+        >
           <WorkspaceFilters
             statusFilters={statusFilters}
             agentFilters={agentFilters}
@@ -856,19 +919,25 @@ const searchParams = useSearchParams();
         <section className="min-w-0">
           {error ? <ErrorBanner message={error} /> : null}
           <div className="grid min-w-0 gap-4 p-4 pb-0 2xl:grid-cols-[minmax(0,1fr)_minmax(460px,0.85fr)]">
-            <ResourceCapacityPanel
-              saturation={resourceSaturation}
-              error={resourceError}
-              workspaceSummary={workspaceSummary}
-              workspaceSummaryError={workspaceSummaryError}
-            />
-            <MergeQueuePanel
-              items={mergeQueue}
-              hasMore={mergeQueueHasMore}
-              status={mergeQueueStatus}
-              error={mergeQueueError}
-            />
-            <div className="2xl:col-span-2">
+            <div id="awf-capacity" className="min-w-0 scroll-mt-4">
+              <ResourceCapacityPanel
+                saturation={resourceSaturation}
+                error={resourceError}
+                stale={dataStale}
+                workspaceSummary={workspaceSummary}
+                workspaceSummaryError={workspaceSummaryError}
+              />
+            </div>
+            <div id="awf-merge-queue" className="min-w-0 scroll-mt-4">
+              <MergeQueuePanel
+                items={mergeQueue}
+                hasMore={mergeQueueHasMore}
+                status={mergeQueueStatus}
+                error={mergeQueueError}
+                stale={dataStale}
+              />
+            </div>
+            <div id="awf-failures" className="scroll-mt-4 2xl:col-span-2">
               <FailureAnalysisPanel
                 summary={failureSummary}
                 status={failureSummaryStatus}

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -794,12 +794,13 @@ const searchParams = useSearchParams();
     [overview, taskDetailsWorkspaceId],
   );
 
-  // Per-source stale flags: saturation-backed KPIs and reliability-summary KPIs
-  // dim independently so a failure in one feed never fades fresh values from the
-  // other.
-  const apiDown = apiState === "error";
-  const saturationStale = (apiDown || resourceError != null) && resourceSaturation != null;
-  const summaryStale = (apiDown || workspaceSummaryError != null) && workspaceSummary != null;
+  // Per-source stale flags: each feed polls on its own timer, so staleness is
+  // keyed off that feed's OWN refresh error (showing a cached snapshot), not the
+  // shared /health check (which is surfaced separately via the API pill). This
+  // keeps freshly-refreshed values bright even if /health blips, and a real
+  // outage still fails each feed's poll and sets its own error.
+  const saturationStale = resourceError != null && resourceSaturation != null;
+  const summaryStale = workspaceSummaryError != null && workspaceSummary != null;
 
   const fleetKpis = useMemo<FleetKpi[]>(() => {
     const counts = resourceSaturation?.workspace_counts ?? null;
@@ -884,8 +885,8 @@ const searchParams = useSearchParams();
   // previously-loaded snapshot AND its feed errored. On first-load failures
   // there is no cached snapshot, so the panel shows its loading/error state
   // instead of a misleading "last snapshot" badge.
-  const mergeErrored = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
-  const failureErrored = apiDown || failureSummaryStatus === "error";
+  const mergeErrored = mergeQueueError != null || mergeQueueStatus === "error";
+  const failureErrored = failureSummaryStatus === "error";
   const capacityStale = saturationStale;
   const mergeStale = mergeErrored && mergeQueue.length > 0;
   const failureStale = failureErrored && failureSummary != null;

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -872,13 +872,16 @@ const searchParams = useSearchParams();
   // there is no cached snapshot, so the panel shows its loading/error state
   // instead of a misleading "last snapshot" badge.
   const apiDown = apiState === "error";
-  const resourceErrored = apiDown || resourceError != null || workspaceSummaryError != null;
+  // Saturation drives the capacity panel and most fleet KPIs. A reliability
+  // summary error is a separate, secondary source (surfaced via its own banner),
+  // so it must not dim saturation-backed data that is still fresh.
+  const resourceErrored = apiDown || resourceError != null;
   const mergeErrored = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
   const failureErrored = apiDown || failureSummaryStatus === "error";
   const capacityStale = resourceErrored && resourceSaturation != null;
   const mergeStale = mergeErrored && mergeQueue.length > 0;
   const failureStale = failureErrored && failureSummary != null;
-  const fleetStale = resourceErrored && (resourceSaturation != null || workspaceSummary != null);
+  const fleetStale = resourceErrored && resourceSaturation != null;
 
   return (
     <main className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-[var(--background)] text-[var(--foreground)]">

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -928,14 +928,19 @@ const searchParams = useSearchParams();
                 workspaceSummaryError={workspaceSummaryError}
               />
             </div>
-            <div id="awf-merge-queue" className="min-w-0 scroll-mt-4">
-              <MergeQueuePanel
-                items={mergeQueue}
-                hasMore={mergeQueueHasMore}
-                status={mergeQueueStatus}
-                error={mergeQueueError}
-                stale={dataStale}
-              />
+            {/* 2xl: the panel overlays the cell (absolute) so the long merge
+                list never drives the row height — Capacity sets the height and
+                the list scrolls to fill it. Below 2xl it is normal flow. */}
+            <div id="awf-merge-queue" className="min-w-0 scroll-mt-4 2xl:relative">
+              <div className="2xl:absolute 2xl:inset-0">
+                <MergeQueuePanel
+                  items={mergeQueue}
+                  hasMore={mergeQueueHasMore}
+                  status={mergeQueueStatus}
+                  error={mergeQueueError}
+                  stale={dataStale}
+                />
+              </div>
             </div>
             <div id="awf-failures" className="scroll-mt-4 2xl:col-span-2">
               <FailureAnalysisPanel

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -859,18 +859,26 @@ const searchParams = useSearchParams();
         label: "Capacity",
         value: capacity ?? dash,
         suffix: capacity != null ? "%" : undefined,
-        tone: capacity != null ? (capacity >= 90 ? "bad" : capacity >= 75 ? "warn" : "info") : undefined,
+        // Only flag pressure (warn/bad). Low/idle utilization stays neutral so a
+        // value below the warn threshold is not styled like an active signal.
+        tone: capacity != null ? (capacity >= 90 ? "bad" : capacity >= 75 ? "warn" : undefined) : undefined,
       },
     ];
   }, [resourceSaturation, workspaceSummary]);
 
-  // Stale dimming per concern: a panel is stale when the API health check fails
-  // OR that panel's own refresh kept the last snapshot after an error.
+  // Stale dimming per concern: a panel is stale only when it is actually showing
+  // a previously-loaded snapshot AND its data is no longer fresh (API health
+  // check failed, or that panel's own refresh errored). On first-load failures
+  // there is no cached snapshot, so the panel shows its loading/error state
+  // instead of a misleading "last snapshot" badge.
   const apiDown = apiState === "error";
-  const capacityStale = apiDown || resourceError != null || workspaceSummaryError != null;
-  const mergeStale = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
-  const failureStale = apiDown || failureSummaryStatus === "error";
-  const fleetStale = apiDown || resourceError != null || workspaceSummaryError != null;
+  const resourceErrored = apiDown || resourceError != null || workspaceSummaryError != null;
+  const mergeErrored = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
+  const failureErrored = apiDown || failureSummaryStatus === "error";
+  const capacityStale = resourceErrored && resourceSaturation != null;
+  const mergeStale = mergeErrored && mergeQueue.length > 0;
+  const failureStale = failureErrored && failureSummary != null;
+  const fleetStale = resourceErrored && (resourceSaturation != null || workspaceSummary != null);
 
   return (
     <main className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-[var(--background)] text-[var(--foreground)]">

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -963,6 +963,7 @@ const searchParams = useSearchParams();
                 saturation={resourceSaturation}
                 error={resourceError}
                 stale={capacityStale}
+                summaryStale={summaryStale}
                 workspaceSummary={workspaceSummary}
                 workspaceSummaryError={workspaceSummaryError}
               />

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -796,60 +796,82 @@ const searchParams = useSearchParams();
   );
 
   const fleetKpis = useMemo<FleetKpi[]>(() => {
-    const counts = resourceSaturation?.workspace_counts;
+    const counts = resourceSaturation?.workspace_counts ?? null;
     const capacity = resourceSaturation ? capacityUtilizationPct(resourceSaturation) : null;
-    const queued = resourceSaturation?.capacity_queue.queued_workspace_count ?? 0;
+    const queued = resourceSaturation?.capacity_queue.queued_workspace_count ?? null;
     const oldestWait = resourceSaturation?.capacity_queue.oldest_wait_seconds ?? null;
     // Windowed reliability counts (default 24h) — actionable, unlike the
-    // ever-growing cumulative failed total.
-    const windowHours = workspaceSummary?.since_hours ?? 24;
-    const windowHint = `last ${windowHours}h`;
+    // ever-growing cumulative failed total. Only meaningful once the summary
+    // has loaded, so the window hint is omitted while the value is unknown.
+    const windowHint = workspaceSummary ? `last ${workspaceSummary.since_hours}h` : undefined;
     const completed = workspaceSummary?.completed_count;
     const cancelled = workspaceSummary?.cancelled_count;
     const failed = workspaceSummary?.failed_count;
+    const dash = "—";
     return [
-      { id: "active", label: "Active", value: counts?.active_total ?? 0 },
-      { id: "running", label: "Running", value: counts?.running ?? 0, tone: "info" },
-      { id: "monitoring_pr", label: "Monitoring PR", value: counts?.monitoring_pr ?? 0, tone: "info" },
+      { id: "active", label: "Active", value: counts ? counts.active_total : dash },
+      {
+        id: "running",
+        label: "Running",
+        value: counts ? counts.running : dash,
+        tone: counts?.running ? "info" : undefined,
+      },
+      {
+        id: "monitoring_pr",
+        label: "Monitoring PR",
+        value: counts ? counts.monitoring_pr : dash,
+        tone: counts?.monitoring_pr ? "info" : undefined,
+      },
       {
         id: "queued",
         label: "Queued",
-        value: queued,
-        tone: queued > 0 ? "warn" : undefined,
-        hint: oldestWait != null ? `oldest ${compactDuration(oldestWait)}` : "awaiting capacity",
+        value: queued ?? dash,
+        tone: queued ? "warn" : undefined,
+        hint:
+          queued && queued > 0
+            ? oldestWait != null
+              ? `oldest ${compactDuration(oldestWait)}`
+              : "awaiting capacity"
+            : undefined,
       },
       {
         id: "completed",
         label: "Completed",
-        value: completed ?? "—",
-        tone: completed != null ? "good" : undefined,
-        hint: windowHint,
+        value: completed ?? dash,
+        tone: completed ? "good" : undefined,
+        hint: completed != null ? windowHint : undefined,
       },
       {
         id: "cancelled",
         label: "Cancelled",
-        value: cancelled ?? "—",
+        value: cancelled ?? dash,
         tone: cancelled ? "warn" : undefined,
-        hint: windowHint,
+        hint: cancelled != null ? windowHint : undefined,
       },
       {
         id: "failed",
         label: "Failed",
-        value: failed ?? "—",
+        value: failed ?? dash,
         tone: failed ? "bad" : undefined,
-        hint: windowHint,
+        hint: failed != null ? windowHint : undefined,
       },
       {
         id: "capacity",
         label: "Capacity",
-        value: capacity ?? "—",
+        value: capacity ?? dash,
         suffix: capacity != null ? "%" : undefined,
         tone: capacity != null ? (capacity >= 90 ? "bad" : capacity >= 75 ? "warn" : "info") : undefined,
       },
     ];
   }, [resourceSaturation, workspaceSummary]);
 
-  const dataStale = apiState === "error";
+  // Stale dimming per concern: a panel is stale when the API health check fails
+  // OR that panel's own refresh kept the last snapshot after an error.
+  const apiDown = apiState === "error";
+  const capacityStale = apiDown || resourceError != null || workspaceSummaryError != null;
+  const mergeStale = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
+  const failureStale = apiDown || failureSummaryStatus === "error";
+  const fleetStale = apiDown || resourceError != null || workspaceSummaryError != null;
 
   return (
     <main className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-[var(--background)] text-[var(--foreground)]">
@@ -871,13 +893,13 @@ const searchParams = useSearchParams();
         isPending={isPending}
       />
 
-      <FleetHealthStrip kpis={fleetKpis} />
+      <FleetHealthStrip kpis={fleetKpis} stale={fleetStale} />
       <SectionNav />
 
-      <div className="grid min-h-[calc(100vh-57px)] w-full max-w-full grid-cols-1 overflow-x-hidden border-t border-[var(--border)] xl:grid-cols-[440px_minmax(0,1fr)] 2xl:grid-cols-[500px_minmax(0,1fr)]">
+      <div className="grid min-h-[calc(100vh-137px)] w-full max-w-full grid-cols-1 overflow-x-hidden border-t border-[var(--border)] xl:grid-cols-[440px_minmax(0,1fr)] 2xl:grid-cols-[500px_minmax(0,1fr)]">
         <aside
           id="awf-workspaces"
-          className="min-w-0 border-b border-[var(--border)] bg-white xl:border-r xl:border-b-0"
+          className="min-w-0 scroll-mt-14 border-b border-[var(--border)] bg-white xl:border-r xl:border-b-0"
         >
           <WorkspaceFilters
             statusFilters={statusFilters}
@@ -919,11 +941,11 @@ const searchParams = useSearchParams();
         <section className="min-w-0">
           {error ? <ErrorBanner message={error} /> : null}
           <div className="grid min-w-0 gap-4 p-4 pb-0 2xl:grid-cols-[minmax(0,1fr)_minmax(460px,0.85fr)]">
-            <div id="awf-capacity" className="min-w-0 scroll-mt-4">
+            <div id="awf-capacity" className="min-w-0 scroll-mt-14">
               <ResourceCapacityPanel
                 saturation={resourceSaturation}
                 error={resourceError}
-                stale={dataStale}
+                stale={capacityStale}
                 workspaceSummary={workspaceSummary}
                 workspaceSummaryError={workspaceSummaryError}
               />
@@ -931,22 +953,23 @@ const searchParams = useSearchParams();
             {/* 2xl: the panel overlays the cell (absolute) so the long merge
                 list never drives the row height — Capacity sets the height and
                 the list scrolls to fill it. Below 2xl it is normal flow. */}
-            <div id="awf-merge-queue" className="min-w-0 scroll-mt-4 2xl:relative">
+            <div id="awf-merge-queue" className="min-w-0 scroll-mt-14 2xl:relative">
               <div className="2xl:absolute 2xl:inset-0">
                 <MergeQueuePanel
                   items={mergeQueue}
                   hasMore={mergeQueueHasMore}
                   status={mergeQueueStatus}
                   error={mergeQueueError}
-                  stale={dataStale}
+                  stale={mergeStale}
                 />
               </div>
             </div>
-            <div id="awf-failures" className="scroll-mt-4 2xl:col-span-2">
+            <div id="awf-failures" className="scroll-mt-14 2xl:col-span-2">
               <FailureAnalysisPanel
                 summary={failureSummary}
                 status={failureSummaryStatus}
                 error={failureSummaryError}
+                stale={failureStale}
               />
             </div>
           </div>

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -794,6 +794,13 @@ const searchParams = useSearchParams();
     [overview, taskDetailsWorkspaceId],
   );
 
+  // Per-source stale flags: saturation-backed KPIs and reliability-summary KPIs
+  // dim independently so a failure in one feed never fades fresh values from the
+  // other.
+  const apiDown = apiState === "error";
+  const saturationStale = (apiDown || resourceError != null) && resourceSaturation != null;
+  const summaryStale = (apiDown || workspaceSummaryError != null) && workspaceSummary != null;
+
   const fleetKpis = useMemo<FleetKpi[]>(() => {
     const counts = resourceSaturation?.workspace_counts ?? null;
     const capacity = resourceSaturation ? capacityUtilizationPct(resourceSaturation) : null;
@@ -808,18 +815,20 @@ const searchParams = useSearchParams();
     const failed = workspaceSummary?.failed_count;
     const dash = "—";
     return [
-      { id: "active", label: "Active", value: counts ? counts.active_total : dash },
+      { id: "active", label: "Active", value: counts ? counts.active_total : dash, stale: saturationStale },
       {
         id: "running",
         label: "Running",
         value: counts ? counts.running : dash,
         tone: counts?.running ? "info" : undefined,
+        stale: saturationStale,
       },
       {
         id: "monitoring_pr",
         label: "Monitoring PR",
         value: counts ? counts.monitoring_pr : dash,
         tone: counts?.monitoring_pr ? "info" : undefined,
+        stale: saturationStale,
       },
       {
         id: "queued",
@@ -832,6 +841,7 @@ const searchParams = useSearchParams();
               ? `oldest ${compactDuration(oldestWait)}`
               : "awaiting capacity"
             : undefined,
+        stale: saturationStale,
       },
       {
         id: "completed",
@@ -839,6 +849,7 @@ const searchParams = useSearchParams();
         value: completed ?? dash,
         tone: completed ? "good" : undefined,
         hint: completed != null ? windowHint : undefined,
+        stale: summaryStale,
       },
       {
         id: "cancelled",
@@ -846,6 +857,7 @@ const searchParams = useSearchParams();
         value: cancelled ?? dash,
         tone: cancelled ? "warn" : undefined,
         hint: cancelled != null ? windowHint : undefined,
+        stale: summaryStale,
       },
       {
         id: "failed",
@@ -853,6 +865,7 @@ const searchParams = useSearchParams();
         value: failed ?? dash,
         tone: failed ? "bad" : undefined,
         hint: failed != null ? windowHint : undefined,
+        stale: summaryStale,
       },
       {
         id: "capacity",
@@ -862,26 +875,20 @@ const searchParams = useSearchParams();
         // Only flag pressure (warn/bad). Low/idle utilization stays neutral so a
         // value below the warn threshold is not styled like an active signal.
         tone: capacity != null ? (capacity >= 90 ? "bad" : capacity >= 75 ? "warn" : undefined) : undefined,
+        stale: saturationStale,
       },
     ];
-  }, [resourceSaturation, workspaceSummary]);
+  }, [resourceSaturation, workspaceSummary, saturationStale, summaryStale]);
 
-  // Stale dimming per concern: a panel is stale only when it is actually showing
-  // a previously-loaded snapshot AND its data is no longer fresh (API health
-  // check failed, or that panel's own refresh errored). On first-load failures
+  // Panel-level stale dimming: a panel dims only when it is actually showing a
+  // previously-loaded snapshot AND its feed errored. On first-load failures
   // there is no cached snapshot, so the panel shows its loading/error state
   // instead of a misleading "last snapshot" badge.
-  const apiDown = apiState === "error";
-  // Saturation drives the capacity panel and most fleet KPIs. A reliability
-  // summary error is a separate, secondary source (surfaced via its own banner),
-  // so it must not dim saturation-backed data that is still fresh.
-  const resourceErrored = apiDown || resourceError != null;
   const mergeErrored = apiDown || mergeQueueError != null || mergeQueueStatus === "error";
   const failureErrored = apiDown || failureSummaryStatus === "error";
-  const capacityStale = resourceErrored && resourceSaturation != null;
+  const capacityStale = saturationStale;
   const mergeStale = mergeErrored && mergeQueue.length > 0;
   const failureStale = failureErrored && failureSummary != null;
-  const fleetStale = resourceErrored && resourceSaturation != null;
 
   return (
     <main className="min-h-screen w-full max-w-[100vw] overflow-x-hidden bg-[var(--background)] text-[var(--foreground)]">
@@ -903,7 +910,7 @@ const searchParams = useSearchParams();
         isPending={isPending}
       />
 
-      <FleetHealthStrip kpis={fleetKpis} stale={fleetStale} />
+      <FleetHealthStrip kpis={fleetKpis} />
       <SectionNav />
 
       <div className="grid min-h-[calc(100vh-137px)] w-full max-w-full grid-cols-1 overflow-x-hidden border-t border-[var(--border)] xl:grid-cols-[440px_minmax(0,1fr)] 2xl:grid-cols-[500px_minmax(0,1fr)]">

--- a/apps/console/components/workspace-inspector.tsx
+++ b/apps/console/components/workspace-inspector.tsx
@@ -35,18 +35,18 @@ export function WorkspaceInspector({
         />
       )}
       <div
-        className={`fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-slate-200 bg-slate-50 shadow-2xl transition-transform duration-300 xl:w-[calc(100vw-440px)] 2xl:w-[calc(100vw-500px)] ${
+        className={`fixed inset-y-0 right-0 z-50 flex w-full flex-col border-l border-line bg-surface-2 shadow-2xl transition-transform duration-300 xl:w-[calc(100vw-440px)] 2xl:w-[calc(100vw-500px)] ${
           isOpen ? "translate-x-0" : "translate-x-full"
         }`}
         inert={!isOpen ? true : undefined}
       >
-        <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-slate-200 bg-white px-5 sm:px-6">
-          <h2 className="min-w-0 truncate text-sm font-semibold text-slate-900">
+        <div className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-line bg-surface px-5 sm:px-6">
+          <h2 className="min-w-0 truncate text-sm font-semibold text-fg">
             {title || "Workspace Inspector"}
           </h2>
           <button
             onClick={onClose}
-            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-900"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-[var(--radius-control)] text-fg-muted hover:bg-surface-2 hover:text-fg"
             aria-label="Close inspector"
           >
             <X size={18} />

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -174,9 +174,9 @@ test("formatCostWithPricing suppresses stale-pricing suffix when source is ccusa
 });
 
 test("toneFillClass maps warning and bad pressure to distinct fills", () => {
-  assert.equal(toneFillClass("good"), "bg-emerald-500");
-  assert.equal(toneFillClass("warn"), "bg-amber-500");
-  assert.equal(toneFillClass("bad"), "bg-red-500");
+  assert.equal(toneFillClass("good"), "tone-fill-good");
+  assert.equal(toneFillClass("warn"), "tone-fill-warn");
+  assert.equal(toneFillClass("bad"), "tone-fill-bad");
 });
 
 test("renderLogEntries preserves message order inside chunks in asc mode", () => {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -244,6 +244,25 @@ test("capacityUtilizationPct counts a saturated provision lane", () => {
   assert.equal(capacityUtilizationPct(saturation), 100);
 });
 
+test("capacityUtilizationPct returns null when no limit is comparable", () => {
+  const saturation = saturationFixture({
+    allocated_capacity: {
+      steady_cpu: dim(0, 0),
+      peak_cpu: dim(0, null),
+      steady_memory_gb: dim(0, 0),
+      peak_memory_gb: dim(0, null),
+      disk_mb: dim(0, 0),
+      dind_slots: dim(0, 0),
+      pressure_reasons: [],
+    },
+    concurrency: {
+      provision: { limit: 0, in_use: 0, queued: 0, available: 0 },
+      execution: { limit: 0, in_use: 0, queued: 0, available: 0 },
+    },
+  });
+  assert.equal(capacityUtilizationPct(saturation), null);
+});
+
 test("capacityUtilizationPct honors a *_SATURATED pressure reason with no comparable limit", () => {
   const saturation = saturationFixture({
     allocated_capacity: {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  capacityUtilizationPct,
   fallbackLifecycleStages,
   fallbackLlmUsage,
   formatCostWithPricing,
@@ -10,6 +11,30 @@ import {
   renderLogEntries,
   toneFillClass,
 } from "./format.ts";
+
+function dim(reserved, limit) {
+  return { limit, reserved, available: null, available_after_next_default: null, reason_code: null };
+}
+
+function saturationFixture(overrides = {}) {
+  return {
+    allocated_capacity: {
+      steady_cpu: dim(0, 8),
+      peak_cpu: dim(0, 8),
+      steady_memory_gb: dim(0, 16),
+      peak_memory_gb: dim(0, 16),
+      disk_mb: dim(0, 10240),
+      dind_slots: dim(0, 2),
+      pressure_reasons: [],
+      ...(overrides.allocated_capacity ?? {}),
+    },
+    concurrency: {
+      provision: { limit: 2, in_use: 0, queued: 0, available: 2 },
+      execution: { limit: 2, in_use: 0, queued: 0, available: 2 },
+      ...(overrides.concurrency ?? {}),
+    },
+  };
+}
 
 test("fallbackLifecycleStages marks terminal successors skipped", () => {
   const stages = Object.fromEntries(
@@ -177,6 +202,61 @@ test("toneFillClass maps warning and bad pressure to distinct fills", () => {
   assert.equal(toneFillClass("good"), "tone-fill-good");
   assert.equal(toneFillClass("warn"), "tone-fill-warn");
   assert.equal(toneFillClass("bad"), "tone-fill-bad");
+});
+
+test("capacityUtilizationPct takes the worst CPU/memory dimension", () => {
+  const saturation = saturationFixture({
+    allocated_capacity: {
+      steady_cpu: dim(2, 8),
+      peak_cpu: dim(6, 8),
+      steady_memory_gb: dim(4, 16),
+      peak_memory_gb: dim(8, 16),
+      disk_mb: dim(0, 10240),
+      dind_slots: dim(0, 2),
+      pressure_reasons: [],
+    },
+  });
+  assert.equal(capacityUtilizationPct(saturation), 75);
+});
+
+test("capacityUtilizationPct flags a saturated DinD-slot constraint while CPU/memory are idle", () => {
+  const saturation = saturationFixture({
+    allocated_capacity: {
+      steady_cpu: dim(0, 8),
+      peak_cpu: dim(0, 8),
+      steady_memory_gb: dim(0, 16),
+      peak_memory_gb: dim(0, 16),
+      disk_mb: dim(0, 10240),
+      dind_slots: dim(2, 2),
+      pressure_reasons: [],
+    },
+  });
+  assert.equal(capacityUtilizationPct(saturation), 100);
+});
+
+test("capacityUtilizationPct counts a saturated provision lane", () => {
+  const saturation = saturationFixture({
+    concurrency: {
+      provision: { limit: 2, in_use: 2, queued: 1, available: 0 },
+      execution: { limit: 2, in_use: 0, queued: 0, available: 2 },
+    },
+  });
+  assert.equal(capacityUtilizationPct(saturation), 100);
+});
+
+test("capacityUtilizationPct honors a *_SATURATED pressure reason with no comparable limit", () => {
+  const saturation = saturationFixture({
+    allocated_capacity: {
+      steady_cpu: dim(0, 8),
+      peak_cpu: dim(0, 8),
+      steady_memory_gb: dim(0, 16),
+      peak_memory_gb: dim(0, 16),
+      disk_mb: dim(0, 0),
+      dind_slots: dim(0, 0),
+      pressure_reasons: ["DIND_CAPACITY_SATURATED"],
+    },
+  });
+  assert.equal(capacityUtilizationPct(saturation), 100);
 });
 
 test("renderLogEntries preserves message order inside chunks in asc mode", () => {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -271,6 +271,13 @@ test("capacityUtilizationPct treats blocked disk/admission as exhausted", () => 
   assert.equal(capacityUtilizationPct(saturationFixture({ admission: { ok: false } })), 100);
 });
 
+test("capacityUtilizationPct reflects admission saturated as at-least-warn", () => {
+  assert.equal(
+    capacityUtilizationPct(saturationFixture({ admission: { ok: true, status: "saturated" } })),
+    75,
+  );
+});
+
 test("capacityUtilizationPct returns null when no limit is comparable", () => {
   const saturation = saturationFixture({
     allocated_capacity: {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -28,11 +28,17 @@ function saturationFixture(overrides = {}) {
       pressure_reasons: [],
       ...(overrides.allocated_capacity ?? {}),
     },
+    capacity: {
+      pressure_reasons: [],
+      ...(overrides.capacity ?? {}),
+    },
     concurrency: {
       provision: { limit: 2, in_use: 0, queued: 0, available: 2 },
       execution: { limit: 2, in_use: 0, queued: 0, available: 2 },
       ...(overrides.concurrency ?? {}),
     },
+    disk: { ok: true, ...(overrides.disk ?? {}) },
+    admission: { ok: true, ...(overrides.admission ?? {}) },
   };
 }
 
@@ -242,6 +248,27 @@ test("capacityUtilizationPct counts a saturated provision lane", () => {
     },
   });
   assert.equal(capacityUtilizationPct(saturation), 100);
+});
+
+test("capacityUtilizationPct falls back to capacity.pressure_reasons when allocated is empty", () => {
+  const saturation = saturationFixture({
+    allocated_capacity: {
+      steady_cpu: dim(1, 8),
+      peak_cpu: dim(1, 8),
+      steady_memory_gb: dim(0, 16),
+      peak_memory_gb: dim(0, 16),
+      disk_mb: dim(0, 10240),
+      dind_slots: dim(0, 2),
+      pressure_reasons: [],
+    },
+    capacity: { pressure_reasons: ["DIND_CAPACITY_SATURATED"] },
+  });
+  assert.equal(capacityUtilizationPct(saturation), 100);
+});
+
+test("capacityUtilizationPct treats blocked disk/admission as exhausted", () => {
+  assert.equal(capacityUtilizationPct(saturationFixture({ disk: { ok: false } })), 100);
+  assert.equal(capacityUtilizationPct(saturationFixture({ admission: { ok: false } })), 100);
 });
 
 test("capacityUtilizationPct returns null when no limit is comparable", () => {

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -254,7 +254,20 @@ export function capacityUtilizationPct(saturation: ResourceSaturationSummary): n
       pct = Math.max(pct, (lane.in_use / lane.limit) * 100);
     }
   }
-  if (allocated.pressure_reasons?.some((reason) => reason.endsWith("_SATURATED"))) {
+  // Mirror the capacity panel: fall back to capacity.pressure_reasons when the
+  // allocated list is empty.
+  const pressureReasons =
+    allocated.pressure_reasons && allocated.pressure_reasons.length > 0
+      ? allocated.pressure_reasons
+      : (saturation.capacity?.pressure_reasons ?? []);
+  if (pressureReasons.some((reason) => reason.endsWith("_SATURATED"))) {
+    known = true;
+    pct = Math.max(pct, 100);
+  }
+  // The scheduler is actively refusing new work (disk threshold breached or
+  // admission blocked, e.g. INSUFFICIENT_DISK) → capacity is effectively
+  // exhausted regardless of how much workspace disk is reserved.
+  if (saturation.disk?.ok === false || saturation.admission?.ok === false) {
     known = true;
     pct = Math.max(pct, 100);
   }

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -427,18 +427,3 @@ export function statusGlyph(status: string): string {
       return "•";
   }
 }
-
-export function toneGlyph(tone: StatusTone): string {
-  switch (tone) {
-    case "good":
-      return "✓";
-    case "warn":
-      return "⚠";
-    case "bad":
-      return "✕";
-    case "info":
-      return "●";
-    default:
-      return "•";
-  }
-}

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -228,9 +228,11 @@ export function compactDuration(seconds: number | null | undefined): string {
 // (provision, execution), clamped to 0-100. Any dimension flagged saturated via
 // a *_SATURATED pressure reason counts as fully utilized, so the strip cannot
 // read healthy while a hard constraint the capacity panel already shows as
-// saturated has no headroom left.
-export function capacityUtilizationPct(saturation: ResourceSaturationSummary): number {
+// saturated has no headroom left. Returns null when no limit is comparable, so
+// the headline can show "unknown" rather than a misleading 0%.
+export function capacityUtilizationPct(saturation: ResourceSaturationSummary): number | null {
   let pct = 0;
+  let known = false;
   const allocated = saturation.allocated_capacity;
   const dimensions = [
     allocated.steady_cpu,
@@ -242,16 +244,22 @@ export function capacityUtilizationPct(saturation: ResourceSaturationSummary): n
   ];
   for (const dimension of dimensions) {
     if (dimension && dimension.limit && dimension.limit > 0) {
+      known = true;
       pct = Math.max(pct, (dimension.reserved / dimension.limit) * 100);
     }
   }
   for (const lane of [saturation.concurrency.provision, saturation.concurrency.execution]) {
     if (lane && lane.limit > 0) {
+      known = true;
       pct = Math.max(pct, (lane.in_use / lane.limit) * 100);
     }
   }
   if (allocated.pressure_reasons?.some((reason) => reason.endsWith("_SATURATED"))) {
+    known = true;
     pct = Math.max(pct, 100);
+  }
+  if (!known) {
+    return null;
   }
   return Math.min(100, Math.max(0, Math.round(pct)));
 }

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -1,6 +1,7 @@
 import type {
   LlmUsageSummary,
   PricingMetadata,
+  ResourceSaturationSummary,
   WorkspaceLifecycleStage,
   WorkspaceStatus,
 } from "@/lib/types";
@@ -220,6 +221,39 @@ export function compactDuration(seconds: number | null | undefined): string {
     return `${minutes}m ${remainingSeconds}s`;
   }
   return `${remainingSeconds}s`;
+}
+
+// Single fleet-capacity headline: the worst utilization across every allocated
+// capacity dimension (CPU, memory, disk, DinD slots) and both concurrency lanes
+// (provision, execution), clamped to 0-100. Any dimension flagged saturated via
+// a *_SATURATED pressure reason counts as fully utilized, so the strip cannot
+// read healthy while a hard constraint the capacity panel already shows as
+// saturated has no headroom left.
+export function capacityUtilizationPct(saturation: ResourceSaturationSummary): number {
+  let pct = 0;
+  const allocated = saturation.allocated_capacity;
+  const dimensions = [
+    allocated.steady_cpu,
+    allocated.peak_cpu,
+    allocated.steady_memory_gb,
+    allocated.peak_memory_gb,
+    allocated.disk_mb,
+    allocated.dind_slots,
+  ];
+  for (const dimension of dimensions) {
+    if (dimension && dimension.limit && dimension.limit > 0) {
+      pct = Math.max(pct, (dimension.reserved / dimension.limit) * 100);
+    }
+  }
+  for (const lane of [saturation.concurrency.provision, saturation.concurrency.execution]) {
+    if (lane && lane.limit > 0) {
+      pct = Math.max(pct, (lane.in_use / lane.limit) * 100);
+    }
+  }
+  if (allocated.pressure_reasons?.some((reason) => reason.endsWith("_SATURATED"))) {
+    pct = Math.max(pct, 100);
+  }
+  return Math.min(100, Math.max(0, Math.round(pct)));
 }
 
 export function bytes(value: number): string {

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -271,6 +271,13 @@ export function capacityUtilizationPct(saturation: ResourceSaturationSummary): n
     known = true;
     pct = Math.max(pct, 100);
   }
+  // Admission flagged saturated (not yet blocking) is a warning the capacity
+  // panel already surfaces; reflect it as at-least-warn pressure (>=75%) so the
+  // headline can't read healthy while admission is visibly saturated.
+  if (saturation.admission?.status === "saturated") {
+    known = true;
+    pct = Math.max(pct, 75);
+  }
   if (!known) {
     return null;
   }

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -306,7 +306,9 @@ function formatLogStamp(value: string): string {
   }).format(date);
 }
 
-export function statusTone(status: string): "neutral" | "info" | "good" | "warn" | "bad" {
+export type StatusTone = "neutral" | "info" | "good" | "warn" | "bad";
+
+export function statusTone(status: string): StatusTone {
   if (status === "completed" || status === "succeeded" || status === "healthy") {
     return "good";
   }
@@ -324,32 +326,64 @@ export function statusTone(status: string): "neutral" | "info" | "good" | "warn"
   return "neutral";
 }
 
-export function toneClass(tone: ReturnType<typeof statusTone>): string {
-  switch (tone) {
-    case "good":
-      return "border-emerald-200 bg-emerald-50 text-emerald-800";
-    case "warn":
-      return "border-amber-200 bg-amber-50 text-amber-800";
-    case "bad":
-      return "border-red-200 bg-red-50 text-red-800";
-    case "info":
-      return "border-blue-200 bg-blue-50 text-blue-800";
+// Status colors are explicit CSS classes (see globals.css `.tone-*`), not
+// Tailwind utilities — Tailwind does not reliably scan class names composed in
+// this file, so utility strings here would silently fail to generate.
+export function toneClass(tone: StatusTone): string {
+  return `tone-${tone}`;
+}
+
+export function toneFillClass(tone: StatusTone): string {
+  return `tone-fill-${tone}`;
+}
+
+export function toneTextClass(tone: StatusTone): string {
+  return `tone-text-${tone}`;
+}
+
+// Glyph paired with every status badge/dot so state is never conveyed by color
+// alone (ISA-101 / WCAG). Shape + label + color together.
+export function statusGlyph(status: string): string {
+  switch (status) {
+    case "completed":
+    case "succeeded":
+    case "healthy":
+      return "✓";
+    case "failed":
+    case "error":
+    case "dead":
+    case "destroyed":
+      return "✕";
+    case "cancelled":
+      return "⊘";
+    case "destroying":
+      return "◌";
+    case "monitoring_pr":
+      return "◆";
+    case "running":
+    case "validating":
+    case "pushing":
+      return "●";
+    case "requested":
+    case "provisioning":
+    case "ready":
+      return "◷";
     default:
-      return "border-slate-200 bg-slate-50 text-slate-700";
+      return "•";
   }
 }
 
-export function toneFillClass(tone: ReturnType<typeof statusTone>): string {
+export function toneGlyph(tone: StatusTone): string {
   switch (tone) {
     case "good":
-      return "bg-emerald-500";
+      return "✓";
     case "warn":
-      return "bg-amber-500";
+      return "⚠";
     case "bad":
-      return "bg-red-500";
+      return "✕";
     case "info":
-      return "bg-blue-500";
+      return "●";
     default:
-      return "bg-slate-400";
+      return "•";
   }
 }

--- a/apps/console/next.config.ts
+++ b/apps/console/next.config.ts
@@ -3,9 +3,11 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = dirname(fileURLToPath(import.meta.url));
-const allowedDevOrigins = parseAllowedDevOrigins(
-  process.env.AWF_CONSOLE_ALLOWED_DEV_ORIGINS,
-);
+const defaultAllowedDevOrigins = ["127.0.0.1", "localhost"];
+const allowedDevOrigins = uniqueAllowedDevOrigins([
+  ...defaultAllowedDevOrigins,
+  ...parseAllowedDevOrigins(process.env.AWF_CONSOLE_ALLOWED_DEV_ORIGINS),
+]);
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
@@ -22,4 +24,8 @@ function parseAllowedDevOrigins(value: string | undefined): string[] {
     .split(",")
     .map((origin) => origin.trim())
     .filter(Boolean);
+}
+
+function uniqueAllowedDevOrigins(origins: string[]): string[] {
+  return Array.from(new Set(origins));
 }

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -7,7 +7,10 @@
     "": {
       "name": "@awf/console",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
+        "@fontsource/ibm-plex-mono": "^5.2.7",
+        "@fontsource/ibm-plex-sans": "^5.2.8",
         "@tailwindcss/postcss": "^4.2.4",
         "lucide-react": "^1.11.0",
         "next": "^16.2.4",
@@ -527,6 +530,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-mono": {
+      "version": "5.2.7",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-mono/-/ibm-plex-mono-5.2.7.tgz",
+      "integrity": "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/ibm-plex-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/ibm-plex-sans/-/ibm-plex-sans-5.2.8.tgz",
+      "integrity": "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {
@@ -3720,7 +3741,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -13,6 +13,8 @@
     "typecheck": "next typegen && tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/ibm-plex-sans": "^5.2.8",
     "@tailwindcss/postcss": "^4.2.4",
     "lucide-react": "^1.11.0",
     "next": "^16.2.4",
@@ -21,8 +23,8 @@
     "ws": "^8.20.0"
   },
   "devDependencies": {
-    "@types/node": "^25.6.0",
     "@playwright/test": "^1.56.1",
+    "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/ws": "^8.18.1",

--- a/apps/console/tests/theme-accessibility.spec.ts
+++ b/apps/console/tests/theme-accessibility.spec.ts
@@ -145,6 +145,16 @@ test("mobile theme screenshots cover dashboard, workspace, and logs views", asyn
   await page.screenshot({ path: testInfo.outputPath("mobile-logs.png"), fullPage: true });
 });
 
+test("fleet health strip surfaces the status-layer KPIs", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const fleet = page.locator('[aria-label="Fleet health"]');
+  await expect(fleet).toBeVisible();
+  await expect(fleet.getByText("Monitoring PR")).toBeVisible();
+  await expect(fleet.getByText("Capacity", { exact: true })).toBeVisible();
+});
+
 async function seedDarkAccessiblePreferences(page: Page) {
   await page.addInitScript(() => {
     window.localStorage.setItem(


### PR DESCRIPTION
## Summary

Reframes the AWF operator console (`apps/console`) around a "serious control room" design system, grounded in 2026 monitoring best practice (Status → Diagnosis → Action) and ISA-101 high-performance HMI. Authored via a design consultation.

- **Typography:** load **IBM Plex Sans/Mono** via `next/font`. `Inter` was declared in CSS but never shipped (silent fallback to system-ui). `tabular-nums` enforced on metrics.
- **Color tokens:** semantic token system in `globals.css` — one source of truth for light / dark / high-contrast — replacing the hardcoded-hex `slate-*` dark override block. Vivid solid dark status tints.
- **Status semantics:** glyph + color + label (never color alone) via `statusGlyph`; blue `monitoring_pr` with a distinct `◆` glyph. Status tones are **explicit `.tone-*` CSS classes** because Tailwind v4 does not reliably scan class names composed in `lib/format.ts` (this was silently dropping most status colors).
- **Information architecture:** a fleet-health **KPI strip** (Active, Running, Monitoring PR, Queued, and 24h-windowed Completed / Cancelled / Failed, plus Capacity); a **narrow-screen-only** sticky section-jump nav; stale-data dimming wired to API state.
- **Docs:** new `apps/console/DESIGN.md` as the design source of truth + a pointer in `CLAUDE.md`.

Preserves existing behavior, accessibility (light/dark/high-contrast/large-font/reduced-motion), and DOM contracts.

## Test plan

- [x] `npm --prefix apps/console run typecheck`
- [x] `npm --prefix apps/console run lint`
- [x] `npm --prefix apps/console run build`
- [x] `npm --prefix apps/console run test:browser` (21/21; added a fleet-health KPI test, updated the inspector geometry assertion)
- [ ] Visual review in light / dark / high-contrast on a running console

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Console-only presentation and client-side KPI/stale logic; existing theme/accessibility modes preserved with added tests.
> 
> **Overview**
> Introduces a **control-room design system** for the AWF console: new `apps/console/DESIGN.md`, a pointer in `CLAUDE.md`, and a broad visual/IA refresh without changing backend contracts.
> 
> **Tokens & typography:** `globals.css` gains semantic theme variables (`canvas`, `surface`, `fg`, status roles) wired through Tailwind `@theme inline`, plus explicit `.tone-*` classes so runtime-composed status colors actually ship (Tailwind v4 was missing classes built in `lib/format.ts`). **IBM Plex** loads via `@fontsource` in `layout.tsx` (replacing undeclared Inter). Legacy `slate-*` utilities are bridged to tokens in dark/high-contrast modes.
> 
> **Status & metrics:** `statusGlyph` and glyph+label `Badge`s; `capacityUtilizationPct` drives a fleet **Capacity** KPI. **FleetHealthStrip** adds eight at-a-glance KPIs (active/running/PR/queue + 24h completed/cancelled/failed + capacity), with **per-feed stale** dimming (`data-awf-stale`, panel badges) keyed off each poll’s error while a cached snapshot is shown—not global `/health` alone.
> 
> **Layout:** Sticky **SectionNav** (narrow screens only) with section `id`s; merge queue uses flex/absolute layout on `2xl` so capacity sets row height. Capacity panel splits reliability vs saturation stale regions.
> 
> **Tests/chores:** Unit tests for `capacityUtilizationPct` and tone classes; Playwright fleet-health test; `next.config` default dev origins; ignore `design-preview.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 501e293259cae97cb2c63ca66ed64fa039c501f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fleet Health strip with KPI cards, inline “last snapshot” stale warnings, and a narrow-screen section nav for quick dashboard jumps.
  * Dashboard panels (capacity, merge queue, failures) now support a dimmed “stale” state and improved tone-driven visuals; KPI values and queue tiles use semantic tone styling.

* **Design & Typography**
  * New semantic color/token system with high-contrast mappings and compatibility utilities.
  * Self-hosted IBM Plex Sans/Mono and comprehensive design-system guidance added.

* **Tests**
  * End-to-end test verifying Fleet Health visibility.

* **Chores**
  * Local design-preview file ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->