### PR TITLE
fix(console): correct Docker runtime capacity-source label (not Docker Desktop)

### DIFF
--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -315,14 +315,14 @@ function localCapacityLimitLabel(saturation: ResourceSaturationSummary): string 
 function localCapacityDetail(source: LocalCapacitySourceValue | null): string {
   switch (source) {
     case "docker":
-      return "Limits are the CPU/memory the Docker runtime reports via docker info: the VM allocation under Docker Desktop (host may be larger), or the host's own resources under a native Docker Engine";
+      return "Limits from docker info (native Docker Engine: host resources; Docker Desktop: VM allocation, host may be larger)";
     case "operator_config":
       return "Limits are the AWF_LOCAL_CAPACITY_* operator overrides used by the scheduler";
     case "mixed":
       return "Limits combine AWF_LOCAL_CAPACITY_* overrides with Docker runtime detection";
     case null:
     default:
-      return "Limits are the runtime capacity AWF reports for scheduling (the host's own resources under a native Docker Engine; the VM allocation under Docker Desktop)";
+      return "Limits from runtime capacity AWF detects (native Docker Engine: host resources; Docker Desktop: VM allocation)";
   }
 }
 

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -315,15 +315,15 @@ function localCapacityLimitLabel(saturation: ResourceSaturationSummary): string 
 function localCapacityDetail(source: LocalCapacitySourceValue | null): string {
   switch (source) {
     case "docker":
-      return "Limits are read from Docker Desktop via docker info, so host hardware may be larger";
+      return "Limits are the CPU/memory the Docker runtime reports via docker info: the VM allocation under Docker Desktop (host may be larger), or the host's own resources under a native Docker Engine";
     case "operator_config":
       return "Limits are the AWF_LOCAL_CAPACITY_* operator overrides used by the scheduler";
     case "mixed":
       return "Limits combine AWF_LOCAL_CAPACITY_* overrides with Docker runtime detection";
     case null:
-      return "Limits are the runtime capacity AWF reports for scheduling; host hardware may be larger";
+      return "Limits are the runtime capacity AWF reports for scheduling (the host's own resources under a native Docker Engine; the VM allocation under Docker Desktop)";
     default:
-      return "Limits are the runtime capacity AWF reports for scheduling; host hardware may be larger";
+      return "Limits are the runtime capacity AWF reports for scheduling (the host's own resources under a native Docker Engine; the VM allocation under Docker Desktop)";
   }
 }
 

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -321,7 +321,6 @@ function localCapacityDetail(source: LocalCapacitySourceValue | null): string {
     case "mixed":
       return "Limits combine AWF_LOCAL_CAPACITY_* overrides with Docker runtime detection";
     case null:
-      return "Limits are the runtime capacity AWF reports for scheduling (the host's own resources under a native Docker Engine; the VM allocation under Docker Desktop)";
     default:
       return "Limits are the runtime capacity AWF reports for scheduling (the host's own resources under a native Docker Engine; the VM allocation under Docker Desktop)";
   }


### PR DESCRIPTION
## What

The scheduler capacity panel's "Scheduler capacity source" detail hardcoded:

> Limits are read from **Docker Desktop** via docker info, so host hardware may be larger

for any docker-detected capacity source, and the `null`/`default` fallbacks asserted "host hardware may be larger" unconditionally.

## Why this is wrong

On a **native Docker Engine** (e.g. Linux), `docker info` reports the host's own CPU/memory via cgroups — it is **not** Docker Desktop, and there is no larger host hidden behind a VM. Verified on the box where this surfaced:

```
$ docker info --format '{{.OperatingSystem}} | {{.ServerVersion}}'
Ubuntu 24.04.4 LTS | 29.1.3        # native Docker Engine, context=default unix:///var/run/docker.sock
```

The reported `20 cores / 119.7 GiB` IS the host hardware. The "Docker Desktop" attribution and the "host hardware may be larger" caveat only apply to Docker Desktop's VM allocation (which can be smaller than the host).

The backend (`src/awf/service/local_capacity.py`) always emits `source="docker"` with no Docker-Desktop-vs-native distinction; the console (`console-dashboard-capacity.tsx`) then blindly mapped that to the Docker-Desktop copy.

## Change

Reword the `docker` / `null` / `default` capacity-source detail strings so they are accurate for **both** runtimes:
- Docker Desktop → VM allocation (host may be larger)
- native Docker Engine → the host's own resources

Console `typecheck` + `lint` pass. String-literal-only change, no type or logic change.

## Follow-up (not in this PR)

A proper enhancement would have the backend *detect* Docker Desktop (e.g. `OperatingSystem` containing "Docker Desktop" in the `docker info` payload) and surface a runtime flag so the console can pick the exact wording, rather than describing both possibilities. Left as a follow-up to keep this fix minimal.

Closes the "Scheduler capacity source mislabels native Docker Engine as Docker Desktop" report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy only in the console capacity panel; no API, scheduler, or capacity detection logic changes.
> 
> **Overview**
> The **Resource / Runtime Capacity** panel’s “Scheduler capacity source” helper text no longer treats every `docker` source as Docker Desktop or always claims host hardware may be larger.
> 
> For `source === "docker"`, the detail now explains limits come from `docker info`, distinguishing **native Docker Engine** (host resources) from **Docker Desktop** (VM allocation; host may be larger). The `null` and `default` branches use the same dual-runtime wording instead of implying a larger host in all cases.
> 
> Copy-only change in `localCapacityDetail` in `console-dashboard-capacity.tsx`; labels and scheduling logic are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cea1dce43f06d296e4aa646dcea50d6382dbc024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified capacity messaging in the console dashboard: user-facing descriptions now explicitly distinguish native Docker Engine host resources from Docker Desktop VM allocation and remove prior ambiguous scheduling wording, making capacity limits clearer and easier to interpret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->