### PR TITLE
fix(console): pack merge-queue rows at the top (no giant row gap)

### DIFF
--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -381,7 +381,7 @@ export function MergeQueuePanel({
               Showing first {items.length} merge candidates. More are queued.
             </div>
           ) : null}
-          <div className="grid max-h-[460px] min-h-0 gap-2 overflow-auto pr-1 2xl:max-h-none 2xl:flex-1">
+          <div className="grid max-h-[460px] min-h-0 content-start gap-2 overflow-auto pr-1 2xl:max-h-none 2xl:flex-1">
             {items.map((item, index) => {
               const rowKey = item.candidate_id ?? item.workspace_id;
               const expanded = expandedRows.has(rowKey);


### PR DESCRIPTION
## Summary

The Merge Queue list spread its rows with a large vertical gap when only a few candidates were queued.

At the `2xl` breakpoint the list uses `flex-1` to fill the panel height (so it matches the Resource/Runtime Capacity column and scrolls internally). As a CSS grid, when it's taller than its content it distributed the extra vertical space between the rows. Adding `content-start` (align-content: start) packs the rows at the top with the normal `gap-2`, leaving the empty space at the bottom — and it still scrolls when the list overflows.

Verified at 1680px: list fills 600px, `align-content: flex-start`, gap between consecutive rows is 8px (the intended `gap-2`).

## Test plan

- [x] `npm --prefix apps/console run build`
- [x] `npm --prefix apps/console run test:browser` (21/21)
- [ ] Visual check: Merge Queue with 1–2 candidates on a wide screen — rows packed at top, no giant gap

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class on the merge queue list layout with no logic or data changes.
> 
> **Overview**
> On wide (`2xl`) layouts the Merge Queue candidate list grows with `flex-1` to match the adjacent capacity panel. **Adds `content-start`** on that grid so extra vertical space sits below the rows instead of stretching gaps between candidates when only a few items are queued; normal `gap-2` spacing and overflow scrolling are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f600b1f8f498bd216257a98faa6a7cd297acd62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the vertical alignment of merge candidate list content in the console dashboard for improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->