### PR TITLE
fix(security): redact companion_* fields in mount-metadata event (#304 follow-up)

### DIFF
--- a/src/awf/node/provisioner_helpers.py
+++ b/src/awf/node/provisioner_helpers.py
@@ -58,7 +58,13 @@ def _stack_secret_lease_mount_metadata(
         "companion_omitted_optional_env_secrets",
     ):
         if key in plan_metadata:
-            metadata[key] = plan_metadata[key]
+            value = plan_metadata[key]
+            # ``companion_*`` fields carry the same secret metadata that the
+            # dedicated companion-secret event redacts (see
+            # ``_stack_companion_env_secret_event_payload`` below); redact them
+            # here too so this broader mount-metadata event never logs them
+            # unredacted. Non-companion fields are counts/provider/target names.
+            metadata[key] = redact_audit_value(value) if key.startswith("companion_") else value
     return metadata
 
 

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_part_001.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_part_001.py
@@ -1018,6 +1018,59 @@ class TestSuccess:
             assert raw_secret not in json.dumps(event.payload, default=str)
 
     @pytest.mark.unit
+    def test_mount_metadata_event_redacts_companion_secret_fields(self) -> None:
+        """The mount-metadata event redacts ``companion_*`` fields like the companion event.
+
+        Regression: ``_stack_secret_lease_mount_metadata`` copied ``companion_*``
+        secret metadata verbatim while ``_stack_companion_env_secret_event_payload``
+        redacted the same keys, so a sensitive value leaking into a ``companion_*``
+        field would be exposed only in the broader mount-metadata event.
+        """
+        from awf.common.audit import REDACTION_MARKER
+        from awf.node.provisioner_helpers import (
+            _stack_companion_env_secret_event_payload,
+            _stack_secret_lease_mount_metadata,
+        )
+
+        raw_token = "ghp_do_not_log_this"
+        plan = {
+            "schema": "secret_lease_mount_metadata.v1",
+            "mount_plan": "profile_declared_secret_leases",
+            "env_count": 1,
+            "providers": ["env"],
+            "targets": ["GH_TOKEN"],
+            "companion_env_secret_count": 1,
+            "companion_env_secrets": [
+                {"companion": "reviewer", "target": "GH_TOKEN", "token": raw_token},
+            ],
+        }
+        stack_paths = ComposeProjectPaths(
+            project_dir=Path("/tmp/awf-compose/ws_redact"),
+            compose_file=Path("/tmp/awf-compose/ws_redact/compose.yml"),
+            secret_lease_mount_metadata=plan,
+        )
+
+        mount_md = _stack_secret_lease_mount_metadata(
+            workspace_id="ws_redact", stack_paths=stack_paths
+        )
+
+        # The sensitive companion_* field is redacted; the raw token never appears.
+        assert mount_md["companion_env_secrets"] == [
+            {"companion": "reviewer", "target": "GH_TOKEN", "token": REDACTION_MARKER}
+        ]
+        assert raw_token not in json.dumps(mount_md, default=str)
+        # Redaction is identical to the dedicated companion-secret event.
+        companion_event = _stack_companion_env_secret_event_payload(
+            workspace_id="ws_redact", stack_paths=stack_paths
+        )
+        assert companion_event is not None
+        assert mount_md["companion_env_secrets"] == companion_event["companion_env_secrets"]
+        # Non-companion fields stay verbatim (the else branch of the redaction guard).
+        assert mount_md["providers"] == ["env"]
+        assert mount_md["targets"] == ["GH_TOKEN"]
+        assert mount_md["env_count"] == 1
+
+    @pytest.mark.unit
     async def test_uses_persisted_resolved_profile_without_rewriting_it(
         self,
         session_factory: async_sessionmaker[AsyncSession],


### PR DESCRIPTION
Follow-up to #328/#304 addressing a CodeRabbit review finding (https://github.com/dimileeh/aira-agent-workspace-fabric/pull/328#discussion_r3344015028).

`_stack_secret_lease_mount_metadata` copied `companion_*` secret metadata verbatim into the mount-metadata event, while the sibling `_stack_companion_env_secret_event_payload` already redacts those same keys. So a sensitive value leaking into a `companion_*` field would be exposed only in the broader mount-metadata event.

This redacts `companion_*` fields there too (via `redact_audit_value`), making both paths consistent with AWF's redaction-mandatory rule. Defense-in-depth (companion fields are metadata-only today, no active leak). Includes a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow audit-log redaction fix with a regression test; no auth or runtime behavior changes beyond safer event payloads.
> 
> **Overview**
> **Secret-lease mount-metadata** events now run **`companion_*`** fields through **`redact_audit_value`**, matching the dedicated companion-env-secret event path so sensitive values cannot appear only in the broader mount-metadata payload.
> 
> Non-**`companion_*`** keys (counts, providers, targets) are unchanged. A unit test asserts redaction parity with **`_stack_companion_env_secret_event_payload`** and that non-companion fields stay verbatim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14bd1e699a544c4a3d560f27a49567fd43e7f064. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incomplete redaction of sensitive values in companion-related configuration fields within secret lease mount metadata to ensure credentials are properly masked in audit logs.

* **Tests**
  * Added regression test to verify companion secret fields are properly redacted and raw credentials never appear in JSON-rendered audit output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->