### PR TITLE
feat(prompts): agents reason about comments, fix coverage right, stay scoped (#304 follow-up)

### DIFF
--- a/plans/AGENT_PROMPT_REASONING_PLAN.md
+++ b/plans/AGENT_PROMPT_REASONING_PLAN.md
@@ -142,6 +142,28 @@ Sequential — two files but one logical change; trivial. No worktree split need
   - Files: `tests/unit/runtime/test_monitor_prompts.py`, `tests/unit/adapters/test_adapters.py`
   - Verify: full clean-env coverage run stays ≥99%
 
+## Follow-up #4 — coverage-as-you-go discipline (added on PR #360 by request)
+
+Every coverage/TDD mention in the prompts was **reactive** (only when CI is already
+red). Two additions make it **proactive**, while preserving the rule that agents must
+not run the full coverage gate locally:
+
+- **`_AWF_PROMPT_PREAMBLE` rule #7 (`adapters/base.py`)** — cover each behavior you add
+  or change with focused tests (test-first when practical) so total coverage does not
+  drop; reason about which new lines/branches need a test; *but* for genuinely
+  non-behavioral / unreachable / type-only code (e.g. a Protocol stub), add a justified
+  coverage exclusion instead of a hollow test. A line-executing test that asserts
+  nothing is coverage-theater and is rejected.
+- **`_COVERAGE_FAILURE_GUIDANCE` (`monitor_prompts.py`)** — paired the "never `# pragma:
+  no cover` on a live, reachable path" rule with its complement: "when the uncovered
+  code is genuinely non-behavioral/unreachable/type-only, a justified exclusion is the
+  right fix rather than a hollow test." Resolves the exact tension that surfaced in #358.
+
+- [ ] **T5 (P1, human: ~25min / CC: ~3min)** — adapters + runtime — proactive TDD+coverage rule and exclusion-over-theater nuance
+  - Surfaced by: user follow-up — TDD must combine with coverage-thinking; prefer exclusions over pointless tests
+  - Files: `src/awf/adapters/base.py`, `src/awf/runtime/monitor_prompts.py`, both test files
+  - Verify: `pytest tests/unit/runtime/test_monitor_prompts.py tests/unit/adapters/test_adapters.py -q`
+
 ## GSTACK REVIEW REPORT
 
 | Review | Trigger | Why | Runs | Status | Findings |

--- a/plans/AGENT_PROMPT_REASONING_PLAN.md
+++ b/plans/AGENT_PROMPT_REASONING_PLAN.md
@@ -1,0 +1,157 @@
+# Agent prompt reasoning upgrades — PLAN
+
+**Topic:** Teach AWF's coding agents to (1) reason deliberately about each review
+comment, (2) fix CI/coverage failures the disciplined way, and (3) stop exploding
+PRs with unrelated changes. Distilled from the hands-on landing of PR #328 (#304).
+
+**Scope:** 2 source files + 2 test files. No new classes/abstractions. Reuses the
+existing shared-constant prompt pattern (`_SAFETY_POLICY`, `_protected_file_policy`).
+
+---
+
+## Problem
+
+When AWF dispatches a coding agent to address review comments or fix CI, the prompts
+in `runtime/monitor_prompts.py` already emit a 4-way verdict vocabulary
+(FIXED / FALSE POSITIVE / NEEDS_HUMAN / DEFER) and a safety policy — but they give no
+**reasoning framework** for *how* to choose, no **coverage-specific** discipline, and
+**no scope guardrail**. PR #328 is the cautionary tale: the agent, while chasing the
+99% coverage gate, refactored `base.py → _scheduler.py` and ballooned the PR to ~15.7k
+insertions / 114 files / 297 commits. The deliverable (host-port detection, +383 lines)
+was buried in churn.
+
+## What already exists (reused, not rebuilt)
+
+| Sub-problem | Existing code | Gap this plan closes |
+|---|---|---|
+| #1 per-comment reasoning | `address_thread_prompt`, `address_review_comment_prompt` already emit the FIXED/FALSE POSITIVE/NEEDS_HUMAN/DEFER tree + `_SAFETY_POLICY` | No *how-to-decide* framework (verify-against-code-first; evidence for FP; don't reflexively comply/dismiss) |
+| #2 CI/coverage reasoning | `fix_ci_prompt` says "treat every failure as a real bug, don't weaken the check, focused repro first"; preamble forbids broad local coverage runs | No coverage-specific reasoning (gap vs flaky vs env; behavior tests; anti-theater; exact gate) |
+| #3 scope discipline | `quality_gates._build_post_agent_precommit_repair_prompt` ("fix only the hook failures, then stop; don't touch unrelated files"); `remote_prompt_ops` ("smallest corrective edit") | The **preamble / initial build prompt** and the **fix_ci / comment prompts** carry no scope rule — exactly where #328 exploded |
+
+## Locked decisions (from /plan-eng-review)
+
+- **D1 — Scope-discipline home: the cross-cutting preamble.** Add it as rule #6 in
+  `_AWF_PROMPT_PREAMBLE` (`adapters/base.py`), which is prepended to *every* agent run
+  (initial build, every fix-cycle iteration, monitor). One DRY home covers the full
+  #328 failure surface. The #2 coverage block phrases its own "add tests, don't refactor
+  unrelated code" nuance at the fix site, so there's no literal duplication.
+- **D2 — Concise shared blocks** (style of `_SAFETY_POLICY`), not verbose step-by-step
+  frameworks — respects the module's deliberate "terse / finite CLI context" constraint.
+
+## Changes
+
+### 1. `src/awf/adapters/base.py` — `_AWF_PROMPT_PREAMBLE` gains rule #6
+
+```
+6. **Keep changes minimal and scoped.** Fix only what THIS task asks.
+   Do not refactor, rename, or restructure unrelated code, split files,
+   or introduce new abstractions unless the fix strictly requires it. A
+   reviewer should see a small, obviously-correct diff; sprawling diffs
+   get rejected and waste the run.
+```
+
+### 2. `src/awf/runtime/monitor_prompts.py` — new shared `_COMMENT_VERDICT_GUIDANCE`
+
+Reused by both `address_thread_prompt` and `address_review_comment_prompt`, inserted
+right before each existing numbered decision list:
+
+```
+How to decide (deliberate, do not act reflexively):
+  - Verify the claim against the actual code first: locate the exact
+    line(s) the reviewer points at and read the surrounding code. The
+    feedback is only a false positive if you can point to code that
+    already refutes it.
+  - Weigh whether it is a real defect or reviewer breadth-conservatism.
+    Do not change code to satisfy a wrong review, and do not dismiss
+    valid feedback to avoid work.
+  - Pick the verdict that fits: FIXED for a genuine correctness/security/
+    logic bug or a clearly correct improvement; FALSE POSITIVE only with
+    concrete evidence; DEFER for valid but out-of-scope follow-ups;
+    NEEDS_HUMAN for a design/taste/protected-file call you cannot make.
+  - Keep any fix minimal: change only what THIS comment requires; do not
+    refactor unrelated code or expand the PR.
+```
+
+### 3. `src/awf/runtime/monitor_prompts.py` — coverage block in `fix_ci_prompt`
+
+Inserted after the existing "Run focused repro commands first…" guidance:
+
+```
+If a coverage gate is failing, diagnose the root cause before writing
+anything: distinguish a genuine uncovered branch from a flaky/non-
+deterministic test or an environment-specific failure that passes in CI.
+Read the missing-lines report; do not guess. Close real gaps with tests
+that assert BEHAVIOR (inputs -> outputs/effects) — never coverage-theater
+(tests that only execute lines to move the number), never weakened
+assertions, and never `# pragma: no cover` on a live, reachable path. The
+gate is an exact threshold, so a near-miss still fails; prefer one
+meaningful test over many shallow ones.
+```
+
+### 4. Tests (additive — no existing assertion breaks; 192 are substring `in`)
+
+- `tests/unit/runtime/test_monitor_prompts.py`:
+  - `_COMMENT_VERDICT_GUIDANCE` phrases present in **both** comment prompts
+    ("Verify the claim against the actual code", "breadth-conservatism",
+    "do not refactor unrelated code").
+  - Coverage block present in `fix_ci_prompt` ("coverage-theater", "assert BEHAVIOR",
+    "pragma: no cover", "exact threshold").
+- `tests/unit/adapters/test_adapters.py`:
+  - `_AWF_PROMPT_PREAMBLE` contains rule #6 ("Keep changes minimal and scoped",
+    "refactor … unrelated").
+
+## NOT in scope
+
+- **Machine-enforced scope guard** (AWF rejecting diffs over N files / blocking
+  unrelated-file edits) — a policy/enforcement feature, separate from prompt guidance.
+  Defer; revisit if prompt guidance alone proves insufficient.
+- **Changing the verdict vocabulary** or adding new AWF-VERDICT codes — the existing
+  four are sufficient; only the *reasoning* around them changes.
+- **`operator_hint_prompt` / `sync_base_conflict_prompt`** reasoning — not about
+  comments or CI; the new preamble rule #6 already covers their scope discipline.
+- **`quality_gates` precommit-repair prompt** — already disciplined; left as-is (it is
+  the pattern we are matching).
+
+## Failure modes
+
+Pure string builders — no runtime/IO failure path. The only realistic failure is
+**guidance drifting from reality** (e.g. the "gate is exact" claim). It is true today
+(exact-99% boundary, per the `coverage-gate-boundary` learning). Tests assert the text
+is present; correctness of the *claims* is a doc-review concern, not a silent runtime bug.
+
+## Parallelization
+
+Sequential — two files but one logical change; trivial. No worktree split needed.
+
+## Implementation Tasks
+
+- [ ] **T1 (P1, human: ~20min / CC: ~3min)** — adapters — add scope-discipline rule #6 to `_AWF_PROMPT_PREAMBLE`
+  - Surfaced by: Architecture (D1) — PR #328 exploded in build + fix cycle
+  - Files: `src/awf/adapters/base.py`
+  - Verify: `pytest tests/unit/adapters/test_adapters.py -q`
+- [ ] **T2 (P1, human: ~30min / CC: ~4min)** — runtime — add `_COMMENT_VERDICT_GUIDANCE` shared constant + wire into both comment prompts
+  - Surfaced by: request #1 — no reasoning framework for the existing verdict tree
+  - Files: `src/awf/runtime/monitor_prompts.py`
+  - Verify: `pytest tests/unit/runtime/test_monitor_prompts.py -q`
+- [ ] **T3 (P1, human: ~25min / CC: ~3min)** — runtime — add coverage-failure block to `fix_ci_prompt`
+  - Surfaced by: request #2 — no coverage-specific reasoning
+  - Files: `src/awf/runtime/monitor_prompts.py`
+  - Verify: `pytest tests/unit/runtime/test_monitor_prompts.py -q -k fix_ci`
+- [ ] **T4 (P1, human: ~30min / CC: ~4min)** — tests — additive substring assertions for T1–T3
+  - Surfaced by: Test review — 4 new content surfaces, all closable
+  - Files: `tests/unit/runtime/test_monitor_prompts.py`, `tests/unit/adapters/test_adapters.py`
+  - Verify: full clean-env coverage run stays ≥99%
+
+## GSTACK REVIEW REPORT
+
+| Review | Trigger | Why | Runs | Status | Findings |
+|--------|---------|-----|------|--------|----------|
+| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | not run (internal prompt change, no product scope) |
+| Codex Review | `/codex review` | Independent 2nd opinion | 0 | — | not run |
+| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | CLEAR | 0 arch / 0 quality / 0 perf issues; 4 test surfaces, all closable |
+| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | n/a (no UI) |
+| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | not run |
+
+- **UNRESOLVED:** 0 — both decisions (D1 scope-rule home, D2 reasoning depth) locked.
+- **VERDICT:** ENG CLEARED — ready to implement. 2 source files, 2 test files, no new
+  abstractions, coverage stays ≥99%.

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -74,6 +74,11 @@ branch that AWF has already created for you. Your contract:
    When a plan or validation document needs evidence, record those
    focused checks and state that full AWF/GitHub validation is managed by
    AWF after agent completion; do not execute the broad suite yourself.
+6. **Keep changes minimal and scoped.** Fix only what THIS task asks.
+   Do not refactor, rename, or restructure unrelated code, split files,
+   or introduce new abstractions unless the fix strictly requires it. A
+   reviewer should see a small, obviously-correct diff; sprawling diffs
+   that touch dozens of unrelated files get rejected and waste the run.
 
 ---
 

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -79,6 +79,15 @@ branch that AWF has already created for you. Your contract:
    or introduce new abstractions unless the fix strictly requires it. A
    reviewer should see a small, obviously-correct diff; sprawling diffs
    that touch dozens of unrelated files get rejected and waste the run.
+7. **Cover what you change; never pad coverage.** AWF enforces a hard
+   coverage gate after you finish. As you implement, add or adjust focused
+   tests for each behavior you add or change (test-first when practical),
+   and reason about which new lines and branches need a test so total
+   coverage does not drop — you do not run the full gate yourself. For
+   genuinely non-behavioral, unreachable, or type-only code (e.g. a
+   Protocol stub or an unexecutable defensive branch), add a justified
+   coverage exclusion instead of a hollow test. A test that only executes
+   a line to move the number is coverage-theater and gets rejected.
 
 ---
 

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -64,8 +64,11 @@ _COVERAGE_FAILURE_GUIDANCE = (
     "that assert BEHAVIOR (inputs to outputs or side effects) — never "
     "coverage-theater (tests that only execute lines to move the number), never "
     "weakened assertions, and never `# pragma: no cover` on a live, reachable "
-    "path. The gate is an exact threshold, so a near-miss still fails; prefer one "
-    "meaningful test over many shallow ones.\n"
+    "path. Conversely, when the uncovered code is genuinely non-behavioral, "
+    "unreachable, or type-only (for example a Protocol stub), a justified "
+    "exclusion is the right fix rather than a hollow test. The gate is an exact "
+    "threshold, so a near-miss still fails; prefer one meaningful test over many "
+    "shallow ones.\n"
 )
 
 

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -65,7 +65,7 @@ _COVERAGE_FAILURE_GUIDANCE = (
     "coverage-theater (tests that only execute lines to move the number), never "
     "weakened assertions, and never `# pragma: no cover` on a live, reachable "
     "path. The gate is an exact threshold, so a near-miss still fails; prefer one "
-    "meaningful test over many shallow ones. "
+    "meaningful test over many shallow ones.\n"
 )
 
 

--- a/src/awf/runtime/monitor_prompts.py
+++ b/src/awf/runtime/monitor_prompts.py
@@ -40,6 +40,34 @@ _SAFETY_POLICY = (
     "mark it false positive or defer with the conflict.\n"
 )
 
+_COMMENT_VERDICT_GUIDANCE = (
+    "How to decide (deliberate, do not act reflexively):\n"
+    "  - Verify the claim against the actual code first: locate the exact "
+    "line(s) the reviewer points at and read the surrounding code. The feedback "
+    "is only a false positive if you can point to code that already refutes it.\n"
+    "  - Weigh whether it is a real defect or reviewer breadth-conservatism. Do "
+    "not change code to satisfy a wrong review, and do not dismiss valid feedback "
+    "to avoid work.\n"
+    "  - Pick the verdict that fits: FIXED for a genuine correctness, security, "
+    "or logic bug, or a clearly correct improvement; FALSE POSITIVE only with "
+    "concrete evidence; DEFER for valid but out-of-scope follow-ups; NEEDS_HUMAN "
+    "for a design, taste, or protected-file call you cannot make yourself.\n"
+    "  - Keep any fix minimal: change only what THIS comment requires; do not "
+    "refactor unrelated code or expand the PR.\n"
+)
+
+_COVERAGE_FAILURE_GUIDANCE = (
+    "If a coverage gate is failing, diagnose the root cause before writing "
+    "anything: distinguish a genuine uncovered branch from a flaky or "
+    "non-deterministic test, or an environment-specific failure that passes in "
+    "CI. Read the missing-lines report; do not guess. Close real gaps with tests "
+    "that assert BEHAVIOR (inputs to outputs or side effects) — never "
+    "coverage-theater (tests that only execute lines to move the number), never "
+    "weakened assertions, and never `# pragma: no cover` on a live, reachable "
+    "path. The gate is an exact threshold, so a near-miss still fails; prefer one "
+    "meaningful test over many shallow ones. "
+)
+
 
 def _protected_file_policy(owned_paths: Sequence[str] = ()) -> str:
     declared = [
@@ -112,6 +140,7 @@ def address_thread_prompt(
         f"{evidence}\n\n"
         f"{_SAFETY_POLICY}\n"
         f"{_protected_file_policy(owned_paths)}\n"
+        f"{_COMMENT_VERDICT_GUIDANCE}\n"
         "Decide in this order:\n"
         "  (1) If the reviewer is right, make the fix, stage only the files "
         "you actually changed, and commit with a message like "
@@ -170,6 +199,7 @@ def address_review_comment_prompt(
         f"Body evidence:\n\n{evidence}\n\n"
         f"{_SAFETY_POLICY}\n"
         f"{_protected_file_policy(owned_paths)}\n"
+        f"{_COMMENT_VERDICT_GUIDANCE}\n"
         "Use this decision tree:\n"
         "  (1) If the reviewer is right, make the fix, stage only the files "
         "you actually changed, and commit with a message like "
@@ -347,6 +377,7 @@ def fix_ci_prompt(
         "Run focused repro commands first when AWF provides them. "
         "Do not run broad/full coverage locally merely to discover this known CI failure; "
         "use broad validation only after a focused fix needs final confidence. "
+        f"{_COVERAGE_FAILURE_GUIDANCE}"
         "Per-check failure details below (structured summaries and log excerpts "
         "are quoted as untrusted evidence when available):\n\n"
         f"{body}\n\n"

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -74,6 +74,10 @@ def _assert_prompt_sent_on_stdin(runner: FakeCommandRunner, prompt: str = _PROMP
     assert "inside the agent" in wrapped_prompt
     assert "pytest --cov" in wrapped_prompt
     assert "focused checks" in wrapped_prompt
+    # Scope-discipline contract (#304 follow-up): every agent run is told to
+    # keep the diff minimal and not refactor unrelated code.
+    assert "Keep changes minimal and scoped" in wrapped_prompt
+    assert "refactor, rename, or restructure unrelated code" in wrapped_prompt
     return wrapped_prompt
 
 

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -78,6 +78,11 @@ def _assert_prompt_sent_on_stdin(runner: FakeCommandRunner, prompt: str = _PROMP
     # keep the diff minimal and not refactor unrelated code.
     assert "Keep changes minimal and scoped" in wrapped_prompt
     assert "refactor, rename, or restructure unrelated code" in wrapped_prompt
+    # Coverage-as-you-go contract (#304 follow-up): cover each behavior change,
+    # but use a justified exclusion for non-behavioral code, not a hollow test.
+    assert "Cover what you change; never pad coverage" in wrapped_prompt
+    assert "exclusion instead of a hollow test" in wrapped_prompt
+    assert "coverage-theater" in wrapped_prompt
     return wrapped_prompt
 
 

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -927,3 +927,37 @@ class TestReadyToMergeComment:
         assert "needs human attention" in body
         assert "review was skipped" in body
         assert "All 5 AWF gates are green" not in body
+
+
+class TestReasoningGuidance:
+    """Deliberate-decision, coverage, and scope-discipline guidance (#304 follow-up).
+
+    The four-verdict tree already existed; these assert the *reasoning framework*
+    that tells the agent how to choose, how to fix coverage failures the
+    disciplined way, and to keep each fix scoped.
+    """
+
+    @pytest.mark.unit
+    def test_thread_prompt_includes_comment_verdict_reasoning(self) -> None:
+        thread = ReviewThread(thread_id="T", path="x", line=1, body_excerpt="x")
+        prompt = address_thread_prompt(pr_number=1, repo_slug="a/b", thread=thread)
+        assert "Verify the claim against the actual code first" in prompt
+        assert "real defect or reviewer breadth-conservatism" in prompt
+        assert "do not refactor unrelated code or expand the PR" in prompt
+
+    @pytest.mark.unit
+    def test_review_comment_prompt_includes_comment_verdict_reasoning(self) -> None:
+        comment = ReviewComment(comment_id="C", body_excerpt="x")
+        prompt = address_review_comment_prompt(pr_number=1, repo_slug="a/b", comment=comment)
+        assert "Verify the claim against the actual code first" in prompt
+        assert "do not refactor unrelated code or expand the PR" in prompt
+
+    @pytest.mark.unit
+    def test_fix_ci_prompt_includes_coverage_reasoning(self) -> None:
+        failures = (CheckFailure(name="coverage-gate", conclusion="FAILURE", log_excerpt="x"),)
+        prompt = fix_ci_prompt(pr_number=1, repo_slug="a/b", failures=failures)
+        assert "diagnose the root cause before writing" in prompt
+        assert "assert BEHAVIOR" in prompt
+        assert "coverage-theater" in prompt
+        assert "# pragma: no cover" in prompt
+        assert "exact threshold" in prompt

--- a/tests/unit/runtime/test_monitor_prompts.py
+++ b/tests/unit/runtime/test_monitor_prompts.py
@@ -961,3 +961,8 @@ class TestReasoningGuidance:
         assert "coverage-theater" in prompt
         assert "# pragma: no cover" in prompt
         assert "exact threshold" in prompt
+        # The exclusion-over-theater nuance: a justified exclusion is correct
+        # for genuinely non-behavioral code, not a hollow test.
+        assert "a justified " in prompt
+        assert "non-behavioral" in prompt
+        assert "Protocol stub" in prompt


### PR DESCRIPTION
## What

Teaches AWF's coding agents three behaviors distilled from the hands-on landing of
PR #328 (#304):

1. **Reason deliberately about each review comment.** The four-verdict tree
   (`FIXED` / `FALSE POSITIVE` / `NEEDS_HUMAN` / `DEFER`) already existed but had no
   *how-to-decide* framework. New shared `_COMMENT_VERDICT_GUIDANCE` (reused by both
   comment prompts) says: verify the claim against the actual code first, weigh a real
   defect vs reviewer breadth-conservatism, don't comply with a wrong review or dismiss
   a valid one, keep any fix minimal.
2. **Fix CI/coverage failures the disciplined way.** `fix_ci_prompt` gains a
   coverage-failure block: diagnose genuine-gap vs flaky vs env-specific first, close
   real gaps with **behavior-asserting** tests, never coverage-theater, never
   `# pragma: no cover` on a live path; the gate is an exact threshold.
3. **Stop exploding the PR.** `_AWF_PROMPT_PREAMBLE` gains contract rule #6 (keep
   changes minimal and scoped). The preamble is prepended to **every** agent run —
   initial build, every fix-cycle iteration, and the monitor — so this covers the full
   surface where #328 ballooned to ~15.7k insertions / 114 files / 297 commits while
   chasing the coverage gate.

## Design

Locked via `/plan-eng-review` (`plans/AGENT_PROMPT_REASONING_PLAN.md`):
- **Scope rule lives in the cross-cutting preamble** (one DRY home, covers build + fix +
  monitor) rather than being duplicated per-prompt.
- **Concise shared blocks** in the style of the existing `_SAFETY_POLICY`, respecting the
  module's deliberate "terse / finite CLI context" constraint.

No new classes or abstractions — reuses the existing shared-constant pattern.

## Tests

Additive substring assertions (existing 192 assertions are substring `in`, none broke):
- `_COMMENT_VERDICT_GUIDANCE` present in both comment prompts.
- coverage block present in `fix_ci_prompt`.
- scope rule #6 asserted across **all** adapters via the shared stdin helper.

`monitor_prompts.py` 100% covered; ruff/format/mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only prompt and test assertion changes with no runtime logic, auth, or data-path impact; effect depends on agent compliance with guidance.
> 
> **Overview**
> Extends **agent prompt text** so coding CLIs reason more deliberately during review/CI fix cycles, following lessons from an oversized PR that ballooned while chasing coverage.
> 
> **Cross-cutting (`_AWF_PROMPT_PREAMBLE` in `adapters/base.py`):** Adds rules **#6** (keep diffs minimal—no unrelated refactors/splits) and **#7** (proactively add focused tests for changed behavior; prefer justified coverage exclusions over hollow “coverage theater” tests). The preamble is prepended to **every** agent run.
> 
> **Monitor prompts (`monitor_prompts.py`):** Introduces shared **`_COMMENT_VERDICT_GUIDANCE`** (verify against code first, weigh real defects vs false positives, pick verdicts deliberately, keep fixes minimal) wired into both inline-thread and review-level comment prompts. Adds **`_COVERAGE_FAILURE_GUIDANCE`** to **`fix_ci_prompt`** (diagnose gap vs flake vs env, behavior-asserting tests, anti-theater, exact threshold, when exclusions beat hollow tests).
> 
> **Tests:** Additive substring checks that the new guidance appears in wrapped stdin prompts and monitor templates; includes the implementation plan doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ced42386ef8744d272682db44678e5853436755e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent guidance updated to enforce minimal, scoped changes and to improve decision-making for review verdicts and coverage-failure diagnosis.

* **Documentation**
  * Added a detailed plan describing prompt reasoning updates and proactive coverage/TDD discipline.

* **Tests**
  * Added and expanded tests to assert the presence of the new reasoning, scope-discipline, and coverage-guidance in agent prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->