### PR TITLE
fix(console): repair browser-smoke selectors broken by 2f5dbce3 (un-redden CI)

### DIFF
--- a/apps/console/tests/dashboard-usage.spec.ts
+++ b/apps/console/tests/dashboard-usage.spec.ts
@@ -43,8 +43,13 @@ test("dashboard displays llm usage correctly when available", async ({ page }) =
   await page.goto("/");
   await waitForConsoleReady(page);
 
-  // Click the workspace that has usage
-  await page.getByText("Usage Workspace", { exact: true }).first().click();
+  // Open the workspace that has usage via its full-card open-details button.
+  // The title text now sits in a pointer-events-none layer over this button, so
+  // a click on the title text never lands. Use exact matching because the
+  // aria-label is a substring of "...No Usage Workspace".
+  await page
+    .getByRole("button", { name: "Open workspace details for Usage Workspace", exact: true })
+    .click();
 
   // Find the LLM usage block
   const usageBlock = page.locator("section").filter({ hasText: "LLM usage" }).first();
@@ -66,8 +71,10 @@ test("dashboard hides llm usage metrics when unavailable", async ({ page }) => {
   await page.goto("/");
   await waitForConsoleReady(page);
 
-  // Click the workspace that has no usage
-  await page.getByText("No Usage Workspace", { exact: true }).first().click();
+  // Open the workspace that has no usage via its full-card open-details button.
+  await page
+    .getByRole("button", { name: "Open workspace details for No Usage Workspace", exact: true })
+    .click();
 
   // Actually wait, our UsageSummaryBlock renders a div, and it is inside some Panel in details.
   // Wait, let's verify what the text is.
@@ -84,7 +91,9 @@ test("dashboard renders ccusage-backed totals and source label", async ({ page }
   await page.goto("/");
   await waitForConsoleReady(page);
 
-  await page.getByText("Ccusage Workspace", { exact: true }).first().click();
+  await page
+    .getByRole("button", { name: "Open workspace details for Ccusage Workspace", exact: true })
+    .click();
 
   // Scope to the usage block itself: the surrounding details section also
   // carries the workspace title/id/branch ("Ccusage Workspace", "ws_ccusage"),
@@ -104,7 +113,9 @@ test("dashboard renders ccusage unavailable reason", async ({ page }) => {
   await page.goto("/");
   await waitForConsoleReady(page);
 
-  await page.getByText("Ccusage Timeout Workspace", { exact: true }).first().click();
+  await page
+    .getByRole("button", { name: "Open workspace details for Ccusage Timeout Workspace", exact: true })
+    .click();
 
   await expect(page.getByText("LLM usage").first()).toBeVisible();
   await expect(page.getByText("unavailable").first()).toBeVisible();

--- a/apps/console/tests/theme-accessibility.spec.ts
+++ b/apps/console/tests/theme-accessibility.spec.ts
@@ -54,7 +54,10 @@ test("desktop theme screenshots cover dashboard, details, and fullscreen logs", 
   await expectNoViewportOverflow(page);
   await page.screenshot({ path: testInfo.outputPath("desktop-dashboard.png"), fullPage: true });
 
-  await page.getByRole("button", { name: "Details" }).first().click();
+  // The per-card "Details" button opens the Task details dialog. Use exact
+  // matching: the full-card "Open workspace details for ..." buttons also
+  // contain "details", so a substring match would resolve to the wrong button.
+  await page.getByRole("button", { name: "Details", exact: true }).first().click();
   await expect(page.getByRole("dialog", { name: /Task details/i })).toBeVisible();
   await expectNoViewportOverflow(page);
   await page.screenshot({ path: testInfo.outputPath("desktop-workspace-details.png"), fullPage: true });
@@ -71,7 +74,9 @@ test("task details modal scrolls long prompts without moving the dashboard", asy
   await page.setViewportSize({ width: 947, height: 982 });
   await page.goto("/");
   await waitForConsoleReady(page);
-  const detailsButton = page.getByRole("button", { name: "Details" }).first();
+  // Exact match targets the per-card "Details" button (opens the Task details
+  // dialog), not the full-card "Open workspace details for ..." button.
+  const detailsButton = page.getByRole("button", { name: "Details", exact: true }).first();
   await expect(detailsButton).toBeVisible();
   const scrollTarget = await detailsButton.evaluate((node) => {
     const rect = node.getBoundingClientRect();
@@ -132,7 +137,16 @@ test("mobile theme screenshots cover dashboard, workspace, and logs views", asyn
   await expectNoViewportOverflow(page);
   await page.screenshot({ path: testInfo.outputPath("mobile-dashboard.png"), fullPage: true });
 
-  await page.getByRole("button", { name: /policy parity title should wrap fully inside the list row/i }).click();
+  // Open the inspector by clicking the card. The title text sits in a
+  // pointer-events-none layer over the full-card open-details button, and the
+  // copy-id button overlaps that button's centre, so click the title box
+  // directly (above the copy-id control) to land on the open-details button.
+  const cardTitle = page.getByTestId(`workspace-title-${workspaceId}`);
+  const titleBox = await cardTitle.boundingBox();
+  if (!titleBox) {
+    throw new Error(`Workspace title ${workspaceId} did not produce a clickable box`);
+  }
+  await page.mouse.click(titleBox.x + titleBox.width / 2, titleBox.y + titleBox.height / 2);
   await expect(page.getByRole("heading", { name: "Workspace", exact: true })).toBeVisible();
   await expectNoViewportOverflow(page);
   await page.screenshot({ path: testInfo.outputPath("mobile-workspace.png"), fullPage: true });


### PR DESCRIPTION
## Why
The CI `console` job's **Browser smoke** step has been red on `development` since
`2f5dbce3` ("feat(console): show effort and copy workspace ids") — 7 Playwright tests
time out. It also reddens every PR against development (e.g. #363). This is test-only
and un-reddens development's console CI.

## Root cause
`2f5dbce3` restructured the workspace card:
- The title is now a `<span>` in a `pointer-events-none` layer over a full-card
  `<button aria-label="Open workspace details for {title}">`. Clicking the title **text**
  no longer lands (Playwright resolves the span but it can't receive the click → 30s timeout).
- It added per-card buttons whose accessible name contains "details", so
  `getByRole("button", { name: "Details" })` substring-matches the wrong button.

`2f5dbce3` updated `dashboard-inspector.spec.ts` for the new structure but left
`dashboard-usage.spec.ts` and `theme-accessibility.spec.ts` stale.

## Fix (selectors only)
- **dashboard-usage** (×4): click `getByRole("button", { name: "Open workspace details for X", exact: true })` instead of the title text. `exact:true` avoids the "Usage" vs "No Usage" substring overlap.
- **theme-accessibility** (×3): `{ name: "Details", exact: true }` to hit the real per-card Details trigger (opens the Task-details dialog); mobile inspector open uses a title-box coordinate click (mirroring `dashboard-inspector`'s existing helper).

No component/app code changed.

## Verification
- `npm run test:browser`: **22 passed**, 0 failures.
- `npm run lint` ✓ · `npm run typecheck` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only selector updates; no production console or API behavior changes.
> 
> **Overview**
> **Playwright browser-smoke tests** are updated so they match the current workspace card interaction model (no app code changes).
> 
> After the workspace card gained a full-card **Open workspace details for …** button with the title in a `pointer-events-none` overlay, `dashboard-usage.spec.ts` now opens workspaces via that button with **`exact: true`** on the accessible name (avoiding collisions like “Usage” vs “No Usage”). **`theme-accessibility.spec.ts`** uses **`Details` with `exact: true`** so clicks hit the per-card Task details control instead of the full-card button whose name also contains “details”; on mobile, opening the inspector uses a **coordinate click on the title** test id so the click reaches the underlying open-details control past overlapping copy-id UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0880e973c8956c0dfdce96104b5465e75bc9da1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability for dashboard usage verification across all test scenarios.
  * Enhanced test interactions for workspace and detail navigation in theme accessibility checks to ensure more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->