### PR TITLE
Set Dependabot target branch to 'development'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    target-branch: "development"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only Dependabot configuration with no runtime or application code changes.
> 
> **Overview**
> Adds **`.github/dependabot.yml`** so version-update PRs can be routed to the **`development`** branch instead of the repo default.
> 
> The config uses Dependabot **v2**, a **weekly** schedule, root **`/`** manifests, and **`target-branch: "development"`**, matching CI which already runs on **`main`** and **`development`**. **`package-ecosystem`** is still a placeholder, so automated updates won’t run until that value is set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4da81a71cee48c0ae8004b6966f9900a90c8c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->