### PR TITLE
Polish AWF first-run devex

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ awf init <path>
 awf smoke run --project <path> --mocked-local --format pretty
 ```
 
+`awf start` starts the local API, worker, database, and web console at
+<http://127.0.0.1:3000>. Use `awf start --headless` to skip the console or
+`awf start --console-port 3333` to choose another localhost port.
+
 For the source checkout with global tool install lane, run from the checkout:
 
 ```bash

--- a/TODO/awf-full-installer-first-run-setup-backlog.md
+++ b/TODO/awf-full-installer-first-run-setup-backlog.md
@@ -37,9 +37,8 @@ respects an eight-workspace local capacity cap.
   reasoning effort for AWF implementation workspaces unless an operator gives
   an explicit per-wave override. Operator override on 2026-06-03: launch T07,
   T08, T10, and T16 with `claude_code`, `claude-opus-4-8`, `high`. Operator
-  override on 2026-06-06: launch T18 and T20 with `claude_code`,
-  `claude-opus-4-8`, `high`, and launch T21 with the same settings after T20
-  merges.
+  override on 2026-06-06: launch T18, T20, and T21 with `claude_code`,
+  `claude-opus-4-8`, `high`.
 - H04 launch preflight: before launching implementation workspaces, clean
   expired AWF resources, rebuild local service images, and rerun AWF bootstrap.
 
@@ -50,12 +49,13 @@ holds unless a human operator explicitly reopens one of the decisions above.
 ## Verified Progress
 
 Last verified: 2026-06-06 from `git log origin/development`, `gh pr view`,
-and `awf workspace show/list`. T09, T18, and T20 are merged into
+and local full-coverage results. T09, T18, T20, and T21 are merged into
 `development`. T21 implementation work from failed workspace
 `ws_8846dc92df1c4f02929f707b` was salvaged into
 [PR #428](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/428)
-and adopted by AWF PR monitor `ws_9a7281385e294d6faa9ac756`. T19 remains
-blocked on T21.
+and merged as commit `a071c164` on 2026-06-06T09:15:52Z. T19 was completed as
+a local coordination pass with validation recorded in
+`plans/T19_FINAL_INTEGRATION_VALIDATION.md`.
 
 | Task | Status | Evidence |
 | --- | --- | --- |
@@ -78,27 +78,21 @@ blocked on T21.
 | T17 | done - merged | [PR #391](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/391), merge commit `ed9ed32d`, merged 2026-06-05T14:01:49Z |
 | T18 | done - merged | [PR #425](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/425), merge commit `ff96f37b`, merged 2026-06-06T03:14:45Z |
 | T20 | done - merged | [PR #426](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/426), merge commit `35c7b1bf`, merged 2026-06-05T23:45:33Z |
-| T21 | salvaged - PR monitor active | [PR #428](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/428), source workspace `ws_8846dc92df1c4f02929f707b`, PR monitor `ws_9a7281385e294d6faa9ac756` |
+| T21 | done - merged | [PR #428](https://github.com/dimileeh/aira-agent-workspace-fabric/pull/428), merge commit `a071c164`, merged 2026-06-06T09:15:52Z; source workspace `ws_8846dc92df1c4f02929f707b` |
+| T19 | done - validated locally | `plans/T19_FINAL_INTEGRATION_VALIDATION.md`; local final coverage `11656 passed, 1 skipped`, coverage `99.00%` |
 
 Current runnable workspace set:
 
-- T21 source workspace `ws_8846dc92df1c4f02929f707b` failed after producing
-  real implementation commits; the branch is salvaged as PR #428.
-- T21 PR #428 is monitored by `ws_9a7281385e294d6faa9ac756` with
-  `claude_code`, `claude-opus-4-8`, `high`.
-- T19 remains blocked on T21.
-- AWF currently has one active workspace: T21 PR monitor
-  `ws_9a7281385e294d6faa9ac756`.
+- None. All backlog tasks are complete.
+- No backlog implementation workspace remains active.
 
 Scheduled workspace set:
 
-| Task | Current workspace | Agent | Status at verification |
-| --- | --- | --- | --- |
-| T21 | `ws_9a7281385e294d6faa9ac756` | `claude_code` / `claude-opus-4-8` / `high` | PR #428 monitor requested |
+- None.
 
-Next tasks after current work is ready:
+Next task:
 
-- Launch T19 only after T21 merges.
+- None for this backlog.
 
 ## What Already Exists
 
@@ -161,8 +155,8 @@ These are reuse targets, not work to rebuild:
 | T17 | Add support-bundle and log redaction coverage for setup secrets | workspace | done - merged (#391) | P0 | T06, T07 | security |
 | T18 | Add docs drift tests for setup/start/init command grammar | workspace | done - merged (#425) | P1 | T01, T15 | docs |
 | T20 | Add explicit uv bootstrap contract to `install.sh` | workspace | done - merged (#426) | P0 | T12, T15 | installer |
-| T21 | Add hosted one-line `uninstall.sh` with AWF-managed cleanup contract | workspace | salvaged - PR #428 under monitor `ws_9a7281385e294d6faa9ac756` | P0 | T12, T15, T20 | installer |
-| T19 | Final integration, full coverage, and first-run lane validation | coordination | planned | P0 | T07, T09, T14, T15, T16, T17, T18, T20, T21 | final |
+| T21 | Add hosted one-line `uninstall.sh` with AWF-managed cleanup contract | workspace | done - merged (#428) | P0 | T12, T15, T20 | installer |
+| T19 | Final integration, full coverage, and first-run lane validation | coordination | done - validated locally | P0 | T07, T09, T14, T15, T16, T17, T18, T20, T21 | final |
 
 ## Task Cards
 
@@ -1011,8 +1005,7 @@ Required tests:
 
 Owner type: workspace
 
-Status: running in `ws_8846dc92df1c4f02929f707b` with `claude_code`,
-`claude-opus-4-8`, `high`
+Status: done - merged (#428)
 
 Modules touched:
 
@@ -1069,6 +1062,8 @@ Required tests:
 
 Owner type: coordination
 
+Status: done - validated locally
+
 Modules touched:
 
 - Cross-cutting validation only unless small fixes are needed.
@@ -1121,7 +1116,7 @@ H01 ! installer hosting/trust (done)
                          +--> T14* E2E first-run lanes (done)
                          +--> T15* docs lanes (done)
                                 +--> T20* uv bootstrap installer contract (done)
-                                      +--> T21* hosted uninstaller contract (running)
+                                      +--> T21* hosted uninstaller contract (done)
                         +--> T16* release workflow checks (done)
 
 H02 ! credential consent wording (done)
@@ -1174,7 +1169,8 @@ T16* release workflow checks   +--> T19 final integration and coverage
 T17* setup secret redaction    +--> T19 final integration and coverage (done)
 T18* docs drift tests          +--> T19 final integration and coverage (done)
 T20* uv bootstrap installer    +--> T19 final integration and coverage (done)
-T21* hosted uninstaller        +--> T19 final integration and coverage (running)
+T21* hosted uninstaller        +--> T19 final integration and coverage (done)
+T19 final integration          (done)
 ```
 
 ## Eight-Workspace Execution Schedule
@@ -1185,15 +1181,14 @@ likely to collide or wait idle.
 ### Current PM Snapshot - 2026-06-06
 
 Verified merged: T01, T02, T03, T04, T05, T06, T07, T08, T09, T10, T11,
-T12, T13, T14, T15, T16, T17, T18, and T20.
+T12, T13, T14, T15, T16, T17, T18, T20, and T21.
 
-Scheduled workspaces, using 1 of 8 available slots:
+Scheduled workspaces, using 0 of 8 available slots:
 
-- T21 hosted one-line uninstaller: salvaged PR #428 under AWF PR monitor
-  `ws_9a7281385e294d6faa9ac756` with `claude_code`, `claude-opus-4-8`,
-  `high`.
+- None.
 
-T19 remains the final integration task after T21 is merged.
+T19 is complete as a local coordination pass; this backlog has no remaining
+runnable tasks.
 
 ### Human Gate Before Wave 1
 
@@ -1206,7 +1201,7 @@ preflight becomes stale before Wave 1 launch:
 | --- | --- | --- | --- |
 | H01 | done - locked | T11, T12, T13, T16 | Installer hosting and trust-chain decision. |
 | H02 | done - locked | T06 | Plain-secret consent and provider prompt wording. |
-| H03 | done - locked | T01, T02, downstream implementation workspaces | Default execution model: `codex`, `gpt-5.5`, `xhigh`; T07/T08/T10/T16 use the 2026-06-03 operator override `claude_code`, `claude-opus-4-8`, `high`; T18/T20 use the 2026-06-06 operator override `claude_code`, `claude-opus-4-8`, `high`; T21 is planned with the same settings after T20 merges. |
+| H03 | done - locked | T01, T02, downstream implementation workspaces | Default execution model: `codex`, `gpt-5.5`, `xhigh`; T07/T08/T10/T16 use the 2026-06-03 operator override `claude_code`, `claude-opus-4-8`, `high`; T18/T20/T21 use the 2026-06-06 operator override `claude_code`, `claude-opus-4-8`, `high`. |
 | H04 | done - locked | T01, T02, downstream implementation workspaces | Launch preflight: clean expired AWF resources, rebuild local service images, rerun AWF bootstrap. |
 
 Do not hold T06/T11/T12/T13/T16 for additional H01/H02 approval. If a future
@@ -1354,8 +1349,7 @@ Capacity used: 1 workspace at a time.
 
 Recommended launch:
 
-- T21 is salvaged into PR #428 and monitored by
-  `ws_9a7281385e294d6faa9ac756`.
+- T21 is merged as PR #428.
 - Keep T20 focused on `packaging/install.sh`, installer fixture tests, shell
   help text, and only minimal install-lane docs if needed.
 - Keep T21 focused on `packaging/uninstall.sh`, shared uninstall helpers,
@@ -1363,6 +1357,8 @@ Recommended launch:
   needed.
 
 ### Wave 6 - Final Integration
+
+Status: complete. T19 was executed locally without AWF.
 
 Capacity used: 1 coordination workspace or local operator run.
 
@@ -1372,9 +1368,8 @@ Capacity used: 1 coordination workspace or local operator run.
 
 Recommended launch:
 
-- Use one workspace or local operator run for T19.
-- Do not run broad final integration in parallel with open implementation PRs
-  unless the goal is only early signal. The final answer needs merged code.
+- No remaining launch work in this wave.
+- The final integration run used merged code from `development`.
 
 ## Parallel Lane Summary
 
@@ -1409,9 +1404,8 @@ Lane E - Human credential consent
   H02(done) -> T06
 ```
 
-At no point does the recommended schedule require more than six simultaneous
-workspace tasks. The remaining two slots are intentionally left free for PR
-monitor repair, rebases, review-comment fixes, or emergency follow-up work.
+At no point did the recommended schedule require more than six simultaneous
+workspace tasks. This backlog is now complete.
 
 ## Critical Failure Modes To Preserve In Prompts
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -39,6 +39,19 @@ uv run --python 3.12 --extra dev awf service status
 uv run --python 3.12 --extra dev awf service status --format pretty
 ```
 
+Start local AWF Core and the web console:
+
+```bash
+uv run --python 3.12 --extra dev awf start
+uv run --python 3.12 --extra dev awf start --console-port 3333
+uv run --python 3.12 --extra dev awf start --headless
+```
+
+`awf start` starts the API, worker, database, and console through the same
+bootstrap path as service mode. The console is published on
+<http://127.0.0.1:3000> by default. Use `--headless` to skip the console, or
+`--console-port` to change the localhost port.
+
 `awf service status` reports `orphan_workspaces` and `workspace_cleanup` checks
 alongside the existing API / DB / Docker / image / disk checks. It reads
 Docker Compose labels for containers, networks, and volumes, and scans

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -405,7 +405,7 @@ recreated and Alembic upgrades are idempotent.
 The lower-level Compose workflow remains supported:
 
 ```bash
-docker compose up --build
+docker compose up -d --build
 ```
 
 That raw Compose path builds the control-plane image, builds
@@ -1005,7 +1005,7 @@ sent to browser JavaScript.
 Start the full local service and console stack with root Compose:
 
 ```bash
-docker compose up --build
+docker compose up -d --build
 ```
 
 Open <http://127.0.0.1:3000>. Protected API calls use

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -98,11 +98,15 @@ awf smoke run --project "$HOME/awf-eval-project" --mocked-local --format pretty
 
 `awf setup` checks host readiness, imports any legacy `docker/compose/.env`
 values into root `.env`, and configures supported clients such as MCP when
-requested. `awf start` starts the local AWF Core stack, and
+requested. `awf start` starts the local AWF Core stack, including the web
+console at <http://127.0.0.1:3000>, and
 `awf service status --format pretty` confirms API, database, Docker, image,
 disk, provider, and cleanup health. The lower-level
 `awf service bootstrap` command remains available for service-only development
 and is what `awf start` delegates to.
+
+Use `awf start --headless` when a host should not run the console, or
+`awf start --console-port 3333` when port `3000` is already in use.
 
 For the source checkout with global tool install lane, run from the checkout:
 
@@ -128,7 +132,7 @@ For source checkouts or raw Docker installs, root Compose can bring up the full
 local stack with safe loopback-only defaults:
 
 ```bash
-docker compose up --build
+docker compose up -d --build
 ```
 
 Open <http://127.0.0.1:3000> for the console, or call the API at

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -17,7 +17,7 @@ then, use one of the three lanes below.
 
 Mocked smoke does not require live GitHub or provider access. Local first-run
 service URLs use IPv4 loopback: <http://127.0.0.1:8000> for the API and
-<http://127.0.0.1:3000> for the console when it is running.
+<http://127.0.0.1:3000> for the console started by `awf start`.
 
 AWF uses root `.env` for local runtime values. `awf start` seeds it from
 `.env.example` when needed; source-checkout operators can also pre-create it
@@ -57,6 +57,11 @@ awf smoke run --project "$HOME/awf-eval-project" --mocked-local --format pretty
 `awf init "$HOME/awf-eval-project"` is the `awf init <path>` project onboarding
 step. If the project already has `.awf/workspace.yml`, AWF validates it; if not,
 interactive terminals guide profile creation.
+
+`awf start` starts the local API, worker, database, and web console. Use
+`awf start --headless` to skip the console on server or CI hosts, or
+`awf start --console-port 3333` to publish the console on another localhost
+port.
 
 Upgrade with the same package manager you used to install:
 
@@ -153,7 +158,7 @@ For source checkouts or raw Docker installs, root Compose can bring up the full
 local stack with safe loopback-only defaults:
 
 ```bash
-docker compose up --build
+docker compose up -d --build
 ```
 
 Open <http://127.0.0.1:3000> for the console, or call the API at

--- a/docs/SMOKE_COMMAND.md
+++ b/docs/SMOKE_COMMAND.md
@@ -27,11 +27,11 @@ The overall report includes `status` (ok/warn/fail), `project`, `mode`
 
 Smoke reports probe configured console URLs before reporting
 `SMOKE_CONSOLE_READY`. When `AWF_CONSOLE_URL` is not set, they infer and probe
-the default local console URL, `http://localhost:3000`. Start it with
-`npm --prefix apps/console run dev` from an AWF source checkout when the
-`console_links` phase reports `SMOKE_CONSOLE_UNAVAILABLE`. Installed-CLI users
-should start the console through their installed setup rather than this
-source-checkout-specific npm command.
+the default local console URL, `http://localhost:3000`. `awf start` starts that
+console by default; rerun `awf start` without `--headless`, or use
+`awf start --console-port <port>` when port `3000` is unavailable. Source
+checkout developers can still run `npm --prefix apps/console run dev` when they
+are working on the console outside the local Core Compose stack.
 
 ## Options
 

--- a/packaging/install.sh
+++ b/packaging/install.sh
@@ -1365,7 +1365,14 @@ run_install() {
     plan "verify awf reachability"
     verify_awf
 
-    say "Installed ${PACKAGE}. Run 'awf --help' to get started."
+    say "Installed ${PACKAGE}."
+    say ""
+    say "Next steps:"
+    say "  awf setup"
+    say "  awf start"
+    say "  awf init <path>"
+    say ""
+    say "Quickstart: https://github.com/dimileeh/aira-agent-workspace-fabric/blob/development/docs/QUICKSTART.md"
 }
 
 main() {

--- a/plans/AWF_START_CONSOLE_PLAN.md
+++ b/plans/AWF_START_CONSOLE_PLAN.md
@@ -1,0 +1,40 @@
+# AWF Start Console Plan
+
+## Summary
+
+Make `awf start` start the local web console by default, matching the raw
+`docker compose up -d --build` first-run experience. The command should still be
+a friendly wrapper around the existing service bootstrap path, not a second
+Compose implementation.
+
+## Implementation
+
+- Add `--headless` and `--console-port <PORT>` to `awf start`.
+- Reject `--headless --console-port <PORT>` before bootstrap.
+- Pass `ServiceBootstrapOptions(start_console=True)` from `awf start` by
+  default; pass `False` when `--headless` is set.
+- Extend bootstrap stage construction so `start_console=True` appends a
+  `console` Compose stage after `api_worker`.
+- Keep lower-level `awf service bootstrap` behavior unchanged by making
+  `ServiceBootstrapOptions.start_console` default to `False`.
+- When `--console-port` is provided, pass `AWF_CONSOLE_HOST_PORT` into the local
+  service environment before resolving settings and bootstrapping.
+- Derive `ServiceSettings.console_url` from `AWF_CONSOLE_HOST_PORT` when no
+  explicit `AWF_CONSOLE_URL` is configured.
+- In headless success output, omit the console URL and console-open next step.
+
+## Tests
+
+- CLI tests for help text, default console startup, headless startup, console
+  port override, and incompatible flag handling.
+- Bootstrap tests proving the console stage is opt-in at the bootstrap layer.
+- Config tests proving `AWF_CONSOLE_HOST_PORT` derives the displayed console URL,
+  explicit `AWF_CONSOLE_URL` wins, and invalid ports are rejected.
+- Focused docs tests for updated first-run documentation if needed.
+
+## Assumptions
+
+- "Launch console" means start the Docker Compose `console` service on
+  localhost, not open a browser tab.
+- The public CLI spelling is `--console-port`, matching existing hyphenated
+  Typer flag style.

--- a/plans/AWF_START_CONSOLE_VALIDATION.md
+++ b/plans/AWF_START_CONSOLE_VALIDATION.md
@@ -1,0 +1,93 @@
+# AWF Start Console Validation
+
+## Result
+
+Complete. `awf start` now starts the local web console by default, supports
+`--headless`, supports `--console-port <PORT>`, reports the overridden console
+URL, and keeps lower-level service bootstrap console startup opt-in.
+
+## Plan Coverage
+
+- CLI flags added: `--headless` and `--console-port`.
+- `awf start` passes `ServiceBootstrapOptions(start_console=True)` by default.
+- `awf start --headless` passes `start_console=False` and omits console-open
+  success guidance.
+- `awf start --console-port <PORT>` injects `AWF_CONSOLE_HOST_PORT` before
+  settings resolution and bootstrap delegation.
+- Bootstrap appends the `console` Compose stage only when requested.
+- `ServiceSettings.console_url` derives from `AWF_CONSOLE_HOST_PORT` unless an
+  explicit `AWF_CONSOLE_URL` is configured.
+- Explicit `AWF_CONSOLE_URL` precedence is covered for host environment,
+  service environment, and settings-derived values.
+- Public first-run docs describe default console startup, headless mode, and
+  console port override.
+
+## TDD Evidence
+
+Before implementation, the new tests failed because:
+
+- `awf start` did not expose `--headless` or `--console-port`.
+- `ServiceBootstrapOptions` had no `start_console` field.
+- `AWF_CONSOLE_HOST_PORT` did not derive `ServiceSettings.console_url`.
+- Invalid `AWF_CONSOLE_HOST_PORT` values were not rejected.
+
+## Passing Validation
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_start_commands.py -q
+```
+
+Passed: `47 passed`.
+
+Final rerun after branch-coverage additions: `48 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_bootstrap_parts/test_bootstrap_part_003.py -q
+```
+
+Passed: `10 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/service/test_config_parts/test_config_part_001.py -q
+```
+
+Passed: `92 passed`.
+
+Final rerun after branch-coverage additions: `95 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/docs/test_public_docs_status.py -q
+```
+
+Passed: `26 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/docs/command_grammar_drift_parts -q
+```
+
+Passed: `23 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing
+```
+
+Passed: `11673 passed, 1 skipped`; required coverage `99.0%` reached with
+`99.01%` total coverage.
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+```
+
+Passed.
+
+```bash
+uv run --python 3.12 --extra dev mypy src/awf
+```
+
+Passed: `Success: no issues found in 354 source files`.
+
+## Notes
+
+The raw Docker Compose public-doc example now uses
+`docker compose up -d --build`; the docs contract test was corrected to require
+the detached single-command raw Compose path.

--- a/plans/T19_FINAL_INTEGRATION_PLAN.md
+++ b/plans/T19_FINAL_INTEGRATION_PLAN.md
@@ -1,0 +1,87 @@
+# T19 Final Integration Plan
+
+## Problem Statement And Scope
+
+T19 is the final coordination task for the AWF full installer and first-run
+setup backlog. All implementation dependencies are merged, so this task should
+prove that the integrated `development` branch satisfies the backlog contract
+without launching another AWF workspace.
+
+This is a local validation and bookkeeping task. It should not change
+production code unless a validation gate exposes a real bug.
+
+## Requirements Checklist
+
+- Confirm T19 dependencies are merged, including T21 PR #428.
+- Run the integrated Python quality gates: ruff, mypy, unit tests, OpenAPI
+  drift, and full coverage at or above 99%.
+- Verify first-run CLI surfaces: `awf setup`, `awf start`, `awf init`, and
+  `awf mcp serve`.
+- Verify source-checkout setup can run as a read-only dry run.
+- Verify first-run smoke lanes from outside the normal source-checkout path.
+- Verify release package integration: build distributions, generate checksums
+  and install manifest, run release artifact drift check, and run installer
+  checksum smoke.
+- Record validation evidence in `plans/T19_FINAL_INTEGRATION_VALIDATION.md`.
+- Update `TODO/awf-full-installer-first-run-setup-backlog.md` to mark T19 done
+  only after validation succeeds.
+- Commit the T19 validation/bookkeeping result locally only; do not push.
+
+## Execution Steps
+
+1. Ensure the worktree starts on `development`, with only expected backlog
+   bookkeeping changes present.
+2. Run the required static and test gates.
+3. Run the first-run help, dry-run, and smoke checks.
+4. Run release/package integration checks in `artifacts/t19-release/`.
+5. If any gate fails because of an implementation defect, add or update a
+   focused regression test first, fix the defect narrowly, and rerun the failed
+   gate plus any affected final gate.
+6. Write the validation report with requirement-by-requirement status and
+   command evidence.
+7. Mark T19 complete in the backlog once all required gates are green.
+8. Commit the local changes with a T19 validation message.
+
+## Verification Commands
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+uv run --python 3.12 --extra dev mypy src/awf
+uv run --python 3.12 --extra dev pytest tests/unit -q
+uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check
+uv run --python 3.12 --extra dev pytest -n 20 --timeout=300 --cov=awf --cov-report=term-missing --cov-fail-under=99
+uv run --python 3.12 --extra dev awf setup --help
+uv run --python 3.12 --extra dev awf start --help
+uv run --python 3.12 --extra dev awf init --help
+uv run --python 3.12 --extra dev awf mcp serve --help
+uv run --python 3.12 --extra dev awf setup --dry-run --source-checkout "$PWD" --format json
+uv run --python 3.12 --extra dev python scripts/first_run_smoke.py --lane installer-fixture --lane source-uv-run --lane source-tool-install --checkout-root "$PWD"
+mkdir -p artifacts/t19-release/dist artifacts/t19-release/release
+uv run --python 3.12 --with build python -m build --outdir artifacts/t19-release/dist
+sha256sum artifacts/t19-release/dist/* | tee artifacts/t19-release/release/python-distribution-sha256.txt
+uv run --python 3.12 python scripts/generate_install_manifest.py \
+  --dist-dir artifacts/t19-release/dist \
+  --checksums-file artifacts/t19-release/release/python-distribution-sha256.txt \
+  --output artifacts/t19-release/release/awf-install-manifest.json \
+  --version 0.1.0 \
+  --tag v0.1.0 \
+  --repository-url https://github.com/dimileeh/aira-agent-workspace-fabric \
+  --channel auto
+uv run --python 3.12 python scripts/check_release_artifacts.py \
+  --dist-dir artifacts/t19-release/dist \
+  --checksums-file artifacts/t19-release/release/python-distribution-sha256.txt \
+  --manifest artifacts/t19-release/release/awf-install-manifest.json \
+  --version 0.1.0 \
+  --tag v0.1.0 \
+  --repository-url https://github.com/dimileeh/aira-agent-workspace-fabric
+uv run --no-project --python 3.12 python scripts/release_smoke.py \
+  --dist-dir artifacts/t19-release/dist \
+  --manifest artifacts/t19-release/release/awf-install-manifest.json \
+  --smoke-manifest-out artifacts/t19-release/release/awf-install-manifest.smoke.json \
+  --method uv \
+  --run
+```
+
+Pass criteria: every required command exits zero, full coverage is at least
+99%, first-run smoke lanes pass or report only explicitly documented
+environmental skips, and the backlog reflects T19 as complete.

--- a/plans/T19_FINAL_INTEGRATION_VALIDATION.md
+++ b/plans/T19_FINAL_INTEGRATION_VALIDATION.md
@@ -1,0 +1,155 @@
+# T19 Final Integration Validation
+
+Plan reference: `plans/T19_FINAL_INTEGRATION_PLAN.md`
+
+## Summary
+
+Status: satisfied.
+
+T19 was executed locally on `development` without AWF. All backlog dependencies
+are merged, first-run lanes pass, release/package integration passes, and the
+final full coverage gate is green at 99.00%.
+
+## Requirement Status
+
+| Requirement | Status | Evidence |
+| --- | --- | --- |
+| Confirm T19 dependencies are merged, including T21 PR #428 | Complete | `gh pr view 428` returned `state=MERGED`, merge commit `a071c164`, merged 2026-06-06T09:15:52Z. Backlog records T01-T18, T20, and T21 complete. |
+| Run integrated Python quality gates | Complete | Ruff, mypy, OpenAPI drift, unit tests, and final coverage all passed. |
+| Verify first-run CLI surfaces | Complete | `awf setup --help`, `awf start --help`, `awf init --help`, and `awf mcp serve --help` all exited 0. |
+| Verify source-checkout setup dry-run | Complete | Default ports were occupied by the live local AWF stack, so the successful dry-run used `AWF_API_HOST_PORT=18000 AWF_POSTGRES_HOST_PORT=15433`; JSON status was `success` with source checkout verified. |
+| Verify first-run smoke lanes | Complete | `scripts/first_run_smoke.py` passed `installer-fixture`, `source-uv-run`, and `source-tool-install` lanes. |
+| Verify release package integration | Complete | Wheel/sdist build, checksums, install manifest generation, release artifact drift check, and installer checksum smoke all passed under `artifacts/t19-release/`. |
+| Record validation evidence | Complete | This file records the command evidence and the single coverage-gap iteration. |
+| Update backlog after validation | Complete | `TODO/awf-full-installer-first-run-setup-backlog.md` marks T19 `done - validated locally` and records that the backlog is complete. |
+| Commit local result only | Complete | Prepared for local commit; no push performed. |
+
+## Command Evidence
+
+Dependency check:
+
+```text
+gh pr view 428 --json number,state,mergedAt,mergeCommit,title,url
+state=MERGED, mergeCommit=a071c1644db34ce3c8e576ee0f2704200e4da0bd
+```
+
+Static and drift gates:
+
+```text
+uv run --python 3.12 --extra dev ruff check src/awf tests
+All checks passed!
+
+uv run --python 3.12 --extra dev mypy src/awf
+Success: no issues found in 354 source files
+
+uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check
+OK: openapi.json matches the current app spec.
+```
+
+Standalone unit gate:
+
+```text
+uv run --python 3.12 --extra dev pytest tests/unit -q
+11552 passed, 1 skipped in 3902.08s (1:05:02)
+```
+
+Coverage iteration:
+
+```text
+uv run --python 3.12 --extra dev pytest -n 20 --timeout=300 --cov=awf --cov-report=term-missing --cov-fail-under=99
+11655 passed, 1 skipped in 548.02s (0:09:08)
+Coverage failure: total of 98.99 is less than fail-under=99.00
+```
+
+Root cause: the merged T19 dependency surface left the aggregate just below the
+99% threshold. The uncovered path selected for the required regression was
+`_check_worker_heartbeat`'s stale heartbeat branch in
+`src/awf/api/routes/health.py`, which is real readiness behavior.
+
+Fix evidence:
+
+```text
+uv run --python 3.12 --extra dev pytest tests/unit/api/test_health_parts/test_health_part_001.py::test_worker_heartbeat_check_stale_result_includes_age_and_threshold -q
+1 passed in 0.17s
+
+uv run --python 3.12 --extra dev ruff check tests/unit/api/test_health_parts/test_health_part_001.py
+All checks passed!
+```
+
+Final coverage gate:
+
+```text
+uv run --python 3.12 --extra dev pytest -n 20 --timeout=300 --cov=awf --cov-report=term-missing --cov-fail-under=99
+11656 passed, 1 skipped in 540.14s (0:09:00)
+Required test coverage of 99% reached. Total coverage: 99.00%
+```
+
+CLI and MCP surfaces:
+
+```text
+uv run --python 3.12 --extra dev awf setup --help
+uv run --python 3.12 --extra dev awf start --help
+uv run --python 3.12 --extra dev awf init --help
+uv run --python 3.12 --extra dev awf mcp serve --help
+```
+
+All four help commands exited 0.
+
+MCP setup tool registration:
+
+```text
+MCP setup tools registered: awf_get_client_integration_instructions, awf_get_setup_status, awf_initialize_project_profile, awf_start_local_service
+```
+
+Setup dry-run:
+
+```text
+AWF_API_HOST_PORT=18000 AWF_POSTGRES_HOST_PORT=15433 uv run --python 3.12 --extra dev awf setup --dry-run --source-checkout "$PWD" --format json
+status=success
+summary=AWF setup host readiness checks passed; this machine can run AWF Core.
+source_checkout.root=/home/dmitri-lihhatsov/Projects/aira-agent-workspace-fabric
+```
+
+First-run smoke:
+
+```text
+uv run --python 3.12 --extra dev python scripts/first_run_smoke.py --lane installer-fixture --lane source-uv-run --lane source-tool-install --checkout-root "$PWD"
+PASSED installer-fixture
+PASSED source-uv-run awf --help/setup --help/start --help/setup --dry-run
+PASSED source-tool-install uv tool install plus awf --help/setup --help/start --help/setup --dry-run
+```
+
+Release/package integration:
+
+```text
+uv run --python 3.12 --with build python -m build --outdir artifacts/t19-release/dist
+Successfully built agent_workspace_fabric-0.1.0.tar.gz and agent_workspace_fabric-0.1.0-py3-none-any.whl
+
+sha256sum artifacts/t19-release/dist/* | tee artifacts/t19-release/release/python-distribution-sha256.txt
+1cdbb132a8b307ce014cf76658f17fd48e9d6cf0036ef6a7b20f30d78df8c7c3  artifacts/t19-release/dist/agent_workspace_fabric-0.1.0-py3-none-any.whl
+a83722d7187a92c53945873667991a7687337f57062c74d87bf0b7ff782fdff6  artifacts/t19-release/dist/agent_workspace_fabric-0.1.0.tar.gz
+
+uv run --python 3.12 python scripts/generate_install_manifest.py ...
+OK: wrote artifacts/t19-release/release/awf-install-manifest.json
+
+uv run --python 3.12 python scripts/check_release_artifacts.py ...
+OK: artifacts/t19-release/release/awf-install-manifest.json matches the built distributions
+
+uv run --no-project --python 3.12 python scripts/release_smoke.py ... --run
+Checksum verified for agent_workspace_fabric-0.1.0-py3-none-any.whl.
+Dry run complete; no changes were made.
+```
+
+## Gaps
+
+None.
+
+## Notes
+
+- The first setup dry-run with default ports correctly returned
+  `SETUP_READINESS_FAILED` because the live local AWF stack was already using
+  API port 8000 and Postgres port 5433. The rerun with alternate free ports
+  proves source-checkout readiness without stopping the running stack.
+- The standalone unit suite was run before adding the coverage top-up test. The
+  added test passed directly, and the final all-tests coverage run included it
+  and passed, so the final test state is covered by the green coverage gate.

--- a/plans/UV_CLEAN_INSTALL_SMOKE_PLAN.md
+++ b/plans/UV_CLEAN_INSTALL_SMOKE_PLAN.md
@@ -1,0 +1,26 @@
+# UV Clean Install Smoke Plan
+
+## Summary
+
+Replace the skip-prone `python -m venv` + `pip install` clean wheel smoke with
+the same `uv venv` + `uv pip install --python` pattern used by the CI
+release-artifacts wheel smoke. This preserves the clean package-artifact guard
+without requiring Debian/Ubuntu's `python3.12-venv` / `ensurepip` package.
+
+## Implementation
+
+- Rename the clean install test to make the `uv` install lane explicit.
+- Create the temp environment with `uv venv --python 3.12 <tmp>/venv`.
+- Install the built wheel with `uv pip install --python <venv>/bin/python <wheel>`.
+- Run the installed `<venv>/bin/awf` help commands from outside the checkout.
+- Preserve provenance verification by importing `awf` from the temp environment.
+- Keep environmental skips for missing `uv`, unavailable Python setup, or
+  dependency fetch/cache failures.
+- Keep non-environmental wheel install failures as test failures.
+
+## Validation
+
+- Target the renamed clean install smoke directly.
+- Run the full clean install smoke module.
+- Run ruff on touched test/helper files.
+- Rerun the full coverage suite with `-n 20`.

--- a/plans/UV_CLEAN_INSTALL_SMOKE_VALIDATION.md
+++ b/plans/UV_CLEAN_INSTALL_SMOKE_VALIDATION.md
@@ -1,0 +1,54 @@
+# UV Clean Install Smoke Validation
+
+## Result
+
+Complete. The clean install smoke now uses `uv venv` plus
+`uv pip install --python` instead of `python -m venv` plus `pip install`, so it
+does not depend on stdlib `ensurepip` / the Debian `python3.12-venv` package.
+
+## Evidence
+
+The targeted smoke that previously skipped now passes locally:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_clean_install_smoke.py::test_uv_venv_install_help -rs -vv
+```
+
+Passed: `1 passed`.
+
+The full clean install smoke module passes without skips:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/cli/test_clean_install_smoke.py -q
+```
+
+Passed: `2 passed`.
+
+Touched-file lint passed:
+
+```bash
+uv run --python 3.12 --extra dev ruff check tests/unit/cli/test_clean_install_smoke.py tests/packaging_build.py
+```
+
+Full lint passed:
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf tests
+```
+
+Full coverage passed:
+
+```bash
+uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing
+```
+
+Passed: `11674 passed`; required coverage `99.0%` reached with `99.01%`
+total coverage.
+
+## Notes
+
+Environmental skips remain possible when `uv` is missing or dependency
+resolution cannot fetch/cache runtime dependencies. Non-environmental wheel
+install failures still fail loudly so malformed metadata, incompatible
+`Requires-Python`, malformed archives, or missing `awf` entry points remain
+package-artifact regressions.

--- a/src/awf/cli/start_commands.py
+++ b/src/awf/cli/start_commands.py
@@ -83,6 +83,18 @@ def start_command(
         "--skip-agent-runtime-build",
         help="Skip building the AWF agent-runtime image for a faster restart.",
     ),
+    headless: bool = typer.Option(
+        False,
+        "--headless",
+        help="Skip starting the local web console.",
+    ),
+    console_port: int | None = typer.Option(
+        None,
+        "--console-port",
+        min=1,
+        max=65535,
+        help="Publish the local web console on this host port.",
+    ),
     timeout_seconds: float = typer.Option(
         _DEFAULT_START_TIMEOUT_SECONDS,
         "--timeout-seconds",
@@ -111,6 +123,13 @@ def start_command(
             err=True,
         )
         raise typer.Exit(code=2)
+    if headless and console_port is not None:
+        typer.echo(
+            "error: --headless cannot be combined with --console-port; "
+            "choose headless startup or a console port override.",
+            err=True,
+        )
+        raise typer.Exit(code=2)
 
     from awf.host_setup.source_assets import SourceCheckoutError
     from awf.service.bootstrap import (
@@ -125,11 +144,12 @@ def start_command(
         _render_start_payload(_source_checkout_failure_payload(exc), fmt, success=False)
         raise typer.Exit(code=1) from None
 
-    inputs = _resolve_start_bootstrap_inputs(verified)
+    inputs = _resolve_start_bootstrap_inputs(verified, console_port=console_port)
     options = ServiceBootstrapOptions(
         timeout_seconds=timeout_seconds,
         skip_agent_runtime_build=skip_agent_runtime_build,
         force_rebuild=rebuild,
+        start_console=not headless,
     )
     try:
         result = asyncio.run(
@@ -157,6 +177,7 @@ def start_command(
             inputs.settings,
             result,
             env_migration=inputs.env_migration,
+            console_enabled=not headless,
         ),
         fmt,
         success=True,
@@ -193,6 +214,8 @@ def _resolve_start_source_checkout(source_checkout: Path | None) -> VerifiedSour
 
 def _resolve_start_bootstrap_inputs(
     verified: VerifiedSourceCheckout | None,
+    *,
+    console_port: int | None = None,
 ) -> _StartBootstrapInputs:
     """Resolve compose paths, env files, and settings for one bootstrap run."""
     from awf.common.config import Settings
@@ -227,6 +250,8 @@ def _resolve_start_bootstrap_inputs(
         asset_root = None
 
     service_env = local_service_environ(env_file=read_env_file)
+    if console_port is not None:
+        service_env["AWF_CONSOLE_HOST_PORT"] = str(console_port)
     settings = resolve_service_settings(
         Settings(_env_file=read_env_file),
         environ=service_env,
@@ -254,6 +279,7 @@ def _start_success_payload(
     result: ServiceBootstrapResult,
     *,
     env_migration: object | None = None,
+    console_enabled: bool = True,
 ) -> FirstRunPayload:
     """Build the operator success panel from resolved settings and bootstrap result."""
     from awf.service.smoke import DEFAULT_LOCAL_CONSOLE_URL
@@ -262,30 +288,32 @@ def _start_success_payload(
     checks = service_status.get("checks")
     docker_check = checks.get("docker") if isinstance(checks, Mapping) else None
     api_url = _normalize_local_url(str(settings.api_base_url))
-    console_url = _normalize_local_url(str(settings.console_url or DEFAULT_LOCAL_CONSOLE_URL))
     details: dict[str, Any] = {
         "api_url": api_url,
-        "console_url": console_url,
         "docker": _docker_summary(docker_check),
         "providers": _providers_summary(service_status.get("agent_readiness")),
         "health": service_status.get("status", "unknown"),
     }
+    console_url = _normalize_local_url(str(settings.console_url or DEFAULT_LOCAL_CONSOLE_URL))
+    if console_enabled:
+        details["console_url"] = console_url
     if (migration_details := _env_migration_details(env_migration)) is not None:
         details["env_migration"] = migration_details
-    next_steps = (
+    next_steps = [
         # Lead with the provider-free local health proof: a skeptic can verify
         # local Core health without handing AWF GitHub/PR authority or a token.
         "Run awf smoke run --mocked-local to prove local AWF Core health "
         "without provider credentials or GitHub access.",
         "Run awf init <path> to onboard a project repository.",
         "Run awf service status --format pretty to inspect local Core health.",
-        f"Open the console at {console_url} to use the local UI.",
-    )
+    ]
+    if console_enabled:
+        next_steps.append(f"Open the console at {console_url} to use the local UI.")
     return first_run_success_payload(
         command="awf start",
         summary="Local AWF Core is running.",
         details=details,
-        next_steps=next_steps,
+        next_steps=tuple(next_steps),
     )
 
 

--- a/src/awf/service/bootstrap.py
+++ b/src/awf/service/bootstrap.py
@@ -136,6 +136,7 @@ class ServiceBootstrapOptions:
     poll_interval_seconds: float = DEFAULT_BOOTSTRAP_POLL_INTERVAL_SECONDS
     skip_agent_runtime_build: bool = False
     force_rebuild: bool = False
+    start_console: bool = False
     strict_providers: frozenset[str] = field(default_factory=frozenset)
 
 
@@ -932,6 +933,13 @@ def _bootstrap_stages(
             ),
         ]
     )
+    if options.start_console:
+        stages.append(
+            _BootstrapStage(
+                "console",
+                (*compose, "up", "-d", "--build", "--no-deps", "console"),
+            )
+        )
     return tuple(stages)
 
 

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -212,6 +212,12 @@ def resolve_service_settings(
         require_init_field=environ is not None,
         project_dotenv_lookup=project_dotenv_lookup,
     )
+    console_url = _resolve_service_console_url(
+        settings,
+        env,
+        service_env,
+        require_init_field=environ is not None,
+    )
     work_dir = _resolve_service_work_dir(settings, service_env, host_environ=env)
     validate_production_settings(settings, database_url=database_url)
 
@@ -219,7 +225,7 @@ def resolve_service_settings(
         service_name=settings.service_name,
         env=settings.env,
         api_base_url=api_base_url,
-        console_url=settings.console_url,
+        console_url=console_url,
         database_url=database_url,
         docker_host=settings.docker_host,
         agent_runtime_image=settings.agent_runtime_image,
@@ -554,6 +560,39 @@ def _default_local_service_api_base_url(environ: Mapping[str, str]) -> str:
     return f"http://localhost:{parsed_port}"
 
 
+def _resolve_service_console_url(
+    settings: Settings,
+    environ: Mapping[str, str],
+    service_environ: Mapping[str, str],
+    *,
+    require_init_field: bool = False,
+) -> str | None:
+    """Return the operator-facing console URL for local service displays."""
+
+    host_console_url = _empty_to_none(_env_value(environ, "AWF_CONSOLE_URL"))
+    if host_console_url is not None:
+        return host_console_url
+    if _settings_console_url_is_explicit(
+        settings,
+        require_init_field=require_init_field,
+    ):
+        return settings.console_url
+    service_console_url = _empty_to_none(_env_value(service_environ, "AWF_CONSOLE_URL"))
+    if service_console_url is not None:
+        return service_console_url
+    return _default_local_service_console_url(service_environ)
+
+
+def _default_local_service_console_url(environ: Mapping[str, str]) -> str | None:
+    """Return the local console URL matching existing Compose port overrides."""
+
+    host_port = _env_value(environ, "AWF_CONSOLE_HOST_PORT")
+    if not host_port:
+        return None
+    parsed_port = _parse_host_port("AWF_CONSOLE_HOST_PORT", host_port)
+    return f"http://localhost:{parsed_port}"
+
+
 def _parse_host_port(env_key: str, value: str) -> int:
     """Parse a Compose host port override into a TCP port number."""
 
@@ -580,6 +619,20 @@ def _settings_api_base_url_is_explicit(
     if require_init_field or "api_base_url" not in settings.model_fields_set:
         return False
     return _api_base_url_is_explicit(settings.api_base_url, environ)
+
+
+def _settings_console_url_is_explicit(
+    settings: Settings,
+    *,
+    require_init_field: bool = False,
+) -> bool:
+    """Return true when settings carries an explicitly configured console URL."""
+
+    if "console_url" in _settings_init_fields(settings):
+        return True
+    if require_init_field or "console_url" not in settings.model_fields_set:
+        return False
+    return settings.console_url is not None
 
 
 def _api_base_url_is_explicit(api_base_url: str, environ: Mapping[str, str]) -> bool:

--- a/tests/packaging_build.py
+++ b/tests/packaging_build.py
@@ -91,12 +91,13 @@ def _build_failure_is_environmental(output: str) -> bool:
     return any(signature in lowered for signature in _BUILD_ENV_UNAVAILABLE_SIGNATURES)
 
 
-# Substrings in a nonzero ``pip install <wheel>`` output that mark the failure as
-# an offline dependency-fetch problem (pip cannot reach an index to resolve the
+# Substrings in a nonzero wheel-install output that mark the failure as an
+# offline dependency-fetch problem (uv/pip cannot reach an index to resolve the
 # wheel's runtime dependencies) rather than a real regression in the local wheel
-# artifact itself. ``pip`` installs the explicitly-passed local archive directly,
-# so a bad wheel (invalid metadata, incompatible Requires-Python, malformed
-# archive) fails with artifact-specific text that contains none of these.
+# artifact itself. The installer handles the explicitly-passed local archive
+# directly, so a bad wheel (invalid metadata, incompatible Requires-Python,
+# malformed archive) fails with artifact-specific text that contains none of
+# these.
 #
 # Kept strictly transport/DNS/connection-focused on purpose. pip's terminal
 # resolver-miss messages ("could not find a version that satisfies the
@@ -133,10 +134,11 @@ _INSTALL_ENV_UNAVAILABLE_SIGNATURES = (
 
 
 def install_failure_is_environmental(output: str) -> bool:
-    """Return ``True`` when a nonzero ``pip install <wheel>`` looks like an offline
-    dependency-fetch problem rather than a regression in the wheel artifact itself.
+    """Return ``True`` when a nonzero wheel install looks like an offline
+    dependency-fetch problem rather than a regression in the wheel artifact
+    itself.
 
-    The clean-install smoke test (``test_clean_venv_install_help``) skips on
+    The clean-install smoke test (``test_uv_venv_install_help``) skips on
     environmental failures so the unit suite stays robust without network, but
     fails loudly on anything else — invalid wheel metadata, an incompatible
     Requires-Python, or a malformed archive — to preserve the package-artifact

--- a/tests/unit/api/test_health_parts/test_health_part_001.py
+++ b/tests/unit/api/test_health_parts/test_health_part_001.py
@@ -485,6 +485,40 @@ async def test_worker_heartbeat_check_query_failure_is_redacted(
 
 
 @pytest.mark.unit
+async def test_worker_heartbeat_check_stale_result_includes_age_and_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _Session:
+        async def close(self) -> None:
+            return None
+
+    class _StaleWorkerHeartbeatRepository:
+        def __init__(self, _session: _Session) -> None:
+            pass
+
+        async def latest_for_node(self, *, node_id: str) -> SimpleNamespace:
+            assert node_id == "local"
+            return SimpleNamespace(
+                last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=60),
+                poll_interval_seconds=1.0,
+            )
+
+    monkeypatch.setattr(
+        health_route,
+        "WorkerHeartbeatRepository",
+        _StaleWorkerHeartbeatRepository,
+    )
+
+    result = await health_route._check_worker_heartbeat(lambda: _Session(), node_id="local")
+
+    assert result.ok is False
+    assert result.status == "fail"
+    assert result.reason == "WORKER_HEARTBEAT_STALE"
+    assert "Latest worker heartbeat is" in (result.detail or "")
+    assert "stale after" in (result.detail or "")
+
+
+@pytest.mark.unit
 async def test_readyz_egress_audit_returns_posture_counts(
     ready_app_and_client: tuple[Any, AsyncClient],
     engine: AsyncEngine,

--- a/tests/unit/cli/test_clean_install_smoke.py
+++ b/tests/unit/cli/test_clean_install_smoke.py
@@ -5,7 +5,7 @@ commands in a subprocess whose import path puts the extracted wheel first and
 drops the editable repo ``src`` — proving the packaged ``awf`` runs from outside
 the checkout without repo-relative files. It works offline (runtime deps resolve
 from the current interpreter). A second, best-effort test performs a real
-``python -m venv`` + ``pip install`` of the wheel: it skips only when its
+``uv venv`` + ``uv pip install`` of the wheel: it skips only when its
 dependencies cannot be fetched offline, but fails on a real wheel-artifact
 regression (invalid metadata, incompatible Requires-Python, malformed archive);
 CI (with network) runs it fully. The exhaustive install-lane matrix is owned by
@@ -15,6 +15,7 @@ T14.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -74,6 +75,15 @@ print({_SUCCESS_MARKER!r})
 """
 
 
+def _combined_output(result: subprocess.CompletedProcess[str]) -> str:
+    return "\n".join(part for part in (result.stderr, result.stdout) if part)
+
+
+def _output_tail(result: subprocess.CompletedProcess[str], *, length: int = 600) -> str:
+    combined = _combined_output(result).strip()
+    return combined[-length:] if combined else "<no subprocess output>"
+
+
 @pytest.fixture(scope="module")
 def built() -> BuiltDistributions:
     """Build the wheel once for this module, skipping if unavailable."""
@@ -115,27 +125,32 @@ def test_extracted_wheel_help_runs_outside_checkout(
     assert _SUCCESS_MARKER in result.stdout
 
 
-def test_clean_venv_install_help(built: BuiltDistributions, tmp_path: Path) -> None:
-    """A real venv install of the wheel exposes a working ``awf --help`` (CI lane).
+def test_uv_venv_install_help(built: BuiltDistributions, tmp_path: Path) -> None:
+    """A real uv-managed venv install exposes a working ``awf --help`` (CI lane).
 
-    Skips when ``python -m venv`` is unavailable or when the wheel's dependencies
-    cannot be fetched offline, keeping the unit suite robust; but a non-environmental
-    install failure (a regression in the wheel artifact itself) fails the test so
-    the package guard is preserved. CI with network runs the full install.
+    Skips when ``uv``/Python setup is unavailable or when the wheel's
+    dependencies cannot be fetched offline, keeping the unit suite robust; but a
+    non-environmental install failure (a regression in the wheel artifact
+    itself) fails the test so the package guard is preserved. CI with network
+    runs the full install.
     """
+    uv = shutil.which("uv")
+    if uv is None:  # pragma: no cover - env dependent
+        pytest.skip("uv is not available for the clean wheel install smoke")
+
     venv_dir = tmp_path / "venv"
     try:
         create = subprocess.run(
-            [sys.executable, "-m", "venv", str(venv_dir)],
+            [uv, "venv", "--python", "3.12", str(venv_dir)],
             check=False,
             capture_output=True,
             text=True,
             timeout=120,
         )
     except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - env dependent
-        pytest.skip(f"python -m venv could not run: {exc}")
+        pytest.skip(f"uv venv could not run: {exc}")
     if create.returncode != 0:  # pragma: no cover - env dependent
-        pytest.skip(f"python -m venv unavailable: {create.stderr.strip()}")
+        pytest.skip(f"uv venv unavailable: {_output_tail(create)}")
 
     venv_python = venv_dir / "bin" / "python"
     venv_awf = venv_dir / "bin" / "awf"
@@ -144,36 +159,35 @@ def test_clean_venv_install_help(built: BuiltDistributions, tmp_path: Path) -> N
 
     try:
         install = subprocess.run(
-            [str(venv_python), "-m", "pip", "install", str(built.wheel)],
+            [uv, "pip", "install", "--python", str(venv_python), str(built.wheel)],
             check=False,
             capture_output=True,
             text=True,
             timeout=600,
         )
-    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - network dependent
-        pytest.skip(f"wheel install could not run (no network/pip): {exc}")
+    except (OSError, subprocess.SubprocessError) as exc:  # pragma: no cover - env dependent
+        pytest.skip(f"uv wheel install could not run: {exc}")
     if install.returncode != 0:  # pragma: no cover - depends on offline vs regression outcome
-        combined = "\n".join(part for part in (install.stderr, install.stdout) if part)
+        combined = _combined_output(install)
         if install_failure_is_environmental(combined):
             pytest.skip(
-                "wheel install with dependencies unavailable offline: "
-                + (install.stderr[-300:] or install.stdout[-300:])
+                "uv wheel install with dependencies unavailable offline: " + _output_tail(install)
             )
-        # pip processed the local wheel but the install failed for a
+        # uv processed the local wheel but the install failed for a
         # non-environmental reason — invalid wheel metadata, an incompatible
         # Requires-Python, or a malformed archive. Fail loudly so the
         # package-artifact guard catches the regression instead of reporting
         # skipped (PRRT_kwDOSJAM6s6F-8ys).
-        pytest.fail(f"wheel install failed for a non-environmental reason:\n{combined[-1000:]}")
+        pytest.fail(f"uv wheel install failed for a non-environmental reason:\n{combined[-1000:]}")
 
     if not venv_awf.exists():  # pragma: no cover - wheel entry-point regression
-        # pip install succeeded but the ``awf`` console script is absent (e.g. a
+        # uv install succeeded but the ``awf`` console script is absent (e.g. a
         # malformed ``entry_points.txt`` in the wheel). Fail with a diagnostic
         # message rather than letting the subprocess call below raise a bare
         # FileNotFoundError — a missing entry point on this POSIX layout is a
         # real wheel-artifact regression the package guard must surface.
         pytest.fail(
-            f"pip install succeeded but the 'awf' console script is missing at {venv_awf}; "
+            f"uv install succeeded but the 'awf' console script is missing at {venv_awf}; "
             "the wheel's entry-point metadata is malformed."
         )
 

--- a/tests/unit/cli/test_start_commands.py
+++ b/tests/unit/cli/test_start_commands.py
@@ -141,6 +141,8 @@ def test_start_help_advertises_options_and_local_core() -> None:
     for flag in (
         "--rebuild",
         "--skip-agent-runtime-build",
+        "--headless",
+        "--console-port",
         "--timeout-seconds",
         "--source-checkout",
         "--format",
@@ -196,9 +198,67 @@ def test_start_maps_flags_to_bootstrap_options(
     options = records[0]["options"]
     assert options.skip_agent_runtime_build is expected["skip_agent_runtime_build"]
     assert options.force_rebuild is expected["force_rebuild"]
+    assert options.start_console is True
     assert options.timeout_seconds == 12
     # Default discovery: no explicit asset root.
     assert records[0]["asset_root"] is None
+
+
+@pytest.mark.unit
+def test_start_headless_skips_console_bootstrap_and_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--headless` does not start the console or print console-open guidance."""
+    records: list[dict[str, object]] = []
+    _patch_start_wiring(monkeypatch, records=records, result=_success_result())
+
+    result = _runner.invoke(app, ["start", "--headless", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    options = records[0]["options"]
+    assert options.start_console is False
+    payload = json.loads(result.stdout)
+    assert "console_url" not in payload["details"]
+    assert all("Open the console" not in step for step in payload["next_steps"])
+
+
+@pytest.mark.unit
+def test_start_console_port_override_updates_bootstrap_env_and_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`--console-port` publishes the console on that host port and reports it."""
+    records: list[dict[str, object]] = []
+    _patch_start_wiring(monkeypatch, records=records, result=_success_result())
+
+    def _resolve_settings(_base: object, *, environ: dict[str, str]) -> object:
+        return SimpleNamespace(
+            api_base_url="http://localhost:8000",
+            console_url=f"http://localhost:{environ['AWF_CONSOLE_HOST_PORT']}",
+        )
+
+    monkeypatch.setattr("awf.service.config.resolve_service_settings", _resolve_settings)
+
+    result = _runner.invoke(app, ["start", "--console-port", "3333", "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    assert records[0]["service_environ"]["AWF_CONSOLE_HOST_PORT"] == "3333"
+    assert records[0]["options"].start_console is True
+    payload = json.loads(result.stdout)
+    assert payload["details"]["console_url"] == "http://127.0.0.1:3333"
+
+
+@pytest.mark.unit
+def test_start_headless_conflicts_with_console_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`--headless` plus `--console-port` exits 2 without bootstrapping."""
+    records: list[dict[str, object]] = []
+    _patch_start_wiring(monkeypatch, records=records, result=_success_result())
+
+    result = _runner.invoke(app, ["start", "--headless", "--console-port", "3333"])
+
+    assert result.exit_code == 2
+    assert "--headless" in result.stderr
+    assert "--console-port" in result.stderr
+    assert records == []
 
 
 @pytest.mark.unit
@@ -648,6 +708,14 @@ def test_start_success_payload_leads_with_provider_free_proof() -> None:
     # The existing onboarding/console guidance is preserved after the proof.
     joined = "\n".join(next_steps)
     assert "awf init" in joined
+
+
+@pytest.mark.unit
+def test_env_migration_details_ignores_non_callable_to_dict() -> None:
+    """Env migration metadata is included only for callable to_dict providers."""
+    migration = SimpleNamespace(to_dict={"path": ".env"})
+
+    assert start_commands._env_migration_details(migration) is None  # noqa: SLF001
 
 
 @pytest.mark.unit

--- a/tests/unit/docs/test_public_docs_status.py
+++ b/tests/unit/docs/test_public_docs_status.py
@@ -152,7 +152,7 @@ def test_raw_docker_compose_source_path_is_single_command() -> None:
                 "For source checkouts or raw Docker installs",
                 maxsplit=1,
             )[1].split("If ", maxsplit=1)[0]
-        assert "docker compose up --build" in section, doc_name
+        assert "docker compose up -d --build" in section, doc_name
         assert "cp .env.example .env" not in section, doc_name
         assert "docker build -t awf-agent-runtime:latest" not in section, doc_name
         assert "127.0.0.1:3000" in section, doc_name

--- a/tests/unit/installer/test_install_sh_install.py
+++ b/tests/unit/installer/test_install_sh_install.py
@@ -183,6 +183,26 @@ def test_default_install_accepts_uppercase_tag_style_path_awf_version(
 
 
 @pytest.mark.unit
+def test_successful_install_prints_first_run_next_steps(harness: InstallerHarness) -> None:
+    """A successful install tells a first-time user exactly what to run next."""
+    harness.add_uname("Linux", "x86_64")
+    harness.add_uv()
+    harness.add_awf()
+    wheel, digest = harness.write_wheel()
+    manifest = harness.write_manifest(wheel=wheel, sha256=digest)
+
+    result = harness.run([], manifest=manifest)
+
+    assert result.returncode == 0, result.stderr
+    assert "Installed agent-workspace-fabric" in result.stdout
+    assert "Next steps:" in result.stdout
+    assert "awf setup" in result.stdout
+    assert "awf start" in result.stdout
+    assert "awf init <path>" in result.stdout
+    assert "docs/QUICKSTART.md" in result.stdout
+
+
+@pytest.mark.unit
 def test_default_install_bin_off_path_is_reachable_with_advice(
     harness: InstallerHarness,
 ) -> None:

--- a/tests/unit/service/test_bootstrap_parts/test_bootstrap_part_003.py
+++ b/tests/unit/service/test_bootstrap_parts/test_bootstrap_part_003.py
@@ -235,6 +235,60 @@ def test_force_rebuild_skipped_when_agent_runtime_build_skipped(tmp_path: Path) 
 
 
 @pytest.mark.unit
+def test_bootstrap_stages_do_not_start_console_by_default(tmp_path: Path) -> None:
+    """The lower-level bootstrap contract does not start the console unless asked."""
+    root = _write_source_checkout(tmp_path / "pinned-checkout")
+    assets = bootstrap._resolve_bootstrap_assets(  # noqa: SLF001
+        bootstrap.LOCAL_SERVICE_COMPOSE_FILE,
+        require_agent_runtime=False,
+        asset_root=root,
+    )
+
+    stages = bootstrap._bootstrap_stages(  # noqa: SLF001
+        _settings(tmp_path),
+        options=ServiceBootstrapOptions(skip_agent_runtime_build=True),
+        compose_file=bootstrap.LOCAL_SERVICE_COMPOSE_FILE,
+        assets=assets,
+    )
+
+    assert [stage.name for stage in stages] == ["postgres", "migrate", "api_worker"]
+
+
+@pytest.mark.unit
+def test_bootstrap_stages_start_console_when_requested(tmp_path: Path) -> None:
+    """start_console=True appends a console Compose stage after API/worker startup."""
+    root = _write_source_checkout(tmp_path / "pinned-checkout")
+    assets = bootstrap._resolve_bootstrap_assets(  # noqa: SLF001
+        bootstrap.LOCAL_SERVICE_COMPOSE_FILE,
+        require_agent_runtime=False,
+        asset_root=root,
+    )
+
+    stages = bootstrap._bootstrap_stages(  # noqa: SLF001
+        _settings(tmp_path),
+        options=ServiceBootstrapOptions(
+            skip_agent_runtime_build=True,
+            start_console=True,
+        ),
+        compose_file=bootstrap.LOCAL_SERVICE_COMPOSE_FILE,
+        assets=assets,
+    )
+
+    assert [stage.name for stage in stages] == ["postgres", "migrate", "api_worker", "console"]
+    assert stages[-1].command == (
+        "docker",
+        "compose",
+        "-f",
+        str(root / "compose.yaml"),
+        "up",
+        "-d",
+        "--build",
+        "--no-deps",
+        "console",
+    )
+
+
+@pytest.mark.unit
 def test_run_service_bootstrap_pins_root_and_forces_rebuild(tmp_path: Path) -> None:
     """End-to-end: pinned root + force_rebuild issues the expected docker commands."""
     root = _write_source_checkout(tmp_path / "pinned-checkout")

--- a/tests/unit/service/test_config_parts/test_config_part_001.py
+++ b/tests/unit/service/test_config_parts/test_config_part_001.py
@@ -874,6 +874,60 @@ def test_service_settings_default_api_base_url_uses_api_host_port_override() -> 
 
 
 @pytest.mark.unit
+def test_service_settings_default_console_url_uses_console_host_port_override() -> None:
+    settings = resolve_service_settings(
+        Settings(_env_file=None),
+        environ={"AWF_CONSOLE_HOST_PORT": "3333"},
+    )
+
+    assert settings.console_url == "http://localhost:3333"
+
+
+@pytest.mark.unit
+def test_service_settings_host_console_url_wins_over_console_host_port_override() -> None:
+    settings = resolve_service_settings(
+        Settings(_env_file=None),
+        environ={
+            "AWF_CONSOLE_URL": "https://console.host.example",
+            "AWF_CONSOLE_HOST_PORT": "3333",
+        },
+    )
+
+    assert settings.console_url == "https://console.host.example"
+
+
+@pytest.mark.unit
+def test_resolve_service_console_url_uses_service_environment_url() -> None:
+    console_url = service_config._resolve_service_console_url(  # noqa: SLF001
+        Settings(_env_file=None),
+        environ={},
+        service_environ={"AWF_CONSOLE_URL": "https://console.compose.example"},
+    )
+
+    assert console_url == "https://console.compose.example"
+
+
+@pytest.mark.unit
+def test_service_settings_explicit_console_url_ignores_console_host_port_override() -> None:
+    settings = resolve_service_settings(
+        Settings(_env_file=None, console_url="https://console.example.test"),
+        environ={"AWF_CONSOLE_HOST_PORT": "3333"},
+    )
+
+    assert settings.console_url == "https://console.example.test"
+
+
+@pytest.mark.unit
+def test_settings_console_url_is_explicit_for_environment_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWF_CONSOLE_URL", "https://console.env.example")
+    settings = Settings(_env_file=None)
+
+    assert service_config._settings_console_url_is_explicit(settings)  # noqa: SLF001
+
+
+@pytest.mark.unit
 def test_service_settings_default_api_base_url_ignores_operator_base_url() -> None:
     """Do not let AWF_BASE_URL override service-side API base URL defaults."""
     settings = resolve_service_settings(
@@ -1026,6 +1080,21 @@ def test_service_settings_rejects_invalid_api_host_port(host_port: str) -> None:
 
     message = str(exc_info.value)
     assert "AWF_API_HOST_PORT" in message
+    assert repr(host_port) in message
+    assert "integer between 1 and 65535" in message
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("host_port", ["not-a-port", "0", "65536"])
+def test_service_settings_rejects_invalid_console_host_port(host_port: str) -> None:
+    with pytest.raises(ValueError) as exc_info:
+        resolve_service_settings(
+            Settings(_env_file=None),
+            environ={"AWF_CONSOLE_HOST_PORT": host_port},
+        )
+
+    message = str(exc_info.value)
+    assert "AWF_CONSOLE_HOST_PORT" in message
     assert repr(host_port) in message
     assert "integer between 1 and 65535" in message
 


### PR DESCRIPTION
## Summary

- complete T19 final integration validation and backlog status updates
- make `awf start` launch the local console by default with `--headless` and `--console-port` overrides
- document the direct install and Docker Compose first-run paths
- switch the clean-install smoke test from stdlib `venv`/`pip` to `uv venv` plus `uv pip install`

## Validation

- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_clean_install_smoke.py::test_uv_venv_install_help -rs -vv`
- `uv run --python 3.12 --extra dev pytest tests/unit/cli/test_clean_install_smoke.py -q`
- `uv run --python 3.12 --extra dev ruff check src/awf tests`
- `uv run --python 3.12 --extra dev pytest -n 20 --cov=awf --cov-report=term-missing`

Full coverage result: `11674 passed`, total coverage `99.01%`, required `99.0%` reached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes local bootstrap behavior (`awf start` now starts the console Compose service) and service URL resolution from `AWF_CONSOLE_HOST_PORT`, which can affect port conflicts and operator scripts that assumed API-only startup.
> 
> **Overview**
> **`awf start` now brings up the local web console by default**, aligned with the detached `docker compose up -d --build` first-run path. New flags are **`--headless`** (skip the console) and **`--console-port`** (host port override); incompatible combinations exit before bootstrap. `awf start` passes `ServiceBootstrapOptions(start_console=True)` while lower-level **`awf service bootstrap` stays opt-in** (`start_console` defaults to `False`). Console URL resolution derives from **`AWF_CONSOLE_HOST_PORT`** when no explicit `AWF_CONSOLE_URL` is set; headless success output omits console URL and “open console” next steps.
> 
> **First-run docs and installer polish:** README, Quickstart, CLI reference, smoke docs, and related drift tests document default console startup and update raw Compose examples to **`docker compose up -d --build`**. **`install.sh`** prints post-install next steps (`awf setup`, `awf start`, `awf init`) plus a Quickstart link.
> 
> **T19 closure and test hardening:** Backlog marks **T19/T21 complete** with validation evidence in new plan/validation markdown. Clean-install smoke switches from **`python -m venv` + pip** to **`uv venv` + `uv pip install`**. A small **stale worker heartbeat** health test tops coverage back to the 99% gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46487dda04d08042bd6b66084e31123766105321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `awf start` now launches the local web console at `http://127.0.0.1:3000` by default
  * Added `--headless` flag to skip console startup
  * Added `--console-port` flag to customize the console port

* **Documentation**
  * Updated installation and getting started guides with console behavior and control options
  * Clarified Docker Compose examples to run in detached mode

* **Improvements**
  * Installer now provides first-run next steps guidance after successful installation
  * Enhanced console URL resolution for flexible local development setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->