### PR TITLE
Console cancel workspace operator control

### DIFF
--- a/apps/console/app/api/operator/workspaces/[workspaceId]/cancel/route.ts
+++ b/apps/console/app/api/operator/workspaces/[workspaceId]/cancel/route.ts
@@ -1,0 +1,13 @@
+import { handleWorkspaceControlRoute } from "@/lib/workspace-control-routes";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ workspaceId: string }>;
+};
+
+export async function POST(request: Request, context: RouteContext) {
+  const { workspaceId } = await context.params;
+  return handleWorkspaceControlRoute("cancel", workspaceId, request);
+}

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -605,6 +605,8 @@ export function operatorActionReason(action: WorkspaceOperatorAction): string {
       return "operator console refresh";
     case "revalidate":
       return "operator console revalidate";
+    case "cancel":
+      return "operator console cancel";
     default:
       return "operator console";
   }

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -3,6 +3,7 @@
 import {
 Activity,
 AlertCircle,
+Ban,
 CheckCircle2,
 FileText,
 Loader2,
@@ -11,7 +12,8 @@ RefreshCw,
 X
 } from "lucide-react";
 import {
-useLayoutEffect
+useLayoutEffect,
+useState
 } from "react";
 
 import { formatAgentEffort,formatAgentLabel } from "@/lib/agent-format";
@@ -289,6 +291,7 @@ export function WorkspaceSummary({
         <OperatorControlsBlock
           controls={operatorControls}
           state={operatorActionState}
+          workspaceId={overview.workspace_id}
           onAction={onOperatorAction}
         />
         <UsageSummaryBlock
@@ -460,12 +463,15 @@ export function WorkspaceRecoveryBlock({
 export function OperatorControlsBlock({
   controls,
   state,
+  workspaceId,
   onAction,
 }: {
   controls: WorkspaceOperatorControl[];
   state: OperatorActionState;
+  workspaceId: string;
   onAction: (action: WorkspaceOperatorAction, requestedTier?: number) => void;
 }) {
+  const [confirming, setConfirming] = useState<WorkspaceOperatorAction | null>(null);
   const visibleControls = controls.filter((control) => control.visible);
   if (visibleControls.length === 0) {
     return null;
@@ -487,14 +493,20 @@ export function OperatorControlsBlock({
           const submitting = submittingAction === control.action;
           const disabled = busy || !control.enabled;
           const reason = busy && !submitting ? "operation active" : control.reason;
+          const destructive = control.action === "cancel";
+          const buttonClassName = destructive
+            ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+            : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";
           return (
             <div key={control.action} className="flex min-w-0 items-center gap-1.5">
               <button
                 type="button"
-                onClick={() => onAction(control.action, control.requestedTier)}
+                onClick={() =>
+                  destructive ? setConfirming(control.action) : onAction(control.action, control.requestedTier)
+                }
                 disabled={disabled}
                 title={reason ? `${control.label}: ${reason}` : control.label}
-                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50"
+                className={buttonClassName}
               >
                 <OperatorControlIcon action={control.action} spinning={submitting} />
                 {control.label}
@@ -504,6 +516,36 @@ export function OperatorControlsBlock({
           );
         })}
       </div>
+      {confirming === "cancel" ? (
+        <div
+          data-testid="operator-cancel-confirm"
+          className="grid gap-2 rounded-md border border-red-200 bg-red-50 px-2 py-1.5 text-red-900"
+        >
+          <span className="min-w-0 break-words">
+            Cancel workspace <span className="mono">{workspaceId}</span>? This stops its stack and ends the run.
+          </span>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                onAction("cancel");
+                setConfirming(null);
+              }}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-red-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-red-700"
+            >
+              <Ban size={13} aria-hidden />
+              Confirm cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirming(null)}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
       {state.status === "success" ? (
         <div className="rounded-md border border-emerald-200 bg-emerald-50 px-2 py-1.5 text-emerald-900">
           <span>{state.message}</span>
@@ -544,6 +586,9 @@ export function OperatorControlIcon({
   }
   if (action === "refresh") {
     return <RefreshCw size={13} aria-hidden />;
+  }
+  if (action === "cancel") {
+    return <Ban size={13} aria-hidden />;
   }
   return <CheckCircle2 size={13} aria-hidden />;
 }

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -508,7 +508,10 @@ export function OperatorControlsBlock({
       <div className="flex flex-wrap gap-2">
         {visibleControls.map((control) => {
           const submitting = submittingAction === control.action;
-          const disabled = busy || !control.enabled;
+          // Freeze every control while a destructive confirmation is pending so
+          // an operator cannot trigger another action (or re-arm cancel) until
+          // they confirm or dismiss the open dialog.
+          const disabled = busy || !control.enabled || confirming !== null;
           const reason = busy && !submitting ? "operation active" : control.reason;
           const destructive = control.action === "cancel";
           const buttonClassName = destructive

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -290,6 +290,10 @@ export function WorkspaceSummary({
         </div>
         <WorkspaceRecoveryBlock item={mergeQueueItem} workspace={workspace} overview={overview} />
         <OperatorControlsBlock
+          // Reset the block's local confirm state when the operator switches
+          // workspaces so a pending destructive cancel confirmation can never
+          // carry over onto a different (still cancel-enabled) workspace.
+          key={overview.workspace_id}
           controls={operatorControls}
           state={operatorActionState}
           workspaceId={overview.workspace_id}

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -12,6 +12,7 @@ RefreshCw,
 X
 } from "lucide-react";
 import {
+useEffect,
 useLayoutEffect,
 useState
 } from "react";
@@ -473,12 +474,24 @@ export function OperatorControlsBlock({
 }) {
   const [confirming, setConfirming] = useState<WorkspaceOperatorAction | null>(null);
   const visibleControls = controls.filter((control) => control.visible);
-  if (visibleControls.length === 0) {
-    return null;
-  }
 
   const submittingAction = state.status === "submitting" ? state.action : null;
   const busy = submittingAction !== null;
+  const cancelControl = visibleControls.find((control) => control.action === "cancel");
+  const cancelConfirmEnabled = cancelControl !== undefined && cancelControl.enabled && !busy;
+
+  // Drop a pending cancel confirmation as soon as it no longer applies — the
+  // operator switched workspaces, cancel became disabled, or another operation
+  // started — so Confirm cancel can never act on a stale or guarded selection.
+  useEffect(() => {
+    if (confirming === "cancel" && !cancelConfirmEnabled) {
+      setConfirming(null);
+    }
+  }, [confirming, cancelConfirmEnabled]);
+
+  if (visibleControls.length === 0) {
+    return null;
+  }
 
   return (
     <div className="grid gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs">
@@ -516,7 +529,7 @@ export function OperatorControlsBlock({
           );
         })}
       </div>
-      {confirming === "cancel" ? (
+      {confirming === "cancel" && cancelConfirmEnabled ? (
         <div
           data-testid="operator-cancel-confirm"
           className="grid gap-2 rounded-md border border-red-200 bg-red-50 px-2 py-1.5 text-red-900"
@@ -528,10 +541,14 @@ export function OperatorControlsBlock({
             <button
               type="button"
               onClick={() => {
+                if (!cancelConfirmEnabled) {
+                  return;
+                }
                 onAction("cancel");
                 setConfirming(null);
               }}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-red-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-red-700"
+              disabled={!cancelConfirmEnabled}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-red-600 px-2.5 text-[11px] font-medium text-white transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
             >
               <Ban size={13} aria-hidden />
               Confirm cancel

--- a/apps/console/lib/route-source.test.mjs
+++ b/apps/console/lib/route-source.test.mjs
@@ -43,3 +43,17 @@ test("revalidate operator route delegates to the shared control handler", () => 
     /return handleWorkspaceControlRoute\("revalidate", workspaceId, request\);/,
   );
 });
+
+test("cancel operator route delegates to the shared control handler", () => {
+  const source = readFileSync(
+    new URL("../app/api/operator/workspaces/[workspaceId]/cancel/route.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /export async function POST\(request: Request, context: RouteContext\)/);
+  assert.match(source, /const \{ workspaceId \} = await context\.params;/);
+  assert.match(
+    source,
+    /return handleWorkspaceControlRoute\("cancel", workspaceId, request\);/,
+  );
+});

--- a/apps/console/lib/types-contract.test.ts
+++ b/apps/console/lib/types-contract.test.ts
@@ -220,7 +220,7 @@ type OperationAuditFieldsAreNullable = Expect<
 export const operationAuditFieldsAreNullable: OperationAuditFieldsAreNullable = true;
 
 type WorkspaceOperatorActionUnionIsExplicit = Expect<
-  Equal<WorkspaceOperatorAction, "remonitor" | "refresh" | "revalidate">
+  Equal<WorkspaceOperatorAction, "remonitor" | "refresh" | "revalidate" | "cancel">
 >;
 
 type WorkspaceControlResponseShape = Expect<

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -581,7 +581,7 @@ export interface Operation {
   log_stream_ids: string[];
 }
 
-export type WorkspaceOperatorAction = "remonitor" | "refresh" | "revalidate";
+export type WorkspaceOperatorAction = "remonitor" | "refresh" | "revalidate" | "cancel";
 
 export interface WorkspaceControlWarning {
   warning_code: string;

--- a/apps/console/lib/workspace-control-routes.test.mjs
+++ b/apps/console/lib/workspace-control-routes.test.mjs
@@ -60,6 +60,79 @@ test("remonitor BFF posts with server token and idempotency key", async () => {
   assert.equal(responseText.includes("server-token"), false);
 });
 
+test("cancel BFF maps to cancel endpoint and sends stop_stack", async () => {
+  const calls = [];
+  process.env.AWF_API_BASE_URL = "https://awf.example.test";
+  process.env.AWF_API_TOKEN = "server-token";
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init });
+    return jsonResponse({
+      workspace_id: "ws_123",
+      operation_id: "op_cancel",
+      operation_status: "succeeded",
+      status: "cancelled",
+      message: "cancelled",
+    });
+  };
+
+  const response = await handleWorkspaceControlRoute(
+    "cancel",
+    "ws_123",
+    jsonRequest({
+      reason: "operator console cancel",
+      workspace_version: 7,
+      idempotency_key: "cancel-idem",
+    }),
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].url, "https://awf.example.test/v1/workspaces/ws_123/cancel");
+  assert.equal(calls[0].init.method, "POST");
+  const headers = normalizeHeaders(calls[0].init.headers);
+  assert.equal(headers.authorization, "Bearer server-token");
+  assert.equal(headers["idempotency-key"], "cancel-idem");
+  assert.equal(headers["if-match"], "7");
+  assert.deepEqual(JSON.parse(calls[0].init.body), {
+    reason: "operator console cancel",
+    stop_stack: true,
+  });
+});
+
+test("cancel BFF sends stop_stack even without a reason", async () => {
+  const calls = recordAwfProxy({
+    workspace_id: "ws_123",
+    operation_id: "op_cancel",
+    operation_status: "succeeded",
+    status: "cancelled",
+    message: "cancelled",
+  });
+
+  const response = await handleWorkspaceControlRoute("cancel", "ws_123", rawRequest(""));
+
+  assert.equal(response.status, 200);
+  assert.equal(calls.length, 1);
+  assert.deepEqual(JSON.parse(calls[0].init.body), { stop_stack: true });
+});
+
+test("cancel BFF rejects requested_tier", async () => {
+  let called = false;
+  globalThis.fetch = async () => {
+    called = true;
+    return jsonResponse({});
+  };
+
+  const response = await handleWorkspaceControlRoute(
+    "cancel",
+    "ws_123",
+    jsonRequest({ requested_tier: 1 }),
+  );
+
+  assert.equal(called, false);
+  assert.equal(response.status, 400);
+  await assertInvalidRequest(response, "requested_tier is only supported for revalidate.");
+});
+
 test("refresh BFF preserves structured AWF errors", async () => {
   process.env.AWF_API_BASE_URL = "https://awf.example.test";
   process.env.AWF_API_TOKEN = "server-token";

--- a/apps/console/lib/workspace-control-routes.ts
+++ b/apps/console/lib/workspace-control-routes.ts
@@ -16,6 +16,7 @@ const actionPaths: Record<AwfControlAction, string> = {
   remonitor: "remonitor",
   refresh: "refresh",
   revalidate: "validate",
+  cancel: "cancel",
 };
 
 const invalidRequestStatus = 400;
@@ -114,13 +115,16 @@ async function parsePayload(
   return { ok: true, value: payload };
 }
 
-function awfBody(action: AwfControlAction, payload: WorkspaceControlRoutePayload): Record<string, string | ValidationTier> {
-  const body: Record<string, string | ValidationTier> = {};
+function awfBody(action: AwfControlAction, payload: WorkspaceControlRoutePayload): Record<string, string | ValidationTier | boolean> {
+  const body: Record<string, string | ValidationTier | boolean> = {};
   if (payload.reason) {
     body.reason = payload.reason;
   }
   if (action === "revalidate" && isValidationTier(payload.requested_tier)) {
     body.requested_tier = payload.requested_tier;
+  }
+  if (action === "cancel") {
+    body.stop_stack = true;
   }
   return body;
 }

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -116,6 +116,96 @@ test("control eligibility revalidate requires validation recovery", () => {
   );
 });
 
+test("cancel control is visible and enabled for active non-terminal statuses", () => {
+  for (const status of [
+    "requested",
+    "provisioning",
+    "ready",
+    "running",
+    "validating",
+    "pushing",
+    "monitoring_pr",
+  ]) {
+    const control = getWorkspaceOperatorControls({
+      overview: overview({ status, pr_url: null }),
+    }).find((item) => item.action === "cancel");
+    assert.ok(control, `missing cancel control for ${status}`);
+    assert.equal(control.visible, true, `cancel should be visible for ${status}`);
+    assert.equal(control.enabled, true, `cancel should be enabled for ${status}`);
+    assert.equal(control.reason, null);
+    assert.equal(control.label, "Cancel");
+  }
+});
+
+test("cancel control is hidden and disabled for terminal and destroy statuses", () => {
+  for (const status of ["completed", "failed", "cancelled", "destroying", "destroyed"]) {
+    const control = getWorkspaceOperatorControls({
+      overview: overview({ status, pr_url: null }),
+    }).find((item) => item.action === "cancel");
+    assert.ok(control, `missing cancel control for ${status}`);
+    assert.equal(control.visible, false, `cancel should be hidden for ${status}`);
+    assert.equal(control.enabled, false, `cancel should be disabled for ${status}`);
+    assert.ok(control.reason, `cancel should carry a reason for ${status}`);
+  }
+});
+
+test("active operation disables cancel but keeps it visible for active statuses", () => {
+  const control = getWorkspaceOperatorControls({
+    overview: overview({ status: "running", pr_url: null, active_operation: "op_active" }),
+  }).find((item) => item.action === "cancel");
+  assert.ok(control, "missing cancel control");
+  assert.equal(control.enabled, false);
+  assert.equal(control.visible, true);
+  assert.equal(control.reason, "active operation");
+});
+
+test("cancel success and failure summaries format the Cancel label", () => {
+  assert.deepEqual(
+    summarizeWorkspaceOperatorSuccess("cancel", {
+      workspace_id: "ws_123",
+      operation_id: "op_cancel",
+      operation_status: "succeeded",
+      status: "cancelled",
+      message: "cancelled",
+    }),
+    {
+      action: "cancel",
+      operationId: "op_cancel",
+      status: "succeeded",
+      message: "Cancel succeeded: op_cancel",
+      warnings: [],
+    },
+  );
+  assert.deepEqual(
+    summarizeWorkspaceOperatorFailure({
+      ok: false,
+      status: 409,
+      message: "Workspace cannot be cancelled from this state.",
+      errorCode: "WORKSPACE_STATE_NOT_CANCELLABLE",
+      detail: {
+        detail: {
+          error_code: "WORKSPACE_STATE_NOT_CANCELLABLE",
+          message: "Workspace cannot be cancelled from this state.",
+        },
+      },
+    }),
+    {
+      errorCode: "WORKSPACE_STATE_NOT_CANCELLABLE",
+      message: "WORKSPACE_STATE_NOT_CANCELLABLE: Workspace cannot be cancelled from this state.",
+    },
+  );
+});
+
+test("active monitoring workspace exposes the full operator action set", () => {
+  const actions = new Set(
+    getWorkspaceOperatorControls({
+      overview: overview({ status: "monitoring_pr", pr_url: "https://github.test/pr/1" }),
+      mergeQueueItem: mergeQueueItem({ required_next_action: "validate" }),
+    }).map((control) => control.action),
+  );
+  assert.deepEqual(actions, new Set(["remonitor", "refresh", "revalidate", "cancel"]));
+});
+
 test("active operation disables all operator controls", () => {
   const eligible = {
     overview: overview({

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -43,7 +43,18 @@ const labels: Record<WorkspaceOperatorAction, string> = {
   remonitor: "Remonitor",
   refresh: "Refresh",
   revalidate: "Revalidate",
+  cancel: "Cancel",
 };
+
+const cancellableStatuses = new Set([
+  "requested",
+  "provisioning",
+  "ready",
+  "running",
+  "validating",
+  "pushing",
+  "monitoring_pr",
+]);
 
 const terminalOperationStatuses = new Set(["succeeded", "failed", "cancelled", "canceled"]);
 
@@ -53,6 +64,7 @@ export function getWorkspaceOperatorControls(context: WorkspaceOperatorContext):
     remonitorControl(context),
     refreshControl(context),
     revalidateControl(context),
+    cancelControl(context),
   ];
 
   if (!active) {
@@ -138,6 +150,17 @@ function revalidateControl(context: WorkspaceOperatorContext): WorkspaceOperator
   return control("revalidate", { visible: Boolean(context.mergeQueueItem) || Boolean(context.workspace), enabled: false, reason: "validation fresh", requestedTier });
 }
 
+function cancelControl(context: WorkspaceOperatorContext): WorkspaceOperatorControl {
+  if (isCancellable(context)) {
+    return control("cancel", { visible: true, enabled: true, reason: null });
+  }
+  return control("cancel", { visible: false, enabled: false, reason: "not cancellable" });
+}
+
+function isCancellable(context: WorkspaceOperatorContext): boolean {
+  return cancellableStatuses.has(context.overview.status);
+}
+
 function control(
   action: WorkspaceOperatorAction,
   state: Omit<WorkspaceOperatorControl, "action" | "label">,
@@ -166,6 +189,9 @@ function eligibleEnoughForActiveReason(action: WorkspaceOperatorAction, context:
   }
   if (action === "refresh") {
     return hasMergeCandidateOrStaleContext(context);
+  }
+  if (action === "cancel") {
+    return isCancellable(context);
   }
   return Boolean(workspacePrUrl(context)) || isPotentialValidationContext(context);
 }

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -114,4 +114,67 @@ test.describe("Operator cancel control", () => {
     await expect(page.getByText("Cancel succeeded:")).toBeVisible();
     expect(cancelPosts).toBe(1);
   });
+
+  test("auto-dismisses an open confirmation when cancel becomes disabled", async ({ page }) => {
+    let cancelPosts = 0;
+    let activeOperation: string | null = null;
+    await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
+      cancelPosts += 1;
+      await route.fulfill({
+        json: {
+          workspace_id: WORKSPACE_ID,
+          operation_id: "op_cancel123",
+          operation_status: "succeeded",
+          status: "cancelled",
+          message: "cancelled",
+        },
+      });
+    });
+
+    const workspacePayload = () => ({
+      workspace_id: WORKSPACE_ID,
+      title: "Mock Workspace",
+      repo_url: "https://github.com/test/repo",
+      base_branch: "main",
+      agent: "test-agent",
+      status: "running",
+      active_operation: activeOperation,
+      version: 7,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+    });
+
+    // Re-register the overview/detail routes so they reflect the mutable
+    // active-operation state instead of the static bootstrap payload.
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await route.fulfill({ json: { items: [workspacePayload()], has_more: false } });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}`, async (route) => {
+      await route.fulfill({ json: workspacePayload() });
+    });
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeEnabled();
+
+    // Open the cancel confirmation while cancel is still available.
+    await cancelButton.click();
+    const confirmation = page.getByTestId("operator-cancel-confirm");
+    await expect(confirmation).toBeVisible();
+
+    // A background operation begins while the confirmation is open, so the
+    // cancel control becomes disabled. The still-open confirmation must drop
+    // itself and Confirm cancel must never POST against the guarded workspace.
+    activeOperation = "op_busy";
+
+    await expect(cancelButton).toBeDisabled({ timeout: 15000 });
+    await expect(confirmation).not.toBeVisible();
+    await page.waitForTimeout(200);
+    expect(cancelPosts).toBe(0);
+  });
 });

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -93,6 +93,10 @@ test.describe("Operator cancel control", () => {
     await expect(confirmation).toBeVisible();
     await expect(confirmation).toContainText(WORKSPACE_ID);
 
+    // While the confirmation is open every operator control is frozen so a stray
+    // click cannot trigger another action (or re-arm cancel) mid-confirmation.
+    await expect(cancelButton).toBeDisabled();
+
     // 2. Dismiss does not POST.
     await page.getByRole("button", { name: "Dismiss", exact: true }).click();
     await expect(confirmation).not.toBeVisible();

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const WORKSPACE_ID = "ws_mock123";
+
+async function mockBootstrap(page: Page) {
+  await page.route("/api/awf/health", async (route) => {
+    await route.fulfill({ json: { status: "ok" } });
+  });
+  await page.route("/api/awf/metrics/resources/saturation", async (route) => {
+    await route.fulfill({ json: { generated_at: new Date().toISOString() } });
+  });
+  await page.route("/api/awf/metrics/workspaces/summary", async (route) => {
+    await route.fulfill({ json: { active: 1, failed: 0 } });
+  });
+  await page.route("/api/awf/merge-queue*", async (route) => {
+    await route.fulfill({ json: { items: [], has_more: false } });
+  });
+  await page.route("/api/awf/metrics/failures/summary", async (route) => {
+    await route.fulfill({ json: { taxonomy: [], latest_examples: [], total_failures: 0 } });
+  });
+
+  const mockWorkspace = {
+    workspace_id: WORKSPACE_ID,
+    title: "Mock Workspace",
+    repo_url: "https://github.com/test/repo",
+    base_branch: "main",
+    agent: "test-agent",
+    status: "running",
+    version: 7,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    lifecycle: [],
+    llm_usage: null,
+    recovery: null,
+  };
+
+  await page.route("/api/awf/workspaces/overview*", async (route) => {
+    await route.fulfill({ json: { items: [mockWorkspace], has_more: false } });
+  });
+  await page.route(`/api/awf/workspaces/${WORKSPACE_ID}`, async (route) => {
+    await route.fulfill({ json: mockWorkspace });
+  });
+  await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/runtime`, async (route) => {
+    await route.fulfill({ json: { status: "running" } });
+  });
+  await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/events*`, async (route) => {
+    await route.fulfill({ json: { items: [], has_more: false } });
+  });
+  await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/operations*`, async (route) => {
+    await route.fulfill({ json: { items: [], has_more: false } });
+  });
+  await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/logs`, async (route) => {
+    await route.fulfill({ json: { items: [], has_more: false } });
+  });
+  await page.route("/api/awf/workspaces/*/stream*", async (route) => {
+    await route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" },
+      body: `data: ${JSON.stringify({ type: "connected", workspace_id: WORKSPACE_ID })}\n\n`,
+    });
+  });
+}
+
+test.describe("Operator cancel control", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockBootstrap(page);
+  });
+
+  test("renders cancel, requires confirmation, and POSTs only on confirm", async ({ page }) => {
+    let cancelPosts = 0;
+    await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
+      cancelPosts += 1;
+      await route.fulfill({
+        json: {
+          workspace_id: WORKSPACE_ID,
+          operation_id: "op_cancel123",
+          operation_status: "succeeded",
+          status: "cancelled",
+          message: "cancelled",
+        },
+      });
+    });
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeEnabled();
+
+    // 1. Clicking Cancel reveals confirmation that mentions the workspace id.
+    await cancelButton.click();
+    const confirmation = page.getByTestId("operator-cancel-confirm");
+    await expect(confirmation).toBeVisible();
+    await expect(confirmation).toContainText(WORKSPACE_ID);
+
+    // 2. Dismiss does not POST.
+    await page.getByRole("button", { name: "Dismiss", exact: true }).click();
+    await expect(confirmation).not.toBeVisible();
+    await page.waitForTimeout(200);
+    expect(cancelPosts).toBe(0);
+
+    // 3. Confirm issues exactly one POST and renders the success state.
+    await cancelButton.click();
+    await expect(confirmation).toBeVisible();
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        (req) =>
+          req.url().includes(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`) &&
+          req.method() === "POST",
+      ),
+      page.getByRole("button", { name: "Confirm cancel", exact: true }).click(),
+    ]);
+    expect(request.method()).toBe("POST");
+    await expect(page.getByText("Cancel succeeded:")).toBeVisible();
+    expect(cancelPosts).toBe(1);
+  });
+});

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -177,4 +177,75 @@ test.describe("Operator cancel control", () => {
     await page.waitForTimeout(200);
     expect(cancelPosts).toBe(0);
   });
+
+  test("does not carry an open cancel confirmation across a workspace switch", async ({ page }) => {
+    const SECOND_WORKSPACE_ID = "ws_mock456";
+
+    const workspacePayload = (id: string, title: string) => ({
+      workspace_id: id,
+      title,
+      repo_url: "https://github.com/test/repo",
+      base_branch: "main",
+      agent: "test-agent",
+      status: "running",
+      version: 7,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+    });
+
+    // Two running, cancel-enabled workspaces. Switching between them keeps cancel
+    // enabled, so only a per-workspace state reset can drop a stale confirmation.
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await route.fulfill({
+        json: {
+          items: [
+            workspacePayload(WORKSPACE_ID, "First Workspace"),
+            workspacePayload(SECOND_WORKSPACE_ID, "Second Workspace"),
+          ],
+          has_more: false,
+        },
+      });
+    });
+    for (const id of [WORKSPACE_ID, SECOND_WORKSPACE_ID]) {
+      const title = id === WORKSPACE_ID ? "First Workspace" : "Second Workspace";
+      await page.route(`/api/awf/workspaces/${id}`, async (route) => {
+        await route.fulfill({ json: workspacePayload(id, title) });
+      });
+      await page.route(`/api/awf/workspaces/${id}/runtime`, async (route) => {
+        await route.fulfill({ json: { status: "running" } });
+      });
+      await page.route(`/api/awf/workspaces/${id}/events*`, async (route) => {
+        await route.fulfill({ json: { items: [], has_more: false } });
+      });
+      await page.route(`/api/awf/workspaces/${id}/operations*`, async (route) => {
+        await route.fulfill({ json: { items: [], has_more: false } });
+      });
+      await page.route(`/api/awf/workspaces/${id}/logs`, async (route) => {
+        await route.fulfill({ json: { items: [], has_more: false } });
+      });
+    }
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeEnabled();
+
+    // Open the cancel confirmation for the first workspace.
+    await cancelButton.click();
+    const confirmation = page.getByTestId("operator-cancel-confirm");
+    await expect(confirmation).toBeVisible();
+    await expect(confirmation).toContainText(WORKSPACE_ID);
+
+    // Switch to the second (also cancel-enabled) workspace. The destructive
+    // confirmation must not survive the switch onto a different workspace.
+    await page
+      .getByRole("button", { name: "Open workspace details for Second Workspace" })
+      .click();
+    await expect(page.getByText(SECOND_WORKSPACE_ID, { exact: false }).first()).toBeVisible();
+    await expect(confirmation).not.toBeVisible();
+  });
 });


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_6d75b9b209f745d2a5113af0` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Implement the Console Cancel Workspace Control plan exactly and narrowly.

Goal:
Add one destructive Cancel operator control to the AWF web console workspace detail panel. The control must be visible for active/non-terminal workspaces, require confirmation, call AWF's existing cancel endpoint with stack stop enabled, and refresh console state so the operator sees the transition to cancelled.

Mandatory plan workflow:
- Before coding, create plans/CONSOLE_CANCEL_WORKSPACE_CONTROL_PLAN.md with this implementation plan summarized against the current repo.
- After validation, create plans/CONSOLE_CANCEL_WORKSPACE_CONTROL_VALIDATION.md with commands run, results, and any gaps.

Implementation requirements:
- Extend WorkspaceOperatorAction from remonitor | refresh | revalidate to include cancel.
- Add Cancel to apps/console/lib/workspace-operator-controls.ts.
  - Label: Cancel.
  - Visible and enabled for active/non-terminal statuses: requested, provisioning, ready, running, validating, pushing, monitoring_pr.
  - Disabled or hidden for terminal/destroy states with a short reason.
  - Disabled while any operator operation is active.
- Add confirmation before submitting cancel. The message must include the workspace id. Dismissing the confirmation must not POST.
- Add a Next.js BFF route at apps/console/app/api/operator/workspaces/[workspaceId]/cancel/route.ts that delegates to handleWorkspaceControlRoute("cancel", ...).
- Update apps/console/lib/workspace-control-routes.ts so cancel maps to /v1/workspaces/{id}/cancel and sends stop_stack: true.
  - Forward reason, workspace_version/If-Match, and idempotency key as existing controls do.
  - requested_tier remains invalid for cancel.
- Update UI polish in apps/console/components/console-dashboard-workspace-detail.tsx.
  - Cancel should use a restrained destructive/red button variant and a lucide destructive icon.
  - Disabled styling should remain consistent with existing controls.
  - Success summary should read like Cancel succeeded: op_...

Tests required:
- Update apps/console/lib/workspace-operator-controls.test.mjs:
  - cancel appears and is enabled for active statuses;
  - cancel is disabled/hidden for terminal/destroy states;
  - active operations disable cancel;
  - success/failure summaries format Cancel correctly.
- Update apps/console/lib/workspace-control-routes.test.mjs:
  - cancel maps to /v1/workspaces/{id}/cancel;
  - forwards reason, If-Match, and Idempotency-Key;
  - sends stop_stack: true;
  - rejects requested_tier for cancel.
- Add or update a focused Playwright spec for the operator-control behavior:
  - button renders for a running workspace;
  - confirmation is shown;
  - dismissing confirmation does not POST;
  - accepting confirmation POSTs and shows success state.
- Update type contract tests for the new WorkspaceOperatorAction union.

Validation commands to run inside the workspace:
- npm --prefix apps/console run test
- npm --prefix apps/console run lint
- npm --prefix apps/console run typecheck
- Targeted Playwright spec for the operator-control behavior only.

Important constraints:
- Do not change AWF backend/core API behavior unless tests reveal a real route-contract gap. The REST/MCP/CLI cancel capability already exists.
- Do not add a separate Stop button.
- Do not run full Python coverage or whole-repo validation inside the workspace. Focus on console tests and touched files; GitHub/AWF CI owns broad coverage.
- Keep changes scoped to the console/BFF/plan docs needed for this feature.

---
Validation: 7 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Destructive workspace cancellation with stack stop, but scoped to console/BFF proxying an existing API and guarded by confirmation plus stale-state dismissal.
> 
> **Overview**
> Adds a **Cancel** operator action so the console can stop an in-flight workspace run via the existing AWF cancel API (with **stop_stack: true**).
> 
> **Backend/BFF:** Extends `WorkspaceOperatorAction` with `cancel`, maps it to `POST /v1/workspaces/{id}/cancel` through a new Next.js operator route and shared `handleWorkspaceControlRoute`, forwarding reason, If-Match, and idempotency like other controls. Rejects `requested_tier` for cancel.
> 
> **Eligibility:** Cancel is shown and enabled for active non-terminal statuses (`requested` through `monitoring_pr`); hidden/disabled for terminal/destroy states and when another operation is active.
> 
> **UI:** Destructive red **Cancel** button opens an inline confirmation naming the workspace id; dismiss avoids POST, confirm submits once. Controls freeze while confirmation is open; confirmation clears on workspace switch, when cancel becomes disabled, or when an active operation starts (`key` + `useEffect` guards).
> 
> **Tests:** Unit coverage for control rules, BFF mapping/body, route delegation, and type contracts; Playwright for confirm/dismiss/POST and confirmation lifecycle edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3127f690c4b0abfdf206654db47330d7a7ead7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace cancellation is now available in the operator console
  * Cancel action requires explicit confirmation before execution to prevent accidental operations
  * Control intelligently enables/disables based on workspace state and active operations
  * Confirmation state auto-clears when cancellation becomes unavailable
  * Cancel button uses an updated visual icon for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->