### PR TITLE
Polish console operator controls

### DIFF
--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -518,7 +518,7 @@ export function OperatorControlsBlock({
           const buttonClassName = destructive
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";
-            return (
+          return (
             <div
               key={control.action}
               tabIndex={disabled && reason ? 0 : undefined}
@@ -531,7 +531,6 @@ export function OperatorControlsBlock({
                   destructive ? setConfirming(control.action) : onAction(control.action, control.requestedTier)
                 }
                 disabled={disabled}
-                aria-describedby={!disabled && reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
                 className={buttonClassName}
               >
                 <OperatorControlIcon action={control.action} spinning={submitting} />

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -541,7 +541,7 @@ export function OperatorControlsBlock({
                 <span
                   id={`operator-control-tip-${workspaceId}-${control.action}`}
                   role="tooltip"
-                  className="pointer-events-none absolute left-0 top-[calc(100%+6px)] z-20 hidden max-w-56 rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-medium text-white shadow-lg group-focus-within:block group-hover:block"
+                  className="pointer-events-none absolute left-0 top-[calc(100%+6px)] z-20 sr-only max-w-56 rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-medium text-white shadow-lg group-focus-within:not-sr-only group-hover:not-sr-only"
                 >
                   {tooltip}
                 </span>

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -514,24 +514,33 @@ export function OperatorControlsBlock({
           const disabled = busy || !control.enabled || confirming !== null;
           const reason = busy && !submitting ? "operation active" : control.reason;
           const destructive = control.action === "cancel";
+          const tooltip = reason ? `${control.label}: ${reason}` : control.label;
           const buttonClassName = destructive
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";
           return (
-            <div key={control.action} className="flex min-w-0 items-center gap-1.5">
+            <div key={control.action} className="group relative flex min-w-0 items-center gap-1.5">
               <button
                 type="button"
                 onClick={() =>
                   destructive ? setConfirming(control.action) : onAction(control.action, control.requestedTier)
                 }
                 disabled={disabled}
-                title={reason ? `${control.label}: ${reason}` : control.label}
+                aria-describedby={reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
                 className={buttonClassName}
               >
                 <OperatorControlIcon action={control.action} spinning={submitting} />
                 {control.label}
               </button>
-              {reason ? <span className="max-w-32 truncate text-[11px] text-slate-500">{reason}</span> : null}
+              {reason ? (
+                <span
+                  id={`operator-control-tip-${workspaceId}-${control.action}`}
+                  role="tooltip"
+                  className="pointer-events-none absolute left-0 top-[calc(100%+6px)] z-20 hidden max-w-56 rounded-md border border-slate-700 bg-slate-950 px-2 py-1 text-[11px] font-medium text-white shadow-lg group-focus-within:block group-hover:block"
+                >
+                  {tooltip}
+                </span>
+              ) : null}
             </div>
           );
         })}

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -518,10 +518,10 @@ export function OperatorControlsBlock({
           const buttonClassName = destructive
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";
-          return (
+            return (
             <div
               key={control.action}
-              tabIndex={reason ? 0 : undefined}
+              tabIndex={disabled && reason ? 0 : undefined}
               aria-describedby={disabled && reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
               className="group relative flex min-w-0 items-center gap-1.5"
             >

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -522,6 +522,7 @@ export function OperatorControlsBlock({
             <div
               key={control.action}
               tabIndex={reason ? 0 : undefined}
+              aria-describedby={disabled && reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
               className="group relative flex min-w-0 items-center gap-1.5"
             >
               <button
@@ -530,7 +531,7 @@ export function OperatorControlsBlock({
                   destructive ? setConfirming(control.action) : onAction(control.action, control.requestedTier)
                 }
                 disabled={disabled}
-                aria-describedby={reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
+                aria-describedby={!disabled && reason ? `operator-control-tip-${workspaceId}-${control.action}` : undefined}
                 className={buttonClassName}
               >
                 <OperatorControlIcon action={control.action} spinning={submitting} />

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -514,7 +514,7 @@ export function OperatorControlsBlock({
           const disabled = busy || !control.enabled || confirming !== null;
           const reason = busy && !submitting ? "operation active" : control.reason;
           const destructive = control.action === "cancel";
-          const tooltip = reason ? `${control.label}: ${reason}` : control.label;
+          const tooltip = control.label + ": " + reason;
           const buttonClassName = destructive
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -514,7 +514,7 @@ export function OperatorControlsBlock({
           const disabled = busy || !control.enabled || confirming !== null;
           const reason = busy && !submitting ? "operation active" : control.reason;
           const destructive = control.action === "cancel";
-          const tooltip = control.label + ": " + reason;
+          const tooltip = reason ? `${control.label}: ${reason}` : null;
           const buttonClassName = destructive
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -519,7 +519,11 @@ export function OperatorControlsBlock({
             ? "inline-flex h-8 items-center gap-1.5 rounded-md border border-red-300 bg-white px-2.5 text-[11px] font-medium text-red-700 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
             : "inline-flex h-8 items-center gap-1.5 rounded-md border border-slate-300 bg-white px-2.5 text-[11px] font-medium text-slate-800 transition hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-50";
           return (
-            <div key={control.action} className="group relative flex min-w-0 items-center gap-1.5">
+            <div
+              key={control.action}
+              tabIndex={reason ? 0 : undefined}
+              className="group relative flex min-w-0 items-center gap-1.5"
+            >
               <button
                 type="button"
                 onClick={() =>

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -485,8 +485,8 @@ export function OperatorControlsBlock({
   const cancelConfirmEnabled = cancelControl !== undefined && cancelControl.enabled && !busy;
 
   // Drop a pending cancel confirmation as soon as it no longer applies — the
-  // operator switched workspaces, cancel became disabled, or another operation
-  // started — so Confirm cancel can never act on a stale or guarded selection.
+  // cancel became disabled or is no longer available, so Confirm cancel can never
+  // act on a stale or guarded selection.
   useEffect(() => {
     if (confirming === "cancel" && !cancelConfirmEnabled) {
       setConfirming(null);

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -53,6 +53,16 @@ test("operator controls block renders success warnings", () => {
   assert.match(blockSource, /warning\.message \|\| warning\.warning_code/);
 });
 
+test("operator controls block keeps inactive reasons in hover tooltips", () => {
+  const blockSource = extractFunctionSource("OperatorControlsBlock");
+
+  assert.match(blockSource, /const tooltip = reason \? `\$\{control\.label\}: \$\{reason\}` : control\.label;/);
+  assert.match(blockSource, /role="tooltip"/);
+  assert.match(blockSource, /group-hover:block/);
+  assert.match(blockSource, /group-focus-within:block/);
+  assert.doesNotMatch(blockSource, />\{reason\}<\/span>/);
+});
+
 test("operator action state is guarded by current workspace selection", () => {
   const dashboard = dashboardSource.dashboard;
 

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -71,10 +71,6 @@ test("operator control tooltip-describedby target follows disabled focus state",
     blockSource,
     /aria-describedby=\{disabled && reason \? `operator-control-tip-\$\{workspaceId\}-\$\{control\.action\}` : undefined\}/,
   );
-  assert.match(
-    blockSource,
-    /aria-describedby=\{!disabled && reason \? `operator-control-tip-\$\{workspaceId\}-\$\{control\.action\}` : undefined\}/,
-  );
 });
 
 test("operator action state is guarded by current workspace selection", () => {

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -56,7 +56,7 @@ test("operator controls block renders success warnings", () => {
 test("operator controls block keeps inactive reasons in hover tooltips", () => {
   const blockSource = extractFunctionSource("OperatorControlsBlock");
 
-  assert.match(blockSource, /const tooltip = control\.label \+ ": " \+ reason;/);
+  assert.match(blockSource, /const tooltip = reason \? `\$\{control\.label\}: \${reason}` : null;/);
   assert.match(blockSource, /role="tooltip"/);
   assert.match(blockSource, /group-hover:block/);
   assert.match(blockSource, /group-focus-within:block/);

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -63,6 +63,20 @@ test("operator controls block keeps inactive reasons in hover tooltips", () => {
   assert.doesNotMatch(blockSource, />\{reason\}<\/span>/);
 });
 
+test("operator control tooltip-describedby target follows disabled focus state", () => {
+  const blockSource = extractFunctionSource("OperatorControlsBlock");
+
+  assert.match(blockSource, /tabIndex=\{disabled && reason \? 0 : undefined\}/);
+  assert.match(
+    blockSource,
+    /aria-describedby=\{disabled && reason \? `operator-control-tip-\$\{workspaceId\}-\$\{control\.action\}` : undefined\}/,
+  );
+  assert.match(
+    blockSource,
+    /aria-describedby=\{!disabled && reason \? `operator-control-tip-\$\{workspaceId\}-\$\{control\.action\}` : undefined\}/,
+  );
+});
+
 test("operator action state is guarded by current workspace selection", () => {
   const dashboard = dashboardSource.dashboard;
 

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -58,8 +58,8 @@ test("operator controls block keeps inactive reasons in hover tooltips", () => {
 
   assert.match(blockSource, /const tooltip = reason \? `\$\{control\.label\}: \${reason}` : null;/);
   assert.match(blockSource, /role="tooltip"/);
-  assert.match(blockSource, /group-hover:block/);
-  assert.match(blockSource, /group-focus-within:block/);
+  assert.match(blockSource, /group-hover:not-sr-only/);
+  assert.match(blockSource, /group-focus-within:not-sr-only/);
   assert.doesNotMatch(blockSource, />\{reason\}<\/span>/);
 });
 

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -56,7 +56,7 @@ test("operator controls block renders success warnings", () => {
 test("operator controls block keeps inactive reasons in hover tooltips", () => {
   const blockSource = extractFunctionSource("OperatorControlsBlock");
 
-  assert.match(blockSource, /const tooltip = reason \? `\$\{control\.label\}: \$\{reason\}` : control\.label;/);
+  assert.match(blockSource, /const tooltip = control\.label \+ ": " \+ reason;/);
   assert.match(blockSource, /role="tooltip"/);
   assert.match(blockSource, /group-hover:block/);
   assert.match(blockSource, /group-focus-within:block/);

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -230,6 +230,22 @@ test("cancel remains disabled for stale overview cancel/stop flags without in-fl
   }
 });
 
+test("cancel remains disabled for stale overview cancel/stop flags while operations list is default empty", () => {
+  for (const activeOperation of ["cancel", "stop"]) {
+    const control = getWorkspaceOperatorControls({
+      overview: overview({
+        status: "running",
+        active_operation: activeOperation,
+      }),
+      operations: [],
+    }).find((item) => item.action === "cancel");
+    assert.ok(control, `missing cancel control for ${activeOperation} with empty operations`);
+    assert.equal(control.enabled, false, `cancel should stay disabled while overview is ${activeOperation} and operations list is empty`);
+    assert.equal(control.reason, "cancel/stop already active");
+    assert.equal(control.visible, true);
+  }
+});
+
 test("cancel stays disabled while a running cancel operation exists even if recovery cancel is terminal", () => {
   const control = getWorkspaceOperatorControls({
     overview: overview({

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -149,14 +149,14 @@ test("cancel control is hidden and disabled for terminal and destroy statuses", 
   }
 });
 
-test("active operation disables cancel but keeps it visible for active statuses", () => {
+test("active operation keeps cancel enabled for active statuses", () => {
   const control = getWorkspaceOperatorControls({
     overview: overview({ status: "running", pr_url: null, active_operation: "op_active" }),
   }).find((item) => item.action === "cancel");
   assert.ok(control, "missing cancel control");
-  assert.equal(control.enabled, false);
+  assert.equal(control.enabled, true);
   assert.equal(control.visible, true);
-  assert.equal(control.reason, "active operation");
+  assert.equal(control.reason, null);
 });
 
 test("cancel success and failure summaries format the Cancel label", () => {
@@ -206,7 +206,7 @@ test("active monitoring workspace exposes the full operator action set", () => {
   assert.deepEqual(actions, new Set(["remonitor", "refresh", "revalidate", "cancel"]));
 });
 
-test("active operation disables all operator controls", () => {
+test("active operation disables non-cancel operator controls", () => {
   const eligible = {
     overview: overview({
       status: "monitoring_pr",
@@ -216,8 +216,13 @@ test("active operation disables all operator controls", () => {
     mergeQueueItem: mergeQueueItem({ required_next_action: "validate" }),
   };
   for (const control of getWorkspaceOperatorControls(eligible)) {
-    assert.equal(control.enabled, false);
-    assert.equal(control.reason, "active operation");
+    if (control.action === "cancel") {
+      assert.equal(control.enabled, true);
+      assert.equal(control.reason, null);
+    } else {
+      assert.equal(control.enabled, false);
+      assert.equal(control.reason, "active operation");
+    }
   }
 
   assertControl(

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -213,6 +213,21 @@ test("cancel remains enabled when terminal cancellation operations complete", ()
   }
 });
 
+test("cancel remains enabled for stale overview cancel/stop flags without in-flight operations", () => {
+  for (const activeOperation of ["cancel", "stop"]) {
+    const control = getWorkspaceOperatorControls({
+      overview: overview({
+        status: "running",
+        active_operation: activeOperation,
+      }),
+    }).find((item) => item.action === "cancel");
+    assert.ok(control, `missing cancel control for ${activeOperation}`);
+    assert.equal(control.enabled, true, `cancel should stay enabled after ${activeOperation} metadata is stale`);
+    assert.equal(control.visible, true);
+    assert.equal(control.reason, null);
+  }
+});
+
 test("active monitoring workspace exposes the full operator action set", () => {
   const actions = new Set(
     getWorkspaceOperatorControls({

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -196,24 +196,26 @@ test("cancel success and failure summaries format the Cancel label", () => {
   );
 });
 
-test("cancel remains enabled when terminal cancellation operations complete", () => {
+test("terminal cancellation details re-enable cancel action for overview stop/cancel flags", () => {
   const terminalStatuses = ["succeeded", "failed", "cancelled", "canceled"];
-  for (const status of terminalStatuses) {
-    const control = getWorkspaceOperatorControls({
-      overview: overview({
-        status: "running",
-        active_operation: "cancel",
-      }),
-      operations: [operation({ type: "cancel", status })],
-    }).find((item) => item.action === "cancel");
-    assert.ok(control, `missing cancel control for ${status}`);
-    assert.equal(control.enabled, true, `cancel should be enabled after terminal ${status}`);
-    assert.equal(control.visible, true);
-    assert.equal(control.reason, null);
+  for (const activeOperation of ["cancel", "stop"]) {
+    for (const status of terminalStatuses) {
+      const control = getWorkspaceOperatorControls({
+        overview: overview({
+          status: "running",
+          active_operation: activeOperation,
+        }),
+        operations: [operation({ type: activeOperation, status })],
+      }).find((item) => item.action === "cancel");
+      assert.ok(control, `missing cancel control for ${activeOperation}/${status}`);
+      assert.equal(control.enabled, true, `${activeOperation} should be re-enabled after terminal ${status}`);
+      assert.equal(control.visible, true);
+      assert.equal(control.reason, null);
+    }
   }
 });
 
-test("cancel remains enabled for stale overview cancel/stop flags without in-flight operations", () => {
+test("cancel remains disabled for stale overview cancel/stop flags without in-flight operations", () => {
   for (const activeOperation of ["cancel", "stop"]) {
     const control = getWorkspaceOperatorControls({
       overview: overview({
@@ -222,9 +224,9 @@ test("cancel remains enabled for stale overview cancel/stop flags without in-fli
       }),
     }).find((item) => item.action === "cancel");
     assert.ok(control, `missing cancel control for ${activeOperation}`);
-    assert.equal(control.enabled, true, `cancel should stay enabled after ${activeOperation} metadata is stale`);
+    assert.equal(control.enabled, false, `cancel should stay disabled while ${activeOperation} is in-flight`);
+    assert.equal(control.reason, "cancel/stop already active");
     assert.equal(control.visible, true);
-    assert.equal(control.reason, null);
   }
 });
 

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -224,10 +224,40 @@ test("cancel remains disabled for stale overview cancel/stop flags without in-fl
       }),
     }).find((item) => item.action === "cancel");
     assert.ok(control, `missing cancel control for ${activeOperation}`);
-    assert.equal(control.enabled, false, `cancel should stay disabled while ${activeOperation} is in-flight`);
+    assert.equal(control.enabled, false, `cancel should stay disabled while overview is ${activeOperation} but no operations are available`);
     assert.equal(control.reason, "cancel/stop already active");
     assert.equal(control.visible, true);
   }
+});
+
+test("cancel stays disabled while a running cancel operation exists even if recovery cancel is terminal", () => {
+  const control = getWorkspaceOperatorControls({
+    overview: overview({
+      status: "running",
+      active_operation: "running",
+    }),
+    workspace: workspace({
+      recovery: {
+        current_operation: operation({
+          id: "op-recovery",
+          type: "cancel",
+          status: "succeeded",
+        }),
+      },
+    }),
+    operations: [
+      operation({
+        id: "op-cancel",
+        type: "cancel",
+        status: "running",
+      }),
+    ],
+  }).find((item) => item.action === "cancel");
+
+  assert.ok(control, "missing cancel control for running operations scenario");
+  assert.equal(control.enabled, false, "cancel should stay disabled when a non-terminal cancel operation is running");
+  assert.equal(control.reason, "cancel/stop already active");
+  assert.equal(control.visible, true);
 });
 
 test("active monitoring workspace exposes the full operator action set", () => {

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -196,7 +196,7 @@ test("cancel success and failure summaries format the Cancel label", () => {
   );
 });
 
-test("terminal cancellation details keep cancel action disabled for overview stop/cancel flags", () => {
+test("terminal cancellation details no longer block cancel action when stop/cancel operations are terminal", () => {
   const terminalStatuses = ["succeeded", "failed", "cancelled", "canceled"];
   for (const activeOperation of ["cancel", "stop"]) {
     for (const status of terminalStatuses) {
@@ -208,8 +208,8 @@ test("terminal cancellation details keep cancel action disabled for overview sto
         operations: [operation({ type: activeOperation, status })],
       }).find((item) => item.action === "cancel");
       assert.ok(control, `missing cancel control for ${activeOperation}/${status}`);
-      assert.equal(control.enabled, false, `${activeOperation} should stay disabled while overview is ${activeOperation} even after terminal ${status}`);
-      assert.equal(control.reason, "cancel/stop already active");
+      assert.equal(control.enabled, true, `${activeOperation} should become enabled once cancellation operation is terminal`);
+      assert.equal(control.reason, null);
       assert.equal(control.visible, true);
     }
   }

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -196,7 +196,7 @@ test("cancel success and failure summaries format the Cancel label", () => {
   );
 });
 
-test("terminal cancellation details re-enable cancel action for overview stop/cancel flags", () => {
+test("terminal cancellation details keep cancel action disabled for overview stop/cancel flags", () => {
   const terminalStatuses = ["succeeded", "failed", "cancelled", "canceled"];
   for (const activeOperation of ["cancel", "stop"]) {
     for (const status of terminalStatuses) {
@@ -208,9 +208,9 @@ test("terminal cancellation details re-enable cancel action for overview stop/ca
         operations: [operation({ type: activeOperation, status })],
       }).find((item) => item.action === "cancel");
       assert.ok(control, `missing cancel control for ${activeOperation}/${status}`);
-      assert.equal(control.enabled, true, `${activeOperation} should be re-enabled after terminal ${status}`);
+      assert.equal(control.enabled, false, `${activeOperation} should stay disabled while overview is ${activeOperation} even after terminal ${status}`);
+      assert.equal(control.reason, "cancel/stop already active");
       assert.equal(control.visible, true);
-      assert.equal(control.reason, null);
     }
   }
 });

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -196,6 +196,23 @@ test("cancel success and failure summaries format the Cancel label", () => {
   );
 });
 
+test("cancel remains enabled when terminal cancellation operations complete", () => {
+  const terminalStatuses = ["succeeded", "failed", "cancelled", "canceled"];
+  for (const status of terminalStatuses) {
+    const control = getWorkspaceOperatorControls({
+      overview: overview({
+        status: "running",
+        active_operation: "cancel",
+      }),
+      operations: [operation({ type: "cancel", status })],
+    }).find((item) => item.action === "cancel");
+    assert.ok(control, `missing cancel control for ${status}`);
+    assert.equal(control.enabled, true, `cancel should be enabled after terminal ${status}`);
+    assert.equal(control.visible, true);
+    assert.equal(control.reason, null);
+  }
+});
+
 test("active monitoring workspace exposes the full operator action set", () => {
   const actions = new Set(
     getWorkspaceOperatorControls({

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -199,6 +199,9 @@ function hasActiveCancellationOperation(context: WorkspaceOperatorContext): bool
   if (cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status))) {
     return true;
   }
+  if (cancellationOperations.length > 0) {
+    return false;
+  }
   return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";
 }
 

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -189,8 +189,8 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (recoveryOperation) {
-    if (cancellationOperationTypes.has(recoveryOperation.type)) {
-      return !terminalOperationStatuses.has(recoveryOperation.status);
+    if (cancellationOperationTypes.has(recoveryOperation.type) && !terminalOperationStatuses.has(recoveryOperation.status)) {
+      return true;
     }
   }
   const cancellationOperations = (context.operations ?? []).filter((operation) =>

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -187,19 +187,20 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 }
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
+  const hasOperationsData = context.operations !== undefined && context.operations !== null;
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (recoveryOperation) {
     if (cancellationOperationTypes.has(recoveryOperation.type) && !terminalOperationStatuses.has(recoveryOperation.status)) {
       return true;
     }
   }
-  const cancellationOperations = (context.operations ?? []).filter((operation) =>
+  const cancellationOperations = (hasOperationsData ? context.operations : []).filter((operation) =>
     cancellationOperationTypes.has(operation.type),
   );
   if (cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status))) {
     return true;
   }
-  if (cancellationOperations.length > 0) {
+  if (hasOperationsData) {
     return false;
   }
   return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -187,24 +187,14 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 }
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
-  const hasOperationsData =
-    context.operations !== undefined &&
-    context.operations !== null &&
-    context.operations.length > 0;
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (recoveryOperation) {
     if (cancellationOperationTypes.has(recoveryOperation.type) && !terminalOperationStatuses.has(recoveryOperation.status)) {
       return true;
     }
   }
-  const cancellationOperations = (hasOperationsData ? context.operations : []).filter((operation) =>
-    cancellationOperationTypes.has(operation.type),
-  );
-  if (cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status))) {
+  if ((context.operations ?? []).some((operation) => cancellationOperationTypes.has(operation.type) && !terminalOperationStatuses.has(operation.status))) {
     return true;
-  }
-  if (hasOperationsData) {
-    return false;
   }
   return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";
 }

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -196,8 +196,8 @@ function hasActiveCancellationOperation(context: WorkspaceOperatorContext): bool
   const cancellationOperations = (context.operations ?? []).filter((operation) =>
     cancellationOperationTypes.has(operation.type),
   );
-  if (cancellationOperations.length > 0) {
-    return cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status));
+  if (cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status))) {
+    return true;
   }
   return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";
 }

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -188,26 +188,18 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
-  if (isActiveCancellationOperation(recoveryOperation?.type, recoveryOperation?.status)) {
-    return true;
+  if (recoveryOperation) {
+    if (cancellationOperationTypes.has(recoveryOperation.type)) {
+      return !terminalOperationStatuses.has(recoveryOperation.status);
+    }
   }
-  return (context.operations ?? []).some((operation) =>
-    isActiveCancellationOperation(operation.type, operation.status),
+  const cancellationOperations = (context.operations ?? []).filter((operation) =>
+    cancellationOperationTypes.has(operation.type),
   );
-}
-
-function isActiveCancellationOperation(
-  operationType: string | null | undefined,
-  operationStatus: string | null | undefined,
-): boolean {
-  return (
-    operationType !== null &&
-    operationType !== undefined &&
-    cancellationOperationTypes.has(operationType) &&
-    operationStatus !== null &&
-    operationStatus !== undefined &&
-    !terminalOperationStatuses.has(operationStatus)
-  );
+  if (cancellationOperations.length > 0) {
+    return cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status));
+  }
+  return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";
 }
 
 function eligibleEnoughForActiveReason(action: WorkspaceOperatorAction, context: WorkspaceOperatorContext): boolean {

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -73,9 +73,9 @@ export function getWorkspaceOperatorControls(context: WorkspaceOperatorContext):
 
   return controls.map((control) => ({
     ...control,
-    enabled: false,
+    enabled: control.action === "cancel" ? control.enabled : false,
     visible: control.visible || eligibleEnoughForActiveReason(control.action, context),
-    reason: "active operation",
+    reason: control.action === "cancel" ? control.reason : "active operation",
   }));
 }
 

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -187,16 +187,26 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 }
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
+  const cancellationOperations = (context.operations ?? []).filter((operation) =>
+    cancellationOperationTypes.has(operation.type),
+  );
+
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (recoveryOperation) {
     if (cancellationOperationTypes.has(recoveryOperation.type) && !terminalOperationStatuses.has(recoveryOperation.status)) {
       return true;
     }
   }
-  if ((context.operations ?? []).some((operation) => cancellationOperationTypes.has(operation.type) && !terminalOperationStatuses.has(operation.status))) {
+  if (cancellationOperations.some((operation) => !terminalOperationStatuses.has(operation.status))) {
     return true;
   }
-  return context.overview.active_operation === "cancel" || context.overview.active_operation === "stop";
+  if (cancellationOperations.length > 0) {
+    return false;
+  }
+  if (context.overview.active_operation === "cancel" || context.overview.active_operation === "stop") {
+    return true;
+  }
+  return false;
 }
 
 function eligibleEnoughForActiveReason(action: WorkspaceOperatorAction, context: WorkspaceOperatorContext): boolean {

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -187,7 +187,10 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 }
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
-  const hasOperationsData = context.operations !== undefined && context.operations !== null;
+  const hasOperationsData =
+    context.operations !== undefined &&
+    context.operations !== null &&
+    context.operations.length > 0;
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (recoveryOperation) {
     if (cancellationOperationTypes.has(recoveryOperation.type) && !terminalOperationStatuses.has(recoveryOperation.status)) {

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -57,9 +57,11 @@ const cancellableStatuses = new Set([
 ]);
 
 const terminalOperationStatuses = new Set(["succeeded", "failed", "cancelled", "canceled"]);
+const cancellationOperationTypes = new Set(["cancel", "stop"]);
 
 export function getWorkspaceOperatorControls(context: WorkspaceOperatorContext): WorkspaceOperatorControl[] {
   const active = hasActiveOperation(context);
+  const cancelling = hasActiveCancellationOperation(context);
   const controls = [
     remonitorControl(context),
     refreshControl(context),
@@ -73,9 +75,10 @@ export function getWorkspaceOperatorControls(context: WorkspaceOperatorContext):
 
   return controls.map((control) => ({
     ...control,
-    enabled: control.action === "cancel" ? control.enabled : false,
+    enabled: control.action === "cancel" ? (cancelling ? false : control.enabled) : false,
     visible: control.visible || eligibleEnoughForActiveReason(control.action, context),
-    reason: control.action === "cancel" ? control.reason : "active operation",
+    reason:
+      control.action === "cancel" ? (cancelling ? "cancel/stop already active" : control.reason) : "active operation",
   }));
 }
 
@@ -181,6 +184,33 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
     return true;
   }
   return (context.operations ?? []).some((operation) => !terminalOperationStatuses.has(operation.status));
+}
+
+function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
+  if (cancellationOperationTypes.has(context.overview.active_operation ?? "")) {
+    return true;
+  }
+  const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
+  if (isActiveCancellationOperation(recoveryOperation?.type, recoveryOperation?.status)) {
+    return true;
+  }
+  return (context.operations ?? []).some((operation) =>
+    isActiveCancellationOperation(operation.type, operation.status),
+  );
+}
+
+function isActiveCancellationOperation(
+  operationType: string | null | undefined,
+  operationStatus: string | null | undefined,
+): boolean {
+  return (
+    operationType !== null &&
+    operationType !== undefined &&
+    cancellationOperationTypes.has(operationType) &&
+    operationStatus !== null &&
+    operationStatus !== undefined &&
+    !terminalOperationStatuses.has(operationStatus)
+  );
 }
 
 function eligibleEnoughForActiveReason(action: WorkspaceOperatorAction, context: WorkspaceOperatorContext): boolean {

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -187,9 +187,6 @@ function hasActiveOperation(context: WorkspaceOperatorContext): boolean {
 }
 
 function hasActiveCancellationOperation(context: WorkspaceOperatorContext): boolean {
-  if (cancellationOperationTypes.has(context.overview.active_operation ?? "")) {
-    return true;
-  }
   const recoveryOperation = context.workspace?.recovery?.current_operation ?? context.overview.recovery?.current_operation ?? null;
   if (isActiveCancellationOperation(recoveryOperation?.type, recoveryOperation?.status)) {
     return true;

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -345,7 +345,7 @@ test.describe("Operator cancel control", () => {
     expect(cancelPosts).toBe(0);
   });
 
-  test("keeps cancel disabled when only terminal cancel rows are in details", async ({ page }) => {
+  test("keeps cancel enabled when only terminal cancel rows are in details", async ({ page }) => {
     let cancelPosts = 0;
     await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
       cancelPosts += 1;
@@ -423,7 +423,7 @@ test.describe("Operator cancel control", () => {
 
     const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
     await expect(cancelButton).toBeVisible();
-    await expect(cancelButton).toBeDisabled();
+    await expect(cancelButton).toBeEnabled();
     await page.waitForTimeout(200);
     expect(cancelPosts).toBe(0);
   });

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -262,6 +262,89 @@ test.describe("Operator cancel control", () => {
     expect(cancelPosts).toBe(0);
   });
 
+  test("keeps cancel disabled when only terminal cancel rows are in details", async ({ page }) => {
+    let cancelPosts = 0;
+    await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
+      cancelPosts += 1;
+      await route.fulfill({
+        json: {
+          workspace_id: WORKSPACE_ID,
+          operation_id: "op_cancel123",
+          operation_status: "succeeded",
+          status: "cancelled",
+          message: "cancel requested",
+        },
+      });
+    });
+
+    const workspacePayload = () => ({
+      workspace_id: WORKSPACE_ID,
+      title: "Mock Workspace",
+      repo_url: "https://github.com/test/repo",
+      base_branch: "main",
+      agent: "test-agent",
+      status: "running",
+      active_operation: "cancel",
+      version: 7,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+    });
+
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await route.fulfill({ json: { items: [workspacePayload()], has_more: false } });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}`, async (route) => {
+      await route.fulfill({ json: workspacePayload() });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/operations*`, async (route) => {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              id: "op_cancel456",
+              workspace_id: WORKSPACE_ID,
+              type: "cancel",
+              status: "canceled",
+              error_code: null,
+              error_message: null,
+              payload: null,
+              result: null,
+              idempotency_key: null,
+              created_at: new Date().toISOString(),
+              started_at: new Date().toISOString(),
+              finished_at: new Date().toISOString(),
+              owner: null,
+              source: null,
+              action: null,
+              pr_number: null,
+              pr_url: null,
+              source_head_sha: null,
+              source_base_sha: null,
+              reason: null,
+              reason_code: null,
+              failure_code: null,
+              failure_message: null,
+              log_stream_refs: {},
+              log_stream_ids: [],
+            },
+          ],
+          has_more: false,
+        },
+      });
+    });
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeDisabled();
+    await page.waitForTimeout(200);
+    expect(cancelPosts).toBe(0);
+  });
+
   test("does not carry an open cancel confirmation across a workspace switch", async ({ page }) => {
     const SECOND_WORKSPACE_ID = "ws_mock456";
 

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -119,9 +119,8 @@ test.describe("Operator cancel control", () => {
     expect(cancelPosts).toBe(1);
   });
 
-  test("auto-dismisses an open confirmation when cancel becomes disabled", async ({ page }) => {
+  test("keeps cancel enabled while a workspace operation is active", async ({ page }) => {
     let cancelPosts = 0;
-    let activeOperation: string | null = null;
     await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
       cancelPosts += 1;
       await route.fulfill({
@@ -142,7 +141,7 @@ test.describe("Operator cancel control", () => {
       base_branch: "main",
       agent: "test-agent",
       status: "running",
-      active_operation: activeOperation,
+      active_operation: "op_background",
       version: 7,
       created_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
@@ -165,21 +164,17 @@ test.describe("Operator cancel control", () => {
     const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
     await expect(cancelButton).toBeVisible();
     await expect(cancelButton).toBeEnabled();
+    await expect(cancelButton.locator("..")).not.toContainText("active operation");
+    await expect(page.getByText("active operation", { exact: true })).toHaveCount(0);
 
-    // Open the cancel confirmation while cancel is still available.
+    // A background AWF operation must not disable the emergency cancel path.
     await cancelButton.click();
     const confirmation = page.getByTestId("operator-cancel-confirm");
     await expect(confirmation).toBeVisible();
 
-    // A background operation begins while the confirmation is open, so the
-    // cancel control becomes disabled. The still-open confirmation must drop
-    // itself and Confirm cancel must never POST against the guarded workspace.
-    activeOperation = "op_busy";
-
-    await expect(cancelButton).toBeDisabled({ timeout: 15000 });
-    await expect(confirmation).not.toBeVisible();
-    await page.waitForTimeout(200);
-    expect(cancelPosts).toBe(0);
+    await page.getByRole("button", { name: "Confirm cancel", exact: true }).click();
+    await expect(page.getByText("Cancel succeeded:")).toBeVisible();
+    expect(cancelPosts).toBe(1);
   });
 
   test("does not carry an open cancel confirmation across a workspace switch", async ({ page }) => {

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -262,6 +262,89 @@ test.describe("Operator cancel control", () => {
     expect(cancelPosts).toBe(0);
   });
 
+  test("keeps cancel disabled when overview reports cancel and details contain non-cancel operations", async ({ page }) => {
+    let cancelPosts = 0;
+    await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
+      cancelPosts += 1;
+      await route.fulfill({
+        json: {
+          workspace_id: WORKSPACE_ID,
+          operation_id: "op_cancel123",
+          operation_status: "running",
+          status: "running",
+          message: "cancel requested",
+        },
+      });
+    });
+
+    const workspacePayload = () => ({
+      workspace_id: WORKSPACE_ID,
+      title: "Mock Workspace",
+      repo_url: "https://github.com/test/repo",
+      base_branch: "main",
+      agent: "test-agent",
+      status: "running",
+      active_operation: "cancel",
+      version: 7,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+    });
+
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await route.fulfill({ json: { items: [workspacePayload()], has_more: false } });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}`, async (route) => {
+      await route.fulfill({ json: workspacePayload() });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/operations*`, async (route) => {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              id: "op_provision456",
+              workspace_id: WORKSPACE_ID,
+              type: "provision",
+              status: "running",
+              error_code: null,
+              error_message: null,
+              payload: null,
+              result: null,
+              idempotency_key: null,
+              created_at: new Date().toISOString(),
+              started_at: new Date().toISOString(),
+              finished_at: null,
+              owner: null,
+              source: null,
+              action: null,
+              pr_number: null,
+              pr_url: null,
+              source_head_sha: null,
+              source_base_sha: null,
+              reason: null,
+              reason_code: null,
+              failure_code: null,
+              failure_message: null,
+              log_stream_refs: {},
+              log_stream_ids: [],
+            },
+          ],
+          has_more: false,
+        },
+      });
+    });
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeDisabled();
+    await page.waitForTimeout(200);
+    expect(cancelPosts).toBe(0);
+  });
+
   test("keeps cancel disabled when only terminal cancel rows are in details", async ({ page }) => {
     let cancelPosts = 0;
     await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {

--- a/apps/console/tests/dashboard-cancel-control.spec.ts
+++ b/apps/console/tests/dashboard-cancel-control.spec.ts
@@ -177,6 +177,91 @@ test.describe("Operator cancel control", () => {
     expect(cancelPosts).toBe(1);
   });
 
+  test("disables cancel while a cancel operation is active", async ({ page }) => {
+    let cancelPosts = 0;
+    await page.route(`/api/operator/workspaces/${WORKSPACE_ID}/cancel`, async (route) => {
+      cancelPosts += 1;
+      await route.fulfill({
+        json: {
+          workspace_id: WORKSPACE_ID,
+          operation_id: "op_cancel123",
+          operation_status: "running",
+          status: "running",
+          message: "cancel requested",
+        },
+      });
+    });
+
+    const workspacePayload = () => ({
+      workspace_id: WORKSPACE_ID,
+      title: "Mock Workspace",
+      repo_url: "https://github.com/test/repo",
+      base_branch: "main",
+      agent: "test-agent",
+      status: "running",
+      active_operation: "cancel",
+      version: 7,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      lifecycle: [],
+      llm_usage: null,
+      recovery: null,
+    });
+
+    await page.route("/api/awf/workspaces/overview*", async (route) => {
+      await route.fulfill({ json: { items: [workspacePayload()], has_more: false } });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}`, async (route) => {
+      await route.fulfill({ json: workspacePayload() });
+    });
+    await page.route(`/api/awf/workspaces/${WORKSPACE_ID}/operations*`, async (route) => {
+      await route.fulfill({
+        json: {
+          items: [
+            {
+              id: "op_cancel456",
+              workspace_id: WORKSPACE_ID,
+              type: "cancel",
+              status: "running",
+              error_code: null,
+              error_message: null,
+              payload: null,
+              result: null,
+              idempotency_key: null,
+              created_at: new Date().toISOString(),
+              started_at: new Date().toISOString(),
+              finished_at: null,
+              owner: null,
+              source: null,
+              action: null,
+              pr_number: null,
+              pr_url: null,
+              source_head_sha: null,
+              source_base_sha: null,
+              reason: null,
+              reason_code: null,
+              failure_code: null,
+              failure_message: null,
+              log_stream_refs: {},
+              log_stream_ids: [],
+            },
+          ],
+          has_more: false,
+        },
+      });
+    });
+
+    await page.goto(`/?workspaceId=${WORKSPACE_ID}`);
+
+    const cancelButton = page.getByRole("button", { name: "Cancel", exact: true });
+    await expect(cancelButton).toBeVisible();
+    await expect(cancelButton).toBeDisabled();
+    await expect(page.getByText("Cancel succeeded:")).not.toBeVisible();
+    await expect(page.getByText("active operation", { exact: true })).toHaveCount(0);
+    await page.waitForTimeout(200);
+    expect(cancelPosts).toBe(0);
+  });
+
   test("does not carry an open cancel confirmation across a workspace switch", async ({ page }) => {
     const SECOND_WORKSPACE_ID = "ws_mock456";
 


### PR DESCRIPTION
## Summary
- keep workspace Cancel enabled while AWF has an active background operation
- move inactive operator-control reasons out of inline text and into fast hover/focus tooltips
- update console regressions for active-operation cancel behavior and tooltip-only reasons

## Validation
- npm --prefix apps/console run test -- workspace-operator-controls
- npm --prefix apps/console run test -- dashboard-cancel-control
- npm --prefix apps/console run lint -- components/console-dashboard-workspace-detail.tsx lib/workspace-operator-controls.ts lib/workspace-operator-controls.test.mjs lib/console-dashboard-source.test.mjs tests/dashboard-cancel-control.spec.ts
- npm --prefix apps/console run typecheck
- live Playwright smoke: disabled Remonitor tooltip appears within 300ms on http://127.0.0.1:3000

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator emergency-cancel eligibility and UI affordances for destructive controls; mistakes could allow duplicate cancels or hide why actions are disabled.
> 
> **Overview**
> **Cancel stays available during background AWF work**, while remonitor/refresh/revalidate still lock when any operation is active. `getWorkspaceOperatorControls` now uses `hasActiveCancellationOperation` so Cancel is only blocked when cancel/stop is actually in flight (or overview still says cancel/stop with no terminal cancel rows in details); terminal cancel operations re-enable Cancel even if overview flags look stale.
> 
> **Operator control disabled reasons move off the row** into hover/focus tooltips in `OperatorControlsBlock` (with `aria-describedby` / keyboard focus), instead of truncated inline text beside each button.
> 
> Unit and Playwright coverage updated for the new eligibility rules and tooltip-only reasons.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013d7dc3ae177821ade351b19a506db6a6887228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Operator control reasons now show in interactive tooltips on hover/focus instead of inline text.

* **Bug Fixes**
  * Cancel remains enabled during an active workspace operation unless a cancel/stop is already in progress.
  * All other operator controls are properly disabled and show appropriate status reasons during active operations.

* **Tests**
  * Updated unit and end-to-end tests to cover tooltip behavior and revised cancel logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->