### PR TITLE
Fix #473: resolve addressed review threads even when the fix made them outdated

### DIFF
--- a/docs/awf-plans/ws_b5b4b38e74294f7eae23aab5.md
+++ b/docs/awf-plans/ws_b5b4b38e74294f7eae23aab5.md
@@ -1,0 +1,195 @@
+# Plan — Fix #473: resolve addressed review threads that become OUTDATED
+
+Workspace: `ws_b5b4b38e74294f7eae23aab5`
+
+## Problem (root cause, verified)
+
+When the PR monitor addresses a review thread by changing code **elsewhere**
+(a different file/lines than the comment anchor), the forge marks the original
+thread `isOutdated=true`. Both forge clients **drop outdated threads** from
+`PRStatus.unresolved_inline_threads`:
+
+- `common/github_client.py` `fetch_pr_status` line 612: `if is_resolved or is_outdated: continue`.
+- `common/bitbucket_client_parsing.py` `build_review_threads` line 404: skips `inline_meta["outdated"]`.
+
+Resolves only ever happen inside `runtime/pr_monitor_runner/fix_cycle.py`'s
+`_run_fix_cycle` resolve loop (the **only** `resolve_thread` call site), driven
+by `threads_to_resolve` collected from threads still present in
+`unresolved_inline_threads`. Once a thread goes outdated it disappears from that
+list, `decide()` sees `unresolved_threads=0` and returns `Merge`, the fix cycle
+never runs again for it, and the thread is **never resolved** — leaving a merged
+PR with a lingering "unresolved" comment even though the monitor recorded a
+`fix_committed` verdict in `state.threads_addressed_ids`.
+
+Proven on PR #470: an in-place greptile fix → `isResolved=true`; a same-feedback
+fix made in a different file → `isOutdated=true`, `isResolved=false`, never
+resolved.
+
+The merge-gate semantics are correct (outdated threads are legitimately
+non-blocking). The defect is purely that the **resolve hygiene step is blind to
+addressed-but-now-outdated threads.**
+
+## Chosen design
+
+Forge clients already know which threads are outdated-but-unresolved (they
+currently throw that information away). Surface it, then add a small
+forge-neutral runner step that resolves the ones the monitor has handled.
+
+1. **Surface outdated-unresolved inline threads** via a new, default-empty
+   `PRStatus` field so non-forge constructors are unaffected:
+   - `runtime/pr_monitor.py`: add
+     `outdated_unresolved_inline_threads: tuple[ReviewThread, ...] = ()` to
+     `PRStatus` (appended after existing optional fields; keyword-only
+     construction everywhere, so safe).
+   - `common/github_client.py` `fetch_pr_status`: when a thread is
+     `is_outdated and not is_resolved` and has external comments, build a
+     `ReviewThread(..., is_outdated=True)` and append to a new `outdated` list
+     instead of silently `continue`-ing. Populate the new `PRStatus` field at
+     line ~721. (GraphQL already returns `isOutdated` — no query change.)
+   - `common/bitbucket_client_parsing.py`: add
+     `build_outdated_unresolved_review_threads(comments, *, repo, pr_number,
+     account_id)` that mirrors `build_review_threads` but returns **only** the
+     threads dropped for `outdated` (still not resolved, still has external
+     comments), each `is_outdated=True`. Keep `build_review_threads` behavior
+     unchanged (still drops outdated from the actionable feed).
+   - `common/bitbucket_client.py` `fetch_pr_status`: populate the new field from
+     the new helper. (Reviewer *tasks* have no outdated concept — do not
+     include them.)
+
+2. **Resolve addressed-but-outdated threads** — new focused module
+   `runtime/pr_monitor_runner/outdated_resolution.py` with
+   `_resolve_addressed_outdated_threads(self, *, workspace_id, repo, pr_number,
+   status, state, base_branch, remote_branch, monitor_log)`:
+   - Iterate `status.outdated_unresolved_inline_threads`.
+   - Resolve a thread **only** when its latest recorded verdict
+     `state.threads_addressed_ids.get(thread_id)` is in a narrow set
+     `_OUTDATED_RESOLVABLE_THREAD_VERDICTS = frozenset({"fix_committed",
+     "false_positive"})` (the existing `_RESOLVABLE_THREAD_VERDICTS` **minus
+     `defer`**: defer's resolution is gated on durable capture that we cannot
+     re-verify here). This excludes `defer`, `needs_human`, `agent_failed`
+     ("rejected"/needs-human style) — they legitimately stay open.
+   - Call `self._deps.gh.resolve_thread(thread_id=tid)` (forge-neutral: GitHub
+     `resolveReviewThread` mutation; BitBucket `POST .../resolve`, never DELETE).
+   - Error handling mirrors the fix-cycle resolve loop: catch the shared
+     `ForgeClientError` base; transient → `_wait_after_transient_forge_error`
+     then skip (re-tried next poll, thread stays in outdated set); permanent →
+     `_log.warning("monitor.resolve_outdated_thread_failed", ...)` + audit
+     `failed` event, then skip — **never crash the monitor, never clear the
+     addressed marker** (thread is non-blocking; nothing to wedge). Already-
+     resolved races are tolerated by the same broad catch (idempotent — no
+     double-resolve surfaced as failure).
+   - Record `_AUDIT_COMMENT_RESOLUTION_EVENT` audit events (`action=
+     "resolve_outdated_thread"`, outcomes `succeeded`/`requeued`/`failed`,
+     forge-native `reason_code`), preserving reason codes end-to-end. No secrets
+     logged (reuse `redacted_detail()` / existing redaction helpers).
+   - No `state` mutation needed: the verdict already lives in state and, once
+     resolved, the thread drops out of `outdated_unresolved_inline_threads` next
+     fetch.
+   - Wire it in `runtime/pr_monitor_runner/mixins.py`
+     (`RunnerDelegatesMixin`).
+
+3. **Invoke once per poll, before `decide()`** in
+   `runtime/pr_monitor_runner/runner.py` immediately before
+   `action = decide(status, state, self._config)` (line ~319), where `repo`,
+   `pr_number`, `status`, `state`, `remote_branch`, `ws.branch_base`, and
+   `monitor_log` are all in scope. Running every poll (not only at merge) closes
+   the operator-visible signal as soon as the thread goes outdated and guarantees
+   it is resolved before the `Merge` cycle. Self-contained error handling keeps
+   forge faults from escaping into the loop's existing `ForgeClientError` arms.
+
+This is forge-neutral (gap exists on both, observed on GitHub), keeps AWF core
+generic (no project specifics), and does not touch merge-gate semantics.
+
+## Files to touch
+
+- `src/awf/runtime/pr_monitor.py` — add `PRStatus.outdated_unresolved_inline_threads`.
+- `src/awf/common/github_client.py` — collect + populate outdated-unresolved threads.
+- `src/awf/common/bitbucket_client_parsing.py` — `build_outdated_unresolved_review_threads`.
+- `src/awf/common/bitbucket_client.py` — populate new field in `fetch_pr_status`.
+- `src/awf/runtime/pr_monitor_runner/outdated_resolution.py` — **new** resolve step.
+- `src/awf/runtime/pr_monitor_runner/mixins.py` — wire the delegate.
+- `src/awf/runtime/pr_monitor_runner/runner.py` — invoke before `decide()`.
+- (If a shared constant home is cleaner) reuse `fix_cycle._RESOLVABLE_THREAD_VERDICTS`
+  by deriving the narrower set in the new module; do not change the existing one.
+
+## Tests to write first (strict TDD)
+
+Parsing / forge-client surface:
+- `tests/unit/common/test_github_client_parts/...`: `fetch_pr_status` returns an
+  outdated+unresolved thread in `outdated_unresolved_inline_threads` and **keeps
+  it out of** `unresolved_inline_threads`; a resolved-outdated thread appears in
+  neither; an in-place unresolved thread still appears only in the actionable
+  list.
+- `tests/unit/common/test_bitbucket_client_parts/...`:
+  `build_outdated_unresolved_review_threads` returns only outdated, not-resolved,
+  has-external-comment threads (`is_outdated=True`, `bb:` ids); resolved threads
+  excluded; `build_review_threads` output unchanged; `fetch_pr_status` populates
+  the new field; reviewer tasks are not included.
+
+Runner resolve step (new tests under
+`tests/unit/runtime/test_pr_monitor_runner_*` with a fake `gh` recording
+`resolve_thread` calls):
+- **(a) #473 regression:** a thread recorded `fix_committed` that is now OUTDATED
+  (only in `outdated_unresolved_inline_threads`) IS resolved (`resolve_thread`
+  called with its id) before/at merge. Pin the PR #470 scenario.
+- **(b) in-place still works:** a `fix_committed` thread addressed in-place (still
+  in `unresolved_inline_threads`, not in the outdated list) is resolved by the
+  existing fix-cycle path and is **not** double-resolved by the new step
+  (the new step only reads the outdated list).
+- **(c) keep-open verdicts:** outdated threads recorded `defer`, `needs_human`,
+  and `agent_failed` are **NOT** resolved (no `resolve_thread` call).
+- **(d) forge-neutral / BitBucket:** the same `fix_committed`-outdated scenario
+  with a BitBucket-style `gh` resolves via `resolve_thread` (POST semantics);
+  assert no DELETE/reopen.
+- **(e) idempotent / already-resolved:** `resolve_thread` raising a
+  `ForgeClientError` (transient and permanent variants) does not crash the
+  monitor, does not surface as failure, and (transient) is left for next poll;
+  audit event recorded with the forge-native reason code.
+- Verdict-set unit test: `_OUTDATED_RESOLVABLE_THREAD_VERDICTS` excludes `defer`
+  while the existing `_RESOLVABLE_THREAD_VERDICTS` still includes it (guards the
+  intentional divergence).
+
+## Validation commands
+
+Targeted during development (focused, per workspace contract):
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/common/test_github_client_parts -q -k outdated
+uv run --python 3.12 --extra dev pytest tests/unit/common/test_bitbucket_client_parts -q -k outdated
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_runner_parts -q -k outdated
+uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+uv run --python 3.12 --extra dev mypy
+uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check   # PRStatus is not an API schema; expected no drift
+```
+
+Full local gate (ruff, ruff format --check, mypy, pytest, 99% coverage) and CI
+are owned by AWF/GitHub after the agent phase; do not run the broad suite here.
+
+## Risks & assumptions
+
+- **PRStatus field addition** is safe because every construction site is
+  keyword-only and the field defaults to `()`. Will grep all `PRStatus(`
+  constructors to confirm none rely on positional args; coverage stays full
+  because the default branch is exercised by existing tests and the new field is
+  populated/asserted by new tests.
+- **Repeated permanent resolve failures**: a thread whose resolve permanently
+  fails stays in the outdated set and is retried each poll. This is non-blocking
+  (merge proceeds) and every attempt is logged/audited — acceptable and matches
+  "never hide failures." No silent suppression.
+- **`false_positive` inclusion**: included alongside `fix_committed` because both
+  mean "handled, thread should close, no human follow-up" (existing fix-cycle
+  resolves both). `defer` is deliberately excluded (capture-gated). Documented in
+  code + guarded by test (c) and the verdict-set test.
+- **GitHub `resolveReviewThread` on an outdated thread** resolves normally
+  (outdated ≠ resolved); BitBucket `POST .../resolve` is the resolve verb.
+- Assumes `outdated_unresolved_inline_threads` ids are exactly the ids stored in
+  `state.threads_addressed_ids` (same `thread_id` encoding the fix-cycle used).
+
+## Non-goals (explicit)
+
+- No change to merge-gate semantics — outdated threads remain non-blocking.
+- No backfill of already-merged PRs (e.g. PR #470's lingering thread).
+- No change to `build_review_threads`'s actionable-feed behavior (outdated still
+  excluded there).
+- No new agent invocation / re-address of outdated threads — pure resolve hygiene
+  on threads the monitor already recorded as handled.

--- a/src/awf/common/bitbucket_client.py
+++ b/src/awf/common/bitbucket_client.py
@@ -66,6 +66,7 @@ from awf.common.bitbucket_client_parsing import (
     bb_merge_strategy_for_method,
     build_blocking_reviews,
     build_general_review_comments,
+    build_outdated_unresolved_review_threads,
     build_review_threads,
     build_unresolved_task_threads,
     decode_task_id,
@@ -373,6 +374,13 @@ class BitBucketClient:
             latest_external_review_activity_source=latest_review_source,
             quiet_period_anchor_at=quiet_anchor_at,
             quiet_period_anchor_source=quiet_anchor_source,
+            # Outdated-but-unresolved inline threads (addressed elsewhere) are
+            # dropped from the actionable feed above; surface them so the monitor
+            # can resolve the ones it addressed (#473). Reviewer tasks have no
+            # outdated concept, so they are intentionally not included here.
+            outdated_unresolved_inline_threads=build_outdated_unresolved_review_threads(
+                comments, repo=repo, pr_number=pr_number, account_id=account_id
+            ),
         )
 
     async def fetch_failing_check_logs(

--- a/src/awf/common/bitbucket_client.py
+++ b/src/awf/common/bitbucket_client.py
@@ -66,8 +66,6 @@ from awf.common.bitbucket_client_parsing import (
     bb_merge_strategy_for_method,
     build_blocking_reviews,
     build_general_review_comments,
-    build_outdated_unresolved_review_threads,
-    build_review_threads,
     build_unresolved_task_threads,
     decode_task_id,
     decode_thread_id,
@@ -84,6 +82,7 @@ from awf.common.bitbucket_client_parsing import (
     parse_check_state,
     parse_check_timings,
     parse_pr_terminal_state,
+    partition_inline_review_threads,
     pipeline_has_ref_info,
     pipeline_targets_branch,
     pipeline_targets_pr,
@@ -339,6 +338,13 @@ class BitBucketClient:
             pr_updated_at=parse_bb_datetime(pr.get("updated_on")),
             head_committed_at=None,
         )
+        # Single pass over the inline comments yields both feeds: the actionable
+        # threads that gate the merge and the outdated-but-unresolved ones the
+        # monitor resolves for hygiene (#473). Building them separately would run
+        # the group/sort/map pipeline twice per poll.
+        actionable_inline_threads, outdated_inline_threads = partition_inline_review_threads(
+            comments, repo=repo, pr_number=pr_number, account_id=account_id
+        )
         return PRStatus(
             number=int(pr.get("id") or pr_number),
             head_sha=head_sha,
@@ -348,9 +354,7 @@ class BitBucketClient:
             # gate routes every item to AddressComments regardless of author and
             # resolves through ``resolve_thread`` — which dispatches the ``bbtask:``
             # id to the task PUT. This makes open tasks block merge until addressed.
-            unresolved_inline_threads=build_review_threads(
-                comments, repo=repo, pr_number=pr_number, account_id=account_id
-            )
+            unresolved_inline_threads=actionable_inline_threads
             + build_unresolved_task_threads(
                 tasks, repo=repo, pr_number=pr_number, account_id=account_id
             ),
@@ -378,9 +382,7 @@ class BitBucketClient:
             # dropped from the actionable feed above; surface them so the monitor
             # can resolve the ones it addressed (#473). Reviewer tasks have no
             # outdated concept, so they are intentionally not included here.
-            outdated_unresolved_inline_threads=build_outdated_unresolved_review_threads(
-                comments, repo=repo, pr_number=pr_number, account_id=account_id
-            ),
+            outdated_unresolved_inline_threads=outdated_inline_threads,
         )
 
     async def fetch_failing_check_logs(

--- a/src/awf/common/bitbucket_client_parsing.py
+++ b/src/awf/common/bitbucket_client_parsing.py
@@ -24,7 +24,7 @@ Neutral-type contract is owned by ``runtime.pr_monitor`` (do NOT change it). We 
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -344,19 +344,22 @@ def _resolve_thread_root_id(comment: dict[str, Any], by_id: dict[str, dict[str, 
         current = by_id[parent_id]
 
 
-def build_review_threads(
+def _iter_unresolved_inline_threads(
     comments: list[dict[str, Any]],
     *,
     repo: RepoRef,
     pr_number: int,
     account_id: str | None,
-) -> tuple[ReviewThread, ...]:
-    """Reconstruct inline review threads from BitBucket's flat comment list.
+) -> Iterator[ReviewThread]:
+    """Yield every unresolved inline thread with its ``is_outdated`` flag set.
 
-    Mirrors the GitHub assembly: resolved threads and viewer-authored comments are
-    dropped, and a thread with no remaining external comments is skipped. The
-    neutral ``thread_id`` encodes repo/PR/comment so ``resolve_thread`` can recover
-    BitBucket context from the Protocol's repo-less signature.
+    Shared core for the actionable feed (``build_review_threads``, which keeps
+    only ``is_outdated=False``) and the outdated-resolution feed
+    (``build_outdated_unresolved_review_threads``, which keeps the rest, #473).
+    Resolved threads, viewer-authored-only threads, and threads with no remaining
+    external comment are dropped from both — exactly as the GitHub path does. The
+    neutral ``thread_id`` encodes repo/PR/comment so ``resolve_thread`` can
+    recover BitBucket context from the Protocol's repo-less signature.
     """
     inline = [
         comment
@@ -374,7 +377,6 @@ def build_review_threads(
         if root_id == str(comment["id"]):
             roots[root_id] = comment
 
-    threads: list[ReviewThread] = []
     for root_id, members in grouped.items():
         root = roots.get(root_id, members[0])
         if any(_comment_is_resolved(member) for member in members):
@@ -396,32 +398,77 @@ def build_review_threads(
             continue
         first = external[0]
         inline_meta = root.get("inline") if isinstance(root.get("inline"), dict) else {}
-        # Mirror the GitHub path (github_client.py): an inline comment BitBucket
-        # marks ``outdated`` after a new push no longer describes the current
-        # diff. Downstream gates treat every unresolved thread as actionable and
-        # never consult ``is_outdated``, so keeping it here would drive needless
-        # fix cycles and block merges. Drop it as GitHub drops ``isOutdated``.
-        if isinstance(inline_meta, dict) and bool(inline_meta.get("outdated")):
-            continue
+        # An inline comment BitBucket marks ``outdated`` after a new push no
+        # longer describes the current diff (the feedback was addressed by an
+        # edit elsewhere). Mirror the GitHub path: such threads are non-blocking
+        # for merge, so they are kept out of the actionable feed but still
+        # surfaced (flagged ``is_outdated``) for resolve hygiene (#473).
+        outdated = isinstance(inline_meta, dict) and bool(inline_meta.get("outdated"))
         line = inline_meta.get("to") if isinstance(inline_meta, dict) else None
         if line is None and isinstance(inline_meta, dict):
             line = inline_meta.get("from")
-        threads.append(
-            ReviewThread(
-                thread_id=encode_thread_id(repo=repo, pr_number=pr_number, comment_id=root_id),
-                path=_clean_optional_str(inline_meta.get("path"))
-                if isinstance(inline_meta, dict)
-                else None,
-                line=line if isinstance(line, int) else None,
-                body_excerpt=(first.body or "")[:400],
-                author=first.author,
-                is_resolved=False,
-                comments=external,
-                url=first.url,
-                is_outdated=False,
-            )
+        yield ReviewThread(
+            thread_id=encode_thread_id(repo=repo, pr_number=pr_number, comment_id=root_id),
+            path=_clean_optional_str(inline_meta.get("path"))
+            if isinstance(inline_meta, dict)
+            else None,
+            line=line if isinstance(line, int) else None,
+            body_excerpt=(first.body or "")[:400],
+            author=first.author,
+            is_resolved=False,
+            comments=external,
+            url=first.url,
+            is_outdated=outdated,
         )
-    return tuple(threads)
+
+
+def build_review_threads(
+    comments: list[dict[str, Any]],
+    *,
+    repo: RepoRef,
+    pr_number: int,
+    account_id: str | None,
+) -> tuple[ReviewThread, ...]:
+    """Reconstruct the ACTIONABLE inline review threads (drops outdated).
+
+    Mirrors the GitHub assembly: resolved threads and viewer-authored comments are
+    dropped, a thread with no remaining external comments is skipped, and
+    ``outdated`` threads are excluded (they are non-blocking for merge and would
+    otherwise drive needless fix cycles). The outdated ones are surfaced for
+    resolve hygiene by ``build_outdated_unresolved_review_threads`` instead.
+    """
+    return tuple(
+        thread
+        for thread in _iter_unresolved_inline_threads(
+            comments, repo=repo, pr_number=pr_number, account_id=account_id
+        )
+        if not thread.is_outdated
+    )
+
+
+def build_outdated_unresolved_review_threads(
+    comments: list[dict[str, Any]],
+    *,
+    repo: RepoRef,
+    pr_number: int,
+    account_id: str | None,
+) -> tuple[ReviewThread, ...]:
+    """Reconstruct ONLY the inline threads BitBucket marks ``outdated`` (#473).
+
+    ``build_review_threads`` drops these from the actionable feed because they no
+    longer describe the current diff and are non-blocking for merge. The monitor
+    still needs to resolve the ones it already addressed, so this mirror returns
+    exactly those dropped-for-outdated threads — still unresolved, still carrying
+    an external comment — each flagged ``is_outdated=True``. Resolved threads are
+    excluded; reviewer *tasks* have no outdated concept and are never included.
+    """
+    return tuple(
+        thread
+        for thread in _iter_unresolved_inline_threads(
+            comments, repo=repo, pr_number=pr_number, account_id=account_id
+        )
+        if thread.is_outdated
+    )
 
 
 def _task_is_resolved(task: dict[str, Any]) -> bool:

--- a/src/awf/common/bitbucket_client_parsing.py
+++ b/src/awf/common/bitbucket_client_parsing.py
@@ -422,6 +422,32 @@ def _iter_unresolved_inline_threads(
         )
 
 
+def partition_inline_review_threads(
+    comments: list[dict[str, Any]],
+    *,
+    repo: RepoRef,
+    pr_number: int,
+    account_id: str | None,
+) -> tuple[tuple[ReviewThread, ...], tuple[ReviewThread, ...]]:
+    """Split the unresolved inline threads into ``(actionable, outdated)`` in one pass.
+
+    ``_iter_unresolved_inline_threads`` is the expensive part (grouping, sorting,
+    and mapping every inline comment). The status poll needs both feeds — the
+    actionable threads that gate the merge and the outdated-but-unresolved threads
+    the monitor resolves for hygiene (#473) — so iterate the shared core once and
+    route each thread by its ``is_outdated`` flag, mirroring the single-pass split
+    the GitHub client does inline. ``build_review_threads`` /
+    ``build_outdated_unresolved_review_threads`` remain as thin selectors over this.
+    """
+    actionable: list[ReviewThread] = []
+    outdated: list[ReviewThread] = []
+    for thread in _iter_unresolved_inline_threads(
+        comments, repo=repo, pr_number=pr_number, account_id=account_id
+    ):
+        (outdated if thread.is_outdated else actionable).append(thread)
+    return tuple(actionable), tuple(outdated)
+
+
 def build_review_threads(
     comments: list[dict[str, Any]],
     *,
@@ -437,13 +463,10 @@ def build_review_threads(
     otherwise drive needless fix cycles). The outdated ones are surfaced for
     resolve hygiene by ``build_outdated_unresolved_review_threads`` instead.
     """
-    return tuple(
-        thread
-        for thread in _iter_unresolved_inline_threads(
-            comments, repo=repo, pr_number=pr_number, account_id=account_id
-        )
-        if not thread.is_outdated
+    actionable, _outdated = partition_inline_review_threads(
+        comments, repo=repo, pr_number=pr_number, account_id=account_id
     )
+    return actionable
 
 
 def build_outdated_unresolved_review_threads(
@@ -462,13 +485,10 @@ def build_outdated_unresolved_review_threads(
     an external comment — each flagged ``is_outdated=True``. Resolved threads are
     excluded; reviewer *tasks* have no outdated concept and are never included.
     """
-    return tuple(
-        thread
-        for thread in _iter_unresolved_inline_threads(
-            comments, repo=repo, pr_number=pr_number, account_id=account_id
-        )
-        if thread.is_outdated
+    _actionable, outdated = partition_inline_review_threads(
+        comments, repo=repo, pr_number=pr_number, account_id=account_id
     )
+    return outdated
 
 
 def _task_is_resolved(task: dict[str, Any]) -> bool:

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -582,6 +582,11 @@ class GitHubClient:
 
         # ── Review threads: inline ─────────────────────────────────────
         inline: list[ReviewThread] = []
+        # Threads the forge marks OUTDATED but still unresolved. Kept out of the
+        # actionable ``inline`` feed (they are non-blocking for merge) but
+        # surfaced separately so the monitor can resolve the ones it addressed
+        # before they linger on a merged PR (#473).
+        outdated_unresolved: list[ReviewThread] = []
         thread_nodes = await self._fetch_paginated_pr_connection_nodes(
             repo=repo,
             pr_number=pr_number,
@@ -609,7 +614,12 @@ class GitHubClient:
                     current_source=latest_review_activity_source,
                 )
             )
-            if is_resolved or is_outdated:
+            # Resolved threads are dropped from both feeds — there is nothing
+            # left to action or to resolve. An OUTDATED-but-unresolved thread is
+            # still dropped from the actionable ``inline`` feed (non-blocking for
+            # merge) but routed to ``outdated_unresolved`` so the monitor can
+            # resolve it if it already addressed the underlying feedback (#473).
+            if is_resolved:
                 continue
             comments = tuple(comment for comment in all_comments if not comment.viewer_did_author)
             if not comments:
@@ -617,19 +627,18 @@ class GitHubClient:
             first_comment = comments[0] if comments else None
             body = (first_comment.body if first_comment is not None else "")[:400]
             author = first_comment.author if first_comment is not None else None
-            inline.append(
-                ReviewThread(
-                    thread_id=thread_id,
-                    path=node.get("path"),
-                    line=node.get("line"),
-                    body_excerpt=body,
-                    author=author,
-                    is_resolved=is_resolved,
-                    comments=comments,
-                    url=first_comment.url if first_comment is not None else None,
-                    is_outdated=is_outdated,
-                )
+            thread = ReviewThread(
+                thread_id=thread_id,
+                path=node.get("path"),
+                line=node.get("line"),
+                body_excerpt=body,
+                author=author,
+                is_resolved=is_resolved,
+                comments=comments,
+                url=first_comment.url if first_comment is not None else None,
+                is_outdated=is_outdated,
             )
+            (outdated_unresolved if is_outdated else inline).append(thread)
 
         # ── Review-level (outside-diff) comments ───────────────────────
         # A "review" is a top-level object that may or may not carry a
@@ -734,6 +743,7 @@ class GitHubClient:
             latest_external_review_activity_source=latest_review_activity_source,
             quiet_period_anchor_at=quiet_anchor_at,
             quiet_period_anchor_source=quiet_anchor_source,
+            outdated_unresolved_inline_threads=tuple(outdated_unresolved),
         )
 
     async def _fetch_paginated_pr_connection_nodes(

--- a/src/awf/runtime/monitor_state_keys.py
+++ b/src/awf/runtime/monitor_state_keys.py
@@ -54,6 +54,21 @@ def _merge_method_blocked_key(*, pr_number: int, head_sha: str) -> str:
     return f"__awf_merge_method_blocked__:{pr_number}:{head_sha}"
 
 
+def _outdated_resolve_requeued_key(thread_id: str) -> str:
+    """Build state key flagging an addressed-OUTDATED thread whose resolve was
+    requeued after a TRANSIENT forge fault on this poll.
+
+    The transient resolve path keeps the fix verdict (``fix_committed`` /
+    ``false_positive``) intact so the next poll retries — but those verdicts do
+    NOT block merge, and ``_resolve_addressed_outdated_threads`` runs immediately
+    before ``decide`` in the same iteration. Without this flag ``decide`` could
+    return ``Merge`` on that very poll, merging over the addressed-but-unresolved
+    outdated thread before the promised retry runs. The flag makes ``decide`` hold
+    that thread at ``NotifyHuman`` until the resolve succeeds (flag cleared) or a
+    permanent fault escalates the verdict to ``needs_human``."""
+    return f"__awf_outdated_resolve_requeued__:{thread_id}"
+
+
 def _initial_review_grace_wall_started_value(started_wall_seconds: float) -> str:
     return f"{started_wall_seconds:.6f}"
 

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -1068,13 +1068,21 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # a fresh reviewer reply. That is new, untriaged feedback the outdated-
     # resolution hygiene step refuses to auto-resolve; block here so auto-merge
     # cannot proceed over it and a human is notified instead (#473 follow-up).
+    # A second outdated case also requires a human: when ``resolve_thread``
+    # PERMANENTLY fails, the hygiene step downgrades the verdict to ``needs_human``
+    # and leaves the thread in the outdated feed. That downgrade moves the verdict
+    # OUT of ``_CLOSED_OUTDATED_THREAD_VERDICTS`` so ``_outdated_thread_has_fresh_feedback``
+    # no longer matches it — but ``needs_human`` means operator action is required,
+    # so it must block merge exactly like a non-outdated ``needs_human`` thread.
+    def _outdated_thread_blocks_merge(thread: ReviewThread) -> bool:
+        if state.threads_addressed_ids.get(thread.thread_id) == "needs_human":
+            return True
+        return _outdated_thread_has_fresh_feedback(state, thread)
+
     has_blocking_feedback = (
         any(_thread_blocks_merge(t.thread_id) for t in status.unresolved_inline_threads)
         or any(_review_comment_blocks_merge(c) for c in status.unresolved_review_comments)
-        or any(
-            _outdated_thread_has_fresh_feedback(state, t)
-            for t in status.outdated_unresolved_inline_threads
-        )
+        or any(_outdated_thread_blocks_merge(t) for t in status.outdated_unresolved_inline_threads)
     )
     if has_blocking_feedback:
         return NotifyHuman()

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -40,7 +40,10 @@ from enum import StrEnum
 from typing import Literal
 
 from awf.runtime._docker_pull_detection import _log_shows_docker_registry_timeout
-from awf.runtime.monitor_state_keys import _merge_method_blocked_key
+from awf.runtime.monitor_state_keys import (
+    _merge_method_blocked_key,
+    _outdated_resolve_requeued_key,
+)
 
 # ── Wire-shape dataclasses — what the runner assembles after polling GH ────
 
@@ -1074,8 +1077,17 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # OUT of ``_CLOSED_OUTDATED_THREAD_VERDICTS`` so ``_outdated_thread_has_fresh_feedback``
     # no longer matches it — but ``needs_human`` means operator action is required,
     # so it must block merge exactly like a non-outdated ``needs_human`` thread.
+    # A third case: when ``resolve_thread`` hits a TRANSIENT fault, the hygiene step
+    # leaves the fix verdict intact (so the next poll retries) and flags the thread
+    # requeued. That fix verdict alone does not block merge, and the hygiene step
+    # runs in this same iteration right before ``decide`` — so without honoring the
+    # flag ``decide`` would merge over the addressed-but-unresolved thread on this
+    # very poll, never giving the promised retry a chance. Block until the resolve
+    # lands (flag cleared) or escalates to ``needs_human``.
     def _outdated_thread_blocks_merge(thread: ReviewThread) -> bool:
         if state.threads_addressed_ids.get(thread.thread_id) == "needs_human":
+            return True
+        if state.threads_addressed_ids.get(_outdated_resolve_requeued_key(thread.thread_id)):
             return True
         return _outdated_thread_has_fresh_feedback(state, thread)
 

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -244,6 +244,17 @@ class PRStatus:
     """Timestamp that anchors the quiet-period timer used by quiet-window evaluation."""
     quiet_period_anchor_source: str | None = None
     """Reason that selected this anchor, used to explain quiet-period restarts."""
+    outdated_unresolved_inline_threads: tuple[ReviewThread, ...] = ()
+    """Inline threads the forge marks OUTDATED but still NOT resolved (#473).
+
+    Both forge clients drop outdated threads from ``unresolved_inline_threads``
+    because they are non-blocking for merge (the feedback was addressed by an
+    edit elsewhere, so the thread no longer describes the current diff). This
+    separate, default-empty feed surfaces the same threads so the monitor can
+    RESOLVE the ones it already addressed with a fix verdict — otherwise an
+    addressed thread lingers as "unresolved" on a merged PR. Non-forge
+    constructors leave it empty; only ``decide``-irrelevant resolve hygiene
+    consumes it, never the merge gate."""
 
 
 # ── State — small, serialisable, lives on the workspace row ────────────────

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -589,6 +589,33 @@ def _review_thread_needs_attention(state: MonitorState, thread: ReviewThread) ->
     ) != _review_thread_body_hash(thread)
 
 
+# Verdicts that mean "AWF closed this thread; it should stay resolved". Mirrors
+# the outdated-resolution step's ``_OUTDATED_RESOLVABLE_THREAD_VERDICTS``
+# (``_RESOLVABLE_THREAD_VERDICTS`` minus ``defer``); duplicated here as a small
+# literal rather than imported, because that constant lives in the runner layer
+# (``fix_cycle``) which already imports this pure core — importing back would
+# cycle.
+_CLOSED_OUTDATED_THREAD_VERDICTS = frozenset({"false_positive", "fix_committed"})
+
+
+def _outdated_thread_has_fresh_feedback(state: MonitorState, thread: ReviewThread) -> bool:
+    """True when an AWF-closed OUTDATED thread has gained fresh reviewer feedback.
+
+    Both forge clients drop OUTDATED threads from ``unresolved_inline_threads``
+    (they are non-blocking for merge), so ``decide``'s comment and merge gates
+    never see them. When such a thread was already closed by AWF
+    (``fix_committed`` / ``false_positive``) and a reviewer then replies, its body
+    hash diverges from the recorded snapshot — new, untriaged feedback. The
+    outdated-resolution hygiene step deliberately refuses to auto-resolve it (it
+    would close feedback nothing re-handled), so without this gate the monitor
+    would silently auto-merge over it. Restricted to the closed-verdict set so a
+    never-addressed outdated thread (the #473 "addressed by an edit elsewhere"
+    case) stays non-blocking as designed."""
+    if state.threads_addressed_ids.get(thread.thread_id) not in _CLOSED_OUTDATED_THREAD_VERDICTS:
+        return False
+    return _review_thread_needs_attention(state, thread)
+
+
 def _is_bot_review_thread(thread: ReviewThread) -> bool:
     authors = (
         [comment.author for comment in thread.comments] if thread.comments else [thread.author]
@@ -1036,9 +1063,19 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
             return True
         return verdict == "defer" and not _is_bot_author(comment.author)
 
-    has_blocking_feedback = any(
-        _thread_blocks_merge(t.thread_id) for t in status.unresolved_inline_threads
-    ) or any(_review_comment_blocks_merge(c) for c in status.unresolved_review_comments)
+    # OUTDATED threads are excluded from ``unresolved_inline_threads`` above, so
+    # the two checks miss an AWF-closed thread that went outdated and then gained
+    # a fresh reviewer reply. That is new, untriaged feedback the outdated-
+    # resolution hygiene step refuses to auto-resolve; block here so auto-merge
+    # cannot proceed over it and a human is notified instead (#473 follow-up).
+    has_blocking_feedback = (
+        any(_thread_blocks_merge(t.thread_id) for t in status.unresolved_inline_threads)
+        or any(_review_comment_blocks_merge(c) for c in status.unresolved_review_comments)
+        or any(
+            _outdated_thread_has_fresh_feedback(state, t)
+            for t in status.outdated_unresolved_inline_threads
+        )
+    )
     if has_blocking_feedback:
         return NotifyHuman()
 

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -57,6 +57,9 @@ from awf.runtime.monitor_state_keys import (
 from awf.runtime.monitor_state_keys import (
     _non_check_reviewer_settle_started_prefix as _non_check_reviewer_settle_started_prefix,
 )
+from awf.runtime.monitor_state_keys import (
+    _outdated_resolve_requeued_key as _outdated_resolve_requeued_key,
+)
 from awf.runtime.pr_monitor import (
     CheckFailure,
     CheckTiming,
@@ -318,6 +321,7 @@ def _clear_addressed_state_by_id(state: MonitorState, item_id: str) -> None:
     state.threads_addressed_ids.pop(_review_comment_body_state_key(item_id), None)
     state.threads_addressed_ids.pop(_needs_human_reason_state_key(item_id), None)
     state.threads_addressed_ids.pop(_defer_reason_state_key(item_id), None)
+    state.threads_addressed_ids.pop(_outdated_resolve_requeued_key(item_id), None)
 
 
 def _drop_stale_review_thread_addressed_state(

--- a/src/awf/runtime/pr_monitor_runner/mixins.py
+++ b/src/awf/runtime/pr_monitor_runner/mixins.py
@@ -12,6 +12,7 @@ from awf.runtime.pr_monitor_runner import lifecycle as _lifecycle
 from awf.runtime.pr_monitor_runner import loop as _loop
 from awf.runtime.pr_monitor_runner import operations as _operations
 from awf.runtime.pr_monitor_runner import operator_hints as _operator_hints
+from awf.runtime.pr_monitor_runner import outdated_resolution as _outdated_resolution
 from awf.runtime.pr_monitor_runner import pre_push_validation as _pre_push_validation
 from awf.runtime.pr_monitor_runner import provider_ops as _provider_ops
 from awf.runtime.pr_monitor_runner import remote_ops as _remote_ops
@@ -38,6 +39,7 @@ class RunnerDelegatesMixin:
 
     _run_fix_cycle = _fix_cycle._run_fix_cycle
     _run_operator_hint_cycle = _operator_hints._run_operator_hint_cycle
+    _resolve_addressed_outdated_threads = _outdated_resolution._resolve_addressed_outdated_threads
 
     _active_policy_block_message = _gate_events._active_policy_block_message
     _record_merge_coordination_event = _gate_events._record_merge_coordination_event

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -1,0 +1,162 @@
+"""Resolve addressed review threads that became OUTDATED (#473).
+
+When the PR monitor addresses a review thread by changing code ELSEWHERE (a
+different file/line than the comment anchor), the forge marks the original thread
+``isOutdated=true``. Both forge clients drop outdated threads from
+``PRStatus.unresolved_inline_threads`` because they are non-blocking for merge,
+so ``decide()`` sees zero unresolved threads and proceeds to ``Merge`` — correct.
+But the fix-cycle resolve loop only iterates that actionable feed, so the
+now-outdated thread is never resolved. The result is a merged PR with a lingering
+"unresolved" comment even though the monitor recorded a fix verdict in
+``state.threads_addressed_ids`` — eroding the operator-visible "did AWF handle
+everything?" signal.
+
+This focused step closes that gap forge-neutrally. The forge clients surface the
+addressed-but-outdated threads in ``PRStatus.outdated_unresolved_inline_threads``;
+here we resolve only the ones the monitor already recorded with a fix verdict.
+``defer`` / ``needs_human`` / ``agent_failed`` threads legitimately stay open.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from awf.common.bitbucket_client import BitBucketClientError
+from awf.common.forge_errors import ForgeClientError
+from awf.common.github_client import RepoRef
+from awf.runtime.logs import WorkspaceLogSink
+from awf.runtime.pr_monitor import MonitorState, PRStatus
+from awf.runtime.pr_monitor_runner.constants import (
+    _AUDIT_COMMENT_RESOLUTION_EVENT,
+    _BITBUCKET_TRANSIENT_RETRY_REASON,
+    _GITHUB_TRANSIENT_RETRY_REASON,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle import _RESOLVABLE_THREAD_VERDICTS
+from awf.runtime.pr_monitor_runner.logging import _log
+
+# Verdicts whose now-OUTDATED threads this hygiene step may resolve. This is the
+# fix-cycle's ``_RESOLVABLE_THREAD_VERDICTS`` MINUS ``defer``: a defer's thread
+# is only resolved after its follow-up work is durably captured (an explanatory
+# comment + tracking issue), which the fix cycle gates on at address time. That
+# capture cannot be re-verified here, so an outdated defer thread is left open
+# rather than silently resolved without its tracking issue. The kept verdicts
+# (``fix_committed`` / ``false_positive``) both mean "handled, thread should
+# close, no human follow-up".
+_OUTDATED_RESOLVABLE_THREAD_VERDICTS = _RESOLVABLE_THREAD_VERDICTS - frozenset({"defer"})
+
+
+async def _resolve_addressed_outdated_threads(
+    self: Any,
+    *,
+    workspace_id: str,
+    repo: RepoRef,
+    pr_number: int,
+    status: PRStatus,
+    state: MonitorState,
+    base_branch: str | None,
+    remote_branch: str | None,
+    monitor_log: WorkspaceLogSink | None = None,
+) -> None:
+    """Resolve threads the monitor addressed that have since gone OUTDATED (#473).
+
+    Iterates ``status.outdated_unresolved_inline_threads`` and resolves only the
+    threads whose latest recorded verdict is in
+    ``_OUTDATED_RESOLVABLE_THREAD_VERDICTS``. Error handling mirrors the fix-cycle
+    resolve loop and is fully self-contained so a forge fault never escapes into
+    the monitor's outer loop: a transient fault waits then leaves the thread for
+    the next poll; a permanent fault is logged + audited and skipped. The thread
+    is non-blocking for merge, so the addressed marker is preserved either way
+    (the resolve is simply retried next poll) — there is nothing to wedge. No
+    ``state`` mutation is needed: once resolved, the thread drops out of the
+    outdated feed on the next fetch.
+    """
+    del repo  # repo is recovered from the neutral thread_id by the forge client
+    for thread in status.outdated_unresolved_inline_threads:
+        tid = thread.thread_id
+        if state.threads_addressed_ids.get(tid) not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS:
+            continue
+        try:
+            await self._deps.gh.resolve_thread(thread_id=tid)
+        except ForgeClientError as exc:
+            # Both forges resolve threads through ``self._deps.gh`` (GitHub or
+            # BitBucket), each raising a ``ForgeClientError`` subclass. Catching
+            # the shared base keeps either fault from escaping into the runner's
+            # poll loop. Transient blips wait and leave the thread for the next
+            # poll (already-resolved races are tolerated by the same broad catch
+            # — idempotent, never surfaced as a hard failure). The transient and
+            # permanent audit reason codes stay forge-specific.
+            transient_retry_reason = (
+                _BITBUCKET_TRANSIENT_RETRY_REASON
+                if isinstance(exc, BitBucketClientError)
+                else _GITHUB_TRANSIENT_RETRY_REASON
+            )
+            if await self._wait_after_transient_forge_error(
+                exc,
+                workspace_id=workspace_id,
+                pr_number=pr_number,
+                context="resolve_outdated_thread",
+                monitor_log=monitor_log,
+            ):
+                await self._record_pr_monitor_audit_event(
+                    workspace_id=workspace_id,
+                    event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+                    action="resolve_outdated_thread",
+                    outcome="requeued",
+                    reason_code=transient_retry_reason,
+                    pr_number=pr_number,
+                    status=None,
+                    base_branch=base_branch or "",
+                    remote_branch=remote_branch,
+                    monitor_log=monitor_log,
+                    evidence={
+                        "thread_ids": [tid],
+                        "resolved_thread_count": 0,
+                        "requeued_thread_count": 1,
+                        "error_message": str(exc),
+                    },
+                )
+                continue
+            # Permanent fault: log + audit and skip. The thread is non-blocking,
+            # so we keep the addressed marker and simply retry next poll rather
+            # than wedging the merge gate. ``redacted_detail()`` normalizes the
+            # human detail across forges (gh stderr / BitBucket body).
+            _log.warning(
+                "monitor.resolve_outdated_thread_failed",
+                thread_id=tid,
+                stderr=exc.redacted_detail(),
+            )
+            await self._record_pr_monitor_audit_event(
+                workspace_id=workspace_id,
+                event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+                action="resolve_outdated_thread",
+                outcome="failed",
+                reason_code=exc.reason_code,
+                pr_number=pr_number,
+                status=None,
+                base_branch=base_branch or "",
+                remote_branch=remote_branch,
+                monitor_log=monitor_log,
+                evidence={
+                    "thread_ids": [tid],
+                    "resolved_thread_count": 0,
+                    "failed_thread_count": 1,
+                    "error_message": str(exc),
+                },
+            )
+            continue
+        await self._record_pr_monitor_audit_event(
+            workspace_id=workspace_id,
+            event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+            action="resolve_outdated_thread",
+            outcome="succeeded",
+            reason_code="COMMENT_REPAIR",
+            pr_number=pr_number,
+            status=None,
+            base_branch=base_branch or "",
+            remote_branch=remote_branch,
+            monitor_log=monitor_log,
+            evidence={
+                "thread_ids": [tid],
+                "resolved_thread_count": 1,
+            },
+        )

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -25,7 +25,11 @@ from awf.common.bitbucket_client import BitBucketClientError
 from awf.common.forge_errors import ForgeClientError
 from awf.common.github_client import RepoRef
 from awf.runtime.logs import WorkspaceLogSink
-from awf.runtime.pr_monitor import MonitorState, PRStatus
+from awf.runtime.pr_monitor import (
+    MonitorState,
+    PRStatus,
+    _review_thread_needs_attention,
+)
 from awf.runtime.pr_monitor_runner.constants import (
     _AUDIT_COMMENT_RESOLUTION_EVENT,
     _BITBUCKET_TRANSIENT_RETRY_REASON,
@@ -74,6 +78,14 @@ async def _resolve_addressed_outdated_threads(
     for thread in status.outdated_unresolved_inline_threads:
         tid = thread.thread_id
         if state.threads_addressed_ids.get(tid) not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS:
+            continue
+        # Mirror the fix-cycle's stale-thread guard (#305): an outdated thread can
+        # still gain fresh reviewer replies after its verdict was recorded, which
+        # change its body hash. Resolving it here would close feedback the monitor
+        # never re-handled — and because outdated threads are dropped from the
+        # actionable feed, the fix cycle never re-addresses them either. Leave such
+        # a thread open so the new feedback stays visible to a human.
+        if _review_thread_needs_attention(state, thread):
             continue
         try:
             await self._deps.gh.resolve_thread(thread_id=tid)

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -68,11 +68,13 @@ async def _resolve_addressed_outdated_threads(
     ``_OUTDATED_RESOLVABLE_THREAD_VERDICTS``. Error handling mirrors the fix-cycle
     resolve loop and is fully self-contained so a forge fault never escapes into
     the monitor's outer loop: a transient fault waits then leaves the thread for
-    the next poll; a permanent fault is logged + audited and skipped. The thread
-    is non-blocking for merge, so the addressed marker is preserved either way
-    (the resolve is simply retried next poll) — there is nothing to wedge. No
-    ``state`` mutation is needed: once resolved, the thread drops out of the
-    outdated feed on the next fetch.
+    the next poll (the resolvable verdict is preserved so it is retried); a
+    permanent fault is logged + audited and the verdict is downgraded to
+    ``needs_human`` so the next poll skips it instead of re-issuing the same
+    failing resolve every cycle (a retry storm against a non-fixable fault). The
+    thread is non-blocking for merge and dropped from the actionable feed, so
+    neither path wedges auto-merge. A successful resolve needs no ``state``
+    mutation: the thread drops out of the outdated feed on the next fetch.
     """
     del repo  # repo is recovered from the neutral thread_id by the forge client
     for thread in status.outdated_unresolved_inline_threads:
@@ -128,20 +130,30 @@ async def _resolve_addressed_outdated_threads(
                     },
                 )
                 continue
-            # Permanent fault: log + audit and skip. The thread is non-blocking,
-            # so we keep the addressed marker and simply retry next poll rather
-            # than wedging the merge gate. ``redacted_detail()`` normalizes the
-            # human detail across forges (gh stderr / BitBucket body).
+            # Permanent fault: log + audit, then downgrade the recorded verdict to
+            # ``needs_human`` so the next poll SKIPS this thread (``needs_human`` is
+            # not in ``_OUTDATED_RESOLVABLE_THREAD_VERDICTS``) instead of re-issuing
+            # a known-permanent resolve every cycle. Keeping the resolvable verdict
+            # would retry the same failing forge call on every poll until the PR
+            # merges — burning API quota and spamming logs for no benefit, since the
+            # fault is permanent. This mirrors the fix-cycle's permanent-task path
+            # (a non-fixable resolve fault escalates rather than retrying forever).
+            # The thread is OUTDATED and dropped from the actionable feed, so this
+            # never reaches the merge-gate blocker — it never wedges auto-merge; the
+            # ``needs_human`` audit event surfaces the unresolved-but-handled thread
+            # for an operator. ``redacted_detail()`` normalizes the human detail
+            # across forges (gh stderr / BitBucket body).
             _log.warning(
                 "monitor.resolve_outdated_thread_failed",
                 thread_id=tid,
                 stderr=exc.redacted_detail(),
             )
+            state.mark_addressed(tid, "needs_human")
             await self._record_pr_monitor_audit_event(
                 workspace_id=workspace_id,
                 event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
                 action="resolve_outdated_thread",
-                outcome="failed",
+                outcome="needs_human",
                 reason_code=exc.reason_code,
                 pr_number=pr_number,
                 status=None,
@@ -151,7 +163,7 @@ async def _resolve_addressed_outdated_threads(
                 evidence={
                     "thread_ids": [tid],
                     "resolved_thread_count": 0,
-                    "failed_thread_count": 1,
+                    "needs_human_thread_count": 1,
                     "error_message": str(exc),
                 },
             )

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -143,11 +143,12 @@ async def _resolve_addressed_outdated_threads(
             # merges — burning API quota and spamming logs for no benefit, since the
             # fault is permanent. This mirrors the fix-cycle's permanent-task path
             # (a non-fixable resolve fault escalates rather than retrying forever).
-            # The thread is OUTDATED and dropped from the actionable feed, so this
-            # never reaches the merge-gate blocker — it never wedges auto-merge; the
-            # ``needs_human`` audit event surfaces the unresolved-but-handled thread
-            # for an operator. ``redacted_detail()`` normalizes the human detail
-            # across forges (gh stderr / BitBucket body).
+            # The thread is OUTDATED and dropped from the actionable feed, but the
+            # ``needs_human`` downgrade DOES block auto-merge: ``decide``'s outdated
+            # gate treats an outdated ``needs_human`` thread as a merge blocker
+            # (``NotifyHuman``), so the unresolved-but-handled thread surfaces to an
+            # operator instead of being silently merged over. ``redacted_detail()``
+            # normalizes the human detail across forges (gh stderr / BitBucket body).
             _log.warning(
                 "monitor.resolve_outdated_thread_failed",
                 thread_id=tid,

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -74,7 +74,9 @@ async def _resolve_addressed_outdated_threads(
     failing resolve every cycle (a retry storm against a non-fixable fault). The
     thread is non-blocking for merge and dropped from the actionable feed, so
     neither path wedges auto-merge. A successful resolve needs no ``state``
-    mutation: the thread drops out of the outdated feed on the next fetch.
+    mutation: the thread drops out of the outdated feed on the next fetch. The
+    permanent-fault downgrade IS persisted before returning, so it survives a
+    subsequent transient ``_execute`` fault (which skips ``_persist_state``).
     """
     del repo  # repo is recovered from the neutral thread_id by the forge client
     for thread in status.outdated_unresolved_inline_threads:
@@ -152,6 +154,16 @@ async def _resolve_addressed_outdated_threads(
                 stderr=exc.redacted_detail(),
             )
             state.mark_addressed(tid, "needs_human")
+            # Persist the downgrade immediately. This step runs BEFORE ``decide`` /
+            # ``_execute`` in the runner loop, and ``_execute`` skips ``_persist_state``
+            # when it hits a transient ``ForgeClientError`` (continuing to the next
+            # poll, which reloads clean state from the DB). Without persisting here the
+            # in-memory ``needs_human`` downgrade would be lost on that path, and the
+            # next poll would re-issue the same known-permanent resolve — the exact
+            # retry storm this downgrade exists to stop. The mutation is safe to flush
+            # now: state was loaded fresh this iteration and carries no unconfirmed
+            # fix-cycle markers yet (those only appear inside ``_execute``).
+            await self._persist_state(workspace_id, state)
             await self._record_pr_monitor_audit_event(
                 workspace_id=workspace_id,
                 event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -86,7 +86,10 @@ async def _resolve_addressed_outdated_threads(
         # change its body hash. Resolving it here would close feedback the monitor
         # never re-handled — and because outdated threads are dropped from the
         # actionable feed, the fix cycle never re-addresses them either. Leave such
-        # a thread open so the new feedback stays visible to a human.
+        # a thread open AND let ``decide()`` block auto-merge on it:
+        # ``_outdated_thread_has_fresh_feedback`` matches this exact condition
+        # (closed verdict + changed body) so the new feedback is surfaced to a
+        # human via ``NotifyHuman`` instead of being silently merged over.
         if _review_thread_needs_attention(state, thread):
             continue
         try:

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -25,6 +25,7 @@ from awf.common.bitbucket_client import BitBucketClientError
 from awf.common.forge_errors import ForgeClientError
 from awf.common.github_client import RepoRef
 from awf.runtime.logs import WorkspaceLogSink
+from awf.runtime.monitor_state_keys import _outdated_resolve_requeued_key
 from awf.runtime.pr_monitor import (
     MonitorState,
     PRStatus,
@@ -68,15 +69,19 @@ async def _resolve_addressed_outdated_threads(
     ``_OUTDATED_RESOLVABLE_THREAD_VERDICTS``. Error handling mirrors the fix-cycle
     resolve loop and is fully self-contained so a forge fault never escapes into
     the monitor's outer loop: a transient fault waits then leaves the thread for
-    the next poll (the resolvable verdict is preserved so it is retried); a
-    permanent fault is logged + audited and the verdict is downgraded to
-    ``needs_human`` so the next poll skips it instead of re-issuing the same
-    failing resolve every cycle (a retry storm against a non-fixable fault). The
-    thread is non-blocking for merge and dropped from the actionable feed, so
-    neither path wedges auto-merge. A successful resolve needs no ``state``
-    mutation: the thread drops out of the outdated feed on the next fetch. The
-    permanent-fault downgrade IS persisted before returning, so it survives a
-    subsequent transient ``_execute`` fault (which skips ``_persist_state``).
+    the next poll (the resolvable verdict is preserved so it is retried, and the
+    thread is flagged requeued so ``decide`` — which runs this same iteration —
+    blocks merge instead of merging over it before the retry runs); a permanent
+    fault is logged + audited and the verdict is downgraded to ``needs_human`` so
+    the next poll skips it instead of re-issuing the same failing resolve every
+    cycle (a retry storm against a non-fixable fault). Neither path wedges
+    auto-merge: a persistently transient fault eventually exhausts its retry budget
+    and escalates to the permanent ``needs_human`` path, and a successful resolve
+    clears the flag. A successful resolve otherwise needs no ``state`` mutation: the
+    thread drops out of the outdated feed on the next fetch. The permanent-fault
+    downgrade IS persisted before returning, so it survives a subsequent transient
+    ``_execute`` fault (which skips ``_persist_state``); the transient requeue flag
+    is in-memory only, matching the rest of the transient path.
     """
     del repo  # repo is recovered from the neutral thread_id by the forge client
     for thread in status.outdated_unresolved_inline_threads:
@@ -134,6 +139,19 @@ async def _resolve_addressed_outdated_threads(
                         "error_message": str(exc),
                     },
                 )
+                # Flag the thread requeued so ``decide`` (which runs THIS iteration,
+                # right after this step) blocks merge on it instead of merging over
+                # the addressed-but-unresolved outdated thread before the promised
+                # next-poll retry runs. The fix verdict stays intact so the retry
+                # still fires; the flag only gates merge until it lands. Set
+                # in-memory only — like the rest of the transient path, this is not
+                # persisted, so the next poll reloads clean state and re-attempts the
+                # resolve (which re-sets the flag if it faults again, or clears it on
+                # success). A persistently transient fault eventually exhausts the
+                # retry budget and escalates to the permanent ``needs_human`` path,
+                # which keeps blocking — so this never silently merges over the
+                # thread, and never wedges either.
+                state.threads_addressed_ids[_outdated_resolve_requeued_key(tid)] = "requeued"
                 continue
             # Permanent fault: log + audit, then downgrade the recorded verdict to
             # ``needs_human`` so the next poll SKIPS this thread (``needs_human`` is
@@ -155,6 +173,10 @@ async def _resolve_addressed_outdated_threads(
                 stderr=exc.redacted_detail(),
             )
             state.mark_addressed(tid, "needs_human")
+            # Clear any prior transient requeue flag for this thread: ``needs_human``
+            # now blocks merge on its own, so the flag is redundant and would only
+            # leave stale state behind.
+            state.threads_addressed_ids.pop(_outdated_resolve_requeued_key(tid), None)
             # Persist the downgrade immediately. This step runs BEFORE ``decide`` /
             # ``_execute`` in the runner loop, and ``_execute`` skips ``_persist_state``
             # when it hits a transient ``ForgeClientError`` (continuing to the next
@@ -184,6 +206,9 @@ async def _resolve_addressed_outdated_threads(
                 },
             )
             continue
+        # Resolve landed — clear any transient requeue flag from a prior poll so
+        # ``decide`` no longer holds this thread at ``NotifyHuman``.
+        state.threads_addressed_ids.pop(_outdated_resolve_requeued_key(tid), None)
         await self._record_pr_monitor_audit_event(
             workspace_id=workspace_id,
             event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,

--- a/src/awf/runtime/pr_monitor_runner/runner.py
+++ b/src/awf/runtime/pr_monitor_runner/runner.py
@@ -316,6 +316,25 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                     return
 
                 remote_push_url = _remote_push_url_for_workspace(ws, base_repo=repo)
+                # Resolve threads the monitor already addressed that have since
+                # gone OUTDATED (addressed by an edit elsewhere). They drop out of
+                # ``unresolved_inline_threads`` — so ``decide()`` never re-runs the
+                # fix cycle for them — and would otherwise linger as "unresolved"
+                # on the merged PR. Running every poll (not only at merge) closes
+                # the operator-visible signal as soon as the thread goes outdated
+                # and guarantees it is resolved before the ``Merge`` cycle. The
+                # step is fully self-contained (its own ForgeClientError handling),
+                # so a forge fault cannot escape into the loop's outer arms (#473).
+                await self._resolve_addressed_outdated_threads(
+                    workspace_id=workspace_id,
+                    repo=repo,
+                    pr_number=pr_number,
+                    status=status,
+                    state=state,
+                    base_branch=ws.branch_base,
+                    remote_branch=remote_branch,
+                    monitor_log=monitor_log,
+                )
                 action = decide(status, state, self._config)
                 try:
                     terminal = await self._execute(

--- a/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_003.py
+++ b/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_003.py
@@ -110,6 +110,51 @@ async def test_outdated_thread_is_filtered() -> None:
     assert status.unresolved_inline_threads == ()
 
 
+async def test_fetch_pr_status_surfaces_outdated_unresolved_thread() -> None:
+    # #473: a BitBucket inline thread that went ``outdated`` (addressed elsewhere)
+    # but is still unresolved is kept out of the actionable feed yet surfaced in
+    # ``outdated_unresolved_inline_threads`` so the monitor can resolve the ones it
+    # addressed.
+    fake = FakeBitBucket()
+    _seed_fetch_status(fake, [_inline_comment(100, "stale finding", outdated=True)])
+    client = make_client(fake)
+    status = await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
+    assert status.unresolved_inline_threads == ()
+    assert [t.thread_id for t in status.outdated_unresolved_inline_threads] == [
+        "bb:workspace/repo#42:100"
+    ]
+    thread = status.outdated_unresolved_inline_threads[0]
+    assert thread.is_outdated is True
+    assert thread.is_resolved is False
+    assert thread.body_excerpt == "stale finding"
+
+
+def test_build_outdated_unresolved_review_threads_only_returns_outdated() -> None:
+    from awf.common.bitbucket_client_parsing import (
+        build_outdated_unresolved_review_threads,
+        build_review_threads,
+    )
+
+    comments = [
+        _inline_comment(100, "addressed elsewhere", outdated=True),
+        _inline_comment(101, "still current"),
+        _inline_comment(102, "resolved + outdated", outdated=True, resolved=True),
+        _inline_comment(103, "mine but outdated", account="viewer", outdated=True),
+    ]
+    outdated = build_outdated_unresolved_review_threads(
+        comments, repo=repo(), pr_number=42, account_id="viewer"
+    )
+    assert [t.thread_id for t in outdated] == ["bb:workspace/repo#42:100"]
+    assert outdated[0].is_outdated is True
+    assert outdated[0].is_resolved is False
+
+    # The actionable feed is unchanged: only the still-current, non-outdated,
+    # external thread remains.
+    actionable = build_review_threads(comments, repo=repo(), pr_number=42, account_id="viewer")
+    assert [t.thread_id for t in actionable] == ["bb:workspace/repo#42:101"]
+    assert all(t.is_outdated is False for t in actionable)
+
+
 # ── resolve_thread (POST resolves; DELETE would reopen) ───────────────────────
 
 

--- a/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_003.py
+++ b/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_003.py
@@ -155,6 +155,33 @@ def test_build_outdated_unresolved_review_threads_only_returns_outdated() -> Non
     assert all(t.is_outdated is False for t in actionable)
 
 
+def test_partition_inline_review_threads_single_pass_matches_builders() -> None:
+    from awf.common.bitbucket_client_parsing import (
+        build_outdated_unresolved_review_threads,
+        build_review_threads,
+        partition_inline_review_threads,
+    )
+
+    comments = [
+        _inline_comment(100, "addressed elsewhere", outdated=True),
+        _inline_comment(101, "still current"),
+        _inline_comment(102, "resolved + outdated", outdated=True, resolved=True),
+        _inline_comment(103, "mine but outdated", account="viewer", outdated=True),
+    ]
+    actionable, outdated = partition_inline_review_threads(
+        comments, repo=repo(), pr_number=42, account_id="viewer"
+    )
+    # One pass produces exactly the same two feeds the separate selectors return.
+    assert actionable == build_review_threads(
+        comments, repo=repo(), pr_number=42, account_id="viewer"
+    )
+    assert outdated == build_outdated_unresolved_review_threads(
+        comments, repo=repo(), pr_number=42, account_id="viewer"
+    )
+    assert [t.thread_id for t in actionable] == ["bb:workspace/repo#42:101"]
+    assert [t.thread_id for t in outdated] == ["bb:workspace/repo#42:100"]
+
+
 # ── resolve_thread (POST resolves; DELETE would reopen) ───────────────────────
 
 

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_003.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_003.py
@@ -546,6 +546,75 @@ class TestFetchPrStatusPart002:
         assert [t.thread_id for t in status.unresolved_inline_threads] == ["T_live"]
 
     @pytest.mark.unit
+    async def test_surfaces_outdated_unresolved_threads_for_resolution(self) -> None:
+        """#473: an outdated-but-unresolved thread with external comments is kept
+        out of the actionable feed yet surfaced in
+        ``outdated_unresolved_inline_threads`` so the monitor can resolve the ones
+        it addressed. A resolved-outdated thread appears in neither feed; a live
+        thread appears only in the actionable feed."""
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=_sample_pr_payload(
+                threads=[
+                    {
+                        "id": "T_resolved_outdated",
+                        "isResolved": True,
+                        "isOutdated": True,
+                        "path": "a",
+                        "line": 1,
+                        "comments": {"nodes": [{"bodyText": "done", "author": {"login": "bot"}}]},
+                    },
+                    {
+                        "id": "T_outdated",
+                        "isResolved": False,
+                        "isOutdated": True,
+                        "path": "b",
+                        "line": 2,
+                        "comments": {
+                            "nodes": [
+                                {
+                                    "bodyText": "fixed elsewhere",
+                                    "author": {"login": "greptile"},
+                                    "url": "https://github.example/review/9",
+                                }
+                            ]
+                        },
+                    },
+                    {
+                        "id": "T_outdated_only_viewer",
+                        "isResolved": False,
+                        "isOutdated": True,
+                        "path": "c",
+                        "line": 3,
+                        "comments": {"nodes": [{"bodyText": "self note", "viewerDidAuthor": True}]},
+                    },
+                    {
+                        "id": "T_live",
+                        "isResolved": False,
+                        "isOutdated": False,
+                        "path": "d",
+                        "line": 4,
+                        "comments": {
+                            "nodes": [{"bodyText": "fix me", "author": {"login": "alice"}}]
+                        },
+                    },
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+        status = await client.fetch_pr_status(
+            repo=RepoRef(owner="o", name="r"), pr_number=1, base_behind_count=0
+        )
+        assert [t.thread_id for t in status.unresolved_inline_threads] == ["T_live"]
+        assert [t.thread_id for t in status.outdated_unresolved_inline_threads] == ["T_outdated"]
+        outdated = status.outdated_unresolved_inline_threads[0]
+        assert outdated.is_outdated is True
+        assert outdated.is_resolved is False
+        assert outdated.body_excerpt == "fixed elsewhere"
+        assert outdated.url == "https://github.example/review/9"
+
+    @pytest.mark.unit
     async def test_paginates_comment_history_for_resolved_and_outdated_threads(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -27,15 +27,19 @@ from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import GitHubClientError, RepoRef
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _outdated_resolve_requeued_key
 from awf.runtime.pr_monitor import (
     _CLOSED_OUTDATED_THREAD_VERDICTS,
     CheckState,
     MergeableState,
     MergeStateStatus,
+    MonitorConfig,
     MonitorState,
+    NotifyHuman,
     PRStatus,
     ReviewThread,
     _mark_review_thread_addressed,
+    decide,
 )
 from awf.runtime.pr_monitor_runner.fix_cycle import _RESOLVABLE_THREAD_VERDICTS
 from awf.runtime.pr_monitor_runner.outdated_resolution import (
@@ -174,6 +178,42 @@ async def test_outdated_addressed_thread_is_resolved(
         succeeded = _resolution_events(ws, outcome="succeeded")
         assert len(succeeded) == 1
         assert succeeded[0].reason_code == "COMMENT_REPAIR"
+
+
+@pytest.mark.unit
+async def test_successful_resolve_clears_prior_transient_requeue_flag(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A resolve that lands after an earlier poll's transient fault must clear the
+    requeue flag so ``decide`` stops holding the thread at ``NotifyHuman`` — the
+    block exists only until the resolve succeeds."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    thread = _outdated_thread("T_outdated")
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+    # Simulate a requeue flag left by a prior poll's transient fault.
+    state.threads_addressed_ids[_outdated_resolve_requeued_key("T_outdated")] = "requeued"
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(thread),
+        state=state,
+    )
+
+    assert gh.resolved == ["T_outdated"]
+    assert _outdated_resolve_requeued_key("T_outdated") not in state.threads_addressed_ids
 
 
 @pytest.mark.unit
@@ -431,6 +471,8 @@ async def test_transient_resolve_error_is_requeued_not_failed(
     assert gh.resolved == []
     # The addressed marker is preserved so the next poll retries the resolve.
     assert state.threads_addressed_ids["T_transient"] == "fix_committed"
+    # The thread is flagged requeued so decide() blocks merge this iteration.
+    assert state.threads_addressed_ids[_outdated_resolve_requeued_key("T_transient")] == "requeued"
     assert sleep_fn.calls  # the transient handler waited before re-polling
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
@@ -438,6 +480,45 @@ async def test_transient_resolve_error_is_requeued_not_failed(
         requeued = _resolution_events(ws, outcome="requeued")
         assert len(requeued) == 1
         assert requeued[0].reason_code == "GITHUB_TRANSIENT_RETRY"
+
+
+@pytest.mark.unit
+async def test_transient_resolve_error_blocks_merge_same_iteration(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(e1) The promised next-poll retry is only meaningful if merge does not race
+    it. ``_resolve_addressed_outdated_threads`` runs in the same iteration right
+    before ``decide``; after a transient resolve fault the fix verdict survives
+    (non-blocking) but the requeue flag must make ``decide`` hold the merge-ready
+    PR at ``NotifyHuman`` so the addressed-but-unresolved outdated thread is not
+    merged over before the retry runs."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    transient = GitHubClientError(
+        operation="resolve_thread",
+        returncode=1,
+        stderr="HTTP 503: service unavailable",
+    )
+    gh = _RecordingGitHub(cmd, error=transient)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    thread = _outdated_thread("T_transient")
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+    status = _status_with_outdated(thread)
+
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=state)
+
+    # The merge-ready snapshot would merge but for the requeue flag.
+    action = decide(status=status, state=state, config=MonitorConfig(auto_merge=True))
+    assert isinstance(action, NotifyHuman)
 
 
 @pytest.mark.unit
@@ -473,6 +554,10 @@ async def test_permanent_resolve_error_downgrades_to_needs_human(
     bb_id = "bb:workspace/repo#42:100"
     thread = _outdated_thread(bb_id)
     _mark_review_thread_addressed(state, thread, "fix_committed")
+    # A prior poll's transient fault left a requeue flag; the permanent downgrade
+    # must clear it (``needs_human`` blocks on its own — leaving the flag would be
+    # redundant stale state).
+    state.threads_addressed_ids[_outdated_resolve_requeued_key(bb_id)] = "requeued"
 
     await _call_resolve(
         runner,
@@ -484,6 +569,7 @@ async def test_permanent_resolve_error_downgrades_to_needs_human(
     assert gh.resolved == []
     # Verdict downgraded so the next poll skips it (not in the resolvable set).
     assert state.threads_addressed_ids[bb_id] == "needs_human"
+    assert _outdated_resolve_requeued_key(bb_id) not in state.threads_addressed_ids
     assert "needs_human" not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS
     assert sleep_fn.calls == []  # permanent fault does not wait/retry
     async with factory() as s:

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -1,0 +1,450 @@
+"""Resolve-hygiene for addressed review threads that became OUTDATED (#473).
+
+When the monitor addresses a review thread by changing code ELSEWHERE (a
+different file/line than the comment anchor), the forge marks the original
+thread ``isOutdated=true`` and both forge clients drop it from
+``PRStatus.unresolved_inline_threads`` (outdated threads are non-blocking for
+merge). The fix-cycle resolve loop only iterates that actionable feed, so the
+addressed thread is never resolved and lingers as "unresolved" on a merged PR.
+
+``_resolve_addressed_outdated_threads`` closes that gap forge-neutrally: it
+iterates ``PRStatus.outdated_unresolved_inline_threads`` and resolves only the
+threads the monitor already recorded with a fix verdict
+(``fix_committed`` / ``false_positive``). ``defer`` / ``needs_human`` /
+``agent_failed`` threads legitimately stay open.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.bitbucket_client import BITBUCKET_API_ERROR, BitBucketClientError
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import GitHubClientError, RepoRef
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle import _RESOLVABLE_THREAD_VERDICTS
+from awf.runtime.pr_monitor_runner.outdated_resolution import (
+    _OUTDATED_RESOLVABLE_THREAD_VERDICTS,
+)
+from tests.postgres import postgres_test_engine
+from tests.shared.monitor_runner import DefaultMergeMethodGitHubClient
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+class _RecordingGitHub(DefaultMergeMethodGitHubClient):
+    """Forge stub that records ``resolve_thread`` calls and optionally raises.
+
+    The runner step is forge-neutral — it only calls ``gh.resolve_thread`` — so
+    a single recording stub exercises both the GitHub and BitBucket paths; the
+    POST-not-DELETE resolve semantics are covered by the client-level tests.
+    """
+
+    def __init__(self, inner: FakeCommandRunner, *, error: Exception | None = None) -> None:
+        super().__init__(inner)
+        self.resolved: list[str] = []
+        self.attempts: list[str] = []
+        self._error = error
+
+    async def resolve_thread(self, *, thread_id: str) -> None:
+        self.attempts.append(thread_id)
+        if self._error is not None:
+            raise self._error
+        self.resolved.append(thread_id)
+
+
+def _outdated_thread(tid: str, *, path: str = "src/anchor.py") -> ReviewThread:
+    return ReviewThread(
+        thread_id=tid,
+        path=path,
+        line=7,
+        body_excerpt="please fix this finding",
+        author="greptile",
+        is_resolved=False,
+        is_outdated=True,
+    )
+
+
+def _status_with_outdated(*outdated: ReviewThread) -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+        outdated_unresolved_inline_threads=outdated,
+    )
+
+
+def _resolution_events(ws: object, *, outcome: str | None = None) -> list:
+    return [
+        event
+        for event in ws.events  # type: ignore[attr-defined]
+        if event.event_type == "workspace.audit.comment_resolution"
+        and (event.payload or {}).get("action") == "resolve_outdated_thread"
+        and (outcome is None or (event.payload or {}).get("outcome") == outcome)
+    ]
+
+
+async def _call_resolve(
+    runner: object,
+    *,
+    workspace_id: str,
+    status: PRStatus,
+    state: MonitorState,
+) -> None:
+    await runner._resolve_addressed_outdated_threads(  # type: ignore[attr-defined]
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=status,
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+    )
+
+
+@pytest.mark.unit
+async def test_outdated_addressed_thread_is_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(a) #473 regression — a ``fix_committed`` thread that became OUTDATED (only
+    in ``outdated_unresolved_inline_threads``) IS resolved. Pins the PR #470
+    scenario: feedback addressed by an edit elsewhere, thread went outdated."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    state.mark_addressed("T_outdated", "fix_committed")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread("T_outdated")),
+        state=state,
+    )
+
+    assert gh.resolved == ["T_outdated"]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        succeeded = _resolution_events(ws, outcome="succeeded")
+        assert len(succeeded) == 1
+        assert succeeded[0].reason_code == "COMMENT_REPAIR"
+
+
+@pytest.mark.unit
+async def test_false_positive_outdated_thread_is_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """``false_positive`` is resolvable like ``fix_committed`` — both mean the
+    thread should close with no human follow-up."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    state.mark_addressed("T_fp", "false_positive")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread("T_fp")),
+        state=state,
+    )
+
+    assert gh.resolved == ["T_fp"]
+
+
+@pytest.mark.unit
+async def test_in_place_thread_is_not_double_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(b) An in-place ``fix_committed`` thread (still in the actionable feed, not
+    the outdated feed) is resolved by the existing fix-cycle path and is NOT
+    touched by this step — the step only reads the outdated feed."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    state.mark_addressed("T_inplace", "fix_committed")
+
+    # An in-place thread stays in ``unresolved_inline_threads`` and is absent
+    # from the outdated feed, so this step finds nothing to do.
+    status = PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(
+            ReviewThread(
+                thread_id="T_inplace",
+                path="src/anchor.py",
+                line=7,
+                body_excerpt="please fix this finding",
+                author="greptile",
+            ),
+        ),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=state)
+
+    assert gh.attempts == []
+    assert gh.resolved == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["defer", "needs_human", "agent_failed"])
+async def test_keep_open_verdicts_are_not_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    verdict: str,
+) -> None:
+    """(c) Outdated threads recorded ``defer`` / ``needs_human`` / ``agent_failed``
+    are NOT resolved here — they legitimately stay open (defer is capture-gated,
+    the others need a human)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    state.mark_addressed("T_keep_open", verdict)
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread("T_keep_open")),
+        state=state,
+    )
+
+    assert gh.attempts == []
+
+
+@pytest.mark.unit
+async def test_unaddressed_outdated_thread_is_not_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """An outdated thread the monitor never recorded a verdict for is left alone —
+    only threads the monitor itself addressed are resolved."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread("T_unknown")),
+        state=MonitorState(),
+    )
+
+    assert gh.attempts == []
+
+
+@pytest.mark.unit
+async def test_bitbucket_outdated_thread_resolves_via_resolve_thread(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(d) Forge-neutral: a BitBucket-style addressed-outdated thread resolves via
+    ``resolve_thread`` (the client-level POST/never-DELETE semantics are covered
+    in the BitBucket client tests)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    bb_id = "bb:workspace/repo#42:100"
+    state.mark_addressed(bb_id, "fix_committed")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread(bb_id)),
+        state=state,
+    )
+
+    assert gh.resolved == [bb_id]
+
+
+@pytest.mark.unit
+async def test_transient_resolve_error_is_requeued_not_failed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(e) A transient resolve fault waits and is left for the next poll (the
+    thread stays in the outdated set); the monitor does not crash and records a
+    ``requeued`` audit event with the forge-native retry reason code."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    transient = GitHubClientError(
+        operation="resolve_thread",
+        returncode=1,
+        stderr="HTTP 503: service unavailable",
+    )
+    gh = _RecordingGitHub(cmd, error=transient)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    state.mark_addressed("T_transient", "fix_committed")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread("T_transient")),
+        state=state,
+    )
+
+    assert gh.resolved == []
+    # The addressed marker is preserved so the next poll retries the resolve.
+    assert state.threads_addressed_ids["T_transient"] == "fix_committed"
+    assert sleep_fn.calls  # the transient handler waited before re-polling
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        requeued = _resolution_events(ws, outcome="requeued")
+        assert len(requeued) == 1
+        assert requeued[0].reason_code == "GITHUB_TRANSIENT_RETRY"
+
+
+@pytest.mark.unit
+async def test_permanent_resolve_error_is_tolerated(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(e) A permanent resolve fault does not crash the monitor and is recorded as
+    a ``failed`` audit event carrying the forge-native reason code. The thread is
+    non-blocking, so the addressed marker is preserved (retried next poll)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    permanent = BitBucketClientError(
+        operation="bitbucket resolve_thread",
+        status=403,
+        body="thread resolution is not permitted for this token",
+        reason_code=BITBUCKET_API_ERROR,
+    )
+    gh = _RecordingGitHub(cmd, error=permanent)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    bb_id = "bb:workspace/repo#42:100"
+    state.mark_addressed(bb_id, "fix_committed")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(_outdated_thread(bb_id)),
+        state=state,
+    )
+
+    assert gh.resolved == []
+    assert state.threads_addressed_ids[bb_id] == "fix_committed"
+    assert sleep_fn.calls == []  # permanent fault does not wait/retry
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        failed = _resolution_events(ws, outcome="failed")
+        assert len(failed) == 1
+        assert failed[0].reason_code == BITBUCKET_API_ERROR
+
+
+@pytest.mark.unit
+def test_outdated_resolvable_verdicts_exclude_defer() -> None:
+    """The outdated-resolution verdict set is the fix-cycle's resolvable set MINUS
+    ``defer`` — defer's resolution is gated on durable capture this hygiene step
+    cannot re-verify, so an outdated defer thread stays open."""
+    assert "defer" in _RESOLVABLE_THREAD_VERDICTS
+    assert "defer" not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS
+    assert frozenset({"fix_committed", "false_positive"}) == (_OUTDATED_RESOLVABLE_THREAD_VERDICTS)
+    assert _OUTDATED_RESOLVABLE_THREAD_VERDICTS < _RESOLVABLE_THREAD_VERDICTS

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -34,6 +34,7 @@ from awf.runtime.pr_monitor import (
     MonitorState,
     PRStatus,
     ReviewThread,
+    _mark_review_thread_addressed,
 )
 from awf.runtime.pr_monitor_runner.fix_cycle import _RESOLVABLE_THREAD_VERDICTS
 from awf.runtime.pr_monitor_runner.outdated_resolution import (
@@ -76,12 +77,17 @@ class _RecordingGitHub(DefaultMergeMethodGitHubClient):
         self.resolved.append(thread_id)
 
 
-def _outdated_thread(tid: str, *, path: str = "src/anchor.py") -> ReviewThread:
+def _outdated_thread(
+    tid: str,
+    *,
+    path: str = "src/anchor.py",
+    body_excerpt: str = "please fix this finding",
+) -> ReviewThread:
     return ReviewThread(
         thread_id=tid,
         path=path,
         line=7,
-        body_excerpt="please fix this finding",
+        body_excerpt=body_excerpt,
         author="greptile",
         is_resolved=False,
         is_outdated=True,
@@ -150,12 +156,13 @@ async def test_outdated_addressed_thread_is_resolved(
         gh=gh,
     )
     state = MonitorState()
-    state.mark_addressed("T_outdated", "fix_committed")
+    thread = _outdated_thread("T_outdated")
+    _mark_review_thread_addressed(state, thread, "fix_committed")
 
     await _call_resolve(
         runner,
         workspace_id=workspace_id,
-        status=_status_with_outdated(_outdated_thread("T_outdated")),
+        status=_status_with_outdated(thread),
         state=state,
     )
 
@@ -187,12 +194,13 @@ async def test_false_positive_outdated_thread_is_resolved(
         gh=gh,
     )
     state = MonitorState()
-    state.mark_addressed("T_fp", "false_positive")
+    thread = _outdated_thread("T_fp")
+    _mark_review_thread_addressed(state, thread, "false_positive")
 
     await _call_resolve(
         runner,
         workspace_id=workspace_id,
-        status=_status_with_outdated(_outdated_thread("T_fp")),
+        status=_status_with_outdated(thread),
         state=state,
     )
 
@@ -312,6 +320,44 @@ async def test_unaddressed_outdated_thread_is_not_resolved(
 
 
 @pytest.mark.unit
+async def test_outdated_thread_with_fresh_reply_is_not_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A ``fix_committed`` outdated thread that gained a NEW reviewer reply after
+    the verdict (its body hash changed) is left open — mirroring the fix-cycle's
+    stale-thread guard. Resolving it would close feedback the monitor never
+    re-handled: outdated threads are dropped from the actionable feed, so the fix
+    cycle never re-addresses them either."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    addressed = _outdated_thread("T_reply")
+    _mark_review_thread_addressed(state, addressed, "fix_committed")
+    # A new reviewer reply lands on the now-outdated thread: same id + verdict,
+    # but a changed body, so the recorded body hash no longer matches.
+    with_reply = _outdated_thread("T_reply", body_excerpt="actually this is still broken")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(with_reply),
+        state=state,
+    )
+
+    assert gh.attempts == []
+
+
+@pytest.mark.unit
 async def test_bitbucket_outdated_thread_resolves_via_resolve_thread(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -332,12 +378,13 @@ async def test_bitbucket_outdated_thread_resolves_via_resolve_thread(
     )
     state = MonitorState()
     bb_id = "bb:workspace/repo#42:100"
-    state.mark_addressed(bb_id, "fix_committed")
+    thread = _outdated_thread(bb_id)
+    _mark_review_thread_addressed(state, thread, "fix_committed")
 
     await _call_resolve(
         runner,
         workspace_id=workspace_id,
-        status=_status_with_outdated(_outdated_thread(bb_id)),
+        status=_status_with_outdated(thread),
         state=state,
     )
 
@@ -370,12 +417,13 @@ async def test_transient_resolve_error_is_requeued_not_failed(
         gh=gh,
     )
     state = MonitorState()
-    state.mark_addressed("T_transient", "fix_committed")
+    thread = _outdated_thread("T_transient")
+    _mark_review_thread_addressed(state, thread, "fix_committed")
 
     await _call_resolve(
         runner,
         workspace_id=workspace_id,
-        status=_status_with_outdated(_outdated_thread("T_transient")),
+        status=_status_with_outdated(thread),
         state=state,
     )
 
@@ -419,12 +467,13 @@ async def test_permanent_resolve_error_is_tolerated(
     )
     state = MonitorState()
     bb_id = "bb:workspace/repo#42:100"
-    state.mark_addressed(bb_id, "fix_committed")
+    thread = _outdated_thread(bb_id)
+    _mark_review_thread_addressed(state, thread, "fix_committed")
 
     await _call_resolve(
         runner,
         workspace_id=workspace_id,
-        status=_status_with_outdated(_outdated_thread(bb_id)),
+        status=_status_with_outdated(thread),
         state=state,
     )
 

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -538,6 +538,60 @@ async def test_permanent_resolve_error_is_not_retried_next_poll(
 
 
 @pytest.mark.unit
+async def test_permanent_resolve_downgrade_survives_state_reload(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(e3) The ``needs_human`` downgrade must be PERSISTED, not just held in
+    memory. This step runs before ``_execute``, which skips ``_persist_state`` on
+    a transient fault and reloads clean state from the DB next poll. If the
+    downgrade lived only in memory it would be lost on that path, and the next
+    poll would re-issue the same known-permanent resolve — the retry storm the
+    downgrade exists to prevent. Unlike (e2), which reused one in-memory ``state``
+    across both polls, this reloads state from the DB between polls to mirror the
+    real loop (``state = self._load_state(ws)``)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    permanent = BitBucketClientError(
+        operation="bitbucket resolve_thread",
+        status=403,
+        body="thread resolution is not permitted for this token",
+        reason_code=BITBUCKET_API_ERROR,
+    )
+    gh = _RecordingGitHub(cmd, error=permanent)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    bb_id = "bb:workspace/repo#42:100"
+    thread = _outdated_thread(bb_id)
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+    status = _status_with_outdated(thread)
+
+    # First poll: permanent fault, one attempt, downgrade to needs_human (persisted).
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=state)
+
+    # Next poll mirrors the loop: reload state from the DB rather than reusing the
+    # in-memory object. The persisted downgrade must come back as needs_human.
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        reloaded = runner._load_state(ws)  # type: ignore[attr-defined]
+    assert reloaded.threads_addressed_ids[bb_id] == "needs_human"
+
+    # Second poll with the reloaded state: the verdict is needs_human, so the step
+    # skips it without a second forge call (no retry storm).
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=reloaded)
+
+    assert gh.attempts == [bb_id]  # exactly one resolve attempt across both polls
+
+
+@pytest.mark.unit
 def test_outdated_resolvable_verdicts_exclude_defer() -> None:
     """The outdated-resolution verdict set is the fix-cycle's resolvable set MINUS
     ``defer`` — defer's resolution is gated on durable capture this hygiene step

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -28,6 +28,7 @@ from awf.common.github_client import GitHubClientError, RepoRef
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.runtime.pr_monitor import (
+    _CLOSED_OUTDATED_THREAD_VERDICTS,
     CheckState,
     MergeableState,
     MergeStateStatus,
@@ -600,3 +601,7 @@ def test_outdated_resolvable_verdicts_exclude_defer() -> None:
     assert "defer" not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS
     assert frozenset({"fix_committed", "false_positive"}) == (_OUTDATED_RESOLVABLE_THREAD_VERDICTS)
     assert _OUTDATED_RESOLVABLE_THREAD_VERDICTS < _RESOLVABLE_THREAD_VERDICTS
+    # Guard the hand-written literal in pr_monitor.py against future drift: the two
+    # constants are documented to mirror each other (same verdicts, different
+    # derivation paths), so any new verdict added to one must reach the other.
+    assert _CLOSED_OUTDATED_THREAD_VERDICTS == _OUTDATED_RESOLVABLE_THREAD_VERDICTS

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -440,13 +440,16 @@ async def test_transient_resolve_error_is_requeued_not_failed(
 
 
 @pytest.mark.unit
-async def test_permanent_resolve_error_is_tolerated(
+async def test_permanent_resolve_error_downgrades_to_needs_human(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """(e) A permanent resolve fault does not crash the monitor and is recorded as
-    a ``failed`` audit event carrying the forge-native reason code. The thread is
-    non-blocking, so the addressed marker is preserved (retried next poll)."""
+    """(e) A permanent resolve fault does not crash the monitor. Rather than
+    preserving the resolvable verdict (which would re-issue the same failing
+    resolve every poll — a retry storm), the verdict is downgraded to
+    ``needs_human`` and a ``needs_human`` audit event carrying the forge-native
+    reason code is recorded. The thread is non-blocking, so this never wedges
+    auto-merge; it simply stops the pointless retries."""
     workspace_id = await seed_monitoring_workspace(factory)
     cmd = FakeCommandRunner()
     permanent = BitBucketClientError(
@@ -478,14 +481,60 @@ async def test_permanent_resolve_error_is_tolerated(
     )
 
     assert gh.resolved == []
-    assert state.threads_addressed_ids[bb_id] == "fix_committed"
+    # Verdict downgraded so the next poll skips it (not in the resolvable set).
+    assert state.threads_addressed_ids[bb_id] == "needs_human"
+    assert "needs_human" not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS
     assert sleep_fn.calls == []  # permanent fault does not wait/retry
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
-        failed = _resolution_events(ws, outcome="failed")
-        assert len(failed) == 1
-        assert failed[0].reason_code == BITBUCKET_API_ERROR
+        downgraded = _resolution_events(ws, outcome="needs_human")
+        assert len(downgraded) == 1
+        assert downgraded[0].reason_code == BITBUCKET_API_ERROR
+        assert (downgraded[0].payload or {}).get("evidence", {}).get(
+            "needs_human_thread_count"
+        ) == 1
+
+
+@pytest.mark.unit
+async def test_permanent_resolve_error_is_not_retried_next_poll(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(e2) After a permanent resolve fault downgrades the verdict to
+    ``needs_human``, a subsequent poll that still surfaces the outdated thread
+    must NOT re-issue the resolve — otherwise a non-fixable fault would spam the
+    forge API and logs on every cycle until the (non-blocking) PR merges."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    permanent = BitBucketClientError(
+        operation="bitbucket resolve_thread",
+        status=403,
+        body="thread resolution is not permitted for this token",
+        reason_code=BITBUCKET_API_ERROR,
+    )
+    gh = _RecordingGitHub(cmd, error=permanent)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    bb_id = "bb:workspace/repo#42:100"
+    thread = _outdated_thread(bb_id)
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+    status = _status_with_outdated(thread)
+
+    # First poll: permanent fault, one attempt, downgrade to needs_human.
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=state)
+    # Second poll: the thread is still outdated/unresolved, but the verdict is now
+    # needs_human, so the step must skip it without a second forge call.
+    await _call_resolve(runner, workspace_id=workspace_id, status=status, state=state)
+
+    assert gh.attempts == [bb_id]  # exactly one resolve attempt across both polls
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
@@ -73,6 +73,7 @@ def _status(
     ci_failures: tuple[CheckFailure, ...] = (),
     closed: bool = False,
     merged: bool = False,
+    outdated: tuple[ReviewThread, ...] = (),
 ) -> PRStatus:
     return PRStatus(
         number=42,
@@ -91,6 +92,7 @@ def _status(
         ci_failures=ci_failures,
         closed=closed,
         merged=merged,
+        outdated_unresolved_inline_threads=outdated,
     )
 
 
@@ -229,6 +231,70 @@ class TestDeferredFeedbackGate:
         )
 
         assert _review_thread_needs_attention(state, changed) is True
+
+
+class TestOutdatedFreshFeedbackGate:
+    """An AWF-closed thread that went OUTDATED then gained fresh reviewer
+    feedback must block auto-merge.
+
+    Both forge clients drop outdated threads from ``unresolved_inline_threads``,
+    so the comment/merge gates never see them. The outdated-resolution hygiene
+    step deliberately refuses to auto-resolve a closed-but-changed thread; without
+    a decide() gate the monitor would silently merge over the fresh feedback
+    (#473 follow-up)."""
+
+    @staticmethod
+    def _outdated(tid: str, *, body: str) -> ReviewThread:
+        return ReviewThread(
+            thread_id=tid,
+            path="src/x.py",
+            line=10,
+            body_excerpt=body,
+            author=None,
+            is_outdated=True,
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("verdict", ("fix_committed", "false_positive"))
+    def test_outdated_closed_thread_with_fresh_reply_blocks_merge(self, verdict: str) -> None:
+        state = MonitorState()
+        original = self._outdated("T1", body="bot nit")
+        _mark_review_thread_addressed(state, original, verdict)
+        # Same thread, still outdated, but a fresh reviewer reply changed the body
+        # so the recorded body hash no longer matches.
+        with_reply = self._outdated("T1", body="actually this is still broken")
+        action = decide(
+            status=_status(outdated=(with_reply,)),
+            state=state,
+            config=MonitorConfig(auto_merge=True),
+        )
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    def test_outdated_closed_thread_without_new_feedback_merges(self) -> None:
+        """The common case — a closed outdated thread with no fresh reply — must
+        NOT block: the hygiene step resolves it and merge proceeds."""
+        state = MonitorState()
+        thread = self._outdated("T1", body="bot nit")
+        _mark_review_thread_addressed(state, thread, "fix_committed")
+        action = decide(
+            status=_status(outdated=(thread,)),
+            state=state,
+            config=MonitorConfig(auto_merge=True),
+        )
+        assert isinstance(action, Merge)
+
+    @pytest.mark.unit
+    def test_unaddressed_outdated_thread_does_not_block(self) -> None:
+        """A never-addressed outdated thread (the #473 'addressed by an edit
+        elsewhere' case) stays non-blocking — only AWF-closed threads gate."""
+        state = MonitorState()
+        action = decide(
+            status=_status(outdated=(self._outdated("T9", body="stale anchor"),)),
+            state=state,
+            config=MonitorConfig(auto_merge=True),
+        )
+        assert isinstance(action, Merge)
 
 
 class TestStateImmutability:

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from awf.runtime.monitor_state_keys import _merge_method_blocked_key
+from awf.runtime.monitor_state_keys import (
+    _merge_method_blocked_key,
+    _outdated_resolve_requeued_key,
+)
 from awf.runtime.pr_monitor import (
     CheckFailure,
     CheckState,
@@ -305,6 +308,29 @@ class TestOutdatedFreshFeedbackGate:
         verdict out of ``_CLOSED_OUTDATED_THREAD_VERDICTS`` (so the fresh-feedback
         gate alone no longer matches it)."""
         state = MonitorState(threads_addressed_ids={"T1": "needs_human"})
+        action = decide(
+            status=_status(outdated=(self._outdated("T1", body="bot nit"),)),
+            state=state,
+            config=MonitorConfig(auto_merge=True),
+        )
+        assert isinstance(action, NotifyHuman)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("verdict", ("fix_committed", "false_positive"))
+    def test_outdated_transient_requeue_flag_blocks_merge(self, verdict: str) -> None:
+        """When ``_resolve_addressed_outdated_threads`` hits a TRANSIENT resolve
+        fault it keeps the fix verdict (so the next poll retries) and flags the
+        thread requeued. Because that step runs in the same iteration right before
+        ``decide``, the fix verdict alone would let ``decide`` return ``Merge`` on
+        this very poll — merging over the addressed-but-unresolved outdated thread
+        before the retry runs. The requeue flag must make ``decide`` hold at
+        ``NotifyHuman`` instead."""
+        state = MonitorState(
+            threads_addressed_ids={
+                "T1": verdict,
+                _outdated_resolve_requeued_key("T1"): "requeued",
+            }
+        )
         action = decide(
             status=_status(outdated=(self._outdated("T1", body="bot nit"),)),
             state=state,

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_002.py
@@ -296,6 +296,22 @@ class TestOutdatedFreshFeedbackGate:
         )
         assert isinstance(action, Merge)
 
+    @pytest.mark.unit
+    def test_outdated_needs_human_downgrade_blocks_merge(self) -> None:
+        """When ``_resolve_addressed_outdated_threads`` hits a permanent resolve
+        fault it downgrades the verdict to ``needs_human`` and the thread stays in
+        the outdated feed. ``needs_human`` means operator action is required, so
+        ``decide`` must block auto-merge on it — even though the downgrade moved the
+        verdict out of ``_CLOSED_OUTDATED_THREAD_VERDICTS`` (so the fresh-feedback
+        gate alone no longer matches it)."""
+        state = MonitorState(threads_addressed_ids={"T1": "needs_human"})
+        action = decide(
+            status=_status(outdated=(self._outdated("T1", body="bot nit"),)),
+            state=state,
+            config=MonitorConfig(auto_merge=True),
+        )
+        assert isinstance(action, NotifyHuman)
+
 
 class TestStateImmutability:
     @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_003.py
@@ -33,6 +33,7 @@ from awf.db.repositories import (
     WorkspaceRepository,
 )
 from awf.db.session import make_session_factory
+from awf.runtime.monitor_state_keys import _outdated_resolve_requeued_key
 from awf.runtime.pr_monitor import (
     CheckFailure,
     CheckState,
@@ -507,6 +508,9 @@ def test_changed_review_thread_history_requeues_private_verdict() -> None:
         ),
     )
     _mark_review_thread_addressed(state, original, "false_positive")
+    # A stale outdated-resolve requeue flag from a prior poll must also be wiped
+    # when the thread's addressed state is fully reset for re-triage.
+    state.threads_addressed_ids[_outdated_resolve_requeued_key("T_handled")] = "requeued"
     status = PRStatus(
         number=42,
         head_sha="new-head-after-thread-reply",
@@ -543,6 +547,7 @@ def test_changed_review_thread_history_requeues_private_verdict() -> None:
     assert changed is True
     assert "T_handled" not in state.threads_addressed_ids
     assert _review_thread_body_state_key("T_handled") not in state.threads_addressed_ids
+    assert _outdated_resolve_requeued_key("T_handled") not in state.threads_addressed_ids
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_b5b4b38e74294f7eae23aab5` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix #473: the PR monitor leaves an addressed review thread UNRESOLVED when the agent's fix makes the
thread OUTDATED (addressed-elsewhere, not in-place). Result: a merged PR shows a lingering "unresolved"
comment even though the feedback was handled — eroding the operator-visible "did AWF handle everything?"
signal. Strict TDD, 99% coverage, keep AWF core generic, forge-neutral.

ROOT CAUSE (verified): common/github_client.py fetch_pr_status (~lines 592-616) drops threads from
`unresolved_inline_threads` when `is_resolved or is_outdated` (line 612-613: `if is_resolved or
is_outdated: continue`). When the agent addresses a comment by changing code ELSEWHERE (different
lines/file), GitHub marks the original thread isOutdated=true. The monitor's decide() then sees
unresolved_threads=0 and merges (correct — outdated threads are non-blocking). BUT the resolve step
iterates `unresolved_inline_threads` (pr_monitor_runner/comments.py + helpers.py:328), so it never
resolves the now-outdated thread. The monitor DID address it — it records the verdict in
`state.threads_addressed_ids` (thread_id -> verdict) and even commits with a message referencing the
comment id. Proven on PR #470: one greptile thread fixed IN-PLACE -> isResolved=true (resolve path
works); one fixed in a DIFFERENT file -> isOutdated=true, isResolved=false (never resolved).

FIX: resolve threads the monitor has ADDRESSED (verdict = fix_committed / handled in threads_addressed_ids)
EVEN WHEN they have become outdated and dropped out of unresolved_inline_threads. Design (you choose the
cleanest, via plan-first + TDD):
  - Track/keep the addressed thread ids (already in state.threads_addressed_ids) and ensure the resolve
    step acts on them regardless of whether they are still in unresolved_inline_threads. Likely needs the
    forge client to expose outdated-but-unresolved threads (e.g. a separate query or a dedicated field)
    so the runner can resolve the addressed ones; OR resolve a thread the moment it is recorded as
    fix_committed (while still current) so it never lingers; OR at the pre-merge/resolve step, call
    resolve_thread for each addressed thread id with a fix verdict, tolerating already-resolved.
  - Do NOT resolve threads with verdict defer / needs_human / rejected (those legitimately stay open).
  - FORGE-NEUTRAL: handle the BitBucket resolve_thread path too (the gap is forge-neutral though observed
    on GitHub); preserve BitBucket's existing resolve semantics (resolve_thread is POST, never DELETE).
  - Reason codes / structured logging preserved; never log secrets.

TESTS (TDD): (a) a thread addressed (fix_committed) that becomes OUTDATED is resolved before/at merge
(the #473 regression — pin the exact scenario from PR #470). (b) a thread addressed IN-PLACE still
resolves (regression — don't break the working path). (c) a thread with verdict defer/needs_human/
rejected is NOT resolved. (d) forge-neutral: the same for the BitBucket resolve path. (e) resolving an
already-resolved/idempotent case is tolerated (no crash, no double-resolve error surfaced as failure).

NOT IN SCOPE: changing the merge-gate semantics (outdated threads correctly stay non-blocking for merge);
backfilling already-merged PRs (e.g. PR #470's lingering thread).
VALIDATION: full local gate (ruff, ruff format --check, mypy, pytest, 99% coverage). Close #473.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR monitor merge decision logic and forge resolve paths; incorrect gating could block merge or leave threads unresolved, but behavior is heavily unit-tested and scoped to outdated-thread hygiene.
> 
> **Overview**
> Fixes **#473**: when AWF addresses review feedback by editing code elsewhere, the forge marks the original inline thread **OUTDATED** and drops it from the actionable unresolved feed—so the fix-cycle never calls `resolve_thread` and merged PRs can still show an open comment despite a `fix_committed` / `false_positive` verdict.
> 
> **Forge clients** add `PRStatus.outdated_unresolved_inline_threads` (default empty): GitHub routes outdated-but-unresolved threads into that list instead of discarding them; BitBucket refactors inline parsing with `partition_inline_review_threads` so actionable vs outdated feeds are built in one pass.
> 
> **Monitor runner** adds `_resolve_addressed_outdated_threads` in `outdated_resolution.py`, invoked **each poll before `decide()`**, resolving only threads with `fix_committed` or `false_positive` (not `defer`). It skips threads with fresh reviewer replies (body-hash guard), handles transient vs permanent `ForgeClientError` (requeue flag + merge hold vs persisted `needs_human` downgrade), and emits audit events.
> 
> **Merge gating** still treats unaddressed outdated threads as non-blocking, but **`decide()`** now blocks auto-merge when an outdated thread has fresh feedback after AWF closed it, is `needs_human` after a permanent resolve failure, or carries a transient-resolve requeue flag—so merge cannot race ahead of a pending resolve retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0902ae1f6b4b7c061d72327b7c09fb9aab732b21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed review threads that become outdated after being addressed elsewhere. The monitor now automatically resolves these outdated-but-addressed threads during each poll cycle, preventing them from lingering as unresolved after merge. Includes support for both GitHub and BitBucket with graceful error handling for transient and permanent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->