### PR TITLE
Fix #475: expose pr_number in WorkspaceResponse + forge-neutral console PR label (BitBucket PR button)

### DIFF
--- a/apps/console/components/console-dashboard-logs.tsx
+++ b/apps/console/components/console-dashboard-logs.tsx
@@ -454,7 +454,7 @@ export function WorkspaceLogColumn({
         </div>
         <div className="flex shrink-0 items-center gap-1">
           {workspace.pr_url ? (
-            <SmallExternalAnchor href={workspace.pr_url} label={formatPrLinkLabel(workspace.pr_url)} />
+            <SmallExternalAnchor href={workspace.pr_url} label={formatPrLinkLabel(workspace.pr_url, workspace.pr_number)} />
           ) : null}
           <button
             type="button"

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -239,6 +239,7 @@ export type LogWorkspaceTarget = Pick<
   | "agent_effort_source"
   | "status"
   | "pr_url"
+  | "pr_number"
 >;
 
 export type RetryActionState =
@@ -415,7 +416,7 @@ export function formatPrLinkLabel(href: string, prNumber?: number | null) {
 }
 
 export function extractPrNumberFromHref(href: string): number | null {
-  const match = href.match(/\/pull\/(\d+)(?:[/?#]|$)/);
+  const match = href.match(/\/pull(?:-requests)?\/(\d+)(?:[/?#]|$)/);
   if (!match) {
     return null;
   }
@@ -864,6 +865,7 @@ export function toLogWorkspaceTarget(workspaceId: string, overview: WorkspaceOve
     agent_effort_source: "unavailable",
     status: "running",
     pr_url: null,
+    pr_number: null,
   };
 }
 

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -250,7 +250,7 @@ export function WorkspaceSummary({
             </button>
           ) : null}
           {overview.pr_url ? (
-            <ExternalAnchor href={overview.pr_url} label={formatPrLinkLabel(overview.pr_url)} />
+            <ExternalAnchor href={overview.pr_url} label={formatPrLinkLabel(overview.pr_url, overview.pr_number)} />
           ) : null}
         </div>
       }

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -88,6 +88,31 @@ test("extractPrNumberFromHref regex is forge-neutral (GitHub + BitBucket)", () =
   assert.match(dashboardSource.shared, /pull\(\?:-requests\)\?/);
 });
 
+// Plain-JS mirror of extractPrNumberFromHref (console-dashboard-shared.tsx) for runtime
+// extraction tests. The source-text test above keeps the regex pattern in sync.
+function extractPrNumberFromHref(href) {
+  const match = href.match(/\/pull(?:-requests)?\/(\d+)(?:[/?#]|$)/);
+  if (!match) return null;
+  const number = Number(match[1]);
+  return Number.isSafeInteger(number) && number > 0 ? number : null;
+}
+
+test("extractPrNumberFromHref extracts PR number from GitHub and Bitbucket URLs", () => {
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/42"), 42);
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/42/"), 42);
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/42?foo=bar"), 42);
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/42#comment-1"), 42);
+  assert.equal(extractPrNumberFromHref("https://bitbucket.org/org/repo/pull-requests/42"), 42);
+  assert.equal(extractPrNumberFromHref("https://bitbucket.org/org/repo/pull-requests/42/"), 42);
+});
+
+test("extractPrNumberFromHref returns null for non-PR URLs and edge cases", () => {
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/issues/42"), null);
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/"), null);
+  assert.equal(extractPrNumberFromHref("https://github.com/org/repo/pull/0"), null);
+  assert.equal(extractPrNumberFromHref(""), null);
+});
+
 test("formatPrLinkLabel in logs view passes pr_number", () => {
   assert.match(dashboardSource.logs, /formatPrLinkLabel\(workspace\.pr_url,\s*workspace\.pr_number\)/);
 });

--- a/apps/console/lib/console-dashboard-source.test.mjs
+++ b/apps/console/lib/console-dashboard-source.test.mjs
@@ -7,6 +7,7 @@ const dashboardSource = {
   overview: readFileSync(new URL("../components/console-dashboard-overview.tsx", import.meta.url), "utf8"),
   capacity: readFileSync(new URL("../components/console-dashboard-capacity.tsx", import.meta.url), "utf8"),
   shared: readFileSync(new URL("../components/console-dashboard-shared.tsx", import.meta.url), "utf8"),
+  logs: readFileSync(new URL("../components/console-dashboard-logs.tsx", import.meta.url), "utf8"),
   detail: readFileSync(
     new URL("../components/console-dashboard-workspace-detail.tsx", import.meta.url),
     "utf8",
@@ -81,6 +82,18 @@ test("operator action state is guarded by current workspace selection", () => {
   assert.match(dashboard, /operatorIdempotencyKey\(action, workspaceId\)/);
   assert.match(dashboard, /operatorActionPath\(action, workspaceId\)/);
   assert.match(dashboard, /selectedIdRef\.current !== workspaceId/);
+});
+
+test("extractPrNumberFromHref regex is forge-neutral (GitHub + BitBucket)", () => {
+  assert.match(dashboardSource.shared, /pull\(\?:-requests\)\?/);
+});
+
+test("formatPrLinkLabel in logs view passes pr_number", () => {
+  assert.match(dashboardSource.logs, /formatPrLinkLabel\(workspace\.pr_url,\s*workspace\.pr_number\)/);
+});
+
+test("formatPrLinkLabel in detail view passes pr_number", () => {
+  assert.match(dashboardSource.detail, /formatPrLinkLabel\(overview\.pr_url,\s*overview\.pr_number\)/);
 });
 
 function extractFunctionSource(functionName) {

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -203,7 +203,7 @@ export interface WorkspaceOverview {
   active_operation: string | null;
   last_event: WorkspaceEvent | null;
   pr_url: string | null;
-  pr_number: number | null;
+  pr_number?: number | null;
   failure_reason: string | null;
   failure_message: string | null;
   latest_queue_decision?: QueueDecisionSummary | null;
@@ -503,7 +503,7 @@ export interface Workspace {
   compose_project_name: string | null;
   compose_file_path: string | null;
   pr_url: string | null;
-  pr_number: number | null;
+  pr_number?: number | null;
   failure_reason: string | null;
   failure_message: string | null;
   secret_leases: WorkspaceSecretLease[];

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -203,6 +203,7 @@ export interface WorkspaceOverview {
   active_operation: string | null;
   last_event: WorkspaceEvent | null;
   pr_url: string | null;
+  pr_number: number | null;
   failure_reason: string | null;
   failure_message: string | null;
   latest_queue_decision?: QueueDecisionSummary | null;
@@ -502,6 +503,7 @@ export interface Workspace {
   compose_project_name: string | null;
   compose_file_path: string | null;
   pr_url: string | null;
+  pr_number: number | null;
   failure_reason: string | null;
   failure_message: string | null;
   secret_leases: WorkspaceSecretLease[];

--- a/docs/awf-plans/ws_e977818cf67f462191ee8074.conformance.json
+++ b/docs/awf-plans/ws_e977818cf67f462191ee8074.conformance.json
@@ -1,0 +1,12 @@
+{
+  "status": "needs_iteration",
+  "summary": "All planned implementation changes are present and correct: pr_number added to WorkspaceResponse and WorkspaceOverviewResponse in schemas.py; pr_number added to Workspace and WorkspaceOverview in types.ts; extractPrNumberFromHref regex updated to forge-neutral pattern; both call sites in logs.tsx and detail.tsx pass workspace.pr_number/overview.pr_number to formatPrLinkLabel; Python regression test added; console source-inspection tests added; openapi.json regenerated with pr_number in both schema sections. No implementation gaps remain. Validation evidence is missing — AWF must run the validation phase to confirm all gates pass.",
+  "gaps": [
+    "AWF validation required: run pytest tests/unit/api/test_workspaces_direct.py and full unit suite to confirm test_pr_number_in_workspace_response passes and coverage gate holds.",
+    "AWF validation required: run ruff check and ruff format --check to confirm schema.py and any touched Python files are lint-clean.",
+    "AWF validation required: run mypy to confirm pr_number field additions are type-correct.",
+    "AWF validation required: run python scripts/generate_openapi.py --check to confirm openapi.json drift gate passes (file was regenerated in the commit but gate must be confirmed by AWF).",
+    "AWF validation required: run npm --prefix apps/console run lint, typecheck, build, and test:browser to confirm console changes are type-safe, build-clean, and source-inspection tests pass."
+  ],
+  "reason_code": "CONFORMANCE_REQUIRES_AWF_VALIDATION"
+}

--- a/docs/awf-plans/ws_e977818cf67f462191ee8074.md
+++ b/docs/awf-plans/ws_e977818cf67f462191ee8074.md
@@ -1,0 +1,145 @@
+# Plan: Fix #475 — BitBucket PR number missing from console PR button
+
+## Summary
+
+Two independent gaps prevent the PR button from showing a number for BitBucket workspaces:
+
+- **Gap A (API):** `WorkspaceResponse` (and `WorkspaceOverviewResponse`) expose `pr_url` but omit
+  `pr_number`, so the JSON the console receives never contains the number.
+- **Gap B (Console):** `extractPrNumberFromHref` uses a GitHub-only regex (`/\/pull\/(\d+)/`) that
+  does not match BitBucket's `/pull-requests/N` path. The logs and workspace-detail views also
+  never pass `pr_number` to `formatPrLinkLabel`, so even a URL-parse fix would be sufficient, but
+  the authoritative field is preferred.
+
+DB is already correct (`workspaces.pr_number = 2` for a real BitBucket PR); this fix makes the
+number visible end-to-end.
+
+---
+
+## Files to touch
+
+### Python / API
+
+| File | Change |
+|------|--------|
+| `src/awf/api/schemas.py` | Add `pr_number: int \| None = None` to `WorkspaceResponse` (~line 797) and `WorkspaceOverviewResponse` (~line 1027). Both use `from_attributes=True`/Pydantic ORM mapping; the field auto-populates from the ORM model which already has `pr_number`. |
+| `openapi.json` | Regenerate via `python scripts/generate_openapi.py` to satisfy the drift gate. |
+
+### Console
+
+| File | Change |
+|------|--------|
+| `apps/console/lib/types.ts` | Add `pr_number: number \| null` to `Workspace` interface (after `pr_url` at line 504) and to `WorkspaceOverview` interface (after `pr_url` at line 205). |
+| `apps/console/components/console-dashboard-shared.tsx` | Fix `extractPrNumberFromHref` regex from `/\/pull\/(\d+)(?:[/?#]\|$)/` to `/\/pull(?:-requests)?\/(\d+)(?:[/?#]\|$)/` to handle both GitHub (`/pull/N`) and BitBucket (`/pull-requests/N`). |
+| `apps/console/components/console-dashboard-logs.tsx` | Pass `workspace.pr_number` as the second argument to `formatPrLinkLabel` at line 457. |
+| `apps/console/components/console-dashboard-workspace-detail.tsx` | Pass `overview.pr_number` as the second argument to `formatPrLinkLabel` at line 253. |
+
+### Tests
+
+| File | Change |
+|------|--------|
+| `tests/unit/api/test_workspaces_direct.py` | New test: create workspace with `pr_number=2` and a BitBucket PR URL, call `get_workspace`, assert response JSON contains `"pr_number": 2`. |
+| `apps/console/lib/console-dashboard-source.test.mjs` | New tests: (1) verify `extractPrNumberFromHref` source contains the forge-neutral regex; (2) verify `formatPrLinkLabel` calls in logs and detail views pass `pr_number` as the second argument. |
+
+---
+
+## Step-by-step implementation order (TDD)
+
+1. **Write Python test first** in `tests/unit/api/test_workspaces_direct.py`:
+   - Create a workspace with `pr_number=2`, `pr_url="https://bitbucket.org/org/repo/pull-requests/2"`
+   - Call `get_workspace(workspace_id, session)` and assert `response.pr_number == 2`
+   - Run test — it should **fail** (field missing from `WorkspaceResponse`)
+
+2. **Fix `WorkspaceResponse`** in `src/awf/api/schemas.py`:
+   - Add `pr_number: int | None = None` after the `pr_url` field
+   - Rerun test — it should **pass** (auto-populated via `from_attributes`)
+
+3. **Fix `WorkspaceOverviewResponse`** in `src/awf/api/schemas.py`:
+   - Add `pr_number: int | None = None` after the `pr_url` field
+   - Write an analogous test for the overview response (or extend the existing one)
+
+4. **Regenerate `openapi.json`**:
+   - `python scripts/generate_openapi.py`
+   - Verify `--check` passes
+
+5. **Write console tests first** in `apps/console/lib/console-dashboard-source.test.mjs`:
+   - Test that the shared.tsx source contains the forge-neutral regex pattern
+   - Test that `formatPrLinkLabel` calls in logs.tsx and detail.tsx pass a second argument
+   - Run `npm --prefix apps/console run test` — tests should **fail**
+
+6. **Fix `extractPrNumberFromHref` regex** in `console-dashboard-shared.tsx`
+
+7. **Update console types** in `apps/console/lib/types.ts`:
+   - Add `pr_number: number | null` to `Workspace` and `WorkspaceOverview`
+
+8. **Update call sites** in `console-dashboard-logs.tsx` and `console-dashboard-workspace-detail.tsx`:
+   - Pass the explicit `pr_number` field as second arg to `formatPrLinkLabel`
+
+9. **Run targeted validation**:
+   ```bash
+   uv run --python 3.12 --extra dev pytest tests/unit/api/test_workspaces_direct.py -q
+   uv run --python 3.12 --extra dev ruff check src/awf/api/schemas.py
+   uv run --python 3.12 --extra dev mypy
+   python scripts/generate_openapi.py --check
+   npm --prefix apps/console run test
+   npm --prefix apps/console run lint
+   npm --prefix apps/console run typecheck
+   npm --prefix apps/console run build
+   ```
+
+---
+
+## Test details
+
+### Python: `test_pr_number_in_workspace_response`
+
+Location: `tests/unit/api/test_workspaces_direct.py` (append after existing tests)
+
+```python
+async def test_pr_number_in_workspace_response(session_factory):
+    """WorkspaceResponse must include pr_number so the console can show it."""
+    async with session_factory() as session:
+        ws = make_workspace(...)  # reuse existing helper or build minimal fixture
+        ws.pr_url = "https://bitbucket.org/org/repo/pull-requests/2"
+        ws.pr_number = 2
+        session.add(ws)
+        await session.flush()
+        resp = await get_workspace(ws.id, session)
+        assert resp.pr_number == 2
+```
+
+### Console: source-inspection tests in `console-dashboard-source.test.mjs`
+
+```js
+test("extractPrNumberFromHref regex is forge-neutral (GitHub + BitBucket)", () => {
+  // Verify the source contains the forge-neutral regex
+  assert.match(dashboardSource.shared, /pull\(\?:-requests\)\?/);
+});
+
+test("formatPrLinkLabel in logs view passes pr_number", () => {
+  // The logs view call site should pass a second argument (pr_number)
+  assert.match(dashboardSource.logs, /formatPrLinkLabel\(workspace\.pr_url,\s*workspace\.pr_number\)/);
+});
+
+test("formatPrLinkLabel in detail view passes pr_number", () => {
+  assert.match(dashboardSource.detail, /formatPrLinkLabel\(overview\.pr_url,\s*overview\.pr_number\)/);
+});
+```
+
+---
+
+## Risks and assumptions
+
+| Risk | Mitigation |
+|------|-----------|
+| `WorkspaceOverview` (the list endpoint type) is what the workspace-detail view uses for `overview.pr_url`. Both `WorkspaceResponse` and `WorkspaceOverviewResponse` must be fixed. | Confirmed: `console-dashboard-workspace-detail.tsx` imports `WorkspaceOverview` and types `overview: WorkspaceOverview`. Both schema classes need the field. |
+| `from_attributes=True` auto-maps if field names match exactly. Both schema additions must use `pr_number` (matching the ORM column name). | The ORM column in `db/models.py` is `pr_number`; both schema additions use the same name — no alias needed. |
+| openapi.json drift gate will fail if not regenerated. | Regenerate immediately after schema changes; commit the updated file. |
+| Console `npm run build` is required for CI but is not run by the AWF self-validate phase. | Run build locally as part of targeted validation per the task contract. |
+| Other `formatPrLinkLabel` call sites (overview, capacity, security views) don't need the `pr_number` argument yet — the URL fallback will handle GitHub URLs. The forge-neutral regex fix handles BitBucket URLs for those sites too. | Scope: only logs.tsx and detail.tsx explicitly required per task. The regex fix benefits all sites for free. |
+
+## Non-goals
+
+- Changing `pr_number` persistence or `pr_url` storage (fixed in #468)
+- Other dashboard views beyond workspace logs + detail (overview, capacity, security)
+- Tests for other features or refactoring unrelated code

--- a/openapi.json
+++ b/openapi.json
@@ -9207,6 +9207,17 @@
             "title": "Owned Paths",
             "type": "array"
           },
+          "pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Number"
+          },
           "pr_url": {
             "anyOf": [
               {
@@ -10411,6 +10422,17 @@
             },
             "title": "Policy Findings",
             "type": "array"
+          },
+          "pr_number": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pr Number"
           },
           "pr_url": {
             "anyOf": [

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -795,6 +795,7 @@ class WorkspaceResponse(BaseModel):
     compose_file_path: str | None
 
     pr_url: str | None
+    pr_number: int | None = None
     failure_reason: str | None
     failure_message: str | None
     failure_details: WorkspaceFailureDetailsResponse | None = None
@@ -1025,6 +1026,7 @@ class WorkspaceOverviewResponse(BaseModel):
     active_operation: str | None
     last_event: WorkspaceEventResponse | None
     pr_url: str | None
+    pr_number: int | None = None
     failure_reason: str | None
     failure_message: str | None
     created_at: datetime

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -993,6 +993,8 @@ class TaskAttemptListResponse(BaseModel):
 
 
 class WorkspaceOverviewResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     workspace_id: str
     task_id: str
     title: str

--- a/src/awf/service/workspace_observability.py
+++ b/src/awf/service/workspace_observability.py
@@ -382,6 +382,7 @@ def _workspace_overview_item(ws: Workspace) -> WorkspaceOverviewResponse:
             else None
         ),
         pr_url=ws.pr_url,
+        pr_number=ws.pr_number,
         failure_reason=ws.failure_reason,
         failure_message=ws.failure_message,
         created_at=ws.created_at,

--- a/tests/unit/api/test_workspaces_direct.py
+++ b/tests/unit/api/test_workspaces_direct.py
@@ -447,6 +447,34 @@ class TestGetDirect:
         assert exc.value.status_code == 404
         assert exc.value.detail["error_code"] == "NOT_FOUND"
 
+    @pytest.mark.unit
+    async def test_pr_number_in_workspace_response(
+        self,
+        session: AsyncSession,
+        session_factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """WorkspaceResponse must include pr_number so the console can show it for BitBucket PRs."""
+        created = await create_workspace(
+            payload=_payload(
+                provider_readiness_override=True,
+                task_title="bitbucket pr number",
+            ),
+            idempotency_key=None,
+            settings=_route_settings(),
+            session=session,
+        )
+        assert isinstance(created, WorkspaceAcceptedResponse)
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(created.workspace_id)
+        assert ws is not None
+        ws.pr_url = "https://bitbucket.org/org/repo/pull-requests/2"
+        ws.pr_number = 2
+        await session.commit()
+
+        result = await get_workspace(created.workspace_id, session_factory=session_factory)
+
+        assert result.pr_number == 2
+
 
 class TestListDirect:
     @pytest.mark.unit

--- a/tests/unit/api/test_workspaces_direct.py
+++ b/tests/unit/api/test_workspaces_direct.py
@@ -38,6 +38,7 @@ from awf.common.config import Settings
 from awf.db.enums import AgentRuntime
 from awf.db.repositories import EgressAuditRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
+from awf.service.workspace_observability import list_workspace_overview_response
 from tests.postgres import postgres_test_engine
 
 
@@ -497,6 +498,31 @@ class TestListDirect:
         await session.flush()
         results = await _list_workspace_responses(session, limit=10)
         assert len(results) == 2
+
+    @pytest.mark.unit
+    async def test_pr_number_in_overview_response(self, session: AsyncSession) -> None:
+        """WorkspaceOverviewResponse must include pr_number so the console list view can show it."""
+        created = await create_workspace(
+            payload=_payload(
+                provider_readiness_override=True,
+                task_title="overview pr number",
+            ),
+            idempotency_key=None,
+            settings=_route_settings(),
+            session=session,
+        )
+        assert isinstance(created, WorkspaceAcceptedResponse)
+        repo = WorkspaceRepository(session)
+        ws = await repo.get(created.workspace_id)
+        assert ws is not None
+        ws.pr_url = "https://bitbucket.org/org/repo/pull-requests/7"
+        ws.pr_number = 7
+        await session.flush()
+
+        overview = await list_workspace_overview_response(session, limit=10)
+
+        assert len(overview.items) == 1
+        assert overview.items[0].pr_number == 7
 
 
 class TestPayloadsMatch:

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -751,7 +751,8 @@ class TestWorkspaceDirectRoutes:
             events=events,
             operations=[],
             status=WorkspaceStatus.requested.value,
-            pr_url=None,
+            pr_url="https://github.com/example/app/pull/7",
+            pr_number=7,
             failure_reason=None,
             failure_message=None,
             created_at=base,
@@ -780,6 +781,8 @@ class TestWorkspaceDirectRoutes:
         assert item.last_event is not None
         assert item.last_event.event_type == "workspace.test_marker"
         assert events.iterations == 1
+        assert item.pr_number == 7
+        assert item.pr_url == "https://github.com/example/app/pull/7"
 
     @pytest.mark.unit
     async def test_existing_events_stale_reasons_get_retry_and_list_routes_directly(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e977818cf67f462191ee8074` (agent: `claude_code`, model: `claude-sonnet-4-6`, effort: `xhigh`).


### Task
Fix #475: the console PR button shows no number for a BitBucket workspace. #468 already fixed DB
persistence (the workspace row has pr_number=2), but the number never reaches the button due to TWO gaps:
(A) the API response omits pr_number, and (B) the console derives the number from the URL with a
GitHub-only regex. Fix BOTH. Strict TDD, keep AWF core generic.

ROOT CAUSE (verified end-to-end on a real BitBucket PR pull-requests/2):
- DB correct: workspaces.pr_number=2.
- API: WorkspaceResponse (src/awf/api/schemas.py, ~line 751 — the response model for GET
  /v1/workspaces/{id} AND the list endpoint, which the console consumes) exposes pr_url (~line 797) but
  has NO pr_number field. So the console never receives the number.
- Console: the workspace logs + detail views call formatPrLinkLabel(workspace.pr_url) with no explicit
  number (apps/console/components/console-dashboard-logs.tsx:457, console-dashboard-workspace-detail.tsx:
  253). formatPrLinkLabel (apps/console/components/console-dashboard-shared.tsx:~412-422) parses the
  number from the URL with `href.match(/\/pull\/(\d+)(?:[/?#]|$)/)` — GitHub-only; it does NOT match
  BitBucket `/pull-requests/N`. The capacity view already passes pr_number explicitly (line 663) and works.

FIX PART A (API): add `pr_number: int | None = None` to WorkspaceResponse and ensure it is populated
from the workspace model (the model already has pr_number; if WorkspaceResponse is built via
model_validate/from_attributes it auto-maps, otherwise add the mapping). Keep it in lockstep with the MCP
server (api/schemas.py schemas are reused by MCP) — additive optional field is safe. REGENERATE
openapi.json (python scripts/generate_openapi.py) so the drift gate passes. Add a unit test asserting the
workspace response includes pr_number (e.g. a BitBucket workspace row with pr_number=2 -> response has 2).

FIX PART B (console): (1) make formatPrLinkLabel's URL fallback regex forge-neutral —
`/\/pull(?:-requests)?\/(\d+)(?:[/?#]|$)/` — mirroring the backend _PR_NUMBER_RE so it handles both
GitHub /pull/N and BitBucket /pull-requests/N. (2) Pass workspace.pr_number to formatPrLinkLabel in the
workspace logs + detail views (authoritative, like the capacity view), falling back to URL parsing when
absent. (3) Add pr_number to the console workspace type (apps/console/lib/types.ts, near the existing
pr_url). Add/adjust a console test (the existing test:browser or a unit test) asserting a BitBucket PR URL
renders `#N`.

VALIDATION: Python — ruff, ruff format --check, mypy, pytest, 99% coverage, AND
`python scripts/generate_openapi.py --check` (drift gate). Console — run
`npm --prefix apps/console run lint`, `npm --prefix apps/console run typecheck`,
`npm --prefix apps/console run build` and ensure they pass (the awf-self validate phase does NOT build the
console, so verify it yourself; CI's `console` job will gate it). Close #475.
NOT IN SCOPE: changing pr_number persistence (#468, already correct); other dashboards beyond the
workspace logs/detail PR button.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API field and UI label logic with regression tests; no auth, persistence, or merge-behavior changes.
> 
> **Overview**
> Fixes BitBucket (and GitHub) PR buttons showing a bare **PR** label instead of **PR #N** by exposing `pr_number` from the API and using it in the console.
> 
> **API:** Adds optional `pr_number` to `WorkspaceResponse` and `WorkspaceOverviewResponse`, wires it through workspace overview assembly, and updates `openapi.json`. Unit tests assert `pr_number` on full workspace GET and overview list responses.
> 
> **Console:** Adds `pr_number` to `Workspace` / `WorkspaceOverview` types, updates `extractPrNumberFromHref` to match both `/pull/N` and `/pull-requests/N`, and passes `pr_number` into `formatPrLinkLabel` in workspace logs and detail views (with URL fallback unchanged). Source-inspection and runtime regex tests cover GitHub/Bitbucket URLs.
> 
> Also includes AWF plan/conformance docs for the workspace that produced the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa1f750ba9b90d29f93e8f6f4c646a1784a914a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR numbers are now shown in workspace pull-request links across logs, summaries, and detail views for clearer identification.
  * PR extraction is forge-neutral: the UI recognizes PR IDs from both GitHub and Bitbucket URL formats.

* **Documentation**
  * API and spec docs updated to expose a nullable PR number field so clients can consume PR identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->