### PR TITLE
#483: enforce | tojson on .j2 value interpolations via a CI lint guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           uv venv --python 3.12
           uv pip install -e ".[dev]"
 
+      - name: Check Jinja2 template escaping
+        run: .venv/bin/python scripts/ci/check_j2_tojson.py
+
       - name: Lint (ruff)
         run: .venv/bin/ruff check .
 

--- a/docker/compose/workspace.base.yml.j2
+++ b/docker/compose/workspace.base.yml.j2
@@ -8,8 +8,8 @@
 #}
 services:
   {% for s in services %}
-  {{ s.name }}:
-    container_name: "awf-{{ workspace_id }}-{{ s.name }}"
+  {{ s.name | tojson }}:
+    container_name: {{ ("awf-" ~ workspace_id ~ "-" ~ s.name) | tojson }}
     {% if s.image %}image: {{ s.image | tojson }}
     {% if s.local_image %}pull_policy: never
     {% endif %}{% elif s.build_context %}build:
@@ -22,7 +22,7 @@ services:
       {% for k, v in s.environment %}{{ k | tojson }}: {{ v | tojson }}
       {% endfor %}
     {% endif %}{% if s.depends_on %}depends_on:
-      {% for dep in s.depends_on %}{{ dep }}:
+      {% for dep in s.depends_on %}{{ dep | tojson }}:
         condition: service_healthy
       {% endfor %}
     {% endif %}{% if s.healthcheck_cmd %}healthcheck:
@@ -35,7 +35,7 @@ services:
       start_period: 5s
     {% endif %}{% if s.command %}command: {{ s.command | tojson }}
     {% endif %}{% if s.ports %}ports:
-      {% for cp, hp in s.ports %}- "{{ hp }}:{{ cp }}"
+      {% for cp, hp in s.ports %}- {{ (hp ~ ":" ~ cp) | tojson }}
       {% endfor %}
     {% endif %}{% if s.volumes %}volumes:
       {% for src, tgt in s.volumes %}- {{ (src ~ ":" ~ tgt) | tojson }}
@@ -46,26 +46,26 @@ services:
 
   {% endfor %}
   agent:
-    image: "{{ agent_runtime_image }}"
-    container_name: "awf-{{ workspace_id }}-agent"
+    image: {{ agent_runtime_image | tojson }}
+    container_name: {{ ("awf-" ~ workspace_id ~ "-agent") | tojson }}
     working_dir: /workspace
     environment:
-      WORKSPACE_ID: "{{ workspace_id }}"
+      WORKSPACE_ID: {{ workspace_id | tojson }}
       {% for k, v in agent_environment %}{{ k | tojson }}: {{ v | tojson }}
-      {% endfor %}{% if git_name %}GIT_AUTHOR_NAME: "{{ git_name }}"
-      GIT_COMMITTER_NAME: "{{ git_name }}"{% endif %}
-      {% if git_email %}GIT_AUTHOR_EMAIL: "{{ git_email }}"
-      GIT_COMMITTER_EMAIL: "{{ git_email }}"{% endif %}
+      {% endfor %}{% if git_name %}GIT_AUTHOR_NAME: {{ git_name | tojson }}
+      GIT_COMMITTER_NAME: {{ git_name | tojson }}{% endif %}
+      {% if git_email %}GIT_AUTHOR_EMAIL: {{ git_email | tojson }}
+      GIT_COMMITTER_EMAIL: {{ git_email | tojson }}{% endif %}
     volumes:
-      - "{{ worktree_host_path }}:/workspace"
+      - {{ (worktree_host_path ~ ":/workspace") | tojson }}
       {% if auth_mounts %}{% for m in auth_mounts %}
-      - "{{ m.source }}:{{ m.target }}:{{ m.mode | default('ro') }}"
+      - {{ (m.source ~ ":" ~ m.target ~ ":" ~ (m.mode | default('ro'))) | tojson }}
       {% endfor %}{% endif %}
     {% if host_gateway_enabled -%}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     {% endif %}{% if agent_depends_on %}depends_on:
-      {% for dep in agent_depends_on %}{{ dep }}:
+      {% for dep in agent_depends_on %}{{ dep | tojson }}:
         condition: service_healthy
       {% endfor %}
     {% endif %}networks:
@@ -76,8 +76,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "{{ resources.cpu_limit }}"
-          memory: "{{ resources.memory_limit }}"
+          cpus: {{ resources.cpu_limit | tojson }}
+          memory: {{ resources.memory_limit | tojson }}
     {% endif %}
 
 {% if named_volumes %}volumes:
@@ -89,6 +89,6 @@ services:
 
 networks:
   awf_net:
-    name: "awf-{{ workspace_id }}-net"
+    name: {{ ("awf-" ~ workspace_id ~ "-net") | tojson }}
     {% if network_internal %}internal: true
     {% endif %}

--- a/plans/J2_TOJSON_GUARD_PLAN.md
+++ b/plans/J2_TOJSON_GUARD_PLAN.md
@@ -1,0 +1,54 @@
+# Jinja2 Tojson Guard Plan
+
+## Problem Statement And Scope
+
+Implement the saved AWF plan in
+`docs/awf-plans/ws_0d8428a5b7c44398969950db.md`: add a CI lint guard for
+structured Docker Compose Jinja2 templates so value-emitting `{{ ... }}`
+interpolations in `docker/compose/*.j2` are escaped with `| tojson` or covered
+by a documented inline allowlist exception.
+
+Scope is limited to the checker script, focused unit tests, the compose
+template edits needed for the checker to pass, and the lint-and-type CI hook.
+No compose generation refactor, runtime lifecycle changes, branch changes, push,
+or broad AWF/GitHub validation are part of this work.
+
+## Requirements Checklist
+
+- Add `scripts/ci/check_j2_tojson.py` with clear `path:line` diagnostics and
+  non-zero exit on unjustified raw value interpolation.
+- Discover tracked `docker/compose/*.j2` templates by default, while accepting
+  explicit paths for local and test use.
+- Ignore Jinja control blocks and ordinary comments for violation detection.
+- Treat final approved escaping filters, initially `tojson`, as safe.
+- Support inline allowlist directives keyed by template plus normalized
+  expression, require a non-empty rationale, and flag stale or invalid entries.
+- Update every remaining raw interpolation in
+  `docker/compose/workspace.base.yml.j2` with `| tojson` or a justified
+  allowlist directive.
+- Wire the checker into `.github/workflows/ci.yml` under `lint-and-type`.
+- Add regression coverage for failing raw interpolation and passing escaped
+  interpolation, plus allowlist behavior.
+
+## Implementation Steps
+
+1. Write focused unit tests for checker pass/fail cases and CI workflow wiring.
+2. Run the new focused tests to confirm the expected red phase.
+3. Implement `scripts/ci/check_j2_tojson.py`.
+4. Update `docker/compose/workspace.base.yml.j2` to satisfy the guard.
+5. Wire the checker into the lint-and-type workflow.
+6. Run focused tests and narrow lint/type checks for touched files only.
+7. Write `plans/J2_TOJSON_GUARD_VALIDATION.md` with requirement status and
+   evidence.
+
+## Verification Commands
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_ci_workflow_full_coverage.py -q -k lint_and_type`
+- `uv run --python 3.12 --extra dev python scripts/ci/check_j2_tojson.py`
+- `uv run --python 3.12 --extra dev ruff check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py tests/unit/test_ci_workflow_full_coverage.py`
+- `uv run --python 3.12 --extra dev ruff format --check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py tests/unit/test_ci_workflow_full_coverage.py`
+- `uv run --python 3.12 --extra dev mypy scripts/ci/check_j2_tojson.py`
+
+Full AWF/GitHub validation and coverage gates are intentionally left to AWF
+after agent completion.

--- a/plans/J2_TOJSON_GUARD_VALIDATION.md
+++ b/plans/J2_TOJSON_GUARD_VALIDATION.md
@@ -1,0 +1,59 @@
+# Jinja2 Tojson Guard Validation
+
+## Plan Reference
+
+- `plans/J2_TOJSON_GUARD_PLAN.md`
+- Source contract: `docs/awf-plans/ws_0d8428a5b7c44398969950db.md`
+
+## Requirement Status
+
+- Add `scripts/ci/check_j2_tojson.py` with `path:line` diagnostics and non-zero
+  exit on unjustified raw interpolation: Complete.
+- Discover tracked `docker/compose/*.j2` by default and accept explicit paths:
+  Complete.
+- Ignore control blocks, loop targets, and ordinary comments for violation
+  detection: Complete.
+- Treat final approved escaping filters, currently `tojson`, as safe: Complete.
+- Support inline allowlist directives keyed by template plus normalized
+  expression, with required rationale and stale/invalid detection: Complete.
+- Update remaining raw interpolations in
+  `docker/compose/workspace.base.yml.j2`: Complete. All remaining raw emissions
+  were converted to final-expression `| tojson`; no allowlist entries were
+  needed.
+- Wire the checker into `.github/workflows/ci.yml` under `lint-and-type`:
+  Complete.
+- Add regression coverage for raw failure, escaped success, and allowlist
+  behavior: Complete.
+
+## Evidence
+
+Red phase:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+  failed because `scripts/ci/check_j2_tojson.py` did not exist.
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_ci_workflow_full_coverage.py -q -k lint_and_type`
+  failed because the `lint-and-type` job did not run the checker.
+
+Green phase:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+  passed: 8 passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_ci_workflow_full_coverage.py -q -k lint_and_type`
+  passed: 1 passed, 16 deselected.
+- `uv run --python 3.12 --extra dev python scripts/ci/check_j2_tojson.py`
+  passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/node/test_compose_manager.py -q`
+  passed: 38 passed.
+- `uv run --python 3.12 --extra dev ruff check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py tests/unit/test_ci_workflow_full_coverage.py`
+  passed.
+- `uv run --python 3.12 --extra dev ruff format --check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py tests/unit/test_ci_workflow_full_coverage.py`
+  passed.
+- `uv run --python 3.12 --extra dev mypy scripts/ci/check_j2_tojson.py`
+  passed.
+
+Full AWF/GitHub validation, broad coverage gates, and CI-equivalent frontend
+builds were not run during the agent phase; AWF owns those after completion.
+
+## Gaps
+
+None.

--- a/plans/REVIEW_4664994375_DUPLICATE_STALE_PLAN.md
+++ b/plans/REVIEW_4664994375_DUPLICATE_STALE_PLAN.md
@@ -1,0 +1,45 @@
+# Review 4664994375 Duplicate Stale Diagnostic Plan
+
+## Problem Statement and Scope
+
+Address the remaining review-level issue for PR #485 in
+`scripts/ci/check_j2_tojson.py`: duplicate allowlist directives are already
+reported, but stale-allowlist detection still iterates over duplicate directives.
+When the duplicated expression is now escaped with `| tojson`, the duplicate
+line receives both a duplicate diagnostic and a stale diagnostic.
+
+Scope is limited to the checker's stale allowlist diagnostic behavior and focused
+unit coverage for that edge case.
+
+## Requirements Checklist
+
+- Verify the duplicate-plus-stale claim against the local implementation before
+  editing.
+- Add a regression test where duplicate allowlist directives target an expression
+  that is now escaped.
+- Ensure duplicate directives are not also reported as stale on the same line.
+- Preserve stale diagnostics for the canonical allowlist directive when the
+  expression is no longer used raw.
+- Keep existing duplicate, stale, allowlist, and escaping behavior intact.
+- Run only targeted checker tests; AWF/GitHub own broad validation after agent
+  completion.
+- Commit the scoped fix locally without pushing or switching branches.
+
+## Implementation Steps
+
+1. Add a focused failing regression test in
+   `tests/unit/scripts/test_check_j2_tojson.py`.
+2. Update `scripts/ci/check_j2_tojson.py` so stale detection scans only the
+   canonical non-duplicate allowlist directives.
+3. Run the targeted checker test file.
+4. Create `plans/REVIEW_4664994375_DUPLICATE_STALE_VALIDATION.md` with
+   requirement-by-requirement status and evidence.
+5. Stage only changed files and commit with a conventional review-fix message.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+
+Pass criteria: the focused checker tests pass, including a regression proving a
+duplicate directive line is not also reported as stale. Full AWF/GitHub
+validation is intentionally not run inside the agent phase.

--- a/plans/REVIEW_4664994375_DUPLICATE_STALE_VALIDATION.md
+++ b/plans/REVIEW_4664994375_DUPLICATE_STALE_VALIDATION.md
@@ -1,0 +1,53 @@
+# Review 4664994375 Duplicate Stale Diagnostic Validation
+
+Plan reference: `plans/REVIEW_4664994375_DUPLICATE_STALE_PLAN.md`
+
+## Requirement Status
+
+- Verify the duplicate-plus-stale claim against the local implementation before
+  editing: Complete.
+  - Evidence: reviewed `scripts/ci/check_j2_tojson.py`; duplicate directives
+    were skipped while building `allow_by_expression`, but stale detection still
+    iterated the full `allow_directives` list.
+- Add a regression test where duplicate allowlist directives target an
+  expression that is now escaped: Complete.
+  - Evidence: added
+    `test_checker_does_not_mark_duplicate_allowlist_entry_stale`.
+- Ensure duplicate directives are not also reported as stale on the same line:
+  Complete.
+  - Evidence: the new regression asserts the duplicate line has a duplicate
+    diagnostic and no stale diagnostic.
+- Preserve stale diagnostics for the canonical allowlist directive when the
+  expression is no longer used raw: Complete.
+  - Evidence: the new regression asserts the first directive still receives a
+    stale allowlist diagnostic.
+- Keep existing duplicate, stale, allowlist, and escaping behavior intact:
+  Complete.
+  - Evidence: focused checker test file passed after the fix.
+- Run only targeted checker tests: Complete.
+  - Evidence: ran the focused checker test file and focused ruff command only.
+    Full AWF/GitHub validation is managed after agent completion.
+- Commit the scoped fix locally without pushing or switching branches: Complete.
+  - Evidence: this scoped change set is committed locally for AWF to push after
+    agent completion.
+
+## Commands Run
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+  - First run after adding the regression: failed with `1 failed, 9 passed`,
+    confirming the duplicate line also received a stale diagnostic.
+  - Final run after implementation: passed, `10 passed in 2.56s`.
+- `uv run --python 3.12 --extra dev ruff check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py`
+  - Passed.
+
+## Files Changed
+
+- `scripts/ci/check_j2_tojson.py`
+- `tests/unit/scripts/test_check_j2_tojson.py`
+- `plans/REVIEW_4664994375_DUPLICATE_STALE_PLAN.md`
+- `plans/REVIEW_4664994375_DUPLICATE_STALE_VALIDATION.md`
+
+## Gaps
+
+None. Broad validation was intentionally not run inside the agent phase per the
+AWF workspace contract.

--- a/plans/REVIEW_4664994375_J2_TOJSON_PLAN.md
+++ b/plans/REVIEW_4664994375_J2_TOJSON_PLAN.md
@@ -1,0 +1,37 @@
+# Review 4664994375 Jinja2 Tojson Plan
+
+## Problem Statement and Scope
+
+Address the review-level comment on PR #485 for `scripts/ci/check_j2_tojson.py`.
+The reviewer identified two quality gaps in the new Jinja2 escaping guard:
+
+- Duplicate allowlist directives for the same normalized raw expression are silently absorbed.
+- Per-line lint diagnostics are printed as plain stderr lines instead of GitHub Actions error annotations.
+
+Scope is limited to the checker script and focused unit coverage for those behaviors.
+
+## Requirements Checklist
+
+- Verify the reviewer claims against the local implementation before editing.
+- Add a regression test that duplicate allowlist directives for the same expression produce a diagnostic even when the raw interpolation exists.
+- Add or update a focused test proving per-line diagnostics are emitted in GitHub Actions annotation format.
+- Preserve useful `path:line` diagnostic content for local CLI readability.
+- Keep existing allowlist, stale-entry, and escaping behavior intact.
+- Run only targeted tests for the changed checker behavior; AWF/GitHub own broad validation after agent completion.
+- Commit the scoped fix locally without pushing or switching branches.
+
+## Implementation Steps
+
+1. Add focused failing tests in `tests/unit/scripts/test_check_j2_tojson.py`.
+2. Update `scripts/ci/check_j2_tojson.py` to report duplicate allowlist directives.
+3. Update diagnostic output to use GitHub Actions `::error file=...,line=...,title=...::...` syntax for per-line diagnostics while retaining the existing `path:line` text in the message.
+4. Run the targeted unit test file only.
+5. Create `plans/REVIEW_4664994375_J2_TOJSON_VALIDATION.md` with requirement-by-requirement status and evidence.
+6. Stage only changed files and commit with a conventional review-fix message.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+
+Pass criteria: the focused checker tests pass, including regressions for duplicate allowlist directives and GitHub Actions annotation formatting.
+Full AWF/GitHub validation is intentionally not run inside the agent phase.

--- a/plans/REVIEW_4664994375_J2_TOJSON_VALIDATION.md
+++ b/plans/REVIEW_4664994375_J2_TOJSON_VALIDATION.md
@@ -1,0 +1,39 @@
+# Review 4664994375 Jinja2 Tojson Validation
+
+Plan reference: `plans/REVIEW_4664994375_J2_TOJSON_PLAN.md`
+
+## Requirement Status
+
+- Verify the reviewer claims against the local implementation before editing: Complete.
+  - Evidence: reviewed `scripts/ci/check_j2_tojson.py`; `allow_by_expression` was built by dict comprehension and `Diagnostic.format()` emitted plain `path:line` text.
+- Add a regression test that duplicate allowlist directives for the same expression produce a diagnostic even when the raw interpolation exists: Complete.
+  - Evidence: added `test_checker_flags_duplicate_allowlist_entries`.
+- Add or update a focused test proving per-line diagnostics are emitted in GitHub Actions annotation format: Complete.
+  - Evidence: updated `test_checker_fails_on_raw_scalar_value_interpolation` to assert `::error file=...,line=...,title=...::`.
+- Preserve useful `path:line` diagnostic content for local CLI readability: Complete.
+  - Evidence: annotation message still includes `<template>:<line>: <message>`.
+- Keep existing allowlist, stale-entry, and escaping behavior intact: Complete.
+  - Evidence: focused checker test file passed.
+- Run only targeted tests for the changed checker behavior: Complete.
+  - Evidence: ran focused pytest file and focused ruff command only. Full AWF/GitHub validation is managed after agent completion.
+- Commit the scoped fix locally without pushing or switching branches: Complete.
+  - Evidence: this scoped change set is committed locally for AWF to push after agent completion.
+
+## Commands Run
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/scripts/test_check_j2_tojson.py -q`
+  - First run after test changes: failed on the new duplicate-allowlist and annotation expectations, confirming the regression tests.
+  - Final run after implementation: passed, `9 passed in 2.26s`.
+- `uv run --python 3.12 --extra dev ruff check scripts/ci/check_j2_tojson.py tests/unit/scripts/test_check_j2_tojson.py`
+  - Passed.
+
+## Files Changed
+
+- `scripts/ci/check_j2_tojson.py`
+- `tests/unit/scripts/test_check_j2_tojson.py`
+- `plans/REVIEW_4664994375_J2_TOJSON_PLAN.md`
+- `plans/REVIEW_4664994375_J2_TOJSON_VALIDATION.md`
+
+## Gaps
+
+None. Broad validation was intentionally not run inside the agent phase per the AWF workspace contract.

--- a/scripts/ci/check_j2_tojson.py
+++ b/scripts/ci/check_j2_tojson.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Fail CI when structured-config Jinja2 values render without tojson escaping."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from jinja2 import Environment, TemplateSyntaxError, nodes
+
+APPROVED_FILTERS = frozenset({"tojson"})
+ALLOW_DIRECTIVE_PREFIX = "awf-j2-tojson-allow:"
+ALLOW_DIRECTIVE_SEPARATOR = " -- "
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class TemplateFile:
+    """A template path plus the label to use in diagnostics."""
+
+    path: Path
+    label: str
+
+
+@dataclass(frozen=True)
+class Interpolation:
+    """A Jinja2 output expression found in a template."""
+
+    line: int
+    expression: str
+
+
+@dataclass(frozen=True)
+class AllowDirective:
+    """A documented exception for a raw output expression."""
+
+    line: int
+    expression: str
+    rationale: str
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    """A lint diagnostic tied to a template line."""
+
+    template: str
+    line: int
+    message: str
+
+    def format(self) -> str:
+        """Return the diagnostic in path:line form."""
+        return f"{self.template}:{self.line}: {self.message}"
+
+
+class TemplateReadError(Exception):
+    """Raised when a template cannot be loaded or tokenized."""
+
+
+_ENVIRONMENT = Environment()
+
+
+def _format_expression_tokens(tokens: Sequence[str]) -> str:
+    """Return a stable, whitespace-normalized representation of expression tokens."""
+    normalized = ""
+    previous = ""
+    for token in tokens:
+        if not normalized:
+            normalized = token
+        elif (
+            token in {")", "]", "}", ",", ".", ":"}
+            or (token == "(" and previous and _is_identifier_like(previous))
+            or previous in {"(", "[", "{", "."}
+        ):
+            normalized += token
+        else:
+            normalized += f" {token}"
+        previous = token
+    return normalized
+
+
+def _is_identifier_like(token: str) -> bool:
+    """Return whether a token can be followed by a call parenthesis."""
+    return token.replace("_", "").isalnum()
+
+
+def _expression_tokens(expression: str) -> list[str]:
+    """Lex one Jinja2 expression and return non-whitespace tokens."""
+    tokens: list[str] = []
+    in_variable = False
+    try:
+        stream = _ENVIRONMENT.lex(f"{{{{ {expression} }}}}")
+        for _line, token_type, value in stream:
+            if token_type == "variable_begin":
+                in_variable = True
+            elif token_type == "variable_end":
+                return tokens
+            elif in_variable and token_type != "whitespace":
+                tokens.append(value)
+    except TemplateSyntaxError as exc:
+        raise ValueError(f"invalid allowlist expression {expression!r}: {exc.message}") from exc
+    return tokens
+
+
+def _normalize_expression(expression: str) -> str:
+    """Normalize expression whitespace for diagnostics and allowlist matching."""
+    tokens = _expression_tokens(expression)
+    if not tokens:
+        raise ValueError("allowlist expression is empty")
+    return _format_expression_tokens(tokens)
+
+
+def _parse_allow_directive(comment: str) -> tuple[str, str] | str | None:
+    """Parse an allowlist directive comment.
+
+    Returns ``None`` when the comment is not a directive, an error string when
+    the directive is invalid, or a normalized expression plus rationale.
+    """
+    text = comment.strip()
+    if not text.startswith(ALLOW_DIRECTIVE_PREFIX):
+        return None
+
+    remainder = text.removeprefix(ALLOW_DIRECTIVE_PREFIX).strip()
+    if ALLOW_DIRECTIVE_SEPARATOR not in remainder:
+        return "allowlist directive is missing a rationale after ' -- '"
+
+    expression, rationale = remainder.split(ALLOW_DIRECTIVE_SEPARATOR, 1)
+    if not rationale.strip():
+        return "allowlist directive is missing a rationale"
+    try:
+        normalized_expression = _normalize_expression(expression)
+    except ValueError as exc:
+        return str(exc)
+    return normalized_expression, rationale.strip()
+
+
+def _scan_template(
+    template: TemplateFile,
+) -> tuple[list[Interpolation], list[AllowDirective], list[Diagnostic]]:
+    """Read and lex a Jinja2 template for output expressions and allow directives."""
+    try:
+        source = template.path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise TemplateReadError(f"unable to read {template.label}: {exc}") from exc
+
+    interpolations: list[Interpolation] = []
+    allow_directives: list[AllowDirective] = []
+    diagnostics: list[Diagnostic] = []
+    in_variable = False
+    variable_line = 0
+    variable_tokens: list[str] = []
+    in_comment = False
+    comment_line = 0
+    comment_parts: list[str] = []
+
+    try:
+        stream = _ENVIRONMENT.lex(source)
+        for line, token_type, value in stream:
+            if token_type == "variable_begin":
+                in_variable = True
+                variable_line = line
+                variable_tokens = []
+            elif token_type == "variable_end" and in_variable:
+                in_variable = False
+                expression = _format_expression_tokens(variable_tokens)
+                if expression:
+                    interpolations.append(Interpolation(line=variable_line, expression=expression))
+            elif in_variable:
+                if token_type != "whitespace":
+                    variable_tokens.append(value)
+            elif token_type == "comment_begin":
+                in_comment = True
+                comment_line = line
+                comment_parts = []
+            elif token_type == "comment_end" and in_comment:
+                in_comment = False
+                directive = _parse_allow_directive("".join(comment_parts))
+                if isinstance(directive, str):
+                    diagnostics.append(Diagnostic(template.label, comment_line, directive))
+                elif directive is not None:
+                    expression, rationale = directive
+                    allow_directives.append(
+                        AllowDirective(
+                            line=comment_line,
+                            expression=expression,
+                            rationale=rationale,
+                        )
+                    )
+            elif in_comment:
+                comment_parts.append(value)
+    except TemplateSyntaxError as exc:
+        raise TemplateReadError(f"unable to lex {template.label}: {exc.message}") from exc
+
+    return interpolations, allow_directives, diagnostics
+
+
+def _final_filter(expression: str) -> str | None:
+    """Return the final top-level filter name for a Jinja2 output expression."""
+    try:
+        parsed = _ENVIRONMENT.parse(f"{{{{ {expression} }}}}")
+    except TemplateSyntaxError:
+        return None
+    if len(parsed.body) != 1:
+        return None
+    output = parsed.body[0]
+    if not isinstance(output, nodes.Output):
+        return None
+    output_nodes = cast(Sequence[object], getattr(output, "nodes", ()))
+    if len(output_nodes) != 1:
+        return None
+    expression_node = output_nodes[0]
+    if not isinstance(expression_node, nodes.Filter):
+        return None
+    return cast(str, getattr(expression_node, "name", ""))
+
+
+def _is_escaped(expression: str) -> bool:
+    """Return whether an expression ends in an approved escaping filter."""
+    final_filter = _final_filter(expression)
+    return final_filter in APPROVED_FILTERS
+
+
+def _diagnostics_for_template(template: TemplateFile) -> list[Diagnostic]:
+    """Return lint diagnostics for one template."""
+    interpolations, allow_directives, diagnostics = _scan_template(template)
+    allow_by_expression = {directive.expression: directive for directive in allow_directives}
+    used_allowlist_expressions: set[str] = set()
+
+    for interpolation in interpolations:
+        if _is_escaped(interpolation.expression):
+            continue
+        if interpolation.expression in allow_by_expression:
+            used_allowlist_expressions.add(interpolation.expression)
+            continue
+        approved = ", ".join(sorted(APPROVED_FILTERS))
+        diagnostics.append(
+            Diagnostic(
+                template=template.label,
+                line=interpolation.line,
+                message=(
+                    "raw Jinja2 interpolation must end in an approved escaping "
+                    f"filter ({approved}) or have an allowlist directive: "
+                    f"{interpolation.expression}"
+                ),
+            )
+        )
+
+    for directive in allow_directives:
+        if directive.expression not in used_allowlist_expressions:
+            diagnostics.append(
+                Diagnostic(
+                    template=template.label,
+                    line=directive.line,
+                    message=f"stale allowlist entry for raw interpolation: {directive.expression}",
+                )
+            )
+
+    return diagnostics
+
+
+def _discover_tracked_templates(repo_root: Path) -> list[TemplateFile]:
+    """Return tracked docker/compose Jinja2 templates from git."""
+    result = subprocess.run(
+        ["git", "ls-files", "docker/compose/*.j2"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or "git ls-files failed"
+        raise TemplateReadError(f"unable to discover tracked compose templates: {stderr}")
+    return [
+        TemplateFile(path=repo_root / line, label=line)
+        for line in result.stdout.splitlines()
+        if line.strip()
+    ]
+
+
+def _templates_from_args(paths: Iterable[Path], repo_root: Path) -> list[TemplateFile]:
+    """Resolve explicit CLI paths or discover the default tracked templates."""
+    path_list = list(paths)
+    if not path_list:
+        return _discover_tracked_templates(repo_root)
+    return [TemplateFile(path=path, label=str(path)) for path in path_list]
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the Jinja2 tojson checker CLI."""
+    parser = argparse.ArgumentParser(description=__doc__, exit_on_error=False)
+    parser.add_argument("paths", nargs="*", type=Path)
+    try:
+        args = parser.parse_args(argv)
+    except argparse.ArgumentError as exc:
+        print(f"::error title=Jinja2 tojson checker invalid::{exc}", file=sys.stderr)
+        return 2
+
+    try:
+        templates = _templates_from_args(args.paths, REPO_ROOT)
+        diagnostics = [
+            diagnostic
+            for template in templates
+            for diagnostic in _diagnostics_for_template(template)
+        ]
+    except TemplateReadError as exc:
+        print(f"::error title=Jinja2 tojson checker invalid::{exc}", file=sys.stderr)
+        return 2
+
+    for diagnostic in diagnostics:
+        print(diagnostic.format(), file=sys.stderr)
+    return 1 if diagnostics else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/check_j2_tojson.py
+++ b/scripts/ci/check_j2_tojson.py
@@ -51,10 +51,17 @@ class Diagnostic:
     template: str
     line: int
     message: str
+    title: str = "Jinja2 raw interpolation"
 
     def format(self) -> str:
-        """Return the diagnostic in path:line form."""
-        return f"{self.template}:{self.line}: {self.message}"
+        """Return the diagnostic as a GitHub Actions annotation."""
+        message = f"{self.template}:{self.line}: {self.message}"
+        return (
+            f"::error file={_escape_workflow_command_property(self.template)},"
+            f"line={self.line},"
+            f"title={_escape_workflow_command_property(self.title)}::"
+            f"{_escape_workflow_command_data(message)}"
+        )
 
 
 class TemplateReadError(Exception):
@@ -62,6 +69,16 @@ class TemplateReadError(Exception):
 
 
 _ENVIRONMENT = Environment()
+
+
+def _escape_workflow_command_data(value: str) -> str:
+    """Escape GitHub Actions workflow command message data."""
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _escape_workflow_command_property(value: str) -> str:
+    """Escape GitHub Actions workflow command property values."""
+    return _escape_workflow_command_data(value).replace(":", "%3A").replace(",", "%2C")
 
 
 def _format_expression_tokens(tokens: Sequence[str]) -> str:
@@ -180,7 +197,14 @@ def _scan_template(
                 in_comment = False
                 directive = _parse_allow_directive("".join(comment_parts))
                 if isinstance(directive, str):
-                    diagnostics.append(Diagnostic(template.label, comment_line, directive))
+                    diagnostics.append(
+                        Diagnostic(
+                            template.label,
+                            comment_line,
+                            directive,
+                            title="Jinja2 allowlist directive",
+                        )
+                    )
                 elif directive is not None:
                     expression, rationale = directive
                     allow_directives.append(
@@ -227,7 +251,21 @@ def _is_escaped(expression: str) -> bool:
 def _diagnostics_for_template(template: TemplateFile) -> list[Diagnostic]:
     """Return lint diagnostics for one template."""
     interpolations, allow_directives, diagnostics = _scan_template(template)
-    allow_by_expression = {directive.expression: directive for directive in allow_directives}
+    allow_by_expression: dict[str, AllowDirective] = {}
+    for directive in allow_directives:
+        if directive.expression in allow_by_expression:
+            diagnostics.append(
+                Diagnostic(
+                    template=template.label,
+                    line=directive.line,
+                    message=(
+                        f"duplicate allowlist entry for raw interpolation: {directive.expression}"
+                    ),
+                    title="Jinja2 allowlist directive",
+                )
+            )
+            continue
+        allow_by_expression[directive.expression] = directive
     used_allowlist_expressions: set[str] = set()
 
     for interpolation in interpolations:
@@ -256,6 +294,7 @@ def _diagnostics_for_template(template: TemplateFile) -> list[Diagnostic]:
                     template=template.label,
                     line=directive.line,
                     message=f"stale allowlist entry for raw interpolation: {directive.expression}",
+                    title="Jinja2 allowlist directive",
                 )
             )
 

--- a/scripts/ci/check_j2_tojson.py
+++ b/scripts/ci/check_j2_tojson.py
@@ -287,7 +287,7 @@ def _diagnostics_for_template(template: TemplateFile) -> list[Diagnostic]:
             )
         )
 
-    for directive in allow_directives:
+    for directive in allow_by_expression.values():
         if directive.expression not in used_allowlist_expressions:
             diagnostics.append(
                 Diagnostic(

--- a/tests/unit/scripts/test_check_j2_tojson.py
+++ b/tests/unit/scripts/test_check_j2_tojson.py
@@ -134,6 +134,30 @@ def test_checker_flags_duplicate_allowlist_entries(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_checker_does_not_mark_duplicate_allowlist_entry_stale(
+    tmp_path: Path,
+) -> None:
+    """A duplicate allowlist directive is not also reported as stale."""
+    template = _write_template(
+        tmp_path / "duplicate_stale_allow.yml.j2",
+        (
+            "{# awf-j2-tojson-allow: workspace_id -- Former raw identifier. #}\n"
+            "{# awf-j2-tojson-allow: workspace_id -- Duplicate copy. #}\n"
+            "name: {{ workspace_id | tojson }}\n"
+        ),
+    )
+
+    result = _run_checker(template)
+
+    diagnostics = result.stderr.splitlines()
+    assert result.returncode == 1
+    assert len(diagnostics) == 2
+    assert any(f"{template}:1: stale allowlist entry" in line for line in diagnostics)
+    assert any(f"{template}:2: duplicate allowlist entry" in line for line in diagnostics)
+    assert not any(f"{template}:2: stale allowlist entry" in line for line in diagnostics)
+
+
+@pytest.mark.unit
 def test_checker_flags_allowlist_entries_without_rationale(tmp_path: Path) -> None:
     """Allowlist directives must include a non-empty human rationale."""
     template = _write_template(

--- a/tests/unit/scripts/test_check_j2_tojson.py
+++ b/tests/unit/scripts/test_check_j2_tojson.py
@@ -1,0 +1,154 @@
+"""Tests for the structured-config Jinja2 escaping guard."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "ci" / "check_j2_tojson.py"
+
+
+def _run_checker(*paths: Path) -> subprocess.CompletedProcess[str]:
+    """Run the Jinja2 tojson checker in a subprocess."""
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *(str(path) for path in paths)],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def _write_template(path: Path, content: str) -> Path:
+    """Write a fixture template and return its path."""
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+@pytest.mark.unit
+def test_checker_fails_on_raw_scalar_value_interpolation(tmp_path: Path) -> None:
+    """A raw value interpolation in structured YAML is reported with path and line."""
+    template = _write_template(
+        tmp_path / "unsafe.yml.j2",
+        'services:\n  app:\n    image: "{{ image }}"\n',
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 1
+    assert f"{template}:3:" in result.stderr
+    assert "image" in result.stderr
+    assert "tojson" in result.stderr
+
+
+@pytest.mark.unit
+def test_checker_passes_escaped_scalar_value_interpolation(tmp_path: Path) -> None:
+    """A value interpolation ending in the approved tojson filter is accepted."""
+    template = _write_template(
+        tmp_path / "safe.yml.j2",
+        "services:\n  app:\n    image: {{ image | tojson }}\n",
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+@pytest.mark.unit
+def test_checker_requires_tojson_as_the_final_filter(tmp_path: Path) -> None:
+    """A nested or non-final tojson filter does not count as scalar escaping."""
+    template = _write_template(
+        tmp_path / "non_final.yml.j2",
+        "services:\n  app:\n    image: {{ image | tojson | trim }}\n",
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 1
+    assert f"{template}:3:" in result.stderr
+    assert "image | tojson | trim" in result.stderr
+
+
+@pytest.mark.unit
+def test_checker_ignores_control_blocks_loop_targets_and_comments(tmp_path: Path) -> None:
+    """Only output expressions are checked; Jinja blocks and comments are ignored."""
+    template = _write_template(
+        tmp_path / "blocks.yml.j2",
+        (
+            "{% for image in images %}\n"
+            "{# image: {{ raw_comment_value }} #}\n"
+            "services:\n"
+            "  app:\n"
+            "    image: {{ image | tojson }}\n"
+            "{% endfor %}\n"
+        ),
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+@pytest.mark.unit
+def test_checker_allows_documented_inline_exceptions(tmp_path: Path) -> None:
+    """A raw interpolation can be allowed only by expression plus rationale."""
+    template = _write_template(
+        tmp_path / "allowed.yml.j2",
+        (
+            "{# awf-j2-tojson-allow: workspace_id -- AWF-generated identifier. #}\n"
+            'name: "awf-{{ workspace_id }}-agent"\n'
+        ),
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+@pytest.mark.unit
+def test_checker_flags_allowlist_entries_without_rationale(tmp_path: Path) -> None:
+    """Allowlist directives must include a non-empty human rationale."""
+    template = _write_template(
+        tmp_path / "missing_reason.yml.j2",
+        ('{# awf-j2-tojson-allow: workspace_id #}\nname: "awf-{{ workspace_id }}-agent"\n'),
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 1
+    assert f"{template}:1:" in result.stderr
+    assert "missing a rationale" in result.stderr
+
+
+@pytest.mark.unit
+def test_checker_flags_stale_allowlist_entries(tmp_path: Path) -> None:
+    """Allowlist entries that no longer match a raw interpolation are stale."""
+    template = _write_template(
+        tmp_path / "stale.yml.j2",
+        (
+            "{# awf-j2-tojson-allow: workspace_id -- Former raw identifier. #}\n"
+            "name: {{ workspace_id | tojson }}\n"
+        ),
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 1
+    assert f"{template}:1:" in result.stderr
+    assert "stale allowlist entry" in result.stderr
+
+
+@pytest.mark.unit
+def test_checker_passes_repository_compose_templates_by_default() -> None:
+    """Running with no paths scans the tracked docker/compose Jinja2 templates."""
+    result = _run_checker()
+
+    assert result.returncode == 0
+    assert result.stderr == ""

--- a/tests/unit/scripts/test_check_j2_tojson.py
+++ b/tests/unit/scripts/test_check_j2_tojson.py
@@ -40,6 +40,7 @@ def test_checker_fails_on_raw_scalar_value_interpolation(tmp_path: Path) -> None
     result = _run_checker(template)
 
     assert result.returncode == 1
+    assert f"::error file={template},line=3,title=Jinja2 raw interpolation::" in result.stderr
     assert f"{template}:3:" in result.stderr
     assert "image" in result.stderr
     assert "tojson" in result.stderr
@@ -110,6 +111,26 @@ def test_checker_allows_documented_inline_exceptions(tmp_path: Path) -> None:
 
     assert result.returncode == 0
     assert result.stderr == ""
+
+
+@pytest.mark.unit
+def test_checker_flags_duplicate_allowlist_entries(tmp_path: Path) -> None:
+    """Duplicate allowlist entries are reported even when the expression is used."""
+    template = _write_template(
+        tmp_path / "duplicate_allow.yml.j2",
+        (
+            "{# awf-j2-tojson-allow: workspace_id -- AWF-generated identifier. #}\n"
+            "{# awf-j2-tojson-allow: workspace_id -- Duplicate copy. #}\n"
+            'name: "awf-{{ workspace_id }}-agent"\n'
+        ),
+    )
+
+    result = _run_checker(template)
+
+    assert result.returncode == 1
+    assert f"{template}:2:" in result.stderr
+    assert "duplicate allowlist entry" in result.stderr
+    assert "workspace_id" in result.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -318,6 +318,7 @@ def test_lint_and_type_job_does_not_duplicate_python_test_execution() -> None:
     assert "services" not in job
 
     commands = _run_steps(job)
+    assert "python scripts/ci/check_j2_tojson.py" in commands
     assert "ruff check ." in commands
     assert "ruff format --check ." in commands
     assert ".venv/bin/mypy" in commands


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_0d8428a5b7c44398969950db` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Implement GitHub issue #483: add a CI lint guard that enforces `| tojson` on value interpolations in Jinja2 templates that render structured config (docker/compose/*.j2). SCOPE NARROWLY — do exactly this and nothing more. You may run `gh issue view 483` for the full text.

Background: profile-declared fields are interpolated into docker/compose/workspace.base.yml.j2; a value rendered into quoted YAML WITHOUT `| tojson` lets a project's `.awf/workspace.yml` embed quotes/newlines to break out and inject sibling keys (e.g. `privileged:`, `volumes:`) — a container-injection class. Five fields were already fixed; others remain raw (ports, resource limits, service-name keys, depends_on keys, named-volume names).

Do:
1. Add `scripts/ci/check_j2_tojson.py` (mirror the existing `scripts/ci/check_coverage_threshold.py` style): parse each tracked `*.j2` and flag any `{{ expr }}` that emits a VALUE into a scalar context and does not end in `| tojson` (or another approved escaping filter). Ignore control-flow `{% %}`, loop targets, and comments. Exit non-zero with `path:line` on any unjustified raw value interpolation.
2. Support an ALLOWLIST for justified exceptions (keyed by template + expression), each requiring an inline rationale comment; an allowlist entry that no longer matches anything must itself be flagged (no stale exceptions).
3. Wire it into the `.github/workflows/ci.yml` `lint-and-type` job, and make it runnable locally.
4. For EVERY remaining raw value interpolation in `docker/compose/workspace.base.yml.j2`, decide: switch to `| tojson`, or add an allowlist entry with rationale (AWF-generated identifiers like `workspace_id` are reasonable allowlist entries). The template must pass the new check with zero unexplained raws.
5. Add a regression-test fixture: a `.j2` with an un-escaped value interpolation makes the script exit non-zero; the escaped version exits zero.

Do NOT refactor compose generation, do NOT change runtime behavior beyond the lint guard, do NOT touch unrelated files. Strict TDD; keep ruff/mypy clean and the 99% coverage gate green. git is functional in /workspace — commit before exiting; do not push (AWF handles it).

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect generated Docker Compose YAML (security-sensitive) but are limited to escaping and a lint gate; runtime behavior should match prior intent with safer quoting.
> 
> **Overview**
> Adds a **CI lint guard** (`scripts/ci/check_j2_tojson.py`) that scans tracked `docker/compose/*.j2` templates and fails on value-emitting `{{ ... }}` expressions that do not end in `| tojson` (or a documented inline `awf-j2-tojson-allow` exception). Diagnostics use GitHub Actions `::error` annotations with `path:line` text; the checker also flags duplicate, invalid, and stale allowlist directives.
> 
> **`docker/compose/workspace.base.yml.j2`** is updated so remaining raw interpolations (service keys, ports, resource limits, volume/network names, etc.) use `| tojson`, closing YAML-structure injection via workspace profile values.
> 
> The **`lint-and-type`** job runs the checker before ruff/mypy; unit tests cover pass/fail, allowlist edge cases, and workflow wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6c4acad25bb7cd1f01de44c0b790be35f922152. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->