### PR TITLE
#484: resolve addressed-but-outdated review threads after monitor re-adoption

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -474,6 +474,19 @@ async def _run_fix_cycle(
         if status is not None
         else set()
     )
+    # Threads the settle re-poll reports as already OUTDATED (#484). An in-place
+    # fix can flip a thread to ``isOutdated`` on the forge; a resolve fault on such
+    # a thread must NOT clear its fix verdict. Clearing strands it: outdated threads
+    # are dropped from the actionable feed, so the fix cycle never re-addresses them,
+    # and the next poll's outdated-resolution step skips a thread with no recorded
+    # verdict — leaving the conversation permanently unresolved and the PR BLOCKED.
+    # Preserving ``fix_committed`` lets that step retry the resolve (or escalate to
+    # ``needs_human`` via its own permanent path) instead.
+    outdated_thread_ids = (
+        {t.thread_id for t in status.outdated_unresolved_inline_threads}
+        if status is not None
+        else set()
+    )
     for tid in threads_to_resolve:
         if tid in stale_thread_ids:
             continue
@@ -519,7 +532,11 @@ async def _run_fix_cycle(
                 # and re-surfaces, so it re-routes through AddressComments and the
                 # agent re-addresses already-handled content (redundant but harmless;
                 # the permanent path below special-cases tasks to needs_human).
-                _clear_addressed_state_by_id(state, tid)
+                # #484: an already-OUTDATED thread is the exception — preserve its
+                # verdict so the next poll's outdated-resolution step retries it,
+                # since it can never re-route through AddressComments.
+                if tid not in outdated_thread_ids:
+                    _clear_addressed_state_by_id(state, tid)
                 await self._record_pr_monitor_audit_event(
                     workspace_id=workspace_id,
                     event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
@@ -587,7 +604,13 @@ async def _run_fix_cycle(
             # addressed-state: decide() filters addressed IDs before it returns
             # AddressComments, so retaining a failed resolve would make the next poll
             # treat an open thread as handled forever.
-            _clear_addressed_state_by_id(state, tid)
+            # #484: an already-OUTDATED thread is the exception — clearing strands it
+            # (it can never re-route through AddressComments), so preserve its
+            # verdict and let the next poll's outdated-resolution step retry the
+            # resolve or escalate it to ``needs_human`` via that path's own permanent
+            # arm — never silently merging over it.
+            if tid not in outdated_thread_ids:
+                _clear_addressed_state_by_id(state, tid)
             await self._record_pr_monitor_audit_event(
                 workspace_id=workspace_id,
                 event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -79,6 +79,15 @@ async def _seed_outdated_thread_verdicts_from_branch_evidence(
     too — otherwise the resolve loop's ``_review_thread_needs_attention`` guard
     would skip the freshly-seeded thread.
 
+    Trade-off (accepted): the snapshot is taken HERE, at re-adoption time, not at
+    the prior instance's fix time. So if a reviewer replied to the outdated thread
+    AFTER that fix but BEFORE this re-adoption, the reply is already baked into the
+    seeded hash and ``_review_thread_needs_attention`` can never fire for it — the
+    post-fix reply is accepted as-is and the thread is resolved without being
+    re-triaged. This is deliberate: the only alternative (not seeding) leaves the
+    PR permanently BLOCKED on an invisible collapsed conversation. The guard still
+    protects against replies that arrive AFTER seeding, on subsequent polls.
+
     Best-effort and self-contained: runs only for outdated threads lacking a
     verdict (no git call in steady state), uses a bounded ``git log -n 1`` grep,
     and leaves a thread untouched on a non-``ok`` git result or no match. Never

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -29,6 +29,7 @@ from awf.runtime.monitor_state_keys import _outdated_resolve_requeued_key
 from awf.runtime.pr_monitor import (
     MonitorState,
     PRStatus,
+    _mark_review_thread_addressed,
     _review_thread_needs_attention,
 )
 from awf.runtime.pr_monitor_runner.constants import (
@@ -37,6 +38,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _GITHUB_TRANSIENT_RETRY_REASON,
 )
 from awf.runtime.pr_monitor_runner.fix_cycle import _RESOLVABLE_THREAD_VERDICTS
+from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
 from awf.runtime.pr_monitor_runner.logging import _log
 
 # Verdicts whose now-OUTDATED threads this hygiene step may resolve. This is the
@@ -48,6 +50,71 @@ from awf.runtime.pr_monitor_runner.logging import _log
 # (``fix_committed`` / ``false_positive``) both mean "handled, thread should
 # close, no human follow-up".
 _OUTDATED_RESOLVABLE_THREAD_VERDICTS = _RESOLVABLE_THREAD_VERDICTS - frozenset({"defer"})
+
+
+async def _seed_outdated_thread_verdicts_from_branch_evidence(
+    self: Any,
+    *,
+    workspace_id: str,
+    status: PRStatus,
+    state: MonitorState,
+) -> None:
+    """Seed missing verdicts for outdated threads the PR branch already addressed (#484).
+
+    After a re-adoption / instance handoff, an outdated thread a PRIOR instance
+    addressed (via an in-place ``fix: address …`` commit) carries no verdict in
+    THIS instance's ``state.threads_addressed_ids``. The #473 resolution below
+    gates on a recorded verdict, and outdated threads are dropped from the
+    actionable feed, so without one the thread can never be resolved and GitHub
+    keeps the PR BLOCKED on an invisible (collapsed) conversation while the monitor
+    reports ``unresolved_threads=0`` and loops on ``NotifyHuman``.
+
+    Reconcile the verdict from durable branch evidence: a commit on the worktree
+    HEAD whose message references BOTH the unique thread id (``PRRT_…``) AND the
+    ``fix: address`` prefix — the two shapes AWF emits for review-thread fixes
+    (``comments.py``: ``fix: address PR review thread <id>``; ``monitor_prompts.py``:
+    ``fix: address <id> — …``). A match is strong proof THIS branch already fixed
+    the feedback, so record ``fix_committed``. Use ``_mark_review_thread_addressed``
+    (not bare ``state.mark_addressed``) so the current body-hash snapshot is stored
+    too — otherwise the resolve loop's ``_review_thread_needs_attention`` guard
+    would skip the freshly-seeded thread.
+
+    Best-effort and self-contained: runs only for outdated threads lacking a
+    verdict (no git call in steady state), uses a bounded ``git log -n 1`` grep,
+    and leaves a thread untouched on a non-``ok`` git result or no match. Never
+    raises.
+    """
+    unseeded = [
+        thread
+        for thread in status.outdated_unresolved_inline_threads
+        if state.threads_addressed_ids.get(thread.thread_id) is None
+    ]
+    if not unseeded:
+        return
+    worktree_path = self._worktrees_root / workspace_id
+    for thread in unseeded:
+        # ``-F --all-match`` requires BOTH literal substrings (the unique thread id
+        # AND ``fix: address``) present in one commit message — matching both AWF
+        # commit shapes while staying specific enough not to seed a thread the
+        # branch never addressed.
+        result = await self._deps.runner.run(
+            git_worktree_command(
+                worktree_path,
+                "log",
+                "-n",
+                "1",
+                "--format=%H",
+                "-F",
+                "--all-match",
+                "--grep",
+                thread.thread_id,
+                "--grep",
+                "fix: address",
+                "HEAD",
+            )
+        )
+        if result.ok and result.stdout.strip():
+            _mark_review_thread_addressed(state, thread, "fix_committed")
 
 
 async def _resolve_addressed_outdated_threads(
@@ -84,6 +151,16 @@ async def _resolve_addressed_outdated_threads(
     is in-memory only, matching the rest of the transient path.
     """
     del repo  # repo is recovered from the neutral thread_id by the forge client
+    # #484: seed verdicts for outdated threads a prior instance already addressed
+    # (re-adoption / handoff) from durable branch evidence, so the resolve loop
+    # below — which gates on a recorded verdict — can resolve them this iteration
+    # instead of leaving the PR permanently BLOCKED on an invisible conversation.
+    await _seed_outdated_thread_verdicts_from_branch_evidence(
+        self,
+        workspace_id=workspace_id,
+        status=status,
+        state=state,
+    )
     for thread in status.outdated_unresolved_inline_threads:
         tid = thread.thread_id
         if state.threads_addressed_ids.get(tid) not in _OUTDATED_RESOLVABLE_THREAD_VERDICTS:

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_outdated_preserve.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_outdated_preserve.py
@@ -1,0 +1,325 @@
+"""Preserve an outdated thread's fix verdict on an in-cycle resolve fault (#484).
+
+The fix cycle's in-cycle resolve loop normally CLEARS the addressed marker on a
+``resolve_thread`` fault so the next poll re-addresses the still-open thread. But
+if an in-place fix already made the thread ``isOutdated`` on the forge, clearing
+the verdict strands it: outdated threads are dropped from the actionable feed, so
+the fix cycle never re-addresses them, and the next poll's outdated-resolution
+step skips a thread with no recorded verdict — leaving the PR permanently BLOCKED
+(the second trigger in #484).
+
+These tests pin that the verdict is PRESERVED (``fix_committed``) for a thread the
+settle re-poll reports as outdated, on both the transient and permanent resolve
+arms, while a non-outdated thread still clears (regression guard).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.bitbucket_client import BITBUCKET_API_ERROR, BitbucketClientError
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import GitHubClientError, RepoRef
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from tests.postgres import postgres_test_engine
+from tests.shared.monitor_runner import DefaultMergeMethodGitHubClient
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+class _SettleAndResolveClient(DefaultMergeMethodGitHubClient):
+    """Command-based gh double with a scripted settle status + raising resolve.
+
+    Overriding ``fetch_pr_status`` lets the settle re-poll return a status whose
+    ``outdated_unresolved_inline_threads`` carries the addressed thread (so the fix
+    cycle's ``outdated_thread_ids`` set includes it), while ``resolve_thread``
+    raises the configured forge fault. The rest of the flow (push, rev-parse) stays
+    command-based.
+    """
+
+    def __init__(
+        self,
+        runner: FakeCommandRunner,
+        *,
+        settle_status: PRStatus,
+        resolve_exc: Exception,
+    ) -> None:
+        super().__init__(runner)
+        self._settle_status = settle_status
+        self._resolve_exc = resolve_exc
+        self.attempts: list[str] = []
+
+    async def fetch_pr_status(
+        self, *, repo: RepoRef, pr_number: int, base_behind_count: int
+    ) -> PRStatus:
+        del repo, pr_number, base_behind_count
+        return self._settle_status
+
+    async def resolve_thread(self, *, thread_id: str) -> None:
+        self.attempts.append(thread_id)
+        raise self._resolve_exc
+
+
+def _outdated_settle_status(thread: ReviewThread) -> PRStatus:
+    """A merge-ready settle status that reports ``thread`` as outdated-unresolved."""
+    return PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+        outdated_unresolved_inline_threads=(thread,),
+    )
+
+
+def _resolution_events(events: list, *, outcome: str) -> list:
+    return [
+        event
+        for event in events
+        if event.payload is not None
+        and event.payload.get("action") == "resolve_thread"
+        and event.payload.get("outcome") == outcome
+    ]
+
+
+@pytest.mark.unit
+async def test_permanent_resolve_fault_on_outdated_thread_preserves_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(b) A PERMANENT resolve fault on a thread the settle re-poll reports as
+    outdated must NOT clear the ``fix_committed`` verdict — clearing strands the
+    thread (#484). The verdict is preserved so the next poll's outdated-resolution
+    step retries it (or escalates to ``needs_human`` on its own permanent path),
+    and a ``failed`` resolve audit event is still recorded."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout="newsha\n")  # rev-parse HEAD
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed fix locally.")
+    thread = ReviewThread(
+        thread_id="PRRT_outdated",
+        path="src/foo.py",
+        line=12,
+        body_excerpt="please adjust this",
+        author="review-bot",
+    )
+    gh = _SettleAndResolveClient(
+        cmd,
+        settle_status=_outdated_settle_status(thread),
+        resolve_exc=BitbucketClientError(
+            operation="bitbucket resolve_thread",
+            status=403,
+            body="forbidden: missing scope",
+            reason_code=BITBUCKET_API_ERROR,
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=(thread,),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert gh.attempts == ["PRRT_outdated"]
+    # Verdict preserved (NOT dropped to None) so the outdated-resolution step can
+    # retry/escalate it next poll.
+    assert state.threads_addressed_ids.get("PRRT_outdated") == "fix_committed"
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        resolution_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.comment_resolution",
+            limit=10,
+        )
+    failed = _resolution_events(resolution_events, outcome="failed")
+    assert len(failed) == 1
+    assert failed[0].payload is not None
+    assert failed[0].payload["reason_code"] == BITBUCKET_API_ERROR
+
+
+@pytest.mark.unit
+async def test_transient_resolve_fault_on_outdated_thread_preserves_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A TRANSIENT resolve fault on a now-outdated thread also preserves the
+    ``fix_committed`` verdict (rather than clearing it) so the next poll retries —
+    covering the transient ``tid in outdated_thread_ids`` branch."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout="newsha\n")  # rev-parse HEAD
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed fix locally.")
+    thread = ReviewThread(
+        thread_id="PRRT_outdated",
+        path="src/foo.py",
+        line=12,
+        body_excerpt="please adjust this",
+        author="review-bot",
+    )
+    gh = _SettleAndResolveClient(
+        cmd,
+        settle_status=_outdated_settle_status(thread),
+        resolve_exc=GitHubClientError(
+            operation="resolve_thread",
+            returncode=1,
+            stderr="HTTP 503: service unavailable",
+        ),
+    )
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=(thread,),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert gh.attempts == ["PRRT_outdated"]
+    assert state.threads_addressed_ids.get("PRRT_outdated") == "fix_committed"
+    assert sleep_fn.calls  # the transient handler waited
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        resolution_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.comment_resolution",
+            limit=10,
+        )
+    requeued = _resolution_events(resolution_events, outcome="requeued")
+    assert len(requeued) == 1
+
+
+@pytest.mark.unit
+async def test_permanent_resolve_fault_on_non_outdated_thread_still_clears_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Regression guard: a permanent resolve fault on a thread that is NOT outdated
+    still CLEARS the addressed marker (the pre-#484 behavior) so the next poll
+    re-addresses the still-open thread — locking the ``tid not in
+    outdated_thread_ids`` branch."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout="newsha\n")  # rev-parse HEAD
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed fix locally.")
+    thread = ReviewThread(
+        thread_id="PRRT_active",
+        path="src/foo.py",
+        line=12,
+        body_excerpt="please adjust this",
+        author="review-bot",
+    )
+    # Settle status with NO outdated threads: the addressed thread is not outdated,
+    # so a permanent resolve fault must clear its verdict.
+    settle_status = PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+    gh = _SettleAndResolveClient(
+        cmd,
+        settle_status=settle_status,
+        resolve_exc=BitbucketClientError(
+            operation="bitbucket resolve_thread",
+            status=403,
+            body="forbidden: missing scope",
+            reason_code=BITBUCKET_API_ERROR,
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=(thread,),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert gh.attempts == ["PRRT_active"]
+    # Not outdated → verdict cleared so the next poll re-addresses it.
+    assert "PRRT_active" not in state.threads_addressed_ids

--- a/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
+++ b/tests/unit/runtime/test_pr_monitor_outdated_resolution.py
@@ -678,6 +678,182 @@ async def test_permanent_resolve_downgrade_survives_state_reload(
     assert gh.attempts == [bb_id]  # exactly one resolve attempt across both polls
 
 
+def _grep_argv(worktree_path: Path, thread_id: str) -> list[str]:
+    """The bounded ``git log`` evidence grep the seeding helper issues (#484)."""
+    return [
+        "git",
+        "-c",
+        f"safe.directory={worktree_path}",
+        "-C",
+        str(worktree_path),
+        "log",
+        "-n",
+        "1",
+        "--format=%H",
+        "-F",
+        "--all-match",
+        "--grep",
+        thread_id,
+        "--grep",
+        "fix: address",
+        "HEAD",
+    ]
+
+
+@pytest.mark.unit
+async def test_outdated_thread_seeded_from_branch_evidence_is_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """(a) #484 regression — after a re-adoption / instance handoff, an outdated
+    thread whose ``fix: address PRRT_…`` commit is already on the branch head but
+    which has NO verdict in this instance's ``threads_addressed_ids`` is seeded
+    from that durable branch evidence and resolved THIS iteration — not looped on
+    ``NotifyHuman`` forever."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    # Empty state — the prior instance addressed+outdated the thread, this one has
+    # no record of it.
+    state = MonitorState()
+    thread = _outdated_thread("PRRT_kwDOSJAM6s6IMBmJ")
+    # The branch head carries the prior instance's fix: address commit (non-empty SHA).
+    cmd.queue_result(returncode=0, stdout="7772e1ecommitsha\n")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(thread),
+        state=state,
+    )
+
+    assert gh.resolved == ["PRRT_kwDOSJAM6s6IMBmJ"]
+    assert state.threads_addressed_ids["PRRT_kwDOSJAM6s6IMBmJ"] == "fix_committed"
+    worktree = tmp_path / "worktrees" / workspace_id
+    assert [c.args for c in cmd.calls] == [_grep_argv(worktree, "PRRT_kwDOSJAM6s6IMBmJ")]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        succeeded = _resolution_events(ws, outcome="succeeded")
+        assert len(succeeded) == 1
+        assert succeeded[0].reason_code == "COMMENT_REPAIR"
+
+
+@pytest.mark.unit
+async def test_outdated_thread_without_branch_evidence_is_left_open(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """No ``fix: address`` commit references the thread → no verdict is seeded and
+    the thread is left open (the monitor never claims a fix the branch lacks)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    thread = _outdated_thread("PRRT_unknown")
+    # Empty stdout: no commit on HEAD matches both the thread id and ``fix: address``.
+    cmd.queue_result(returncode=0, stdout="")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(thread),
+        state=state,
+    )
+
+    assert gh.attempts == []
+    assert "PRRT_unknown" not in state.threads_addressed_ids
+    worktree = tmp_path / "worktrees" / workspace_id
+    assert [c.args for c in cmd.calls] == [_grep_argv(worktree, "PRRT_unknown")]
+
+
+@pytest.mark.unit
+async def test_outdated_thread_seeding_git_failure_is_best_effort(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A git read failure during seeding is best-effort: no crash, no verdict, no
+    resolve. The thread stays non-blocking via the existing path and a later poll
+    can re-seed once the worktree read succeeds."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    thread = _outdated_thread("PRRT_giterr")
+    # Non-zero return: the worktree read failed (e.g. transient lock / missing ref).
+    cmd.queue_result(returncode=1, stdout="", stderr="fatal: not a git repository")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(thread),
+        state=state,
+    )
+
+    assert gh.attempts == []
+    assert "PRRT_giterr" not in state.threads_addressed_ids
+
+
+@pytest.mark.unit
+async def test_already_seeded_outdated_thread_skips_branch_evidence_grep(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """An outdated thread that already carries a ``fix_committed`` verdict (recorded
+    by THIS instance) resolves through the existing #473 path WITHOUT issuing the
+    seeding grep — the git read runs only for unseeded outdated threads, so it does
+    not recur in steady state."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    gh = _RecordingGitHub(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    state = MonitorState()
+    thread = _outdated_thread("PRRT_seeded")
+    _mark_review_thread_addressed(state, thread, "fix_committed")
+
+    await _call_resolve(
+        runner,
+        workspace_id=workspace_id,
+        status=_status_with_outdated(thread),
+        state=state,
+    )
+
+    assert gh.resolved == ["PRRT_seeded"]
+    # No git grep was issued — the thread already had a verdict.
+    assert cmd.calls == []
+
+
 @pytest.mark.unit
 def test_outdated_resolvable_verdicts_exclude_defer() -> None:
     """The outdated-resolution verdict set is the fix-cycle's resolvable set MINUS


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_5e6cf2b54fff4512b69b9d09` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Implement the MINIMAL fix for GitHub issue #484 and nothing more. SCOPE NARROWLY to the review-thread resolution dead-end; do NOT refactor the monitor. You may run `gh issue view 484` for the full analysis.

Confirmed root cause: an addressed-but-OUTDATED review thread is left permanently unresolved when the current monitor instance has no verdict for it in `state.threads_addressed_ids`. This happens after a re-adoption / instance handoff (a prior instance addressed+outdated the thread via an in-place fix commit, then the PR was re-adopted into a fresh workspace). The #473 outdated-resolution (`src/awf/runtime/pr_monitor_runner/outdated_resolution.py`, ~line 89) only resolves outdated threads whose verdict is recorded in THIS instance; and outdated threads are dropped from the actionable feed (`src/awf/common/github_client.py`) so the new instance can never re-address them. Net: GitHub stays BLOCKED on the unresolved conversation while the monitor reports `unresolved_threads=0` and loops on `NotifyHuman`.

Implement the narrowest robust fix:
1. Seed `state.threads_addressed_ids` from durable evidence on monitor adoption/resume — e.g. the PR branch's `fix: address PRRT_<id>` commit messages (and/or GitHub's current resolved/outdated state) — so a thread a prior instance addressed gets a verdict and the existing #473 outdated-resolution resolves it.
2. In the in-cycle resolve loop (`src/awf/runtime/pr_monitor_runner/fix_cycle.py`), do NOT clear the verdict (`_clear_addressed_state_by_id`) for a thread that is already outdated; preserve it (or downgrade to needs_human) so it stays resolvable.

Add regression tests: (a) a monitor that starts on a branch whose head already contains an `awf` `fix: address PRRT_X` commit that outdated thread X, with an EMPTY `threads_addressed_ids`, resolves X rather than looping; (b) an in-cycle resolve failure on a now-outdated thread does NOT drop the verdict.

Do NOT broaden scope beyond the thread-resolution path. Strict TDD; ruff/mypy clean; 99% coverage. If you add a reason code, regenerate docs/REASON_CATALOG.md (and keep test_doctor_reasons in sync). git is functional in /workspace — commit before exiting; do not push (AWF handles it).

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor merge-blocking behavior around outdated threads and fix-cycle state rollback; mistakes could leave PRs blocked or merge with unresolved conversations, but scope is narrow with extensive unit tests.
> 
> **Overview**
> Fixes **#484**: addressed-but-outdated review threads no longer strand the PR when monitor state is empty after re-adoption, or when an in-cycle `resolve_thread` fails after the thread has gone outdated.
> 
> **Outdated resolution** now runs `_seed_outdated_thread_verdicts_from_branch_evidence` before resolving: for outdated threads with no verdict in this instance, it best-effort greps `git log` on the worktree for a commit message containing both the thread id and `fix: address`, then records `fix_committed` via `_mark_review_thread_addressed` so the existing #473 resolve path can close the thread in the same poll.
> 
> **Fix cycle** builds `outdated_thread_ids` from the settle re-poll’s `outdated_unresolved_inline_threads` and **skips** `_clear_addressed_state_by_id` on transient and permanent resolve faults for those ids, so a `fix_committed` verdict survives for the outdated-resolution step instead of being cleared (which would block re-addressing because outdated threads are not in the actionable feed).
> 
> Regression coverage adds fix-cycle preserve-vs-clear behavior and seeding/resolve tests (branch evidence, no match, git failure, steady-state skip of grep).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6e3cfb5c53045c16c54bb632b6daa707a501d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of outdated review threads to prevent PRs from being permanently blocked. The system now preserves resolution verdicts for outdated threads instead of discarding them, and can recover previous resolution attempts from branch history, enabling better retry and escalation workflows for pending outdated thread resolutions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->