### PR TITLE
Release: GitHub Actions SHA-pinning + Mako/brace-expansion CVE fixes (development → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
@@ -68,10 +70,12 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
@@ -111,7 +115,7 @@ jobs:
 
       - name: Upload coverage shard
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: python-coverage-shard-${{ matrix.shard }}
           path: coverage-artifacts/.coverage.shard-${{ matrix.shard }}
@@ -130,10 +134,12 @@ jobs:
           echo "python-coverage-shards result: ${{ needs.python-coverage-shards.result }}"
           exit 1
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
@@ -145,7 +151,7 @@ jobs:
         run: uv sync --python 3.12 --extra dev
 
       - name: Download coverage shards
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: python-coverage-shard-*
           path: coverage-artifacts
@@ -169,7 +175,7 @@ jobs:
 
       - name: Upload full coverage artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: full-coverage-report
           path: coverage.xml
@@ -179,10 +185,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6
         with:
           node-version: "24"
           cache: npm
@@ -210,10 +218,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
@@ -259,10 +269,10 @@ jobs:
           PY
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5  # v4
 
       - name: Validate control-plane image build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: docker/control-plane.Dockerfile
@@ -270,7 +280,7 @@ jobs:
           push: false
 
       - name: Validate agent-runtime image build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7
         with:
           context: .
           file: docker/agent-runtime.Dockerfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,15 +26,24 @@ jobs:
       manifest_generated: ${{ steps.build.outputs.manifest_generated }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           fetch-tags: true
+          # This is the most release-sensitive checkout in the repo (it builds
+          # and checksums the PyPI distributions); do not leave the GITHUB_TOKEN
+          # persisted in .git/config where a later build step could reuse it.
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
+          # Disable uv-cache integration: this job builds and checksums the
+          # release distributions, so restoring/uploading a shared cache is a
+          # cache-poisoning vector (flagged by zizmor). enable-cache defaults to
+          # "auto" (on for GitHub-hosted runners), so it must be set explicitly.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -106,14 +115,14 @@ jobs:
           fi
 
       - name: Upload distributions
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: python-distributions
           path: dist/*
           if-no-files-found: error
 
       - name: Upload release audit artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
         with:
           name: python-distribution-checksums
           path: |
@@ -131,25 +140,34 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          # Match the build job and ci.yml: do not persist GITHUB_TOKEN in
+          # .git/config for the artifact-verification smoke checkout.
+          persist-credentials: false
 
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-distributions
           path: dist
 
       - name: Download release audit artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-distribution-checksums
           path: artifacts/release
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
         with:
           version: "0.5.31"
           github-token: ""
+          # Disable uv-cache integration: this job verifies release-artifact
+          # checksums, so restoring/uploading a shared cache is a cache-poisoning
+          # vector (flagged by zizmor). enable-cache defaults to "auto" (on for
+          # GitHub-hosted runners), so it must be set explicitly.
+          enable-cache: false
 
       - name: Set up Python
         run: uv python install 3.12
@@ -204,12 +222,12 @@ jobs:
       id-token: write
     steps:
       - name: Download distributions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-distributions
           path: dist
 
       - name: Publish via PyPI Trusted Publishing
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: ${{ inputs.publish_target == 'testpypi' && 'https://test.pypi.org/legacy/' || 'https://upload.pypi.org/legacy/' }}

--- a/apps/console/package-lock.json
+++ b/apps/console/package-lock.json
@@ -380,9 +380,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -461,9 +461,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2585,9 +2585,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3284,9 +3284,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3557,9 +3557,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -25,9 +25,13 @@ _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 def _assert_sha_pinned(uses: object, expected_action: str) -> None:
     """Assert a ``uses:`` ref pins ``expected_action`` to a full 40-char commit SHA."""
-    assert isinstance(uses, str)
+    assert isinstance(uses, str), (
+        f"expected 'uses' to be a string, but got {type(uses).__name__} (action: {expected_action})"
+    )
     action, sep, ref = uses.partition("@")
-    assert sep == "@" and action == expected_action, uses
+    assert sep == "@" and action == expected_action, (
+        f"expected action '{expected_action}', but got '{uses}'"
+    )
     assert _SHA_RE.fullmatch(ref), f"{expected_action} must be pinned to a 40-char SHA: {uses}"
 
 

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tomllib
 from pathlib import Path
 from typing import Any
@@ -19,6 +20,15 @@ DOCKER_SKIP_ENV = "AWF_SKIP_DOCKER_TESTS"
 TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
 GITHUB_HOSTED_RUNNER = "ubuntu-latest"
 SETUP_UV_VERSION = "0.5.31"
+_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
+
+def _assert_sha_pinned(uses: object, expected_action: str) -> None:
+    """Assert a ``uses:`` ref pins ``expected_action`` to a full 40-char commit SHA."""
+    assert isinstance(uses, str)
+    action, sep, ref = uses.partition("@")
+    assert sep == "@" and action == expected_action, uses
+    assert _SHA_RE.fullmatch(ref), f"{expected_action} must be pinned to a 40-char SHA: {uses}"
 
 
 def _workflow() -> dict[str, Any]:
@@ -67,7 +77,7 @@ def _step_run(job: dict[str, Any], name: str) -> str:
 
 def _setup_uv_step(workflow: dict[str, Any], job_name: str) -> dict[str, Any]:
     step = _named_step(_job(workflow, job_name), "Install uv")
-    assert step.get("uses") == "astral-sh/setup-uv@v7"
+    _assert_sha_pinned(step.get("uses"), "astral-sh/setup-uv")
     return step
 
 
@@ -195,7 +205,7 @@ def test_ci_has_parallel_python_coverage_shards() -> None:
 
     upload_step = _named_step(job, "Upload coverage shard")
     assert upload_step.get("if") == "${{ always() }}"
-    assert upload_step.get("uses") == "actions/upload-artifact@v7"
+    _assert_sha_pinned(upload_step.get("uses"), "actions/upload-artifact")
     assert upload_step.get("with") == {
         "name": "python-coverage-shard-${{ matrix.shard }}",
         "path": "coverage-artifacts/.coverage.shard-${{ matrix.shard }}",
@@ -241,7 +251,7 @@ def test_ci_has_authoritative_python_full_coverage_gate() -> None:
     assert "exit 1" in verify_run
 
     download_step = _named_step(job, "Download coverage shards")
-    assert download_step.get("uses") == "actions/download-artifact@v4"
+    _assert_sha_pinned(download_step.get("uses"), "actions/download-artifact")
     assert download_step.get("with") == {
         "pattern": "python-coverage-shard-*",
         "path": "coverage-artifacts",
@@ -399,7 +409,8 @@ def test_publish_workflow_builds_on_tags_and_uses_trusted_publishing() -> None:
 
     publish_steps = _steps(publish_job)
     assert any(
-        step.get("uses") == "pypa/gh-action-pypi-publish@release/v1" for step in publish_steps
+        str(step.get("uses", "")).split("@", 1)[0] == "pypa/gh-action-pypi-publish"
+        for step in publish_steps
     )
     assert "secrets.PYPI_API_TOKEN" not in PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
 
@@ -419,6 +430,69 @@ def test_required_ci_gate_rolls_up_full_coverage_and_required_jobs() -> None:
     commands = _run_steps(job)
     assert "A required CI job did not pass." in commands
     assert '!= "success"' in commands
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("action", "ref"),
+    [
+        ("actions/checkout", "v4"),
+        ("astral-sh/setup-uv", "v7"),
+        ("actions/upload-artifact", "v7"),
+        ("actions/download-artifact", "v4"),
+        ("actions/setup-node", "v6"),
+        ("docker/setup-buildx-action", "v4"),
+        ("docker/build-push-action", "v7"),
+    ],
+)
+def test_ci_workflow_actions_pinned_to_sha_with_version_comment(action: str, ref: str) -> None:
+    """Every ``uses:`` ref is pinned to a 40-char SHA with the Dependabot ``# <ref>`` comment."""
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # No floating-tag refs remain for this action.
+    assert not re.search(rf"{re.escape(action)}@{re.escape(ref)}(?=\s|$)", text), action
+    # Every ``uses:`` occurrence is pinned to a 40-char SHA with the version comment, so a
+    # single mis-pinned duplicate cannot hide behind a correctly pinned sibling.
+    uses_lines = re.findall(rf"^\s*(?:-\s*)?uses:\s*{re.escape(action)}@\S+.*", text, re.MULTILINE)
+    assert uses_lines, f"No occurrences of {action} found"
+    for line in uses_lines:
+        assert re.search(
+            rf"uses:\s*{re.escape(action)}@[0-9a-f]{{40}}\s+# {re.escape(ref)}\b", line
+        ), f"Action {action} in line '{line}' is not pinned to a 40-char SHA with comment '# {ref}'"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "job_name",
+    [
+        "lint-and-type",
+        "python-coverage-shards",
+        "python-full-coverage",
+        "console",
+        "release-artifacts",
+    ],
+)
+def test_ci_workflow_checkouts_disable_persisted_credentials(job_name: str) -> None:
+    """Every checkout in ci.yml sets ``persist-credentials: false``.
+
+    Mirrors ``test_publish_workflow_checkouts_disable_persisted_credentials``
+    so the two workflows are symmetrically enforced: a future edit that drops
+    the flag from any ci.yml checkout fails the suite instead of silently
+    re-persisting the GITHUB_TOKEN in ``.git/config``.
+    """
+    job = _job(_workflow(), job_name)
+    checkouts = [
+        step
+        for step in _steps(job)
+        if str(step.get("uses", "")).split("@", 1)[0] == "actions/checkout"
+    ]
+    assert checkouts, f"{job_name} job has no checkout step"
+    for checkout in checkouts:
+        with_config = checkout.get("with", {})
+        assert isinstance(with_config, dict)
+        assert with_config.get("persist-credentials") is False, (
+            f"checkout in {job_name} must set persist-credentials: false"
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -466,6 +466,28 @@ def test_ci_workflow_actions_pinned_to_sha_with_version_comment(action: str, ref
 
 
 @pytest.mark.unit
+def test_ci_workflow_all_external_actions_are_sha_pinned() -> None:
+    """Every non-local ``uses:`` is SHA-pinned with a ``# <ref>`` comment, exhaustively.
+
+    The parametrized guard above only checks the actions it names, so a newly
+    added external ``uses:`` entry could regress to a floating tag and still pass.
+    This pass walks *every* non-local ``uses:`` line in ci.yml and enforces
+    ``@<40-char SHA>  # <ref>`` so the hardening cannot silently regress. Mirrors
+    ``test_publish_workflow_all_external_actions_are_sha_pinned``.
+    """
+    text = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Collect every uses: line that is not a local (``./``) action reference.
+    uses_lines = re.findall(r"^\s*(?:-\s*)?uses:\s*(?!\./)\S+.*", text, re.MULTILINE)
+    assert uses_lines, "No external uses: entries found in ci.yml"
+    for line in uses_lines:
+        assert re.search(r"uses:\s*[^@\s]+@[0-9a-f]{40}\s+#\s+\S+\b", line), (
+            f"External action in line '{line.strip()}' is not pinned to a "
+            "40-char SHA with a '# <ref>' comment"
+        )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     "job_name",
     [

--- a/tests/unit/test_publish_workflow_release_artifacts.py
+++ b/tests/unit/test_publish_workflow_release_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -52,7 +53,7 @@ def _uploaded_paths(job: dict[str, Any]) -> set[str]:
     """Collect artifact upload paths declared by a workflow job."""
     paths: set[str] = set()
     for step in _steps(job):
-        if step.get("uses") != "actions/upload-artifact@v7":
+        if str(step.get("uses", "")).split("@", 1)[0] != "actions/upload-artifact":
             continue
         with_config = step.get("with", {})
         assert isinstance(with_config, dict)
@@ -62,6 +63,84 @@ def _uploaded_paths(job: dict[str, Any]) -> set[str]:
         elif isinstance(raw_path, list):
             paths.update(str(line).strip() for line in raw_path if str(line).strip())
     return paths
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("action", "ref"),
+    [
+        ("actions/checkout", "v4"),
+        ("astral-sh/setup-uv", "v7"),
+        ("actions/upload-artifact", "v7"),
+        ("actions/download-artifact", "v4"),
+        ("pypa/gh-action-pypi-publish", "release/v1"),
+    ],
+)
+def test_publish_workflow_actions_pinned_to_sha_with_version_comment(action: str, ref: str) -> None:
+    """Every ``uses:`` ref is pinned to a 40-char SHA with the Dependabot ``# <ref>`` comment."""
+    text = PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # No floating-ref refs remain for this action.
+    assert not re.search(rf"{re.escape(action)}@{re.escape(ref)}(?=\s|$)", text), action
+    # Every ``uses:`` occurrence is pinned to a 40-char SHA with the version comment, so a
+    # single mis-pinned duplicate cannot hide behind a correctly pinned sibling.
+    uses_lines = re.findall(rf"^\s*(?:-\s*)?uses:\s*{re.escape(action)}@\S+.*", text, re.MULTILINE)
+    assert uses_lines, f"No occurrences of {action} found"
+    for line in uses_lines:
+        assert re.search(
+            rf"uses:\s*{re.escape(action)}@[0-9a-f]{{40}}\s+# {re.escape(ref)}\b", line
+        ), f"Action {action} in line '{line}' is not pinned to a 40-char SHA with comment '# {ref}'"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("job_name", ["build", "installer-smoke"])
+def test_publish_workflow_checkouts_disable_persisted_credentials(job_name: str) -> None:
+    """Every checkout in publish.yml sets ``persist-credentials: false``.
+
+    The build job builds and checksums the PyPI distributions, so leaving the
+    GITHUB_TOKEN persisted in ``.git/config`` is the highest-stakes omission in
+    the repo. This mirrors the same zizmor-driven hardening already enforced on
+    every ci.yml checkout.
+    """
+    job = _job(_publish_workflow(), job_name)
+    checkouts = [
+        step
+        for step in _steps(job)
+        if str(step.get("uses", "")).split("@", 1)[0] == "actions/checkout"
+    ]
+    assert checkouts, f"{job_name} job has no checkout step"
+    for checkout in checkouts:
+        with_config = checkout.get("with", {})
+        assert isinstance(with_config, dict)
+        assert with_config.get("persist-credentials") is False, (
+            f"checkout in {job_name} must set persist-credentials: false"
+        )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("job_name", ["build", "installer-smoke"])
+def test_publish_workflow_setup_uv_disables_cache(job_name: str) -> None:
+    """Every ``setup-uv`` in publish.yml sets ``enable-cache: false``.
+
+    The build job builds/checksums the PyPI distributions and installer-smoke
+    verifies those checksums, so restoring or uploading a shared uv cache is a
+    cache-poisoning vector (flagged by zizmor). ``enable-cache`` defaults to
+    ``auto`` (on for GitHub-hosted runners), so the flag must be set
+    explicitly; this guard keeps the hardening from silently regressing.
+    """
+    job = _job(_publish_workflow(), job_name)
+    setup_uv_steps = [
+        step
+        for step in _steps(job)
+        if str(step.get("uses", "")).split("@", 1)[0] == "astral-sh/setup-uv"
+    ]
+    assert setup_uv_steps, f"{job_name} job has no setup-uv step"
+    for setup_uv in setup_uv_steps:
+        with_config = setup_uv.get("with", {})
+        assert isinstance(with_config, dict)
+        assert with_config.get("enable-cache") is False, (
+            f"setup-uv in {job_name} must set enable-cache: false"
+        )
 
 
 @pytest.mark.unit
@@ -120,7 +199,7 @@ def test_publish_workflow_has_installer_smoke_job_consuming_release_artifacts() 
     downloaded = {
         step.get("with", {}).get("name")
         for step in _steps(smoke_job)
-        if step.get("uses") == "actions/download-artifact@v4"
+        if str(step.get("uses", "")).split("@", 1)[0] == "actions/download-artifact"
     }
     assert "python-distributions" in downloaded
     assert "python-distribution-checksums" in downloaded
@@ -184,7 +263,8 @@ def test_publish_workflow_publish_job_keeps_manual_trusted_publishing_gate() -> 
 
     publish_steps = _steps(publish_job)
     assert any(
-        step.get("uses") == "pypa/gh-action-pypi-publish@release/v1" for step in publish_steps
+        str(step.get("uses", "")).split("@", 1)[0] == "pypa/gh-action-pypi-publish"
+        for step in publish_steps
     )
 
 

--- a/tests/unit/test_publish_workflow_release_artifacts.py
+++ b/tests/unit/test_publish_workflow_release_artifacts.py
@@ -13,6 +13,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PUBLISH_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "publish.yml"
 
 
+def _action_name(uses_ref: str) -> str:
+    """Extract the action name from a ``uses:`` reference, stripping the ``@ref`` suffix."""
+    return uses_ref.split("@", 1)[0]
+
+
 def _publish_workflow() -> dict[str, Any]:
     """Load the publish workflow YAML as a mapping."""
     loaded = yaml.safe_load(PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8"))
@@ -53,7 +58,7 @@ def _uploaded_paths(job: dict[str, Any]) -> set[str]:
     """Collect artifact upload paths declared by a workflow job."""
     paths: set[str] = set()
     for step in _steps(job):
-        if str(step.get("uses", "")).split("@", 1)[0] != "actions/upload-artifact":
+        if _action_name(str(step.get("uses", ""))) != "actions/upload-artifact":
             continue
         with_config = step.get("with", {})
         assert isinstance(with_config, dict)
@@ -127,7 +132,7 @@ def test_publish_workflow_checkouts_disable_persisted_credentials(job_name: str)
     checkouts = [
         step
         for step in _steps(job)
-        if str(step.get("uses", "")).split("@", 1)[0] == "actions/checkout"
+        if _action_name(str(step.get("uses", ""))) == "actions/checkout"
     ]
     assert checkouts, f"{job_name} job has no checkout step"
     for checkout in checkouts:
@@ -153,7 +158,7 @@ def test_publish_workflow_setup_uv_disables_cache(job_name: str) -> None:
     setup_uv_steps = [
         step
         for step in _steps(job)
-        if str(step.get("uses", "")).split("@", 1)[0] == "astral-sh/setup-uv"
+        if _action_name(str(step.get("uses", ""))) == "astral-sh/setup-uv"
     ]
     assert setup_uv_steps, f"{job_name} job has no setup-uv step"
     for setup_uv in setup_uv_steps:
@@ -220,7 +225,7 @@ def test_publish_workflow_has_installer_smoke_job_consuming_release_artifacts() 
     downloaded = {
         step.get("with", {}).get("name")
         for step in _steps(smoke_job)
-        if str(step.get("uses", "")).split("@", 1)[0] == "actions/download-artifact"
+        if _action_name(str(step.get("uses", ""))) == "actions/download-artifact"
     }
     assert "python-distributions" in downloaded
     assert "python-distribution-checksums" in downloaded
@@ -284,7 +289,7 @@ def test_publish_workflow_publish_job_keeps_manual_trusted_publishing_gate() -> 
 
     publish_steps = _steps(publish_job)
     assert any(
-        str(step.get("uses", "")).split("@", 1)[0] == "pypa/gh-action-pypi-publish"
+        _action_name(str(step.get("uses", ""))) == "pypa/gh-action-pypi-publish"
         for step in publish_steps
     )
 

--- a/tests/unit/test_publish_workflow_release_artifacts.py
+++ b/tests/unit/test_publish_workflow_release_artifacts.py
@@ -93,6 +93,27 @@ def test_publish_workflow_actions_pinned_to_sha_with_version_comment(action: str
 
 
 @pytest.mark.unit
+def test_publish_workflow_all_external_actions_are_sha_pinned() -> None:
+    """Every non-local ``uses:`` is SHA-pinned with a ``# <ref>`` comment, exhaustively.
+
+    The parametrized guard above only checks the actions it names, so a newly
+    added external ``uses:`` entry could regress to a floating tag and still pass.
+    This pass walks *every* non-local ``uses:`` line in publish.yml and enforces
+    ``@<40-char SHA>  # <ref>`` so the hardening cannot silently regress.
+    """
+    text = PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Collect every uses: line that is not a local (``./``) action reference.
+    uses_lines = re.findall(r"^\s*(?:-\s*)?uses:\s*(?!\./)\S+.*", text, re.MULTILINE)
+    assert uses_lines, "No external uses: entries found in publish.yml"
+    for line in uses_lines:
+        assert re.search(r"uses:\s*[^@\s]+@[0-9a-f]{40}\s+#\s+\S+\b", line), (
+            f"External action in line '{line.strip()}' is not pinned to a "
+            "40-char SHA with a '# <ref>' comment"
+        )
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("job_name", ["build", "installer-smoke"])
 def test_publish_workflow_checkouts_disable_persisted_credentials(job_name: str) -> None:
     """Every checkout in publish.yml sets ``persist-credentials: false``.

--- a/tests/unit/test_publish_workflow_release_artifacts.py
+++ b/tests/unit/test_publish_workflow_release_artifacts.py
@@ -80,7 +80,7 @@ def test_publish_workflow_actions_pinned_to_sha_with_version_comment(action: str
     """Every ``uses:`` ref is pinned to a 40-char SHA with the Dependabot ``# <ref>`` comment."""
     text = PUBLISH_WORKFLOW_PATH.read_text(encoding="utf-8")
 
-    # No floating-ref refs remain for this action.
+    # No floating-tag refs remain for this action.
     assert not re.search(rf"{re.escape(action)}@{re.escape(ref)}(?=\s|$)", text), action
     # Every ``uses:`` occurrence is pinned to a 40-char SHA with the version comment, so a
     # single mis-pinned duplicate cannot hide behind a correctly pinned sibling.

--- a/uv.lock
+++ b/uv.lock
@@ -948,14 +948,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.11"
+version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Release: supply-chain hardening + CVE patches

Lands `development` onto `main` — 2 commits.

### Security (Dependabot alerts)
- **#1 (HIGH)** — `Mako` 1.3.11→1.3.12 (`uv.lock`): path traversal via backslash
  URI on Windows in `TemplateLookup` (GHSA-2h4p-vjrc-8xpq). Transitive via Alembic.
- **#20 (MEDIUM)** — `brace-expansion` 5.0.5→5.0.6 (`apps/console/package-lock.json`,
  dev-scope): large numeric range defeats the documented `max` DoS guard
  (GHSA-jxxr-4gwj-5jf2).

### Supply-chain hardening (closes #505, #506)
- Pin every GitHub Action in `.github/workflows/ci.yml` and `publish.yml` to its
  immutable 40-char commit SHA with a `# vX` comment (so Dependabot keeps
  maintaining them). Workflow-content tests updated to match.

### Validation
- Full coverage suite green at **99.02%** (the 3 local failures are the known
  config-token env artifact + two `-n 20` parallelism-flaky merge tests that pass
  in CI).
- SHA pins verified to resolve to the correct tags (checkout v4, setup-uv v7,
  upload-artifact v7, …).

Closes #505
Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are workflow pinning, checkout/cache hardening, and dependency patch bumps with test guards; no application runtime logic changes.
> 
> **Overview**
> **Supply-chain and dependency security** for CI/CD and transitive packages.
> 
> **GitHub Actions** in `ci.yml` and `publish.yml` now reference third-party actions by **immutable 40-character commit SHAs** with `# vX` comments (Dependabot-friendly), instead of floating tags. **Checkouts** set `persist-credentials: false` everywhere so `GITHUB_TOKEN` is not left in `.git/config`. On **publish**, `setup-uv` sets **`enable-cache: false`** in build and installer-smoke jobs to avoid shared-cache poisoning on release checksum paths.
> 
> **CVE-driven lockfile bumps:** `Mako` **1.3.11 → 1.3.12** in `uv.lock` (Alembic transitive); `brace-expansion` **5.0.5/1.1.14 → 5.0.6/1.1.15** in `apps/console/package-lock.json` (dev tooling).
> 
> **Regression tests** enforce exhaustive SHA pinning, checkout credential policy, and publish `enable-cache: false`, and relax action assertions to match by action name rather than exact `@v` strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19bdbb9c635e8e36e3a8a7b72fa1afd507730760. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Hardened CI/CD workflows by pinning third-party actions to specific commit SHAs across lint, coverage, build, and publish pipelines for stronger supply-chain integrity and reproducibility.

* **Tests**
  * Added and expanded governance tests enforcing SHA pinning with version comments, forbidding floating refs, and verifying checkout and UV/setup steps disable persisted credentials/cache as required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->