### PR TITLE
fix: broaden awf-self validate phase so non-CLI self-fixes pass conformance (#512)

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -56,11 +56,9 @@ awf:
       - command: uv run --python 3.12 --extra dev pre-commit install --install-hooks
         timeout_seconds: 300
     validate:
-      - command: uv run --python 3.12 --extra dev ruff check src/awf/cli tests/unit/cli
+      - command: uv run --python 3.12 --extra dev ruff check src/awf tests
         timeout_seconds: 300
-      - command: uv run --python 3.12 --extra dev mypy src/awf/cli
-        timeout_seconds: 300
-      - command: uv run --python 3.12 --extra dev pytest tests/unit/cli -q
-        timeout_seconds: 300
-      - command: uv run --python 3.12 --extra dev pytest tests/unit/control/test_test_quality_guardrails_self.py -q
-        timeout_seconds: 300
+      - command: uv run --python 3.12 --extra dev mypy src/awf
+        timeout_seconds: 600
+      - command: uv run --python 3.12 --extra dev pytest tests/unit -n 3 -q
+        timeout_seconds: 1800

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -1,0 +1,85 @@
+"""Guard test: the awf-self profile's validate phase must exercise all of src/awf.
+
+Regression guard for #512. The `awf-self` profile in `.awf/workspace.yml` once
+scoped its `validate` phase to only the CLI slice (`src/awf/cli`,
+`tests/unit/cli`). The post-validation plan-conformance gate
+(`_run_post_validation_conformance_check`) feeds the recorded validation
+commands to the conformance agent as evidence; a CLI-only scope made every
+non-CLI fix (worker, service, gc) look unexercised and falsely failed the
+workspace as `agent_failure`.
+
+These assertions trip if the validate phase is ever silently re-narrowed back
+to the CLI slice.
+"""
+
+from __future__ import annotations
+
+import shlex
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+def _validate_commands() -> list[list[str]]:
+    """Tokenized validate-phase commands of the real awf-self profile."""
+    profile_path = Path(__file__).resolve().parents[2] / ".awf" / "workspace.yml"
+    profile = yaml.safe_load(profile_path.read_text(encoding="utf-8"))["awf"]
+    commands: list[list[str]] = []
+    for entry in profile["phases"]["validate"]:
+        raw = entry["command"] if isinstance(entry, dict) else entry
+        commands.append(shlex.split(raw))
+    return commands
+
+
+def _commands_for_tool(tool: str) -> list[list[str]]:
+    return [tokens for tokens in _validate_commands() if tool in tokens]
+
+
+@pytest.mark.unit
+def test_validate_ruff_covers_whole_package_not_only_cli() -> None:
+    ruff_commands = _commands_for_tool("ruff")
+    assert ruff_commands, "validate phase must run ruff"
+    # An exact `src/awf` token covers the whole package; `src/awf/cli` is a
+    # distinct token, so this does not match the narrow CLI-only scope.
+    assert any("src/awf" in tokens for tokens in ruff_commands), (
+        "ruff must lint the whole src/awf package, not only src/awf/cli"
+    )
+
+
+@pytest.mark.unit
+def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
+    mypy_commands = _commands_for_tool("mypy")
+    assert mypy_commands, "validate phase must run mypy"
+    assert any("src/awf" in tokens for tokens in mypy_commands), (
+        "mypy must type-check the whole src/awf package, not only src/awf/cli"
+    )
+
+
+@pytest.mark.unit
+def test_validate_pytest_covers_full_unit_suite_not_only_cli() -> None:
+    pytest_commands = _commands_for_tool("pytest")
+    assert pytest_commands, "validate phase must run pytest"
+    assert any("tests/unit" in tokens for tokens in pytest_commands), (
+        "pytest must run the full tests/unit suite, not only tests/unit/cli"
+    )
+
+
+@pytest.mark.unit
+def test_no_validate_command_is_scoped_solely_to_the_cli_slice() -> None:
+    """Anti-re-narrowing guard: document what 'too narrow' looks like.
+
+    A command that targets the CLI slice (`src/awf/cli` or `tests/unit/cli`)
+    without also covering the broad `src/awf` / `tests/unit` target is exactly
+    the regression from #512.
+    """
+    cli_only_tokens = {"src/awf/cli", "tests/unit/cli"}
+    broad_tokens = {"src/awf", "tests/unit"}
+    for tokens in _validate_commands():
+        narrow = cli_only_tokens.intersection(tokens)
+        if narrow:
+            assert broad_tokens.intersection(tokens), (
+                f"validate command {tokens!r} is scoped solely to the CLI slice "
+                f"({narrow}); it must also cover the broad src/awf / tests/unit "
+                "target so conformance exercises non-CLI changes"
+            )

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -62,6 +62,12 @@ def test_validate_ruff_covers_whole_package_not_only_cli() -> None:
     assert any(_targets_path(tokens, "src/awf") for tokens in ruff_commands), (
         "ruff must lint the whole src/awf package, not only src/awf/cli"
     )
+    # The `tests` target must also survive: dropping it from
+    # `ruff check src/awf tests` would silently narrow linting coverage of the
+    # test tree without tripping the src/awf guard above.
+    assert any(_targets_path(tokens, "tests") for tokens in ruff_commands), (
+        "ruff must also lint the tests tree, not only src/awf"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -36,13 +36,30 @@ def _commands_for_tool(tool: str) -> list[list[str]]:
     return [tokens for tokens in _validate_commands() if tool in tokens]
 
 
+def _targets_path(tokens: list[str], target: str) -> bool:
+    """Return True if any token names ``target`` or a parent of it.
+
+    Uses ``pathlib.Path`` comparison so equivalent spellings — ``src/awf`` vs
+    ``src/awf/`` — match identically and a trailing slash can never cause a
+    false failure. ``Path(str)`` never raises, so no defensive guard is needed.
+    """
+    target_path = Path(target)
+    return any(Path(token) == target_path or Path(token) in target_path.parents for token in tokens)
+
+
+def _targets_subpath(tokens: list[str], target: str) -> bool:
+    """Return True if any token names ``target`` or a path nested under it."""
+    target_path = Path(target)
+    return any(Path(token) == target_path or target_path in Path(token).parents for token in tokens)
+
+
 @pytest.mark.unit
 def test_validate_ruff_covers_whole_package_not_only_cli() -> None:
     ruff_commands = _commands_for_tool("ruff")
     assert ruff_commands, "validate phase must run ruff"
-    # An exact `src/awf` token covers the whole package; `src/awf/cli` is a
-    # distinct token, so this does not match the narrow CLI-only scope.
-    assert any("src/awf" in tokens for tokens in ruff_commands), (
+    # A `src/awf` token (or a parent of it) covers the whole package; a
+    # `src/awf/cli` subpath does not, so this does not match the CLI-only scope.
+    assert any(_targets_path(tokens, "src/awf") for tokens in ruff_commands), (
         "ruff must lint the whole src/awf package, not only src/awf/cli"
     )
 
@@ -51,7 +68,7 @@ def test_validate_ruff_covers_whole_package_not_only_cli() -> None:
 def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
     mypy_commands = _commands_for_tool("mypy")
     assert mypy_commands, "validate phase must run mypy"
-    assert any("src/awf" in tokens for tokens in mypy_commands), (
+    assert any(_targets_path(tokens, "src/awf") for tokens in mypy_commands), (
         "mypy must type-check the whole src/awf package, not only src/awf/cli"
     )
 
@@ -60,7 +77,7 @@ def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
 def test_validate_pytest_covers_full_unit_suite_not_only_cli() -> None:
     pytest_commands = _commands_for_tool("pytest")
     assert pytest_commands, "validate phase must run pytest"
-    assert any("tests/unit" in tokens for tokens in pytest_commands), (
+    assert any(_targets_path(tokens, "tests/unit") for tokens in pytest_commands), (
         "pytest must run the full tests/unit suite, not only tests/unit/cli"
     )
 
@@ -71,15 +88,17 @@ def test_no_validate_command_is_scoped_solely_to_the_cli_slice() -> None:
 
     A command that targets the CLI slice (`src/awf/cli` or `tests/unit/cli`)
     without also covering the broad `src/awf` / `tests/unit` target is exactly
-    the regression from #512.
+    the regression from #512. Path-based matching means a trailing slash or a
+    deeper CLI subpath cannot bypass this guard.
     """
-    cli_only_tokens = {"src/awf/cli", "tests/unit/cli"}
-    broad_tokens = {"src/awf", "tests/unit"}
     for tokens in _validate_commands():
-        narrow = cli_only_tokens.intersection(tokens)
-        if narrow:
-            assert broad_tokens.intersection(tokens), (
-                f"validate command {tokens!r} is scoped solely to the CLI slice "
-                f"({narrow}); it must also cover the broad src/awf / tests/unit "
-                "target so conformance exercises non-CLI changes"
+        targets_cli = _targets_subpath(tokens, "src/awf/cli") or _targets_subpath(
+            tokens, "tests/unit/cli"
+        )
+        if targets_cli:
+            targets_broad = _targets_path(tokens, "src/awf") or _targets_path(tokens, "tests/unit")
+            assert targets_broad, (
+                f"validate command {tokens!r} is scoped solely to the CLI slice; "
+                "it must also cover the broad src/awf / tests/unit target so "
+                "conformance exercises non-CLI changes"
             )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_faa22f747eaa4ceb8c265c80` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix #512: the awf-self profile's validation only runs the CLI area's tests, so AWF's post-validation plan-conformance gate falsely rejects correct fixes to any non-CLI area (worker, service, gc). Broaden the self-validation so it actually exercises the change, and add a guard test so it can't silently re-narrow.

## Problem (verified)
When AWF fixes its own code under the `awf-self` profile, its `validate` phase (`.awf/workspace.yml`, the `phases.validate:` block, ~lines 58-66) runs only `ruff check src/awf/cli`, `mypy src/awf/cli`, `pytest tests/unit/cli`, and one guardrail test. The post-validation conformance check (`src/awf/control/executor/planning_ops.py:_run_post_validation_conformance_check`, ~267-389) then compares the recorded `ValidationRun.commands` against the diff and correctly reports "AWF validation evidence does not exercise the change" for any change outside `src/awf/cli` — failing the workspace as `agent_failure`. This sank the #509 fix workspace (it lived in `src/awf/control/worker/*`) and forced a manual salvage. Secondary harm: the CLI-scoped phase never runs broad repo guardrails like `tests/unit/test_core_decomposition_maintainability.py` (the 1500-line file-limit check), so it can hide real deterministic failures (the #509 salvage tripped exactly that, caught only by a manual full-suite run).

`strategy.edit_gate: targeted` is set in the profile but never actually drives command derivation.

## Approach (LOCKED — broaden + guard)
1. Broaden the `awf-self` `validate` phase in `.awf/workspace.yml` so it exercises ALL of `src/awf` and runs the full unit suite, not just the CLI slice:
   - `ruff check src/awf tests` (whole package + tests, not just `src/awf/cli`)
   - `mypy src/awf`
   - `pytest tests/unit -q` run in PARALLEL (use the project's xdist setup, e.g. `-n auto` or a fixed worker count, matching how the `coverage:` command already parallelizes) with a generous `timeout_seconds` (e.g. 1800) so the phase stays reasonable.
   Keep the `setup` phase and the `coverage:` block as they are. IMPORTANT: first check whether the profile's `coverage:` block (the full `pytest --cov=awf`) already runs during workspace validation. If it already runs the full suite during validation, do NOT double-run it — instead the minimal change is to ensure the conformance gate's evidence reflects that full run (broaden the validate phase only as much as needed to make `_run_post_validation_conformance_check` see that non-CLI changes are exercised). Prefer the simplest change that makes a worker/service fix pass conformance without running the whole suite twice. Explain in the PR which path you took and why.
2. Add a guard test (new file `tests/unit/test_awf_self_profile_validation_scope.py`) that loads `.awf/workspace.yml`, finds the `awf-self` profile's `validate` phase, and asserts its commands cover `src/awf` broadly (ruff/mypy target `src/awf`, not only `src/awf/cli`; the pytest command targets `tests/unit`, not only `tests/unit/cli`). This both exercises the config change (so conformance passes) and prevents a future silent re-narrowing.

## Why the guard test matters for THIS workspace (chicken-and-egg)
This workspace itself runs under the OLD (CLI-scoped) validate phase loaded at creation; your edit to `.awf/workspace.yml` only takes effect for FUTURE workspaces. So for THIS workspace's own validation to pass conformance, the validation must exercise your change. The launch passes `--test` pointing at the new guard test (`tests/unit/test_awf_self_profile_validation_scope.py`), which reads and asserts the broadened config — that is what exercises the diff. Put the guard test at exactly that path so the `--test` command runs it. Keep the change minimal: the profile edit + that one guard test (plus any tiny helper if needed).

## Tests
- The guard test above (behavioral: parse the YAML, assert scope; include a negative-style assertion documenting what "too narrow" looks like).
- Run `ruff`, `mypy`, and the full `--cov=awf --cov-fail-under=99` suite green.

## Scope discipline
Touch only `.awf/workspace.yml` and the new guard test (+ minimal helper if truly needed). `.awf/workspace.yml` is a protected file — it is in your owned paths for this workspace. PR to development.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI/dogfood validation config and a new unit guard test; no runtime product logic.
> 
> **Overview**
> Fixes **#512** by widening the `awf-self` profile **`validate`** phase so post-validation plan conformance sees evidence for changes outside the CLI.
> 
> **`.awf/workspace.yml`** replaces CLI-only checks with **`ruff check src/awf tests`**, **`mypy src/awf`**, and **`pytest tests/unit -n 3 -q`** (1800s timeout). It drops the separate CLI pytest run and the single guardrail test that lived in validate.
> 
> **`tests/unit/test_awf_self_profile_validation_scope.py`** loads the real profile YAML and asserts ruff/mypy/pytest targets cover **`src/awf`** and **`tests/unit`**, plus a rule that no validate command may target only **`src/awf/cli`** / **`tests/unit/cli`** without the broad paths—blocking silent re-narrowing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37c2ba2a0c525bab7aaeaae30212a8672b5b0486. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced validation framework to ensure comprehensive testing and code quality checks across the entire codebase rather than isolated components.

* **Chores**
  * Improved internal validation configuration for broader code coverage verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->