### PR TITLE
fix: bounded-retry transient forge auth errors in PR monitor, GitHub + BitBucket (#515)

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/config.py
+++ b/src/awf/runtime/pr_monitor_runner/config.py
@@ -36,3 +36,13 @@ class MonitorRunnerConfig:
     transient_base_fetch_max_retries: int = 5
     transient_base_fetch_initial_backoff_seconds: float = 5.0
     transient_base_fetch_max_backoff_seconds: float = 120.0
+    # Transient forge (GitHub/Bitbucket) API faults — an ambiguous auth blip
+    # (a bare ``HTTP 401`` / ``Requires authentication`` with no strong permanent
+    # marker, or a Bitbucket 401/403), a 5xx, a rate-limit, or a transport fault —
+    # are bounded-retryable with exponential backoff so a momentary blip recovers
+    # instead of terminating a healthy auto-merge (#515). Kept separate from the
+    # base-fetch knobs (own config + own per-context retry count) so the two never
+    # entangle, while sharing only the pure backoff schedule.
+    transient_forge_max_retries: int = 5
+    transient_forge_initial_backoff_seconds: float = 5.0
+    transient_forge_max_backoff_seconds: float = 120.0

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -17,9 +17,15 @@ from awf.service.staleness import (
 
 _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES = RETRYABLE_MONITOR_OPERATION_STATUSES
 
+# Strong, unambiguous permanent markers. A fault carrying any of these is a
+# genuine credential/identity/repository failure that no amount of retrying can
+# fix, so the monitor fails fast. Deliberately does NOT include the broad
+# ``"authentication"`` / ``"auth failed"`` substrings: a bare
+# ``Requires authentication (HTTP 401)`` is frequently a transient GraphQL blip
+# on a valid token (#515) and is handled as bounded-retryable below. These strong
+# markers are checked first in ``_is_transient_github_client_error`` and win, so a
+# 401 combined with e.g. ``Bad credentials`` still fails fast.
 _NON_TRANSIENT_GITHUB_ERROR_MARKERS = (
-    "authentication",
-    "auth failed",
     "bad credentials",
     "not logged in",
     "please run gh auth login",
@@ -63,11 +69,23 @@ _TRANSIENT_GITHUB_ERROR_MARKERS = (
     "temporary failure in name resolution",
     "name or service not known",
     "could not resolve proxy",
+    # Ambiguous auth blips: a bare ``HTTP 401`` / ``Requires authentication`` with
+    # no strong permanent marker is treated as a recoverable transient (#515). The
+    # strong markers above are checked first and win, so a genuine bad-credentials
+    # 401 still fails fast. Git's own auth wording (``fatal: Authentication
+    # failed`` / ``returned error: 401``) contains neither substring, so base-fetch
+    # classification is unaffected and git auth failures still terminate.
+    "http 401",
+    "requires authentication",
 )
 
 _GITHUB_TRANSIENT_RETRY_REASON = "GITHUB_TRANSIENT_RETRY"
 
+_GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON = "GITHUB_TRANSIENT_RETRY_EXHAUSTED"
+
 _BITBUCKET_TRANSIENT_RETRY_REASON = "BITBUCKET_TRANSIENT_RETRY"
+
+_BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON = "BITBUCKET_TRANSIENT_RETRY_EXHAUSTED"
 
 # Bitbucket HTTP statuses that the monitor treats as recoverable server-side
 # blips (symmetric to GitHub's 5xx transient markers).
@@ -171,6 +189,11 @@ _TOKEN_RE = re.compile(
 _BROKEN_AWF_REF_RE = re.compile(r"refs/heads/awf/(ws_[A-Za-z0-9_-]+)")
 
 _BASE_FETCH_RETRY_COUNT_KEY_PREFIX = "__awf_base_fetch_retry_count:"
+
+# Per-context retry counter for transient forge (GitHub/Bitbucket) API faults,
+# parallel to ``_BASE_FETCH_RETRY_COUNT_KEY_PREFIX`` but fully separate so forge
+# and base-fetch budgets never share state (#515).
+_FORGE_TRANSIENT_RETRY_COUNT_KEY_PREFIX = "__awf_forge_transient_retry_count:"
 
 _SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY = "__awf_sync_base_no_progress_signature"
 

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -69,12 +69,20 @@ _TRANSIENT_GITHUB_ERROR_MARKERS = (
     "temporary failure in name resolution",
     "name or service not known",
     "could not resolve proxy",
-    # Ambiguous auth blips: a bare ``HTTP 401`` / ``Requires authentication`` with
-    # no strong permanent marker is treated as a recoverable transient (#515). The
-    # strong markers above are checked first and win, so a genuine bad-credentials
-    # 401 still fails fast. Git's own auth wording (``fatal: Authentication
-    # failed`` / ``returned error: 401``) contains neither substring, so base-fetch
-    # classification is unaffected and git auth failures still terminate.
+)
+
+# Ambiguous auth blips: a bare ``HTTP 401`` / ``Requires authentication`` with no
+# strong permanent marker is a recoverable transient on the GitHub *API* client
+# path (a GraphQL blip on a valid token, #515). The strong markers above are
+# checked first and win, so a genuine bad-credentials 401 still fails fast.
+#
+# These markers apply ONLY to ``_is_transient_github_client_error``, never to raw
+# git base-fetch stderr: git's smart-HTTP transport surfaces genuine credential
+# failures as ``error: RPC failed; HTTP 401`` (a contiguous ``HTTP 401``
+# substring), which must fail fast rather than be bounded-retried. They are
+# therefore deliberately kept out of ``_TRANSIENT_GITHUB_ERROR_MARKERS`` so
+# ``_is_transient_base_fetch_error`` never matches them.
+_AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = (
     "http 401",
     "requires authentication",
 )

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -18,6 +18,7 @@ from awf.common.bitbucket_client import BitbucketClientError
 from awf.common.bitbucket_client_parsing import is_task_thread_id
 from awf.common.forge_errors import ForgeClientError
 from awf.common.github_client import (
+    GitHubClientError,
     RepoRef,
 )
 from awf.runtime.logs import WorkspaceLogSink
@@ -38,13 +39,17 @@ from awf.runtime.pr_monitor_runner.comments import (
 from awf.runtime.pr_monitor_runner.constants import (
     _AUDIT_COMMENT_RESOLUTION_EVENT,
     _AUDIT_GIT_PUSH_EVENT,
+    _BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
     _BITBUCKET_TRANSIENT_RETRY_REASON,
+    _GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
     _GITHUB_TRANSIENT_RETRY_REASON,
     _GITHUB_WORKFLOW_SCOPE_REQUIRED_REASON,
 )
 from awf.runtime.pr_monitor_runner.helpers import (
     _clear_addressed_state_by_id,
     _defer_reason_state_key,
+    _is_transient_bitbucket_client_error,
+    _is_transient_github_client_error,
     _mark_review_comment_addressed,
     _redact_and_truncate_forge_error,
     _review_comment_needs_attention,
@@ -593,6 +598,55 @@ async def _run_fix_cycle(
                     action="resolve_thread",
                     outcome="needs_human",
                     reason_code=exc.reason_code,
+                    pr_number=pr_number,
+                    status=None,
+                    base_branch=base_branch or "",
+                    remote_branch=remote_branch,
+                    operation_id=operation_id,
+                    operation_type=operation_type,
+                    monitor_log=monitor_log,
+                    source_head_sha=pushed_head_sha,
+                    evidence={
+                        "thread_ids": [tid],
+                        "resolved_thread_count": 0,
+                        "needs_human_thread_count": 1,
+                        "error_message": str(exc),
+                    },
+                )
+                continue
+            # ``_wait_after_transient_forge_error`` returns False for BOTH a
+            # deterministic resolve fault and a still-*transient* blip whose bounded
+            # retry budget was just exhausted. These must NOT share the clear-marker
+            # path for a still-open (non-outdated) comment thread: a deterministic
+            # fault clears the marker so the next poll re-routes the open thread
+            # through AddressComments (the #305-safe default). On exhaustion the
+            # underlying fault is still transient (auth/transport/5xx) — something the
+            # agent cannot fix — and the per-context counter is deliberately kept at
+            # its ceiling, so clearing the marker would re-address the thread, hit the
+            # budget again on the very next resolve, re-clear, and re-run the agent
+            # every poll: the exact fix-cycle storm the bounded budget exists to stop.
+            # Escalate to ``needs_human`` instead (mirroring the task path above): the
+            # thread stays UNRESOLVED so the merge gate keeps blocking, decide() routes
+            # it to NotifyHuman (not AddressComments), and an operator repairs the
+            # forge fault. Outdated threads are excluded — they can never re-route
+            # through AddressComments, so the storm does not apply and their verdict
+            # is preserved for the outdated-resolution step below.
+            if isinstance(exc, BitbucketClientError):
+                forge_fault_is_transient = _is_transient_bitbucket_client_error(exc)
+                exhausted_reason = _BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON
+            else:
+                forge_fault_is_transient = _is_transient_github_client_error(
+                    cast(GitHubClientError, exc)
+                )
+                exhausted_reason = _GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON
+            if forge_fault_is_transient and tid not in outdated_thread_ids:
+                state.mark_addressed(tid, "needs_human")
+                await self._record_pr_monitor_audit_event(
+                    workspace_id=workspace_id,
+                    event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
+                    action="resolve_thread",
+                    outcome="needs_human",
+                    reason_code=exhausted_reason,
                     pr_number=pr_number,
                     status=None,
                     base_branch=base_branch or "",

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -339,6 +339,7 @@ async def _run_fix_cycle(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="fix_cycle_settle_fetch_pr_status",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 break
@@ -524,6 +525,7 @@ async def _run_fix_cycle(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="resolve_thread",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 # Transient fault: clear the addressed marker so the next poll
@@ -788,6 +790,7 @@ async def _capture_deferred_review_thread(
             workspace_id=workspace_id,
             pr_number=pr_number,
             context="capture_deferred_thread",
+            state=state,
             monitor_log=monitor_log,
         ):
             # Transient (502 / rate-limit / reset): a temporary issue-API outage

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -344,6 +344,13 @@ async def _run_fix_cycle(
             ):
                 break
             raise
+        # The settle re-poll succeeded: clear any stale retry count for this context
+        # so a recovered blip never accumulates toward the budget across fix cycles.
+        await self._clear_forge_transient_retry_state_on_success(
+            workspace_id=workspace_id,
+            state=state,
+            context="fix_cycle_settle_fetch_pr_status",
+        )
         new_threads = [
             t for t in status.unresolved_inline_threads if _review_thread_needs_attention(state, t)
         ]
@@ -639,6 +646,13 @@ async def _run_fix_cycle(
                 },
             )
         else:
+            # The resolve landed: clear any stale ``resolve_thread`` retry count so a
+            # recovered transient blip never accumulates toward the bounded budget.
+            await self._clear_forge_transient_retry_state_on_success(
+                workspace_id=workspace_id,
+                state=state,
+                context="resolve_thread",
+            )
             await self._record_pr_monitor_audit_event(
                 workspace_id=workspace_id,
                 event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,
@@ -840,6 +854,13 @@ async def _capture_deferred_review_thread(
             evidence={"thread_ids": [thread.thread_id], "error_message": redacted_error},
         )
         return False
+    # The tracking issue was filed: clear any stale ``capture_deferred_thread``
+    # retry count so a recovered blip never accumulates toward the bounded budget.
+    await self._clear_forge_transient_retry_state_on_success(
+        workspace_id=workspace_id,
+        state=state,
+        context="capture_deferred_thread",
+    )
     # Filing the tracking issue is the durable capture. Record it immediately so
     # a later retry (e.g. after a failed push) never files a duplicate, even if
     # the explanatory comment below fails. The comment is best-effort courtesy.

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from awf.common.bitbucket_client import (
     BITBUCKET_API_ERROR,
+    BITBUCKET_AUTH_FAILED,
     BITBUCKET_MERGE_IN_PROGRESS,
     BITBUCKET_MERGE_TASK_TIMEOUT,
     BITBUCKET_RATE_LIMITED,
@@ -90,6 +91,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _AWF_VERDICT,
     _BASE_FETCH_RETRY_COUNT_KEY_PREFIX,
     _BITBUCKET_TRANSIENT_HTTP_STATUSES,
+    _FORGE_TRANSIENT_RETRY_COUNT_KEY_PREFIX,
     _NON_TRANSIENT_GITHUB_ERROR_MARKERS,
     _PENDING_CHECK_STATUSES,
     _PR_MONITOR_REASON_CODES_BY_STALE_REASON,
@@ -551,8 +553,10 @@ def _transient_github_retry_payload(
     context: str,
     pr_number: int,
     wait_seconds: float,
+    retry_number: int | None = None,
+    max_retries: int | None = None,
 ) -> dict[str, object]:
-    return {
+    payload: dict[str, object] = {
         "context": context,
         "operation": exc.operation,
         "returncode": exc.returncode,
@@ -561,6 +565,11 @@ def _transient_github_retry_payload(
         "message": _redact_and_truncate_forge_error(str(exc)),
         "stderr": _redact_and_truncate_forge_error(exc.stderr),
     }
+    if retry_number is not None:
+        payload["retry_number"] = retry_number
+    if max_retries is not None:
+        payload["max_retries"] = max_retries
+    return payload
 
 
 def _transient_bitbucket_retry_payload(
@@ -569,10 +578,12 @@ def _transient_bitbucket_retry_payload(
     context: str,
     pr_number: int,
     wait_seconds: float,
+    retry_number: int | None = None,
+    max_retries: int | None = None,
 ) -> dict[str, object]:
     # ``exc`` already carries a redacted body (set at construction), so its
     # ``str()`` is safe to log/persist; truncate to match the GitHub payload.
-    return {
+    payload: dict[str, object] = {
         "context": context,
         "operation": exc.operation,
         "status": exc.status,
@@ -581,6 +592,11 @@ def _transient_bitbucket_retry_payload(
         "wait_seconds": wait_seconds,
         "message": str(exc)[:400],
     }
+    if retry_number is not None:
+        payload["retry_number"] = retry_number
+    if max_retries is not None:
+        payload["max_retries"] = max_retries
+    return payload
 
 
 def _transient_base_fetch_retry_payload(
@@ -633,10 +649,15 @@ def _is_transient_bitbucket_client_error(exc: BitbucketClientError) -> bool:
     a 409 on the merge POST signalling an already-in-flight merge
     (``BITBUCKET_MERGE_IN_PROGRESS``), an exhausted async-merge poll budget while
     the merge task was still PENDING (``BITBUCKET_MERGE_TASK_TIMEOUT`` — Bitbucket
-    may still complete it server-side), and 5xx server faults. Deterministic
-    faults — auth, other 4xx, JSON parse, and
-    the pagination/SSRF safety aborts (which also carry ``status=None`` but
-    map to ``BITBUCKET_API_ERROR``) — must fail fast.
+    may still complete it server-side), 5xx server faults, and — symmetric with
+    GitHub's ambiguous-401 handling (#515) — any 401/403 auth fault
+    (``BITBUCKET_AUTH_FAILED``, set only for 401/403). A momentary auth blip
+    recovers within the bounded forge-retry budget; a genuinely bad token exhausts
+    the budget and terminates. ``BITBUCKET_AUTH_NOT_CONFIGURED`` (a deterministic
+    env-config error) is a distinct code and stays non-transient. Other
+    deterministic faults — non-auth 4xx, JSON parse, and the pagination/SSRF safety
+    aborts (which also carry ``status=None`` but map to ``BITBUCKET_API_ERROR``) —
+    must fail fast.
     """
 
     if exc.reason_code in (
@@ -644,6 +665,7 @@ def _is_transient_bitbucket_client_error(exc: BitbucketClientError) -> bool:
         BITBUCKET_TRANSPORT_ERROR,
         BITBUCKET_MERGE_IN_PROGRESS,
         BITBUCKET_MERGE_TASK_TIMEOUT,
+        BITBUCKET_AUTH_FAILED,
     ):
         return True
     if exc.reason_code != BITBUCKET_API_ERROR:
@@ -683,6 +705,33 @@ def _clear_transient_base_fetch_retry_state(state: MonitorState, *, context: str
     return state.threads_addressed_ids.pop(key, None) is not None
 
 
+def _forge_transient_retry_count_key(context: str) -> str:
+    return f"{_FORGE_TRANSIENT_RETRY_COUNT_KEY_PREFIX}{context}"
+
+
+def _increment_forge_transient_retry_count(state: MonitorState, context: str) -> int:
+    """Bump and return the per-context transient-forge retry count.
+
+    Mirrors :func:`_increment_base_fetch_retry_count` (own key prefix, own
+    counter) and is corrupt-value-safe: a non-integer stored value resets to 1 so
+    a malformed resumed state can never wedge the budget.
+    """
+    key = _forge_transient_retry_count_key(context)
+    raw_count = state.threads_addressed_ids.get(key, "0")
+    try:
+        current = int(raw_count)
+    except ValueError:
+        current = 0
+    retry_number = current + 1
+    state.threads_addressed_ids[key] = str(retry_number)
+    return retry_number
+
+
+def _clear_transient_forge_retry_state(state: MonitorState, *, context: str) -> bool:
+    key = _forge_transient_retry_count_key(context)
+    return state.threads_addressed_ids.pop(key, None) is not None
+
+
 def _ci_transient_rerun_attempt(
     state: MonitorState,
     *,
@@ -719,17 +768,38 @@ def _ci_failure_payload(failure: CheckFailure) -> dict[str, object]:
     }
 
 
+def _exponential_backoff_wait_seconds(
+    *,
+    retry_number: int,
+    initial_backoff_seconds: float,
+    max_backoff_seconds: float,
+) -> float:
+    """Compute the capped exponential backoff wait for the Nth retry.
+
+    Shared by the base-fetch and forge transient-retry paths so both use a single,
+    byte-identical schedule (DRY) without coupling their separate config knobs or
+    retry counters. ``retry_number`` is 1-based: the first retry waits
+    ``initial_backoff_seconds``, the second ``2x``, and so on, capped at
+    ``max_backoff_seconds``.
+    """
+    initial = max(initial_backoff_seconds, 0.0)
+    cap = max(max_backoff_seconds, 0.0)
+    exponent = min(max(retry_number - 1, 0), 30)
+    wait_seconds = initial * float(2**exponent)
+    return wait_seconds if wait_seconds < cap else cap
+
+
 def _base_fetch_retry_wait_seconds(
     *,
     retry_number: int,
     initial_backoff_seconds: float,
     max_backoff_seconds: float,
 ) -> float:
-    initial = max(initial_backoff_seconds, 0.0)
-    cap = max(max_backoff_seconds, 0.0)
-    exponent = min(max(retry_number - 1, 0), 30)
-    wait_seconds = initial * float(2**exponent)
-    return wait_seconds if wait_seconds < cap else cap
+    return _exponential_backoff_wait_seconds(
+        retry_number=retry_number,
+        initial_backoff_seconds=initial_backoff_seconds,
+        max_backoff_seconds=max_backoff_seconds,
+    )
 
 
 def _notification_key(*, head_sha: str, blocker_reason: str | None) -> str:

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -547,6 +547,25 @@ def _bitbucket_merge_rejection_reason(exc: BitbucketClientError) -> str:
     return f"Bitbucket rejected the merge attempt: {detail}"
 
 
+def _attach_transient_retry_counters(
+    payload: dict[str, object],
+    *,
+    retry_number: int | None,
+    max_retries: int | None,
+) -> dict[str, object]:
+    """Attach the optional retry-budget fields shared by forge retry payloads.
+
+    Both the GitHub and Bitbucket transient-retry payloads carry ``retry_number``
+    and ``max_retries`` only when the bounded-retry budget supplies them; centralise
+    that conditional attachment so the two builders stay in lockstep.
+    """
+    if retry_number is not None:
+        payload["retry_number"] = retry_number
+    if max_retries is not None:
+        payload["max_retries"] = max_retries
+    return payload
+
+
 def _transient_github_retry_payload(
     exc: GitHubClientError,
     *,
@@ -565,11 +584,9 @@ def _transient_github_retry_payload(
         "message": _redact_and_truncate_forge_error(str(exc)),
         "stderr": _redact_and_truncate_forge_error(exc.stderr),
     }
-    if retry_number is not None:
-        payload["retry_number"] = retry_number
-    if max_retries is not None:
-        payload["max_retries"] = max_retries
-    return payload
+    return _attach_transient_retry_counters(
+        payload, retry_number=retry_number, max_retries=max_retries
+    )
 
 
 def _transient_bitbucket_retry_payload(
@@ -592,11 +609,9 @@ def _transient_bitbucket_retry_payload(
         "wait_seconds": wait_seconds,
         "message": str(exc)[:400],
     }
-    if retry_number is not None:
-        payload["retry_number"] = retry_number
-    if max_retries is not None:
-        payload["max_retries"] = max_retries
-    return payload
+    return _attach_transient_retry_counters(
+        payload, retry_number=retry_number, max_retries=max_retries
+    )
 
 
 def _transient_base_fetch_retry_payload(

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -87,6 +87,7 @@ from awf.runtime.pr_monitor_runner.comments import (
     VerdictResult,
 )
 from awf.runtime.pr_monitor_runner.constants import (
+    _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
     _AUTHORIZATION_BEARER_RE,
     _AWF_VERDICT,
     _BASE_FETCH_RETRY_COUNT_KEY_PREFIX,
@@ -650,7 +651,11 @@ def _is_transient_github_client_error(exc: GitHubClientError) -> bool:
     text = f"{exc.operation}\n{exc.stderr}".lower()
     if any(marker in text for marker in _NON_TRANSIENT_GITHUB_ERROR_MARKERS):
         return False
-    return any(marker in text for marker in _TRANSIENT_GITHUB_ERROR_MARKERS)
+    if any(marker in text for marker in _TRANSIENT_GITHUB_ERROR_MARKERS):
+        return True
+    # Ambiguous auth blips are transient only on the GitHub API client path (#515);
+    # ``_is_transient_base_fetch_error`` deliberately does not consult them.
+    return any(marker in text for marker in _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS)
 
 
 def _is_transient_bitbucket_client_error(exc: BitbucketClientError) -> bool:

--- a/src/awf/runtime/pr_monitor_runner/lifecycle.py
+++ b/src/awf/runtime/pr_monitor_runner/lifecycle.py
@@ -484,6 +484,39 @@ async def _persist_forge_transient_retry_count(
         await s.commit()
 
 
+async def _remove_forge_transient_retry_count(
+    self: Any,
+    workspace_id: str,
+    *,
+    context: str,
+) -> None:
+    """Remove ONLY the bounded forge-transient retry counter for ``context``.
+
+    The success-path counterpart to :func:`_persist_forge_transient_retry_count`:
+    once a context's forge operation finally succeeds the incident is over, so the
+    persisted counter must be dropped. Like the persist side, it must touch *only*
+    the counter key, merged onto the DB-persisted state — never flush the whole
+    in-memory ``MonitorState``. Inside a fix-cycle the in-memory state can still
+    carry *unconfirmed* addressed verdicts for *later* ``threads_to_resolve`` whose
+    forge resolve calls have not run yet; the full :func:`_persist_state` would
+    flush those before their own resolve/rollback, so a cancel during a subsequent
+    transient resolve wait would reload them as addressed and let ``decide()`` skip
+    still-open feedback and merge over it (#305). Removing just the counter key
+    keeps the bounded-budget reset durable without persisting any unconfirmed
+    marker.
+    """
+    key = _forge_transient_retry_count_key(context)
+    async with self._deps.session_factory() as s:
+        ws = await WorkspaceRepository(s).get_for_update(workspace_id)
+        if ws is None:
+            return
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        if threads_addressed.pop(key, None) is None:
+            return
+        ws.monitor_threads_addressed = threads_addressed
+        await s.commit()
+
+
 async def _terminate_completed(
     self: Any,
     workspace_id: str,

--- a/src/awf/runtime/pr_monitor_runner/lifecycle.py
+++ b/src/awf/runtime/pr_monitor_runner/lifecycle.py
@@ -50,6 +50,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _SYNC_BASE_NO_PROGRESS_SIGNATURE_KEY,
 )
 from awf.runtime.pr_monitor_runner.helpers import (
+    _forge_transient_retry_count_key,
     _initial_review_grace_done_key,
     _initial_review_grace_started_key,
     _initial_review_grace_state_for_persistence,
@@ -446,6 +447,41 @@ async def _persist_state(self: Any, workspace_id: str, state: MonitorState) -> N
             ws.monitor_started_at = now_wall - timedelta(seconds=elapsed_seconds)
         await s.commit()
         state.clear_changed_thread_ids(newly_marked_thread_ids)
+
+
+async def _persist_forge_transient_retry_count(
+    self: Any,
+    workspace_id: str,
+    *,
+    context: str,
+    retry_number: int,
+) -> None:
+    """Persist ONLY the bounded forge-transient retry counter for ``context``.
+
+    The full :func:`_persist_state` flushes the entire in-memory ``MonitorState``.
+    Inside a fix-cycle ``_execute`` pass that state can still carry an
+    *unconfirmed* addressed verdict — e.g. a ``fix_committed`` thread whose
+    ``resolve_thread`` call, or a ``defer`` thread whose tracking-issue creation,
+    is the very forge operation being retried; the caller only rolls that verdict
+    back *after* the wait returns. Flushing the whole state during the backoff
+    would persist the unconfirmed marker before the rollback: if the monitor is
+    cancelled or restarted mid-wait, the next poll reloads the thread as addressed
+    even though the forge call failed, so ``decide()`` could skip still-open review
+    feedback and merge over it (#305). The fix-cycle safety model relies on
+    ``_execute`` never persisting unconfirmed markers (see
+    ``_resolve_addressed_outdated_threads``). Persist only the retry counter,
+    merged onto the DB-persisted state, so the bounded budget still survives across
+    polls without flushing any unconfirmed verdict.
+    """
+    key = _forge_transient_retry_count_key(context)
+    async with self._deps.session_factory() as s:
+        ws = await WorkspaceRepository(s).get_for_update(workspace_id)
+        if ws is None:
+            return
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        threads_addressed[key] = str(retry_number)
+        ws.monitor_threads_addressed = threads_addressed
+        await s.commit()
 
 
 async def _terminate_completed(

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -1398,6 +1398,13 @@ async def _execute(
                 error_message=str(exc),
             )
             raise
+        # The notification posted: clear any stale ``post_human_notification`` retry
+        # count so a recovered blip never accumulates toward the bounded budget.
+        await self._clear_forge_transient_retry_state_on_success(
+            workspace_id=workspace_id,
+            state=state,
+            context="post_human_notification",
+        )
         await self._deps.sleep(self._config.poll_interval_seconds)
         await self._finish_monitor_operation(
             operation,

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -1371,6 +1371,7 @@ async def _execute(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="post_human_notification",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 await self._finish_monitor_operation(

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -41,6 +41,7 @@ from awf.runtime.pr_monitor_runner.gates import (
 from awf.runtime.pr_monitor_runner.helpers import (
     _bitbucket_merge_rejection_reason,
     _clear_transient_base_fetch_retry_state,
+    _clear_transient_forge_retry_state,
     _gate_requires_validation_recovery,
     _initial_review_grace_wait_seconds,
     _merge_gate_blocks,
@@ -845,6 +846,11 @@ async def handle_merge_action(
                         state,
                         context="pre_merge_recheck",
                     )
+                    if _clear_transient_forge_retry_state(
+                        state,
+                        context="pre_merge_recheck",
+                    ):
+                        pre_merge_state_changed = True
                     if await self._refresh_pr_feedback_resolution_state(
                         workspace_id=workspace_id,
                         repo=repo,
@@ -1218,6 +1224,7 @@ async def handle_merge_action(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="pre_merge_recheck",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 return False
@@ -1239,6 +1246,7 @@ async def handle_merge_action(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="merge_method_preflight",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 return False
@@ -1280,6 +1288,7 @@ async def handle_merge_action(
                     workspace_id=workspace_id,
                     pr_number=pr_number,
                     context="post_human_notification",
+                    state=state,
                     monitor_log=monitor_log,
                 ):
                     return False
@@ -1324,6 +1333,7 @@ async def handle_merge_action(
                     workspace_id=workspace_id,
                     pr_number=pr_number,
                     context="merge_pr",
+                    state=state,
                     monitor_log=monitor_log,
                 ):
                     return False
@@ -1335,6 +1345,7 @@ async def handle_merge_action(
                     workspace_id=workspace_id,
                     pr_number=pr_number,
                     context="merge_pr",
+                    state=state,
                     monitor_log=monitor_log,
                 ):
                     return False

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -1293,8 +1293,24 @@ async def handle_merge_action(
                 ):
                     return False
                 raise
+            # The notification posted: clear any stale ``post_human_notification``
+            # retry count so a recovered blip never accumulates toward the budget.
+            await self._clear_forge_transient_retry_state_on_success(
+                workspace_id=workspace_id,
+                state=state,
+                context="post_human_notification",
+            )
             await self._deps.sleep(self._config.poll_interval_seconds)
             return False
+
+        # Past the preflight guard with no captured error: the merge-method preflight
+        # succeeded this attempt, so clear any stale ``merge_method_preflight`` retry
+        # count to keep a recovered blip from accumulating across merge attempts.
+        await self._clear_forge_transient_retry_state_on_success(
+            workspace_id=workspace_id,
+            state=state,
+            context="merge_method_preflight",
+        )
 
         if merge_method_notification_reason is not None:
             _log.warning(
@@ -1351,6 +1367,15 @@ async def handle_merge_action(
                     return False
                 blocker_detail = _redact_and_truncate_forge_error(merge_blocker.stderr)
                 blocker_reason = _merge_rejection_reason(merge_blocker.stderr)
+            # The merge call completed with a deterministic (non-transient) blocker:
+            # this incident is over, so clear any stale ``merge_pr`` retry count to
+            # give the next merge attempt a fresh bounded budget rather than resuming
+            # from blips that already recovered.
+            await self._clear_forge_transient_retry_state_on_success(
+                workspace_id=workspace_id,
+                state=state,
+                context="merge_pr",
+            )
             # Branch protection / restrictions often block merges; fall back to
             # the release-PR notify flow rather than failing the workspace.
             _log.warning(

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -44,6 +44,8 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _clear_transient_forge_retry_state,
     _gate_requires_validation_recovery,
     _initial_review_grace_wait_seconds,
+    _is_transient_bitbucket_client_error,
+    _is_transient_github_client_error,
     _merge_gate_blocks,
     _merge_rejection_reason,
     _non_check_reviewer_settle_decision,
@@ -1355,6 +1357,7 @@ async def handle_merge_action(
                     return False
                 blocker_detail = str(merge_blocker)[:400]
                 blocker_reason = _bitbucket_merge_rejection_reason(merge_blocker)
+                blocker_is_transient = _is_transient_bitbucket_client_error(merge_blocker)
             else:
                 if await self._wait_after_transient_github_error(
                     merge_blocker,
@@ -1367,15 +1370,23 @@ async def handle_merge_action(
                     return False
                 blocker_detail = _redact_and_truncate_forge_error(merge_blocker.stderr)
                 blocker_reason = _merge_rejection_reason(merge_blocker.stderr)
-            # The merge call completed with a deterministic (non-transient) blocker:
-            # this incident is over, so clear any stale ``merge_pr`` retry count to
-            # give the next merge attempt a fresh bounded budget rather than resuming
-            # from blips that already recovered.
-            await self._clear_forge_transient_retry_state_on_success(
-                workspace_id=workspace_id,
-                state=state,
-                context="merge_pr",
-            )
+                blocker_is_transient = _is_transient_github_client_error(merge_blocker)
+            # Reaching here means the wait helper returned False for one of two
+            # reasons: a *deterministic* blocker (the merge call got a definitive
+            # rejection) or a still-*transient* blip whose bounded retry budget was
+            # just exhausted (an under-budget transient would have returned True and
+            # re-polled above). Only the deterministic case is "incident over", so
+            # only then clear the stale ``merge_pr`` retry count to give the next
+            # merge attempt a fresh bounded budget. On exhaustion the blocker is still
+            # transient, so keep the persisted counter — otherwise each later poll
+            # re-spends a full retry budget instead of failing closed via the
+            # exhausted path, symmetric with fetch_pr_status / pre_merge_recheck.
+            if not blocker_is_transient:
+                await self._clear_forge_transient_retry_state_on_success(
+                    workspace_id=workspace_id,
+                    state=state,
+                    context="merge_pr",
+                )
             # Branch protection / restrictions often block merges; fall back to
             # the release-PR notify flow rather than failing the workspace.
             _log.warning(

--- a/src/awf/runtime/pr_monitor_runner/mixins.py
+++ b/src/awf/runtime/pr_monitor_runner/mixins.py
@@ -60,6 +60,7 @@ class RunnerDelegatesMixin:
     _refresh_operator_state_from_workspace = _lifecycle._refresh_operator_state_from_workspace
     _persist_state = _lifecycle._persist_state
     _persist_forge_transient_retry_count = _lifecycle._persist_forge_transient_retry_count
+    _remove_forge_transient_retry_count = _lifecycle._remove_forge_transient_retry_count
     _terminate_completed = _lifecycle._terminate_completed
     _reconcile_target_branch_after_merge = _lifecycle._reconcile_target_branch_after_merge
     _teardown_compose_stack = _lifecycle._teardown_compose_stack

--- a/src/awf/runtime/pr_monitor_runner/mixins.py
+++ b/src/awf/runtime/pr_monitor_runner/mixins.py
@@ -152,5 +152,8 @@ class RunnerDelegatesMixin:
     _wait_after_transient_github_error = _transient_ops._wait_after_transient_github_error
     _wait_after_transient_bitbucket_error = _transient_ops._wait_after_transient_bitbucket_error
     _wait_after_transient_forge_error = _transient_ops._wait_after_transient_forge_error
+    _clear_forge_transient_retry_state_on_success = (
+        _transient_ops._clear_forge_transient_retry_state_on_success
+    )
     _wait_after_transient_base_fetch_error = _transient_ops._wait_after_transient_base_fetch_error
     _write_defer_signal = _transient_ops._write_defer_signal

--- a/src/awf/runtime/pr_monitor_runner/mixins.py
+++ b/src/awf/runtime/pr_monitor_runner/mixins.py
@@ -59,6 +59,7 @@ class RunnerDelegatesMixin:
     _load_state = _lifecycle._load_state
     _refresh_operator_state_from_workspace = _lifecycle._refresh_operator_state_from_workspace
     _persist_state = _lifecycle._persist_state
+    _persist_forge_transient_retry_count = _lifecycle._persist_forge_transient_retry_count
     _terminate_completed = _lifecycle._terminate_completed
     _reconcile_target_branch_after_merge = _lifecycle._reconcile_target_branch_after_merge
     _teardown_compose_stack = _lifecycle._teardown_compose_stack

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -295,6 +295,7 @@ async def _resolve_addressed_outdated_threads(
                 workspace_id=workspace_id,
                 pr_number=pr_number,
                 context="resolve_outdated_thread",
+                state=state,
                 monitor_log=monitor_log,
             ):
                 await self._record_pr_monitor_audit_event(

--- a/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
+++ b/src/awf/runtime/pr_monitor_runner/outdated_resolution.py
@@ -386,6 +386,13 @@ async def _resolve_addressed_outdated_threads(
         # Resolve landed — clear any transient requeue flag from a prior poll so
         # ``decide`` no longer holds this thread at ``NotifyHuman``.
         state.threads_addressed_ids.pop(_outdated_resolve_requeued_key(tid), None)
+        # Also clear any stale bounded-retry count for this context so a recovered
+        # blip never accumulates toward the budget across polls.
+        await self._clear_forge_transient_retry_state_on_success(
+            workspace_id=workspace_id,
+            state=state,
+            context="resolve_outdated_thread",
+        )
         await self._record_pr_monitor_audit_event(
             workspace_id=workspace_id,
             event_type=_AUDIT_COMMENT_RESOLUTION_EVENT,

--- a/src/awf/runtime/pr_monitor_runner/runner.py
+++ b/src/awf/runtime/pr_monitor_runner/runner.py
@@ -48,6 +48,7 @@ from awf.runtime.pr_monitor_runner.config import (
 from awf.runtime.pr_monitor_runner.constants import _GIT_BASE_BEHIND_FAILED_REASON
 from awf.runtime.pr_monitor_runner.helpers import (
     _clear_transient_base_fetch_retry_state,
+    _clear_transient_forge_retry_state,
     _infer_service_work_dir,
 )
 from awf.runtime.pr_monitor_runner.mixins import RunnerDelegatesMixin
@@ -234,6 +235,7 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                         workspace_id=workspace_id,
                         pr_number=pr_number,
                         context="fetch_pr_status",
+                        state=state,
                         monitor_log=monitor_log,
                     ):
                         continue
@@ -259,7 +261,12 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                         reason_code=exc.reason_code,
                     )
                     return
-                if _clear_transient_base_fetch_retry_state(state, context="fetch_pr_status"):
+                cleared_retry_state = _clear_transient_base_fetch_retry_state(
+                    state, context="fetch_pr_status"
+                )
+                if _clear_transient_forge_retry_state(state, context="fetch_pr_status"):
+                    cleared_retry_state = True
+                if cleared_retry_state:
                     await self._persist_state(workspace_id, state)
                 feedback_state_changed = await self._refresh_pr_feedback_resolution_state(
                     workspace_id=workspace_id,
@@ -359,33 +366,43 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                     # subclass (e.g. the notify-permanent re-raise). Catching the
                     # shared base keeps either forge's fault from escaping ``run()``
                     # and crashing the background monitor task. Recoverable blips
-                    # wait and re-poll; deterministic faults terminate with the
-                    # preserved reason code. GitHub carries the base default
-                    # (``GITHUB_API_ERROR``); Bitbucket its specific code.
+                    # wait and re-poll (now with bounded exponential backoff so a
+                    # persistent execute-path blip exhausts the budget and
+                    # terminates instead of looping forever); deterministic faults
+                    # terminate with the preserved reason code. GitHub carries the
+                    # base default (``GITHUB_API_ERROR``); Bitbucket its specific
+                    # code.
+                    #
+                    # Pass a CLEAN state snapshot reloaded from the DB — never the
+                    # live ``state`` — to the bounded-retry helper. ``_execute``
+                    # mutates ``state`` in-memory as it works (e.g. the fix cycle
+                    # marks a thread addressed *before* the forge ``resolve_thread``
+                    # call), and when a ``ForgeClientError`` escapes ``_execute`` the
+                    # fix-cycle arms may not have run their roll-back
+                    # (``_clear_addressed_state_by_id``), so the live ``state`` can
+                    # carry unconfirmed addressed markers for threads whose API call
+                    # actually failed. The helper persists the state it is given;
+                    # persisting those markers would leave a thread
+                    # marked-addressed-but-open, and ``decide()`` filters addressed
+                    # IDs — so it would treat the still-open thread as handled
+                    # forever and let auto-merge bypass live feedback (the #305
+                    # mode). The reloaded snapshot carries only the already-committed
+                    # pre-``_execute`` mutations plus the durable per-context retry
+                    # count, so the budget accumulates across polls without leaking
+                    # in-flight markers.
+                    execute_retry_ws = await self._load_workspace(workspace_id)
+                    execute_retry_state = self._load_state(execute_retry_ws)
                     if await self._wait_after_transient_forge_error(
                         exc,
                         workspace_id=workspace_id,
                         pr_number=pr_number,
                         context="execute_action",
+                        state=execute_retry_state,
                         monitor_log=monitor_log,
                     ):
-                        # Do NOT persist ``state`` here. ``_execute`` mutates it
-                        # in-memory as it works (e.g. the fix cycle marks a thread
-                        # addressed *before* the forge ``resolve_thread`` call).
-                        # When a ``ForgeClientError`` escapes ``_execute`` the
-                        # fix-cycle arms may not have run their roll-back
-                        # (``_clear_addressed_state_by_id``), so the in-memory
-                        # ``state`` can carry unconfirmed addressed markers for
-                        # threads whose API call actually failed. Persisting them
-                        # would leave a thread marked-addressed-but-open, and
-                        # ``decide()`` filters addressed IDs — so it would treat the
-                        # still-open thread as handled forever and let auto-merge
-                        # bypass live feedback (the #305 mode). Mirror the
-                        # status-fetch transient arms (bare ``continue``): the next
-                        # outer iteration reloads clean state from the DB, and
-                        # threads genuinely resolved on the forge are not re-listed
-                        # while a failed resolve is re-addressed. Pre-``_execute``
-                        # mutations already persisted themselves above.
+                        # The next outer iteration reloads clean state from the DB,
+                        # and threads genuinely resolved on the forge are not
+                        # re-listed while a failed resolve is re-addressed.
                         continue
                     forge_label = "bitbucket" if isinstance(exc, BitbucketClientError) else "github"
                     await self._write_monitor_log(

--- a/src/awf/runtime/pr_monitor_runner/runner.py
+++ b/src/awf/runtime/pr_monitor_runner/runner.py
@@ -421,6 +421,11 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                         reason_code=exc.reason_code,
                     )
                     return
+                # ``_execute`` returned without raising, so the execute-path forge
+                # calls recovered: clear any stale ``execute_action`` retry count so a
+                # recovered blip never accumulates toward the budget across polls. The
+                # unconditional persist below flushes the clear (no extra write).
+                _clear_transient_forge_retry_state(state, context="execute_action")
                 await self._persist_state(workspace_id, state)
                 if terminal:
                     return

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -162,6 +162,23 @@ async def _run_bounded_transient_forge_retry(
     (classifier, payload builder, event names, reason codes).
     """
     if not spec.is_transient(exc):
+        # Deterministic (non-transient) fault: there is no retry to bound, so the
+        # bounded-retry incident this context may still be carrying is over. Clear
+        # any stale per-context counter left by a *prior* recovered transient blip
+        # before returning — otherwise the non-terminal callers (``resolve_thread``
+        # / ``capture_deferred_thread`` / ...) leave it in ``state`` and the runner
+        # persists it on the next save, so a later *unrelated* transient in the same
+        # context resumes from the old count and can exhaust the budget immediately.
+        # The exhausted path below deliberately keeps its counter (still transient →
+        # fail closed), mirroring ``merge_pr``'s ``if not blocker_is_transient``
+        # clear in ``merge_loop``. Clears (and persists) only when a counter is
+        # actually present, so the common deterministic-without-prior-blip path adds
+        # no extra DB write.
+        await self._clear_forge_transient_retry_state_on_success(
+            workspace_id=workspace_id,
+            state=state,
+            context=context,
+        )
         return False
     retry_number = _increment_forge_transient_retry_count(state, context)
     max_retries = max(self._runner_config.transient_forge_max_retries, 0)

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -396,9 +396,17 @@ async def _clear_forge_transient_retry_state_on_success(
     already perform, factored into one helper so every increment context resets
     symmetrically. Persists only when a counter was actually present, so the
     common no-blip success path adds no extra DB write.
+
+    The persist removes *only* the counter key, never the whole in-memory state
+    (:func:`_remove_forge_transient_retry_count`): a fix-cycle caller can hold
+    unconfirmed addressed verdicts for *later* ``threads_to_resolve`` whose forge
+    resolve calls have not run yet, and flushing those here would let a cancel
+    during a subsequent transient resolve wait reload them as addressed so
+    ``decide()`` skips still-open feedback and merges over it (#305) — symmetric
+    with :func:`_persist_forge_transient_retry_count` on the wait path.
     """
     if _clear_transient_forge_retry_state(state, context=context):
-        await self._persist_state(workspace_id, state)
+        await self._remove_forge_transient_retry_count(workspace_id, context=context)
 
 
 async def _wait_after_transient_base_fetch_error(

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -198,7 +198,14 @@ async def _run_bounded_transient_forge_retry(
                 )
             ],
         )
-        await self._persist_state(workspace_id, state)
+        # Persist only the bounded retry counter, never the whole in-memory state:
+        # a fix-cycle caller may still hold an unconfirmed addressed verdict that it
+        # rolls back only after this returns, and flushing it here would let a
+        # crash/restart reload it as addressed and merge over still-open feedback
+        # (#305). See _persist_forge_transient_retry_count.
+        await self._persist_forge_transient_retry_count(
+            workspace_id, context=context, retry_number=retry_number
+        )
         return False
     wait_seconds = _exponential_backoff_wait_seconds(
         retry_number=retry_number,
@@ -237,7 +244,14 @@ async def _run_bounded_transient_forge_retry(
             )
         ],
     )
-    await self._persist_state(workspace_id, state)
+    # Persist only the bounded retry counter, never the whole in-memory state: a
+    # fix-cycle caller may still hold an unconfirmed addressed verdict that it rolls
+    # back only after this returns, and flushing it here would let a crash/restart
+    # during the backoff reload it as addressed and merge over still-open feedback
+    # (#305). See _persist_forge_transient_retry_count.
+    await self._persist_forge_transient_retry_count(
+        workspace_id, context=context, retry_number=retry_number
+    )
     await self._deps.sleep(wait_seconds)
     return True
 

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -36,6 +36,7 @@ from awf.runtime.pr_monitor_runner.constants import (
 )
 from awf.runtime.pr_monitor_runner.helpers import (
     _base_fetch_retry_wait_seconds,
+    _clear_transient_forge_retry_state,
     _collect_defer_items,
     _exponential_backoff_wait_seconds,
     _increment_base_fetch_retry_count,
@@ -348,6 +349,32 @@ async def _wait_after_transient_forge_error(
     raise RuntimeError(  # pragma: no cover - only GitHub/Bitbucket subclasses exist
         f"unknown ForgeClientError subclass: {type(exc).__name__}"
     )
+
+
+async def _clear_forge_transient_retry_state_on_success(
+    self: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    context: str,
+) -> None:
+    """Reset a context's bounded forge-transient retry counter after success.
+
+    The per-context counter (:func:`_increment_forge_transient_retry_count`) is
+    persisted on every transient forge blip so a *consecutive* run of failures
+    stays bounded across polls. Once that context's forge operation finally
+    succeeds the incident is over, so the counter must be cleared — otherwise a
+    recovered one-off blip leaves a stale count behind, and later unrelated blips
+    in the same context resume from it and exhaust the bounded budget
+    prematurely, downgrading or terminating an otherwise-healthy monitor.
+
+    Mirrors the inline clear the ``fetch_pr_status`` / ``pre_merge_recheck`` paths
+    already perform, factored into one helper so every increment context resets
+    symmetrically. Persists only when a counter was actually present, so the
+    common no-blip success path adds no extra DB write.
+    """
+    if _clear_transient_forge_retry_state(state, context=context):
+        await self._persist_state(workspace_id, state)
 
 
 async def _wait_after_transient_base_fetch_error(

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -26,16 +26,20 @@ from awf.runtime.pr_monitor import (
     PRStatus,
 )
 from awf.runtime.pr_monitor_runner.constants import (
+    _BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
     _BITBUCKET_TRANSIENT_RETRY_REASON,
     _GIT_BASE_FETCH_TRANSIENT_RETRY_EXHAUSTED_REASON,
     _GIT_BASE_FETCH_TRANSIENT_RETRY_REASON,
     _GIT_FETCH_BASE_FAILED_REASON,
+    _GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
     _GITHUB_TRANSIENT_RETRY_REASON,
 )
 from awf.runtime.pr_monitor_runner.helpers import (
     _base_fetch_retry_wait_seconds,
     _collect_defer_items,
+    _exponential_backoff_wait_seconds,
     _increment_base_fetch_retry_count,
+    _increment_forge_transient_retry_count,
     _is_transient_base_fetch_error,
     _is_transient_bitbucket_client_error,
     _is_transient_github_client_error,
@@ -98,16 +102,72 @@ async def _wait_after_transient_github_error(
     workspace_id: str,
     pr_number: int,
     context: str,
+    state: MonitorState,
     monitor_log: WorkspaceLogSink | None,
 ) -> bool:
+    """Wait and keep polling on a recoverable GitHub blip, with bounded backoff.
+
+    A transient classification (5xx, rate-limit, transport, or an ambiguous
+    ``HTTP 401`` / ``Requires authentication`` with no strong permanent marker —
+    #515) increments a per-context retry count and, while under the budget, sleeps
+    an exponential backoff and returns ``True`` (retry). Once the budget is
+    exhausted it emits a distinct exhausted event, persists state, and returns
+    ``False`` so the caller terminates via its existing path with the forge's
+    preserved ``reason_code``. A non-transient (strong permanent) fault returns
+    ``False`` immediately. Mirrors the base-fetch bounded-retry machinery with its
+    own config + per-context counter so the two never entangle.
+    """
     if not _is_transient_github_client_error(exc):
         return False
-    wait_seconds = self._config.poll_interval_seconds
+    retry_number = _increment_forge_transient_retry_count(state, context)
+    max_retries = max(self._runner_config.transient_forge_max_retries, 0)
+    if retry_number > max_retries:
+        payload = _transient_github_retry_payload(
+            exc,
+            context=context,
+            pr_number=pr_number,
+            wait_seconds=0.0,
+            retry_number=retry_number,
+            max_retries=max_retries,
+        )
+        _log.warning(
+            "monitor.github_transient_error_retry_exhausted",
+            workspace_id=workspace_id,
+            **payload,
+        )
+        await self._write_monitor_log(
+            monitor_log,
+            {
+                "event": "monitor.github_transient_error_retry_exhausted",
+                "workspace_id": workspace_id,
+                "reason_code": _GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
+                **payload,
+            },
+        )
+        await self._append_workspace_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type="monitor.github_transient_error_retry_exhausted",
+                    reason_code=_GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
+                    payload=payload,
+                )
+            ],
+        )
+        await self._persist_state(workspace_id, state)
+        return False
+    wait_seconds = _exponential_backoff_wait_seconds(
+        retry_number=retry_number,
+        initial_backoff_seconds=self._runner_config.transient_forge_initial_backoff_seconds,
+        max_backoff_seconds=self._runner_config.transient_forge_max_backoff_seconds,
+    )
     payload = _transient_github_retry_payload(
         exc,
         context=context,
         pr_number=pr_number,
         wait_seconds=wait_seconds,
+        retry_number=retry_number,
+        max_retries=max_retries,
     )
     _log.warning(
         "monitor.github_transient_error_retrying",
@@ -133,6 +193,7 @@ async def _wait_after_transient_github_error(
             )
         ],
     )
+    await self._persist_state(workspace_id, state)
     await self._deps.sleep(wait_seconds)
     return True
 
@@ -144,23 +205,71 @@ async def _wait_after_transient_bitbucket_error(
     workspace_id: str,
     pr_number: int,
     context: str,
+    state: MonitorState,
     monitor_log: WorkspaceLogSink | None,
 ) -> bool:
-    """Wait and keep polling on a recoverable Bitbucket blip.
+    """Wait and keep polling on a recoverable Bitbucket blip, with bounded backoff.
 
     Mirrors :func:`_wait_after_transient_github_error` so Bitbucket workspaces
-    survive transient rate-limit/transport/5xx faults instead of terminating
-    immediately. Returns ``True`` when the caller should retry (``continue``),
-    ``False`` when the error is deterministic and must fail the monitor.
+    survive transient rate-limit/transport/5xx faults — and, symmetric with
+    GitHub's ambiguous-401 handling (#515), any 401/403 auth blip — instead of
+    terminating immediately. A transient classification increments a per-context
+    retry count and, while under the budget, sleeps an exponential backoff and
+    returns ``True`` (retry); once exhausted it emits a distinct exhausted event,
+    persists state, and returns ``False`` so the caller terminates with the
+    preserved ``reason_code``. A deterministic fault returns ``False`` immediately.
     """
     if not _is_transient_bitbucket_client_error(exc):
         return False
-    wait_seconds = self._config.poll_interval_seconds
+    retry_number = _increment_forge_transient_retry_count(state, context)
+    max_retries = max(self._runner_config.transient_forge_max_retries, 0)
+    if retry_number > max_retries:
+        payload = _transient_bitbucket_retry_payload(
+            exc,
+            context=context,
+            pr_number=pr_number,
+            wait_seconds=0.0,
+            retry_number=retry_number,
+            max_retries=max_retries,
+        )
+        _log.warning(
+            "monitor.bitbucket_transient_error_retry_exhausted",
+            workspace_id=workspace_id,
+            **payload,
+        )
+        await self._write_monitor_log(
+            monitor_log,
+            {
+                "event": "monitor.bitbucket_transient_error_retry_exhausted",
+                "workspace_id": workspace_id,
+                "reason_code": _BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
+                **payload,
+            },
+        )
+        await self._append_workspace_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type="monitor.bitbucket_transient_error_retry_exhausted",
+                    reason_code=_BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
+                    payload=payload,
+                )
+            ],
+        )
+        await self._persist_state(workspace_id, state)
+        return False
+    wait_seconds = _exponential_backoff_wait_seconds(
+        retry_number=retry_number,
+        initial_backoff_seconds=self._runner_config.transient_forge_initial_backoff_seconds,
+        max_backoff_seconds=self._runner_config.transient_forge_max_backoff_seconds,
+    )
     payload = _transient_bitbucket_retry_payload(
         exc,
         context=context,
         pr_number=pr_number,
         wait_seconds=wait_seconds,
+        retry_number=retry_number,
+        max_retries=max_retries,
     )
     _log.warning(
         "monitor.bitbucket_transient_error_retrying",
@@ -186,6 +295,7 @@ async def _wait_after_transient_bitbucket_error(
             )
         ],
     )
+    await self._persist_state(workspace_id, state)
     await self._deps.sleep(wait_seconds)
     return True
 
@@ -197,6 +307,7 @@ async def _wait_after_transient_forge_error(
     workspace_id: str,
     pr_number: int,
     context: str,
+    state: MonitorState,
     monitor_log: WorkspaceLogSink | None,
 ) -> bool:
     """Wait and keep polling on a recoverable forge (GitHub/Bitbucket) blip.
@@ -204,8 +315,10 @@ async def _wait_after_transient_forge_error(
     The forge-neutral entry point for the consolidated ``except ForgeClientError``
     catch arms: it dispatches to the per-forge wait helper so each keeps emitting
     its own transient-retry event and reason code (behaviour-preserving), while
-    callers no longer need to branch on the concrete forge type. Returns ``True``
-    when the caller should retry, ``False`` when the fault is deterministic.
+    callers no longer need to branch on the concrete forge type. ``state`` carries
+    the per-context bounded-retry counter through to the dispatched helper. Returns
+    ``True`` when the caller should retry, ``False`` when the fault is
+    deterministic or the bounded retry budget is exhausted.
     """
     if isinstance(exc, BitbucketClientError):
         return await _wait_after_transient_bitbucket_error(
@@ -214,6 +327,7 @@ async def _wait_after_transient_forge_error(
             workspace_id=workspace_id,
             pr_number=pr_number,
             context=context,
+            state=state,
             monitor_log=monitor_log,
         )
     if isinstance(exc, GitHubClientError):
@@ -223,6 +337,7 @@ async def _wait_after_transient_forge_error(
             workspace_id=workspace_id,
             pr_number=pr_number,
             context=context,
+            state=state,
             monitor_log=monitor_log,
         )
     # No per-forge wait helper exists for an unknown subclass, so we cannot emit

--- a/src/awf/runtime/pr_monitor_runner/transient_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/transient_ops.py
@@ -11,6 +11,8 @@ import json as json
 import os as os
 import re as re
 import time as time
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, cast
 
 from awf.common.bitbucket_client import BitbucketClientError
@@ -96,6 +98,150 @@ async def _fetch_status_for_decision(
     return cast(PRStatus, status)
 
 
+@dataclass(frozen=True)
+class _ForgeTransientRetrySpec:
+    """Forge-specific knobs for the shared bounded transient-retry routine.
+
+    The control flow for waiting on a recoverable GitHub vs Bitbucket blip is
+    byte-identical; only the classifier, payload builder, structured-event names,
+    and reason codes differ per forge. Capturing exactly those differences here
+    lets :func:`_run_bounded_transient_forge_retry` carry the single shared
+    implementation while each forge keeps emitting its own distinct event +
+    reason code (behaviour-preserving).
+    """
+
+    is_transient: Callable[[Any], bool]
+    build_payload: Callable[..., dict[str, object]]
+    retrying_event: str
+    exhausted_event: str
+    retrying_reason: str
+    exhausted_reason: str
+
+
+_GITHUB_TRANSIENT_RETRY_SPEC = _ForgeTransientRetrySpec(
+    is_transient=_is_transient_github_client_error,
+    build_payload=_transient_github_retry_payload,
+    retrying_event="monitor.github_transient_error_retrying",
+    exhausted_event="monitor.github_transient_error_retry_exhausted",
+    retrying_reason=_GITHUB_TRANSIENT_RETRY_REASON,
+    exhausted_reason=_GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
+)
+
+
+_BITBUCKET_TRANSIENT_RETRY_SPEC = _ForgeTransientRetrySpec(
+    is_transient=_is_transient_bitbucket_client_error,
+    build_payload=_transient_bitbucket_retry_payload,
+    retrying_event="monitor.bitbucket_transient_error_retrying",
+    exhausted_event="monitor.bitbucket_transient_error_retry_exhausted",
+    retrying_reason=_BITBUCKET_TRANSIENT_RETRY_REASON,
+    exhausted_reason=_BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
+)
+
+
+async def _run_bounded_transient_forge_retry(
+    self: Any,
+    exc: ForgeClientError,
+    *,
+    workspace_id: str,
+    pr_number: int,
+    context: str,
+    state: MonitorState,
+    monitor_log: WorkspaceLogSink | None,
+    spec: _ForgeTransientRetrySpec,
+) -> bool:
+    """Shared bounded-backoff retry routine for one forge's transient blips.
+
+    A transient classification (per ``spec.is_transient``) increments a
+    per-context retry count and, while under the budget, sleeps an exponential
+    backoff and returns ``True`` (retry). Once the budget is exhausted it emits a
+    distinct exhausted event, persists state, and returns ``False`` so the caller
+    terminates via its existing path with the forge's preserved ``reason_code``. A
+    non-transient (deterministic) fault returns ``False`` immediately. Mirrors the
+    base-fetch bounded-retry machinery with its own config + per-context counter so
+    the two never entangle; ``spec`` supplies the only forge-specific differences
+    (classifier, payload builder, event names, reason codes).
+    """
+    if not spec.is_transient(exc):
+        return False
+    retry_number = _increment_forge_transient_retry_count(state, context)
+    max_retries = max(self._runner_config.transient_forge_max_retries, 0)
+    if retry_number > max_retries:
+        payload = spec.build_payload(
+            exc,
+            context=context,
+            pr_number=pr_number,
+            wait_seconds=0.0,
+            retry_number=retry_number,
+            max_retries=max_retries,
+        )
+        _log.warning(
+            spec.exhausted_event,
+            workspace_id=workspace_id,
+            **payload,
+        )
+        await self._write_monitor_log(
+            monitor_log,
+            {
+                "event": spec.exhausted_event,
+                "workspace_id": workspace_id,
+                "reason_code": spec.exhausted_reason,
+                **payload,
+            },
+        )
+        await self._append_workspace_events(
+            workspace_id=workspace_id,
+            events=[
+                WorkspaceEventCreate(
+                    event_type=spec.exhausted_event,
+                    reason_code=spec.exhausted_reason,
+                    payload=payload,
+                )
+            ],
+        )
+        await self._persist_state(workspace_id, state)
+        return False
+    wait_seconds = _exponential_backoff_wait_seconds(
+        retry_number=retry_number,
+        initial_backoff_seconds=self._runner_config.transient_forge_initial_backoff_seconds,
+        max_backoff_seconds=self._runner_config.transient_forge_max_backoff_seconds,
+    )
+    payload = spec.build_payload(
+        exc,
+        context=context,
+        pr_number=pr_number,
+        wait_seconds=wait_seconds,
+        retry_number=retry_number,
+        max_retries=max_retries,
+    )
+    _log.warning(
+        spec.retrying_event,
+        workspace_id=workspace_id,
+        **payload,
+    )
+    await self._write_monitor_log(
+        monitor_log,
+        {
+            "event": spec.retrying_event,
+            "workspace_id": workspace_id,
+            "reason_code": spec.retrying_reason,
+            **payload,
+        },
+    )
+    await self._append_workspace_events(
+        workspace_id=workspace_id,
+        events=[
+            WorkspaceEventCreate(
+                event_type=spec.retrying_event,
+                reason_code=spec.retrying_reason,
+                payload=payload,
+            )
+        ],
+    )
+    await self._persist_state(workspace_id, state)
+    await self._deps.sleep(wait_seconds)
+    return True
+
+
 async def _wait_after_transient_github_error(
     self: Any,
     exc: GitHubClientError,
@@ -115,88 +261,19 @@ async def _wait_after_transient_github_error(
     exhausted it emits a distinct exhausted event, persists state, and returns
     ``False`` so the caller terminates via its existing path with the forge's
     preserved ``reason_code``. A non-transient (strong permanent) fault returns
-    ``False`` immediately. Mirrors the base-fetch bounded-retry machinery with its
-    own config + per-context counter so the two never entangle.
+    ``False`` immediately. Thin wrapper over
+    :func:`_run_bounded_transient_forge_retry` with the GitHub spec.
     """
-    if not _is_transient_github_client_error(exc):
-        return False
-    retry_number = _increment_forge_transient_retry_count(state, context)
-    max_retries = max(self._runner_config.transient_forge_max_retries, 0)
-    if retry_number > max_retries:
-        payload = _transient_github_retry_payload(
-            exc,
-            context=context,
-            pr_number=pr_number,
-            wait_seconds=0.0,
-            retry_number=retry_number,
-            max_retries=max_retries,
-        )
-        _log.warning(
-            "monitor.github_transient_error_retry_exhausted",
-            workspace_id=workspace_id,
-            **payload,
-        )
-        await self._write_monitor_log(
-            monitor_log,
-            {
-                "event": "monitor.github_transient_error_retry_exhausted",
-                "workspace_id": workspace_id,
-                "reason_code": _GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
-                **payload,
-            },
-        )
-        await self._append_workspace_events(
-            workspace_id=workspace_id,
-            events=[
-                WorkspaceEventCreate(
-                    event_type="monitor.github_transient_error_retry_exhausted",
-                    reason_code=_GITHUB_TRANSIENT_RETRY_EXHAUSTED_REASON,
-                    payload=payload,
-                )
-            ],
-        )
-        await self._persist_state(workspace_id, state)
-        return False
-    wait_seconds = _exponential_backoff_wait_seconds(
-        retry_number=retry_number,
-        initial_backoff_seconds=self._runner_config.transient_forge_initial_backoff_seconds,
-        max_backoff_seconds=self._runner_config.transient_forge_max_backoff_seconds,
-    )
-    payload = _transient_github_retry_payload(
+    return await _run_bounded_transient_forge_retry(
+        self,
         exc,
-        context=context,
+        workspace_id=workspace_id,
         pr_number=pr_number,
-        wait_seconds=wait_seconds,
-        retry_number=retry_number,
-        max_retries=max_retries,
+        context=context,
+        state=state,
+        monitor_log=monitor_log,
+        spec=_GITHUB_TRANSIENT_RETRY_SPEC,
     )
-    _log.warning(
-        "monitor.github_transient_error_retrying",
-        workspace_id=workspace_id,
-        **payload,
-    )
-    await self._write_monitor_log(
-        monitor_log,
-        {
-            "event": "monitor.github_transient_error_retrying",
-            "workspace_id": workspace_id,
-            "reason_code": _GITHUB_TRANSIENT_RETRY_REASON,
-            **payload,
-        },
-    )
-    await self._append_workspace_events(
-        workspace_id=workspace_id,
-        events=[
-            WorkspaceEventCreate(
-                event_type="monitor.github_transient_error_retrying",
-                reason_code=_GITHUB_TRANSIENT_RETRY_REASON,
-                payload=payload,
-            )
-        ],
-    )
-    await self._persist_state(workspace_id, state)
-    await self._deps.sleep(wait_seconds)
-    return True
 
 
 async def _wait_after_transient_bitbucket_error(
@@ -219,86 +296,19 @@ async def _wait_after_transient_bitbucket_error(
     returns ``True`` (retry); once exhausted it emits a distinct exhausted event,
     persists state, and returns ``False`` so the caller terminates with the
     preserved ``reason_code``. A deterministic fault returns ``False`` immediately.
+    Thin wrapper over :func:`_run_bounded_transient_forge_retry` with the Bitbucket
+    spec.
     """
-    if not _is_transient_bitbucket_client_error(exc):
-        return False
-    retry_number = _increment_forge_transient_retry_count(state, context)
-    max_retries = max(self._runner_config.transient_forge_max_retries, 0)
-    if retry_number > max_retries:
-        payload = _transient_bitbucket_retry_payload(
-            exc,
-            context=context,
-            pr_number=pr_number,
-            wait_seconds=0.0,
-            retry_number=retry_number,
-            max_retries=max_retries,
-        )
-        _log.warning(
-            "monitor.bitbucket_transient_error_retry_exhausted",
-            workspace_id=workspace_id,
-            **payload,
-        )
-        await self._write_monitor_log(
-            monitor_log,
-            {
-                "event": "monitor.bitbucket_transient_error_retry_exhausted",
-                "workspace_id": workspace_id,
-                "reason_code": _BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
-                **payload,
-            },
-        )
-        await self._append_workspace_events(
-            workspace_id=workspace_id,
-            events=[
-                WorkspaceEventCreate(
-                    event_type="monitor.bitbucket_transient_error_retry_exhausted",
-                    reason_code=_BITBUCKET_TRANSIENT_RETRY_EXHAUSTED_REASON,
-                    payload=payload,
-                )
-            ],
-        )
-        await self._persist_state(workspace_id, state)
-        return False
-    wait_seconds = _exponential_backoff_wait_seconds(
-        retry_number=retry_number,
-        initial_backoff_seconds=self._runner_config.transient_forge_initial_backoff_seconds,
-        max_backoff_seconds=self._runner_config.transient_forge_max_backoff_seconds,
-    )
-    payload = _transient_bitbucket_retry_payload(
+    return await _run_bounded_transient_forge_retry(
+        self,
         exc,
-        context=context,
+        workspace_id=workspace_id,
         pr_number=pr_number,
-        wait_seconds=wait_seconds,
-        retry_number=retry_number,
-        max_retries=max_retries,
+        context=context,
+        state=state,
+        monitor_log=monitor_log,
+        spec=_BITBUCKET_TRANSIENT_RETRY_SPEC,
     )
-    _log.warning(
-        "monitor.bitbucket_transient_error_retrying",
-        workspace_id=workspace_id,
-        **payload,
-    )
-    await self._write_monitor_log(
-        monitor_log,
-        {
-            "event": "monitor.bitbucket_transient_error_retrying",
-            "workspace_id": workspace_id,
-            "reason_code": _BITBUCKET_TRANSIENT_RETRY_REASON,
-            **payload,
-        },
-    )
-    await self._append_workspace_events(
-        workspace_id=workspace_id,
-        events=[
-            WorkspaceEventCreate(
-                event_type="monitor.bitbucket_transient_error_retrying",
-                reason_code=_BITBUCKET_TRANSIENT_RETRY_REASON,
-                payload=payload,
-            )
-        ],
-    )
-    await self._persist_state(workspace_id, state)
-    await self._deps.sleep(wait_seconds)
-    return True
 
 
 async def _wait_after_transient_forge_error(

--- a/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
+++ b/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
@@ -839,8 +839,9 @@ class TestBitbucketApiError:
             compose_project="proj",
             compose_file=tmp_path / "compose.yml",
         )
-        # The transient 503 made the monitor wait one poll interval and re-poll.
-        assert sleep_fn.calls == [60]
+        # The transient 503 made the monitor wait the initial bounded-retry
+        # backoff (5.0s, retry #1) and re-poll — see #515.
+        assert sleep_fn.calls == [5.0]
         assert gh.calls == 2
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)

--- a/tests/unit/runtime/test_pr_monitor_merge_methods.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_methods.py
@@ -480,7 +480,7 @@ async def test_transient_merge_method_preflight_error_retries_without_blocker(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert gh.merge_calls == []
     assert gh.comments == []
     assert not any(
@@ -512,7 +512,7 @@ async def test_empty_branch_rules_slurp_preflight_error_retries_without_blocker(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert gh.merge_calls == []
     assert gh.comments == []
     assert not any(
@@ -583,7 +583,7 @@ async def test_merge_method_preflight_notification_transient_error_retries(
     assert terminal is False
     assert gh.merge_calls == []
     assert gh.comments == []
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert any(
         key.startswith("__awf_merge_method_blocked__:") for key in state.threads_addressed_ids
     )
@@ -623,7 +623,7 @@ async def test_merge_method_preflight_notification_transient_bitbucket_error_ret
     assert terminal is False
     assert gh.merge_calls == []
     assert gh.comments == []
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert any(
         key.startswith("__awf_merge_method_blocked__:") for key in state.threads_addressed_ids
     )
@@ -939,7 +939,7 @@ async def test_transient_first_merge_failure_does_not_retry_allowed_alternative(
 
     assert terminal is False
     assert gh.merge_calls == ["squash"]
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert gh.comments == []
     assert not any(
         key.startswith("__awf_merge_method_blocked__:") for key in state.threads_addressed_ids
@@ -1251,7 +1251,7 @@ async def test_transient_bitbucket_merge_failure_waits_without_notify(
     assert terminal is False
     assert gh.merge_calls == ["squash"]
     assert gh.comments == []
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
 
 
 @pytest.mark.unit
@@ -1296,7 +1296,7 @@ async def test_in_progress_bitbucket_merge_does_not_record_failed_operation(
     assert terminal is False
     assert gh.merge_calls == ["squash"]
     assert gh.comments == []
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
 
     async with factory() as session:
         operations = await OperationRepository(session).list_for_workspace(
@@ -1371,7 +1371,7 @@ async def test_merge_task_timeout_cancels_operation_and_keeps_polling(
     assert gh.merge_calls == ["squash"]
     # No "merge rejected" notification while the async merge may still be running.
     assert gh.comments == []
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
 
     async with factory() as session:
         operations = await OperationRepository(session).list_for_workspace(

--- a/tests/unit/runtime/test_pr_monitor_merge_methods.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_methods.py
@@ -947,6 +947,82 @@ async def test_transient_first_merge_failure_does_not_retry_allowed_alternative(
 
 
 @pytest.mark.unit
+async def test_exhausted_transient_merge_failure_preserves_retry_counter(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """An exhausted *transient* merge blip must not reset the ``merge_pr`` budget.
+
+    When the bounded forge-retry helper returns ``False`` because the budget is
+    exhausted (the merge error is still transient, not a deterministic rejection),
+    the merge arm falls back to notify-and-keep-polling. It must keep the persisted
+    ``merge_pr`` retry counter so later polls fail closed via the exhausted path,
+    rather than clearing it as if the blocker were deterministic and handing each
+    subsequent merge attempt a fresh full retry budget — symmetric with
+    ``fetch_pr_status`` / ``pre_merge_recheck`` (regression for the PR #516
+    merge-path counter-reset bug).
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    gh = _MergeMethodClient(
+        repo_methods=("squash",),
+        branch_methods=("squash",),
+        merge_results=[
+            GitHubClientError(
+                operation="gh pr merge",
+                returncode=1,
+                stderr="HTTP 502 Bad Gateway",
+            )
+        ],
+    )
+    gh.expect_context(
+        repo=_TEST_REPO,
+        pr_number=_TEST_PR_NUMBER,
+        base_branch=_TEST_DEFAULT_BASE_BRANCH,
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    # Zero retries: the first transient blip exhausts the budget immediately and
+    # drives the merge arm down the notify-and-keep-polling fallback.
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 0)
+    state = MonitorState()
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=workspace_id,
+        repo_url=f"git@github.com:{_TEST_REPO.slug()}.git",
+        repo=_TEST_REPO,
+        pr_number=_TEST_PR_NUMBER,
+        status=_mergeable_status(),
+        state=state,
+        base_branch=_TEST_DEFAULT_BASE_BRANCH,
+        remote_branch=f"awf/{workspace_id}",
+        remote_push_url=f"git@github.com:{_TEST_REPO.slug()}.git",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    assert terminal is False
+    assert gh.merge_calls == ["squash"]
+    # The exhausted-transient counter survives in memory and in the DB instead of
+    # being wiped like a deterministic blocker; the next poll therefore exhausts
+    # immediately rather than re-spending a full bounded budget.
+    counter_key = "__awf_forge_transient_retry_count:merge_pr"
+    assert state.threads_addressed_ids.get(counter_key) == "1"
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert (ws.monitor_threads_addressed or {}).get(counter_key) == "1"
+
+
+@pytest.mark.unit
 async def test_unclassified_first_merge_failure_notifies_without_method_mismatch(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
@@ -278,12 +278,15 @@ async def test_monitor_run_terminates_on_bitbucket_execute_error(
 
     async def fake_execute(**_kwargs: object) -> bool:
         # Model a non-merge forge call (e.g. resolve_thread) raising a
-        # deterministic Bitbucket fault the GitHubClientError-only arm misses.
+        # deterministic Bitbucket fault the GitHubClientError-only arm misses. A
+        # non-auth 4xx (``BITBUCKET_API_ERROR`` 404) is genuinely deterministic —
+        # 401/403 are now bounded-retryable (#515), so they would NOT terminate
+        # immediately here.
         raise BitbucketClientError(
             operation="bitbucket resolve_thread",
-            status=403,
-            body="thread resolution is not permitted for this token",
-            reason_code=BITBUCKET_AUTH_FAILED,
+            status=404,
+            body="thread not found",
+            reason_code=BITBUCKET_API_ERROR,
         )
 
     runner._execute = fake_execute  # type: ignore[method-assign]
@@ -300,7 +303,7 @@ async def test_monitor_run_terminates_on_bitbucket_execute_error(
         assert ws is not None
         assert ws.status == WorkspaceStatus.failed.value
         assert "bitbucket error" in (ws.failure_message or "")
-        assert ws.events[-1].reason_code == BITBUCKET_AUTH_FAILED
+        assert ws.events[-1].reason_code == BITBUCKET_API_ERROR
         # Deterministic fault terminates rather than entering the transient
         # re-poll loop.
         assert _bitbucket_retry_events(ws) == []
@@ -365,7 +368,7 @@ async def test_monitor_run_retries_transient_bitbucket_execute_error(
         compose_file=tmp_path / "compose.yml",
     )
 
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert gh.merge_attempts == 1
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
@@ -438,7 +441,7 @@ async def test_transient_bitbucket_execute_error_discards_unconfirmed_addressed_
     )
 
     assert calls["n"] == 2
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -490,7 +493,7 @@ async def test_monitor_run_transient_status_fetch_preserves_state_operations_and
             compose_file=tmp_path / "compose.yml",
         )
 
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     worktree = tmp_path / "worktrees" / workspace_id
     assert cmd.calls[0].args == _git_worktree_command(
         worktree,
@@ -512,7 +515,13 @@ async def test_monitor_run_transient_status_fetch_preserves_state_operations_and
         assert ws.status == WorkspaceStatus.monitoring_pr.value
         assert ws.failure_message is None
         assert ws.monitor_iter_count == 7
-        assert ws.monitor_threads_addressed == {"T_old": "defer"}
+        # The transient retry persists the per-context forge retry counter
+        # alongside the preserved pre-existing markers so the bounded budget
+        # survives the reload on the next poll (#515).
+        assert ws.monitor_threads_addressed == {
+            "T_old": "defer",
+            "__awf_forge_transient_retry_count:fetch_pr_status": "1",
+        }
         assert ws.monitor_last_commit_sha == "oldsha"
         assert _as_utc(ws.monitor_started_at) == started_at
         operation = await OperationRepository(s).get(operation_id)
@@ -529,7 +538,9 @@ async def test_monitor_run_transient_status_fetch_preserves_state_operations_and
             "operation": "gh api graphql",
             "returncode": 1,
             "pr_number": 42,
-            "wait_seconds": 60,
+            "wait_seconds": 5,
+            "retry_number": 1,
+            "max_retries": 5,
             "message": (
                 "gh api graphql failed (exit=1): HTTP 502 Bad Gateway for token <redacted>"
             ),
@@ -566,7 +577,7 @@ async def test_monitor_run_retries_transient_github_status_error(
         compose_file=tmp_path / "compose.yml",
     )
 
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -599,11 +610,58 @@ def test_transient_github_error_classifier_keeps_auth_errors_terminal() -> None:
             ),
         )
     )
+    # #515: a bare ``Requires authentication (HTTP 401)`` blip on a valid token is
+    # an ambiguous transient — it must now be bounded-retryable, not terminal.
+    assert _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh api graphql",
+            returncode=1,
+            stderr="Requires authentication (HTTP 401)",
+        )
+    )
+    # The exact #515 failure string.
+    assert _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh api graphql",
+            returncode=1,
+            stderr="gh api graphql failed (exit=1): gh: Requires authentication (HTTP 401)",
+        )
+    )
+    # Strong, unambiguous permanent markers still fail fast — including when
+    # combined with a 401 (the strong marker is checked first and wins).
     assert not _is_transient_github_client_error(
         GitHubClientError(
             operation="gh api graphql",
             returncode=1,
             stderr="Bad credentials",
+        )
+    )
+    assert not _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh api graphql",
+            returncode=1,
+            stderr="not logged in to any GitHub hosts",
+        )
+    )
+    assert not _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh auth status",
+            returncode=1,
+            stderr="To get started with GitHub CLI, please run gh auth login",
+        )
+    )
+    assert not _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh api graphql",
+            returncode=1,
+            stderr="could not resolve to a Repository with the name 'org/repo'",
+        )
+    )
+    assert not _is_transient_github_client_error(
+        GitHubClientError(
+            operation="gh api graphql",
+            returncode=1,
+            stderr="Bad credentials; Requires authentication (HTTP 401)",
         )
     )
     assert not _is_transient_github_client_error(
@@ -633,6 +691,19 @@ def test_transient_base_fetch_classifier_and_corrupt_retry_count_recovery() -> N
     )
     assert not _is_transient_base_fetch_error(
         BaseFetchError("git fetch origin development failed: repository not found")
+    )
+    # #515 regression: narrowing the GitHub non-transient markers (dropping the
+    # broad ``"authentication"`` substring) must NOT make git auth failures
+    # retryable — git's wording contains neither ``http 401`` nor
+    # ``requires authentication`` so it still classifies non-transient (terminate).
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError("fatal: Authentication failed for 'https://github.com/org/repo.git/'")
+    )
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError(
+            "fatal: unable to access 'https://github.com/org/repo.git/': "
+            "The requested URL returned error: 401"
+        )
     )
     retry_key = "__awf_base_fetch_retry_count:sync_base"
     state = MonitorState(threads_addressed_ids={retry_key: "not-an-integer"})
@@ -711,16 +782,20 @@ async def test_transient_retry_event_payload_is_structured_and_redacted(
         f"https://user:{secret}@github.com/example/repo " + ("x" * 600)
     )
 
+    state = MonitorState()
     retried = await runner._wait_after_transient_github_error(
         GitHubClientError(operation="gh api graphql", returncode=1, stderr=noisy_stderr),
         workspace_id=workspace_id,
         pr_number=42,
         context="fetch_pr_status",
+        state=state,
         monitor_log=None,
     )
 
     assert retried is True
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
+    # The bounded-retry counter is tracked per context and persisted.
+    assert state.threads_addressed_ids["__awf_forge_transient_retry_count:fetch_pr_status"] == "1"
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -734,7 +809,9 @@ async def test_transient_retry_event_payload_is_structured_and_redacted(
         assert payload["operation"] == "gh api graphql"
         assert payload["returncode"] == 1
         assert payload["pr_number"] == 42
-        assert payload["wait_seconds"] == 60
+        assert payload["wait_seconds"] == 5
+        assert payload["retry_number"] == 1
+        assert payload["max_retries"] == 5
         assert secret not in str(payload)
         assert "https://<redacted>@github.com/example/repo" in payload["stderr"]
         assert len(payload["stderr"]) <= 400
@@ -774,13 +851,15 @@ def test_is_transient_bitbucket_client_error_classifies_recoverable_blips() -> N
     assert _is_transient_bitbucket_client_error(
         err(status=None, reason_code=BITBUCKET_MERGE_TASK_TIMEOUT)
     )
+    # #515: a Bitbucket 401/403 auth fault (``BITBUCKET_AUTH_FAILED``, set only for
+    # 401/403) is now bounded-retryable, symmetric with GitHub's ambiguous-401
+    # handling — a momentary blip recovers, a real bad token exhausts the budget.
+    assert _is_transient_bitbucket_client_error(err(status=401, reason_code=BITBUCKET_AUTH_FAILED))
+    assert _is_transient_bitbucket_client_error(err(status=403, reason_code=BITBUCKET_AUTH_FAILED))
 
-    # Deterministic: auth failure, 4xx client error, JSON parse (2xx body), and
+    # Deterministic: non-auth 4xx client error, JSON parse (2xx body), and
     # the pagination/SSRF safety aborts — which also carry ``status=None`` but
     # map to ``BITBUCKET_API_ERROR`` and must fail fast, not loop.
-    assert not _is_transient_bitbucket_client_error(
-        err(status=403, reason_code=BITBUCKET_AUTH_FAILED)
-    )
     assert not _is_transient_bitbucket_client_error(
         err(status=404, reason_code=BITBUCKET_API_ERROR)
     )
@@ -814,16 +893,19 @@ async def test_wait_after_transient_bitbucket_error_retries_and_records_event(
         reason_code=BITBUCKET_API_ERROR,
     )
 
+    state = MonitorState()
     retried = await runner._wait_after_transient_bitbucket_error(
         exc,
         workspace_id=workspace_id,
         pr_number=42,
         context="fetch_pr_status",
+        state=state,
         monitor_log=None,
     )
 
     assert retried is True
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
+    assert state.threads_addressed_ids["__awf_forge_transient_retry_count:fetch_pr_status"] == "1"
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -838,7 +920,9 @@ async def test_wait_after_transient_bitbucket_error_retries_and_records_event(
         assert payload["status"] == 503
         assert payload["reason_code"] == BITBUCKET_API_ERROR
         assert payload["pr_number"] == 42
-        assert payload["wait_seconds"] == 60
+        assert payload["wait_seconds"] == 5
+        assert payload["retry_number"] == 1
+        assert payload["max_retries"] == 5
         assert secret not in str(payload)
         assert len(payload["message"]) <= 400
 
@@ -857,23 +941,29 @@ async def test_wait_after_transient_bitbucket_error_fails_fast_on_deterministic_
         sleep_fn=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
     )
+    # A non-auth 4xx is genuinely deterministic: 401/403 are now bounded-retryable
+    # (#515), so use a 404 ``BITBUCKET_API_ERROR`` to exercise the fail-fast path.
     exc = BitbucketClientError(
         operation="bitbucket fetch_pr_status",
-        status=403,
-        body="forbidden",
-        reason_code=BITBUCKET_AUTH_FAILED,
+        status=404,
+        body="not found",
+        reason_code=BITBUCKET_API_ERROR,
     )
 
+    state = MonitorState()
     retried = await runner._wait_after_transient_bitbucket_error(
         exc,
         workspace_id=workspace_id,
         pr_number=42,
         context="fetch_pr_status",
+        state=state,
         monitor_log=None,
     )
 
     assert retried is False
     assert sleep_fn.calls == []
+    # A deterministic fault must not touch the bounded-retry counter.
+    assert "__awf_forge_transient_retry_count:fetch_pr_status" not in state.threads_addressed_ids
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
@@ -705,6 +705,14 @@ def test_transient_base_fetch_classifier_and_corrupt_retry_count_recovery() -> N
             "The requested URL returned error: 401"
         )
     )
+    # #516 (PRRT_kwDOSJAM6s6InGJP) regression: git smart-HTTP surfaces genuine
+    # credential failures as ``error: RPC failed; HTTP 401`` — a contiguous
+    # ``HTTP 401`` substring. The ambiguous-auth markers are scoped to the GitHub
+    # API client path only, so this base-fetch auth failure must still fail fast
+    # rather than be bounded-retried as a transient blip.
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError("error: RPC failed; HTTP 401 curl 22 The requested URL returned error: 401")
+    )
     retry_key = "__awf_base_fetch_retry_count:sync_base"
     state = MonitorState(threads_addressed_ids={retry_key: "not-an-integer"})
 

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
@@ -1327,3 +1327,174 @@ async def test_task_resolve_forbidden_blocks_as_needs_human_without_retry_storm(
     assert payload["evidence"]["needs_human_thread_count"] == 1
     # Task body_excerpt should not leak into event payloads.
     assert "please add a regression test" not in repr(resolution_events[0].payload)
+
+
+@pytest.mark.unit
+async def test_resolve_thread_exhausted_transient_blocks_as_needs_human(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """When a still-open comment thread's resolve keeps hitting a transient forge
+    fault until the bounded retry budget is exhausted, the fix cycle must escalate
+    to ``needs_human`` rather than clear the addressed marker.
+
+    Clearing the marker (the deterministic-fault path) would re-route the still-open
+    thread through AddressComments next poll, immediately re-exhaust the deliberately
+    persisted counter on the next resolve, and re-run the agent every poll — the
+    exact storm the bounded budget exists to prevent. ``needs_human`` keeps the
+    thread UNRESOLVED so the merge gate keeps blocking and decide() routes to
+    NotifyHuman, and the exhausted reason code stays diagnosable in the audit event.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed fix locally.")
+    cmd.queue_result(returncode=0, stdout=pr_payload())
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=0, stdout="newsha\n")
+    cmd.queue_result(returncode=1, stderr="HTTP 502 Bad Gateway")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    # A budget of 0 retries exhausts on the first transient resolve fault — no
+    # backoff sleep, straight to the exhausted path within this single fix cycle.
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 0)
+    thread = ReviewThread(
+        thread_id="T_resolve",
+        path="src/foo.py",
+        line=12,
+        body_excerpt="please adjust this",
+        author="review-bot",
+    )
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=(thread,),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    # Escalated to needs_human (kept addressed → no re-address storm), NOT cleared.
+    assert state.threads_addressed_ids.get("T_resolve") == "needs_human"
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        # Not terminated: the workspace keeps polling.
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        # Exhaustion is recorded as such; no further backoff sleep happened.
+        exhausted_events = [
+            event
+            for event in ws.events
+            if event.event_type == "monitor.github_transient_error_retry_exhausted"
+        ]
+        assert _retry_events(ws) == []
+        resolution_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.comment_resolution",
+            limit=10,
+        )
+    assert len(exhausted_events) == 1
+    assert exhausted_events[0].reason_code == "GITHUB_TRANSIENT_RETRY_EXHAUSTED"
+    assert len(resolution_events) == 1
+    payload = resolution_events[0].payload
+    assert payload is not None
+    assert payload["action"] == "resolve_thread"
+    assert payload["outcome"] == "needs_human"
+    assert resolution_events[0].reason_code == "GITHUB_TRANSIENT_RETRY_EXHAUSTED"
+    assert payload["evidence"]["needs_human_thread_count"] == 1
+    assert payload["evidence"]["thread_ids"] == ["T_resolve"]
+    assert "please adjust this" not in repr(resolution_events[0].payload)
+
+
+@pytest.mark.unit
+async def test_resolve_thread_exhausted_transient_bitbucket_blocks_as_needs_human(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Bitbucket symmetry: an exhausted transient resolve budget on a still-open
+    comment thread escalates to ``needs_human`` with the Bitbucket exhausted reason
+    code, rather than clearing the marker and re-running the agent forever."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    adapter = FakeAdapter()
+    adapter.queue(stdout="Committed fix locally.")
+    cmd.queue_result(returncode=0, stdout=pr_payload())
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=0, stdout="newsha\n")
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        gh=_BitbucketResolveThreadClient(
+            cmd,
+            BitbucketClientError(
+                operation="bitbucket resolve_thread",
+                status=429,
+                body="rate limited",
+                reason_code=BITBUCKET_RATE_LIMITED,
+            ),
+        ),
+    )
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 0)
+    thread = ReviewThread(
+        thread_id="T_resolve",
+        path="src/foo.py",
+        line=12,
+        body_excerpt="please adjust this",
+        author="review-bot",
+    )
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=(thread,),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert state.threads_addressed_ids.get("T_resolve") == "needs_human"
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.monitoring_pr.value
+        exhausted_events = [
+            event
+            for event in ws.events
+            if event.event_type == "monitor.bitbucket_transient_error_retry_exhausted"
+        ]
+        resolution_events = await WorkspaceEventRepository(s).list(
+            workspace_id=workspace_id,
+            event_type="workspace.audit.comment_resolution",
+            limit=10,
+        )
+    assert len(exhausted_events) == 1
+    assert exhausted_events[0].reason_code == "BITBUCKET_TRANSIENT_RETRY_EXHAUSTED"
+    assert len(resolution_events) == 1
+    payload = resolution_events[0].payload
+    assert payload is not None
+    assert payload["action"] == "resolve_thread"
+    assert payload["outcome"] == "needs_human"
+    assert resolution_events[0].reason_code == "BITBUCKET_TRANSIENT_RETRY_EXHAUSTED"
+    assert payload["evidence"]["needs_human_thread_count"] == 1
+    assert "please adjust this" not in repr(resolution_events[0].payload)

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
@@ -9,7 +9,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.bitbucket_client import (
-    BITBUCKET_AUTH_FAILED,
+    BITBUCKET_API_ERROR,
     BITBUCKET_RATE_LIMITED,
     BITBUCKET_TASK_RESOLVE_FORBIDDEN,
     BitbucketClientError,
@@ -201,10 +201,11 @@ async def test_transient_github_merge_error_retries_without_human_escalation(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert len(cmd.calls) == 1
     assert cmd.calls[0].args[:3] == ["gh", "pr", "merge"]
-    assert state.threads_addressed_ids == {}
+    # Only the bounded-retry bookkeeping key is left behind — no thread markers.
+    assert state.threads_addressed_ids == {"__awf_forge_transient_retry_count:merge_pr": "1"}
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -215,7 +216,7 @@ async def test_transient_github_merge_error_retries_without_human_escalation(
         assert events[0].reason_code == "GITHUB_TRANSIENT_RETRY"
         assert events[0].payload["context"] == "merge_pr"
         assert events[0].payload["operation"] == "gh pr merge"
-        assert events[0].payload["wait_seconds"] == 60
+        assert events[0].payload["wait_seconds"] == 5
 
 
 @pytest.mark.unit
@@ -363,10 +364,13 @@ async def test_transient_human_notification_comment_error_retries_without_crashi
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [60]
+    assert sleep_fn.calls == [5]
     assert len(cmd.calls) == 1
     assert cmd.calls[0].args[:3] == ["gh", "pr", "comment"]
-    assert state.threads_addressed_ids == {}
+    # Only the bounded-retry bookkeeping key is left behind — no thread markers.
+    assert state.threads_addressed_ids == {
+        "__awf_forge_transient_retry_count:post_human_notification": "1"
+    }
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -377,7 +381,7 @@ async def test_transient_human_notification_comment_error_retries_without_crashi
         assert events[0].reason_code == "GITHUB_TRANSIENT_RETRY"
         assert events[0].payload["context"] == "post_human_notification"
         assert events[0].payload["operation"] == "gh pr comment"
-        assert events[0].payload["wait_seconds"] == 60
+        assert events[0].payload["wait_seconds"] == 5
 
 
 @pytest.mark.unit
@@ -459,8 +463,11 @@ async def test_transient_bitbucket_human_notification_comment_error_retries(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [60]
-    assert state.threads_addressed_ids == {}
+    assert sleep_fn.calls == [5]
+    # Only the bounded-retry bookkeeping key is left behind — no thread markers.
+    assert state.threads_addressed_ids == {
+        "__awf_forge_transient_retry_count:post_human_notification": "1"
+    }
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -562,7 +569,7 @@ async def test_fix_cycle_treats_transient_settle_poll_as_retryable(
         compose_file=tmp_path / "compose.yml",
     )
 
-    assert sleep_fn.calls == [30, 60]
+    assert sleep_fn.calls == [30, 5]
     assert state.threads_addressed_ids["T_retry"] == "fix_committed"
     assert _review_thread_body_state_key("T_retry") in state.threads_addressed_ids
     worktree = tmp_path / "worktrees" / workspace_id
@@ -624,7 +631,7 @@ async def test_resolve_thread_transient_failure_requeues_thread_safely(
         compose_file=tmp_path / "compose.yml",
     )
 
-    assert sleep_fn.calls == [30, 60]
+    assert sleep_fn.calls == [30, 5]
     assert "T_resolve" not in state.threads_addressed_ids
     assert state.last_push_sha == "newsha"
     worktree = tmp_path / "worktrees" / workspace_id
@@ -757,11 +764,13 @@ async def test_resolve_thread_permanent_bitbucket_failure_keeps_monitor_alive(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    # A permanent Bitbucket fault (403, token lacks the scope) during resolve_thread
-    # must forward the forge-native reason code (BITBUCKET_AUTH_FAILED here) and clear
-    # the addressed marker WITHOUT escaping the fix cycle — mirroring the GitHub arm's
-    # "do NOT drop out of the monitor" behaviour rather than terminating the workspace,
-    # and keeping the fault diagnosable instead of collapsing it to a generic placeholder.
+    # A permanent Bitbucket fault during resolve_thread must forward the
+    # forge-native reason code and clear the addressed marker WITHOUT escaping the
+    # fix cycle — mirroring the GitHub arm's "do NOT drop out of the monitor"
+    # behaviour rather than terminating the workspace, and keeping the fault
+    # diagnosable instead of collapsing it to a generic placeholder. A non-auth 4xx
+    # (``BITBUCKET_API_ERROR`` 404) is genuinely deterministic — 401/403 are now
+    # bounded-retryable (#515), so they would route through the transient arm.
     workspace_id = await seed_monitoring_workspace(factory)
     cmd = FakeCommandRunner()
     sleep_fn = RecordedSleep()
@@ -780,9 +789,9 @@ async def test_resolve_thread_permanent_bitbucket_failure_keeps_monitor_alive(
             cmd,
             BitbucketClientError(
                 operation="bitbucket resolve_thread",
-                status=403,
-                body="forbidden: missing scope",
-                reason_code=BITBUCKET_AUTH_FAILED,
+                status=404,
+                body="thread not found",
+                reason_code=BITBUCKET_API_ERROR,
             ),
         ),
     )
@@ -833,12 +842,12 @@ async def test_resolve_thread_permanent_bitbucket_failure_keeps_monitor_alive(
     assert resolution_events[0].payload is not None
     assert resolution_events[0].payload["action"] == "resolve_thread"
     assert resolution_events[0].payload["outcome"] == "failed"
-    assert resolution_events[0].payload["reason_code"] == BITBUCKET_AUTH_FAILED
+    assert resolution_events[0].payload["reason_code"] == BITBUCKET_API_ERROR
     assert resolution_events[0].payload["evidence"] == {
         "thread_ids": ["T_resolve"],
         "resolved_thread_count": 0,
         "failed_thread_count": 1,
-        "error_message": "bitbucket resolve_thread failed (status=403): forbidden: missing scope",
+        "error_message": "bitbucket resolve_thread failed (status=404): thread not found",
     }
     assert "please adjust this" not in repr(resolution_events[0].payload)
 
@@ -900,7 +909,7 @@ async def test_fix_cycle_treats_transient_bitbucket_settle_poll_as_retryable(
 
     # The transient blip breaks the settle loop and proceeds to push + resolve;
     # the addressed marker survives because the fix shipped.
-    assert sleep_fn.calls == [30, 60]
+    assert sleep_fn.calls == [30, 5]
     assert state.threads_addressed_ids["T_settle"] == "fix_committed"
     worktree = tmp_path / "worktrees" / workspace_id
     assert cmd.calls[0].args[:5] == _git_worktree_command(worktree)

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py
@@ -12,7 +12,6 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.bitbucket_client import (
     BITBUCKET_API_ERROR,
-    BITBUCKET_AUTH_FAILED,
     BitbucketClientError,
 )
 from awf.common.commands import FakeCommandRunner
@@ -584,7 +583,7 @@ async def test_pre_merge_recheck_transient_github_error_retries_later(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [2, 60]
+    assert sleep_fn.calls == [2, 5]
     assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
     assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
     async with factory() as s:
@@ -601,7 +600,7 @@ async def test_pre_merge_recheck_transient_github_error_retries_later(
         assert events[0].reason_code == "GITHUB_TRANSIENT_RETRY"
         assert events[0].payload["context"] == "pre_merge_recheck"
         assert events[0].payload["operation"] == "gh api graphql"
-        assert events[0].payload["wait_seconds"] == 60
+        assert events[0].payload["wait_seconds"] == 5
 
 
 @pytest.mark.unit
@@ -651,7 +650,7 @@ async def test_pre_merge_recheck_transient_bitbucket_error_retries_later(
     )
 
     assert terminal is False
-    assert sleep_fn.calls == [2, 60]
+    assert sleep_fn.calls == [2, 5]
     async with factory() as s:
         ws = await WorkspaceRepository(s).get(workspace_id)
         assert ws is not None
@@ -661,7 +660,7 @@ async def test_pre_merge_recheck_transient_bitbucket_error_retries_later(
         assert len(retry_events) == 1
         assert retry_events[0].reason_code == "BITBUCKET_TRANSIENT_RETRY"
         assert retry_events[0].payload["context"] == "pre_merge_recheck"
-        assert retry_events[0].payload["wait_seconds"] == 60
+        assert retry_events[0].payload["wait_seconds"] == 5
 
 
 @pytest.mark.unit
@@ -671,7 +670,11 @@ async def test_pre_merge_recheck_bitbucket_error_fails_workspace(
     mocker: pytest_mock.MockerFixture,
 ) -> None:
     """A deterministic Bitbucket fault during the pre-merge recheck terminates the
-    workspace with the actionable reason code preserved end-to-end."""
+    workspace with the actionable reason code preserved end-to-end.
+
+    A non-auth 4xx (``BITBUCKET_API_ERROR`` 404) is genuinely deterministic —
+    401/403 are now bounded-retryable (#515), so they route through the transient
+    arm rather than terminating immediately."""
     sleep_fn = RecordedSleep()
     workspace_id = await seed_monitoring_workspace(factory)
     runner = make_runner(
@@ -688,9 +691,9 @@ async def test_pre_merge_recheck_bitbucket_error_fails_workspace(
         mocker.AsyncMock(
             side_effect=BitbucketClientError(
                 operation="bitbucket fetch_pr_status",
-                status=403,
-                body="forbidden",
-                reason_code=BITBUCKET_AUTH_FAILED,
+                status=404,
+                body="not found",
+                reason_code=BITBUCKET_API_ERROR,
             )
         ),
     )
@@ -717,7 +720,7 @@ async def test_pre_merge_recheck_bitbucket_error_fails_workspace(
         assert ws is not None
         assert ws.status == WorkspaceStatus.failed.value
         assert "bitbucket error during pre-merge recheck" in (ws.failure_message or "")
-        assert ws.events[-1].reason_code == BITBUCKET_AUTH_FAILED
+        assert ws.events[-1].reason_code == BITBUCKET_API_ERROR
         assert _bitbucket_retry_events(ws) == []
 
 
@@ -778,7 +781,7 @@ async def test_pre_merge_recheck_unknown_status_after_retry_never_uses_old_green
 
     assert first_terminal is False
     assert second_terminal is False
-    assert sleep_fn.calls == [2, 60, 2, 60]
+    assert sleep_fn.calls == [2, 5, 2, 60]
     assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
     assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
     async with factory() as s:

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -392,6 +392,75 @@ async def test_clear_on_success_resets_per_context_budget_and_persists(
 
 
 @pytest.mark.unit
+async def test_clear_on_success_persists_only_counter_not_unconfirmed_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The success-path counter clear must persist ONLY the counter removal,
+    never the whole in-memory state.
+
+    In a fix cycle with multiple ``threads_to_resolve`` the in-memory state
+    already carries addressed verdicts for *later* threads whose forge resolve
+    calls have not run yet. When an earlier thread's resolve succeeds after a
+    prior transient blip, clearing its counter must not flush those later
+    unconfirmed verdicts: if the monitor is cancelled during a subsequent
+    transient resolve wait before its rollback executes, a full-state flush here
+    would reload those still-open threads as addressed and let ``decide()`` skip
+    them (#305).
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 2)
+    exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+    state = MonitorState()
+
+    # A prior transient ``resolve_thread`` blip persisted the counter to the DB.
+    assert (
+        await runner._wait_after_transient_github_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    assert state.threads_addressed_ids[_RESOLVE_THREAD_COUNT_KEY] == "1"
+
+    # The in-memory state now also holds an addressed verdict for a *later*
+    # thread whose resolve has not yet landed — exactly the unconfirmed marker
+    # that must never reach the DB before its own resolve/rollback.
+    state.threads_addressed_ids["PRRT_later"] = "fix_committed"
+
+    # This thread's resolve then succeeds: the counter is cleared in memory and
+    # the removal is persisted, but the later unconfirmed verdict must NOT be.
+    await runner._clear_forge_transient_retry_state_on_success(
+        workspace_id=workspace_id,
+        state=state,
+        context="resolve_thread",
+    )
+    assert _RESOLVE_THREAD_COUNT_KEY not in state.threads_addressed_ids
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        persisted = ws.monitor_threads_addressed or {}
+        assert _RESOLVE_THREAD_COUNT_KEY not in persisted
+        assert "PRRT_later" not in persisted
+
+
+@pytest.mark.unit
 async def test_clear_on_success_is_noop_without_a_counter(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -416,3 +416,89 @@ async def test_clear_on_success_is_noop_without_a_counter(
 
     # Unrelated state is untouched and no forge-retry key was introduced.
     assert state.threads_addressed_ids == {"PRRT_x": "false_positive"}
+
+
+@pytest.mark.unit
+async def test_transient_wait_persists_only_counter_not_unconfirmed_verdict(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A fix-cycle transient wait must persist ONLY the bounded retry counter,
+    never the whole in-memory state.
+
+    When ``resolve_thread`` (or deferred-issue capture) faults transiently, the
+    in-memory state still holds the thread's unconfirmed ``fix_committed`` verdict
+    — the caller only rolls it back *after* the wait returns. If the wait flushed
+    the whole state, a crash/restart during the backoff would reload the thread as
+    addressed even though the forge resolve failed, so ``decide()`` would skip the
+    still-open thread and let auto-merge bypass live feedback (#305). The counter
+    must still be persisted so the bounded budget survives across polls.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 2)
+    exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+    # The unconfirmed addressed verdict the resolve_thread caller has not yet
+    # rolled back at the moment the wait runs.
+    state = MonitorState(threads_addressed_ids={"PRRT_open": "fix_committed"})
+
+    # Transient retry branch: returns True, persists the counter, but must NOT
+    # flush the unconfirmed verdict.
+    assert (
+        await runner._wait_after_transient_github_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        persisted = ws.monitor_threads_addressed or {}
+        assert persisted.get(_RESOLVE_THREAD_COUNT_KEY) == "1"
+        assert "PRRT_open" not in persisted
+
+    # Exhaustion branch: also persists only the counter, never the unconfirmed
+    # verdict, so the terminal path cannot strand an addressed-but-unresolved
+    # thread in the DB either.
+    assert (
+        await runner._wait_after_transient_github_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    exhausted = await runner._wait_after_transient_github_error(
+        exc,
+        workspace_id=workspace_id,
+        pr_number=42,
+        context="resolve_thread",
+        state=state,
+        monitor_log=None,
+    )
+    assert exhausted is False
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        persisted = ws.monitor_threads_addressed or {}
+        assert persisted.get(_RESOLVE_THREAD_COUNT_KEY) == "3"
+        assert "PRRT_open" not in persisted

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -315,3 +315,104 @@ async def test_monitor_run_terminates_after_github_401_retry_budget_exhausted(
         assert ws.events[-1].reason_code == GITHUB_API_ERROR
         assert len(_events(ws, "monitor.github_transient_error_retrying")) == 1
         assert len(_events(ws, "monitor.github_transient_error_retry_exhausted")) == 1
+
+
+_RESOLVE_THREAD_COUNT_KEY = "__awf_forge_transient_retry_count:resolve_thread"
+
+
+@pytest.mark.unit
+async def test_clear_on_success_resets_per_context_budget_and_persists(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A recovered blip must not leak its count: once the context's operation
+    succeeds the counter is cleared (and the clear is persisted), so later
+    independent blips in the same context start from a fresh bounded budget
+    instead of resuming from a stale count and exhausting it prematurely."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 2)
+    exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+    state = MonitorState()
+
+    # First incident: two recovered blips bring ``resolve_thread`` to the budget
+    # edge. The wait helper persists the running count on every blip.
+    for expected_count in (1, 2):
+        assert (
+            await runner._wait_after_transient_github_error(
+                exc,
+                workspace_id=workspace_id,
+                pr_number=42,
+                context="resolve_thread",
+                state=state,
+                monitor_log=None,
+            )
+            is True
+        )
+        assert state.threads_addressed_ids[_RESOLVE_THREAD_COUNT_KEY] == str(expected_count)
+
+    # The operation then succeeds: the counter is cleared in memory AND the clear
+    # is persisted over the previously-persisted "2".
+    await runner._clear_forge_transient_retry_state_on_success(
+        workspace_id=workspace_id,
+        state=state,
+        context="resolve_thread",
+    )
+    assert _RESOLVE_THREAD_COUNT_KEY not in state.threads_addressed_ids
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert _RESOLVE_THREAD_COUNT_KEY not in (ws.monitor_threads_addressed or {})
+
+    # A later, independent blip starts a fresh budget rather than tipping straight
+    # into exhaustion off the stale count.
+    assert (
+        await runner._wait_after_transient_github_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    assert state.threads_addressed_ids[_RESOLVE_THREAD_COUNT_KEY] == "1"
+
+
+@pytest.mark.unit
+async def test_clear_on_success_is_noop_without_a_counter(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Clearing a context that never blipped is a harmless no-op that adds no
+    state mutation (and so no extra DB write on the common happy path)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    state = MonitorState(threads_addressed_ids={"PRRT_x": "false_positive"})
+
+    await runner._clear_forge_transient_retry_state_on_success(
+        workspace_id=workspace_id,
+        state=state,
+        context="merge_pr",
+    )
+
+    # Unrelated state is untouched and no forge-retry key was introduced.
+    assert state.threads_addressed_ids == {"PRRT_x": "false_positive"}

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -1,0 +1,317 @@
+"""Bounded-retry coverage for transient forge auth blips (#515).
+
+A transient forge auth error (an ambiguous ``HTTP 401`` / ``Requires
+authentication`` on GitHub, or any 401/403 on Bitbucket) must be bounded-retryable
+with exponential backoff rather than terminating a healthy auto-merge on a
+momentary blip. These tests pin the new backoff schedule, the per-context retry
+counter (with corrupt-value recovery and clear-on-success), the exhaustion path,
+and the end-to-end #515 regression.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.bitbucket_client import (
+    BITBUCKET_AUTH_FAILED,
+    BitbucketClientError,
+)
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import GITHUB_API_ERROR, GitHubClientError
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Workspace
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor_runner.helpers import (
+    _clear_transient_forge_retry_state,
+    _exponential_backoff_wait_seconds,
+    _increment_forge_transient_retry_count,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    seed_monitoring_workspace,
+)
+
+_FORGE_COUNT_KEY = "__awf_forge_transient_retry_count:fetch_pr_status"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _events(ws: Workspace, event_type: str) -> list:
+    return [event for event in ws.events if event.event_type == event_type]
+
+
+@pytest.mark.unit
+def test_exponential_backoff_schedule_grows_then_caps() -> None:
+    # 1-based retry number: the first retry waits the initial backoff, doubling
+    # each step, capped at the maximum.
+    waits = [
+        _exponential_backoff_wait_seconds(
+            retry_number=n,
+            initial_backoff_seconds=5.0,
+            max_backoff_seconds=120.0,
+        )
+        for n in range(1, 7)
+    ]
+    assert waits == [5.0, 10.0, 20.0, 40.0, 80.0, 120.0]
+    # A huge retry number stays clamped at the ceiling (no overflow).
+    assert (
+        _exponential_backoff_wait_seconds(
+            retry_number=100,
+            initial_backoff_seconds=5.0,
+            max_backoff_seconds=120.0,
+        )
+        == 120.0
+    )
+
+
+@pytest.mark.unit
+def test_increment_forge_transient_retry_count_recovers_from_corrupt_value() -> None:
+    state = MonitorState(threads_addressed_ids={_FORGE_COUNT_KEY: "not-an-integer"})
+
+    retry_number = _increment_forge_transient_retry_count(state, "fetch_pr_status")
+
+    assert retry_number == 1
+    assert state.threads_addressed_ids[_FORGE_COUNT_KEY] == "1"
+    # The counter is per-context — a distinct context starts its own budget.
+    assert _increment_forge_transient_retry_count(state, "merge_pr") == 1
+    assert state.threads_addressed_ids[_FORGE_COUNT_KEY] == "1"
+
+
+@pytest.mark.unit
+def test_clear_transient_forge_retry_state_reports_whether_present() -> None:
+    state = MonitorState(threads_addressed_ids={_FORGE_COUNT_KEY: "3"})
+
+    assert _clear_transient_forge_retry_state(state, context="fetch_pr_status") is True
+    assert _FORGE_COUNT_KEY not in state.threads_addressed_ids
+    # Idempotent: clearing an absent counter reports no change.
+    assert _clear_transient_forge_retry_state(state, context="fetch_pr_status") is False
+
+
+@pytest.mark.unit
+async def test_github_transient_401_retries_with_backoff_then_exhausts(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    # The exact #515 failure string — a bare 401 with no strong permanent marker.
+    exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+    state = MonitorState()
+
+    # The default budget is 5: the first five calls retry with the exponential
+    # backoff schedule; the sixth exhausts.
+    for expected_count in range(1, 6):
+        retried = await runner._wait_after_transient_github_error(
+            exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="fetch_pr_status",
+            state=state,
+            monitor_log=None,
+        )
+        assert retried is True
+        assert state.threads_addressed_ids[_FORGE_COUNT_KEY] == str(expected_count)
+
+    assert sleep_fn.calls == [5, 10, 20, 40, 80]
+
+    exhausted = await runner._wait_after_transient_github_error(
+        exc,
+        workspace_id=workspace_id,
+        pr_number=42,
+        context="fetch_pr_status",
+        state=state,
+        monitor_log=None,
+    )
+
+    # Exhaustion: no further sleep, the helper returns False so the caller
+    # terminates, and a distinct exhausted event is recorded.
+    assert exhausted is False
+    assert sleep_fn.calls == [5, 10, 20, 40, 80]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        retrying = _events(ws, "monitor.github_transient_error_retrying")
+        assert len(retrying) == 5
+        exhausted_events = _events(ws, "monitor.github_transient_error_retry_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason_code == "GITHUB_TRANSIENT_RETRY_EXHAUSTED"
+        assert exhausted_events[0].payload["retry_number"] == 6
+        assert exhausted_events[0].payload["max_retries"] == 5
+
+
+@pytest.mark.unit
+async def test_bitbucket_transient_403_retries_with_backoff_then_exhausts(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    # Keep the test fast: a budget of 2 retries before exhaustion.
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 2)
+    exc = BitbucketClientError(
+        operation="bitbucket fetch_pr_status",
+        status=403,
+        body="forbidden",
+        reason_code=BITBUCKET_AUTH_FAILED,
+    )
+    state = MonitorState()
+
+    for _ in range(2):
+        assert (
+            await runner._wait_after_transient_bitbucket_error(
+                exc,
+                workspace_id=workspace_id,
+                pr_number=42,
+                context="fetch_pr_status",
+                state=state,
+                monitor_log=None,
+            )
+            is True
+        )
+
+    assert sleep_fn.calls == [5, 10]
+
+    exhausted = await runner._wait_after_transient_bitbucket_error(
+        exc,
+        workspace_id=workspace_id,
+        pr_number=42,
+        context="fetch_pr_status",
+        state=state,
+        monitor_log=None,
+    )
+
+    assert exhausted is False
+    assert sleep_fn.calls == [5, 10]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert len(_events(ws, "monitor.bitbucket_transient_error_retrying")) == 2
+        exhausted_events = _events(ws, "monitor.bitbucket_transient_error_retry_exhausted")
+        assert len(exhausted_events) == 1
+        assert exhausted_events[0].reason_code == "BITBUCKET_TRANSIENT_RETRY_EXHAUSTED"
+        assert exhausted_events[0].payload["reason_code"] == BITBUCKET_AUTH_FAILED
+
+
+@pytest.mark.unit
+async def test_monitor_run_survives_github_401_auth_blip_and_clears_retry_count(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The exact #515 regression: a transient GraphQL 401 on the first poll must
+    retry (not terminate), and the next green poll merges and clears the counter."""
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    # Poll 1: base fetch + base-behind ok, then the gh graphql 401 blip.
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=0, stdout="0\n")
+    cmd.queue_result(returncode=1, stderr="gh: Requires authentication (HTTP 401)")
+    # Poll 2: base fetch + base-behind ok, PR already merged upstream → complete.
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=0, stdout="0\n")
+    cmd.queue_result(returncode=0, stdout=pr_payload(merged=True))
+    cmd.queue_result(returncode=0)  # compose down
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    # The auto-merge survived the blip: one bounded retry (backoff 5s) then complete.
+    assert sleep_fn.calls == [5]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+        assert ws.failure_message is None
+        retrying = _events(ws, "monitor.github_transient_error_retrying")
+        assert len(retrying) == 1
+        assert retrying[0].reason_code == "GITHUB_TRANSIENT_RETRY"
+        # The 401 carries GitHub's base reason code (no native HTTP code).
+        assert retrying[0].payload["context"] == "fetch_pr_status"
+        # The clear-on-success poll removed the counter so an intermittent blip
+        # never accumulates toward exhaustion.
+        assert _FORGE_COUNT_KEY not in (ws.monitor_threads_addressed or {})
+
+
+@pytest.mark.unit
+async def test_monitor_run_terminates_after_github_401_retry_budget_exhausted(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A genuinely-persistent 401 exhausts the bounded budget and terminates with
+    the forge reason code preserved — no tight unbounded loop."""
+    cmd = FakeCommandRunner()
+    sleep_fn = RecordedSleep()
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    # Budget of 1 retry keeps the test to two polls before termination.
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 1)
+    # Every poll: base fetch + base-behind ok, then the gh graphql 401.
+    for _ in range(2):
+        cmd.queue_result(returncode=0)
+        cmd.queue_result(returncode=0, stdout="0\n")
+        cmd.queue_result(returncode=1, stderr="gh: Requires authentication (HTTP 401)")
+
+    await runner.run(
+        workspace_id=workspace_id,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    # One bounded retry (5s) then terminate — not an unbounded loop.
+    assert sleep_fn.calls == [5]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.failed.value
+        assert "github error" in (ws.failure_message or "")
+        assert ws.events[-1].reason_code == GITHUB_API_ERROR
+        assert len(_events(ws, "monitor.github_transient_error_retrying")) == 1
+        assert len(_events(ws, "monitor.github_transient_error_retry_exhausted")) == 1

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -571,3 +571,94 @@ async def test_transient_wait_persists_only_counter_not_unconfirmed_verdict(
         persisted = ws.monitor_threads_addressed or {}
         assert persisted.get(_RESOLVE_THREAD_COUNT_KEY) == "3"
         assert "PRRT_open" not in persisted
+
+
+@pytest.mark.unit
+async def test_deterministic_fault_clears_stale_prior_transient_counter(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A deterministic forge fault must clear a stale counter left by a *prior*
+    recovered transient blip in the same context.
+
+    The non-terminal callers (``resolve_thread`` / ``capture_deferred_thread``)
+    do not terminate on a deterministic fault — they keep polling and the runner
+    later persists ``state``. If the deterministic early return left the prior
+    transient counter behind, a later *unrelated* transient in the same context
+    would resume from the stale count and exhaust the bounded budget immediately,
+    downgrading or terminating an otherwise-healthy monitor. Only the deterministic
+    case clears the counter; the exhausted-transient path keeps it (still
+    transient → fail closed).
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    object.__setattr__(runner._runner_config, "transient_forge_max_retries", 2)
+    transient_exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+    # A strong permanent marker ("bad credentials") => deterministic, never retried,
+    # even though the same string also carries the ambiguous ``HTTP 401`` token.
+    deterministic_exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr="gh: Bad credentials (HTTP 401)",
+    )
+    state = MonitorState()
+
+    # A prior recovered transient blip persists the counter to the DB.
+    assert (
+        await runner._wait_after_transient_github_error(
+            transient_exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    assert state.threads_addressed_ids[_RESOLVE_THREAD_COUNT_KEY] == "1"
+
+    # A deterministic fault then arrives in the same context: it returns False (no
+    # retry, no backoff) AND clears the stale counter both in memory and over the DB.
+    assert (
+        await runner._wait_after_transient_github_error(
+            deterministic_exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is False
+    )
+    assert _RESOLVE_THREAD_COUNT_KEY not in state.threads_addressed_ids
+    assert sleep_fn.calls == [5]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        assert _RESOLVE_THREAD_COUNT_KEY not in (ws.monitor_threads_addressed or {})
+
+    # A later, independent transient starts from a fresh budget rather than
+    # resuming the stale count and exhausting prematurely.
+    assert (
+        await runner._wait_after_transient_github_error(
+            transient_exc,
+            workspace_id=workspace_id,
+            pr_number=42,
+            context="resolve_thread",
+            state=state,
+            monitor_log=None,
+        )
+        is True
+    )
+    assert state.threads_addressed_ids[_RESOLVE_THREAD_COUNT_KEY] == "1"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e0a8d61bccf84e59943a802b` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix #515: the PR monitor terminates a workspace on a TRANSIENT forge auth blip instead of retrying. Make transient forge auth errors bounded-retryable with exponential backoff, forge-agnostically (GitHub AND BitBucket).

## Problem (verified)
The monitor terminated a workspace as `infrastructure_failure` with `monitor: github error: gh api graphql failed (exit=1): gh: Requires authentication (HTTP 401)`. The token was valid throughout — a transient GraphQL 401 blip. The monitor treated it as permanent and killed an otherwise-healthy auto-merge.

The retry infra already exists (`src/awf/runtime/pr_monitor_runner/transient_ops.py:_wait_after_transient_forge_error` → per-forge classifiers in `helpers.py`). Three gaps:
1. GitHub misclassifies the blip as permanent: `_NON_TRANSIENT_GITHUB_ERROR_MARKERS` (`src/awf/runtime/pr_monitor_runner/constants.py:20-29`) contains the broad substring `"authentication"`, so `"Requires authentication (HTTP 401)"` matches non-transient (`helpers.py:616-622`; raised at `src/awf/common/github_client.py:1224-1243`, which exposes only stderr text, no HTTP status).
2. BitBucket has the same class of bug: 401/403 → `BITBUCKET_AUTH_FAILED` permanent (`src/awf/common/bitbucket_client.py` `_error_for`, ~1407-1462); `helpers.py:625-651` classifies it non-transient. (BitBucket already retries 429 with backoff at `bitbucket_client.py:1351-1354`; it DOES expose HTTP status + body.)
3. No bounded backoff for forge transient errors: base-fetch has `transient_base_fetch_max_retries=5` + exponential backoff (`config.py:36-38`, `helpers.py:_base_fetch_retry_wait_seconds`), but forge transient errors just sleep once (`poll_interval_seconds`) and return retry=True — unbounded, no ceiling.

## Approach (LOCKED via eng-review)
Treat AMBIGUOUS auth errors as BOUNDED-RETRYABLE with exponential backoff; keep UNAMBIGUOUS permanent errors fail-fast.

1. **Bounded backoff for forge errors (DRY — reuse the existing helper).** Add `transient_forge_max_retries` / `transient_forge_initial_backoff_seconds` / `transient_forge_max_backoff_seconds` to `pr_monitor_runner/config.py`, mirroring the base-fetch defaults (5, 5.0, 120.0). Reuse `_base_fetch_retry_wait_seconds` (or factor out a shared `_exponential_backoff_wait_seconds` if cleaner) for the schedule. Track a per-error retry count and clear it on success, exactly like the base-fetch retry-count pattern. After the retry budget is exhausted, terminate with a clear message (so: a transient blip recovers within a few retries; a genuinely permanent error fails in ~minutes; there is no tight unbounded loop). Do NOT entangle or change base-fetch's own retry behavior — give forge errors their own config + count, reusing only the backoff helper.

2. **GitHub:** narrow the over-broad `"authentication"` non-transient marker in `constants.py`. KEEP fail-fast for the strong, unambiguous permanent markers: `bad credentials`, `not logged in`, `please run gh auth login`, `not found`, `could not resolve to a repository`, `could not resolve to a node`. A bare `HTTP 401` / `requires authentication` WITHOUT one of those strong markers becomes bounded-retryable (move it to the transient path). Be careful the new transient match for "401"/"requires authentication" does not also swallow the strong-permanent cases — strong markers win.

3. **BitBucket — Option A (uniform bounded-retry, symmetric with GitHub).** Treat any BitBucket 401/403 as bounded-retryable through the same bounded-backoff path. Do NOT add response-body/header heuristics to distinguish blip-vs-permanent (that was the rejected Option B — forge-asymmetric, brittle). The bounded retry naturally fails a real bad token after exhausting the budget. Implement this in the monitor's BitBucket classifier (`helpers.py:_is_transient_bitbucket_client_error` / `transient_ops.py:_wait_after_transient_bitbucket_error`); keep the existing 429 + transport-error behavior unchanged. If a distinct reason code reads cleaner than reclassifying `BITBUCKET_AUTH_FAILED`, you may add one in `src/awf/common/bitbucket_client_errors.py`, but uniform bounded-retry on 401/403 is the requirement, not body inspection.

## Files
`src/awf/runtime/pr_monitor_runner/{constants,helpers,transient_ops,config}.py`; optionally `src/awf/common/bitbucket_client_errors.py`. Mirror the existing per-forge symmetry in `transient_ops.py` (`_wait_after_transient_github_error` / `_wait_after_transient_bitbucket_error` / `_wait_after_transient_forge_error`).

## Tests (full coverage; behavior + edge + error paths)
- GitHub: `Requires authentication (HTTP 401)` now RETRIES up to the bound, then terminates after exhaustion (assert the retry-count increments + the backoff schedule + the final terminate). A strong permanent marker (`bad credentials` / `not logged in`) still fails FAST (no retries). Transient 5xx behavior preserved.
- BitBucket: 401/403 bounded-retry then terminate after exhaustion; 429 retry path unchanged; transport error unchanged; permanent non-auth still fails.
- Retry-count increment + clear-on-success; max-retries ceiling; no tight loop.
- Mirror the existing monitor-error simulation in `tests/unit/runtime/test_pr_monitor_runner_parts/` and the forge-client/classifier tests in `tests/unit/common/`. Watch first-party file line limits — split into a sibling test file if a part file would exceed 1500 lines.
- Run ruff, mypy, and the full `--cov=awf --cov-fail-under=99` suite green.

## Scope discipline
Only the monitor runtime + (optionally) the bitbucket error-codes module + tests. No protected paths. PR to development.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core monitor loop behavior around forge failures, merge gates, and persisted thread state; mistakes could skip feedback or loop forever, but extensive #305/#515 guards and tests target those paths.
> 
> **Overview**
> Fixes **#515**: transient forge API blips (especially bare GitHub `HTTP 401` / `Requires authentication`) no longer kill an otherwise healthy PR monitor auto-merge.
> 
> **Bounded forge retries** replace a single `poll_interval_seconds` sleep with per-context counters, configurable max retries (default 5), and shared exponential backoff (5s → 120s cap). GitHub and Bitbucket share `_run_bounded_transient_forge_retry`; exhausted budgets emit distinct audit events and terminate with the forge `reason_code`.
> 
> **Classification:** GitHub drops broad `"authentication"` from permanent markers; ambiguous `http 401` / `requires authentication` retry only on the API client path (not `git fetch` `HTTP 401`). Bitbucket **401/403** (`BITBUCKET_AUTH_FAILED`) are now retryable like other transient blips.
> 
> **Safety (#305):** Retry counter persistence touches only `__awf_forge_transient_retry_count:*` keys—never full `MonitorState` during fix-cycle waits—so unconfirmed thread verdicts are not flushed. `execute_action` retries use a DB-reloaded state snapshot. After transient **retry exhaustion** on `resolve_thread`, open threads escalate to **`needs_human`** instead of clearing markers (avoids agent re-run storms). Counters clear on success; deterministic faults clear stale counters; exhausted transient merge blockers keep counters for fail-closed behavior.
> 
> Tests updated for 5s backoff and expanded coverage in `test_pr_monitor_runner_coverage_edges_part_017.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e4e26b3e5c42aee20fbb11a96a0c2001e1d5826. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-context bounded retry for forge (GitHub/Bitbucket) API blips with configurable retry budget and exponential backoff; ambiguous auth failures can be retried when appropriate.
* **Bug Fixes**
  * Shortened transient backoff from 60s to 5s and clear stale transient retry counters on success.
  * Prevents unrelated in-memory state from being persisted when tracking forge retry counters.
* **Tests**
  * Expanded tests for backoff, exhaustion, counter persistence, and clearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->