### PR TITLE
fix: reap terminal-workspace auth dirs from the worker (#513)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,6 +150,12 @@ AWF_AUTO_CLEANUP_ORPHANS=false
 # --execute and never removes the current-signature, live-mounted, or pinned base.
 AWF_CLAUDE_BASE_GC_ENABLED=true
 AWF_CLAUDE_BASE_REAP_SCAN_INTERVAL_SECONDS=3600
+# Terminal-workspace auth-dir GC (per-workspace ~1.7 GB auth dirs for
+# completed/cancelled/destroyed workspaces). Driven from the worker (which holds
+# CAP_SYS_ADMIN) so the overlay unmount-before-remove succeeds; failed workspaces
+# are preserved. On by default.
+AWF_TERMINAL_WORKSPACE_GC_ENABLED=true
+AWF_TERMINAL_WORKSPACE_GC_SCAN_INTERVAL_SECONDS=3600
 AWF_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS=3600
 AWF_ORPHAN_RECONCILE_MAX_PER_SCAN=50
 AWF_ORPHAN_RECONCILE_MIN_AGE_HOURS=168

--- a/src/awf/common/config.py
+++ b/src/awf/common/config.py
@@ -447,6 +447,24 @@ class Settings(BaseSettings):
             "reaper sweeps (GC-B). Gated by ``claude_base_gc_enabled``."
         ),
     )
+    terminal_workspace_gc_enabled: bool = Field(
+        default=True,
+        description=(
+            "Whether the worker drives per-workspace terminal-workspace auth-dir GC "
+            "(the ~1.7 GB auth/<id>/ dirs of completed/cancelled/destroyed "
+            "workspaces). The worker holds CAP_SYS_ADMIN so its overlay "
+            "unmount-before-remove succeeds; the capability-less API GC path skips. "
+            "Failed workspaces are preserved. On by default (#513)."
+        ),
+    )
+    terminal_workspace_gc_scan_interval_seconds: float = Field(
+        default=DEFAULT_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS,
+        gt=0,
+        description=(
+            "Interval between worker terminal-workspace auth-dir GC sweeps (#513). "
+            "Gated by ``terminal_workspace_gc_enabled``."
+        ),
+    )
     orphan_reconcile_max_per_scan: int = Field(
         default=DEFAULT_ORPHAN_RECONCILE_LIMIT,
         gt=0,

--- a/src/awf/control/worker/cleanup.py
+++ b/src/awf/control/worker/cleanup.py
@@ -15,7 +15,7 @@ import uuid as uuid
 from datetime import UTC, datetime
 from pathlib import Path
 from time import monotonic
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -50,6 +50,7 @@ from awf.control.worker.constants import (
     _TERMINAL_RUNTIME_RELEASE_FAILED_EVENT_TYPE,
     _TERMINAL_RUNTIME_RELEASE_FAILED_REASON_CODE,
     _TERMINAL_RUNTIME_RELEASE_REASON_CODE,
+    _TERMINAL_WORKSPACE_GC_REAP_FAILED_REASON_CODE,
 )
 from awf.control.worker.helpers import (
     _worker_exception_is_transient_db_connection,
@@ -320,6 +321,89 @@ def _log_claude_base_reap_summary(report: dict[str, object]) -> None:
             reason_code=report.get("reason_code"),
             errors=report.get("errors") or [],
             unverifiable=report.get("unverifiable") or [],
+        )
+
+
+async def _maybe_reap_terminal_workspace_gc(self: Any) -> None:
+    """Periodically reap per-workspace terminal-workspace auth dirs from the worker (#513).
+
+    The terminal-workspace GC (``service.gc.run_service_workspace_gc``) reclaims the
+    per-workspace ``auth/<id>/`` dirs (~1.7 GB each) of completed/cancelled/destroyed
+    workspaces. Removing one first unmounts a possible live Claude overlay at
+    ``auth/<id>/claude/merged``, and ``teardown_workspace_auth_overlay`` raises
+    ``OverlayUnmountUnverifiableError`` whenever the caller cannot prove it holds
+    CAP_SYS_ADMIN — so the capability-less API ``/v1/service/gc`` path records every
+    auth path ``skipped`` and deletes nothing. Only the worker holds CAP_SYS_ADMIN and
+    shares the agent's mount namespace, so this loop drives the same already-tested GC
+    from the worker, where the unmount-before-remove actually succeeds. Reuses the GC's
+    classification, path planning, ``WorkspaceGCPathOutcome`` bookkeeping, and the
+    ``preserves_failed_workspaces=True`` policy (failed workspaces are never reaped).
+
+    No-op when no reaper callback is wired or the kill-switch
+    (``terminal_workspace_gc_enabled``) is off, in which case the cursor is left
+    eligible so enabling the flag does not wait out a stale interval (mirrors
+    ``_maybe_reap_superseded_claude_bases``). The reaper closure ``await``s the async
+    GC (which offloads its blocking multi-GB ``rmtree``/DB work via
+    ``asyncio.to_thread`` internally) and returns a report dict rather than raising for
+    expected partial/skipped cases, so failures are summarised and the cursor is always
+    rescheduled. Any unexpected exception is logged loudly via ``_log.exception`` and
+    swallowed so one failed sweep cannot block provisioning or dispatch.
+    ``asyncio.CancelledError`` propagates for cooperative shutdown.
+    """
+    if self._terminal_gc_reaper is None:
+        return
+    if not self._config.terminal_workspace_gc_enabled:
+        return
+
+    now = monotonic()
+    if now < self._next_terminal_gc_reap_scan_at:
+        return
+
+    try:
+        report = await self._terminal_gc_reaper()
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        _log.exception(
+            "worker.terminal_workspace_gc_reap_failed",
+            reason_code=_TERMINAL_WORKSPACE_GC_REAP_FAILED_REASON_CODE,
+        )
+    else:
+        _log_terminal_gc_reap_summary(report)
+
+    interval = max(0.0, self._config.terminal_workspace_gc_scan_interval_seconds)
+    self._next_terminal_gc_reap_scan_at = monotonic() + interval
+
+
+def _log_terminal_gc_reap_summary(report: dict[str, object]) -> None:
+    """Emit a structured summary for a completed terminal-workspace GC sweep.
+
+    Logs ``info`` when auth/worktree/compose paths were reclaimed and ``warning`` when
+    the GC self-reported a ``partial`` (e.g. a delete error or an unverifiable overlay
+    unmount). A clean run that reclaimed nothing (no eligible candidates, or a dry-run
+    preview) is intentionally silent to avoid log noise each interval. Only counts and
+    the reason code the GC report already surfaces are logged — never auth-dir contents
+    or secrets.
+    """
+    deleted_path_count = report.get("deleted_path_count") or 0
+    # Independent conditions, not mutually exclusive: a ``partial`` pass can still have
+    # reclaimed some paths while another path errored, so surface both the reclaim
+    # (info) and the partial (warning) rather than masking one behind the other.
+    if deleted_path_count:
+        _log.info(
+            "worker.terminal_workspace_gc_reaped",
+            reason_code=report.get("reason_code"),
+            deleted_path_count=deleted_path_count,
+            candidate_count=report.get("candidate_count"),
+            preserved_count=report.get("preserved_count"),
+        )
+    if report.get("status") == "partial":
+        _log.warning(
+            "worker.terminal_workspace_gc_partial",
+            reason_code=report.get("reason_code"),
+            # Count only — never the per-path ``error``/``path`` entries — so an
+            # auth-dir path can't leak into the worker log.
+            delete_error_count=len(cast("list[object]", report.get("delete_errors") or [])),
         )
 
 

--- a/src/awf/control/worker/config.py
+++ b/src/awf/control/worker/config.py
@@ -31,6 +31,16 @@ class WorkerConfig:
     # verification is trustworthy and it can actually reap superseded bases (#509).
     claude_base_gc_enabled: bool = True
     claude_base_reap_scan_interval_seconds: float = 3600.0
+    # Kill-switch for the worker-side terminal-workspace auth-dir GC sweep (#513),
+    # sourced from ``settings.terminal_workspace_gc_enabled``. The per-workspace
+    # ``auth/<id>/`` dirs (~1.7 GB each) for completed/cancelled/destroyed
+    # workspaces can only be reclaimed in a CAP_SYS_ADMIN context: removing one
+    # first unmounts a possible live Claude overlay, which the capability-less API
+    # ``/v1/service/gc`` path cannot verify (it self-protects and skips). The worker
+    # holds CAP_SYS_ADMIN + the agent's mount namespace, so it drives the real
+    # reclaim. Failed workspaces are preserved (inherited GC policy).
+    terminal_workspace_gc_enabled: bool = True
+    terminal_workspace_gc_scan_interval_seconds: float = 3600.0
     # NOTE: the interval fields above are read by the worker cleanup loops. The
     # two fields below are informational mirrors of the same settings: the
     # *effective* values are captured by the ``_reconcile_orphan_dirs`` closure

--- a/src/awf/control/worker/constants.py
+++ b/src/awf/control/worker/constants.py
@@ -264,6 +264,15 @@ raises for expected partial/permission cases — it returns a report dict — so
 fires only for an unexpected failure of the injected closure (e.g. the blocking
 ``rmtree`` raising an unhandled error)."""
 
+_TERMINAL_WORKSPACE_GC_REAP_FAILED_REASON_CODE = "TERMINAL_WORKSPACE_GC_SWEEP_FAILED"
+"""Reason code logged when the worker terminal-workspace auth-dir GC sweep fails (#513).
+
+Worker-internal structured-log reason code only, not a doctor/catalog entry
+(mirrors ``_CLAUDE_BASE_REAP_SWEEP_FAILED_REASON_CODE``). The driven GC itself never
+raises for expected partial/skipped cases — it returns a ``WorkspaceGCResult`` report
+dict — so this fires only for an unexpected failure of the injected closure (e.g. the
+blocking ``rmtree`` or DB work raising an unhandled error)."""
+
 _TERMINAL_RELEASE_STATUSES: tuple[WorkspaceStatus, ...] = (
     WorkspaceStatus.failed,
     WorkspaceStatus.cancelled,

--- a/src/awf/control/worker/manager.py
+++ b/src/awf/control/worker/manager.py
@@ -95,6 +95,7 @@ class ControlWorker(WorkerDelegatesMixin):
         orphan_dir_reconciler: Callable[[], Awaitable[OrphanDirReconcileResult]] | None = None,
         classified_orphan_reaper: Callable[[], Awaitable[OrphanReapResult]] | None = None,
         claude_base_reaper: Callable[[], Awaitable[dict[str, object]]] | None = None,
+        terminal_gc_reaper: Callable[[], Awaitable[dict[str, object]]] | None = None,
         auth_overlay_work_dir: Path | None = None,
         config: WorkerConfig,
     ) -> None:
@@ -111,6 +112,12 @@ class ControlWorker(WorkerDelegatesMixin):
         # the API ``/v1/service/gc`` path self-protects and reaps nothing; this
         # closure (built in ``service/worker.py``) drives the real reclaim.
         self._claude_base_reaper = claude_base_reaper
+        # CAP_SYS_ADMIN-context reaper for per-workspace terminal-workspace auth dirs
+        # (#513). Only the worker can unmount a reaped workspace's live Claude overlay
+        # to satisfy the GC's unmount-before-remove contract, so the API
+        # ``/v1/service/gc`` path skips every auth dir; this closure (built in
+        # ``service/worker.py``) drives the real per-workspace reclaim.
+        self._terminal_gc_reaper = terminal_gc_reaper
         # The host work dir that backs ``auth/<id>/claude/...`` overlays. When set,
         # the terminal-runtime-release sweep unmounts a reaped workspace's overlay
         # in the worker's (CAP_SYS_ADMIN) mount namespace before GC removes the dir.
@@ -137,6 +144,7 @@ class ControlWorker(WorkerDelegatesMixin):
         self._next_orphan_reconcile_scan_at = 0.0
         self._next_classified_orphan_reap_scan_at = 0.0
         self._next_claude_base_reap_scan_at = 0.0
+        self._next_terminal_gc_reap_scan_at = 0.0
         self._requested_capacity_resume_after: SchedulerOrderCursor | None = None
         self._requested_capacity_resume_signature: _AllocatedReservationSignature | None = None
         self._requested_capacity_resume_queue_signature: _RequestedCapacityQueueSignature | None = (
@@ -196,6 +204,7 @@ class ControlWorker(WorkerDelegatesMixin):
         await self._maybe_reconcile_orphan_dirs()
         await self._maybe_reap_classified_orphans()
         await self._maybe_reap_superseded_claude_bases()
+        await self._maybe_reap_terminal_workspace_gc()
 
         if self._executor is not None:
             # Preserved-active-validation redispatches enqueued during recovery

--- a/src/awf/control/worker/mixins.py
+++ b/src/awf/control/worker/mixins.py
@@ -41,6 +41,7 @@ class WorkerDelegatesMixin:
     _maybe_reconcile_orphan_dirs = _cleanup._maybe_reconcile_orphan_dirs
     _maybe_reap_classified_orphans = _cleanup._maybe_reap_classified_orphans
     _maybe_reap_superseded_claude_bases = _cleanup._maybe_reap_superseded_claude_bases
+    _maybe_reap_terminal_workspace_gc = _cleanup._maybe_reap_terminal_workspace_gc
     _release_terminal_runtime_resources = _cleanup._release_terminal_runtime_resources
     _resume_pending_planning_scope_auto_retries_after_terminal_release = (
         _cleanup._resume_pending_planning_scope_auto_retries_after_terminal_release

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -117,6 +117,10 @@ class ServiceSettings:
         DEFAULT_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS
     )
     claude_base_reap_scan_interval_seconds: float = DEFAULT_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS
+    terminal_workspace_gc_enabled: bool = True
+    terminal_workspace_gc_scan_interval_seconds: float = (
+        DEFAULT_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS
+    )
     orphan_reconcile_max_per_scan: int = DEFAULT_ORPHAN_RECONCILE_LIMIT
     orphan_reconcile_min_age_hours: float = DEFAULT_ORPHAN_RECONCILE_MIN_AGE_HOURS
     network_posture_open_legacy_cutoff: datetime | None = None
@@ -261,6 +265,10 @@ def resolve_service_settings(
             settings.classified_orphan_reap_scan_interval_seconds
         ),
         claude_base_reap_scan_interval_seconds=settings.claude_base_reap_scan_interval_seconds,
+        terminal_workspace_gc_enabled=settings.terminal_workspace_gc_enabled,
+        terminal_workspace_gc_scan_interval_seconds=(
+            settings.terminal_workspace_gc_scan_interval_seconds
+        ),
         orphan_reconcile_max_per_scan=settings.orphan_reconcile_max_per_scan,
         orphan_reconcile_min_age_hours=settings.orphan_reconcile_min_age_hours,
         network_posture_open_legacy_cutoff=settings.network_posture_open_legacy_cutoff,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -7,7 +7,7 @@ import os
 import shlex
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from sqlalchemy.engine import make_url
 from sqlalchemy.exc import ArgumentError
@@ -23,7 +23,7 @@ from awf.common.github_client import BranchOpenPullRequestResolver
 from awf.common.logging import get_logger
 from awf.control.executor import ExecutorConfig, WorkspaceExecutor
 from awf.control.worker import ControlWorker, WorkerConfig
-from awf.db.enums import TaskKind
+from awf.db.enums import TaskKind, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.session import make_engine, make_session_factory
 from awf.node.auth_mounts import ServiceAuthMountResolver
@@ -46,7 +46,7 @@ from awf.runtime.release_pr_monitor import build_feature_pr_monitor, build_relea
 from awf.runtime.validation import ValidationRunner
 from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
 from awf.service.config import ServiceSettings
-from awf.service.gc import run_service_workspace_gc
+from awf.service.gc import CLEANUP_EXECUTION_PARTIAL, run_service_workspace_gc
 from awf.service.gc_claude_base import reap_superseded_claude_bases
 from awf.service.gc_reconcile import (
     OrphanDirReconcileResult,
@@ -105,6 +105,36 @@ def _release_forge_client_after_build_error(gh: ForgeClient) -> None:
     closer = loop.create_task(gh.aclose())
     _PENDING_FORGE_CLIENT_CLOSERS.add(closer)
     closer.add_done_callback(_PENDING_FORGE_CLIENT_CLOSERS.discard)
+
+
+def _combine_terminal_gc_reports(
+    default_report: dict[str, object], discarded_report: dict[str, object]
+) -> dict[str, object]:
+    """Fold the discarded-status (cancelled/destroyed) GC pass into the default pass.
+
+    The worker runs the terminal-workspace GC twice — once under the conservative
+    default policy and once with an explicit ``include_statuses`` for the
+    cancelled/destroyed rows that policy never classifies (#513) — and the cleanup
+    loop logs a single summary, so the two reports are merged here. The passes act on
+    disjoint status sets and never reclaim the same path, so deleted paths /
+    candidates / delete-errors concatenate and preserved counts sum. A ``partial``
+    from either pass wins (it leaked disk it could not reclaim), so a self-protected
+    sweep is never masked behind the other's clean success.
+    """
+    combined = dict(default_report)
+    for key in ("deleted_paths", "candidates", "delete_errors"):
+        first = cast("list[object]", default_report.get(key) or [])
+        second = cast("list[object]", discarded_report.get(key) or [])
+        combined[key] = [*first, *second]
+    combined["deleted_path_count"] = len(cast("list[object]", combined["deleted_paths"]))
+    combined["candidate_count"] = len(cast("list[object]", combined["candidates"]))
+    combined["preserved_count"] = cast("int", default_report.get("preserved_count") or 0) + cast(
+        "int", discarded_report.get("preserved_count") or 0
+    )
+    if "partial" in (default_report.get("status"), discarded_report.get("status")):
+        combined["status"] = "partial"
+        combined["reason_code"] = CLEANUP_EXECUTION_PARTIAL
+    return combined
 
 
 def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
@@ -354,11 +384,22 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         just ``await`` it (no extra ``to_thread`` wrap, unlike the sync claude-base
         reaper above). Reuse the worker's ``compose`` ComposeManager so the GC does not
         re-resolve the workspace template into a second manager. Return the report dict
-        for the worker's summary logger. The GC inherits its ``preserves_failed_
+        for the worker's summary logger. The first pass inherits its ``preserves_failed_
         workspaces=True`` policy and ``min_age_hours`` retention — failed and too-young
         workspaces are preserved.
+
+        The conservative default policy only classifies completed/failed/superseded rows
+        (``plan_terminal_workspace_gc``; guarded by the
+        ``test_default_gc_policy_ignores_non_pr_terminal_and_unknown_statuses``
+        regression), so it never even looks at ``cancelled``/``destroyed`` workspaces —
+        yet their ~1.7 GB auth dirs leak just the same (#513 lists completed/cancelled/
+        destroyed). Those discarded rows carry no merged-PR work to preserve, so a second
+        explicit ``include_statuses`` pass reaps them by age without disturbing the first
+        pass's completed-merged / failed-preservation / superseded age-cap nuance. The
+        global claude-base reap and companion-image prune already ran in the first pass,
+        so the second pass leaves them off. Both reports are folded into one summary.
         """
-        result = await run_service_workspace_gc(
+        default_result = await run_service_workspace_gc(
             session_factory,
             work_dir=work_dir,
             execute=True,
@@ -371,7 +412,20 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             reap_claude_bases=settings.claude_base_gc_enabled,
             compose_manager=compose,
         )
-        return result.to_dict()
+        discarded_result = await run_service_workspace_gc(
+            session_factory,
+            work_dir=work_dir,
+            execute=True,
+            min_age_hours=settings.completed_workspace_retention_hours,
+            limit=settings.workspace_cleanup_batch_limit,
+            cleanup_enabled=settings.workspace_cleanup_enabled,
+            include_statuses=(
+                WorkspaceStatus.cancelled.value,
+                WorkspaceStatus.destroyed.value,
+            ),
+            compose_manager=compose,
+        )
+        return _combine_terminal_gc_reports(default_result.to_dict(), discarded_result.to_dict())
 
     worker = ControlWorker(
         session_factory=session_factory,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -46,6 +46,7 @@ from awf.runtime.release_pr_monitor import build_feature_pr_monitor, build_relea
 from awf.runtime.validation import ValidationRunner
 from awf.runtime.workspace_prompt_context import render_workspace_runtime_context
 from awf.service.config import ServiceSettings
+from awf.service.gc import run_service_workspace_gc
 from awf.service.gc_claude_base import reap_superseded_claude_bases
 from awf.service.gc_reconcile import (
     OrphanDirReconcileResult,
@@ -331,6 +332,47 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             execute=True,
         )
 
+    async def _reap_terminal_workspace_gc() -> dict[str, object]:
+        """Reap per-workspace terminal-workspace auth dirs from the worker (#513).
+
+        The per-workspace ``auth/<id>/`` dirs (~1.7 GB each) of completed/cancelled/
+        destroyed workspaces leak because reclaiming one first unmounts a possible
+        live Claude overlay at ``auth/<id>/claude/merged``, and
+        ``teardown_workspace_auth_overlay`` raises ``OverlayUnmountUnverifiableError``
+        whenever the caller cannot prove it holds CAP_SYS_ADMIN — so the
+        capability-less API ``/v1/service/gc`` path records every auth path ``skipped``
+        and deletes nothing. The worker holds CAP_SYS_ADMIN and shares the agent's
+        mount namespace, so driving the same already-tested GC here makes the
+        unmount-before-remove succeed and the dir is actually removed (same root cause
+        as #509's shared-base reaper, but for the per-workspace dirs it did not cover).
+
+        Reuse the exact assembly wrapper the API route calls
+        (``run_service_workspace_gc``) so the volume-removing compose teardown,
+        companion-image prune, and same-pass claude-base reap are threaded identically
+        and worker/API behaviour stays in lockstep. It is ``async`` and offloads its
+        blocking multi-GB ``rmtree``/DB work via ``asyncio.to_thread`` internally, so
+        just ``await`` it (no extra ``to_thread`` wrap, unlike the sync claude-base
+        reaper above). Reuse the worker's ``compose`` ComposeManager so the GC does not
+        re-resolve the workspace template into a second manager. Return the report dict
+        for the worker's summary logger. The GC inherits its ``preserves_failed_
+        workspaces=True`` policy and ``min_age_hours`` retention — failed and too-young
+        workspaces are preserved.
+        """
+        result = await run_service_workspace_gc(
+            session_factory,
+            work_dir=work_dir,
+            execute=True,
+            min_age_hours=settings.completed_workspace_retention_hours,
+            limit=settings.workspace_cleanup_batch_limit,
+            cleanup_enabled=settings.workspace_cleanup_enabled,
+            companion_image_cache_enabled=settings.companion_image_cache_enabled,
+            companion_image_retention_hours=settings.companion_image_retention_hours,
+            host_home=host_home,
+            reap_claude_bases=settings.claude_base_gc_enabled,
+            compose_manager=compose,
+        )
+        return result.to_dict()
+
     worker = ControlWorker(
         session_factory=session_factory,
         provisioner=provisioner,
@@ -340,6 +382,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         orphan_dir_reconciler=_reconcile_orphan_dirs,
         classified_orphan_reaper=_reap_classified_orphans,
         claude_base_reaper=_reap_superseded_claude_bases,
+        terminal_gc_reaper=_reap_terminal_workspace_gc,
         # The work dir backs ``auth/<id>/claude`` overlays; the worker (alone
         # holding CAP_SYS_ADMIN + the agent's mount namespace) unmounts a reaped
         # workspace's overlay on terminal-runtime-release before GC removes the dir.
@@ -357,6 +400,10 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             claude_base_gc_enabled=settings.claude_base_gc_enabled,
             claude_base_reap_scan_interval_seconds=(
                 settings.claude_base_reap_scan_interval_seconds
+            ),
+            terminal_workspace_gc_enabled=settings.terminal_workspace_gc_enabled,
+            terminal_workspace_gc_scan_interval_seconds=(
+                settings.terminal_workspace_gc_scan_interval_seconds
             ),
             orphan_reconcile_max_per_scan=settings.orphan_reconcile_max_per_scan,
             orphan_reconcile_min_age_hours=settings.orphan_reconcile_min_age_hours,

--- a/tests/unit/cli/test_service_cli_parts/test_service_cli_part_003.py
+++ b/tests/unit/cli/test_service_cli_parts/test_service_cli_part_003.py
@@ -524,6 +524,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
             orphan_dir_reconciler: object = None,
             classified_orphan_reaper: object = None,
             claude_base_reaper: object = None,
+            terminal_gc_reaper: object = None,
             auth_overlay_work_dir: object = None,
         ) -> None:
             created["worker_session_factory"] = session_factory
@@ -535,6 +536,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
             created["worker_orphan_dir_reconciler"] = orphan_dir_reconciler
             created["worker_classified_orphan_reaper"] = classified_orphan_reaper
             created["worker_claude_base_reaper"] = claude_base_reaper
+            created["worker_terminal_gc_reaper"] = terminal_gc_reaper
             created["worker_auth_overlay_work_dir"] = auth_overlay_work_dir
 
         async def run_once(self) -> int:
@@ -614,6 +616,7 @@ def test_worker_entrypoint_wires_control_worker_dependencies(
     assert created["worker_orphan_dir_reconciler"] is not None
     assert created["worker_classified_orphan_reaper"] is not None
     assert created["worker_claude_base_reaper"] is not None
+    assert created["worker_terminal_gc_reaper"] is not None
     assert created["provisioner_config"].node_id == "node-1"
     assert created["worker_config"].poll_interval_seconds == 0.25
     assert created["worker_config"].max_concurrent_provisions == 2

--- a/tests/unit/control/test_worker_parts/test_worker_part_050.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_050.py
@@ -1,0 +1,281 @@
+"""ControlWorker terminal-workspace auth-dir GC reaper sweep wiring (#513).
+
+These tests cover the worker-side interval gating, kill-switch gating, and error
+handling for the CAP_SYS_ADMIN-context terminal-workspace GC loop, plus an
+end-to-end reap through the real ``run_service_workspace_gc`` engine (in the
+sibling ``tests/unit/service/test_worker_terminal_gc_reaper.py``). The GC engine
+itself (classification, path planning, ``preserves_failed_workspaces`` policy) is
+covered under ``tests/unit/service/test_gc*``; here we prove the worker loop
+drives it from the one context (CAP_SYS_ADMIN) where the overlay
+unmount-before-remove actually succeeds, unlike the capability-less API path.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from awf.control.worker import ControlWorker, WorkerConfig
+
+pytestmark = pytest.mark.unit
+
+
+def _ok_report() -> dict[str, object]:
+    """Build a successful (nothing-reclaimed) GC report for worker tests."""
+    return {
+        "status": "succeeded",
+        "reason_code": "WORKSPACE_GC_OK",
+        "deleted_path_count": 0,
+        "candidate_count": 0,
+        "preserved_count": 0,
+        "delete_errors": [],
+    }
+
+
+def _reaped_report() -> dict[str, object]:
+    """Build a report that reclaimed one terminal-workspace auth dir."""
+    return {
+        "status": "succeeded",
+        "reason_code": "WORKSPACE_GC_OK",
+        "deleted_path_count": 1,
+        "candidate_count": 1,
+        "preserved_count": 1,
+        "delete_errors": [],
+    }
+
+
+def _make_worker(
+    reaper: object | None,
+    *,
+    terminal_workspace_gc_enabled: bool,
+    interval: float = 3600.0,
+) -> ControlWorker:
+    """Create a minimally wired worker with the terminal-workspace GC reaper."""
+    return ControlWorker(
+        session_factory=SimpleNamespace(),  # type: ignore[arg-type]
+        provisioner=SimpleNamespace(),  # type: ignore[arg-type]
+        terminal_gc_reaper=reaper,  # type: ignore[arg-type]
+        config=WorkerConfig(
+            poll_interval_seconds=0.01,
+            max_concurrent_provisions=0,
+            terminal_workspace_gc_enabled=terminal_workspace_gc_enabled,
+            terminal_workspace_gc_scan_interval_seconds=interval,
+        ),
+    )
+
+
+async def test_no_op_when_terminal_gc_reaper_is_none() -> None:
+    """The terminal-GC loop is inert when no reaper callback is wired."""
+    worker = _make_worker(None, terminal_workspace_gc_enabled=True)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert worker._next_terminal_gc_reap_scan_at == 0.0  # noqa: SLF001
+
+
+async def test_does_not_fire_when_terminal_workspace_gc_disabled() -> None:
+    """The kill-switch prevents the reaper from running and keeps the cursor eligible."""
+    calls = 0
+
+    async def _reap() -> dict[str, object]:
+        """Fail the test if the disabled kill-switch invokes the reaper."""
+        nonlocal calls
+        calls += 1
+        raise AssertionError("reaper must not fire while terminal_workspace_gc is disabled")
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=False)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert calls == 0
+    # Keep the cursor eligible so enabling the kill-switch does not wait out a
+    # stale disabled-period interval.
+    assert worker._next_terminal_gc_reap_scan_at == 0.0  # noqa: SLF001
+
+
+async def test_fires_and_reschedules_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An eligible reaper run executes once and advances its cursor by the interval."""
+    current_time = 1_000.0
+    monkeypatch.setattr("awf.control.worker.cleanup.monotonic", lambda: current_time)
+    calls = 0
+
+    async def _reap() -> dict[str, object]:
+        """Record successful reaper invocations."""
+        nonlocal calls
+        calls += 1
+        return _ok_report()
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True, interval=3600.0)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+    assert calls == 1
+    assert worker._next_terminal_gc_reap_scan_at == current_time + 3600.0  # noqa: SLF001
+
+    # A second call within the interval is gated out.
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+    assert calls == 1
+
+
+async def test_fatal_error_logged_swallowed_and_reschedules(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected reaper failures are logged loudly, swallowed, and rescheduled."""
+    current_time = 3_000.0
+    monkeypatch.setattr("awf.control.worker.cleanup.monotonic", lambda: current_time)
+    logged: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "awf.control.worker.cleanup._log.exception",
+        lambda event, **fields: logged.append((event, fields)),
+    )
+
+    async def _reap() -> dict[str, object]:
+        """Raise the fatal reaper failure under test."""
+        raise RuntimeError("rmtree blew up")
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True, interval=60.0)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert [event for event, _ in logged] == ["worker.terminal_workspace_gc_reap_failed"]
+    assert logged[0][1]["reason_code"] == "TERMINAL_WORKSPACE_GC_SWEEP_FAILED"
+    assert worker._next_terminal_gc_reap_scan_at == current_time + 60.0  # noqa: SLF001
+
+
+async def test_partial_report_is_warned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A self-protecting ``partial`` report is surfaced as a warning, not an error."""
+    current_time = 4_000.0
+    monkeypatch.setattr("awf.control.worker.cleanup.monotonic", lambda: current_time)
+    warned: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "awf.control.worker.cleanup._log.warning",
+        lambda event, **fields: warned.append((event, fields)),
+    )
+
+    async def _reap() -> dict[str, object]:
+        """Return a partial report with one delete error and no reclaimed paths."""
+        return {
+            "status": "partial",
+            "reason_code": "WORKSPACE_GC_PARTIAL",
+            "deleted_path_count": 0,
+            "candidate_count": 1,
+            "preserved_count": 0,
+            "delete_errors": [
+                {"workspace_id": "ws_x", "kind": "auth", "path": "/w/auth/ws_x", "error": "boom"}
+            ],
+        }
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True, interval=120.0)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert [event for event, _ in warned] == ["worker.terminal_workspace_gc_partial"]
+    assert warned[0][1]["reason_code"] == "WORKSPACE_GC_PARTIAL"
+    # Only the count is surfaced, never the auth-dir path/contents.
+    assert warned[0][1]["delete_error_count"] == 1
+    assert worker._next_terminal_gc_reap_scan_at == current_time + 120.0  # noqa: SLF001
+
+
+async def test_successful_reclaim_is_logged_at_info(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When paths are reclaimed the sweep logs an ``info`` summary with counts only."""
+    monkeypatch.setattr("awf.control.worker.cleanup.monotonic", lambda: 5_000.0)
+    info: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "awf.control.worker.cleanup._log.info",
+        lambda event, **fields: info.append((event, fields)),
+    )
+
+    async def _reap() -> dict[str, object]:
+        """Return a report that reclaimed one terminal-workspace auth dir."""
+        return _reaped_report()
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert [event for event, _ in info] == ["worker.terminal_workspace_gc_reaped"]
+    assert info[0][1]["deleted_path_count"] == 1
+    assert info[0][1]["preserved_count"] == 1
+    assert info[0][1]["reason_code"] == "WORKSPACE_GC_OK"
+
+
+async def test_clean_no_op_report_is_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A succeeded run that reclaimed nothing logs neither info nor warning."""
+    monkeypatch.setattr("awf.control.worker.cleanup.monotonic", lambda: 6_000.0)
+    info: list[tuple[str, dict[str, object]]] = []
+    warned: list[tuple[str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        "awf.control.worker.cleanup._log.info",
+        lambda event, **fields: info.append((event, fields)),
+    )
+    monkeypatch.setattr(
+        "awf.control.worker.cleanup._log.warning",
+        lambda event, **fields: warned.append((event, fields)),
+    )
+
+    async def _reap() -> dict[str, object]:
+        """Return a clean no-op report."""
+        return _ok_report()
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    assert info == []
+    assert warned == []
+
+
+async def test_run_once_invokes_terminal_gc_reap_loop() -> None:
+    """The worker run-once path includes the terminal-workspace GC reaper loop."""
+    calls = 0
+
+    async def _reap() -> dict[str, object]:
+        """Record run-once reaper invocation."""
+        nonlocal calls
+        calls += 1
+        return _ok_report()
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True)
+    worker._next_secret_lease_expiration_scan_at = float("inf")  # noqa: SLF001
+    worker._next_terminal_runtime_release_scan_at = float("inf")  # noqa: SLF001
+    worker._next_orphan_reconcile_scan_at = float("inf")  # noqa: SLF001
+    worker._next_classified_orphan_reap_scan_at = float("inf")  # noqa: SLF001
+    worker._next_claude_base_reap_scan_at = float("inf")  # noqa: SLF001
+
+    dispatched = await worker.run_once()
+
+    assert dispatched == 0
+    assert calls == 1
+
+
+async def test_cancelled_error_propagates() -> None:
+    """A cooperative-shutdown ``CancelledError`` propagates and does not reschedule."""
+    import asyncio
+
+    async def _reap() -> dict[str, object]:
+        """Raise CancelledError to simulate shutdown mid-sweep."""
+        raise asyncio.CancelledError
+
+    worker = _make_worker(_reap, terminal_workspace_gc_enabled=True, interval=300.0)
+    worker._next_terminal_gc_reap_scan_at = 0.0  # noqa: SLF001
+
+    with pytest.raises(asyncio.CancelledError):
+        await worker._maybe_reap_terminal_workspace_gc()  # noqa: SLF001
+
+    # Cursor is not rescheduled when the sweep is cancelled.
+    assert worker._next_terminal_gc_reap_scan_at == 0.0  # noqa: SLF001

--- a/tests/unit/service/test_config_parts/test_config_part_003.py
+++ b/tests/unit/service/test_config_parts/test_config_part_003.py
@@ -397,3 +397,30 @@ def test_orphan_reconcile_settings_flow_from_environment() -> None:
     assert settings.claude_base_reap_scan_interval_seconds == 1234.0
     assert settings.orphan_reconcile_max_per_scan == 7
     assert settings.orphan_reconcile_min_age_hours == 12.0
+
+
+@pytest.mark.unit
+def test_terminal_workspace_gc_defaults_are_on_and_sane() -> None:
+    settings = resolve_service_settings(Settings(_env_file=None), environ={})
+
+    assert settings.terminal_workspace_gc_enabled is True
+    assert (
+        settings.terminal_workspace_gc_scan_interval_seconds
+        == DEFAULT_ORPHAN_RECONCILE_SCAN_INTERVAL_SECONDS
+    )
+
+
+@pytest.mark.unit
+def test_terminal_workspace_gc_settings_flow_from_environment() -> None:
+    base = Settings(
+        _env_file=None,
+        terminal_workspace_gc_enabled=False,
+        terminal_workspace_gc_scan_interval_seconds=555.0,
+    )
+
+    settings = resolve_service_settings(base, environ={})
+
+    # Settings -> ServiceSettings passthrough (the WorkerConfig forward is covered
+    # by tests/unit/service/test_worker_terminal_gc_reaper.py).
+    assert settings.terminal_workspace_gc_enabled is False
+    assert settings.terminal_workspace_gc_scan_interval_seconds == 555.0

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -215,6 +215,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
             orphan_dir_reconciler: object = None,
             classified_orphan_reaper: object = None,
             claude_base_reaper: object = None,
+            terminal_gc_reaper: object = None,
             auth_overlay_work_dir: object = None,
             config: object,
         ) -> None:
@@ -868,6 +869,7 @@ def test_build_worker_runtime_uses_local_service_node_id_instead_of_container_ho
             orphan_dir_reconciler: object = None,
             classified_orphan_reaper: object = None,
             claude_base_reaper: object = None,
+            terminal_gc_reaper: object = None,
             auth_overlay_work_dir: object = None,
             config: object,
         ) -> None:
@@ -958,6 +960,7 @@ def test_build_worker_runtime_defaults_unset_service_node_id_to_local(
             orphan_dir_reconciler: object = None,
             classified_orphan_reaper: object = None,
             claude_base_reaper: object = None,
+            terminal_gc_reaper: object = None,
             auth_overlay_work_dir: object = None,
             config: object,
         ) -> None:
@@ -1344,6 +1347,7 @@ def _stub_worker_runtime_dependencies(
             orphan_dir_reconciler: object = None,
             classified_orphan_reaper: object = None,
             claude_base_reaper: object = None,
+            terminal_gc_reaper: object = None,
             auth_overlay_work_dir: object = None,
             config: object,
         ) -> None:

--- a/tests/unit/service/test_worker_terminal_gc_reaper.py
+++ b/tests/unit/service/test_worker_terminal_gc_reaper.py
@@ -1,0 +1,268 @@
+"""Worker-runtime wiring for the terminal-workspace auth-dir GC reaper (#513).
+
+Split out of ``test_worker.py`` to keep that module under the first-party file
+line limit (``test_first_party_code_files_stay_under_line_limit``). Shares the
+``_settings`` / ``_in_process_merge_coordinator`` builders with the parent
+module.
+
+The terminal-workspace GC (``run_service_workspace_gc``) is the same engine the
+``POST /v1/service/gc`` route calls, but that route runs in the capability-less
+API container and skips every per-workspace auth dir (the overlay
+unmount-before-remove cannot be verified without CAP_SYS_ADMIN). Only the worker
+holds CAP_SYS_ADMIN, so these tests prove (a) the worker is wired with a closure
+that drives the real GC and (b) the kill-switch/interval forward end to end into
+``WorkerConfig`` — guarding the #511-class regression — and (c) the closure
+actually removes a terminal-workspace auth dir while preserving a failed one.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.node.compose_manager import ComposeTeardownResult
+from awf.service import worker as worker_mod
+from tests.unit.service.test_worker import (
+    _in_process_merge_coordinator,
+    _settings,
+)
+
+
+@pytest.fixture
+async def session_factory(
+    engine: AsyncEngine,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    yield make_session_factory(engine)
+
+
+class _AnyInit:
+    """A no-op stand-in for the node/runtime classes the runtime constructs."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+
+class _FakeComposeManager:
+    """ComposeManager stand-in whose teardown always succeeds (no real docker)."""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        pass
+
+    async def teardown_project(
+        self,
+        *,
+        project_name: str,
+        compose_file: Path,
+        workspace_id: str,
+        remove_volumes: bool = True,
+    ) -> ComposeTeardownResult:
+        return ComposeTeardownResult(
+            status="succeeded", reason_code="DOCKER_COMPOSE_DOWN_SUCCEEDED"
+        )
+
+
+def _patch_runtime_constructors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out the heavyweight node/runtime classes ``build_worker_runtime`` builds."""
+    for name in (
+        "AsyncioSubprocessRunner",
+        "LogStore",
+        "ValidationRunner",
+        "PullRequestCreator",
+        "BranchOpenPullRequestResolver",
+        "GitManager",
+        "ServiceAuthMountResolver",
+        "LocalSecretLeaseMountResolver",
+        "ComposeStackLauncher",
+        "Provisioner",
+        "WorkspaceExecutor",
+        "CcusageCollector",
+    ):
+        monkeypatch.setattr(worker_mod, name, _AnyInit)
+    monkeypatch.setattr(worker_mod, "ComposeManager", _FakeComposeManager)
+    monkeypatch.setattr(
+        worker_mod, "_merge_coordinator_for_database_url", _in_process_merge_coordinator
+    )
+    monkeypatch.setattr(worker_mod, "_companion_image_builder_for", lambda *_a, **_k: None)
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+    monkeypatch.setattr(worker_mod, "_apply_service_git_environment", lambda _env: None)
+    monkeypatch.setattr(worker_mod, "build_default_compose_teardown", lambda _manager: object())
+    monkeypatch.setattr(worker_mod, "build_orphan_compose_teardown", lambda _manager: object())
+
+
+@pytest.mark.unit
+def test_build_worker_runtime_wires_terminal_gc_reaper_and_forwards_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The worker is wired with a terminal-GC reaper and the kill-switch/interval forward (#513).
+
+    Asserts the closure is wired and that ``terminal_workspace_gc_enabled`` /
+    ``terminal_workspace_gc_scan_interval_seconds`` flow ``Settings`` →
+    ``ServiceSettings`` → ``WorkerConfig`` (the forward #511 originally dropped for
+    the claude-base interval). A non-default interval proves it is the settings
+    value, not a hard-coded default.
+    """
+    created: dict[str, Any] = {}
+
+    class _ControlWorker:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            created["terminal_gc_reaper"] = kwargs["terminal_gc_reaper"]
+            created["worker_config"] = kwargs["config"]
+
+    monkeypatch.setattr(worker_mod, "make_engine", lambda _url: object())
+    monkeypatch.setattr(worker_mod, "make_session_factory", lambda _engine: object())
+    _patch_runtime_constructors(monkeypatch)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+
+    settings = dataclasses.replace(
+        _settings(tmp_path),
+        terminal_workspace_gc_enabled=True,
+        terminal_workspace_gc_scan_interval_seconds=1800.0,
+    )
+
+    worker_mod.build_worker_runtime(settings)
+
+    reaper = created["terminal_gc_reaper"]
+    assert reaper is not None
+    assert callable(reaper)
+    config = created["worker_config"]
+    assert config.terminal_workspace_gc_enabled is settings.terminal_workspace_gc_enabled
+    assert (
+        config.terminal_workspace_gc_scan_interval_seconds
+        == settings.terminal_workspace_gc_scan_interval_seconds
+    )
+
+
+async def _terminal_workspace_with_auth_overlay(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    work_dir: Path,
+    status: WorkspaceStatus,
+    updated_at: datetime,
+) -> tuple[str, Path]:
+    """Seed a terminal workspace plus a Claude auth-overlay scratch dir.
+
+    The auth dir holds an overlay ``upper`` (the writable scratch) with no live
+    ``merged`` mount and no ``.overlay-unmounted`` marker, so the GC's
+    unmount-before-remove path is exercised: a capability-less probe would refuse
+    (``OverlayUnmountUnverifiableError``), but the worker's CAP_SYS_ADMIN vantage
+    verifies there is nothing to release and removal proceeds.
+    """
+    async with session_factory() as session:
+        workspace = await WorkspaceRepository(session).create(
+            repo_url="git@github.com:example/repo.git",
+            branch_base="development",
+            task_title="gc candidate",
+            task_prompt="p",
+            agent="claude",
+            test_commands=[],
+        )
+        workspace.status = status.value
+        workspace.updated_at = updated_at
+        if status == WorkspaceStatus.completed:
+            workspace.pr_url = "https://github.com/example/repo/pull/7"
+            workspace.pr_number = 7
+            workspace.pr_merge_sha = "a" * 40
+        workspace_id = workspace.id
+        await session.commit()
+
+    upper = work_dir / "auth" / workspace_id / "claude" / "upper"
+    upper.mkdir(parents=True)
+    (upper / "scratch").write_text("y" * 256, encoding="utf-8")
+    return workspace_id, (work_dir / "auth" / workspace_id)
+
+
+@pytest.mark.unit
+async def test_worker_terminal_gc_reaper_removes_auth_dir_and_preserves_failed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """End-to-end: the wired closure removes a completed auth dir and preserves a failed one.
+
+    Drives the real ``run_service_workspace_gc`` from the worker closure against a
+    temp ``work_dir`` seeded with a completed (reaped) and a failed (preserved)
+    terminal workspace, each with a Claude overlay scratch. A forced True
+    capability probe stands in for the worker's CAP_SYS_ADMIN, so the
+    unmount-before-remove succeeds instead of raising — exactly the gap the API
+    path cannot close (#513). The ``preserves_failed_workspaces=True`` policy is
+    inherited from the GC, so the failed auth dir must survive.
+    """
+    created: dict[str, Any] = {}
+
+    class _ControlWorker:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            created["terminal_gc_reaper"] = kwargs["terminal_gc_reaper"]
+
+    monkeypatch.setattr(worker_mod, "make_engine", lambda _url: object())
+    monkeypatch.setattr(worker_mod, "make_session_factory", lambda _engine: session_factory)
+    _patch_runtime_constructors(monkeypatch)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+    # The worktree remover runs ``git worktree remove`` — stub it so the GC does
+    # not shell out for the (non-existent) candidate worktrees.
+    from unittest.mock import AsyncMock
+
+    from awf.service.gc import WorkspaceGCWorktreeRemoveResult
+
+    monkeypatch.setattr(
+        "awf.service.gc._default_worktree_remover",
+        AsyncMock(
+            return_value=WorkspaceGCWorktreeRemoveResult(
+                status="succeeded", reason_code="WORKTREE_REMOVE_SUCCEEDED"
+            )
+        ),
+    )
+    # Force a trustworthy capability probe so the no-overlay test host does not
+    # raise ``OverlayUnmountUnverifiableError`` (mirrors the worker's CAP_SYS_ADMIN
+    # vantage). The default ``teardown_workspace_auth_overlay`` probe resolves
+    # ``_has_cap_sys_admin`` from ``awf.node.auth_mounts_claude``.
+    monkeypatch.setattr("awf.node.auth_mounts_claude._has_cap_sys_admin", lambda: True)
+
+    # Keep the focus on per-workspace auth dirs: the same-pass claude-base reap is
+    # covered by #509's tests, and disabling it avoids the host ``~/.claude``
+    # signature machinery here.
+    settings = dataclasses.replace(
+        _settings(tmp_path, completed_workspace_retention_hours=24.0),
+        claude_base_gc_enabled=False,
+        # The companion-image prune shells out to docker; off keeps the run focused
+        # on the auth-dir reclaim (and avoids a spurious ``partial`` on a host with
+        # no docker).
+        companion_image_cache_enabled=False,
+    )
+    work_dir = Path(settings.work_dir).resolve()
+    old = datetime.now(UTC) - timedelta(hours=200)
+    completed_id, completed_auth = await _terminal_workspace_with_auth_overlay(
+        session_factory,
+        work_dir=work_dir,
+        status=WorkspaceStatus.completed,
+        updated_at=old,
+    )
+    _failed_id, failed_auth = await _terminal_workspace_with_auth_overlay(
+        session_factory,
+        work_dir=work_dir,
+        status=WorkspaceStatus.failed,
+        updated_at=old,
+    )
+    assert completed_auth.is_dir()
+    assert failed_auth.is_dir()
+
+    worker_mod.build_worker_runtime(settings)
+    reaper = created["terminal_gc_reaper"]
+
+    report = await reaper()
+
+    # The completed workspace's auth dir is reclaimed; the failed one is preserved.
+    assert not completed_auth.exists()
+    assert failed_auth.is_dir()
+    assert report["status"] == "succeeded"
+    assert str(completed_auth) in report["deleted_paths"]
+    assert completed_id in {c["workspace_id"] for c in report["candidates"]}

--- a/tests/unit/service/test_worker_terminal_gc_reaper.py
+++ b/tests/unit/service/test_worker_terminal_gc_reaper.py
@@ -266,3 +266,160 @@ async def test_worker_terminal_gc_reaper_removes_auth_dir_and_preserves_failed(
     assert report["status"] == "succeeded"
     assert str(completed_auth) in report["deleted_paths"]
     assert completed_id in {c["workspace_id"] for c in report["candidates"]}
+
+
+@pytest.mark.unit
+async def test_worker_terminal_gc_reaper_reaps_cancelled_and_destroyed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    """The wired closure reaps cancelled/destroyed auth dirs the default policy skips (#513).
+
+    ``plan_terminal_workspace_gc``'s conservative default policy only classifies
+    completed/failed/superseded rows (guarded by
+    ``test_default_gc_policy_ignores_non_pr_terminal_and_unknown_statuses``), so a
+    single default-policy sweep never even looks at ``cancelled``/``destroyed``
+    workspaces and their ~1.7 GB auth dirs leak — the exact case #513 set out to
+    fix. The worker therefore runs a second, explicit ``include_statuses`` pass for
+    those discarded statuses (they carry no merged-PR work to preserve, so an
+    age-based sweep is correct) while leaving the first pass's completed-merged /
+    failed-preservation nuance untouched. This proves both discarded dirs are
+    removed and the failed one still survives.
+    """
+    created: dict[str, Any] = {}
+
+    class _ControlWorker:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            created["terminal_gc_reaper"] = kwargs["terminal_gc_reaper"]
+
+    monkeypatch.setattr(worker_mod, "make_engine", lambda _url: object())
+    monkeypatch.setattr(worker_mod, "make_session_factory", lambda _engine: session_factory)
+    _patch_runtime_constructors(monkeypatch)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+    from unittest.mock import AsyncMock
+
+    from awf.service.gc import WorkspaceGCWorktreeRemoveResult
+
+    monkeypatch.setattr(
+        "awf.service.gc._default_worktree_remover",
+        AsyncMock(
+            return_value=WorkspaceGCWorktreeRemoveResult(
+                status="succeeded", reason_code="WORKTREE_REMOVE_SUCCEEDED"
+            )
+        ),
+    )
+    monkeypatch.setattr("awf.node.auth_mounts_claude._has_cap_sys_admin", lambda: True)
+
+    settings = dataclasses.replace(
+        _settings(tmp_path, completed_workspace_retention_hours=24.0),
+        claude_base_gc_enabled=False,
+        companion_image_cache_enabled=False,
+    )
+    work_dir = Path(settings.work_dir).resolve()
+    old = datetime.now(UTC) - timedelta(hours=200)
+    cancelled_id, cancelled_auth = await _terminal_workspace_with_auth_overlay(
+        session_factory,
+        work_dir=work_dir,
+        status=WorkspaceStatus.cancelled,
+        updated_at=old,
+    )
+    destroyed_id, destroyed_auth = await _terminal_workspace_with_auth_overlay(
+        session_factory,
+        work_dir=work_dir,
+        status=WorkspaceStatus.destroyed,
+        updated_at=old,
+    )
+    _failed_id, failed_auth = await _terminal_workspace_with_auth_overlay(
+        session_factory,
+        work_dir=work_dir,
+        status=WorkspaceStatus.failed,
+        updated_at=old,
+    )
+    assert cancelled_auth.is_dir()
+    assert destroyed_auth.is_dir()
+    assert failed_auth.is_dir()
+
+    worker_mod.build_worker_runtime(settings)
+    reaper = created["terminal_gc_reaper"]
+
+    report = await reaper()
+
+    # Both discarded-status auth dirs are reclaimed; the failed one is preserved.
+    assert not cancelled_auth.exists()
+    assert not destroyed_auth.exists()
+    assert failed_auth.is_dir()
+    assert report["status"] == "succeeded"
+    deleted = set(report["deleted_paths"])
+    assert str(cancelled_auth) in deleted
+    assert str(destroyed_auth) in deleted
+    candidate_ids = {c["workspace_id"] for c in report["candidates"]}
+    assert {cancelled_id, destroyed_id} <= candidate_ids
+
+
+@pytest.mark.unit
+def test_combine_terminal_gc_reports_concatenates_and_sums() -> None:
+    """A clean default pass + clean discarded pass fold into one ``succeeded`` summary."""
+    default_report: dict[str, Any] = {
+        "status": "succeeded",
+        "reason_code": "CLEANUP_EXECUTION_SUCCEEDED",
+        "deleted_paths": ["/a"],
+        "candidates": [{"workspace_id": "ws_completed"}],
+        "delete_errors": [],
+        "preserved_count": 1,
+        "deleted_path_count": 1,
+        "candidate_count": 1,
+    }
+    discarded_report: dict[str, Any] = {
+        "status": "succeeded",
+        "reason_code": "CLEANUP_EXECUTION_SUCCEEDED",
+        "deleted_paths": ["/b", "/c"],
+        "candidates": [{"workspace_id": "ws_cancelled"}, {"workspace_id": "ws_destroyed"}],
+        "delete_errors": [],
+        "preserved_count": 2,
+        "deleted_path_count": 2,
+        "candidate_count": 2,
+    }
+
+    combined = worker_mod._combine_terminal_gc_reports(default_report, discarded_report)
+
+    assert combined["status"] == "succeeded"
+    assert combined["reason_code"] == "CLEANUP_EXECUTION_SUCCEEDED"
+    assert combined["deleted_paths"] == ["/a", "/b", "/c"]
+    assert combined["deleted_path_count"] == 3
+    assert combined["candidate_count"] == 3
+    assert combined["preserved_count"] == 3
+
+
+@pytest.mark.unit
+def test_combine_terminal_gc_reports_partial_in_either_pass_wins() -> None:
+    """A ``partial`` from the discarded pass is never masked behind the default pass.
+
+    The discarded-status pass leaked disk it could not reclaim, so the merged
+    summary must report ``partial`` (and the partial reason code) even though the
+    default pass reported a clean success.
+    """
+    from awf.service.gc import CLEANUP_EXECUTION_PARTIAL
+
+    default_report: dict[str, Any] = {
+        "status": "succeeded",
+        "reason_code": "CLEANUP_EXECUTION_SUCCEEDED",
+        "deleted_paths": [],
+        "candidates": [],
+        "delete_errors": [],
+        "preserved_count": 0,
+    }
+    discarded_report: dict[str, Any] = {
+        "status": "partial",
+        "reason_code": CLEANUP_EXECUTION_PARTIAL,
+        "deleted_paths": [],
+        "candidates": [],
+        "delete_errors": [{"kind": "auth", "error": "boom"}],
+        "preserved_count": 0,
+    }
+
+    combined = worker_mod._combine_terminal_gc_reports(default_report, discarded_report)
+
+    assert combined["status"] == "partial"
+    assert combined["reason_code"] == CLEANUP_EXECUTION_PARTIAL
+    assert combined["delete_errors"] == [{"kind": "auth", "error": "boom"}]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_7d839ce954d4472095bf4bfa` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix #513: terminal-workspace auth dirs leak because the GC step that needs CAP_SYS_ADMIN only runs from the capability-less API. Drive the existing terminal-workspace GC from the WORKER instead.

## Problem (verified)
Per-workspace auth dirs at `~/.awf/service/auth/<ws_id>/` (~1.7 GB each) for terminal workspaces (completed/cancelled/destroyed) are never reclaimed and leak tens of GB. Removing an auth dir requires first unmounting a possible live Claude overlay at `auth/<id>/claude/merged` (the unmount-before-remove contract in `src/awf/service/gc_auth_overlay.py`). `teardown_workspace_auth_overlay` raises `OverlayUnmountUnverifiableError` whenever the caller cannot verify it holds CAP_SYS_ADMIN. The GC entrypoint `run_terminal_workspace_gc` (`src/awf/service/gc.py:347-453`; skip recorded at ~830-848 / 885-915) is invoked from `POST /v1/service/gc` (`src/awf/api/routes/service.py:31-65`), which runs in the API container WITHOUT CAP_SYS_ADMIN. So it records per-path `status: skipped`, top-level `status: partial`, and deletes nothing. Only the worker container holds CAP_SYS_ADMIN + the agent mount namespace.

This is the same root cause as #509, which wired the `_shared/claude-base` reaper into the worker. #509 did NOT cover the per-workspace terminal-workspace auth-dir GC. Confirmed gap: no worker loop deletes terminal-workspace auth dirs today (`_maybe_reconcile_orphan_dirs` = deleted rows only; `_maybe_reap_classified_orphans`/`sweep_classified_orphans` = Docker resources + worktrees, not auth; `_maybe_release_terminal_runtime` unmounts the overlay but does not rmtree the dir).

## Approach (LOCKED — reuse, do not duplicate)
Drive the EXISTING `run_terminal_workspace_gc` from a new worker periodic cleanup loop, mirroring exactly how #509 wired the claude-base reaper. Running the same, already-tested GC from the worker (which holds CAP_SYS_ADMIN) makes `teardown_workspace_auth_overlay` succeed instead of skipping. This reuses the GC's classification, path-planning, DB-outcome bookkeeping (`WorkspaceGCPathOutcome`), and the `preserves_failed_workspaces=True` status policy automatically. DO NOT write a separate lean auth-only reaper that re-implements the terminal-workspace query or replicates/skips the DB bookkeeping — that would violate DRY.

## Files (mirror the #509 pattern — study these first)
Study how #509 wired `reap_superseded_claude_bases`:
- `src/awf/service/worker.py:317-342` — the `_reap_superseded_claude_bases` closure passed to `ControlWorker(claude_base_reaper=...)`.
- `src/awf/control/worker/cleanup.py:249-293` — `_maybe_reap_superseded_claude_bases` (gate on closure wired + kill-switch + interval; never raise; log summary; reschedule cursor; CancelledError propagates).
- `src/awf/control/worker/manager.py` — the `claude_base_reaper` param + storage + the `run_once` call site.
- `src/awf/control/worker/config.py` — `claude_base_gc_enabled` + `claude_base_reap_scan_interval_seconds`.
- `src/awf/service/config.py` + `src/awf/common/config.py` — settings passthrough.

Then add the parallel terminal-workspace-GC wiring:
1. `src/awf/service/worker.py` — a `_reap_terminal_workspace_gc` async closure that wraps `run_terminal_workspace_gc(...)` in `asyncio.to_thread` (it does blocking multi-GB rmtree + DB work; check what session/work_dir/docker_host args it needs and supply them from the worker runtime the same way the other reapers get their deps). Pass it to `ControlWorker(..., terminal_gc_reaper=_reap_terminal_workspace_gc)`.
2. `src/awf/control/worker/{manager,cleanup,config}.py` — store the new reaper, add `_maybe_reap_terminal_workspace_gc` mirroring `_maybe_reap_superseded_claude_bases`, drive it from `run_once`, and add `terminal_workspace_gc_enabled: bool = True` + `terminal_workspace_gc_scan_interval_seconds: float` to WorkerConfig.
3. `src/awf/service/config.py` + `src/awf/common/config.py` — add the settings + **forward them into WorkerConfig**. CRITICAL: #509 added a `claude_base_reap_scan_interval_seconds` field but forgot to forward it from `settings`; that was caught in the dev->main review of #511 (commit 5456dd48 fixed it). Do NOT repeat that mistake — wire the new interval/flag end to end (Settings -> ServiceSettings -> WorkerConfig) and assert the passthrough in a config test.
4. `.env.example` — document the new `AWF_TERMINAL_WORKSPACE_GC_ENABLED` + `AWF_TERMINAL_WORKSPACE_GC_SCAN_INTERVAL_SECONDS`.

## Behavior / safety (match #509)
- Gated by the kill-switch; no-op when disabled or no closure wired.
- `asyncio.to_thread` for the blocking work; never raise (return/handle the GC report dict); `_log.exception` on unexpected errors; always reschedule the interval cursor; `asyncio.CancelledError` propagates for shutdown.
- Honor the existing GC policy: completed/cancelled/destroyed are reaped; `failed` workspaces are PRESERVED (`preserves_failed_workspaces=True`) — this is inherited from `run_terminal_workspace_gc`, do not override it. Honor `min_age_hours` retention. Never touch active (provisioning/monitoring_pr) workspaces.
- The API `POST /v1/service/gc` endpoint stays as-is (still capability-limited; the GC is idempotent so the overlap is harmless).

## Tests (full coverage; behavior + edge + error paths)
- A worker cleanup-loop test mirroring the #509 claude-base loop tests (closure-not-wired no-op; kill-switch off no-op; interval gating; never-raise on reaper error; cursor reschedule).
- A service-worker wiring test asserting `build_worker_runtime` passes the closure + the kill-switch/interval flow from settings into WorkerConfig. WATCH THE 1500-LINE FILE LIMIT: `tests/unit/service/test_worker.py` is near it — if your additions would push it over, put the new test in a sibling file (see how #509 used `tests/unit/service/test_worker_claude_base_reaper.py`, importing shared helpers `_settings`/`_in_process_merge_coordinator`).
- An integration-style test that seeds a terminal-workspace auth dir under a temp work_dir and asserts the worker reaper removes it (force a True capability probe so the no-overlay test host doesn't mark it unverifiable, exactly like `test_build_worker_runtime_wires_claude_base_reaper` does for the claude-base reaper).
- A config passthrough test for the new settings.
- Run `ruff`, `mypy`, and the full `--cov=awf --cov-fail-under=99` suite green.

## Scope discipline
Only the files above (worker/service/config + tests + .env.example). No protected paths. PR to development.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Periodic destructive removal of multi-GB auth paths depends on overlay unmount in the worker; mitigated by reusing the existing GC engine, failed-workspace preservation, kill-switch, and batch limits.
> 
> **Overview**
> Fixes **#513** by running terminal-workspace auth-dir cleanup from the **worker** (CAP_SYS_ADMIN) instead of relying on the API GC path, which skips auth dirs when overlay unmount cannot be verified.
> 
> A new periodic sweep **`_maybe_reap_terminal_workspace_gc`** mirrors the superseded-Claude-base reaper: kill-switch **`terminal_workspace_gc_enabled`**, configurable scan interval, interval gating, structured logging, and errors swallowed so provisioning is not blocked. **`build_worker_runtime`** wires **`terminal_gc_reaper`** to call **`run_service_workspace_gc`** twice—default retention policy (failed workspaces preserved) plus an explicit pass for **cancelled/destroyed** statuses the default planner omits—then merges both reports via **`_combine_terminal_gc_reports`**.
> 
> Settings flow **Settings → ServiceSettings → WorkerConfig**; **`.env.example`** documents **`AWF_TERMINAL_WORKSPACE_GC_*`**. Unit and integration-style tests cover loop behavior, config passthrough, and real auth-dir removal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d9e5ae4fe5ba9f45d828b647f2dd6c46d4d5d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal workspace garbage collection now runs automatically, with configurable controls to enable/disable and set scan intervals for authentication directory cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->