### PR TITLE
Promote console clipboard fallback + favicon + lib/ gitignore fix to main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,11 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+# Anchored to the repo root: these are Python build/packaging output dirs. Without
+# the leading slash, the bare `lib/` also matched apps/console/lib (the Next.js
+# console's source modules), silently ignoring new files there — anchor to root.
+/lib/
+/lib64/
 parts/
 sdist/
 var/

--- a/apps/console/app/icon.svg
+++ b/apps/console/app/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" role="img" aria-label="AWF Console">
+  <!-- Matches the in-app logo: the lucide "Boxes" mark in white on slate-950. -->
+  <rect width="32" height="32" rx="7" fill="#020617"/>
+  <g transform="translate(6 6) scale(0.83333)" fill="none" stroke="#ffffff" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M2.97 12.92A2 2 0 0 0 2 14.63v3.24a2 2 0 0 0 .97 1.71l3 1.8a2 2 0 0 0 2.06 0L12 19v-5.5l-5-3-4.03 2.42Z"/>
+    <path d="m7 16.5-4.74-2.85"/>
+    <path d="m7 16.5 5-3"/>
+    <path d="M7 16.5v5.17"/>
+    <path d="M12 13.5V19l3.97 2.38a2 2 0 0 0 2.06 0l3-1.8a2 2 0 0 0 .97-1.71v-3.24a2 2 0 0 0-.97-1.71L17 10.5l-5 3Z"/>
+    <path d="m17 16.5-5-3"/>
+    <path d="m17 16.5 4.74-2.85"/>
+    <path d="M17 16.5v5.17"/>
+    <path d="M7.97 4.42A2 2 0 0 0 7 6.13v4.37l5 3 5-3V6.13a2 2 0 0 0-.97-1.71l-3-1.8a2 2 0 0 0-2.06 0l-3 1.8Z"/>
+    <path d="M12 8 7.26 5.15"/>
+    <path d="m12 8 4.74-2.85"/>
+    <path d="M12 13.5V8"/>
+  </g>
+</svg>

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -627,6 +627,17 @@ export function WorkspaceList({
   const copyWorkspaceId = async (event: SyntheticEvent<HTMLElement>, workspaceId: string) => {
     event.preventDefault();
     event.stopPropagation();
+    // Clear any pending timers upfront so every copy attempt starts from a clean
+    // state — otherwise stale timers from a prior successful copy could fire during
+    // the await or after a failed attempt and unexpectedly mutate the toast state.
+    if (copyFadeTimeoutRef.current !== null) {
+      clearTimeout(copyFadeTimeoutRef.current);
+      copyFadeTimeoutRef.current = null;
+    }
+    if (copyClearTimeoutRef.current !== null) {
+      clearTimeout(copyClearTimeoutRef.current);
+      copyClearTimeoutRef.current = null;
+    }
     // Use the fallback-aware helper: navigator.clipboard is unavailable over plain
     // HTTP (e.g. a Tailscale address), so it falls back to execCommand there.
     const copied = await copyTextToClipboard(workspaceId);
@@ -637,12 +648,6 @@ export function WorkspaceList({
     }
     setCopiedWorkspaceId(workspaceId);
     setCopyToastVisible(true);
-    if (copyFadeTimeoutRef.current !== null) {
-      clearTimeout(copyFadeTimeoutRef.current);
-    }
-    if (copyClearTimeoutRef.current !== null) {
-      clearTimeout(copyClearTimeoutRef.current);
-    }
     copyFadeTimeoutRef.current = setTimeout(() => {
       setCopyToastVisible(false);
     }, 1000);

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -35,6 +35,7 @@ useState
 } from "react";
 
 import { formatAgentLabel,formatAgentTitle } from "@/lib/agent-format";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { summarizeVisibleCoordinationWarnings } from "@/lib/coordination-format";
 import {
 compactId,
@@ -626,26 +627,28 @@ export function WorkspaceList({
   const copyWorkspaceId = async (event: SyntheticEvent<HTMLElement>, workspaceId: string) => {
     event.preventDefault();
     event.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(workspaceId);
-      setCopiedWorkspaceId(workspaceId);
-      setCopyToastVisible(true);
-      if (copyFadeTimeoutRef.current !== null) {
-        clearTimeout(copyFadeTimeoutRef.current);
-      }
-      if (copyClearTimeoutRef.current !== null) {
-        clearTimeout(copyClearTimeoutRef.current);
-      }
-      copyFadeTimeoutRef.current = setTimeout(() => {
-        setCopyToastVisible(false);
-      }, 1000);
-      copyClearTimeoutRef.current = setTimeout(() => {
-        setCopiedWorkspaceId((current) => (current === workspaceId ? null : current));
-      }, 1400);
-    } catch {
+    // Use the fallback-aware helper: navigator.clipboard is unavailable over plain
+    // HTTP (e.g. a Tailscale address), so it falls back to execCommand there.
+    const copied = await copyTextToClipboard(workspaceId);
+    if (!copied) {
       setCopiedWorkspaceId(null);
       setCopyToastVisible(false);
+      return;
     }
+    setCopiedWorkspaceId(workspaceId);
+    setCopyToastVisible(true);
+    if (copyFadeTimeoutRef.current !== null) {
+      clearTimeout(copyFadeTimeoutRef.current);
+    }
+    if (copyClearTimeoutRef.current !== null) {
+      clearTimeout(copyClearTimeoutRef.current);
+    }
+    copyFadeTimeoutRef.current = setTimeout(() => {
+      setCopyToastVisible(false);
+    }, 1000);
+    copyClearTimeoutRef.current = setTimeout(() => {
+      setCopiedWorkspaceId((current) => (current === workspaceId ? null : current));
+    }, 1400);
   };
 
   if (items.length === 0) {

--- a/apps/console/lib/clipboard.test.mjs
+++ b/apps/console/lib/clipboard.test.mjs
@@ -18,7 +18,12 @@ function setGlobal(name, value) {
   };
 }
 
-function makeFakeDocument({ execResult = true, throwOnExec = false, withSelection = false } = {}) {
+function makeFakeDocument({
+  execResult = true,
+  throwOnExec = false,
+  throwOnFocus = false,
+  withSelection = false,
+} = {}) {
   const appended = [];
   const removed = [];
   const execCalls = [];
@@ -30,6 +35,7 @@ function makeFakeDocument({ execResult = true, throwOnExec = false, withSelectio
     setAttribute() {},
     focus(options) {
       focusOptions.push(options);
+      if (throwOnFocus) throw new Error("focus blocked");
     },
     select() {},
     remove() {
@@ -230,6 +236,27 @@ test("resolves to false (never rejects) when a legacy DOM op throws", async () =
   const restoreDoc = setGlobal("document", doc);
   try {
     assert.equal(await copyTextToClipboard("ws_dom_throw"), false);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("cleans up the textarea and restores selection/focus when focus() throws", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, removed, restoredRanges, range, triggerFocusOptions } = makeFakeDocument({
+    throwOnFocus: true,
+    withSelection: true,
+  });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    // A sandboxed iframe that blocks focus makes textarea.focus() throw before
+    // execCommand runs; the finally block must still tear down the textarea and
+    // restore the user's selection/focus rather than stranding a 1x1 element.
+    assert.equal(await copyTextToClipboard("ws_focus_throw"), false);
+    assert.equal(removed.length, 1, "textarea is removed even when focus throws");
+    assert.deepEqual(restoredRanges, [range], "the displaced selection is restored");
+    assert.deepEqual(triggerFocusOptions, [{ preventScroll: true }], "focus is handed back");
   } finally {
     restoreDoc();
     restoreNav();

--- a/apps/console/lib/clipboard.test.mjs
+++ b/apps/console/lib/clipboard.test.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { copyTextToClipboard } from "./clipboard.ts";
+
+// Swap a property on globalThis (navigator/document) for the duration of a test,
+// returning a restore function. `document` does not exist in Node by default, so
+// the restore deletes it; `navigator` does, so we restore the prior descriptor.
+function setGlobal(name, value) {
+  const prev = Object.getOwnPropertyDescriptor(globalThis, name);
+  Object.defineProperty(globalThis, name, { configurable: true, writable: true, value });
+  return () => {
+    if (prev) {
+      Object.defineProperty(globalThis, name, prev);
+    } else {
+      delete globalThis[name];
+    }
+  };
+}
+
+function makeFakeDocument({ execResult = true, throwOnExec = false, withSelection = false } = {}) {
+  const appended = [];
+  const removed = [];
+  const execCalls = [];
+  const restoredRanges = [];
+  const focusOptions = [];
+  const textarea = {
+    value: "",
+    style: {},
+    setAttribute() {},
+    focus(options) {
+      focusOptions.push(options);
+    },
+    select() {},
+    remove() {
+      removed.push(this);
+    },
+  };
+  const range = { id: "prev-range" };
+  const selection = withSelection
+    ? {
+        rangeCount: 1,
+        getRangeAt: () => range,
+        removeAllRanges() {},
+        addRange: (r) => restoredRanges.push(r),
+      }
+    : { rangeCount: 0, getRangeAt: () => null, removeAllRanges() {}, addRange() {} };
+  const triggerFocusOptions = [];
+  const trigger = {
+    focus(options) {
+      triggerFocusOptions.push(options);
+    },
+  };
+  const doc = {
+    createElement: () => textarea,
+    body: { appendChild: (el) => appended.push(el) },
+    getSelection: () => selection,
+    activeElement: trigger,
+    execCommand(cmd) {
+      execCalls.push(cmd);
+      if (throwOnExec) throw new Error("execCommand unavailable");
+      return execResult;
+    },
+  };
+  return {
+    doc,
+    textarea,
+    appended,
+    removed,
+    execCalls,
+    restoredRanges,
+    range,
+    focusOptions,
+    trigger,
+    triggerFocusOptions,
+  };
+}
+
+test("uses navigator.clipboard.writeText in a secure context", async () => {
+  let written = null;
+  const restoreNav = setGlobal("navigator", {
+    clipboard: { writeText: async (t) => { written = t; } },
+  });
+  const restoreDoc = setGlobal("document", undefined);
+  try {
+    assert.equal(await copyTextToClipboard("ws_secure"), true);
+    assert.equal(written, "ws_secure");
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("falls back to execCommand when navigator.clipboard is missing (HTTP / Tailscale)", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, textarea, appended, removed, execCalls } = makeFakeDocument({ execResult: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_http"), true);
+    assert.equal(textarea.value, "ws_http");
+    assert.deepEqual(execCalls, ["copy"]);
+    assert.equal(appended.length, 1);
+    assert.equal(removed.length, 1, "textarea is cleaned up");
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("falls back to execCommand when navigator.clipboard.writeText rejects", async () => {
+  const restoreNav = setGlobal("navigator", {
+    clipboard: { writeText: async () => { throw new Error("blocked"); } },
+  });
+  const { doc, execCalls } = makeFakeDocument({ execResult: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_reject"), true);
+    assert.deepEqual(execCalls, ["copy"]);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("focuses the textarea with preventScroll so the page does not jump", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, focusOptions } = makeFakeDocument({ execResult: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    await copyTextToClipboard("ws_focus");
+    assert.deepEqual(focusOptions, [{ preventScroll: true }]);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("restores the prior text selection after the legacy copy", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, restoredRanges, range } = makeFakeDocument({ execResult: true, withSelection: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    await copyTextToClipboard("ws_sel");
+    assert.deepEqual(restoredRanges, [range], "the displaced selection is re-added");
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("restores focus to the triggering element after the legacy copy", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, triggerFocusOptions } = makeFakeDocument({ execResult: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    await copyTextToClipboard("ws_focus_restore");
+    assert.deepEqual(
+      triggerFocusOptions,
+      [{ preventScroll: true }],
+      "the element focused before the copy regains focus without scrolling",
+    );
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("does not throw when the active element cannot receive focus", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc } = makeFakeDocument({ execResult: true });
+  // e.g. document.activeElement is null, or an object without a focus() method.
+  doc.activeElement = {};
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_no_focus"), true);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("returns false when execCommand reports failure but still cleans up", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc, removed } = makeFakeDocument({ execResult: false });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_fail"), false);
+    assert.equal(removed.length, 1);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("returns false when execCommand throws", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc } = makeFakeDocument({ throwOnExec: true });
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_throw"), false);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("returns false when document.body is not yet available (early load / SSR)", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc } = makeFakeDocument({ execResult: true });
+  doc.body = null;
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_no_body"), false);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("resolves to false (never rejects) when a legacy DOM op throws", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const { doc } = makeFakeDocument({ execResult: true });
+  // appendChild raising is one of several legacy DOM ops outside execCommand's
+  // own try/catch; the helper must still resolve to a boolean, not reject.
+  doc.body = {
+    appendChild() {
+      throw new Error("appendChild failed");
+    },
+  };
+  const restoreDoc = setGlobal("document", doc);
+  try {
+    assert.equal(await copyTextToClipboard("ws_dom_throw"), false);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});
+
+test("returns false when neither the clipboard API nor document is available", async () => {
+  const restoreNav = setGlobal("navigator", {});
+  const restoreDoc = setGlobal("document", undefined);
+  try {
+    assert.equal(await copyTextToClipboard("ws_none"), false);
+  } finally {
+    restoreDoc();
+    restoreNav();
+  }
+});

--- a/apps/console/lib/clipboard.ts
+++ b/apps/console/lib/clipboard.ts
@@ -1,0 +1,111 @@
+/**
+ * Copy text to the clipboard in both secure and non-secure browsing contexts.
+ *
+ * `navigator.clipboard` only exists in a *secure context*: HTTPS, or the
+ * `localhost`/`127.0.0.1` special case. When the console is reached over plain
+ * HTTP — e.g. via a Tailscale address like `http://host.tailnet.ts.net` — the
+ * async Clipboard API is unavailable, so `navigator.clipboard.writeText` throws
+ * and copying silently fails. That is why "click the workspace id to copy" works
+ * on 127.0.0.1 but not over Tailscale.
+ *
+ * Strategy: use the modern Clipboard API when it is present, and otherwise fall
+ * back to the legacy `document.execCommand("copy")` path (a hidden, selected
+ * textarea), which works over plain HTTP. Returns whether the copy succeeded so
+ * callers can decide whether to show success feedback.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  if (
+    typeof navigator !== "undefined" &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.writeText === "function"
+  ) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // The async API is present but rejected (blocked permission, or a browser
+      // that exposes it over HTTP yet refuses to write). Fall through to the
+      // legacy path rather than reporting failure outright.
+    }
+  }
+  // `legacyCopyText` guards its own `execCommand` call, but the surrounding DOM
+  // operations (createElement/appendChild/focus/selection restore) can still
+  // throw. Catch here so this async function always resolves to a boolean rather
+  // than rejecting and leaving the caller's success gate with an unhandled
+  // rejection.
+  try {
+    return legacyCopyText(text);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Legacy clipboard write via a transient, off-screen textarea + `execCommand`.
+ * Deprecated but still the only option that works over plain HTTP, and supported
+ * by every browser the console targets.
+ */
+function legacyCopyText(text: string): boolean {
+  if (
+    typeof document === "undefined" ||
+    !document.body ||
+    typeof document.execCommand !== "function"
+  ) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Keep the element out of the viewport and non-interactive so selecting it
+  // does not scroll the page or flash a focus ring.
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("aria-hidden", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.padding = "0";
+  textarea.style.border = "none";
+  textarea.style.outline = "none";
+  textarea.style.boxShadow = "none";
+  textarea.style.background = "transparent";
+  textarea.style.opacity = "0";
+
+  // Preserve any existing user selection so we can restore it afterwards.
+  const selection = typeof document.getSelection === "function" ? document.getSelection() : null;
+  const previousRange = selection && selection.rangeCount > 0 ? selection.getRangeAt(0) : null;
+  // Remember which element had focus (typically the button that triggered the
+  // copy) so we can hand focus back after the textarea is gone — otherwise
+  // focusing then removing the textarea drops focus to <body>, which breaks
+  // keyboard navigation for the user who just clicked/activated the control.
+  const previouslyFocused = document.activeElement;
+
+  document.body.appendChild(textarea);
+  // `preventScroll` stops the browser from scrolling/jumping to the textarea on
+  // focus, which can happen even for a `position: fixed` element.
+  textarea.focus({ preventScroll: true });
+  textarea.select();
+
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  }
+
+  textarea.remove();
+
+  if (selection && previousRange) {
+    selection.removeAllRanges();
+    selection.addRange(previousRange);
+  }
+
+  // Restore focus to the triggering element. `preventScroll` keeps this from
+  // jumping the viewport, mirroring the textarea focus above.
+  if (previouslyFocused && typeof (previouslyFocused as HTMLElement).focus === "function") {
+    (previouslyFocused as HTMLElement).focus({ preventScroll: true });
+  }
+
+  return copied;
+}

--- a/apps/console/lib/clipboard.ts
+++ b/apps/console/lib/clipboard.ts
@@ -82,29 +82,34 @@ function legacyCopyText(text: string): boolean {
   const previouslyFocused = document.activeElement;
 
   document.body.appendChild(textarea);
-  // `preventScroll` stops the browser from scrolling/jumping to the textarea on
-  // focus, which can happen even for a `position: fixed` element.
-  textarea.focus({ preventScroll: true });
-  textarea.select();
-
   let copied = false;
   try {
-    copied = document.execCommand("copy");
-  } catch {
-    copied = false;
-  }
+    // `preventScroll` stops the browser from scrolling/jumping to the textarea on
+    // focus, which can happen even for a `position: fixed` element.
+    textarea.focus({ preventScroll: true });
+    textarea.select();
+    try {
+      copied = document.execCommand("copy");
+    } catch {
+      copied = false;
+    }
+  } finally {
+    // `focus`/`select` can throw (e.g. a sandboxed iframe that blocks focus);
+    // the `finally` guarantees the transient textarea is removed and the user's
+    // selection/focus is restored even on that path, so we never strand an
+    // invisible 1×1 element in the DOM.
+    textarea.remove();
 
-  textarea.remove();
+    if (selection && previousRange) {
+      selection.removeAllRanges();
+      selection.addRange(previousRange);
+    }
 
-  if (selection && previousRange) {
-    selection.removeAllRanges();
-    selection.addRange(previousRange);
-  }
-
-  // Restore focus to the triggering element. `preventScroll` keeps this from
-  // jumping the viewport, mirroring the textarea focus above.
-  if (previouslyFocused && typeof (previouslyFocused as HTMLElement).focus === "function") {
-    (previouslyFocused as HTMLElement).focus({ preventScroll: true });
+    // Restore focus to the triggering element. `preventScroll` keeps this from
+    // jumping the viewport, mirroring the textarea focus above.
+    if (previouslyFocused && typeof (previouslyFocused as HTMLElement).focus === "function") {
+      (previouslyFocused as HTMLElement).focus({ preventScroll: true });
+    }
   }
 
   return copied;

--- a/apps/console/tests/dashboard-inspector.spec.ts
+++ b/apps/console/tests/dashboard-inspector.spec.ts
@@ -206,6 +206,7 @@ test.describe("Dashboard Workspace Inspector", () => {
       .toBe("ws_mock123");
     await expect(page.getByText("copied", { exact: true })).toBeVisible();
     await expect(page).not.toHaveURL(/workspaceId=ws_mock123/);
+    await expect(page.locator("h2", { hasText: "Mock Workspace" }).first()).not.toBeVisible();
   });
 
   test("Inspector fullscreen logs always use the currently inspected workspace", async ({ page }) => {

--- a/apps/console/tests/dashboard-inspector.spec.ts
+++ b/apps/console/tests/dashboard-inspector.spec.ts
@@ -180,6 +180,34 @@ test.describe("Dashboard Workspace Inspector", () => {
     await expect(page.getByText("copied", { exact: true })).not.toBeVisible({ timeout: 2500 });
   });
 
+  test("Workspace id copies via execCommand fallback when the Clipboard API is unavailable (HTTP/Tailscale)", async ({ page }) => {
+    // Simulate a non-secure context (plain HTTP via a Tailscale address): no async
+    // Clipboard API, so the helper must fall back to document.execCommand("copy").
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+      document.execCommand = ((command: string) => {
+        if (command === "copy") {
+          const active = document.activeElement as HTMLTextAreaElement | null;
+          (window as typeof window & { __copiedViaExec?: string }).__copiedViaExec = active?.value;
+          return true;
+        }
+        return false;
+      }) as typeof document.execCommand;
+    });
+
+    await page.goto("/");
+
+    const copyId = page.getByLabel("Copy workspace id ws_mock123");
+    await expect(copyId).toBeVisible();
+    await copyId.click();
+
+    await expect
+      .poll(() => page.evaluate(() => (window as typeof window & { __copiedViaExec?: string }).__copiedViaExec))
+      .toBe("ws_mock123");
+    await expect(page.getByText("copied", { exact: true })).toBeVisible();
+    await expect(page).not.toHaveURL(/workspaceId=ws_mock123/);
+  });
+
   test("Inspector fullscreen logs always use the currently inspected workspace", async ({ page }) => {
     await page.goto("/");
 


### PR DESCRIPTION
## Summary

Promotes the console fixes from `development` to `main` (PR #519):

- **Clipboard copy works over plain HTTP (Tailscale).** `navigator.clipboard` only exists in a secure context (HTTPS / localhost), so clicking a workspace id to copy silently failed over a Tailscale address. Added a fallback-aware helper (Clipboard API → off-screen `<textarea>` + `execCommand`).
- **Favicon** matching the in-app logo (lucide Boxes on slate-950), so the tab is easy to find.
- **`.gitignore`** — anchored the Python-packaging `lib/`/`lib64/` rules to the repo root so `apps/console/lib` is no longer silently ignored.

Tests: 7 clipboard unit tests + a Playwright fallback test; reviewed and merged to development via #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only console changes with localized clipboard behavior and tests; `.gitignore` anchoring reduces risk of silently ignoring new console lib files.
> 
> **Overview**
> Fixes **copy workspace ID** on plain HTTP (e.g. Tailscale) by routing clicks through a new **`copyTextToClipboard`** helper that prefers `navigator.clipboard` and falls back to a transient textarea + **`execCommand("copy")`**, always resolving to a boolean. The dashboard only shows the “copied” toast when that helper succeeds, clears copy timers before each attempt, and hides feedback on failure.
> 
> Adds **`apps/console/app/icon.svg`** (Boxes mark on slate-950) for the browser tab icon.
> 
> Anchors **`.gitignore`** **`/lib/`** and **`/lib64/`** to the repo root so Python packaging dirs are ignored without matching **`apps/console/lib`**.
> 
> Coverage: Node unit tests for clipboard paths and a Playwright case that stubs missing Clipboard API to assert the execCommand fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd2df289955ed986280f15804d6bfc6cd893dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved "Copy workspace ID" behavior and UI feedback with robust clipboard handling and clearer success/failure handling across browsers.
* **Tests**
  * Added end-to-end and unit tests covering modern Clipboard API and legacy fallback scenarios to ensure reliable copy behavior.
* **Chores**
  * Updated ignore rules to avoid unintended matches for packaging artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->