### PR TITLE
fix(ci): least-privilege GITHUB_TOKEN permissions in ci.yml (CodeQL #1-6)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default GITHUB_TOKEN scope for every job. No ci.yml job pushes
+# packages/images (image builds use ``push: false``), creates releases, comments
+# on PRs, or writes statuses; ``actions/upload-artifact`` uses the per-run Actions
+# artifact service (not the ``contents`` scope). So read-only contents — the
+# minimum for ``actions/checkout`` — is sufficient and strictly least-privilege.
+# Resolves CodeQL ``actions/missing-workflow-permissions``.
+permissions:
+  contents: read
+
 jobs:
   lint-and-type:
     runs-on: ubuntu-latest

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -80,11 +80,20 @@ def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
 
 
 @pytest.mark.unit
-def test_validate_pytest_covers_full_unit_suite_not_only_cli() -> None:
-    pytest_commands = _commands_for_tool("pytest")
-    assert pytest_commands, "validate phase must run pytest"
-    assert any(_targets_path(tokens, "tests/unit") for tokens in pytest_commands), (
-        "pytest must run the full tests/unit suite, not only tests/unit/cli"
+def test_validate_phase_delegates_pytest_to_github_ci() -> None:
+    """In-workspace pytest is intentionally delegated to GitHub CI.
+
+    GitHub CI runs the full sharded pytest+coverage on every PR commit (the
+    authoritative gate), so the validate phase runs no in-workspace test suite —
+    duplicating it only slows the run and saturates the host. Should a pytest
+    command ever be added back, the #512 anti-narrowing guard in
+    ``test_no_validate_command_is_scoped_solely_to_the_cli_slice`` still rejects
+    a ``tests/unit/cli``-only scope, and this assertion forces the removal to be
+    revisited as a deliberate choice rather than a silent reintroduction.
+    """
+    assert _commands_for_tool("pytest") == [], (
+        "validate phase must not run an in-workspace pytest; GitHub CI owns the "
+        "full sharded pytest+coverage gate"
     )
 
 

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -547,8 +547,11 @@ def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
     Resolves CodeQL ``actions/missing-workflow-permissions`` (alerts #1–#6): with
     no ``permissions:`` block the default GITHUB_TOKEN scope is broad. The fix is a
     single workflow-level ``contents: read`` default; this guard asserts that
-    default exists, that no job silently broadens it, and that a future job added
-    without coverage (no workflow default + no job-level block) fails here.
+    default exists and that no job silently broadens it. Assertion #1 is the gate
+    that covers every job — including any future job — because the workflow-level
+    default applies to all jobs that lack their own block. Assertion #2 then encodes
+    the coverage invariant explicitly (job-level block *or* workflow default) so the
+    check still holds if coverage is ever moved from the default to per-job blocks.
     """
     workflow = _workflow()
 
@@ -568,7 +571,10 @@ def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
         job_permissions = job.get("permissions")
 
         # 2. Every job is covered by an explicit permissions block: either its own
-        #    job-level mapping or the workflow-level default above.
+        #    job-level mapping or the workflow-level default. Given assertion #1 pins
+        #    that default, the RHS holds today and #1 is the real gate; this encodes
+        #    the coverage invariant so it still bites if coverage ever moves to
+        #    per-job blocks (default dropped + a job missing its own block).
         assert job_permissions is not None or "permissions" in workflow, (
             f"job {name!r} has no permissions coverage (no job-level block and no "
             "workflow-level default)"

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -532,10 +532,12 @@ _EXPECTED_CI_JOBS = frozenset(
     }
 )
 _VALID_PERMISSION_VALUES = frozenset({"read", "write", "none"})
-# Job-level scopes that may be granted ``write`` (currently none — the entire
-# workflow is least-privilege read-only). A future job that genuinely needs a
-# broader scope must be added here deliberately, which is the point of the gate.
-_CONTENTS_WRITE_WHITELIST: frozenset[str] = frozenset()
+# Jobs that may be granted ``write`` on *any* permission scope (currently none —
+# the entire workflow is least-privilege read-only). A future job that genuinely
+# needs a broader scope must be added here deliberately, which is the point of the
+# gate. Generalized beyond ``contents`` so that ``packages``, ``id-token``,
+# ``pull-requests`` and every other scope are held to the same least-privilege bar.
+_WRITE_PERMISSION_WHITELIST: frozenset[str] = frozenset()
 
 
 @pytest.mark.unit
@@ -573,16 +575,16 @@ def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
         )
 
         # 3. No job over-grants. Any job-level block must be a scope->level mapping
-        #    and may not grant contents: write unless explicitly whitelisted.
+        #    and may not grant write on any scope unless explicitly whitelisted.
         if job_permissions is not None:
             assert isinstance(job_permissions, dict), name
             for scope, level in job_permissions.items():
                 assert level in _VALID_PERMISSION_VALUES, (
                     f"job {name!r} grants invalid permission {scope}={level!r}"
                 )
-                if scope == "contents" and level == "write":
-                    assert name in _CONTENTS_WRITE_WHITELIST, (
-                        f"job {name!r} over-grants contents: write"
+                if level == "write":
+                    assert name in _WRITE_PERMISSION_WHITELIST, (
+                        f"job {name!r} over-grants {scope}: write"
                     )
 
 

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -532,12 +532,14 @@ _EXPECTED_CI_JOBS = frozenset(
     }
 )
 _VALID_PERMISSION_VALUES = frozenset({"read", "write", "none"})
-# Jobs that may be granted ``write`` on *any* permission scope (currently none —
-# the entire workflow is least-privilege read-only). A future job that genuinely
-# needs a broader scope must be added here deliberately, which is the point of the
-# gate. Generalized beyond ``contents`` so that ``packages``, ``id-token``,
-# ``pull-requests`` and every other scope are held to the same least-privilege bar.
-_WRITE_PERMISSION_WHITELIST: frozenset[str] = frozenset()
+# ``(job, scope)`` pairs that may be granted ``write`` (currently none — the entire
+# workflow is least-privilege read-only). A future job that genuinely needs a broader
+# scope must add the *specific* ``(job, scope)`` pair here deliberately, which is the
+# point of the gate. Keyed by ``(job, scope)`` rather than job name alone so a
+# whitelisted job is approved only for the exact scope it needs and cannot silently
+# acquire write on additional scopes (``packages``, ``id-token``, ``pull-requests``,
+# etc.) without a separate, deliberate entry.
+_WRITE_PERMISSION_WHITELIST: frozenset[tuple[str, str]] = frozenset()
 
 
 @pytest.mark.unit
@@ -592,7 +594,7 @@ def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
                     f"job {name!r} grants invalid permission {scope}={level!r}"
                 )
                 if level == "write":
-                    assert name in _WRITE_PERMISSION_WHITELIST, (
+                    assert (name, scope) in _WRITE_PERMISSION_WHITELIST, (
                         f"job {name!r} over-grants {scope}: write"
                     )
 

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -521,6 +521,71 @@ def test_ci_workflow_checkouts_disable_persisted_credentials(job_name: str) -> N
         )
 
 
+_EXPECTED_CI_JOBS = frozenset(
+    {
+        "lint-and-type",
+        "python-coverage-shards",
+        "python-full-coverage",
+        "console",
+        "release-artifacts",
+        "ci-required",
+    }
+)
+_VALID_PERMISSION_VALUES = frozenset({"read", "write", "none"})
+# Job-level scopes that may be granted ``write`` (currently none — the entire
+# workflow is least-privilege read-only). A future job that genuinely needs a
+# broader scope must be added here deliberately, which is the point of the gate.
+_CONTENTS_WRITE_WHITELIST: frozenset[str] = frozenset()
+
+
+@pytest.mark.unit
+def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
+    """Every ci.yml job is covered by an explicit least-privilege ``permissions:`` block.
+
+    Resolves CodeQL ``actions/missing-workflow-permissions`` (alerts #1–#6): with
+    no ``permissions:`` block the default GITHUB_TOKEN scope is broad. The fix is a
+    single workflow-level ``contents: read`` default; this guard asserts that
+    default exists, that no job silently broadens it, and that a future job added
+    without coverage (no workflow default + no job-level block) fails here.
+    """
+    workflow = _workflow()
+
+    # 1. Workflow-level default is read-only (PyYAML loads ``read`` as a string).
+    assert workflow.get("permissions") == {"contents": "read"}
+
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+
+    # The known six jobs must all still be present so the covered set can't shrink
+    # unnoticed, and drive coverage off the *live* job keys so a newly added job is
+    # also checked.
+    assert _EXPECTED_CI_JOBS.issubset(jobs.keys())
+
+    for name, job in jobs.items():
+        assert isinstance(job, dict), name
+        job_permissions = job.get("permissions")
+
+        # 2. Every job is covered by an explicit permissions block: either its own
+        #    job-level mapping or the workflow-level default above.
+        assert job_permissions is not None or "permissions" in workflow, (
+            f"job {name!r} has no permissions coverage (no job-level block and no "
+            "workflow-level default)"
+        )
+
+        # 3. No job over-grants. Any job-level block must be a scope->level mapping
+        #    and may not grant contents: write unless explicitly whitelisted.
+        if job_permissions is not None:
+            assert isinstance(job_permissions, dict), name
+            for scope, level in job_permissions.items():
+                assert level in _VALID_PERMISSION_VALUES, (
+                    f"job {name!r} grants invalid permission {scope}={level!r}"
+                )
+                if scope == "contents" and level == "write":
+                    assert name in _CONTENTS_WRITE_WHITELIST, (
+                        f"job {name!r} over-grants contents: write"
+                    )
+
+
 @pytest.mark.unit
 def test_contributor_docs_require_ci_rollup_status_check() -> None:
     docs = CONTRIBUTING_PATH.read_text(encoding="utf-8")

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -577,7 +577,10 @@ def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
         # 3. No job over-grants. Any job-level block must be a scope->level mapping
         #    and may not grant write on any scope unless explicitly whitelisted.
         if job_permissions is not None:
-            assert isinstance(job_permissions, dict), name
+            assert isinstance(job_permissions, dict), (
+                f"job {name!r} permissions must be a dictionary, got "
+                f"{type(job_permissions).__name__}"
+            )
             for scope, level in job_permissions.items():
                 assert level in _VALID_PERMISSION_VALUES, (
                     f"job {name!r} grants invalid permission {scope}={level!r}"


### PR DESCRIPTION
Salvaged from AWF workspace `ws_1e9af389bb5e4fdfbd278993` (the agent finished + committed these fixes; the broken #512 validate phase — now fixed in `e787d31b` — stalled its in-AWF validation, so this goes through normal PR CI instead).

Resolves CodeQL alerts #1-#6. Includes behavior-preserving tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only workflow token scope and test-only guards; no runtime or auth logic changes.
> 
> **Overview**
> Adds a workflow-level **`permissions: contents: read`** default on **CI** so the **GITHUB_TOKEN** is least-privilege (fixes CodeQL **`actions/missing-workflow-permissions`** alerts #1–#6) without changing job behavior.
> 
> Adds regression tests that pin that default, ensure every **`ci.yml`** job stays covered by explicit or workflow-level permissions, and block unexpected **`write`** scopes unless deliberately whitelisted. Also adds a unit test documenting that the **awf-self** validate phase runs **no in-workspace pytest**—full sharded pytest+coverage stays on GitHub CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dac183642cab0a7a8f4946618cdd6999e4b1c993. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enforced least-privilege CI token permissions by default, restricting workflow-level access to read-only.
* **Tests**
  * Added regression tests to validate CI job permission settings, ensure every job has explicit or default permissions, and block unexpected write scopes unless whitelisted.
  * Updated a unit test to assert that local validate-phase pytest execution is delegated to GitHub CI (no local pytest commands).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->