### PR TITLE
fix(security): harden regexes against ReDoS (CodeQL #17-28)

### DIFF
--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -194,10 +194,20 @@ class RepoRef:
             )
 
         # SSH scp-like form: ``git@<host>:owner/repo(.git)?``.
+        # Possessive groups (``++``) make the owner/name split unambiguous — ``/``
+        # is excluded from the class, so a token never needs to give a character
+        # back — eliminating the same lazy ``([^/]+?)`` + ``(?:\.git)?`` overlap
+        # (CodeQL py/redos) that was hardened on the bare-slug path above. The
+        # trailing ``.git`` strip moves into ``_strip_bare_slug_git_suffix`` so the
+        # original lazy behavior (only a non-empty suffix is stripped) is preserved.
         for host, forge in _HOST_FORGES.items():
-            ssh_match = re.fullmatch(rf"git@{re.escape(host)}:([^/]+)/([^/]+?)(?:\.git)?/?", value)
+            ssh_match = re.fullmatch(rf"git@{re.escape(host)}:([^/]++)/([^/]++)/?", value)
             if ssh_match:
-                return cls(owner=ssh_match.group(1), name=ssh_match.group(2), forge=forge)
+                return cls(
+                    owner=ssh_match.group(1),
+                    name=_strip_bare_slug_git_suffix(ssh_match.group(2)),
+                    forge=forge,
+                )
 
         parsed = urlsplit(value)
         parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -138,6 +138,19 @@ _FORGE_HOSTS: dict[ForgeKind, str] = {
 _HOST_FORGES: dict[str, ForgeKind] = {host: forge for forge, host in _FORGE_HOSTS.items()}
 
 
+def _strip_bare_slug_git_suffix(name: str) -> str:
+    """Strip a trailing ``.git`` from a bare-slug repo name.
+
+    Replicates the original lazy ``([^/\\s]+?)(?:\\.git)?`` behavior exactly: the
+    suffix is removed only when something precedes it (``len > 4``), so
+    ``owner/.git`` keeps the literal ``.git`` name while ``owner/repo.git``
+    becomes ``repo`` and ``owner/repo.git.git`` becomes ``repo.git``.
+    """
+    if name.endswith(".git") and len(name) > 4:
+        return name[:-4]
+    return name
+
+
 @dataclass(frozen=True)
 class RepoRef:
     """Owner + repo name parsed out of URLs like
@@ -162,14 +175,23 @@ class RepoRef:
         """
         value = repo_url.strip()
         # Bare ``owner/repo`` slug (no host, no scheme) defaults to GitHub.
-        slug_match = re.fullmatch(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?", value)
+        # Possessive groups (``++``) make the owner/name split unambiguous — ``/``
+        # is excluded from the class, so a token never needs to give a character
+        # back — eliminating the ReDoS backtracking the lazy ``([^/\s]+?)`` +
+        # ``(?:\.git)?`` overlap allowed (CodeQL py/redos). The trailing ``.git``
+        # strip moves into code to preserve the original lazy behavior exactly.
+        slug_match = re.fullmatch(r"([^/\s]++)/([^/\s]++)/?", value)
         if (
             slug_match
             and "github.com" not in value
             and "bitbucket.org" not in value
             and ":" not in value
         ):
-            return cls(owner=slug_match.group(1), name=slug_match.group(2), forge="github")
+            return cls(
+                owner=slug_match.group(1),
+                name=_strip_bare_slug_git_suffix(slug_match.group(2)),
+                forge="github",
+            )
 
         # SSH scp-like form: ``git@<host>:owner/repo(.git)?``.
         for host, forge in _HOST_FORGES.items():

--- a/src/awf/control/quality_gates.py
+++ b/src/awf/control/quality_gates.py
@@ -214,7 +214,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -223,7 +223,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_pyproject.py
+++ b/src/awf/control/quality_gates_pyproject.py
@@ -208,7 +208,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -217,7 +217,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow.py
+++ b/src/awf/control/quality_gates_workflow.py
@@ -210,7 +210,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -219,7 +219,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow_actions.py
+++ b/src/awf/control/quality_gates_workflow_actions.py
@@ -206,7 +206,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -215,7 +215,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow_commands.py
+++ b/src/awf/control/quality_gates_workflow_commands.py
@@ -207,7 +207,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -216,7 +216,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/mcp/setup_tools.py
+++ b/src/awf/mcp/setup_tools.py
@@ -121,7 +121,13 @@ _SOURCE_CHECKOUT_REMEDIATION_REASON_CODES = frozenset(
 _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN = re.compile(
     r"(?P<setup>\bawf setup --dry-run(?P<setup_suffix>[.,;):]|$|\s+to\b))"
     r"|(?P<start_source>\bawf start\s+--source-checkout(?:=|\s+)"
-    r"(?:'[^']*'|\"[^\"]*\"|\S)+?"
+    # Value tokens form a unique partition so no position matches two branches,
+    # removing the quoted-vs-``\S`` overlap that caused exponential backtracking
+    # (CodeQL py/redos): an atomic complete quoted string (which may hold spaces),
+    # a single non-quote char, or a lone quote reachable only when it does *not*
+    # open a complete quoted string — reproducing the original ``\S``-matches-an-
+    # unbalanced-quote behavior on the realistic single-argument inputs seen here.
+    r"(?:(?>'[^']*+'|\"[^\"]*+\")|[^\s'\"]|(?!'[^']*+')(?!\"[^\"]*+\")['\"])+?"
     r"(?P<start_source_suffix>[.,;):](?=\s|$)|$|\s+to\b))"
     r"|(?P<start>\bawf start(?P<start_suffix>[.,;):]|$|\s+to\b))"
 )

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -79,17 +79,26 @@ def test_bare_slug_git_suffix_strip_edges(value: str, expected_name: str) -> Non
 
 @pytest.mark.unit
 def test_bare_slug_pathological_tail_is_linear() -> None:
-    """A long dot/``.git``-heavy tail must parse in linear time.
+    """A long ``.git``-overlap tail with a non-matching terminator parses linearly.
 
     Regression for CodeQL ``py/redos`` on ``github_client.py:165``. The original
     lazy-group + ``(?:\\.git)?`` overlap is the backtracking anti-pattern CodeQL
     flagged; the hardened possessive form has a single unambiguous match path
-    and completes in microseconds. The 5.0s budget is far above any realistic
-    parse time (so a loaded/memory-constrained CI runner won't fail spuriously)
-    yet far below the seconds-to-minutes a re-introduced backtracking regression
-    would take. This guards against the ambiguity being re-introduced.
+    and completes in microseconds.
+
+    The input must actually exercise that overlap to pin the fix: it repeats real
+    ``.git`` fragments (so the lazy group and the optional ``(?:\\.git)?`` fight
+    over every fragment boundary) and ends in a non-matching ``/x`` terminator,
+    forcing the *failure* path where a re-introduced lazy pattern backtracks. A
+    bare ``b.g``-style tail never contains the ``.git`` suffix and parses as a
+    trivial success under either pattern, so it would not catch a regression.
+
+    The 5.0s budget is far above any realistic parse time (so a loaded/
+    memory-constrained CI runner won't fail spuriously) yet far below the
+    seconds-to-minutes a re-introduced backtracking regression would take.
     """
-    pathological = "a" * 5000 + "/" + "b.g" * 2000
+    pathological = "a" * 5000 + "/" + "b.git" * 2000 + "/x"
     start = time.perf_counter()
-    RepoRef.from_url(pathological)
+    with pytest.raises(ValueError):
+        RepoRef.from_url(pathological)
     assert time.perf_counter() - start < 5.0

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -84,10 +84,12 @@ def test_bare_slug_pathological_tail_is_linear() -> None:
     Regression for CodeQL ``py/redos`` on ``github_client.py:165``. The original
     lazy-group + ``(?:\\.git)?`` overlap is the backtracking anti-pattern CodeQL
     flagged; the hardened possessive form has a single unambiguous match path
-    and completes well under the 1.0s budget. This guards against the ambiguity
-    being re-introduced.
+    and completes in microseconds. The 5.0s budget is far above any realistic
+    parse time (so a loaded/memory-constrained CI runner won't fail spuriously)
+    yet far below the seconds-to-minutes a re-introduced backtracking regression
+    would take. This guards against the ambiguity being re-introduced.
     """
     pathological = "a" * 5000 + "/" + "b.g" * 2000
     start = time.perf_counter()
     RepoRef.from_url(pathological)
-    assert time.perf_counter() - start < 1.0
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -23,10 +23,23 @@ from awf.common.github_client import RepoRef
 # shipping the vulnerable pattern in production code.
 _ORIGINAL_BARE_SLUG_RE = re.compile(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?")
 
+# Embedded copy of the ORIGINAL (pre-hardening) SSH scp-like regex, kept local for
+# the same reason: it carried the identical lazy ``([^/]+?)`` + ``(?:\.git)?``
+# overlap (CodeQL py/redos) that the bare-slug pattern had.
+_ORIGINAL_SSH_RE = re.compile(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?")
+
 
 def _original_parse(value: str) -> tuple[str, str] | None:
     """Replicate the original bare-slug owner/name extraction."""
     match = _ORIGINAL_BARE_SLUG_RE.fullmatch(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _original_ssh_parse(value: str) -> tuple[str, str] | None:
+    """Replicate the original SSH scp-like owner/name extraction."""
+    match = _ORIGINAL_SSH_RE.fullmatch(value)
     if match is None:
         return None
     return match.group(1), match.group(2)
@@ -98,6 +111,52 @@ def test_bare_slug_pathological_tail_is_linear() -> None:
     seconds-to-minutes a re-introduced backtracking regression would take.
     """
     pathological = "a" * 5000 + "/" + "b.git" * 2000 + "/x"
+    start = time.perf_counter()
+    with pytest.raises(ValueError):
+        RepoRef.from_url(pathological)
+    assert time.perf_counter() - start < 5.0
+
+
+_SSH_CASES = [
+    "git@github.com:owner/repo",
+    "git@github.com:owner/repo.git",
+    "git@github.com:owner/repo/",
+    "git@github.com:owner/repo.git/",
+    "git@github.com:owner/repo.git.git",
+    "git@github.com:owner/.git",
+    "git@github.com:owner/repo.github",
+    "git@github.com:o/r",
+    "git@github.com:o/r.git",
+    "git@github.com:dimileeh/aira-web",
+    "git@github.com:dimileeh/aira-web.git",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", _SSH_CASES)
+def test_ssh_owner_name_matches_original(value: str) -> None:
+    """Hardened SSH parsing yields the same owner/name the original regex produced."""
+    expected = _original_ssh_parse(value)
+    assert expected is not None, "test corpus entry must be a valid SSH ref"
+    ref = RepoRef.from_url(value)
+    assert (ref.owner, ref.name) == expected
+    assert ref.forge == "github"
+
+
+@pytest.mark.unit
+def test_ssh_pathological_tail_is_linear() -> None:
+    """A pathological SSH ``.git``-overlap tail parses linearly.
+
+    Regression for the SSH scp-like form on ``github_client.py:198``, which shared
+    the same lazy ``([^/]+?)`` + ``(?:\\.git)?`` overlap CodeQL flagged on the
+    bare-slug path. The tail repeats real ``.git`` fragments (so the lazy group and
+    the optional ``(?:\\.git)?`` fight over every fragment boundary) and ends in a
+    trailing ``/x`` the name group cannot consume, forcing the *failure* path where
+    a re-introduced lazy pattern backtracks. The hardened possessive form has a
+    single match path and completes in microseconds. The 5.0s budget mirrors the
+    bare-slug guard: well above any real parse time, well below a regression's.
+    """
+    pathological = "git@github.com:owner/" + "b.git" * 4000 + "/x"
     start = time.perf_counter()
     with pytest.raises(ValueError):
         RepoRef.from_url(pathological)

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -1,0 +1,93 @@
+"""ReDoS hardening regressions for ``RepoRef.from_url`` bare-slug parsing.
+
+CodeQL alert (``py/redos``) flagged the bare ``owner/repo`` slug regex in
+``RepoRef.from_url`` for catastrophic backtracking: the lazy ``([^/\\s]+?)``
+group immediately followed by ``(?:\\.git)?`` (whose ``.git`` characters are
+themselves in ``[^/\\s]``) gave a quote/dot-heavy tail exponentially many ways
+to split. These tests pin the *exact* accept/reject set and parsed owner/name
+against an embedded copy of the original (pre-hardening) pattern, and bound the
+runtime on a pathological input so the backtracking cannot return.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from awf.common.github_client import RepoRef
+
+# Embedded copy of the ORIGINAL (pre-hardening) bare-slug regex. Kept local to
+# the test (not imported) so the differential guard proves equivalence without
+# shipping the vulnerable pattern in production code.
+_ORIGINAL_BARE_SLUG_RE = re.compile(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?")
+
+
+def _original_parse(value: str) -> tuple[str, str] | None:
+    """Replicate the original bare-slug owner/name extraction."""
+    match = _ORIGINAL_BARE_SLUG_RE.fullmatch(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+_BARE_SLUG_CASES = [
+    "owner/repo",
+    "owner/repo.git",
+    "owner/repo/",
+    "owner/repo.git/",
+    "owner/repo.git.git",
+    "owner/.git",
+    "owner/repo.github",
+    "o/r",
+    "o/r.git",
+    "owner/repo.gitfoo",
+    "owner/.gitignore",
+    "dimileeh/aira-web",
+    "dimileeh/aira-web.git",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", _BARE_SLUG_CASES)
+def test_bare_slug_owner_name_matches_original(value: str) -> None:
+    """Hardened parsing yields the same owner/name the original regex produced."""
+    expected = _original_parse(value)
+    assert expected is not None, "test corpus entry must be a valid bare slug"
+    ref = RepoRef.from_url(value)
+    assert (ref.owner, ref.name) == expected
+    assert ref.forge == "github"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value, expected_name",
+    [
+        ("owner/repo", "repo"),
+        ("owner/repo.git", "repo"),
+        ("owner/repo.git/", "repo"),
+        ("owner/repo.git.git", "repo.git"),
+        ("owner/.git", ".git"),  # len == 4: trailing ``.git`` is NOT stripped
+        ("owner/repo.github", "repo.github"),
+    ],
+)
+def test_bare_slug_git_suffix_strip_edges(value: str, expected_name: str) -> None:
+    """The ``.git`` strip replicates the original lazy behavior exactly."""
+    assert RepoRef.from_url(value).name == expected_name
+
+
+@pytest.mark.unit
+def test_bare_slug_pathological_tail_is_linear() -> None:
+    """A long dot/``.git``-heavy tail must parse in linear time.
+
+    Regression for CodeQL ``py/redos`` on ``github_client.py:165``. The original
+    lazy-group + ``(?:\\.git)?`` overlap is the backtracking anti-pattern CodeQL
+    flagged; the hardened possessive form has a single unambiguous match path
+    and completes well under the 1.0s budget. This guards against the ambiguity
+    being re-introduced.
+    """
+    pathological = "a" * 5000 + "/" + "b.g" * 2000
+    start = time.perf_counter()
+    RepoRef.from_url(pathological)
+    assert time.perf_counter() - start < 1.0

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
@@ -1,0 +1,145 @@
+"""ReDoS hardening regressions for the ``quality_gates*`` validation regexes.
+
+CodeQL flagged ``_VALIDATION_TEST_COMMAND_RE`` and ``_VALIDATION_TEST_PATH_RE``
+(``py/redos`` / ``py/polynomial-redos``) in all five ``quality_gates*`` modules.
+Both carry a repeated separator group whose greedy inner token class overlaps an
+adjacent ``\\s+`` boundary, so a long run of flag-like tokens has exponentially
+many ways to split → catastrophic backtracking.
+
+The five modules carry byte-identical copies of these constants, so the same
+accept-set + timing assertions run against every module's compiled pattern.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from types import ModuleType
+
+import pytest
+
+from awf.control import quality_gates as _qg
+from awf.control import quality_gates_pyproject as _qg_pyproject
+from awf.control import quality_gates_workflow as _qg_workflow
+from awf.control import quality_gates_workflow_actions as _qg_actions
+from awf.control import quality_gates_workflow_commands as _qg_commands
+
+_MODULES: tuple[ModuleType, ...] = (
+    _qg,
+    _qg_pyproject,
+    _qg_workflow,
+    _qg_actions,
+    _qg_commands,
+)
+
+# Embedded copies of the ORIGINAL (pre-hardening) patterns. Kept local to the
+# test so the differential guard proves equivalence without re-shipping the
+# vulnerable regexes from production.
+_ORIGINAL_TEST_COMMAND_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])"
+    r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"\s+test(?:\s|$)"
+)
+_ORIGINAL_TEST_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])"
+    r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"\s+tests/[^\s;&|]*"
+)
+
+_TEST_COMMAND_INPUTS = [
+    # positives
+    "npm test",
+    "pnpm run test",
+    "yarn exec test",
+    "uv run --frozen test",
+    "cargo  test",
+    "make test",
+    "npm --foo test",
+    "go run --x --y test",
+    "poetry run --no-root test ",
+    # negatives
+    "npm testing",
+    "npm run build",
+    "gotest",
+    "pytest",
+    "mytest",
+    "xnpm test",
+    "npm--test",
+    "npm run --frozen build",
+]
+
+_TEST_PATH_INPUTS = [
+    # positives
+    "python tests/x.py",
+    "uv run python3.12 tests/unit",
+    "python -q tests/a",
+    "python3 --foo tests/unit/x",
+    "poetry run python tests/",
+    # negatives
+    "python tests",
+    "pythontests/x",
+    "python testsuite",
+    "python -q tests",
+    "xpython tests/a",
+]
+
+
+def _attr(module: ModuleType, name: str) -> re.Pattern[str]:
+    pattern = getattr(module, name)
+    assert isinstance(pattern, re.Pattern)
+    return pattern
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+@pytest.mark.parametrize("text", _TEST_COMMAND_INPUTS)
+def test_test_command_re_matches_original(module: ModuleType, text: str) -> None:
+    """Hardened ``_VALIDATION_TEST_COMMAND_RE`` keeps the original match/span."""
+    expected = _ORIGINAL_TEST_COMMAND_RE.search(text)
+    actual = _attr(module, "_VALIDATION_TEST_COMMAND_RE").search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+@pytest.mark.parametrize("text", _TEST_PATH_INPUTS)
+def test_test_path_re_matches_original(module: ModuleType, text: str) -> None:
+    """Hardened ``_VALIDATION_TEST_PATH_RE`` keeps the original match/span."""
+    expected = _ORIGINAL_TEST_PATH_RE.search(text)
+    actual = _attr(module, "_VALIDATION_TEST_PATH_RE").search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+def test_test_command_re_no_catastrophic_backtracking(module: ModuleType) -> None:
+    """A long flag run with no trailing ``test`` must reject in linear time.
+
+    Regression for CodeQL ``py/redos`` — the original pattern blows up
+    exponentially on this input; the possessive form rejects in ~microseconds.
+    """
+    pathological = "npm " + "--x " * 5000 + "z"
+    pattern = _attr(module, "_VALIDATION_TEST_COMMAND_RE")
+    start = time.perf_counter()
+    assert pattern.search(pathological) is None
+    assert time.perf_counter() - start < 1.0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+def test_test_path_re_no_catastrophic_backtracking(module: ModuleType) -> None:
+    """A long flag run with no trailing ``tests/`` must reject in linear time.
+
+    Regression for CodeQL ``py/polynomial-redos`` on the test-path detector.
+    """
+    pathological = "python " + "--x " * 5000 + "z"
+    pattern = _attr(module, "_VALIDATION_TEST_PATH_RE")
+    start = time.perf_counter()
+    assert pattern.search(pathological) is None
+    assert time.perf_counter() - start < 1.0

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
@@ -128,7 +128,10 @@ def test_test_command_re_no_catastrophic_backtracking(module: ModuleType) -> Non
     pattern = _attr(module, "_VALIDATION_TEST_COMMAND_RE")
     start = time.perf_counter()
     assert pattern.search(pathological) is None
-    assert time.perf_counter() - start < 1.0
+    # 5.0s is far above the ~microsecond possessive-form reject and far below
+    # the seconds-to-minutes a backtracking regression would take, so a loaded
+    # CI runner won't fail spuriously.
+    assert time.perf_counter() - start < 5.0
 
 
 @pytest.mark.unit
@@ -142,4 +145,5 @@ def test_test_path_re_no_catastrophic_backtracking(module: ModuleType) -> None:
     pattern = _attr(module, "_VALIDATION_TEST_PATH_RE")
     start = time.perf_counter()
     assert pattern.search(pathological) is None
-    assert time.perf_counter() - start < 1.0
+    # 5.0s budget: far above the possessive-form reject, far below a regression.
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/mcp/test_setup_tools_redos.py
+++ b/tests/unit/mcp/test_setup_tools_redos.py
@@ -49,6 +49,10 @@ _REPRESENTATIVE_NEXT_STEPS = [
     "awf start --source-checkout=/p/r:",
     "awf start --source-checkout=/p/r",
     "awf start --source-checkout=it's/repo",  # unbalanced quote -> lone-quote branch
+    # shlex.join() escapes an apostrophe path as adjacent quoted segments
+    # ('it' + "'" + 's/repo'); the partitioned value must tokenize the run as a
+    # series of atomic quoted strings rather than a single one.
+    "awf start --source-checkout='it'\"'\"'s/repo'",
     "awf start --source-checkout /opt/aira.",
     "Then run awf setup --dry-run to provision.",
     "awf start to begin.",
@@ -87,6 +91,13 @@ def test_next_step_pattern_matches_original(text: str) -> None:
             "awf start --source-checkout=/old/r",
             "awf start --source-checkout=/new/repo",
             "awf start --source-checkout=/new/repo",
+        ),
+        (
+            # shlex.join()-escaped apostrophe path (adjacent quoted segments) as
+            # the step's source-checkout token must rewrite as a single unit.
+            "awf start --source-checkout='/old'\"'\"'s/r'.",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo.",
         ),
     ],
 )

--- a/tests/unit/mcp/test_setup_tools_redos.py
+++ b/tests/unit/mcp/test_setup_tools_redos.py
@@ -109,11 +109,13 @@ def test_next_step_pattern_no_catastrophic_backtracking() -> None:
     Regression for CodeQL ``py/redos`` on ``setup_tools.py:124``. A long quote
     run followed by a non-suffix boundary forces the original ``\\S``-overlap
     value to explore Catalan-many tokenizations (exponential); the partitioned
-    form completes well under the 1.0s budget.
+    form completes in microseconds. The 5.0s budget sits far above any realistic
+    parse time (so a loaded CI runner won't fail spuriously) yet far below the
+    seconds-to-minutes a re-introduced regression would take.
     """
     # Trailing ``" x"`` denies any valid suffix, so the original pattern would
     # backtrack across every tokenization of the quote run before failing.
     pathological = "awf start --source-checkout=" + "'" * 5000 + " x"
     start = time.perf_counter()
     assert _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(pathological) is None
-    assert time.perf_counter() - start < 1.0
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/mcp/test_setup_tools_redos.py
+++ b/tests/unit/mcp/test_setup_tools_redos.py
@@ -1,0 +1,119 @@
+"""ReDoS hardening regressions for the setup-status next-step command pattern.
+
+CodeQL flagged the ``start_source`` value sub-pattern in
+``_SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN`` (``setup_tools.py:124``) for
+catastrophic backtracking: the ``(?:'[^']*'|"[^"]*"|\\S)+?`` value lets the
+``\\S`` branch overlap the quoted-string branches (a quote is also ``\\S``), so
+a quote-heavy run has Catalan-many tokenizations.
+
+The hardened pattern makes the three branches a unique partition (atomic quoted
+strings, non-quote chars, and a lone-quote branch reachable only when it does
+*not* open a complete quoted string). This preserves the match on the realistic
+AWF-generated next-step inputs the pattern actually sees (paths, optionally
+quoted, with the documented suffix forms) and removes the backtracking.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from awf.mcp.setup_tools import (
+    _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN,
+    _setup_status_next_step_for_source_checkout,
+)
+
+# Embedded copy of the ORIGINAL (pre-hardening) full pattern, kept local to the
+# test so the differential guard proves equivalence without re-shipping the
+# vulnerable ``\S``-overlap value sub-pattern.
+_ORIGINAL_NEXT_STEP_PATTERN = re.compile(
+    r"(?P<setup>\bawf setup --dry-run(?P<setup_suffix>[.,;):]|$|\s+to\b))"
+    r"|(?P<start_source>\bawf start\s+--source-checkout(?:=|\s+)"
+    r"(?:'[^']*'|\"[^\"]*\"|\S)+?"
+    r"(?P<start_source_suffix>[.,;):](?=\s|$)|$|\s+to\b))"
+    r"|(?P<start>\bawf start(?P<start_suffix>[.,;):]|$|\s+to\b))"
+)
+
+# Representative next-step strings (the only shape this pattern sees in
+# production: a single ``--source-checkout`` argument — bare or fully quoted —
+# followed by one of the documented suffix forms).
+_REPRESENTATIVE_NEXT_STEPS = [
+    "Run awf start --source-checkout=/path/to/repo.",
+    "Run awf start --source-checkout=/path/to/repo to deploy.",
+    "awf start --source-checkout='/p with space/r'",
+    'awf start --source-checkout="/p with space/r" to continue',
+    "awf start --source-checkout=/p/r;",
+    "awf start --source-checkout=/p/r)",
+    "awf start --source-checkout=/p/r:",
+    "awf start --source-checkout=/p/r",
+    "awf start --source-checkout=it's/repo",  # unbalanced quote -> lone-quote branch
+    "awf start --source-checkout /opt/aira.",
+    "Then run awf setup --dry-run to provision.",
+    "awf start to begin.",
+    "awf start.",
+    "no command here at all",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("text", _REPRESENTATIVE_NEXT_STEPS)
+def test_next_step_pattern_matches_original(text: str) -> None:
+    """Hardened pattern keeps the original span + named groups on real inputs."""
+    expected = _ORIGINAL_NEXT_STEP_PATTERN.search(text)
+    actual = _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+        assert actual.groupdict() == expected.groupdict()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "step, start_command, expected",
+    [
+        (
+            "Run awf start --source-checkout=/old/path to deploy.",
+            "awf start --source-checkout=/new/repo",
+            "Run awf start --source-checkout=/new/repo to deploy.",
+        ),
+        (
+            "awf start --source-checkout='/old path/r'.",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo.",
+        ),
+        (
+            "awf start --source-checkout=/old/r",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo",
+        ),
+    ],
+)
+def test_next_step_rewrite_substitutes_command(
+    step: str, start_command: str, expected: str
+) -> None:
+    """The hardened pattern drives ``.sub`` rewrites identically to before."""
+    result = _setup_status_next_step_for_source_checkout(
+        step,
+        setup_command="awf setup --dry-run",
+        start_command=start_command,
+    )
+    assert result == expected
+
+
+@pytest.mark.unit
+def test_next_step_pattern_no_catastrophic_backtracking() -> None:
+    """A long quote run must not trigger exponential backtracking.
+
+    Regression for CodeQL ``py/redos`` on ``setup_tools.py:124``. A long quote
+    run followed by a non-suffix boundary forces the original ``\\S``-overlap
+    value to explore Catalan-many tokenizations (exponential); the partitioned
+    form completes well under the 1.0s budget.
+    """
+    # Trailing ``" x"`` denies any valid suffix, so the original pattern would
+    # backtrack across every tokenization of the quote run before failing.
+    pathological = "awf start --source-checkout=" + "'" * 5000 + " x"
+    start = time.perf_counter()
+    assert _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(pathological) is None
+    assert time.perf_counter() - start < 1.0

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -80,12 +80,25 @@ def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
 
 
 @pytest.mark.unit
-def test_validate_pytest_covers_full_unit_suite_not_only_cli() -> None:
+def test_validate_pytest_if_present_covers_full_unit_suite_not_only_cli() -> None:
+    """The validate phase delegates the full pytest suite to CI by design.
+
+    Commit cb3352379 deliberately dropped the in-workspace full-suite pytest
+    from the ``awf-self`` validate phase: GitHub CI runs the authoritative
+    sharded pytest+coverage gate on every PR commit, so duplicating it
+    in-workspace only saturates the host. ruff + mypy over the changed tree
+    satisfy the pre-push conformance check.
+
+    The original #512 anti-re-narrowing guard still applies, though: if a
+    pytest command is ever re-added to the validate phase it must run the full
+    ``tests/unit`` suite rather than being scoped back to the CLI slice.
+    """
     pytest_commands = _commands_for_tool("pytest")
-    assert pytest_commands, "validate phase must run pytest"
-    assert any(_targets_path(tokens, "tests/unit") for tokens in pytest_commands), (
-        "pytest must run the full tests/unit suite, not only tests/unit/cli"
-    )
+    for tokens in pytest_commands:
+        assert _targets_path(tokens, "tests/unit"), (
+            "if the validate phase runs pytest it must cover the full "
+            "tests/unit suite, not only tests/unit/cli"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Salvaged from AWF workspace `ws_2d9591859e364e2db731f1d6` (the agent finished + committed these fixes; the broken #512 validate phase — now fixed in `e787d31b` — stalled its in-AWF validation, so this goes through normal PR CI instead).

Resolves CodeQL alerts #17-#28. Includes behavior-preserving tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving regex refactors with differential and timing tests; risk is mainly a subtle parsing mismatch on unusual repo slugs or workflow command strings.
> 
> **Overview**
> Addresses CodeQL **py/redos** alerts (#17–#28) by rewriting several regexes so they cannot catastrophically backtrack, while keeping observable behavior the same.
> 
> **`RepoRef.from_url`** in `github_client.py` switches bare-slug and SSH scp-like patterns to possessive groups and moves optional `.git` stripping into **`_strip_bare_slug_git_suffix`**, preserving edge cases such as `owner/.git`.
> 
> **Quality-gate** validation detectors (`_VALIDATION_TEST_COMMAND_RE`, `_VALIDATION_TEST_PATH_RE`) use possessive repeats in all five mirrored `quality_gates*` modules.
> 
> **MCP setup** next-step command matching repartitions the `--source-checkout` value sub-pattern so quoted strings and `\S` no longer overlap.
> 
> New unit tests compare hardened patterns to embedded copies of the old regexes (match/span equivalence) and bound runtime on pathological inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf74e13f7a178615155b4ca240acb4005fd3513d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository URL/slug parsing to handle trailing “.git” and related edge cases.

* **Performance**
  * Hardened and optimized validation and setup-command pattern matching to prevent catastrophic backtracking.

* **Tests**
  * Added comprehensive regression and performance tests to ensure parsing and pattern matching correctness and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->