### PR TITLE
Promote CodeQL fixes + light awf-self validate phase to main

### DIFF
--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -64,5 +64,7 @@ awf:
         timeout_seconds: 600
       - command: uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check
         timeout_seconds: 300
-      - command: uv run --python 3.12 --extra dev pytest tests/unit -n 3 -q
-        timeout_seconds: 1800
+      # No in-workspace test suite: GitHub CI runs the full sharded pytest+coverage
+      # on every PR commit (the authoritative gate). ruff + mypy above already run
+      # over the changed files, which satisfies the pre-push conformance check
+      # without duplicating CI or saturating the host.

--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -64,5 +64,9 @@ awf:
         timeout_seconds: 600
       - command: uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check
         timeout_seconds: 300
-      - command: uv run --python 3.12 --extra dev pytest tests/unit -n 3 -q
-        timeout_seconds: 1800
+      # `-n auto` (all cores) keeps the full unit suite well under the timeout
+      # (~9 min vs ~30-60 min at -n 3, which could not finish in 1800s). Do NOT
+      # run many awf-self workspaces in parallel: each validation saturates the
+      # host, so several at once crawl and starve each other.
+      - command: uv run --python 3.12 --extra dev pytest tests/unit -n auto -q
+        timeout_seconds: 2400

--- a/.awf/workspace.yml
+++ b/.awf/workspace.yml
@@ -64,9 +64,5 @@ awf:
         timeout_seconds: 600
       - command: uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check
         timeout_seconds: 300
-      # `-n auto` (all cores) keeps the full unit suite well under the timeout
-      # (~9 min vs ~30-60 min at -n 3, which could not finish in 1800s). Do NOT
-      # run many awf-self workspaces in parallel: each validation saturates the
-      # host, so several at once crawl and starve each other.
-      - command: uv run --python 3.12 --extra dev pytest tests/unit -n auto -q
-        timeout_seconds: 2400
+      - command: uv run --python 3.12 --extra dev pytest tests/unit -n 3 -q
+        timeout_seconds: 1800

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least-privilege default GITHUB_TOKEN scope for every job. No ci.yml job pushes
+# packages/images (image builds use ``push: false``), creates releases, comments
+# on PRs, or writes statuses; ``actions/upload-artifact`` uses the per-run Actions
+# artifact service (not the ``contents`` scope). So read-only contents — the
+# minimum for ``actions/checkout`` — is sufficient and strictly least-privilege.
+# Resolves CodeQL ``actions/missing-workflow-permissions``.
+permissions:
+  contents: read
+
 jobs:
   lint-and-type:
     runs-on: ubuntu-latest

--- a/src/awf/cli/workspace_commands.py
+++ b/src/awf/cli/workspace_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import urllib.parse
 from typing import Any
 
@@ -676,6 +677,39 @@ def workspace_rebase(
     _handle_response(response, fmt)
 
 
+def _repo_targets_github_host(repo: str) -> bool:
+    """Return True only when *repo* carries ``github.com`` as an actual host.
+
+    The ``--repo`` option accepts either a full repo URL (SSH
+    ``git@github.com:owner/repo.git``, HTTPS ``https://github.com/owner/repo``,
+    or the scheme-less ``github.com/owner/repo``) or a bare ``owner/repo`` slug.
+    A bare substring check (``"github.com" in repo``) is bypassable by a hostile
+    host such as ``github.com.evil.example`` (CodeQL
+    ``py/incomplete-url-substring-sanitization``), so parse the host and compare
+    it on a host boundary: equality with ``github.com`` or a proper
+    ``.github.com`` suffix.
+    """
+    value = repo.strip()
+    # scp-style "[user@]host:owner/repo(.git)" — urlsplit cannot extract the host.
+    scp = re.match(r"^[^@/]+@([^:/]+):", value)
+    if scp is not None:
+        host: str | None = scp.group(1).lower()
+    else:
+        # Prefix a "//" for scheme-less "github.com/owner/repo" so urlsplit reads
+        # the leading token as netloc; real "https://..."/"ssh://..." URLs
+        # already carry "//". Malformed input (e.g. an unbalanced IPv6 bracket)
+        # makes urlsplit raise ValueError; treat such values as non-github rather
+        # than crashing the command.
+        try:
+            parsed = urllib.parse.urlsplit(value if "//" in value else f"//{value}")
+        except ValueError:
+            return False
+        host = parsed.hostname.lower() if parsed.hostname else None
+    if host is None:
+        return False
+    return host == "github.com" or host.endswith(".github.com")
+
+
 @workspace_app.command("adopt-pr", cls=MinRichHelpWidthCommand)
 def workspace_adopt_pr(
     repo: str | None = typer.Option(
@@ -734,6 +768,9 @@ def workspace_adopt_pr(
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
 ) -> None:
     """Adopt an already-open GitHub PR into AWF PR monitoring."""
+    repo = repo.strip() if repo is not None else None
+    if repo == "":
+        repo = None
     if pr_url is None and (repo is None or pr_number is None):
         raise typer.BadParameter(
             "select a PR with exactly one selector: either --pr-url or both --repo and --pr"
@@ -742,9 +779,10 @@ def workspace_adopt_pr(
         raise typer.BadParameter(
             "select a PR with exactly one selector: either --pr-url or both --repo and --pr"
         )
+    _repo_is_url = repo is not None and _repo_targets_github_host(repo)
     body: dict[str, Any] = {
-        "repo_url": repo if repo and "github.com" in repo else None,
-        "repo_slug": repo if repo and "github.com" not in repo else None,
+        "repo_url": repo if _repo_is_url else None,
+        "repo_slug": repo if repo and not _repo_is_url else None,
         "pr_number": pr_number,
         "pr_url": pr_url,
         "agent": agent,

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -138,6 +138,19 @@ _FORGE_HOSTS: dict[ForgeKind, str] = {
 _HOST_FORGES: dict[str, ForgeKind] = {host: forge for forge, host in _FORGE_HOSTS.items()}
 
 
+def _strip_bare_slug_git_suffix(name: str) -> str:
+    """Strip a trailing ``.git`` from a bare-slug repo name.
+
+    Replicates the original lazy ``([^/\\s]+?)(?:\\.git)?`` behavior exactly: the
+    suffix is removed only when something precedes it (``len > 4``), so
+    ``owner/.git`` keeps the literal ``.git`` name while ``owner/repo.git``
+    becomes ``repo`` and ``owner/repo.git.git`` becomes ``repo.git``.
+    """
+    if name.endswith(".git") and len(name) > 4:
+        return name[:-4]
+    return name
+
+
 @dataclass(frozen=True)
 class RepoRef:
     """Owner + repo name parsed out of URLs like
@@ -162,20 +175,39 @@ class RepoRef:
         """
         value = repo_url.strip()
         # Bare ``owner/repo`` slug (no host, no scheme) defaults to GitHub.
-        slug_match = re.fullmatch(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?", value)
+        # Possessive groups (``++``) make the owner/name split unambiguous — ``/``
+        # is excluded from the class, so a token never needs to give a character
+        # back — eliminating the ReDoS backtracking the lazy ``([^/\s]+?)`` +
+        # ``(?:\.git)?`` overlap allowed (CodeQL py/redos). The trailing ``.git``
+        # strip moves into code to preserve the original lazy behavior exactly.
+        slug_match = re.fullmatch(r"([^/\s]++)/([^/\s]++)/?", value)
         if (
             slug_match
             and "github.com" not in value
             and "bitbucket.org" not in value
             and ":" not in value
         ):
-            return cls(owner=slug_match.group(1), name=slug_match.group(2), forge="github")
+            return cls(
+                owner=slug_match.group(1),
+                name=_strip_bare_slug_git_suffix(slug_match.group(2)),
+                forge="github",
+            )
 
         # SSH scp-like form: ``git@<host>:owner/repo(.git)?``.
+        # Possessive groups (``++``) make the owner/name split unambiguous — ``/``
+        # is excluded from the class, so a token never needs to give a character
+        # back — eliminating the same lazy ``([^/]+?)`` + ``(?:\.git)?`` overlap
+        # (CodeQL py/redos) that was hardened on the bare-slug path above. The
+        # trailing ``.git`` strip moves into ``_strip_bare_slug_git_suffix`` so the
+        # original lazy behavior (only a non-empty suffix is stripped) is preserved.
         for host, forge in _HOST_FORGES.items():
-            ssh_match = re.fullmatch(rf"git@{re.escape(host)}:([^/]+)/([^/]+?)(?:\.git)?/?", value)
+            ssh_match = re.fullmatch(rf"git@{re.escape(host)}:([^/]++)/([^/]++)/?", value)
             if ssh_match:
-                return cls(owner=ssh_match.group(1), name=ssh_match.group(2), forge=forge)
+                return cls(
+                    owner=ssh_match.group(1),
+                    name=_strip_bare_slug_git_suffix(ssh_match.group(2)),
+                    forge=forge,
+                )
 
         parsed = urlsplit(value)
         parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -256,8 +256,16 @@ class RepoRef:
         """Return a clone URL matching the requested transport style."""
         host = self._forge_host()
         stripped = repo_url.strip()
-        parsed = urlsplit(stripped)
-        parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None
+        # ``urlsplit``/``.hostname`` raise ``ValueError`` (e.g. "Invalid IPv6 URL")
+        # on malformed authorities like ``https://[bad``. Unlike ``from_url``, this
+        # method returns a URL rather than parsing one, so an unhandled crash here
+        # would be unexpected: treat an unparseable URL as a non-match and fall back
+        # to the canonical HTTPS clone URL (same as other unrecognized inputs).
+        try:
+            parsed = urlsplit(stripped)
+            parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None
+        except ValueError:
+            return self.https_url()
         # Match SSH by scheme (not a no-port prefix) so explicit-port forms such
         # as ssh://git@github.com:22/owner/repo.git are preserved as SSH instead
         # of silently falling through to HTTPS (thread PRRT_kwDOSJAM6s6IQkBd).
@@ -269,11 +277,7 @@ class RepoRef:
         if stripped.startswith(f"git@{host}:") or is_ssh_url:
             return self.ssh_url()
 
-        if (
-            parsed.scheme in {"http", "https"}
-            and parsed.hostname is not None
-            and parsed.hostname.lower() == host
-        ):
+        if parsed.scheme in {"http", "https"} and parsed_host == host:
             userinfo, sep, _host = parsed.netloc.rpartition("@")
             if sep and userinfo:
                 return f"https://{userinfo}@{host}/{self.owner}/{self.name}.git"

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -209,8 +209,15 @@ class RepoRef:
                     forge=forge,
                 )
 
-        parsed = urlsplit(value)
-        parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None
+        # ``urlsplit``/``.hostname`` raise a bespoke ``ValueError`` (e.g. "Invalid
+        # IPv6 URL") on malformed authorities like ``https://[bad``. Normalize that
+        # to this method's standard parse-failure message so callers see one
+        # consistent error and no urllib internals leak through.
+        try:
+            parsed = urlsplit(value)
+            parsed_host = parsed.hostname.lower() if parsed.hostname is not None else None
+        except ValueError as exc:
+            raise ValueError(f"Cannot parse repo from URL: {repo_url!r}") from exc
         url_forge = _HOST_FORGES.get(parsed_host) if parsed_host is not None else None
         is_http_url = parsed.scheme in {"http", "https"}
         is_ssh_url = parsed.scheme == "ssh" and (

--- a/src/awf/control/quality_gates.py
+++ b/src/awf/control/quality_gates.py
@@ -214,7 +214,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -223,7 +223,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_pyproject.py
+++ b/src/awf/control/quality_gates_pyproject.py
@@ -208,7 +208,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -217,7 +217,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow.py
+++ b/src/awf/control/quality_gates_workflow.py
@@ -210,7 +210,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -219,7 +219,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow_actions.py
+++ b/src/awf/control/quality_gates_workflow_actions.py
@@ -206,7 +206,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -215,7 +215,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/control/quality_gates_workflow_commands.py
+++ b/src/awf/control/quality_gates_workflow_commands.py
@@ -207,7 +207,7 @@ _SCRIPT_SUFFIXES: Final[tuple[str, ...]] = (
 _VALIDATION_TEST_COMMAND_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]++))*+"
     r"\s+test(?:\s|$)"
 )
 _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
@@ -216,7 +216,7 @@ _VALIDATION_UNITTEST_COMMAND_RE: Final = re.compile(
 _VALIDATION_TEST_PATH_RE: Final = re.compile(
     r"(?<![A-Za-z0-9_./-])"
     r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]++)*+"
     r"\s+tests/[^\s;&|]*"
 )
 _PINNED_WORKFLOW_USES_SHA_RE: Final = re.compile(r"^[0-9a-fA-F]{40}$")

--- a/src/awf/mcp/setup_tools.py
+++ b/src/awf/mcp/setup_tools.py
@@ -121,7 +121,13 @@ _SOURCE_CHECKOUT_REMEDIATION_REASON_CODES = frozenset(
 _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN = re.compile(
     r"(?P<setup>\bawf setup --dry-run(?P<setup_suffix>[.,;):]|$|\s+to\b))"
     r"|(?P<start_source>\bawf start\s+--source-checkout(?:=|\s+)"
-    r"(?:'[^']*'|\"[^\"]*\"|\S)+?"
+    # Value tokens form a unique partition so no position matches two branches,
+    # removing the quoted-vs-``\S`` overlap that caused exponential backtracking
+    # (CodeQL py/redos): an atomic complete quoted string (which may hold spaces),
+    # a single non-quote char, or a lone quote reachable only when it does *not*
+    # open a complete quoted string — reproducing the original ``\S``-matches-an-
+    # unbalanced-quote behavior on the realistic single-argument inputs seen here.
+    r"(?:(?>'[^']*+'|\"[^\"]*+\")|[^\s'\"]|(?!'[^']*+')(?!\"[^\"]*+\")['\"])+?"
     r"(?P<start_source_suffix>[.,;):](?=\s|$)|$|\s+to\b))"
     r"|(?P<start>\bawf start(?P<start_suffix>[.,;):]|$|\s+to\b))"
 )

--- a/src/awf/runtime/_docker_pull_detection.py
+++ b/src/awf/runtime/_docker_pull_detection.py
@@ -395,8 +395,17 @@ def _line_url_host_is(line: str, host: str) -> bool:
     (the ``//<host>/`` boundary can itself sit anywhere in another host's URL).
     """
     for match in re.finditer(r"https?://[^\s\"']+", line):
-        if urlsplit(match.group(0)).hostname == host:
-            return True
+        # ``urlsplit``/``.hostname`` raise ``ValueError`` (e.g. "Invalid IPv6 URL")
+        # on malformed authorities like ``https://[bad/token``.  A malformed URL in
+        # CI output must not crash PR-log classification — treat an unparseable
+        # candidate as a non-match and keep scanning the remaining tokens
+        # (PRRT_kwDOSJAM6s6I3BzX), mirroring how ``clone_url_like`` and
+        # ``RepoRef.from_url`` guard their own ``urlsplit`` calls.
+        try:
+            if urlsplit(match.group(0)).hostname == host:
+                return True
+        except ValueError:
+            continue
     return False
 
 

--- a/src/awf/runtime/_docker_pull_detection.py
+++ b/src/awf/runtime/_docker_pull_detection.py
@@ -11,6 +11,7 @@ The public entry point is ``_log_shows_docker_registry_timeout``.
 from __future__ import annotations
 
 import re
+from urllib.parse import urlsplit
 
 # Docker pull / service-container registry timeouts. Unlike the unconditional
 # markers above, these Go context-timeout and net/http phrases also surface in
@@ -382,6 +383,23 @@ def _forward_detail_ref_matches_pull(
     return True
 
 
+def _line_url_host_is(line: str, host: str) -> bool:
+    """Whether any ``http(s)`` URL embedded in *line* has *host* as its real host.
+
+    Each candidate URL is parsed with ``urlsplit`` and its authority host is
+    compared to *host* exactly, so a target host appearing only in a URL *path*
+    or at an arbitrary position — e.g. ``https://evil.example//auth.docker.io/token``
+    (real host ``evil.example``) or ``https://evil.example/auth.docker.io/token``
+    — does not match.  This closes the ``py/incomplete-url-substring-sanitization``
+    gap that a bare ``"//<host>/" in line`` substring check still leaves open
+    (the ``//<host>/`` boundary can itself sit anywhere in another host's URL).
+    """
+    for match in re.finditer(r"https?://[^\s\"']+", line):
+        if urlsplit(match.group(0)).hostname == host:
+            return True
+    return False
+
+
 def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
     """Whether a daemon error line's quoted URL is attributable to *image_ref*.
 
@@ -556,10 +574,13 @@ def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
             # Unqualified Docker Hub ref: require a Docker Hub auth or registry
             # host in the token URL so an error from a different registry is
             # not attributed to a Docker Hub pull (mirrors PRRT_kwDOSJAM6s6HtNI4).
-            # Use the "//<host>/" URL-boundary delimiter (as elsewhere in this
-            # file, PRRT_kwDOSJAM6s6HtfLR) so a path-only "auth.docker.io" — e.g.
-            # "https://evil/auth.docker.io/token" — does not falsely match.
-            return "//auth.docker.io/" in line or any(
+            # Parse the URL host (PRRT_kwDOSJAM6s6I2gvY) rather than substring-
+            # matching "//auth.docker.io/": the boundary form still matches an
+            # arbitrary-position occurrence such as
+            # "https://evil/auth.docker.io/token" (path segment) or
+            # "https://evil//auth.docker.io/token" (real host "evil"), so only an
+            # exact urlsplit host comparison rejects both.
+            return _line_url_host_is(line, "auth.docker.io") or any(
                 f"//{h}/" in line for h in _DOCKER_HUB_REGISTRY_HOSTS
             )
         # Docker Hub registry hosts use auth.docker.io as their token service,

--- a/src/awf/runtime/_docker_pull_detection.py
+++ b/src/awf/runtime/_docker_pull_detection.py
@@ -556,13 +556,18 @@ def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
             # Unqualified Docker Hub ref: require a Docker Hub auth or registry
             # host in the token URL so an error from a different registry is
             # not attributed to a Docker Hub pull (mirrors PRRT_kwDOSJAM6s6HtNI4).
-            return "auth.docker.io" in line or any(
+            # Use the "//<host>/" URL-boundary delimiter (as elsewhere in this
+            # file, PRRT_kwDOSJAM6s6HtfLR) so a path-only "auth.docker.io" — e.g.
+            # "https://evil/auth.docker.io/token" — does not falsely match.
+            return "//auth.docker.io/" in line or any(
                 f"//{h}/" in line for h in _DOCKER_HUB_REGISTRY_HOSTS
             )
         # Docker Hub registry hosts use auth.docker.io as their token service,
-        # not the registry host itself — accept either.
+        # not the registry host itself — accept either.  Match on the
+        # "//<host>/" URL boundary (PRRT_kwDOSJAM6s6HtfLR) so a path-only
+        # "auth.docker.io" does not falsely match.
         if _host in _DOCKER_HUB_REGISTRY_HOSTS:
-            return "auth.docker.io" in line or f"//{_host}/" in line
+            return "//auth.docker.io/" in line or f"//{_host}/" in line
         # Use "//<host>/" as the URL-boundary delimiter so a hostname that is a
         # suffix of another host (e.g. "registry.example.com" inside
         # "prod.registry.example.com") does not falsely match.  Token-service
@@ -580,7 +585,9 @@ def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
         lib_token_scope = f"scope=repository%3alibrary%2f{repo_path}%3apull"
         unencoded_lib_token_scope = f"scope=repository:library/{repo_path}:pull"
         if lib_token_scope in line or unencoded_lib_token_scope in line:
-            return "auth.docker.io" in line or any(
+            # Boundary-anchored host match ("//auth.docker.io/") so a path-only
+            # "auth.docker.io" does not falsely match (PRRT_kwDOSJAM6s6HtfLR).
+            return "//auth.docker.io/" in line or any(
                 f"//{h}/" in line for h in _DOCKER_HUB_REGISTRY_HOSTS
             )
     return False

--- a/src/awf/runtime/_docker_pull_detection.py
+++ b/src/awf/runtime/_docker_pull_detection.py
@@ -584,11 +584,14 @@ def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
                 f"//{h}/" in line for h in _DOCKER_HUB_REGISTRY_HOSTS
             )
         # Docker Hub registry hosts use auth.docker.io as their token service,
-        # not the registry host itself — accept either.  Match on the
-        # "//<host>/" URL boundary (PRRT_kwDOSJAM6s6HtfLR) so a path-only
-        # "auth.docker.io" does not falsely match.
+        # not the registry host itself — accept either.  Parse the URL host for
+        # auth.docker.io (PRRT_kwDOSJAM6s6I2gvt) rather than substring-matching
+        # "//auth.docker.io/": the boundary form still matches an arbitrary-
+        # position occurrence such as "https://evil//auth.docker.io/token"
+        # (real host "evil"), so only an exact urlsplit host comparison rejects
+        # it.
         if _host in _DOCKER_HUB_REGISTRY_HOSTS:
-            return "//auth.docker.io/" in line or f"//{_host}/" in line
+            return _line_url_host_is(line, "auth.docker.io") or f"//{_host}/" in line
         # Use "//<host>/" as the URL-boundary delimiter so a hostname that is a
         # suffix of another host (e.g. "registry.example.com" inside
         # "prod.registry.example.com") does not falsely match.  Token-service
@@ -606,9 +609,12 @@ def _image_ref_matches_daemon_url(image_ref: str, line: str) -> bool:
         lib_token_scope = f"scope=repository%3alibrary%2f{repo_path}%3apull"
         unencoded_lib_token_scope = f"scope=repository:library/{repo_path}:pull"
         if lib_token_scope in line or unencoded_lib_token_scope in line:
-            # Boundary-anchored host match ("//auth.docker.io/") so a path-only
-            # "auth.docker.io" does not falsely match (PRRT_kwDOSJAM6s6HtfLR).
-            return "//auth.docker.io/" in line or any(
+            # Parse the URL host for auth.docker.io (PRRT_kwDOSJAM6s6I2gvt)
+            # rather than substring-matching "//auth.docker.io/": the boundary
+            # form still matches an arbitrary-position occurrence such as
+            # "https://evil//auth.docker.io/token" (real host "evil"), so only
+            # an exact urlsplit host comparison rejects it.
+            return _line_url_host_is(line, "auth.docker.io") or any(
                 f"//{h}/" in line for h in _DOCKER_HUB_REGISTRY_HOSTS
             )
     return False

--- a/tests/unit/cli/test_workspace_commands_helpers.py
+++ b/tests/unit/cli/test_workspace_commands_helpers.py
@@ -519,6 +519,10 @@ def test_workspace_create_rejects_non_object_companion_json(
         {"repo": None, "pr_number": None, "pr_url": None},
         {"repo": "owner/repo", "pr_number": None, "pr_url": "https://github.com/owner/repo/pull/1"},
         {"repo": None, "pr_number": 1, "pr_url": "https://github.com/owner/repo/pull/1"},
+        # Empty/whitespace --repo normalizes to None, so --pr alone is an incomplete
+        # selector and must fail fast in the CLI rather than deferring to the API.
+        {"repo": "", "pr_number": 1, "pr_url": None},
+        {"repo": "   ", "pr_number": 1, "pr_url": None},
     ],
 )
 def test_workspace_adopt_pr_requires_exactly_one_selector(
@@ -585,3 +589,108 @@ def test_workspace_adopt_pr_accepts_cursor_agent(
     assert captured["method"] == "POST"
     assert captured["path"] == "/v1/workspaces/adopt-pr"
     assert captured["json"]["agent"] == "cursor"  # type: ignore[index]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "git@github.com:org/app.git",
+        "https://github.com/org/app",
+        "github.com/org/app",
+        "ssh://git@github.com/org/app.git",
+    ],
+)
+def test_repo_targets_github_host_accepts_real_github_urls(repo: str) -> None:
+    """Real github.com repo URLs (scp, https, scheme-less, ssh) are host-matched."""
+    assert workspace_commands._repo_targets_github_host(repo) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "repo",
+    [
+        "owner/repo",
+        "dimileeh/aira-web",
+        # Bypass attempts that the old "github.com" in repo substring check
+        # would have wrongly accepted as github.com URLs.
+        "github.com.evil.example/org/app",
+        "https://github.com.evil.example/org/app",
+        "git@github.com.evil.example:org/app.git",
+        "https://evil.example/github.com/org/app",
+    ],
+)
+def test_repo_targets_github_host_rejects_slugs_and_bypasses(repo: str) -> None:
+    """Bare slugs and host-boundary bypasses are not treated as github.com hosts."""
+    assert workspace_commands._repo_targets_github_host(repo) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "repo",
+    [
+        # Unbalanced IPv6 bracket: urlsplit raises ValueError("Invalid IPv6 URL").
+        "[bad",
+        "git@[::1",
+        "https://[::1/org/app",
+    ],
+)
+def test_repo_targets_github_host_returns_false_on_unparseable_url(repo: str) -> None:
+    """Malformed URLs that make urlsplit raise ValueError are treated as non-github (no crash)."""
+    assert workspace_commands._repo_targets_github_host(repo) is False
+
+
+def _adopt_pr_body(monkeypatch: pytest.MonkeyPatch, repo: str) -> dict[str, object]:
+    """Invoke workspace_adopt_pr and capture the posted JSON body."""
+    captured: dict[str, object] = {}
+
+    def _call(method: str, path: str, **kwargs: object) -> httpx.Response:
+        captured.update(kwargs)
+        return httpx.Response(202, json={"id": "ws"})
+
+    monkeypatch.setattr(workspace_commands, "_call", _call)
+    monkeypatch.setattr(workspace_commands, "_handle_response", lambda *_args, **_kwargs: None)
+
+    workspace_commands.workspace_adopt_pr(
+        repo=repo,
+        pr_number=7,
+        pr_url=None,
+        agent="codex",
+        model=None,
+        effort=None,
+        owned_paths=None,
+        profile_ref="auto",
+        auto_merge=True,
+        initial_review_grace_period_seconds=None,
+        task_title=None,
+        task_prompt=None,
+        reason=None,
+        api_token=None,
+        base_url=None,
+        fmt=OutputFormat.json,
+    )
+    return captured["json"]  # type: ignore[return-value]
+
+
+@pytest.mark.unit
+def test_adopt_pr_routes_github_url_to_repo_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An scp-style github.com URL is sent as repo_url, not repo_slug."""
+    body = _adopt_pr_body(monkeypatch, "git@github.com:org/app.git")
+    assert body["repo_url"] == "git@github.com:org/app.git"
+    assert body["repo_slug"] is None
+
+
+@pytest.mark.unit
+def test_adopt_pr_routes_slug_to_repo_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bare owner/repo slug is sent as repo_slug, not repo_url."""
+    body = _adopt_pr_body(monkeypatch, "dimileeh/aira-web")
+    assert body["repo_slug"] == "dimileeh/aira-web"
+    assert body["repo_url"] is None
+
+
+@pytest.mark.unit
+def test_adopt_pr_routes_lookalike_host_to_repo_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A github.com look-alike host is NOT routed to repo_url (CodeQL alert #16)."""
+    body = _adopt_pr_body(monkeypatch, "github.com.evil.example/org/app")
+    assert body["repo_url"] is None
+    assert body["repo_slug"] == "github.com.evil.example/org/app"

--- a/tests/unit/cli/test_workspace_commands_helpers.py
+++ b/tests/unit/cli/test_workspace_commands_helpers.py
@@ -610,6 +610,23 @@ def test_repo_targets_github_host_accepts_real_github_urls(repo: str) -> None:
 @pytest.mark.parametrize(
     "repo",
     [
+        # The `.github.com` suffix branch deliberately admits GitHub subdomains
+        # (API/raw/gist and future GHES-style hosts) as URL targets, not slugs.
+        "git@api.github.com:org/app.git",
+        "https://raw.github.com/org/app",
+        "gist.github.com/org/app",
+        "ssh://git@codeload.github.com/org/app.git",
+    ],
+)
+def test_repo_targets_github_host_accepts_github_subdomains(repo: str) -> None:
+    """The `.github.com` suffix branch host-matches GitHub subdomains, not just the apex."""
+    assert workspace_commands._repo_targets_github_host(repo) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "repo",
+    [
         "owner/repo",
         "dimileeh/aira-web",
         # Bypass attempts that the old "github.com" in repo substring check

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -5,69 +5,48 @@ CodeQL alert (``py/redos``) flagged the bare ``owner/repo`` slug regex in
 group immediately followed by ``(?:\\.git)?`` (whose ``.git`` characters are
 themselves in ``[^/\\s]``) gave a quote/dot-heavy tail exponentially many ways
 to split. These tests pin the *exact* accept/reject set and parsed owner/name
-against an embedded copy of the original (pre-hardening) pattern, and bound the
-runtime on a pathological input so the backtracking cannot return.
+against results captured once from the original (pre-hardening) pattern, and
+bound the runtime on a pathological input so the backtracking cannot return.
+
+The expected owner/name pairs below were captured once from the pre-hardening
+patterns. We bake the expected results as literals rather than re-compiling the
+original (vulnerable) regexes here: re-shipping those literals would itself be a
+``py/redos`` finding, and the differential guard is just as strong asserting the
+hardened parser against the captured pairs.
 """
 
 from __future__ import annotations
 
-import re
 import time
 
 import pytest
 
 from awf.common.github_client import RepoRef
 
-# Embedded copy of the ORIGINAL (pre-hardening) bare-slug regex. Kept local to
-# the test (not imported) so the differential guard proves equivalence without
-# shipping the vulnerable pattern in production code.
-_ORIGINAL_BARE_SLUG_RE = re.compile(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?")
-
-# Embedded copy of the ORIGINAL (pre-hardening) SSH scp-like regex, kept local for
-# the same reason: it carried the identical lazy ``([^/]+?)`` + ``(?:\.git)?``
-# overlap (CodeQL py/redos) that the bare-slug pattern had.
-_ORIGINAL_SSH_RE = re.compile(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?")
-
-
-def _original_parse(value: str) -> tuple[str, str] | None:
-    """Replicate the original bare-slug owner/name extraction."""
-    match = _ORIGINAL_BARE_SLUG_RE.fullmatch(value)
-    if match is None:
-        return None
-    return match.group(1), match.group(2)
-
-
-def _original_ssh_parse(value: str) -> tuple[str, str] | None:
-    """Replicate the original SSH scp-like owner/name extraction."""
-    match = _ORIGINAL_SSH_RE.fullmatch(value)
-    if match is None:
-        return None
-    return match.group(1), match.group(2)
-
-
-_BARE_SLUG_CASES = [
-    "owner/repo",
-    "owner/repo.git",
-    "owner/repo/",
-    "owner/repo.git/",
-    "owner/repo.git.git",
-    "owner/.git",
-    "owner/repo.github",
-    "o/r",
-    "o/r.git",
-    "owner/repo.gitfoo",
-    "owner/.gitignore",
-    "dimileeh/aira-web",
-    "dimileeh/aira-web.git",
+# (input, expected (owner, name)) captured once from the ORIGINAL pre-hardening
+# bare-slug regex ``([^/\s]+)/([^/\s]+?)(?:\.git)?/?``. Every corpus entry is a
+# valid bare slug, so the expected value is never ``None``.
+_BARE_SLUG_CASES: list[tuple[str, tuple[str, str]]] = [
+    ("owner/repo", ("owner", "repo")),
+    ("owner/repo.git", ("owner", "repo")),
+    ("owner/repo/", ("owner", "repo")),
+    ("owner/repo.git/", ("owner", "repo")),
+    ("owner/repo.git.git", ("owner", "repo.git")),
+    ("owner/.git", ("owner", ".git")),
+    ("owner/repo.github", ("owner", "repo.github")),
+    ("o/r", ("o", "r")),
+    ("o/r.git", ("o", "r")),
+    ("owner/repo.gitfoo", ("owner", "repo.gitfoo")),
+    ("owner/.gitignore", ("owner", ".gitignore")),
+    ("dimileeh/aira-web", ("dimileeh", "aira-web")),
+    ("dimileeh/aira-web.git", ("dimileeh", "aira-web")),
 ]
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("value", _BARE_SLUG_CASES)
-def test_bare_slug_owner_name_matches_original(value: str) -> None:
+@pytest.mark.parametrize("value, expected", _BARE_SLUG_CASES)
+def test_bare_slug_owner_name_matches_original(value: str, expected: tuple[str, str]) -> None:
     """Hardened parsing yields the same owner/name the original regex produced."""
-    expected = _original_parse(value)
-    assert expected is not None, "test corpus entry must be a valid bare slug"
     ref = RepoRef.from_url(value)
     assert (ref.owner, ref.name) == expected
     assert ref.forge == "github"
@@ -117,27 +96,28 @@ def test_bare_slug_pathological_tail_is_linear() -> None:
     assert time.perf_counter() - start < 5.0
 
 
-_SSH_CASES = [
-    "git@github.com:owner/repo",
-    "git@github.com:owner/repo.git",
-    "git@github.com:owner/repo/",
-    "git@github.com:owner/repo.git/",
-    "git@github.com:owner/repo.git.git",
-    "git@github.com:owner/.git",
-    "git@github.com:owner/repo.github",
-    "git@github.com:o/r",
-    "git@github.com:o/r.git",
-    "git@github.com:dimileeh/aira-web",
-    "git@github.com:dimileeh/aira-web.git",
+# (input, expected (owner, name)) captured once from the ORIGINAL pre-hardening
+# SSH scp-like regex ``git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?``. Every
+# corpus entry is a valid SSH ref, so the expected value is never ``None``.
+_SSH_CASES: list[tuple[str, tuple[str, str]]] = [
+    ("git@github.com:owner/repo", ("owner", "repo")),
+    ("git@github.com:owner/repo.git", ("owner", "repo")),
+    ("git@github.com:owner/repo/", ("owner", "repo")),
+    ("git@github.com:owner/repo.git/", ("owner", "repo")),
+    ("git@github.com:owner/repo.git.git", ("owner", "repo.git")),
+    ("git@github.com:owner/.git", ("owner", ".git")),
+    ("git@github.com:owner/repo.github", ("owner", "repo.github")),
+    ("git@github.com:o/r", ("o", "r")),
+    ("git@github.com:o/r.git", ("o", "r")),
+    ("git@github.com:dimileeh/aira-web", ("dimileeh", "aira-web")),
+    ("git@github.com:dimileeh/aira-web.git", ("dimileeh", "aira-web")),
 ]
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("value", _SSH_CASES)
-def test_ssh_owner_name_matches_original(value: str) -> None:
+@pytest.mark.parametrize("value, expected", _SSH_CASES)
+def test_ssh_owner_name_matches_original(value: str, expected: tuple[str, str]) -> None:
     """Hardened SSH parsing yields the same owner/name the original regex produced."""
-    expected = _original_ssh_parse(value)
-    assert expected is not None, "test corpus entry must be a valid SSH ref"
     ref = RepoRef.from_url(value)
     assert (ref.owner, ref.name) == expected
     assert ref.forge == "github"

--- a/tests/unit/common/test_github_client_parts/test_github_client_redos.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_redos.py
@@ -1,0 +1,163 @@
+"""ReDoS hardening regressions for ``RepoRef.from_url`` bare-slug parsing.
+
+CodeQL alert (``py/redos``) flagged the bare ``owner/repo`` slug regex in
+``RepoRef.from_url`` for catastrophic backtracking: the lazy ``([^/\\s]+?)``
+group immediately followed by ``(?:\\.git)?`` (whose ``.git`` characters are
+themselves in ``[^/\\s]``) gave a quote/dot-heavy tail exponentially many ways
+to split. These tests pin the *exact* accept/reject set and parsed owner/name
+against an embedded copy of the original (pre-hardening) pattern, and bound the
+runtime on a pathological input so the backtracking cannot return.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from awf.common.github_client import RepoRef
+
+# Embedded copy of the ORIGINAL (pre-hardening) bare-slug regex. Kept local to
+# the test (not imported) so the differential guard proves equivalence without
+# shipping the vulnerable pattern in production code.
+_ORIGINAL_BARE_SLUG_RE = re.compile(r"([^/\s]+)/([^/\s]+?)(?:\.git)?/?")
+
+# Embedded copy of the ORIGINAL (pre-hardening) SSH scp-like regex, kept local for
+# the same reason: it carried the identical lazy ``([^/]+?)`` + ``(?:\.git)?``
+# overlap (CodeQL py/redos) that the bare-slug pattern had.
+_ORIGINAL_SSH_RE = re.compile(r"git@github\.com:([^/]+)/([^/]+?)(?:\.git)?/?")
+
+
+def _original_parse(value: str) -> tuple[str, str] | None:
+    """Replicate the original bare-slug owner/name extraction."""
+    match = _ORIGINAL_BARE_SLUG_RE.fullmatch(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+def _original_ssh_parse(value: str) -> tuple[str, str] | None:
+    """Replicate the original SSH scp-like owner/name extraction."""
+    match = _ORIGINAL_SSH_RE.fullmatch(value)
+    if match is None:
+        return None
+    return match.group(1), match.group(2)
+
+
+_BARE_SLUG_CASES = [
+    "owner/repo",
+    "owner/repo.git",
+    "owner/repo/",
+    "owner/repo.git/",
+    "owner/repo.git.git",
+    "owner/.git",
+    "owner/repo.github",
+    "o/r",
+    "o/r.git",
+    "owner/repo.gitfoo",
+    "owner/.gitignore",
+    "dimileeh/aira-web",
+    "dimileeh/aira-web.git",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", _BARE_SLUG_CASES)
+def test_bare_slug_owner_name_matches_original(value: str) -> None:
+    """Hardened parsing yields the same owner/name the original regex produced."""
+    expected = _original_parse(value)
+    assert expected is not None, "test corpus entry must be a valid bare slug"
+    ref = RepoRef.from_url(value)
+    assert (ref.owner, ref.name) == expected
+    assert ref.forge == "github"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "value, expected_name",
+    [
+        ("owner/repo", "repo"),
+        ("owner/repo.git", "repo"),
+        ("owner/repo.git/", "repo"),
+        ("owner/repo.git.git", "repo.git"),
+        ("owner/.git", ".git"),  # len == 4: trailing ``.git`` is NOT stripped
+        ("owner/repo.github", "repo.github"),
+    ],
+)
+def test_bare_slug_git_suffix_strip_edges(value: str, expected_name: str) -> None:
+    """The ``.git`` strip replicates the original lazy behavior exactly."""
+    assert RepoRef.from_url(value).name == expected_name
+
+
+@pytest.mark.unit
+def test_bare_slug_pathological_tail_is_linear() -> None:
+    """A long ``.git``-overlap tail with a non-matching terminator parses linearly.
+
+    Regression for CodeQL ``py/redos`` on ``github_client.py:165``. The original
+    lazy-group + ``(?:\\.git)?`` overlap is the backtracking anti-pattern CodeQL
+    flagged; the hardened possessive form has a single unambiguous match path
+    and completes in microseconds.
+
+    The input must actually exercise that overlap to pin the fix: it repeats real
+    ``.git`` fragments (so the lazy group and the optional ``(?:\\.git)?`` fight
+    over every fragment boundary) and ends in a non-matching ``/x`` terminator,
+    forcing the *failure* path where a re-introduced lazy pattern backtracks. A
+    bare ``b.g``-style tail never contains the ``.git`` suffix and parses as a
+    trivial success under either pattern, so it would not catch a regression.
+
+    The 5.0s budget is far above any realistic parse time (so a loaded/
+    memory-constrained CI runner won't fail spuriously) yet far below the
+    seconds-to-minutes a re-introduced backtracking regression would take.
+    """
+    pathological = "a" * 5000 + "/" + "b.git" * 2000 + "/x"
+    start = time.perf_counter()
+    with pytest.raises(ValueError):
+        RepoRef.from_url(pathological)
+    assert time.perf_counter() - start < 5.0
+
+
+_SSH_CASES = [
+    "git@github.com:owner/repo",
+    "git@github.com:owner/repo.git",
+    "git@github.com:owner/repo/",
+    "git@github.com:owner/repo.git/",
+    "git@github.com:owner/repo.git.git",
+    "git@github.com:owner/.git",
+    "git@github.com:owner/repo.github",
+    "git@github.com:o/r",
+    "git@github.com:o/r.git",
+    "git@github.com:dimileeh/aira-web",
+    "git@github.com:dimileeh/aira-web.git",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", _SSH_CASES)
+def test_ssh_owner_name_matches_original(value: str) -> None:
+    """Hardened SSH parsing yields the same owner/name the original regex produced."""
+    expected = _original_ssh_parse(value)
+    assert expected is not None, "test corpus entry must be a valid SSH ref"
+    ref = RepoRef.from_url(value)
+    assert (ref.owner, ref.name) == expected
+    assert ref.forge == "github"
+
+
+@pytest.mark.unit
+def test_ssh_pathological_tail_is_linear() -> None:
+    """A pathological SSH ``.git``-overlap tail parses linearly.
+
+    Regression for the SSH scp-like form on ``github_client.py:198``, which shared
+    the same lazy ``([^/]+?)`` + ``(?:\\.git)?`` overlap CodeQL flagged on the
+    bare-slug path. The tail repeats real ``.git`` fragments (so the lazy group and
+    the optional ``(?:\\.git)?`` fight over every fragment boundary) and ends in a
+    trailing ``/x`` the name group cannot consume, forcing the *failure* path where
+    a re-introduced lazy pattern backtracks. The hardened possessive form has a
+    single match path and completes in microseconds. The 5.0s budget mirrors the
+    bare-slug guard: well above any real parse time, well below a regression's.
+    """
+    pathological = "git@github.com:owner/" + "b.git" * 4000 + "/x"
+    start = time.perf_counter()
+    with pytest.raises(ValueError):
+        RepoRef.from_url(pathological)
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/common/test_repo_ref_forge.py
+++ b/tests/unit/common/test_repo_ref_forge.py
@@ -99,6 +99,22 @@ class TestRepoRefForgeDetection:
     @pytest.mark.parametrize(
         "url",
         [
+            "https://[bad",
+            "https://[bad]:notaport/owner/repo",
+        ],
+    )
+    def test_malformed_ipv6_url_raises_standard_message(self, url: str) -> None:
+        # ``urlsplit``/``.hostname`` raise a bespoke ``ValueError`` (e.g. "Invalid
+        # IPv6 URL") on malformed authorities; normalize to the standard
+        # parse-failure message so no urllib internals leak (thread
+        # PRRT_kwDOSJAM6s6I2g-d).
+        with pytest.raises(ValueError, match=r"^Cannot parse repo from URL: "):
+            RepoRef.from_url(url)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "url",
+        [
             "https://bitbucket.org/workspace",
             "git@gitlab.com:org/repo.git",
         ],

--- a/tests/unit/common/test_repo_ref_forge.py
+++ b/tests/unit/common/test_repo_ref_forge.py
@@ -194,3 +194,18 @@ class TestRepoRefHostAwareBuilders:
             ref.clone_url_like("ssh://git@github.com:22/dimileeh/source.git")
             == "git@github.com:contributor/aira-web.git"
         )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "malformed_url",
+        [
+            "https://[bad/dimileeh/source.git",
+            "ssh://git@[::1bad/dimileeh/source.git",
+        ],
+    )
+    def test_clone_url_like_malformed_url_falls_back_to_https(self, malformed_url: str) -> None:
+        # ``urlsplit``/``.hostname`` raise ``ValueError`` ("Invalid IPv6 URL") on
+        # malformed authorities; ``clone_url_like`` must not crash — it falls back
+        # to the canonical HTTPS clone URL (review comment 4477925645).
+        ref = RepoRef(owner="contributor", name="aira-web")
+        assert ref.clone_url_like(malformed_url) == "https://github.com/contributor/aira-web.git"

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
@@ -2,12 +2,18 @@
 
 CodeQL flagged ``_VALIDATION_TEST_COMMAND_RE`` and ``_VALIDATION_TEST_PATH_RE``
 (``py/redos`` / ``py/polynomial-redos``) in all five ``quality_gates*`` modules.
-Both carry a repeated separator group whose greedy inner token class overlaps an
-adjacent ``\\s+`` boundary, so a long run of flag-like tokens has exponentially
+Both carried a repeated separator group whose greedy inner token class overlapped
+an adjacent ``\\s+`` boundary, so a long run of flag-like tokens had exponentially
 many ways to split → catastrophic backtracking.
 
 The five modules carry byte-identical copies of these constants, so the same
 accept-set + timing assertions run against every module's compiled pattern.
+
+The expected ``search`` spans below were captured once from the pre-hardening
+patterns. We bake the expected results as literals rather than re-compiling the
+original (vulnerable) regexes here: re-shipping those literals would itself be a
+``py/redos`` finding, and the differential guard is just as strong asserting the
+hardened pattern against the captured spans.
 """
 
 from __future__ import annotations
@@ -32,57 +38,45 @@ _MODULES: tuple[ModuleType, ...] = (
     _qg_commands,
 )
 
-# Embedded copies of the ORIGINAL (pre-hardening) patterns. Kept local to the
-# test so the differential guard proves equivalence without re-shipping the
-# vulnerable regexes from production.
-_ORIGINAL_TEST_COMMAND_RE = re.compile(
-    r"(?<![A-Za-z0-9_./-])"
-    r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
-    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
-    r"\s+test(?:\s|$)"
-)
-_ORIGINAL_TEST_PATH_RE = re.compile(
-    r"(?<![A-Za-z0-9_./-])"
-    r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
-    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
-    r"\s+tests/[^\s;&|]*"
-)
-
-_TEST_COMMAND_INPUTS = [
+# (input, expected search span) captured from the ORIGINAL pre-hardening
+# ``_VALIDATION_TEST_COMMAND_RE``. ``None`` == no match.
+_TEST_COMMAND_CASES: list[tuple[str, tuple[int, int] | None]] = [
     # positives
-    "npm test",
-    "pnpm run test",
-    "yarn exec test",
-    "uv run --frozen test",
-    "cargo  test",
-    "make test",
-    "npm --foo test",
-    "go run --x --y test",
-    "poetry run --no-root test ",
+    ("npm test", (0, 8)),
+    ("pnpm run test", (0, 13)),
+    ("yarn exec test", (0, 14)),
+    ("uv run --frozen test", (0, 20)),
+    ("cargo  test", (0, 11)),
+    ("make test", (0, 9)),
+    ("npm --foo test", (0, 14)),
+    ("go run --x --y test", (0, 19)),
+    ("poetry run --no-root test ", (0, 26)),
     # negatives
-    "npm testing",
-    "npm run build",
-    "gotest",
-    "pytest",
-    "mytest",
-    "xnpm test",
-    "npm--test",
-    "npm run --frozen build",
+    ("npm testing", None),
+    ("npm run build", None),
+    ("gotest", None),
+    ("pytest", None),
+    ("mytest", None),
+    ("xnpm test", None),
+    ("npm--test", None),
+    ("npm run --frozen build", None),
 ]
 
-_TEST_PATH_INPUTS = [
+# (input, expected search span) captured from the ORIGINAL pre-hardening
+# ``_VALIDATION_TEST_PATH_RE``. ``None`` == no match.
+_TEST_PATH_CASES: list[tuple[str, tuple[int, int] | None]] = [
     # positives
-    "python tests/x.py",
-    "uv run python3.12 tests/unit",
-    "python -q tests/a",
-    "python3 --foo tests/unit/x",
-    "poetry run python tests/",
+    ("python tests/x.py", (0, 17)),
+    ("uv run python3.12 tests/unit", (0, 28)),
+    ("python -q tests/a", (0, 17)),
+    ("python3 --foo tests/unit/x", (0, 26)),
+    ("poetry run python tests/", (0, 24)),
     # negatives
-    "python tests",
-    "pythontests/x",
-    "python testsuite",
-    "python -q tests",
-    "xpython tests/a",
+    ("python tests", None),
+    ("pythontests/x", None),
+    ("python testsuite", None),
+    ("python -q tests", None),
+    ("xpython tests/a", None),
 ]
 
 
@@ -94,26 +88,28 @@ def _attr(module: ModuleType, name: str) -> re.Pattern[str]:
 
 @pytest.mark.unit
 @pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
-@pytest.mark.parametrize("text", _TEST_COMMAND_INPUTS)
-def test_test_command_re_matches_original(module: ModuleType, text: str) -> None:
+@pytest.mark.parametrize("text, expected_span", _TEST_COMMAND_CASES)
+def test_test_command_re_matches_original(
+    module: ModuleType, text: str, expected_span: tuple[int, int] | None
+) -> None:
     """Hardened ``_VALIDATION_TEST_COMMAND_RE`` keeps the original match/span."""
-    expected = _ORIGINAL_TEST_COMMAND_RE.search(text)
     actual = _attr(module, "_VALIDATION_TEST_COMMAND_RE").search(text)
-    assert (actual is None) == (expected is None)
-    if expected is not None and actual is not None:
-        assert actual.span() == expected.span()
+    assert (actual is None) == (expected_span is None)
+    if actual is not None and expected_span is not None:
+        assert actual.span() == expected_span
 
 
 @pytest.mark.unit
 @pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
-@pytest.mark.parametrize("text", _TEST_PATH_INPUTS)
-def test_test_path_re_matches_original(module: ModuleType, text: str) -> None:
+@pytest.mark.parametrize("text, expected_span", _TEST_PATH_CASES)
+def test_test_path_re_matches_original(
+    module: ModuleType, text: str, expected_span: tuple[int, int] | None
+) -> None:
     """Hardened ``_VALIDATION_TEST_PATH_RE`` keeps the original match/span."""
-    expected = _ORIGINAL_TEST_PATH_RE.search(text)
     actual = _attr(module, "_VALIDATION_TEST_PATH_RE").search(text)
-    assert (actual is None) == (expected is None)
-    if expected is not None and actual is not None:
-        assert actual.span() == expected.span()
+    assert (actual is None) == (expected_span is None)
+    if actual is not None and expected_span is not None:
+        assert actual.span() == expected_span
 
 
 @pytest.mark.unit
@@ -121,7 +117,7 @@ def test_test_path_re_matches_original(module: ModuleType, text: str) -> None:
 def test_test_command_re_no_catastrophic_backtracking(module: ModuleType) -> None:
     """A long flag run with no trailing ``test`` must reject in linear time.
 
-    Regression for CodeQL ``py/redos`` — the original pattern blows up
+    Regression for CodeQL ``py/redos`` — the original pattern blew up
     exponentially on this input; the possessive form rejects in ~microseconds.
     """
     pathological = "npm " + "--x " * 5000 + "z"

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_redos.py
@@ -1,0 +1,149 @@
+"""ReDoS hardening regressions for the ``quality_gates*`` validation regexes.
+
+CodeQL flagged ``_VALIDATION_TEST_COMMAND_RE`` and ``_VALIDATION_TEST_PATH_RE``
+(``py/redos`` / ``py/polynomial-redos``) in all five ``quality_gates*`` modules.
+Both carry a repeated separator group whose greedy inner token class overlaps an
+adjacent ``\\s+`` boundary, so a long run of flag-like tokens has exponentially
+many ways to split → catastrophic backtracking.
+
+The five modules carry byte-identical copies of these constants, so the same
+accept-set + timing assertions run against every module's compiled pattern.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from types import ModuleType
+
+import pytest
+
+from awf.control import quality_gates as _qg
+from awf.control import quality_gates_pyproject as _qg_pyproject
+from awf.control import quality_gates_workflow as _qg_workflow
+from awf.control import quality_gates_workflow_actions as _qg_actions
+from awf.control import quality_gates_workflow_commands as _qg_commands
+
+_MODULES: tuple[ModuleType, ...] = (
+    _qg,
+    _qg_pyproject,
+    _qg_workflow,
+    _qg_actions,
+    _qg_commands,
+)
+
+# Embedded copies of the ORIGINAL (pre-hardening) patterns. Kept local to the
+# test so the differential guard proves equivalence without re-shipping the
+# vulnerable regexes from production.
+_ORIGINAL_TEST_COMMAND_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])"
+    r"(?:npm|pnpm|yarn|bun|go|cargo|make|mvn|gradle|gradlew|tox|nox|uv|poetry|pipenv)"
+    r"(?:\s+(?:run|exec|--?[A-Za-z0-9_.=:/-]+))*"
+    r"\s+test(?:\s|$)"
+)
+_ORIGINAL_TEST_PATH_RE = re.compile(
+    r"(?<![A-Za-z0-9_./-])"
+    r"(?:(?:uv|poetry|pipenv)\s+run\s+)?python(?:3(?:\.\d+)?)?"
+    r"(?:\s+--?[A-Za-z0-9_.=:/-]+)*"
+    r"\s+tests/[^\s;&|]*"
+)
+
+_TEST_COMMAND_INPUTS = [
+    # positives
+    "npm test",
+    "pnpm run test",
+    "yarn exec test",
+    "uv run --frozen test",
+    "cargo  test",
+    "make test",
+    "npm --foo test",
+    "go run --x --y test",
+    "poetry run --no-root test ",
+    # negatives
+    "npm testing",
+    "npm run build",
+    "gotest",
+    "pytest",
+    "mytest",
+    "xnpm test",
+    "npm--test",
+    "npm run --frozen build",
+]
+
+_TEST_PATH_INPUTS = [
+    # positives
+    "python tests/x.py",
+    "uv run python3.12 tests/unit",
+    "python -q tests/a",
+    "python3 --foo tests/unit/x",
+    "poetry run python tests/",
+    # negatives
+    "python tests",
+    "pythontests/x",
+    "python testsuite",
+    "python -q tests",
+    "xpython tests/a",
+]
+
+
+def _attr(module: ModuleType, name: str) -> re.Pattern[str]:
+    pattern = getattr(module, name)
+    assert isinstance(pattern, re.Pattern)
+    return pattern
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+@pytest.mark.parametrize("text", _TEST_COMMAND_INPUTS)
+def test_test_command_re_matches_original(module: ModuleType, text: str) -> None:
+    """Hardened ``_VALIDATION_TEST_COMMAND_RE`` keeps the original match/span."""
+    expected = _ORIGINAL_TEST_COMMAND_RE.search(text)
+    actual = _attr(module, "_VALIDATION_TEST_COMMAND_RE").search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+@pytest.mark.parametrize("text", _TEST_PATH_INPUTS)
+def test_test_path_re_matches_original(module: ModuleType, text: str) -> None:
+    """Hardened ``_VALIDATION_TEST_PATH_RE`` keeps the original match/span."""
+    expected = _ORIGINAL_TEST_PATH_RE.search(text)
+    actual = _attr(module, "_VALIDATION_TEST_PATH_RE").search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+def test_test_command_re_no_catastrophic_backtracking(module: ModuleType) -> None:
+    """A long flag run with no trailing ``test`` must reject in linear time.
+
+    Regression for CodeQL ``py/redos`` — the original pattern blows up
+    exponentially on this input; the possessive form rejects in ~microseconds.
+    """
+    pathological = "npm " + "--x " * 5000 + "z"
+    pattern = _attr(module, "_VALIDATION_TEST_COMMAND_RE")
+    start = time.perf_counter()
+    assert pattern.search(pathological) is None
+    # 5.0s is far above the ~microsecond possessive-form reject and far below
+    # the seconds-to-minutes a backtracking regression would take, so a loaded
+    # CI runner won't fail spuriously.
+    assert time.perf_counter() - start < 5.0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("module", _MODULES, ids=lambda m: m.__name__.rsplit(".", 1)[-1])
+def test_test_path_re_no_catastrophic_backtracking(module: ModuleType) -> None:
+    """A long flag run with no trailing ``tests/`` must reject in linear time.
+
+    Regression for CodeQL ``py/polynomial-redos`` on the test-path detector.
+    """
+    pathological = "python " + "--x " * 5000 + "z"
+    pattern = _attr(module, "_VALIDATION_TEST_PATH_RE")
+    start = time.perf_counter()
+    assert pattern.search(pathological) is None
+    # 5.0s budget: far above the possessive-form reject, far below a regression.
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/mcp/test_setup_tools_redos.py
+++ b/tests/unit/mcp/test_setup_tools_redos.py
@@ -2,20 +2,25 @@
 
 CodeQL flagged the ``start_source`` value sub-pattern in
 ``_SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN`` (``setup_tools.py:124``) for
-catastrophic backtracking: the ``(?:'[^']*'|"[^"]*"|\\S)+?`` value lets the
+catastrophic backtracking: the ``(?:'[^']*'|"[^"]*"|\\S)+?`` value let the
 ``\\S`` branch overlap the quoted-string branches (a quote is also ``\\S``), so
-a quote-heavy run has Catalan-many tokenizations.
+a quote-heavy run had Catalan-many tokenizations.
 
 The hardened pattern makes the three branches a unique partition (atomic quoted
 strings, non-quote chars, and a lone-quote branch reachable only when it does
 *not* open a complete quoted string). This preserves the match on the realistic
 AWF-generated next-step inputs the pattern actually sees (paths, optionally
 quoted, with the documented suffix forms) and removes the backtracking.
+
+The expected span + named groups below were captured once from the pre-hardening
+pattern. We bake them as literals rather than re-compiling the original
+(vulnerable) regex here: re-shipping that literal would itself be a ``py/redos``
+finding, and the differential guard is just as strong asserting the hardened
+pattern against the captured span/groups.
 """
 
 from __future__ import annotations
 
-import re
 import time
 
 import pytest
@@ -25,52 +30,201 @@ from awf.mcp.setup_tools import (
     _setup_status_next_step_for_source_checkout,
 )
 
-# Embedded copy of the ORIGINAL (pre-hardening) full pattern, kept local to the
-# test so the differential guard proves equivalence without re-shipping the
-# vulnerable ``\S``-overlap value sub-pattern.
-_ORIGINAL_NEXT_STEP_PATTERN = re.compile(
-    r"(?P<setup>\bawf setup --dry-run(?P<setup_suffix>[.,;):]|$|\s+to\b))"
-    r"|(?P<start_source>\bawf start\s+--source-checkout(?:=|\s+)"
-    r"(?:'[^']*'|\"[^\"]*\"|\S)+?"
-    r"(?P<start_source_suffix>[.,;):](?=\s|$)|$|\s+to\b))"
-    r"|(?P<start>\bawf start(?P<start_suffix>[.,;):]|$|\s+to\b))"
-)
-
-# Representative next-step strings (the only shape this pattern sees in
-# production: a single ``--source-checkout`` argument — bare or fully quoted —
-# followed by one of the documented suffix forms).
-_REPRESENTATIVE_NEXT_STEPS = [
-    "Run awf start --source-checkout=/path/to/repo.",
-    "Run awf start --source-checkout=/path/to/repo to deploy.",
-    "awf start --source-checkout='/p with space/r'",
-    'awf start --source-checkout="/p with space/r" to continue',
-    "awf start --source-checkout=/p/r;",
-    "awf start --source-checkout=/p/r)",
-    "awf start --source-checkout=/p/r:",
-    "awf start --source-checkout=/p/r",
-    "awf start --source-checkout=it's/repo",  # unbalanced quote -> lone-quote branch
-    # shlex.join() escapes an apostrophe path as adjacent quoted segments
-    # ('it' + "'" + 's/repo'); the partitioned value must tokenize the run as a
-    # series of atomic quoted strings rather than a single one.
-    "awf start --source-checkout='it'\"'\"'s/repo'",
-    "awf start --source-checkout /opt/aira.",
-    "Then run awf setup --dry-run to provision.",
-    "awf start to begin.",
-    "awf start.",
-    "no command here at all",
+# (input, expected span, expected groupdict) captured from the ORIGINAL
+# pre-hardening ``_SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN``. ``None`` span == no
+# match. The shapes are the only ones this pattern sees in production: a single
+# ``--source-checkout`` argument — bare or fully quoted — followed by one of the
+# documented suffix forms.
+_NEXT_STEP_CASES: list[tuple[str, tuple[int, int] | None, dict[str, str | None]]] = [
+    (
+        "Run awf start --source-checkout=/path/to/repo.",
+        (4, 46),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/path/to/repo.",
+            "start_source_suffix": ".",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "Run awf start --source-checkout=/path/to/repo to deploy.",
+        (4, 48),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/path/to/repo to",
+            "start_source_suffix": " to",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout='/p with space/r'",
+        (0, 45),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout='/p with space/r'",
+            "start_source_suffix": "",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        'awf start --source-checkout="/p with space/r" to continue',
+        (0, 48),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": 'awf start --source-checkout="/p with space/r" to',
+            "start_source_suffix": " to",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout=/p/r;",
+        (0, 33),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/p/r;",
+            "start_source_suffix": ";",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout=/p/r)",
+        (0, 33),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/p/r)",
+            "start_source_suffix": ")",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout=/p/r:",
+        (0, 33),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/p/r:",
+            "start_source_suffix": ":",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout=/p/r",
+        (0, 32),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=/p/r",
+            "start_source_suffix": "",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        # unbalanced quote -> lone-quote branch
+        "awf start --source-checkout=it's/repo",
+        (0, 37),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout=it's/repo",
+            "start_source_suffix": "",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        # shlex.join() escapes an apostrophe path as adjacent quoted segments
+        # ('it' + "'" + 's/repo'); the partitioned value must tokenize the run as
+        # a series of atomic quoted strings rather than a single one.
+        "awf start --source-checkout='it'\"'\"'s/repo'",
+        (0, 43),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout='it'\"'\"'s/repo'",
+            "start_source_suffix": "",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start --source-checkout /opt/aira.",
+        (0, 38),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": "awf start --source-checkout /opt/aira.",
+            "start_source_suffix": ".",
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "Then run awf setup --dry-run to provision.",
+        (9, 31),
+        {
+            "setup": "awf setup --dry-run to",
+            "setup_suffix": " to",
+            "start_source": None,
+            "start_source_suffix": None,
+            "start": None,
+            "start_suffix": None,
+        },
+    ),
+    (
+        "awf start to begin.",
+        (0, 12),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": None,
+            "start_source_suffix": None,
+            "start": "awf start to",
+            "start_suffix": " to",
+        },
+    ),
+    (
+        "awf start.",
+        (0, 10),
+        {
+            "setup": None,
+            "setup_suffix": None,
+            "start_source": None,
+            "start_source_suffix": None,
+            "start": "awf start.",
+            "start_suffix": ".",
+        },
+    ),
+    ("no command here at all", None, {}),
 ]
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("text", _REPRESENTATIVE_NEXT_STEPS)
-def test_next_step_pattern_matches_original(text: str) -> None:
+@pytest.mark.parametrize("text, expected_span, expected_groups", _NEXT_STEP_CASES)
+def test_next_step_pattern_matches_original(
+    text: str,
+    expected_span: tuple[int, int] | None,
+    expected_groups: dict[str, str | None],
+) -> None:
     """Hardened pattern keeps the original span + named groups on real inputs."""
-    expected = _ORIGINAL_NEXT_STEP_PATTERN.search(text)
     actual = _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(text)
-    assert (actual is None) == (expected is None)
-    if expected is not None and actual is not None:
-        assert actual.span() == expected.span()
-        assert actual.groupdict() == expected.groupdict()
+    assert (actual is None) == (expected_span is None)
+    if actual is not None and expected_span is not None:
+        assert actual.span() == expected_span
+        assert actual.groupdict() == expected_groups
 
 
 @pytest.mark.unit
@@ -118,7 +272,7 @@ def test_next_step_pattern_no_catastrophic_backtracking() -> None:
     """A long quote run must not trigger exponential backtracking.
 
     Regression for CodeQL ``py/redos`` on ``setup_tools.py:124``. A long quote
-    run followed by a non-suffix boundary forces the original ``\\S``-overlap
+    run followed by a non-suffix boundary forced the original ``\\S``-overlap
     value to explore Catalan-many tokenizations (exponential); the partitioned
     form completes in microseconds. The 5.0s budget sits far above any realistic
     parse time (so a loaded CI runner won't fail spuriously) yet far below the

--- a/tests/unit/mcp/test_setup_tools_redos.py
+++ b/tests/unit/mcp/test_setup_tools_redos.py
@@ -1,0 +1,132 @@
+"""ReDoS hardening regressions for the setup-status next-step command pattern.
+
+CodeQL flagged the ``start_source`` value sub-pattern in
+``_SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN`` (``setup_tools.py:124``) for
+catastrophic backtracking: the ``(?:'[^']*'|"[^"]*"|\\S)+?`` value lets the
+``\\S`` branch overlap the quoted-string branches (a quote is also ``\\S``), so
+a quote-heavy run has Catalan-many tokenizations.
+
+The hardened pattern makes the three branches a unique partition (atomic quoted
+strings, non-quote chars, and a lone-quote branch reachable only when it does
+*not* open a complete quoted string). This preserves the match on the realistic
+AWF-generated next-step inputs the pattern actually sees (paths, optionally
+quoted, with the documented suffix forms) and removes the backtracking.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+
+import pytest
+
+from awf.mcp.setup_tools import (
+    _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN,
+    _setup_status_next_step_for_source_checkout,
+)
+
+# Embedded copy of the ORIGINAL (pre-hardening) full pattern, kept local to the
+# test so the differential guard proves equivalence without re-shipping the
+# vulnerable ``\S``-overlap value sub-pattern.
+_ORIGINAL_NEXT_STEP_PATTERN = re.compile(
+    r"(?P<setup>\bawf setup --dry-run(?P<setup_suffix>[.,;):]|$|\s+to\b))"
+    r"|(?P<start_source>\bawf start\s+--source-checkout(?:=|\s+)"
+    r"(?:'[^']*'|\"[^\"]*\"|\S)+?"
+    r"(?P<start_source_suffix>[.,;):](?=\s|$)|$|\s+to\b))"
+    r"|(?P<start>\bawf start(?P<start_suffix>[.,;):]|$|\s+to\b))"
+)
+
+# Representative next-step strings (the only shape this pattern sees in
+# production: a single ``--source-checkout`` argument — bare or fully quoted —
+# followed by one of the documented suffix forms).
+_REPRESENTATIVE_NEXT_STEPS = [
+    "Run awf start --source-checkout=/path/to/repo.",
+    "Run awf start --source-checkout=/path/to/repo to deploy.",
+    "awf start --source-checkout='/p with space/r'",
+    'awf start --source-checkout="/p with space/r" to continue',
+    "awf start --source-checkout=/p/r;",
+    "awf start --source-checkout=/p/r)",
+    "awf start --source-checkout=/p/r:",
+    "awf start --source-checkout=/p/r",
+    "awf start --source-checkout=it's/repo",  # unbalanced quote -> lone-quote branch
+    # shlex.join() escapes an apostrophe path as adjacent quoted segments
+    # ('it' + "'" + 's/repo'); the partitioned value must tokenize the run as a
+    # series of atomic quoted strings rather than a single one.
+    "awf start --source-checkout='it'\"'\"'s/repo'",
+    "awf start --source-checkout /opt/aira.",
+    "Then run awf setup --dry-run to provision.",
+    "awf start to begin.",
+    "awf start.",
+    "no command here at all",
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("text", _REPRESENTATIVE_NEXT_STEPS)
+def test_next_step_pattern_matches_original(text: str) -> None:
+    """Hardened pattern keeps the original span + named groups on real inputs."""
+    expected = _ORIGINAL_NEXT_STEP_PATTERN.search(text)
+    actual = _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(text)
+    assert (actual is None) == (expected is None)
+    if expected is not None and actual is not None:
+        assert actual.span() == expected.span()
+        assert actual.groupdict() == expected.groupdict()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "step, start_command, expected",
+    [
+        (
+            "Run awf start --source-checkout=/old/path to deploy.",
+            "awf start --source-checkout=/new/repo",
+            "Run awf start --source-checkout=/new/repo to deploy.",
+        ),
+        (
+            "awf start --source-checkout='/old path/r'.",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo.",
+        ),
+        (
+            "awf start --source-checkout=/old/r",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo",
+        ),
+        (
+            # shlex.join()-escaped apostrophe path (adjacent quoted segments) as
+            # the step's source-checkout token must rewrite as a single unit.
+            "awf start --source-checkout='/old'\"'\"'s/r'.",
+            "awf start --source-checkout=/new/repo",
+            "awf start --source-checkout=/new/repo.",
+        ),
+    ],
+)
+def test_next_step_rewrite_substitutes_command(
+    step: str, start_command: str, expected: str
+) -> None:
+    """The hardened pattern drives ``.sub`` rewrites identically to before."""
+    result = _setup_status_next_step_for_source_checkout(
+        step,
+        setup_command="awf setup --dry-run",
+        start_command=start_command,
+    )
+    assert result == expected
+
+
+@pytest.mark.unit
+def test_next_step_pattern_no_catastrophic_backtracking() -> None:
+    """A long quote run must not trigger exponential backtracking.
+
+    Regression for CodeQL ``py/redos`` on ``setup_tools.py:124``. A long quote
+    run followed by a non-suffix boundary forces the original ``\\S``-overlap
+    value to explore Catalan-many tokenizations (exponential); the partitioned
+    form completes in microseconds. The 5.0s budget sits far above any realistic
+    parse time (so a loaded CI runner won't fail spuriously) yet far below the
+    seconds-to-minutes a re-introduced regression would take.
+    """
+    # Trailing ``" x"`` denies any valid suffix, so the original pattern would
+    # backtrack across every tokenization of the quote run before failing.
+    pathological = "awf start --source-checkout=" + "'" * 5000 + " x"
+    start = time.perf_counter()
+    assert _SETUP_STATUS_NEXT_STEP_COMMAND_PATTERN.search(pathological) is None
+    assert time.perf_counter() - start < 5.0

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
@@ -12,6 +12,7 @@ from awf.runtime._docker_pull_detection import (
     _evidence_line_is_permanent_pull_failure,
     _forward_detail_ref_matches_pull,
     _image_ref_matches_daemon_url,
+    _line_url_host_is,
     _strip_image_tag,
 )
 from awf.runtime.pr_monitor import (
@@ -1028,6 +1029,46 @@ class TestImageRefMatchesDaemonUrl:
             '?scope=repository%3alibrary%2fpostgres%3apull": denied'
         )
         assert _image_ref_matches_daemon_url("postgres:16", real_line) is True
+
+
+class TestLineUrlHostIs:
+    """Unit tests for ``_line_url_host_is``."""
+
+    @pytest.mark.unit
+    def test_real_host_matches(self) -> None:
+        assert _line_url_host_is('get "https://auth.docker.io/token": denied', "auth.docker.io")
+
+    @pytest.mark.unit
+    def test_host_in_path_does_not_match(self) -> None:
+        # ``auth.docker.io`` only in the path of another host's URL must not match.
+        assert (
+            _line_url_host_is(
+                'get "https://evil.example//auth.docker.io/token": denied', "auth.docker.io"
+            )
+            is False
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "malformed_line",
+        [
+            'get "https://[bad/token": denied',
+            'head "https://[::1bad/auth.docker.io/token": denied',
+        ],
+    )
+    def test_malformed_url_does_not_crash(self, malformed_line: str) -> None:
+        # ``urlsplit``/``.hostname`` raise ``ValueError`` ("Invalid IPv6 URL") on
+        # malformed authorities; ``_line_url_host_is`` must not propagate it during
+        # PR-log classification — it skips the bad token and returns False
+        # (PRRT_kwDOSJAM6s6I3BzX).
+        assert _line_url_host_is(malformed_line, "auth.docker.io") is False
+
+    @pytest.mark.unit
+    def test_malformed_url_does_not_mask_later_real_host(self) -> None:
+        # A malformed token earlier in the line must not stop the scan from
+        # matching a real host token that follows.
+        line = 'first "https://[bad/x" then "https://auth.docker.io/token": denied'
+        assert _line_url_host_is(line, "auth.docker.io") is True
 
 
 class TestStripImageTag:

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
@@ -876,6 +876,81 @@ class TestImageRefMatchesDaemonUrl:
         )
         assert _log_shows_docker_registry_timeout(log) is True
 
+    @pytest.mark.unit
+    def test_org_image_token_auth_host_in_url_path_does_not_match(self) -> None:
+        """An ``auth.docker.io`` token denial whose host is a *different* registry
+        must NOT match an unqualified Docker Hub org image, even when
+        ``auth.docker.io`` appears only inside the URL path.
+
+        ``docker pull org/app:latest`` is an implicit Docker Hub pull.  A bare
+        substring check ``"auth.docker.io" in line`` is satisfied by
+        ``https://evil.example/auth.docker.io/token?...`` where ``auth.docker.io``
+        is a path segment, not the token-service host — a CodeQL
+        ``py/incomplete-url-substring-sanitization`` bypass.  The URL-host
+        boundary check (``"//auth.docker.io/"``) rejects it.
+
+        Regression for CodeQL alert #7."""
+        bypass_line = (
+            'get "https://evil.example/auth.docker.io/token'
+            '?scope=repository%3aorg%2fapp%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("org/app:latest", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = 'get "https://auth.docker.io/token?scope=repository%3aorg%2fapp%3apull": denied'
+        assert _image_ref_matches_daemon_url("org/app:latest", real_line) is True
+
+    @pytest.mark.unit
+    def test_docker_hub_alias_token_auth_host_in_url_path_does_not_match(self) -> None:
+        """A Docker Hub alias ref must NOT match an ``auth.docker.io`` token denial
+        whose host is a different registry and that only embeds ``auth.docker.io``
+        in the URL path.
+
+        ``docker pull docker.io/library/postgres:16`` resolves through the
+        Docker Hub token service (``auth.docker.io``).  A path-only occurrence of
+        ``auth.docker.io`` (e.g. ``https://evil.example/auth.docker.io/token``)
+        must not satisfy the Docker Hub host guard — only the URL-host boundary
+        form ``//auth.docker.io/`` (or ``//docker.io/``) counts.
+
+        Regression for CodeQL alert #8."""
+        bypass_line = (
+            'get "https://evil.example/auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("docker.io/library/postgres:16", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = (
+            'get "https://auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("docker.io/library/postgres:16", real_line) is True
+
+    @pytest.mark.unit
+    def test_library_image_token_auth_host_in_url_path_does_not_match(self) -> None:
+        """An unqualified Docker Hub library image must NOT match an
+        ``auth.docker.io`` token denial whose host is a different registry and
+        that only embeds ``auth.docker.io`` in the URL path.
+
+        ``docker pull postgres:16`` is an implicit Docker Hub library pull.  A
+        path-only ``auth.docker.io`` (``https://evil.example/auth.docker.io/token``)
+        must not satisfy the Docker Hub host guard via a bare substring — only
+        the boundary form ``//auth.docker.io/`` counts.
+
+        Regression for CodeQL alert #9."""
+        bypass_line = (
+            'get "https://evil.example/auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("postgres:16", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = (
+            'get "https://auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("postgres:16", real_line) is True
+
 
 class TestStripImageTag:
     """Unit tests for ``_strip_image_tag``."""

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
@@ -951,6 +951,33 @@ class TestImageRefMatchesDaemonUrl:
         assert _image_ref_matches_daemon_url("docker.io/library/postgres:16", real_line) is True
 
     @pytest.mark.unit
+    def test_docker_hub_alias_token_auth_host_arbitrary_position_does_not_match(self) -> None:
+        """A Docker Hub alias ref must NOT match an ``auth.docker.io`` token denial
+        when ``//auth.docker.io/`` appears at an *arbitrary position* in a
+        different registry's URL rather than as the real host.
+
+        The earlier ``"//auth.docker.io/" in line`` boundary check still treats
+        the host as a substring, so a double-slash placement such as
+        ``https://evil.example//auth.docker.io/token`` (real host
+        ``evil.example``) satisfies it — the
+        ``py/incomplete-url-substring-sanitization`` gap CodeQL re-flagged.
+        Parsing the URL host with ``urlsplit`` rejects it.
+
+        Regression for PRRT_kwDOSJAM6s6I2gvt."""
+        bypass_line = (
+            'get "https://evil.example//auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("docker.io/library/postgres:16", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = (
+            'get "https://auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("docker.io/library/postgres:16", real_line) is True
+
+    @pytest.mark.unit
     def test_library_image_token_auth_host_in_url_path_does_not_match(self) -> None:
         """An unqualified Docker Hub library image must NOT match an
         ``auth.docker.io`` token denial whose host is a different registry and
@@ -964,6 +991,33 @@ class TestImageRefMatchesDaemonUrl:
         Regression for CodeQL alert #9."""
         bypass_line = (
             'get "https://evil.example/auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("postgres:16", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = (
+            'get "https://auth.docker.io/token'
+            '?scope=repository%3alibrary%2fpostgres%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("postgres:16", real_line) is True
+
+    @pytest.mark.unit
+    def test_library_image_token_auth_host_arbitrary_position_does_not_match(self) -> None:
+        """An unqualified Docker Hub library image must NOT match an
+        ``auth.docker.io`` token denial when ``//auth.docker.io/`` appears at an
+        *arbitrary position* in a different registry's URL rather than as the
+        real host.
+
+        A double-slash placement such as
+        ``https://evil.example//auth.docker.io/token`` (real host
+        ``evil.example``) satisfies the bare ``"//auth.docker.io/" in line``
+        boundary check — the ``py/incomplete-url-substring-sanitization`` gap
+        CodeQL re-flagged.  Parsing the URL host with ``urlsplit`` rejects it.
+
+        Regression for PRRT_kwDOSJAM6s6I2gvt."""
+        bypass_line = (
+            'get "https://evil.example//auth.docker.io/token'
             '?scope=repository%3alibrary%2fpostgres%3apull": denied'
         )
         assert _image_ref_matches_daemon_url("postgres:16", bypass_line) is False

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_006.py
@@ -901,6 +901,30 @@ class TestImageRefMatchesDaemonUrl:
         assert _image_ref_matches_daemon_url("org/app:latest", real_line) is True
 
     @pytest.mark.unit
+    def test_org_image_token_auth_host_arbitrary_position_does_not_match(self) -> None:
+        """An ``auth.docker.io`` token denial must NOT match an unqualified Docker
+        Hub org image when ``//auth.docker.io/`` appears at an *arbitrary
+        position* in a different registry's URL rather than as the real host.
+
+        The earlier ``"//auth.docker.io/" in line`` boundary check still treats
+        the host as a substring, so a path/double-slash placement such as
+        ``https://evil.example//auth.docker.io/token`` (real host
+        ``evil.example``) satisfies it — the
+        ``py/incomplete-url-substring-sanitization`` gap CodeQL re-flagged.
+        Parsing the URL host with ``urlsplit`` rejects it.
+
+        Regression for CodeQL alert #29 (PRRT_kwDOSJAM6s6I2gvY)."""
+        bypass_line = (
+            'get "https://evil.example//auth.docker.io/token'
+            '?scope=repository%3aorg%2fapp%3apull": denied'
+        )
+        assert _image_ref_matches_daemon_url("org/app:latest", bypass_line) is False
+
+        # Sanity: the real Docker Hub token service still matches.
+        real_line = 'get "https://auth.docker.io/token?scope=repository%3aorg%2fapp%3apull": denied'
+        assert _image_ref_matches_daemon_url("org/app:latest", real_line) is True
+
+    @pytest.mark.unit
     def test_docker_hub_alias_token_auth_host_in_url_path_does_not_match(self) -> None:
         """A Docker Hub alias ref must NOT match an ``auth.docker.io`` token denial
         whose host is a different registry and that only embeds ``auth.docker.io``

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -80,6 +80,24 @@ def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
 
 
 @pytest.mark.unit
+def test_validate_phase_delegates_pytest_to_github_ci() -> None:
+    """In-workspace pytest is intentionally delegated to GitHub CI.
+
+    GitHub CI runs the full sharded pytest+coverage on every PR commit (the
+    authoritative gate), so the validate phase runs no in-workspace test suite —
+    duplicating it only slows the run and saturates the host. Should a pytest
+    command ever be added back, the #512 anti-narrowing guard in
+    ``test_no_validate_command_is_scoped_solely_to_the_cli_slice`` still rejects
+    a ``tests/unit/cli``-only scope, and this assertion forces the removal to be
+    revisited as a deliberate choice rather than a silent reintroduction.
+    """
+    assert _commands_for_tool("pytest") == [], (
+        "validate phase must not run an in-workspace pytest; GitHub CI owns the "
+        "full sharded pytest+coverage gate"
+    )
+
+
+@pytest.mark.unit
 def test_validate_pytest_if_present_covers_full_unit_suite_not_only_cli() -> None:
     """Guard intent is anti-re-narrowing, not pytest-presence.
 

--- a/tests/unit/test_awf_self_profile_validation_scope.py
+++ b/tests/unit/test_awf_self_profile_validation_scope.py
@@ -80,12 +80,23 @@ def test_validate_mypy_covers_whole_package_not_only_cli() -> None:
 
 
 @pytest.mark.unit
-def test_validate_pytest_covers_full_unit_suite_not_only_cli() -> None:
+def test_validate_pytest_if_present_covers_full_unit_suite_not_only_cli() -> None:
+    """Guard intent is anti-re-narrowing, not pytest-presence.
+
+    The validate phase intentionally no longer runs the in-workspace test suite
+    (GitHub CI runs the authoritative sharded pytest+coverage on every PR
+    commit). So an absent pytest command is the expected, deliberate state — the
+    #512 regression this file guards against was a *narrowed* validate phase
+    (pytest scoped to ``tests/unit/cli``), not the absence of pytest. If a
+    pytest command is ever re-added, it must still cover the full ``tests/unit``
+    suite rather than the CLI-only slice.
+    """
     pytest_commands = _commands_for_tool("pytest")
-    assert pytest_commands, "validate phase must run pytest"
-    assert any(_targets_path(tokens, "tests/unit") for tokens in pytest_commands), (
-        "pytest must run the full tests/unit suite, not only tests/unit/cli"
-    )
+    for tokens in pytest_commands:
+        assert _targets_path(tokens, "tests/unit"), (
+            "a validate-phase pytest command must run the full tests/unit suite, "
+            "not only tests/unit/cli"
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -521,6 +521,84 @@ def test_ci_workflow_checkouts_disable_persisted_credentials(job_name: str) -> N
         )
 
 
+_EXPECTED_CI_JOBS = frozenset(
+    {
+        "lint-and-type",
+        "python-coverage-shards",
+        "python-full-coverage",
+        "console",
+        "release-artifacts",
+        "ci-required",
+    }
+)
+_VALID_PERMISSION_VALUES = frozenset({"read", "write", "none"})
+# ``(job, scope)`` pairs that may be granted ``write`` (currently none — the entire
+# workflow is least-privilege read-only). A future job that genuinely needs a broader
+# scope must add the *specific* ``(job, scope)`` pair here deliberately, which is the
+# point of the gate. Keyed by ``(job, scope)`` rather than job name alone so a
+# whitelisted job is approved only for the exact scope it needs and cannot silently
+# acquire write on additional scopes (``packages``, ``id-token``, ``pull-requests``,
+# etc.) without a separate, deliberate entry.
+_WRITE_PERMISSION_WHITELIST: frozenset[tuple[str, str]] = frozenset()
+
+
+@pytest.mark.unit
+def test_ci_workflow_jobs_have_least_privilege_permissions() -> None:
+    """Every ci.yml job is covered by an explicit least-privilege ``permissions:`` block.
+
+    Resolves CodeQL ``actions/missing-workflow-permissions`` (alerts #1–#6): with
+    no ``permissions:`` block the default GITHUB_TOKEN scope is broad. The fix is a
+    single workflow-level ``contents: read`` default; this guard asserts that
+    default exists and that no job silently broadens it. Assertion #1 is the gate
+    that covers every job — including any future job — because the workflow-level
+    default applies to all jobs that lack their own block. Assertion #2 then encodes
+    the coverage invariant explicitly (job-level block *or* workflow default) so the
+    check still holds if coverage is ever moved from the default to per-job blocks.
+    """
+    workflow = _workflow()
+
+    # 1. Workflow-level default is read-only (PyYAML loads ``read`` as a string).
+    assert workflow.get("permissions") == {"contents": "read"}
+
+    jobs = workflow.get("jobs", {})
+    assert isinstance(jobs, dict)
+
+    # The known six jobs must all still be present so the covered set can't shrink
+    # unnoticed, and drive coverage off the *live* job keys so a newly added job is
+    # also checked.
+    assert _EXPECTED_CI_JOBS.issubset(jobs.keys())
+
+    for name, job in jobs.items():
+        assert isinstance(job, dict), name
+        job_permissions = job.get("permissions")
+
+        # 2. Every job is covered by an explicit permissions block: either its own
+        #    job-level mapping or the workflow-level default. Given assertion #1 pins
+        #    that default, the RHS holds today and #1 is the real gate; this encodes
+        #    the coverage invariant so it still bites if coverage ever moves to
+        #    per-job blocks (default dropped + a job missing its own block).
+        assert job_permissions is not None or "permissions" in workflow, (
+            f"job {name!r} has no permissions coverage (no job-level block and no "
+            "workflow-level default)"
+        )
+
+        # 3. No job over-grants. Any job-level block must be a scope->level mapping
+        #    and may not grant write on any scope unless explicitly whitelisted.
+        if job_permissions is not None:
+            assert isinstance(job_permissions, dict), (
+                f"job {name!r} permissions must be a dictionary, got "
+                f"{type(job_permissions).__name__}"
+            )
+            for scope, level in job_permissions.items():
+                assert level in _VALID_PERMISSION_VALUES, (
+                    f"job {name!r} grants invalid permission {scope}={level!r}"
+                )
+                if level == "write":
+                    assert (name, scope) in _WRITE_PERMISSION_WHITELIST, (
+                        f"job {name!r} over-grants {scope}: write"
+                    )
+
+
 @pytest.mark.unit
 def test_contributor_docs_require_ci_rollup_status_check() -> None:
     docs = CONTRIBUTING_PATH.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Promotes the CodeQL code-scanning fixes (and the awf-self validate-phase correction) from `development` to `main`.

### CodeQL fixes (resolves the 22 real alerts; CodeQL re-scans main on merge)
- **#521** — least-privilege `permissions:` on every ci.yml job (alerts #1–6)
- **#522** — ReDoS regex hardening, behavior-preserving + fast-path tests (alerts #17–28)
- **#523** — host-boundary URL checks instead of bare substrings (alerts #7, #8, #9, #16)

The other 12 alerts were dismissed as false positives (test assertions / fake-secret test fixtures / a mis-tainted timeout log), with documented reasons.

### awf-self profile
- Validate phase made **light** — dropped the in-workspace full `pytest tests/unit`; it now runs only ruff + ruff-format + mypy + the OpenAPI check. GitHub CI is the authoritative test gate; running the suite in-workspace duplicated CI and saturated the host. (The interim `-n auto` change and its revert net to a no-op.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR adoption routing, repo URL parsing, and CI log classification—security-sensitive but behavior-preserving with broad regression tests; awf-self no longer runs full unit tests locally before push.
> 
> **Overview**
> Addresses **CodeQL** findings across CI, CLI, parsing, and PR-monitor log classification without changing intended behavior.
> 
> **CI & dogfood:** Adds workflow-level `permissions: contents: read` (least-privilege `GITHUB_TOKEN`). The **awf-self** validate phase **drops in-workspace `pytest`**; GitHub CI remains the authoritative test/coverage gate.
> 
> **Security / robustness:** `workspace adopt-pr` routes `--repo` via **`_repo_targets_github_host`** (parsed host boundary) instead of a `github.com` substring. **`RepoRef.from_url`** / **`clone_url_like`** use possessive regex + explicit `.git` stripping (ReDoS), and normalize malformed URL parse errors. **Docker pull detection** matches `auth.docker.io` with **`urlsplit` host checks** via **`_line_url_host_is`**. **Quality-gates** and **MCP setup-tools** regexes get the same ReDoS hardening.
> 
> **Tests:** New/expanded unit tests pin prior match behavior, bypass cases, timing guards, and CI permission coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2fc2ab5f81432cdea53b9294fa311111d18312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->