### PR TITLE
fix: forge-aware setup — don't require gh for BitBucket (#525)

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -10,8 +10,11 @@ Install:
 - `uv`.
 - Docker Desktop or Docker Engine with Compose plugin.
 - Git.
-- GitHub CLI `gh`.
-- A GitHub account with access to the target repo.
+- Forge access for the target repo — choose the one that matches your repo's host:
+  - **GitHub:** the GitHub CLI `gh`, plus a GitHub account with access to the
+    target repo.
+  - **BitBucket:** `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
+    `BITBUCKET_AUTH_MODE` (e.g. `basic`) set in `.env` — no `gh` required.
 - SSH key or Git credentials that can clone and push the repo.
 - At least one coding-agent credential:
   - Codex CLI auth in `~/.codex`, or OpenAI auth environment as supported by
@@ -21,11 +24,16 @@ Install:
   - Gemini auth in `~/.gemini` or Google/Gemini env vars.
   - OpenCode via Ollama auth/state in `~/.config/opencode` and `~/.ollama`.
 
-Verify GitHub CLI:
+Verify forge access (run the check that matches your repo's host):
 
-```bash
-gh auth status
-```
+- **GitHub:**
+
+  ```bash
+  gh auth status
+  ```
+
+- **BitBucket:** confirm `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
+  `BITBUCKET_AUTH_MODE` are present in `.env` (no `gh` needed).
 
 Verify Docker:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,7 +13,7 @@ Install:
 - Forge access for the target repo — choose the one that matches your repo's host:
   - **GitHub:** the GitHub CLI `gh`, plus a GitHub account with access to the
     target repo.
-  - **BitBucket:** `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
+  - **Bitbucket:** `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
     `BITBUCKET_AUTH_MODE` (e.g. `basic`) set in `.env` — no `gh` required.
 - SSH key or Git credentials that can clone and push the repo.
 - At least one coding-agent credential:
@@ -32,7 +32,7 @@ Verify forge access (run the check that matches your repo's host):
   gh auth status
   ```
 
-- **BitBucket:** confirm `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
+- **Bitbucket:** confirm `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
   `BITBUCKET_AUTH_MODE` are present in `.env` (no `gh` needed).
 
 Verify Docker:

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -122,7 +122,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Use `opencode run` to inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -36,6 +36,20 @@ The root `.env` is the single local runtime env file for source checkouts and
 package installs. Existing legacy `docker/compose/.env` files are migration
 sources only.
 
+### Forge authentication (detect before installing anything)
+
+AWF is forge-agnostic, so configure **only** the auth the target repo actually
+needs — do not unconditionally install or authenticate the GitHub CLI `gh`.
+Detect the forge from the repo's `origin` remote (`git remote -v`):
+
+- **`github.com` → GitHub:** install and authenticate `gh` (`gh auth status`).
+- **`bitbucket.org` → BitBucket:** set `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`,
+  and `BITBUCKET_AUTH_MODE` (e.g. `basic`) in `.env`. **No `gh` install or auth
+  is required** for BitBucket repos.
+
+The per-provider prompts below all follow this rule: detect the forge first,
+then require only the matching auth.
+
 ## One-message prompt
 
 Use this with Codex, Claude Code, Cursor, Gemini, OpenCode, Grok, or a human
@@ -43,7 +57,10 @@ operator:
 
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace, push,
-open a PR, or start project services. Start with:
+open a PR, or start project services. First detect the forge from the repo's
+origin remote (git remote -v) and configure only the matching auth: GitHub
+(github.com) needs gh; BitBucket (bitbucket.org) needs BITBUCKET_API_TOKEN +
+BITBUCKET_EMAIL + BITBUCKET_AUTH_MODE in .env and no gh. Then start with:
 
 `awf init . --write-profile --yes`
 `awf profile preview .`
@@ -63,10 +80,11 @@ generic for any repository and do not contain project-specific assumptions.
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
-2. Run `awf profile preview .` to preview the resolved profile.
-3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
+3. Run `awf profile preview .` to preview the resolved profile.
+4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -76,10 +94,11 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 I will inspect this repository for AWF onboarding. I will not launch a workspace yet.
 
-1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
-2. Run `awf profile preview .` to preview the resolved profile.
-3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
+3. Run `awf profile preview .` to preview the resolved profile.
+4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -89,10 +108,11 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Analyze this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
-2. Run `awf profile preview .` to preview the resolved profile.
-3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
+3. Run `awf profile preview .` to preview the resolved profile.
+4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -102,10 +122,11 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Use `opencode run` to inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
-2. Run `awf profile preview .` to preview the resolved profile.
-3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
+3. Run `awf profile preview .` to preview the resolved profile.
+4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```
@@ -115,10 +136,11 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
-2. Run `awf profile preview .` to preview the resolved profile.
-3. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
-4. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
+3. Run `awf profile preview .` to preview the resolved profile.
+4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
+5. Once the smoke workspace succeeds, implement the requested feature through AWF by creating a real workspace with an appropriate task prompt and owned paths.
 
 Keep secrets as profile declarations or `${VAR}` placeholders; never write raw secret values.
 ```

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -59,7 +59,7 @@ operator:
 Inspect this repository for AWF onboarding. Do not launch a workspace, push,
 open a PR, or start project services. First detect the forge from the repo's
 origin remote (git remote -v) and configure only the matching auth: GitHub
-(github.com) needs gh; BitBucket (bitbucket.org) needs BITBUCKET_API_TOKEN +
+(github.com) needs gh; Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN +
 BITBUCKET_EMAIL + BITBUCKET_AUTH_MODE in .env and no gh. Then start with:
 
 `awf init . --write-profile --yes`

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -94,7 +94,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 I will inspect this repository for AWF onboarding. I will not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -108,7 +108,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Analyze this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -43,9 +43,9 @@ needs — do not unconditionally install or authenticate the GitHub CLI `gh`.
 Detect the forge from the repo's `origin` remote (`git remote -v`):
 
 - **`github.com` → GitHub:** install and authenticate `gh` (`gh auth status`).
-- **`bitbucket.org` → BitBucket:** set `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`,
+- **`bitbucket.org` → Bitbucket:** set `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`,
   and `BITBUCKET_AUTH_MODE` (e.g. `basic`) in `.env`. **No `gh` install or auth
-  is required** for BitBucket repos.
+  is required** for Bitbucket repos.
 
 The per-provider prompts below all follow this rule: detect the forge first,
 then require only the matching auth.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -80,7 +80,7 @@ generic for any repository and do not contain project-specific assumptions.
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -136,7 +136,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; BitBucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/src/awf/host_setup/system_checks/checks_core.py
+++ b/src/awf/host_setup/system_checks/checks_core.py
@@ -172,7 +172,9 @@ def check_gh(*, which: WhichFn = shutil.which) -> SetupCheckResult:
             "for GitHub auth and PR operations. For bitbucket.org repos, set "
             "BITBUCKET_API_TOKEN, BITBUCKET_EMAIL, and BITBUCKET_AUTH_MODE (e.g. "
             "basic) in .env instead of installing gh.",
-            fix="For GitHub repos: install the GitHub CLI before configuring GitHub provider access.",
+            fix="For GitHub repos: install the GitHub CLI before configuring GitHub "
+            "provider access. For bitbucket.org repos: set BITBUCKET_API_TOKEN, "
+            "BITBUCKET_EMAIL, and BITBUCKET_AUTH_MODE in .env instead.",
             docs_link=_GH_DOCS,
             data={"binary": "gh", "available": False},
         )

--- a/src/awf/host_setup/system_checks/checks_core.py
+++ b/src/awf/host_setup/system_checks/checks_core.py
@@ -172,7 +172,7 @@ def check_gh(*, which: WhichFn = shutil.which) -> SetupCheckResult:
             "for GitHub auth and PR operations. For bitbucket.org repos, set "
             "BITBUCKET_API_TOKEN, BITBUCKET_EMAIL, and BITBUCKET_AUTH_MODE (e.g. "
             "basic) in .env instead of installing gh.",
-            fix="Install the GitHub CLI before configuring GitHub provider access.",
+            fix="For GitHub repos: install the GitHub CLI before configuring GitHub provider access.",
             docs_link=_GH_DOCS,
             data={"binary": "gh", "available": False},
         )

--- a/src/awf/host_setup/system_checks/checks_core.py
+++ b/src/awf/host_setup/system_checks/checks_core.py
@@ -169,7 +169,8 @@ def check_gh(*, which: WhichFn = shutil.which) -> SetupCheckResult:
             level=SetupCheckLevel.WARNING,
             summary="GitHub CLI (gh) is not installed.",
             detail="`gh` is not required for host readiness, but AWF PR workflows use it "
-            "for GitHub auth and PR operations.",
+            "for GitHub auth and PR operations. For bitbucket.org repos, set "
+            "BITBUCKET_API_TOKEN in .env instead of installing gh.",
             fix="Install the GitHub CLI before configuring GitHub provider access.",
             docs_link=_GH_DOCS,
             data={"binary": "gh", "available": False},

--- a/src/awf/host_setup/system_checks/checks_core.py
+++ b/src/awf/host_setup/system_checks/checks_core.py
@@ -170,7 +170,8 @@ def check_gh(*, which: WhichFn = shutil.which) -> SetupCheckResult:
             summary="GitHub CLI (gh) is not installed.",
             detail="`gh` is not required for host readiness, but AWF PR workflows use it "
             "for GitHub auth and PR operations. For bitbucket.org repos, set "
-            "BITBUCKET_API_TOKEN in .env instead of installing gh.",
+            "BITBUCKET_API_TOKEN, BITBUCKET_EMAIL, and BITBUCKET_AUTH_MODE (e.g. "
+            "basic) in .env instead of installing gh.",
             fix="Install the GitHub CLI before configuring GitHub provider access.",
             docs_link=_GH_DOCS,
             data={"binary": "gh", "available": False},

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -397,7 +397,7 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     missing = check_gh(which=lambda _cmd: None)
     assert present.level is SetupCheckLevel.OK
     assert missing.level is SetupCheckLevel.WARNING
-    # The missing-gh warning must point BitBucket users at the .env auth path so
+    # The missing-gh warning must point Bitbucket users at the .env auth path so
     # they are not told to install gh for a forge that does not need it (#525).
     assert "BITBUCKET_API_TOKEN" in missing.detail
     assert "bitbucket.org" in missing.detail

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -405,6 +405,10 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     # the warning must name them — token alone leaves PR/git auth broken (#528).
     assert "BITBUCKET_EMAIL" in missing.detail
     assert "BITBUCKET_AUTH_MODE" in missing.detail
+    # The fix must be scoped to GitHub so it does not contradict the Bitbucket
+    # guidance in the detail — a Bitbucket user should not be told to install gh.
+    assert missing.fix is not None
+    assert missing.fix.startswith("For GitHub repos:")
 
 
 # --- Python runtime -------------------------------------------------------

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -413,6 +413,11 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     # user sees the .env auth path, not just the gh-install path (#528).
     assert "bitbucket.org" in missing.fix
     assert "BITBUCKET_API_TOKEN" in missing.fix
+    # Basic auth also needs the email and auth-mode vars in the fix, not just the
+    # detail — otherwise a Bitbucket user following the fix sets only the token and
+    # still has broken PR/git auth (#528).
+    assert "BITBUCKET_EMAIL" in missing.fix
+    assert "BITBUCKET_AUTH_MODE" in missing.fix
 
 
 # --- Python runtime -------------------------------------------------------

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -409,6 +409,10 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     # guidance in the detail — a Bitbucket user should not be told to install gh.
     assert missing.fix is not None
     assert missing.fix.startswith("For GitHub repos:")
+    # The fix must also offer the forge-aware Bitbucket alternative so a Bitbucket
+    # user sees the .env auth path, not just the gh-install path (#528).
+    assert "bitbucket.org" in missing.fix
+    assert "BITBUCKET_API_TOKEN" in missing.fix
 
 
 # --- Python runtime -------------------------------------------------------

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -401,6 +401,10 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     # they are not told to install gh for a forge that does not need it (#525).
     assert "BITBUCKET_API_TOKEN" in missing.detail
     assert "bitbucket.org" in missing.detail
+    # Basic auth mode (the default) also requires the email and auth-mode vars, so
+    # the warning must name them — token alone leaves PR/git auth broken (#528).
+    assert "BITBUCKET_EMAIL" in missing.detail
+    assert "BITBUCKET_AUTH_MODE" in missing.detail
 
 
 # --- Python runtime -------------------------------------------------------

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -397,6 +397,10 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     missing = check_gh(which=lambda _cmd: None)
     assert present.level is SetupCheckLevel.OK
     assert missing.level is SetupCheckLevel.WARNING
+    # The missing-gh warning must point BitBucket users at the .env auth path so
+    # they are not told to install gh for a forge that does not need it (#525).
+    assert "BITBUCKET_API_TOKEN" in missing.detail
+    assert "bitbucket.org" in missing.detail
 
 
 # --- Python runtime -------------------------------------------------------


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8ede259bee9840b890203901` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `medium`).


### Task
Make AWF setup forge-aware (issue #525): a BitBucket user is wrongly told to install/auth the GitHub CLI `gh`, even though AWF fully supports BitBucket via `.env` with no `gh`.

The CODE is already forge-agnostic — only the docs/onboarding aren't:
- `src/awf/host_setup/system_checks/checks_core.py` `check_gh` is WARNING-level ("gh is not required for host readiness").
- BitBucket auth is via `.env`: `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, `BITBUCKET_AUTH_MODE=basic` (`.env.example`).

## Do
1. `docs/GETTING_STARTED.md`: make the forge prerequisite CONDITIONAL — **GitHub** (gh CLI + a GitHub account) **OR** **BitBucket** (`BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env`; NO gh). Make the "Verify GitHub CLI: gh auth status" step conditional (gh for GitHub; confirm the BITBUCKET_* keys for BitBucket).
2. `docs/PROJECT_ONBOARDING.md` (the install prompt the agent follows): have it detect/ask which forge the target repo uses and require ONLY the matching auth — do not always install gh.
3. `src/awf/host_setup/system_checks/checks_core.py`: extend the `check_gh` WARNING `detail` to add "For bitbucket.org repos, set BITBUCKET_API_TOKEN in .env instead of installing gh." Update/extend the existing host_setup test that asserts the check_gh message.

Docs-only for 1-2; one message string + its test for 3. No behavior change to the forge clients. PR to development. Resolves #525.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and advisory setup-check copy only; no runtime or auth logic changes.
> 
> **Overview**
> Makes AWF setup **forge-aware** so Bitbucket users are not steered toward installing the GitHub CLI when `.env` auth is enough.
> 
> **Docs:** `GETTING_STARTED.md` splits prerequisites and verification into **GitHub** (`gh` + `gh auth status`) vs **Bitbucket** (`BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, `BITBUCKET_AUTH_MODE` in `.env`, no `gh`). `PROJECT_ONBOARDING.md` adds a **Forge authentication** section (detect host from `git remote -v`) and updates the shared onboarding prompt plus Codex/Claude/Gemini/OpenCode/Grok copy-paste flows so **step 1** is forge detection and matching auth only.
> 
> **Host setup:** The non-blocking `check_gh` **WARNING** when `gh` is missing now explains Bitbucket `.env` setup in **detail** and **fix**, with GitHub install guidance scoped to GitHub repos. Unit tests lock in that messaging (#525, #528).
> 
> No change to forge client behavior—guidance and operator messaging only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72a98f991bbebd7f12713fb9c968d7fba85e35c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Getting started guide now includes host-specific authentication requirements (GitHub CLI for GitHub repos, BitBucket environment variables for BitBucket repos)
  * Project onboarding guide enhanced with automatic repository forge detection and tailored authentication setup instructions
  * All per-provider setup prompts updated with initial authentication verification steps

* **Tests**
  * Improved test coverage to validate authentication requirement messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->