### PR TITLE
docs: private-registry Docker auth in DinD recipe (#527 item 5)

### DIFF
--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -266,3 +266,7 @@ Local-mode refs currently support `provider: env` with `ref: NAME` or
 `${HOME}`, `${AWF_HOST_HOME}`, `~`, `/home/<user>`, or `/Users/<user>` roots.
 Do not paste token values into `.awf/workspace.yml`. AWF records sanitized lease
 metadata only; this local path does not implement a cloud secret broker.
+
+For a worked example that mounts a host Docker `config.json` so `docker`/Gradle
+in a Docker-in-Docker workspace can pull from a **private registry**, see
+[docs/recipes/dind-private-registry-auth.md](recipes/dind-private-registry-auth.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,5 +7,6 @@
 - [MCP Setup](MCP_SETUP.md)
 - [Release Checklist](../RELEASING.md)
 - [Protected Quality-Gate Files](PROTECTED_FILES.md)
+- [Recipe: DinD private-registry Docker auth](recipes/dind-private-registry-auth.md)
 
 The repository README links the primary public guides and references.

--- a/docs/recipes/dind-private-registry-auth.md
+++ b/docs/recipes/dind-private-registry-auth.md
@@ -1,0 +1,114 @@
+# Recipe: private-registry Docker auth in a Docker-in-Docker workspace
+
+**Problem.** Your project builds or pulls images from a **private registry**
+(e.g. a Bitbucket Java/Gradle build that needs `docker pull registry.example.com/...`
+during its Gradle tasks). Inside an AWF workspace running in Docker-in-Docker
+(`docker.mode: dind`), `docker`/Gradle talk to the managed DinD daemon at
+`tcp://docker:2375`, but that daemon has **no registry credentials**, so private
+pulls fail with `unauthorized` / `denied`.
+
+**Solution.** Give the agent container a Docker `config.json` (the same file
+`docker login` writes) by mounting the host copy read-only via a profile **secret
+lease**, then point `DOCKER_CONFIG` at the directory that contains it. Docker and
+Gradle then read `$DOCKER_CONFIG/config.json` and authenticate to the registry.
+
+Everything below uses existing AWF mechanisms — no core code change is required.
+
+## Copy-pasteable `.awf/workspace.yml`
+
+```yaml
+# .awf/workspace.yml — DinD workspace authenticating to a private registry.
+name: my-project
+version: 1
+
+runtime:
+  environment:
+    # Docker (and Gradle's Docker integration) read $DOCKER_CONFIG/config.json
+    # for registry credentials. Point it at the DIRECTORY, not the file.
+    DOCKER_CONFIG: /run/awf/secrets/docker
+    # DOCKER_HOST is auto-injected for docker.mode: dind; shown here for clarity.
+    DOCKER_HOST: tcp://docker:2375
+
+docker:
+  mode: dind
+
+secrets:
+  - name: docker-registry-auth
+    kind: mount
+    mode: ro
+    provider: local-file        # 'host-file' is an accepted alias.
+    # Absolute path to the host Docker config.json holding the registry creds.
+    # NOTE: '~', '$HOME', '${AWF_HOST_HOME}', '/home/<user>' and '/Users/<user>'
+    # roots are rejected as too broad — use a literal path.
+    ref: /home/youruser/.docker/config.json
+    target: /run/awf/secrets/docker/config.json
+```
+
+A ready-to-run copy of this profile lives at
+[`examples/dind-private-registry/.awf/workspace.yml`](examples/dind-private-registry/.awf/workspace.yml).
+
+## How it fits together
+
+- **`provider: local-file`** (alias `host-file`) mounts an existing host file
+  read-only into the agent container. Unlike `local-auth` it does **not** restrict
+  the mount target to a fixed allowlist, so an arbitrary target such as
+  `/run/awf/secrets/docker/config.json` is allowed. Use a `/run/awf/secrets/...`
+  target to match AWF's safe-mount convention.
+- **`provider: local-auth`** only knows the fixed refs `gh`, `gcloud`, `gitconfig`,
+  and `ssh` — there is **no** `docker` ref — so it cannot mount an arbitrary
+  `config.json`. Lead with `local-file` for this recipe.
+- **`DOCKER_CONFIG` points at a directory**, not the file. Docker reads
+  `$DOCKER_CONFIG/config.json`. Mount the file at `/run/awf/secrets/docker/config.json`
+  and set `DOCKER_CONFIG=/run/awf/secrets/docker`.
+- **`DOCKER_HOST` is auto-injected** for `docker.mode: dind` (AWF sets
+  `DOCKER_HOST=tcp://docker:2375` when the profile does not already declare it), so
+  the `runtime.environment` line above is optional — included only for clarity.
+
+## `ref` restrictions (read before copying)
+
+`ref` must be a **literal absolute path to an existing file**. AWF deliberately
+rejects "too broad" home-rooted sources to avoid mounting an entire home directory:
+
+| Rejected `ref`                        | Reason code (resolution)        |
+| ------------------------------------- | ------------------------------- |
+| `~/.docker/config.json`               | `SECRET_LEASE_SOURCE_TOO_BROAD` |
+| `$HOME/...`, `${HOME}/...`            | `SECRET_LEASE_SOURCE_TOO_BROAD` |
+| `$AWF_HOST_HOME/...`, `${AWF_HOST_HOME}/...` | `SECRET_LEASE_SOURCE_TOO_BROAD` |
+| `/home/<user>`, `/Users/<user>` (root) | `SECRET_LEASE_SOURCE_TOO_BROAD` |
+
+So write the full path explicitly, e.g. `/home/alice/.docker/config.json`. Other
+guards: the source must already **exist** and be a **file** (else
+`SECRET_LEASE_SOURCE_INVALID`), and the mount must be **read-only** (`mode: ro`;
+`rw` raises `SECRET_LEASE_WRITABLE_UNSUPPORTED`).
+
+## Required vs optional leases
+
+- `required: true` (the default): if the host `config.json` is missing at provision
+  time, the workspace fails with `SECRET_LEASE_SOURCE_MISSING` — fail-fast when the
+  registry auth is mandatory.
+- `required: false`: a missing source is **skipped** and recorded in sanitized lease
+  metadata (no secret value), so the workspace still provisions. Use this when the
+  private pull is optional or only some contributors have credentials.
+
+## Security notes
+
+- **Never paste token values** into `.awf/workspace.yml`. The lease references a host
+  file by path; AWF mounts it read-only and records only **sanitized lease metadata**
+  (name, provider, target, reason codes) — never the file contents or any token.
+- The mount is **read-only**, so the agent cannot rewrite your host `config.json`.
+- This is a local-mode path; it is **not** a cloud secret broker.
+
+## Verify inside the agent
+
+Once the workspace is up, from the agent container:
+
+```bash
+# DOCKER_CONFIG is already set from runtime.environment; the config.json is mounted.
+docker pull registry.example.com/your-org/private-image:tag
+
+# Or run a Gradle build that performs the private pull:
+./gradlew build
+```
+
+A successful authenticated pull confirms the mounted `config.json` and
+`DOCKER_CONFIG` are wired correctly.

--- a/docs/recipes/dind-private-registry-auth.md
+++ b/docs/recipes/dind-private-registry-auth.md
@@ -12,6 +12,29 @@ pulls fail with `unauthorized` / `denied`.
 lease**, then point `DOCKER_CONFIG` at the directory that contains it. Docker and
 Gradle then read `$DOCKER_CONFIG/config.json` and authenticate to the registry.
 
+> **Prerequisite — the config must hold _inline_ credentials.** This recipe mounts
+> only `config.json`, so it works when that file carries the registry creds inline
+> under an `"auths"` entry (a base64 `auth` token, as `docker login` writes by
+> default). It does **not** work when the host config delegates to a credential
+> helper via `"credsStore"` (e.g. `desktop`, `osxkeychain`, `secretservice` — common
+> on Docker Desktop and some Linux setups) or `"credHelpers"`: those configs store no
+> token in the file itself and instead shell out to a `docker-credential-*` binary
+> that must be on the Docker client's `$PATH` (per Docker's `docker login`
+> credential-store docs). The mounted file alone would leave the agent container
+> without that helper, so private pulls still fail with `unauthorized` / `denied`.
+> Before using this recipe, either:
+>
+> - **Materialize inline auths**: on the host, produce a helper-free config — e.g.
+>   `DOCKER_CONFIG=$(mktemp -d) docker login registry.example.com` writes a plain
+>   `auths` entry into a throwaway `config.json` you can point `ref:` at — or hand-write
+>   a config with an `auths.<registry>.auth` base64 `user:token`; then mount that.
+> - **Or provide the helper too**: ensure the matching `docker-credential-*` binary
+>   (and any backing store it needs) is available on the agent container's `$PATH`,
+>   which is outside the scope of this file-mount-only recipe.
+>
+> Check before relying on it: `grep -E 'credsStore|credHelpers' ~/.docker/config.json`
+> returning nothing means your config is inline-auth and ready to mount as-is.
+
 Everything below uses existing AWF mechanisms — no core code change is required.
 
 ## Copy-pasteable `.awf/workspace.yml`

--- a/docs/recipes/dind-private-registry-auth.md
+++ b/docs/recipes/dind-private-registry-auth.md
@@ -64,6 +64,34 @@ A ready-to-run copy of this profile lives at
   `DOCKER_HOST=tcp://docker:2375` when the profile does not already declare it), so
   the `runtime.environment` line above is optional — included only for clarity.
 
+## Make the host `config.json` visible to the control plane (bundled local-service stack)
+
+AWF validates the lease **inside the control-plane worker container**: the
+resolver calls `source.exists()` on the `ref` path *before* the agent container is
+created (`src/awf/node/secret_mounts.py`, run from `src/awf/service/worker.py`). In
+the bundled `docker/compose/local-service.yml` stack the `api`/`worker` containers
+only bind-mount a **fixed allowlist** of host auth paths — `~/.config/gh`,
+`~/.config/gcloud`, `~/.gitconfig`, `~/.ssh`, `~/.codex`, `~/.claude`, `~/.gemini`,
+`~/.config/opencode`, `~/.grok`, `~/.ollama` — and **`~/.docker` is not one of them.**
+So a `ref:` pointing at `~/.docker/config.json` resolves to a path the worker cannot
+see, and a `required: true` lease (the default) fails at provision time with
+`SECRET_LEASE_SOURCE_MISSING` even though the file exists on the host.
+
+Before using this recipe on that stack, make the host config visible to the control
+plane at the **same absolute path** (AWF mounts host auth paths host-equal). Add a
+read-only bind mount of the host `config.json` to **both** the `api` and `worker`
+services, mirroring the existing auth volumes:
+
+```yaml
+# Add to the `api` AND `worker` `volumes:` lists in docker/compose/local-service.yml
+# (or a Compose override merged on top), then point `ref:` at the same host path.
+- ${AWF_HOST_HOME:-${HOME}}/.docker/config.json:${AWF_HOST_HOME:-${HOME}}/.docker/config.json:ro
+```
+
+This applies only to the **bundled local-service stack**. When you run `awf worker`
+directly on the host (no control-plane container), the worker already sees
+`~/.docker/config.json` on the host filesystem and no extra mount is required.
+
 ## `ref` restrictions (read before copying)
 
 `ref` must be a **literal absolute path to an existing file**. AWF deliberately

--- a/docs/recipes/dind-private-registry-auth.md
+++ b/docs/recipes/dind-private-registry-auth.md
@@ -105,11 +105,15 @@ earlier as `SECRET_LEASE_SOURCE_TOO_BROAD` per that same table.)
 
 Before using this recipe on that stack, make the host config visible to the control
 plane at the **same absolute path** (AWF mounts host auth paths host-equal). Add a
-read-only bind mount of the host `config.json` to **both** the `api` and `worker`
-services, mirroring the existing auth volumes:
+read-only bind mount of the host `config.json` to the **`worker`** service only —
+the worker is the container that resolves the lease (`source.exists()` runs in
+`LocalSecretLeaseMountResolver`, started from `src/awf/service/worker.py`). The `api`
+container never reads the host `config.json` (its `SecretLeaseService` only reports
+lease status from DB records), so do **not** mount the secret there — that would
+widen the secret's exposure surface for no benefit:
 
 ```yaml
-# Add to the `api` AND `worker` `volumes:` lists in docker/compose/local-service.yml
+# Add to the `worker` `volumes:` list in docker/compose/local-service.yml
 # (or a Compose override merged on top), then point `ref:` at the same host path.
 - ${AWF_HOST_HOME:-${HOME}}/.docker/config.json:${AWF_HOST_HOME:-${HOME}}/.docker/config.json:ro
 ```

--- a/docs/recipes/dind-private-registry-auth.md
+++ b/docs/recipes/dind-private-registry-auth.md
@@ -96,9 +96,12 @@ the bundled `docker/compose/local-service.yml` stack the `api`/`worker` containe
 only bind-mount a **fixed allowlist** of host auth paths — `~/.config/gh`,
 `~/.config/gcloud`, `~/.gitconfig`, `~/.ssh`, `~/.codex`, `~/.claude`, `~/.gemini`,
 `~/.config/opencode`, `~/.grok`, `~/.ollama` — and **`~/.docker` is not one of them.**
-So a `ref:` pointing at `~/.docker/config.json` resolves to a path the worker cannot
-see, and a `required: true` lease (the default) fails at provision time with
-`SECRET_LEASE_SOURCE_MISSING` even though the file exists on the host.
+So a `ref:` written as the literal absolute path the [`ref` restrictions](#ref-restrictions-read-before-copying)
+require — e.g. `/home/youruser/.docker/config.json` — resolves to a path the worker
+cannot see, and a `required: true` lease (the default) fails at provision time with
+`SECRET_LEASE_SOURCE_MISSING` even though the file exists on the host. (The
+`~/.docker/config.json` shorthand never reaches this existence check: it is rejected
+earlier as `SECRET_LEASE_SOURCE_TOO_BROAD` per that same table.)
 
 Before using this recipe on that stack, make the host config visible to the control
 plane at the **same absolute path** (AWF mounts host auth paths host-equal). Add a

--- a/docs/recipes/examples/dind-private-registry/.awf/workspace.yml
+++ b/docs/recipes/examples/dind-private-registry/.awf/workspace.yml
@@ -1,0 +1,36 @@
+# .awf/workspace.yml — DinD workspace authenticating to a private registry.
+#
+# This is the copy-pasteable companion to
+# docs/recipes/dind-private-registry-auth.md. It mounts the host Docker
+# ``config.json`` read-only via a ``local-file`` secret lease and points
+# ``DOCKER_CONFIG`` at the directory that contains it, so ``docker``/Gradle
+# inside the agent (talking to the managed DinD daemon at
+# ``tcp://docker:2375``) authenticate to the private registry.
+#
+# NOTE: ``ref`` must be a literal absolute path to an existing file. ``~``,
+# ``$HOME``, ``${AWF_HOST_HOME}``, ``/home/<user>``, and ``/Users/<user>``
+# roots are rejected as too broad. Replace ``/home/youruser`` with your own
+# absolute home path before using this profile.
+name: dind-private-registry
+version: 1
+description: DinD workspace with private-registry Docker auth via a mounted config.json.
+
+runtime:
+  environment:
+    # Docker (and Gradle's Docker integration) read $DOCKER_CONFIG/config.json
+    # for registry credentials. Point it at the DIRECTORY, not the file.
+    DOCKER_CONFIG: /run/awf/secrets/docker
+    # DOCKER_HOST is auto-injected for docker.mode: dind; shown here for clarity.
+    DOCKER_HOST: tcp://docker:2375
+
+docker:
+  mode: dind
+
+secrets:
+  - name: docker-registry-auth
+    kind: mount
+    mode: ro
+    provider: local-file        # 'host-file' is an accepted alias.
+    # Absolute path to the host Docker config.json holding the registry creds.
+    ref: /home/youruser/.docker/config.json
+    target: /run/awf/secrets/docker/config.json

--- a/plans/DIND_PRIVATE_REGISTRY_PLAN.md
+++ b/plans/DIND_PRIVATE_REGISTRY_PLAN.md
@@ -1,0 +1,68 @@
+# DinD Private-Registry Docker Auth Recipe — Plan
+
+## Problem statement and scope
+
+Projects running in an AWF Docker-in-Docker workspace (`docker.mode: dind`) talk to
+the managed DinD daemon at `tcp://docker:2375`, which has **no registry
+credentials**. Private `docker pull` / Gradle pulls therefore fail with
+`unauthorized` / `denied`. We need a documented, copy-pasteable recipe that wires
+registry auth into a DinD workspace using **existing AWF mechanisms only** (no core
+code change).
+
+Scope (PR #529, `docs(#527)`):
+
+- `docs/recipes/dind-private-registry-auth.md` — the recipe.
+- `docs/recipes/examples/dind-private-registry/.awf/workspace.yml` — a canonical,
+  parseable sample profile referenced by the recipe.
+- `tests/unit/node/test_dind_private_registry_recipe.py` — keeps the sample honest.
+- `docs/README.md`, `docs/PROJECT_ONBOARDING.md` — discoverability links.
+
+Out of scope: any change to `src/awf` core (secret-lease resolution, compose
+rendering, and DinD `DOCKER_HOST` injection already exist).
+
+## Assumptions
+
+- `provider: local-file` (alias `host-file`) mounts an existing host file read-only
+  at an arbitrary target; `local-auth` only knows fixed refs (`gh`, `gcloud`,
+  `gitconfig`, `ssh`) and has no `docker` ref, so it cannot mount `config.json`.
+- AWF auto-injects `DOCKER_HOST=tcp://docker:2375` for `docker.mode: dind` when the
+  profile does not declare it.
+- Secret-lease source guards already reject "too broad" home-rooted refs
+  (`SECRET_LEASE_SOURCE_TOO_BROAD`), non-existent / non-file refs
+  (`SECRET_LEASE_SOURCE_INVALID`), and writable mounts
+  (`SECRET_LEASE_WRITABLE_UNSUPPORTED`).
+
+## Explicit requirements checklist
+
+1. Explain why private pulls fail under `docker.mode: dind`.
+2. Provide a copy-pasteable `.awf/workspace.yml` that:
+   - sets `DOCKER_CONFIG` to the **directory** `/run/awf/secrets/docker`;
+   - declares a `local-file` mount lease with `mode: ro` whose `target` is
+     `/run/awf/secrets/docker/config.json`.
+3. Ship a parseable sample profile at the documented `examples/...` path.
+4. Document `ref` restrictions (literal absolute path; rejected broad roots and
+   their reason codes) and `required: true` vs `false` behavior.
+5. Document security properties: never paste tokens, read-only mount, sanitized
+   lease metadata only, local-mode (not a cloud broker).
+6. Add a test that the sample profile parses as a `WorkspaceProfile` and resolves
+   the lease into the exact read-only mount with `DOCKER_CONFIG` = mount-dir.
+
+## Implementation steps
+
+1. Write the recipe doc (problem, solution, profile, "how it fits together", `ref`
+   restrictions table, required-vs-optional, security notes, verify steps).
+2. Add the canonical sample profile under
+   `docs/recipes/examples/dind-private-registry/.awf/workspace.yml`.
+3. Add `tests/unit/node/test_dind_private_registry_recipe.py` asserting parse +
+   lease resolution into `AuthMount(target=/run/awf/secrets/docker/config.json,
+   mode=ro)`.
+4. Link the recipe from `docs/README.md` and `docs/PROJECT_ONBOARDING.md`.
+
+## Verification commands and pass criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/node/test_dind_private_registry_recipe.py -q`
+  → both tests pass.
+- Doc and sample profile agree on `DOCKER_CONFIG`, mount target, provider, and mode.
+
+Full repo-wide validation (lint/type/coverage/CI) is owned by AWF + GitHub CI after
+the agent phase, per the workspace contract.

--- a/plans/DIND_PRIVATE_REGISTRY_VALIDATION.md
+++ b/plans/DIND_PRIVATE_REGISTRY_VALIDATION.md
@@ -25,7 +25,7 @@ Plan reference: [`DIND_PRIVATE_REGISTRY_PLAN.md`](DIND_PRIVATE_REGISTRY_PLAN.md)
 
 ## Evidence — focused tests run
 
-```
+```bash
 uv run --python 3.12 --extra dev pytest tests/unit/node/test_dind_private_registry_recipe.py -q
 ```
 

--- a/plans/DIND_PRIVATE_REGISTRY_VALIDATION.md
+++ b/plans/DIND_PRIVATE_REGISTRY_VALIDATION.md
@@ -1,0 +1,47 @@
+# DinD Private-Registry Docker Auth Recipe — Validation
+
+Plan reference: [`DIND_PRIVATE_REGISTRY_PLAN.md`](DIND_PRIVATE_REGISTRY_PLAN.md)
+
+## Requirement-by-requirement status
+
+| # | Requirement | Status | Evidence |
+| - | ----------- | ------ | -------- |
+| 1 | Explain why private pulls fail under DinD | Complete | `docs/recipes/dind-private-registry-auth.md` §Problem (daemon at `tcp://docker:2375` has no creds) |
+| 2 | Copy-pasteable `.awf/workspace.yml` with `DOCKER_CONFIG` dir + `local-file` ro lease targeting `.../config.json` | Complete | recipe lines 19–45; `DOCKER_CONFIG: /run/awf/secrets/docker`, `target: /run/awf/secrets/docker/config.json`, `mode: ro` |
+| 3 | Parseable sample profile at documented path | Complete | `docs/recipes/examples/dind-private-registry/.awf/workspace.yml`; test loads & `model_validate`s it |
+| 4 | `ref` restrictions + required/optional documented | Complete | recipe §`ref` restrictions (reason-code table) and §Required vs optional leases |
+| 5 | Security properties documented | Complete | recipe §Security notes (no token paste, read-only, sanitized metadata, local-mode) |
+| 6 | Test: sample parses + resolves to exact read-only mount | Complete | `tests/unit/node/test_dind_private_registry_recipe.py` (2 tests) |
+
+## Evidence — files changed
+
+- `docs/recipes/dind-private-registry-auth.md` (new)
+- `docs/recipes/examples/dind-private-registry/.awf/workspace.yml` (new)
+- `tests/unit/node/test_dind_private_registry_recipe.py` (new)
+- `docs/README.md`, `docs/PROJECT_ONBOARDING.md` (recipe links)
+- `plans/DIND_PRIVATE_REGISTRY_PLAN.md`, `plans/DIND_PRIVATE_REGISTRY_VALIDATION.md`
+  (this protocol artifact set, added retroactively to satisfy
+  `plans/PLAN_EXECUTION_PROTOCOL.md`)
+
+## Evidence — focused tests run
+
+```
+uv run --python 3.12 --extra dev pytest tests/unit/node/test_dind_private_registry_recipe.py -q
+```
+
+- `test_recipe_profile_parses_with_dind_and_docker_config_env` — asserts
+  `docker.mode == dind`, `DOCKER_CONFIG == /run/awf/secrets/docker`, and the single
+  `local-file` ro secret targets `/run/awf/secrets/docker/config.json`.
+- `test_recipe_profile_resolves_config_json_into_readonly_mount` — repoints `ref`
+  at a real temp `config.json` and asserts the resolver yields exactly
+  `AuthMount(target="/run/awf/secrets/docker/config.json", mode="ro")`.
+
+Broad validation (ruff/mypy/full pytest/coverage gate, OpenAPI drift, console) is
+owned by AWF and GitHub CI after the agent phase, per the AWF workspace contract;
+not re-run here.
+
+## Gaps / iteration
+
+None. All planned requirements are `Complete`. No documentation-only `PLAN_ONLY_OUTPUT`
+risk: user-visible work (recipe, sample profile, test) exists alongside these
+protocol artifacts.

--- a/tests/unit/node/test_dind_private_registry_recipe.py
+++ b/tests/unit/node/test_dind_private_registry_recipe.py
@@ -1,0 +1,83 @@
+"""Validate the DinD private-registry auth recipe sample profile.
+
+The recipe doc (``docs/recipes/dind-private-registry-auth.md``) ships a
+copy-pasteable ``.awf/workspace.yml`` whose canonical, parseable form lives at
+``docs/recipes/examples/dind-private-registry/.awf/workspace.yml``. These tests
+keep that sample honest: it must parse as a ``WorkspaceProfile`` and resolve the
+declared ``local-file`` lease into the exact read-only Docker config mount the
+doc promises, with ``DOCKER_CONFIG`` pointing at the mount's directory.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from awf.node.compose_manager import AuthMount
+from awf.node.secret_mounts import LocalSecretLeaseMountResolver
+from awf.profiles.models import DockerMode, WorkspaceProfile
+
+_RECIPE_PROFILE = (
+    Path(__file__).resolve().parents[3]
+    / "docs"
+    / "recipes"
+    / "examples"
+    / "dind-private-registry"
+    / ".awf"
+    / "workspace.yml"
+)
+
+
+def _load_profile() -> WorkspaceProfile:
+    raw = yaml.safe_load(_RECIPE_PROFILE.read_text(encoding="utf-8"))
+    return WorkspaceProfile.model_validate(raw)
+
+
+@pytest.mark.unit
+def test_recipe_profile_parses_with_dind_and_docker_config_env() -> None:
+    profile = _load_profile()
+
+    assert profile.docker.mode == DockerMode.dind
+    # DOCKER_CONFIG must point at the directory that contains config.json.
+    assert profile.runtime.environment["DOCKER_CONFIG"] == "/run/awf/secrets/docker"
+
+    (secret,) = profile.secrets
+    assert secret.provider == "local-file"
+    assert secret.kind == "mount"
+    assert secret.mode == "ro"
+    assert secret.target == "/run/awf/secrets/docker/config.json"
+    # DOCKER_CONFIG (the directory) is the parent of the mount target (the file).
+    assert secret.target == f"{profile.runtime.environment['DOCKER_CONFIG']}/config.json"
+
+
+@pytest.mark.unit
+def test_recipe_profile_resolves_config_json_into_readonly_mount(tmp_path: Path) -> None:
+    profile = _load_profile()
+    (declared,) = profile.secrets
+
+    # The shipped ``ref`` is a placeholder host path; repoint it at a real temp
+    # file so the resolver's existence check passes deterministically without
+    # depending on a developer's ~/.docker/config.json.
+    config_json = tmp_path / ".docker" / "config.json"
+    config_json.parent.mkdir(parents=True)
+    config_json.write_text('{"auths": {}}', encoding="utf-8")
+    resolvable = profile.model_copy(
+        update={"secrets": [declared.model_copy(update={"ref": str(config_json)})]}
+    )
+
+    resolver = LocalSecretLeaseMountResolver(
+        host_home=tmp_path / "host-home",
+        work_dir=tmp_path / "work",
+        host_env={},
+    )
+    resolution = resolver.resolve(resolvable, workspace_id="ws_dind_registry")
+
+    assert resolution.mounts == (
+        AuthMount(
+            source=str(config_json),
+            target="/run/awf/secrets/docker/config.json",
+            mode="ro",
+        ),
+    )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e5cfd9eedaa04c9e95d276ee` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `medium`).


### Task
Add a first-class recipe + helper for private-registry Docker auth inside Docker-in-Docker (issue #527, item 5). During a real Bitbucket Java/Gradle onboarding, DinD needed a mounted Docker `config.json` for private-registry pulls; there's no documented path for it today.

## Do
- **Documented recipe** (a focused doc, e.g. `docs/recipes/dind-private-registry-auth.md`, linked from the onboarding docs): show exactly how to give a DinD workspace private-registry auth — declare a profile secret (`provider: local-file` or `local-auth`) that mounts the host `~/.docker/config.json` to a path, and point `DOCKER_CONFIG` at it in `runtime.environment` so `docker`/Gradle inside the agent (with `docker.mode: dind`, `DOCKER_HOST=tcp://docker:2375`) authenticates to the private registry. Include a complete, copy-pasteable `.awf/workspace.yml` profile snippet.
- **Optional small helper** ONLY if cheap and non-conflicting: a profile convenience (e.g. a documented `docker.registry_auth` hint or a sample template) — but prefer the documented recipe + example profile over new core code.

## Scope guard
Keep this to docs + a sample profile/example. Do NOT edit `src/awf/cli/profile_smoke_commands.py` or `src/awf/service/profile_doctor.py` (a sibling owns the preflight command) and do NOT edit `src/awf/profiles/models.py` (a sibling owns toolchain schema). If you add any code, keep it to a small, isolated helper with its own test. PR to development. Addresses #527 (item 5).

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, example profile, and unit tests only; no changes to secret resolution, provisioning, or authentication runtime paths.
> 
> **Overview**
> Adds a **DinD private-registry Docker auth** recipe so agents in `docker.mode: dind` can pull from private registries by mounting the host `config.json` via a `local-file` read-only secret lease and setting `DOCKER_CONFIG` to the mount directory (not the file path).
> 
> The new guide covers inline `auths` vs credential-helper pitfalls, `ref` path restrictions and lease reason codes, optional `worker` Compose bind for the bundled local-service stack when `~/.docker` is not in the allowlist, security notes, and verification steps. **Discoverability** links were added from `docs/README.md` and `docs/PROJECT_ONBOARDING.md`, plus a canonical example at `docs/recipes/examples/dind-private-registry/.awf/workspace.yml`.
> 
> **Tests** assert the example profile parses and that `LocalSecretLeaseMountResolver` resolves it to the documented read-only `AuthMount`. Plan/validation markdown under `plans/` documents scope and evidence; no runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9677ebd825f27602ec3c59e4404720aede1d419. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step recipe for authenticating to private Docker registries in Docker-in-Docker workspaces, plus links from the docs index and onboarding guide.
  * Included a copy-paste example workspace profile and explicit security/usage notes for read-only host Docker credential mounts.
  * Added plan and validation artifacts describing requirements and evidence for the recipe.
* **Tests**
  * Added unit tests that parse the example profile and verify the read-only credential mount and environment settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->