### PR TITLE
feat: profile-declared Java/JDK toolchains (#527 item 6)

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -63,7 +63,9 @@ Profiles keep AWF generic rather than tied to one application stack.
 
 A `WorkspaceProfile` can describe:
 
-- `runtime`: agent image, toolchain image, environment variables.
+- `runtime`: agent image, toolchain image, environment variables, and declared
+  language toolchains (e.g. the JDK versions the build needs — see
+  [Declaring language toolchains](#declaring-language-toolchains)).
 - `docker`: no Docker or per-workspace DinD.
 - `services`: profile-declared sidecars.
 - `phases`: setup, pre-agent, post-agent, validate, cleanup commands.
@@ -152,6 +154,45 @@ Preview the profile AWF would resolve for a checkout:
 ```bash
 uv run --python 3.12 --extra dev awf profile preview . --profile auto
 ```
+
+### Declaring language toolchains
+
+`runtime.toolchains` lets a profile declare the language toolchain versions the
+build needs, so satisfying them is a preflight/runtime concern rather than an
+ad-hoc agent repair. It maps a language identifier to the versions that must be
+available in the runtime/toolchain image:
+
+```yaml
+# .awf/workspace.yml — a Gradle repo that builds with JDK 17 but also wants 21 on hand
+gradle-service:
+  name: gradle-service
+  version: 1
+  description: Gradle service that runs its test suite on JDK 17.
+  runtime:
+    toolchains:
+      java: ["17", "21"]
+  phases:
+    setup:
+      - command: ./gradlew --no-daemon dependencies
+    validate:
+      - command: ./gradlew --no-daemon test
+```
+
+The declaration is optional and backward-compatible: an absent `toolchains` map
+(the default) means no toolchain requirement and changes nothing. Language keys
+are normalized to lowercase and must be safe identifiers (`^[a-z][a-z0-9+_.-]*$`);
+each version is a dotted-numeric string (`17`, `21`, `1.8`, `11.0.2`), de-duplicated
+while preserving order. Declarations are bounded (at most 16 languages, 16 versions
+each).
+
+The runtime/toolchain image is expected to provide each declared version side by
+side — for example JDKs installed under `/usr/lib/jvm/temurin-17` and
+`/usr/lib/jvm/temurin-21`, selected per command via `JAVA_HOME` or
+`update-alternatives`. When a declared version is not present in the image, AWF
+surfaces a `RUNTIME_TOOLCHAIN_UNAVAILABLE` warning at preflight (instead of leaving
+the agent to install a JDK by hand). The built-in `java` profile declares
+`java: ["17", "21"]` for exactly this reason: a real Gradle repo needed JDK 17 for
+test execution while the runtime shipped JDK 21.
 
 ### Local egress policy
 

--- a/openapi.json
+++ b/openapi.json
@@ -3146,6 +3146,17 @@
               }
             ],
             "title": "Toolchain Image"
+          },
+          "toolchains": {
+            "additionalProperties": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "description": "Language toolchains the workspace needs, mapping a language identifier to the versions that must be available in the runtime/toolchain image, e.g. ``{\"java\": [\"17\", \"21\"]}``. Absent (the default empty mapping) means no toolchain requirement is declared. The runtime/toolchain image is expected to provide each declared version side by side (selected per-command via ``JAVA_HOME``/``update-alternatives``); AWF surfaces a ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` preflight warning when a declared version is missing.",
+            "title": "Toolchains",
+            "type": "object"
           }
         },
         "title": "ProfileRuntime",

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -977,9 +977,14 @@ def runtime_toolchain_findings(
     """
     if available is None:
         return ()
+    # Profile toolchain keys are normalized to lowercase (see ProfileRuntime._validate_toolchains),
+    # but ``available`` keys come from external image discovery with no case guarantee. Fold the
+    # availability keys to lowercase so a mixed-case ``"Java"`` does not produce a false-positive
+    # RUNTIME_TOOLCHAIN_UNAVAILABLE warning against a declared ``"java"`` toolchain.
+    available_lower = {key.lower(): value for key, value in available.items()}
     findings: list[ProfileLintFinding] = []
     for language, versions in profile.runtime.toolchains.items():
-        available_versions = available.get(language, set())
+        available_versions = available_lower.get(language, set())
         for version in versions:
             if version in available_versions:
                 continue

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 import shlex
+from collections.abc import Mapping
 from enum import StrEnum
 from pathlib import PurePosixPath, PureWindowsPath
 from typing import Annotated, Any, Literal
@@ -52,6 +53,16 @@ class EndpointVisibility(StrEnum):
     internal = "internal"
 
 
+# Toolchain declaration bounds (see ``ProfileRuntime.toolchains``). Language keys
+# stay conservative safe identifiers; versions are dotted numeric strings such as
+# ``17``, ``21``, ``1.8`` or ``11.0.2``. Counts are capped so a declaration stays
+# bounded and cannot be used to inflate the schema.
+_TOOLCHAIN_LANGUAGE_PATTERN = re.compile(r"^[a-z][a-z0-9+_.-]*$")
+_TOOLCHAIN_VERSION_PATTERN = re.compile(r"^[0-9]+(\.[0-9]+){0,3}$")
+_MAX_TOOLCHAIN_LANGUAGES = 16
+_MAX_TOOLCHAIN_VERSIONS = 16
+
+
 class ProfileRuntime(BaseModel):
     """Runtime-level settings for the agent container."""
 
@@ -60,6 +71,74 @@ class ProfileRuntime(BaseModel):
     agent_image: str | None = Field(default=None, max_length=512)
     toolchain_image: str | None = Field(default=None, max_length=512)
     environment: dict[str, str] = Field(default_factory=dict)
+    toolchains: dict[str, list[str]] = Field(
+        default_factory=dict,
+        description=(
+            "Language toolchains the workspace needs, mapping a language identifier "
+            "to the versions that must be available in the runtime/toolchain image, "
+            'e.g. ``{"java": ["17", "21"]}``. Absent (the default empty mapping) '
+            "means no toolchain requirement is declared. The runtime/toolchain image "
+            "is expected to provide each declared version side by side (selected "
+            "per-command via ``JAVA_HOME``/``update-alternatives``); AWF surfaces a "
+            "``RUNTIME_TOOLCHAIN_UNAVAILABLE`` preflight warning when a declared "
+            "version is missing."
+        ),
+    )
+
+    @field_validator("toolchains", mode="before")
+    @classmethod
+    def _validate_toolchains(cls, value: object) -> object:
+        """Normalize and bound the toolchain declaration.
+
+        Lowercases language keys, validates each against a conservative identifier
+        pattern, requires a non-empty list of dotted-numeric versions per language,
+        de-duplicates versions while preserving declaration order, and caps the
+        number of languages/versions. An absent or empty declaration is a no-op.
+        """
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise ValueError("runtime.toolchains must be a mapping of language to versions")
+        if len(value) > _MAX_TOOLCHAIN_LANGUAGES:
+            raise ValueError(
+                f"runtime.toolchains declares too many languages (max {_MAX_TOOLCHAIN_LANGUAGES})"
+            )
+        normalized: dict[str, list[str]] = {}
+        for raw_language, raw_versions in value.items():
+            if not isinstance(raw_language, str):
+                raise ValueError("runtime.toolchains language keys must be strings")
+            language = raw_language.strip().lower()
+            if not _TOOLCHAIN_LANGUAGE_PATTERN.fullmatch(language):
+                raise ValueError(f"invalid toolchain language identifier: {raw_language!r}")
+            if language in normalized:
+                raise ValueError(f"duplicate toolchain language: {language}")
+            if isinstance(raw_versions, str) or not isinstance(raw_versions, (list, tuple)):
+                raise ValueError(
+                    f"runtime.toolchains[{language!r}] must be a non-empty list of version strings"
+                )
+            if not raw_versions:
+                raise ValueError(
+                    f"runtime.toolchains[{language!r}] must declare at least one version"
+                )
+            if len(raw_versions) > _MAX_TOOLCHAIN_VERSIONS:
+                raise ValueError(
+                    f"runtime.toolchains[{language!r}] declares too many versions "
+                    f"(max {_MAX_TOOLCHAIN_VERSIONS})"
+                )
+            versions: list[str] = []
+            seen: set[str] = set()
+            for raw_version in raw_versions:
+                if not isinstance(raw_version, str):
+                    raise ValueError(f"runtime.toolchains[{language!r}] versions must be strings")
+                version = raw_version.strip()
+                if not _TOOLCHAIN_VERSION_PATTERN.fullmatch(version):
+                    raise ValueError(f"invalid toolchain version for {language!r}: {raw_version!r}")
+                if version in seen:
+                    continue
+                versions.append(version)
+                seen.add(version)
+            normalized[language] = versions
+        return normalized
 
 
 class ProfileDocker(BaseModel):
@@ -874,6 +953,52 @@ def normalize_inline_profile_snapshot(
 
 def _normalized_endpoint_env_name(name: str) -> str:
     return re.sub(r"[^a-zA-Z0-9]+", "_", name).strip("_").upper()
+
+
+# Reason code emitted when a profile declares a language toolchain version that the
+# runtime/toolchain image does not provide. Profile-lint reason codes are free-form
+# strings consumed by preflight/console, not part of the generated doctor catalog.
+RUNTIME_TOOLCHAIN_UNAVAILABLE = "RUNTIME_TOOLCHAIN_UNAVAILABLE"
+
+
+def runtime_toolchain_findings(
+    profile: WorkspaceProfile,
+    available: Mapping[str, set[str]] | None,
+) -> tuple[ProfileLintFinding, ...]:
+    """Warn about declared language toolchains missing from the runtime image.
+
+    Pure, I/O-free seam for a (sibling-owned) preflight: ``available`` maps each
+    language to the set of versions actually discovered in the runtime/toolchain
+    image. ``available is None`` means the image contents are unknown, so this layer
+    stays silent (it never fails resolution on unknown availability). For every
+    declared ``(language, version)`` absent from ``available`` — including a language
+    not present at all — a ``warning``-severity :class:`ProfileLintFinding` carrying
+    the ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` reason code is returned.
+    """
+    if available is None:
+        return ()
+    findings: list[ProfileLintFinding] = []
+    for language, versions in profile.runtime.toolchains.items():
+        available_versions = available.get(language, set())
+        for version in versions:
+            if version in available_versions:
+                continue
+            findings.append(
+                ProfileLintFinding(
+                    reason_code=RUNTIME_TOOLCHAIN_UNAVAILABLE,
+                    message=(
+                        f"runtime image does not provide {language} toolchain version {version}"
+                    ),
+                    path=f"runtime.toolchains.{language}",
+                    severity=ProfileLintSeverity.warning,
+                    details={
+                        "language": language,
+                        "version": version,
+                        "available_versions": sorted(available_versions),
+                    },
+                )
+            )
+    return tuple(findings)
 
 
 class ProfileResolution(BaseModel):

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -980,8 +980,16 @@ def runtime_toolchain_findings(
     # Profile toolchain keys are normalized to lowercase (see ProfileRuntime._validate_toolchains),
     # but ``available`` keys come from external image discovery with no case guarantee. Fold the
     # availability keys to lowercase so a mixed-case ``"Java"`` does not produce a false-positive
-    # RUNTIME_TOOLCHAIN_UNAVAILABLE warning against a declared ``"java"`` toolchain.
-    available_lower = {key.lower(): value for key, value in available.items()}
+    # RUNTIME_TOOLCHAIN_UNAVAILABLE warning against a declared ``"java"`` toolchain. Merge (rather
+    # than overwrite) sets so two casings of the same language — e.g. ``"JAVA"`` and ``"Java"`` —
+    # union their versions instead of silently dropping all but the last.
+    available_lower: dict[str, set[str]] = {}
+    for key, value in available.items():
+        k = key.lower()
+        if k in available_lower:
+            available_lower[k] = available_lower[k] | value
+        else:
+            available_lower[k] = value
     findings: list[ProfileLintFinding] = []
     for language, versions in profile.runtime.toolchains.items():
         available_versions = available_lower.get(language, set())

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -97,7 +97,10 @@ class ProfileRuntime(BaseModel):
         """
         if value is None:
             return {}
-        if not isinstance(value, dict):
+        # Accept any Mapping (matching the declared contract / the in-scope ``Mapping`` import),
+        # not just ``dict`` — a ``MappingProxyType``/``ChainMap`` passed by a caller is normalized
+        # into a plain dict below rather than spuriously rejected. ``str``/list/tuple stay rejected.
+        if not isinstance(value, Mapping):
             raise ValueError("runtime.toolchains must be a mapping of language to versions")
         if len(value) > _MAX_TOOLCHAIN_LANGUAGES:
             raise ValueError(

--- a/src/awf/profiles/registry.py
+++ b/src/awf/profiles/registry.py
@@ -135,6 +135,11 @@ def java_profile(*, build_tool: str = "maven", source: str = "builtin:java") -> 
         source=source,
         confidence="medium",
         description=description,
+        # Declare the JDKs the build needs side by side: a Gradle repo may require
+        # JDK 17 for test execution even when the runtime ships a newer JDK 21
+        # (issue #527, item 6). Preflight surfaces RUNTIME_TOOLCHAIN_UNAVAILABLE if
+        # the runtime/toolchain image can't provide a declared version.
+        runtime=ProfileRuntime(toolchains={"java": ["17", "21"]}),
         phases={
             "setup": [setup],
             "validate": [validate],

--- a/tests/unit/profiles/test_profile_lint.py
+++ b/tests/unit/profiles/test_profile_lint.py
@@ -905,6 +905,29 @@ def test_runtime_toolchain_findings_language_entirely_absent_warns_each_version(
 
 
 @pytest.mark.unit
+def test_runtime_toolchain_findings_mixed_case_availability_keys_match_lowercased() -> None:
+    """Availability keys discovered from the image may be mixed-case; folding them to
+    lowercase prevents false-positive warnings against lowercase profile toolchain keys."""
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    assert runtime_toolchain_findings(profile, {"Java": {"17", "21"}}) == ()
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_mixed_case_availability_keys_still_detect_missing() -> None:
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    findings = runtime_toolchain_findings(profile, {"Java": {"21"}})
+
+    assert len(findings) == 1
+    assert findings[0].details == {
+        "language": "java",
+        "version": "17",
+        "available_versions": ["21"],
+    }
+
+
+@pytest.mark.unit
 def test_runtime_toolchain_findings_no_declaration_never_warns() -> None:
     profile = WorkspaceProfile.model_validate({"name": "plain"})
 

--- a/tests/unit/profiles/test_profile_lint.py
+++ b/tests/unit/profiles/test_profile_lint.py
@@ -12,7 +12,12 @@ from awf.profiles.lint import (
     profile_lint_errors,
     profile_service_volume_lint_errors,
 )
-from awf.profiles.models import ProfileLintSeverity, WorkspaceProfile
+from awf.profiles.models import (
+    RUNTIME_TOOLCHAIN_UNAVAILABLE,
+    ProfileLintSeverity,
+    WorkspaceProfile,
+    runtime_toolchain_findings,
+)
 from awf.profiles.resolver import ProfileResolutionError, resolve_workspace_profile
 
 _PRIVATE_KEY_SENTINEL = "-----BEGIN " + "PRIVATE KEY-----"
@@ -847,3 +852,61 @@ def test_host_home_mount_to_auth_like_or_root_target_is_blocked() -> None:
         "HOST_HOME_AUTH_MOUNT_TOO_BROAD",
         "HOST_HOME_AUTH_MOUNT_TOO_BROAD",
     ]
+
+
+def _profile_with_toolchains(toolchains: dict[str, list[str]]) -> WorkspaceProfile:
+    return WorkspaceProfile.model_validate(
+        {"name": "toolchain-profile", "runtime": {"toolchains": toolchains}}
+    )
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_unknown_availability_is_silent() -> None:
+    """``available is None`` means image contents are unknown -> never warn."""
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    assert runtime_toolchain_findings(profile, None) == ()
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_all_versions_present_no_findings() -> None:
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    assert runtime_toolchain_findings(profile, {"java": {"17", "21"}}) == ()
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_single_missing_version_warns() -> None:
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    findings = runtime_toolchain_findings(profile, {"java": {"21"}})
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE
+    assert finding.severity == ProfileLintSeverity.warning
+    assert finding.path == "runtime.toolchains.java"
+    assert finding.details == {
+        "language": "java",
+        "version": "17",
+        "available_versions": ["21"],
+    }
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_language_entirely_absent_warns_each_version() -> None:
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    findings = runtime_toolchain_findings(profile, {"python": {"3.12"}})
+
+    assert [f.details["version"] for f in findings] == ["17", "21"]
+    assert all(f.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE for f in findings)
+    assert all(f.details["available_versions"] == [] for f in findings)
+
+
+@pytest.mark.unit
+def test_runtime_toolchain_findings_no_declaration_never_warns() -> None:
+    profile = WorkspaceProfile.model_validate({"name": "plain"})
+
+    assert runtime_toolchain_findings(profile, {"java": {"21"}}) == ()
+    assert runtime_toolchain_findings(profile, None) == ()

--- a/tests/unit/profiles/test_profile_lint.py
+++ b/tests/unit/profiles/test_profile_lint.py
@@ -928,6 +928,15 @@ def test_runtime_toolchain_findings_mixed_case_availability_keys_still_detect_mi
 
 
 @pytest.mark.unit
+def test_runtime_toolchain_findings_duplicate_casing_availability_keys_merge_versions() -> None:
+    """Two casings of the same availability key union their versions instead of letting the
+    later entry overwrite the earlier one — otherwise a dropped version warns falsely."""
+    profile = _profile_with_toolchains({"java": ["17", "21"]})
+
+    assert runtime_toolchain_findings(profile, {"JAVA": {"17", "21"}, "Java": {"17"}}) == ()
+
+
+@pytest.mark.unit
 def test_runtime_toolchain_findings_no_declaration_never_warns() -> None:
     profile = WorkspaceProfile.model_validate({"name": "plain"})
 

--- a/tests/unit/profiles/test_profile_models_helpers.py
+++ b/tests/unit/profiles/test_profile_models_helpers.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from awf.profiles.models import (
     ProfileAppEndpoint,
     ProfileAppEndpointHealth,
     ProfileHealthCheck,
+    ProfileRuntime,
     normalize_inline_profile_snapshot,
 )
 
@@ -48,6 +50,108 @@ def test_app_endpoint_normalizes_scheme_to_lowercase() -> None:
     endpoint = ProfileAppEndpoint(name="web", service="app", port=8080, scheme="HTTPS")
 
     assert endpoint.scheme == "https"
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_absent_defaults_to_empty_no_behavior_change() -> None:
+    """An absent toolchains declaration is a no-op: the runtime keeps its prior shape."""
+    runtime = ProfileRuntime()
+
+    assert runtime.toolchains == {}
+    # Round-trips through dump/validate without gaining the field as anything but {}.
+    assert ProfileRuntime.model_validate(runtime.model_dump()).toolchains == {}
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_explicit_none_is_treated_as_empty() -> None:
+    """An explicit ``toolchains: null`` (e.g. an empty YAML key) means no requirement."""
+    runtime = ProfileRuntime.model_validate({"toolchains": None})
+
+    assert runtime.toolchains == {}
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_non_string_language_key() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {17: ["17"]}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_normalizes_lowercases_and_dedupes_preserving_order() -> None:
+    runtime = ProfileRuntime.model_validate({"toolchains": {"Java": ["17", "21", "17"]}})
+
+    assert runtime.toolchains == {"java": ["17", "21"]}
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_accepts_dotted_numeric_versions() -> None:
+    runtime = ProfileRuntime.model_validate({"toolchains": {"java": ["1.8", "11.0.2"]}})
+
+    assert runtime.toolchains == {"java": ["1.8", "11.0.2"]}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_version", ["17a", "", "  ", "v17", "17.", ".17"])
+def test_runtime_toolchains_rejects_malformed_version(bad_version: str) -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"java": [bad_version]}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_empty_version_list() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"java": []}})
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("bad_language", ["", "  ", "17java", "java lang", "Java!"])
+def test_runtime_toolchains_rejects_blank_or_invalid_language(bad_language: str) -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {bad_language: ["17"]}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_non_mapping() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": ["java"]})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_non_list_versions() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"java": "17"}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_non_string_version_entry() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"java": [17]}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_too_many_languages() -> None:
+    too_many = {f"lang{i}": ["1"] for i in range(17)}
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": too_many})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_too_many_versions() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"java": [str(i) for i in range(17)]}})
+
+
+@pytest.mark.unit
+def test_runtime_toolchains_rejects_duplicate_language_after_lowercasing() -> None:
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"toolchains": {"Java": ["17"], "java": ["21"]}})
+
+
+@pytest.mark.unit
+def test_runtime_extra_keys_still_forbidden() -> None:
+    """Regression: adding ``toolchains`` must not loosen ``extra='forbid'``."""
+    with pytest.raises(ValidationError):
+        ProfileRuntime.model_validate({"unknown_runtime_key": "value"})
 
 
 @pytest.mark.unit

--- a/tests/unit/profiles/test_profile_models_helpers.py
+++ b/tests/unit/profiles/test_profile_models_helpers.py
@@ -117,6 +117,18 @@ def test_runtime_toolchains_rejects_non_mapping() -> None:
 
 
 @pytest.mark.unit
+def test_runtime_toolchains_accepts_non_dict_mapping() -> None:
+    """The guard accepts any Mapping (e.g. ``MappingProxyType``), not only ``dict``."""
+    from types import MappingProxyType
+
+    runtime = ProfileRuntime.model_validate(
+        {"toolchains": MappingProxyType({"Java": ["17", "21"]})}
+    )
+
+    assert runtime.toolchains == {"java": ["17", "21"]}
+
+
+@pytest.mark.unit
 def test_runtime_toolchains_rejects_non_list_versions() -> None:
     with pytest.raises(ValidationError):
         ProfileRuntime.model_validate({"toolchains": {"java": "17"}})

--- a/tests/unit/profiles/test_profiles_part_002.py
+++ b/tests/unit/profiles/test_profiles_part_002.py
@@ -12,6 +12,7 @@ from awf.profiles.registry import (
     detect_profile,
     docker_compose_profile,
     get_builtin_profile,
+    java_profile,
 )
 
 
@@ -39,6 +40,26 @@ def test_java_builtin_without_detected_build_tool_uses_default_profile(tmp_path:
 
     assert profile is not None
     assert profile.phases.setup[0].command == "mvn -B -DskipTests dependency:go-offline"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "build_tool",
+    ["maven", "maven-wrapper", "gradle", "gradle-wrapper"],
+)
+def test_java_profile_declares_jdk_toolchains(build_tool: str) -> None:
+    """Every java build-tool variant declares its JDK needs (issue #527, item 6)."""
+    profile = java_profile(build_tool=build_tool)
+
+    assert profile.runtime.toolchains == {"java": ["17", "21"]}
+
+
+@pytest.mark.unit
+def test_java_builtin_resolution_carries_jdk_toolchains(tmp_path: Path) -> None:
+    profile = get_builtin_profile("java", worktree_path=tmp_path)
+
+    assert profile is not None
+    assert profile.runtime.toolchains == {"java": ["17", "21"]}
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_00fcb9026c964ac6814017fb` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Let profiles declare language toolchains (Java/JDK versions) and surface a finding when the runtime can't satisfy them (issue #527, item 6). A real Gradle repo needed JDK 17 for test execution while the runtime shipped JDK 21; the agent had to install JDK 17 ad hoc. Profiles should declare this so it's a preflight/runtime concern, not an agent repair.

## Do
- Extend `ProfileRuntime` in `src/awf/profiles/models.py` (currently `agent_image`, `toolchain_image`, `environment`) with a structured **toolchains** declaration, e.g. `toolchains: {java: ["17", "21"]}` (validated, optional, backward-compatible — absent ⇒ no change).
- Wire it so it's honored/surfaced: at minimum, a clear finding/warning when a declared toolchain isn't available in the runtime/toolchain image (and document how the runtime/toolchain image is expected to provide multiple JDKs). Update the `java_profile()` example in `src/awf/profiles/registry.py` to declare its JDK needs.
- Document the new field (profile schema docs) with a Gradle multi-JDK example.

## Scope guard
ONLY touch `src/awf/profiles/models.py`, `src/awf/profiles/registry.py`, the profile schema docs, and tests. Do NOT edit `src/awf/cli/profile_smoke_commands.py` / `profile_doctor.py` (sibling owns preflight) or add Docker-auth code (sibling owns that). Backward-compatible schema change; tests for the new field (valid/invalid, absent=no-op). ruff/mypy green. PR to development. Addresses #527 (item 6).

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional schema field with validation and warning-only lint helpers; preflight wiring lives outside this diff.
> 
> **Overview**
> Adds optional **`runtime.toolchains`** on workspace profiles so repos can declare required language versions (e.g. `java: ["17", "21"]`) instead of leaving JDK gaps for the agent to fix. **`ProfileRuntime`** validates and normalizes declarations (lowercase language keys, dotted-numeric versions, dedupe, caps at 16 languages/versions); empty/absent means no requirement.
> 
> Introduces **`runtime_toolchain_findings()`** and reason code **`RUNTIME_TOOLCHAIN_UNAVAILABLE`** to emit warning-level profile lint findings when image-discovered toolchains omit a declared version (silent when availability is unknown). The built-in **`java`** profile now declares **`java: ["17", "21"]`**. Docs and OpenAPI describe the field and multi-JDK expectations; unit tests cover validation and availability matching (including mixed-case availability keys).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda3175d19ad9ff86b2d641c90fd869f61b7e3ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace profiles can declare required language toolchains and version lists.
  * Java profile now declares Java 17 and 21.
  * Preflight now warns when declared toolchain versions are unavailable.

* **Documentation**
  * Added guide for declaring language toolchains, normalization, validation, ordering, and examples.

* **Tests**
  * Added unit tests covering toolchain validation, normalization, availability warnings, and Java profile declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->