### PR TITLE
docs: forge-aware gh in README + QUICKSTART (finish #525)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,9 +165,9 @@ Set up Agent Workspace Fabric (AWF) on this machine and onboard my repo.
    skills/awf-scheduler/SKILL.md and docs/QUICKSTART.md before doing anything.
 2. Check prerequisites (Docker running, uv, git). For PR automation, configure only
    the auth my repo's forge needs: GitHub (github.com) needs gh authenticated;
-   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN + BITBUCKET_EMAIL +
-   BITBUCKET_AUTH_MODE in .env and no gh. If any are missing, STOP and tell me — do
-   not guess.
+   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN (and either BITBUCKET_EMAIL
+   or BITBUCKET_AUTH_MODE=bearer) in .env and no gh. If any are missing, STOP and
+   tell me — do not guess.
 3. Install via the source lane: uv tool install . --force, then awf setup, awf start,
    and awf service status --format pretty.
 4. Onboard my project at <PATH>: awf init <PATH> --write-profile --yes, then

--- a/README.md
+++ b/README.md
@@ -163,8 +163,11 @@ your project's path):
 Set up Agent Workspace Fabric (AWF) on this machine and onboard my repo.
 1. Clone https://github.com/dimileeh/agent-workspace-fabric and READ
    skills/awf-scheduler/SKILL.md and docs/QUICKSTART.md before doing anything.
-2. Check prerequisites (Docker running, uv, git, and gh authenticated if I want PR
-   automation). If any are missing, STOP and tell me — do not guess.
+2. Check prerequisites (Docker running, uv, git). For PR automation, configure only
+   the auth my repo's forge needs: GitHub (github.com) needs gh authenticated;
+   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN + BITBUCKET_EMAIL +
+   BITBUCKET_AUTH_MODE in .env and no gh. If any are missing, STOP and tell me — do
+   not guess.
 3. Install via the source lane: uv tool install . --force, then awf setup, awf start,
    and awf service status --format pretty.
 4. Onboard my project at <PATH>: awf init <PATH> --write-profile --yes, then

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -13,8 +13,9 @@ Install:
 - Forge access for the target repo — choose the one that matches your repo's host:
   - **GitHub:** the GitHub CLI `gh`, plus a GitHub account with access to the
     target repo.
-  - **Bitbucket:** `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
-    `BITBUCKET_AUTH_MODE` (e.g. `basic`) set in `.env` — no `gh` required.
+  - **Bitbucket:** `BITBUCKET_API_TOKEN` plus either `BITBUCKET_EMAIL` (for the
+    default `basic` auth mode) or `BITBUCKET_AUTH_MODE=bearer` (token alone) set in
+    `.env` — no `gh` required.
 - SSH key or Git credentials that can clone and push the repo.
 - At least one coding-agent credential:
   - Codex CLI auth in `~/.codex`, or OpenAI auth environment as supported by
@@ -32,8 +33,9 @@ Verify forge access (run the check that matches your repo's host):
   gh auth status
   ```
 
-- **Bitbucket:** confirm `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and
-  `BITBUCKET_AUTH_MODE` are present in `.env` (no `gh` needed).
+- **Bitbucket:** confirm `BITBUCKET_API_TOKEN` is present in `.env`, plus either
+  `BITBUCKET_EMAIL` (default `basic` mode) or `BITBUCKET_AUTH_MODE=bearer` (token
+  alone) (no `gh` needed).
 
 Verify Docker:
 

--- a/docs/PROJECT_ONBOARDING.md
+++ b/docs/PROJECT_ONBOARDING.md
@@ -43,8 +43,9 @@ needs — do not unconditionally install or authenticate the GitHub CLI `gh`.
 Detect the forge from the repo's `origin` remote (`git remote -v`):
 
 - **`github.com` → GitHub:** install and authenticate `gh` (`gh auth status`).
-- **`bitbucket.org` → Bitbucket:** set `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`,
-  and `BITBUCKET_AUTH_MODE` (e.g. `basic`) in `.env`. **No `gh` install or auth
+- **`bitbucket.org` → Bitbucket:** set `BITBUCKET_API_TOKEN` plus either
+  `BITBUCKET_EMAIL` (for the default `basic` auth mode) or
+  `BITBUCKET_AUTH_MODE=bearer` (token alone) in `.env`. **No `gh` install or auth
   is required** for Bitbucket repos.
 
 The per-provider prompts below all follow this rule: detect the forge first,
@@ -59,8 +60,9 @@ operator:
 Inspect this repository for AWF onboarding. Do not launch a workspace, push,
 open a PR, or start project services. First detect the forge from the repo's
 origin remote (git remote -v) and configure only the matching auth: GitHub
-(github.com) needs gh; Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN +
-BITBUCKET_EMAIL + BITBUCKET_AUTH_MODE in .env and no gh. Then start with:
+(github.com) needs gh; Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN
+(plus either BITBUCKET_EMAIL for basic auth or BITBUCKET_AUTH_MODE=bearer for
+bearer tokens) in .env and no gh. Then start with:
 
 `awf init . --write-profile --yes`
 `awf profile preview .`
@@ -80,7 +82,7 @@ generic for any repository and do not contain project-specific assumptions.
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` (plus either `BITBUCKET_EMAIL` for the default basic auth or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
@@ -94,7 +96,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 I will inspect this repository for AWF onboarding. I will not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` (plus either `BITBUCKET_EMAIL` for the default basic auth or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
@@ -108,7 +110,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Analyze this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` (plus either `BITBUCKET_EMAIL` for the default basic auth or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
@@ -122,7 +124,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Use `opencode run` to inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` (plus either `BITBUCKET_EMAIL` for the default basic auth or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.
@@ -136,7 +138,7 @@ Keep secrets as profile declarations or `${VAR}` placeholders; never write raw s
 ```text
 Inspect this repository for AWF onboarding. Do not launch a workspace yet.
 
-1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env` and no `gh`.
+1. Detect the forge from `git remote -v` and configure only the matching auth (see "Forge authentication" above): GitHub (github.com) needs `gh`; Bitbucket (bitbucket.org) needs `BITBUCKET_API_TOKEN` (plus either `BITBUCKET_EMAIL` for the default basic auth or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` and no `gh`.
 2. Run `awf init . --write-profile --yes` to inspect the repo and write `.awf/workspace.yml`.
 3. Run `awf profile preview .` to preview the resolved profile.
 4. Run `awf init . --include-smoke-request` to produce a smoke workspace request, then submit it to validate the profile end-to-end.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -48,9 +48,9 @@ Set up Agent Workspace Fabric (AWF) on this machine and onboard my repo.
    skills/awf-scheduler/SKILL.md and docs/QUICKSTART.md before doing anything.
 2. Check prerequisites (Docker running, uv, git). For PR automation, configure only
    the auth my repo's forge needs: GitHub (github.com) needs gh authenticated;
-   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN + BITBUCKET_EMAIL +
-   BITBUCKET_AUTH_MODE in .env and no gh. If any are missing, STOP and tell me — do
-   not guess.
+   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN (and either BITBUCKET_EMAIL
+   or BITBUCKET_AUTH_MODE=bearer) in .env and no gh. If any are missing, STOP and
+   tell me — do not guess.
 3. Install via the source lane: uv tool install . --force, then awf setup, awf start,
    and awf service status --format pretty.
 4. Onboard my project at <PATH>: awf init <PATH> --write-profile --yes, then

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,10 @@ then, use one of the lanes below.
 - Git.
 - Docker Desktop or Docker Engine with the Compose plugin running.
 - `uv` for the `uv tool` and source lanes, or `pipx` for the `pipx` lane.
-- GitHub CLI `gh` if you want AWF to create or monitor PRs.
+- Forge auth for PR automation — only what your repo's host needs: GitHub
+  (github.com) needs the GitHub CLI `gh` authenticated; Bitbucket (bitbucket.org)
+  needs `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and `BITBUCKET_AUTH_MODE` in
+  `.env` (no `gh` required).
 - At least one coding-agent credential for real workspace execution.
 
 Mocked smoke does not require live GitHub or provider access. Local first-run
@@ -43,8 +46,11 @@ project's path):
 Set up Agent Workspace Fabric (AWF) on this machine and onboard my repo.
 1. Clone https://github.com/dimileeh/agent-workspace-fabric and READ
    skills/awf-scheduler/SKILL.md and docs/QUICKSTART.md before doing anything.
-2. Check prerequisites (Docker running, uv, git, and gh authenticated if I want PR
-   automation). If any are missing, STOP and tell me — do not guess.
+2. Check prerequisites (Docker running, uv, git). For PR automation, configure only
+   the auth my repo's forge needs: GitHub (github.com) needs gh authenticated;
+   Bitbucket (bitbucket.org) needs BITBUCKET_API_TOKEN + BITBUCKET_EMAIL +
+   BITBUCKET_AUTH_MODE in .env and no gh. If any are missing, STOP and tell me — do
+   not guess.
 3. Install via the source lane: uv tool install . --force, then awf setup, awf start,
    and awf service status --format pretty.
 4. Onboard my project at <PATH>: awf init <PATH> --write-profile --yes, then

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -15,8 +15,8 @@ then, use one of the lanes below.
 - `uv` for the `uv tool` and source lanes, or `pipx` for the `pipx` lane.
 - Forge auth for PR automation — only what your repo's host needs: GitHub
   (github.com) needs the GitHub CLI `gh` authenticated; Bitbucket (bitbucket.org)
-  needs `BITBUCKET_API_TOKEN`, `BITBUCKET_EMAIL`, and `BITBUCKET_AUTH_MODE` in
-  `.env` (no `gh` required).
+  needs `BITBUCKET_API_TOKEN` (plus `BITBUCKET_EMAIL` for the default basic auth,
+  or `BITBUCKET_AUTH_MODE=bearer` for bearer tokens) in `.env` (no `gh` required).
 - At least one coding-agent credential for real workspace execution.
 
 Mocked smoke does not require live GitHub or provider access. Local first-run


### PR DESCRIPTION
## Finish #525 — forge-aware `gh` in README + QUICKSTART

#528 (the #525 fix) made `check_gh` warning-level and added full forge-detection guidance to `docs/GETTING_STARTED.md` and `docs/PROJECT_ONBOARDING.md`, but missed the two **most prominent** entry points, which still presented `gh` as a flat prerequisite:

- `README.md` — Lane-0 paste-prompt (step 2)
- `docs/QUICKSTART.md` — prerequisites bullet
- `docs/QUICKSTART.md` — Lane-0 paste-prompt (step 2)

All three now mirror the already-reviewed forge-aware wording from #528:
- **GitHub** (`github.com`) → `gh` authenticated
- **Bitbucket** (`bitbucket.org`) → `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` in `.env`, **no `gh`**

Docs-only; no code, no protected paths. The other `gh` mentions in the tree (`PR_MONITOR_ADOPTION.md`, `REASON_CATALOG.md`, `TROUBLESHOOTING.md`, `CONCEPTS.md`) are intentionally GitHub-specific operator/troubleshooting content and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to prerequisites and copy-paste agent prompts; no runtime or auth code paths modified.
> 
> **Overview**
> Completes forge-aware onboarding docs by aligning **README**, **QUICKSTART**, **GETTING_STARTED**, and **PROJECT_ONBOARDING** so PR automation is described per host instead of treating `gh` as a universal prerequisite.
> 
> **Lane 0** paste-prompts in README and QUICKSTART now split base checks (Docker, `uv`, git) from forge-specific auth: GitHub needs authenticated `gh`; Bitbucket needs `BITBUCKET_API_TOKEN` with either `BITBUCKET_EMAIL` (default **basic**) or `BITBUCKET_AUTH_MODE=bearer` in `.env`, explicitly **without** `gh`. QUICKSTART prerequisites use the same forge-aware wording.
> 
> Bitbucket guidance is tightened across onboarding docs: it no longer implies all three Bitbucket env vars are always required—**bearer** mode is documented as token-only. Forge-detection copy in PROJECT_ONBOARDING (one-message and per-provider prompts) is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47734e955069443d30aa0a932465f1870dca581c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quickstart and setup instructions with clearer prerequisite checks for Docker, uv, and git.
  * Clarified PR automation authentication requirements: GitHub requires gh-authenticated access; Bitbucket requires API token configuration in `.env`.
  * Improved guidance to explicitly halt and report missing prerequisites instead of proceeding with assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->