### PR TITLE
Doctor host_env = worker compose allowlist (#533)

### DIFF
--- a/src/awf/cli/profile_smoke_commands.py
+++ b/src/awf/cli/profile_smoke_commands.py
@@ -83,6 +83,7 @@ def profile_doctor(
         non_empty_env_value,
     )
     from awf.service.profile_doctor import collect_profile_doctor_report
+    from awf.service.worker import _service_git_environment
 
     resolved = repo.expanduser().resolve()
     # Probe secret leases against the SAME host_home the worker uses
@@ -91,6 +92,7 @@ def profile_doctor(
     # shell's HOME, falling back to Path.home() would check the wrong directory
     # and produce false passes/failures despite advertising the worker's context.
     settings = resolve_service_settings()
+    host_home = Path(settings.host_home).expanduser().resolve()
     # The merged Compose view (local_service_environ) overlays docker/compose/.env
     # with the entire caller shell. It is the right source for the Docker
     # daemon/agent-image pins below (the worker reads those from the resolved
@@ -118,16 +120,21 @@ def profile_doctor(
         if allowlist is None
         else {key: value for key, value in merged_env.items() if key in allowlist}
     )
-    # The worker additionally exports settings.github_token into
-    # GH_TOKEN/GITHUB_TOKEN before constructing the resolver (build_worker_runtime
-    # -> _service_git_environment + _apply_service_git_environment). Mirror that
-    # explicit forward so a token that resolves only through service settings (not
-    # the env file) still satisfies a provider: github lease. GH_TOKEN/GITHUB_TOKEN
-    # are on the worker allowlist, so this also supplies a value when it comes from
-    # settings rather than the env file.
-    if settings.github_token:
-        lease_host_env["GH_TOKEN"] = settings.github_token
-        lease_host_env["GITHUB_TOKEN"] = settings.github_token
+    # The worker mutates os.environ via _apply_service_git_environment(git_env) --
+    # os.environ.update(git_env) -- BEFORE constructing its
+    # LocalSecretLeaseMountResolver(host_env=os.environ). So its real lease env
+    # carries EVERY key build_worker_runtime injects after Compose startup, not
+    # just the GH_TOKEN/GITHUB_TOKEN aliases: HOME (= host_home), GIT_CONFIG_GLOBAL,
+    # GIT_SSH_COMMAND, the numbered GIT_CONFIG_* safe.directory entries, SSH_AUTH_SOCK,
+    # and the Bitbucket credential-helper config -- none of which live on the Compose
+    # environment: allowlist. Mirror the SAME git_env (computed from the worker's
+    # host_home + service github_token) and let it OVERRIDE the allowlisted view,
+    # exactly as os.environ.update does, so a provider: env lease satisfiable only by
+    # a worker-injected source (e.g. HOME) the real worker context can satisfy is not
+    # falsely surfaced as SECRET_LEASE_SOURCE_MISSING. This also forwards a github
+    # token that resolves only through service settings (not the env file), since
+    # git_env carries GH_TOKEN/GITHUB_TOKEN when settings.github_token is set.
+    lease_host_env.update(_service_git_environment(host_home, github_token=settings.github_token))
     # Run the image probes against the SAME Docker daemon/config the worker's
     # compose pulls target. The worker selects its daemon from the resolved service
     # environment (AWF_DOCKER_HOST, materialised as DOCKER_HOST -- settings.docker_host
@@ -202,7 +209,7 @@ def profile_doctor(
     report = collect_profile_doctor_report(
         resolved,
         repo_url=detect_repo_url_from_checkout(resolved),
-        host_home=Path(settings.host_home).expanduser().resolve(),
+        host_home=host_home,
         host_env=lease_host_env,
         # Probe the SAME agent runtime image the worker renders into every stack
         # (build_worker_runtime -> ComposeStackLauncher(agent_runtime_image=...)),

--- a/src/awf/cli/profile_smoke_commands.py
+++ b/src/awf/cli/profile_smoke_commands.py
@@ -134,7 +134,22 @@ def profile_doctor(
     # falsely surfaced as SECRET_LEASE_SOURCE_MISSING. This also forwards a github
     # token that resolves only through service settings (not the env file), since
     # git_env carries GH_TOKEN/GITHUB_TOKEN when settings.github_token is set.
-    lease_host_env.update(_service_git_environment(host_home, github_token=settings.github_token))
+    # Feed _service_git_environment the allowlisted lease_host_env as its source_env
+    # (NOT the caller os.environ it defaults to): its Bitbucket/SSH wiring inspects
+    # that env for credentials, and the real worker reads its Compose-forwarded
+    # container env -- modelled by the allowlisted view -- there. Bitbucket creds
+    # present only in docker/compose/.env (BITBUCKET_API_TOKEN/BITBUCKET_EMAIL are on
+    # the worker environment: allowlist) make the worker add GIT_TERMINAL_PROMPT and
+    # the bitbucket GIT_CONFIG_* helper; passing the caller os.environ would omit
+    # those keys (the operator shell lacks the .env-only creds) and still surface
+    # SECRET_LEASE_SOURCE_MISSING for a lease the worker-injected keys satisfy.
+    lease_host_env.update(
+        _service_git_environment(
+            host_home,
+            github_token=settings.github_token,
+            source_env=lease_host_env,
+        )
+    )
     # Run the image probes against the SAME Docker daemon/config the worker's
     # compose pulls target. The worker selects its daemon from the resolved service
     # environment (AWF_DOCKER_HOST, materialised as DOCKER_HOST -- settings.docker_host

--- a/src/awf/cli/profile_smoke_commands.py
+++ b/src/awf/cli/profile_smoke_commands.py
@@ -72,7 +72,11 @@ def profile_doctor(
     import os
 
     from awf.common.git_remote import detect_repo_url_from_checkout
-    from awf.service.config import local_service_environ, resolve_service_settings
+    from awf.service.config import (
+        local_service_environ,
+        local_service_worker_environment_keys,
+        resolve_service_settings,
+    )
     from awf.service.environment import (
         cleared_docker_cli_client_keys,
         env_lookup,
@@ -87,24 +91,43 @@ def profile_doctor(
     # shell's HOME, falling back to Path.home() would check the wrong directory
     # and produce false passes/failures despite advertising the worker's context.
     settings = resolve_service_settings()
-    # Probe secret leases against the SAME effective env the worker uses. The
-    # worker constructs its LocalSecretLeaseMountResolver with host_env=os.environ
-    # from INSIDE the service container, where Compose forwards every provider
-    # credential (e.g. BITBUCKET_API_TOKEN/BITBUCKET_EMAIL) from
-    # docker/compose/.env. Source host_env from that same merged Compose view
-    # (local_service_environ) rather than the bare caller shell, so a provider:
-    # bitbucket (or any env-backed) lease provisioning would satisfy is not
-    # falsely reported as SECRET_LEASE_SOURCE_MISSING when the credential lives in
-    # the service env file but is not exported in the current shell.
-    host_env = dict(local_service_environ())
+    # The merged Compose view (local_service_environ) overlays docker/compose/.env
+    # with the entire caller shell. It is the right source for the Docker
+    # daemon/agent-image pins below (the worker reads those from the resolved
+    # service env), but it OVER-includes every shell export for secret-lease
+    # evaluation. Keep it as merged_env for the Docker/image probes; the lease
+    # env is derived from it but restricted to the worker's real allowlist below.
+    merged_env = dict(local_service_environ())
+    # Probe secret leases against the SAME env the worker's resolver actually
+    # sees. The worker constructs its LocalSecretLeaseMountResolver with
+    # host_env=os.environ from INSIDE the service container, where os.environ is
+    # only what Docker Compose forwarded -- the KEYS on the worker service's
+    # environment: block in docker/compose/local-service.yml (the shared
+    # &awf-environment anchor), each interpolated from .env/host. Restrict the
+    # merged view to that allowlist so a provider: env lease satisfiable only by a
+    # host-only shell export (whose NAME is not on the worker's environment:
+    # block) is surfaced as a finding -- matching provisioning's
+    # SECRET_LEASE_SOURCE_MISSING -- instead of falsely passing. A var that IS on
+    # the allowlist but lives only in the operator shell still passes (Compose
+    # forwards it), preserving the false-negative fix from PR #531. When the
+    # compose asset cannot be located/parsed the allowlist is None and we fall
+    # back to the unrestricted merged view (legacy behavior; never over-fail).
+    allowlist = local_service_worker_environment_keys()
+    lease_host_env = (
+        dict(merged_env)
+        if allowlist is None
+        else {key: value for key, value in merged_env.items() if key in allowlist}
+    )
     # The worker additionally exports settings.github_token into
     # GH_TOKEN/GITHUB_TOKEN before constructing the resolver (build_worker_runtime
     # -> _service_git_environment + _apply_service_git_environment). Mirror that
     # explicit forward so a token that resolves only through service settings (not
-    # the env file) still satisfies a provider: github lease.
+    # the env file) still satisfies a provider: github lease. GH_TOKEN/GITHUB_TOKEN
+    # are on the worker allowlist, so this also supplies a value when it comes from
+    # settings rather than the env file.
     if settings.github_token:
-        host_env["GH_TOKEN"] = settings.github_token
-        host_env["GITHUB_TOKEN"] = settings.github_token
+        lease_host_env["GH_TOKEN"] = settings.github_token
+        lease_host_env["GITHUB_TOKEN"] = settings.github_token
     # Run the image probes against the SAME Docker daemon/config the worker's
     # compose pulls target. The worker selects its daemon from the resolved service
     # environment (AWF_DOCKER_HOST, materialised as DOCKER_HOST -- settings.docker_host
@@ -114,16 +137,18 @@ def profile_doctor(
     # merged service env with DOCKER_HOST forced to the resolved daemon so a stray
     # caller DOCKER_HOST/DOCKER_CONTEXT cannot redirect the probe. Mirror
     # bootstrap._docker_cli_environ's daemon precedence exactly: prefer AWF_DOCKER_HOST
-    # OR a bare DOCKER_HOST from the merged Compose view (host_env, sourced via
+    # OR a bare DOCKER_HOST from the merged Compose view (merged_env, sourced via
     # local_service_environ -- the same view the worker's raw_service_env is built
-    # from -- exactly like the lease checks above). resolve_service_settings()'s
+    # from). The Docker/image probes keep using the full merged view (not the lease
+    # allowlist) because the worker resolves its daemon and agent image from the
+    # resolved service env, not the secret-lease resolver. resolve_service_settings()'s
     # Settings() only reads an AWF_-prefixed, cwd-relative .env, so a daemon selected
     # only via an AWF_DOCKER_HOST/DOCKER_HOST in the Compose env file (with the doctor
     # invoked from another cwd) would otherwise leave the probe on the default socket
     # while the worker targets the env-file daemon, so preflight would not match
     # provisioning.
-    env_docker_host = non_empty_env_value(host_env, "AWF_DOCKER_HOST") or non_empty_env_value(
-        host_env, "DOCKER_HOST"
+    env_docker_host = non_empty_env_value(merged_env, "AWF_DOCKER_HOST") or non_empty_env_value(
+        merged_env, "DOCKER_HOST"
     )
     # Always scrub the Docker CLI client keys (DOCKER_CONFIG/DOCKER_CERT_PATH/
     # DOCKER_TLS*/...) the service environment explicitly clears, exactly as the
@@ -131,7 +156,7 @@ def profile_doctor(
     # without it a stale caller client key (e.g. a TLS config the service env blanks)
     # would survive into the probe and let it talk to a different daemon/config than
     # the worker's compose pulls, so preflight would not match provisioning.
-    scrubbed_keys = set(cleared_docker_cli_client_keys(host_env))
+    scrubbed_keys = set(cleared_docker_cli_client_keys(merged_env))
     # Mirror bootstrap._docker_cli_environ's clears_docker_host: when the merged
     # service env explicitly clears DOCKER_HOST (present but empty) while the caller
     # shell still exports a non-empty host, the worker scrubs DOCKER_HOST/DOCKER_CONTEXT
@@ -139,7 +164,7 @@ def profile_doctor(
     # this the doctor would treat the empty host as merely absent and pin
     # settings.docker_host below, probing a different daemon than the worker uses.
     caller_docker_host_found, caller_docker_host_value = env_lookup(os.environ, "DOCKER_HOST")
-    service_docker_host_found, service_docker_host_value = env_lookup(host_env, "DOCKER_HOST")
+    service_docker_host_found, service_docker_host_value = env_lookup(merged_env, "DOCKER_HOST")
     clears_docker_host = (
         service_docker_host_found
         and not service_docker_host_value
@@ -156,7 +181,7 @@ def profile_doctor(
     if env_docker_host or clears_docker_host:
         scrubbed_keys.update({"DOCKER_CONTEXT", "DOCKER_HOST"})
     docker_environ = {
-        key: value for key, value in host_env.items() if key.upper() not in scrubbed_keys
+        key: value for key, value in merged_env.items() if key.upper() not in scrubbed_keys
     }
     if env_docker_host:
         # Pin DOCKER_HOST to the daemon the worker materialises; DOCKER_CONTEXT was
@@ -178,7 +203,7 @@ def profile_doctor(
         resolved,
         repo_url=detect_repo_url_from_checkout(resolved),
         host_home=Path(settings.host_home).expanduser().resolve(),
-        host_env=host_env,
+        host_env=lease_host_env,
         # Probe the SAME agent runtime image the worker renders into every stack
         # (build_worker_runtime -> ComposeStackLauncher(agent_runtime_image=...)),
         # so a missing/private custom AWF_AGENT_RUNTIME_IMAGE fails preflight here
@@ -188,11 +213,13 @@ def profile_doctor(
         # here only reads an AWF_-prefixed, cwd-relative .env, so an image set only in the
         # Compose env file (with the doctor invoked from another cwd) would leave
         # settings.agent_runtime_image on the bare default while the worker pulls the custom
-        # image. Source AWF_AGENT_RUNTIME_IMAGE from the merged Compose view (host_env, the
-        # same view used for the lease/Docker checks above) first, exactly like the DOCKER_HOST
-        # pin, and fall back to settings.agent_runtime_image.
+        # image. Source AWF_AGENT_RUNTIME_IMAGE from the full merged Compose view
+        # (merged_env, the same view used for the Docker checks above -- not the lease
+        # allowlist) first, exactly like the DOCKER_HOST pin, and fall back to
+        # settings.agent_runtime_image.
         agent_runtime_image=(
-            non_empty_env_value(host_env, "AWF_AGENT_RUNTIME_IMAGE") or settings.agent_runtime_image
+            non_empty_env_value(merged_env, "AWF_AGENT_RUNTIME_IMAGE")
+            or settings.agent_runtime_image
         ),
         docker_environ=docker_environ,
     )

--- a/src/awf/cli/profile_smoke_commands.py
+++ b/src/awf/cli/profile_smoke_commands.py
@@ -74,7 +74,7 @@ def profile_doctor(
     from awf.common.git_remote import detect_repo_url_from_checkout
     from awf.service.config import (
         local_service_environ,
-        local_service_worker_environment_keys,
+        local_service_worker_environment,
         resolve_service_settings,
     )
     from awf.service.environment import (
@@ -103,23 +103,28 @@ def profile_doctor(
     # Probe secret leases against the SAME env the worker's resolver actually
     # sees. The worker constructs its LocalSecretLeaseMountResolver with
     # host_env=os.environ from INSIDE the service container, where os.environ is
-    # only what Docker Compose forwarded -- the KEYS on the worker service's
+    # the MATERIALIZED worker environment: every KEY on the worker service's
     # environment: block in docker/compose/local-service.yml (the shared
-    # &awf-environment anchor), each interpolated from .env/host. Restrict the
-    # merged view to that allowlist so a provider: env lease satisfiable only by a
-    # host-only shell export (whose NAME is not on the worker's environment:
-    # block) is surfaced as a finding -- matching provisioning's
-    # SECRET_LEASE_SOURCE_MISSING -- instead of falsely passing. A var that IS on
-    # the allowlist but lives only in the operator shell still passes (Compose
-    # forwards it), preserving the false-negative fix from PR #531. When the
-    # compose asset cannot be located/parsed the allowlist is None and we fall
-    # back to the unrestricted merged view (legacy behavior; never over-fail).
-    allowlist = local_service_worker_environment_keys()
-    lease_host_env = (
-        dict(merged_env)
-        if allowlist is None
-        else {key: value for key, value in merged_env.items() if key in allowlist}
-    )
+    # &awf-environment anchor), each carrying the VALUE Docker Compose
+    # interpolated from .env/host. Model that materialized view -- not a filter of
+    # the pre-interpolation merged inputs -- so an aliased default such as
+    # AWF_GITHUB_TOKEN: ${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}} (a key
+    # whose NAME is absent from the host shell yet which the worker still receives,
+    # populated from GH_TOKEN) is present for a provider: env lease with
+    # ref: AWF_GITHUB_TOKEN -- matching provisioning -- instead of being falsely
+    # surfaced as SECRET_LEASE_SOURCE_MISSING. A host-only shell export whose NAME
+    # is NOT on the worker's environment: block is dropped (the worker never
+    # receives it), so a lease satisfiable only by it is still surfaced as a
+    # finding. A var that IS on the block but lives only in the operator shell
+    # still passes (Compose forwards it via ${VAR:-...}), preserving the
+    # false-negative fix from PR #531. Empty-resolved keys are kept but treated as
+    # missing by the resolver (matching the worker, which receives them as ""), so
+    # materializing them does not weaken the signal. When the compose asset cannot
+    # be located/parsed the materialized view is None and we fall back to the
+    # unrestricted merged view (legacy behavior; never over-fail).
+    lease_host_env = local_service_worker_environment(merged_env)
+    if lease_host_env is None:
+        lease_host_env = dict(merged_env)
     # The worker mutates os.environ via _apply_service_git_environment(git_env) --
     # os.environ.update(git_env) -- BEFORE constructing its
     # LocalSecretLeaseMountResolver(host_env=os.environ). So its real lease env
@@ -127,19 +132,19 @@ def profile_doctor(
     # just the GH_TOKEN/GITHUB_TOKEN aliases: HOME (= host_home), GIT_CONFIG_GLOBAL,
     # GIT_SSH_COMMAND, the numbered GIT_CONFIG_* safe.directory entries, SSH_AUTH_SOCK,
     # and the Bitbucket credential-helper config -- none of which live on the Compose
-    # environment: allowlist. Mirror the SAME git_env (computed from the worker's
-    # host_home + service github_token) and let it OVERRIDE the allowlisted view,
+    # environment: block. Mirror the SAME git_env (computed from the worker's
+    # host_home + service github_token) and let it OVERRIDE the materialized view,
     # exactly as os.environ.update does, so a provider: env lease satisfiable only by
     # a worker-injected source (e.g. HOME) the real worker context can satisfy is not
     # falsely surfaced as SECRET_LEASE_SOURCE_MISSING. This also forwards a github
     # token that resolves only through service settings (not the env file), since
     # git_env carries GH_TOKEN/GITHUB_TOKEN when settings.github_token is set.
-    # Feed _service_git_environment the allowlisted lease_host_env as its source_env
+    # Feed _service_git_environment the materialized lease_host_env as its source_env
     # (NOT the caller os.environ it defaults to): its Bitbucket/SSH wiring inspects
     # that env for credentials, and the real worker reads its Compose-forwarded
-    # container env -- modelled by the allowlisted view -- there. Bitbucket creds
+    # container env -- modelled by the materialized view -- there. Bitbucket creds
     # present only in docker/compose/.env (BITBUCKET_API_TOKEN/BITBUCKET_EMAIL are on
-    # the worker environment: allowlist) make the worker add GIT_TERMINAL_PROMPT and
+    # the worker environment: block) make the worker add GIT_TERMINAL_PROMPT and
     # the bitbucket GIT_CONFIG_* helper; passing the caller os.environ would omit
     # those keys (the operator shell lacks the .env-only creds) and still surface
     # SECRET_LEASE_SOURCE_MISSING for a lease the worker-injected keys satisfy.

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -366,15 +366,18 @@ def local_service_worker_environment_keys(
             # SafeLoader expands ``<<: *awf-service`` so this already carries the
             # ``&awf-environment`` anchor keys.
             _collect_compose_environment_keys(worker.get("environment"), keys)
-    # Robust fallback that does not depend on merge-key expansion: union the
-    # ``environment`` keys from every top-level ``x-*`` extension template (the
-    # ``x-awf-service`` anchor the worker uses). This captures the anchor keys
-    # even if a loader leaves ``<<`` unexpanded. Intentionally do NOT walk
-    # arbitrary services (avoids pulling in postgres/console env keys the worker
-    # never receives).
-    for key, value in data.items():
-        if isinstance(key, str) and key.startswith("x-") and isinstance(value, Mapping):
-            _collect_compose_environment_keys(value.get("environment"), keys)
+    if not keys:
+        # Robust fallback for loaders that leave ``<<`` unexpanded (so the worker
+        # block above yielded nothing): union the ``environment`` keys from every
+        # top-level ``x-*`` extension template -- the ``x-awf-service`` anchor the
+        # worker uses. Gated on the primary path finding no keys so an unrelated
+        # future ``x-*`` template (e.g. an ``x-debug-service`` for a non-worker
+        # service) cannot silently widen the worker's secret-lease allowlist.
+        # Intentionally does NOT walk arbitrary services (avoids pulling in
+        # postgres/console env keys the worker never receives).
+        for key, value in data.items():
+            if isinstance(key, str) and key.startswith("x-") and isinstance(value, Mapping):
+                _collect_compose_environment_keys(value.get("environment"), keys)
 
     if not keys:
         return None

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -25,7 +25,11 @@ from awf.common.config import (
     settings_constructor_fields,
     validate_production_settings,
 )
-from awf.service.environment import compose_env_file_values
+from awf.service.environment import (
+    compose_env_file_values,
+    compose_expand_value,
+    env_lookup,
+)
 
 DEFAULT_LOCAL_SERVICE_DATABASE_URL = DEFAULT_LOCAL_DATABASE_URL
 DEFAULT_LOCAL_SERVICE_API_BASE_URL = str(Settings.model_fields["api_base_url"].default)
@@ -61,6 +65,7 @@ __all__ = [
     "LOCAL_SERVICE_INCLUDED_COMPOSE_FILE",
     "ServiceSettings",
     "local_service_environ",
+    "local_service_worker_environment",
     "local_service_worker_environment_keys",
     "resolve_local_service_compose_env_file",
     "resolve_local_service_provider_environ",
@@ -345,6 +350,65 @@ def local_service_worker_environment_keys(
     to the unrestricted merged view, preserving legacy behavior).
     """
 
+    pairs = _local_service_worker_environment_pairs(compose_file=compose_file)
+    if pairs is None:
+        return None
+    return frozenset(pairs)
+
+
+def local_service_worker_environment(
+    merged_env: Mapping[str, str], *, compose_file: Path | None = None
+) -> dict[str, str] | None:
+    """Return the worker container's MATERIALIZED Compose environment.
+
+    Unlike :func:`local_service_worker_environment_keys` (NAMES only), this
+    resolves each declared value on the worker's Compose ``environment:`` block by
+    interpolating it against ``merged_env`` (the merged Compose view: env file
+    overlaid with the caller shell), reproducing the values Docker Compose
+    actually injects into the worker container. This materializes aliased defaults
+    such as ``AWF_GITHUB_TOKEN: ${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}``
+    -- a key whose NAME is absent from ``merged_env`` yet which the worker receives
+    populated from ``GH_TOKEN`` -- so a ``provider: env`` lease with
+    ``ref: AWF_GITHUB_TOKEN`` is evaluated against the value the real worker has,
+    rather than being falsely reported as ``SECRET_LEASE_SOURCE_MISSING`` by a
+    filter of the pre-interpolation inputs. A bare list-form entry (``- KEY``)
+    forwards the host value unchanged (omitted when the host does not set it,
+    matching Compose). Keys that resolve to an empty string are kept (the worker
+    receives them as ``""``); the secret-lease resolver treats an empty value as
+    missing, so this does not weaken the signal. ``None`` when the compose asset
+    cannot be located/parsed (caller falls back to the unrestricted merged view,
+    preserving legacy behavior).
+    """
+
+    pairs = _local_service_worker_environment_pairs(compose_file=compose_file)
+    if pairs is None:
+        return None
+    materialized: dict[str, str] = {}
+    for key, raw_value in pairs.items():
+        if raw_value is None:
+            # Bare ``- KEY`` list entry: Compose forwards the host value verbatim,
+            # and omits the key when the host does not set it.
+            found, value = env_lookup(merged_env, key)
+            if found:
+                materialized[key] = value
+            continue
+        materialized[key] = compose_expand_value(raw_value, environ=merged_env)
+    return materialized
+
+
+def _local_service_worker_environment_pairs(
+    *, compose_file: Path | None = None
+) -> dict[str, str | None] | None:
+    """Parse the worker service's Compose ``environment:`` key->raw-value pairs.
+
+    Single source of truth for both the worker env KEY allowlist
+    (:func:`local_service_worker_environment_keys`) and the materialized worker
+    env (:func:`local_service_worker_environment`). Mapping values are kept as
+    declared (interpolated later); a bare list-form entry (``- KEY``) maps to
+    ``None`` meaning "forward the host value". ``None`` when the compose asset
+    cannot be located/parsed.
+    """
+
     resolved = compose_file
     if resolved is None:
         resolved = _local_service_asset_path(LOCAL_SERVICE_INCLUDED_COMPOSE_FILE)
@@ -357,48 +421,55 @@ def local_service_worker_environment_keys(
     if not isinstance(data, Mapping):
         return None
 
-    keys: set[str] = set()
+    pairs: dict[str, str | None] = {}
     services = data.get("services")
     if isinstance(services, Mapping):
         worker = services.get("worker")
         if isinstance(worker, Mapping):
             # Primary source: the worker's own ``environment`` block. PyYAML's
             # SafeLoader expands ``<<: *awf-service`` so this already carries the
-            # ``&awf-environment`` anchor keys.
-            _collect_compose_environment_keys(worker.get("environment"), keys)
-    if not keys:
+            # ``&awf-environment`` anchor entries.
+            _collect_compose_environment_pairs(worker.get("environment"), pairs)
+    if not pairs:
         # Robust fallback for loaders that leave ``<<`` unexpanded (so the worker
-        # block above yielded nothing): union the ``environment`` keys from every
+        # block above yielded nothing): union the ``environment`` entries from every
         # top-level ``x-*`` extension template -- the ``x-awf-service`` anchor the
-        # worker uses. Gated on the primary path finding no keys so an unrelated
+        # worker uses. Gated on the primary path finding no entries so an unrelated
         # future ``x-*`` template (e.g. an ``x-debug-service`` for a non-worker
         # service) cannot silently widen the worker's secret-lease allowlist.
         # Intentionally does NOT walk arbitrary services (avoids pulling in
         # postgres/console env keys the worker never receives).
         for key, value in data.items():
             if isinstance(key, str) and key.startswith("x-") and isinstance(value, Mapping):
-                _collect_compose_environment_keys(value.get("environment"), keys)
+                _collect_compose_environment_pairs(value.get("environment"), pairs)
 
-    if not keys:
+    if not pairs:
         return None
-    return frozenset(keys)
+    return pairs
 
 
-def _collect_compose_environment_keys(environment: object, keys: set[str]) -> None:
-    """Collect Compose ``environment:`` key names from mapping or list shapes."""
+def _collect_compose_environment_pairs(environment: object, pairs: dict[str, str | None]) -> None:
+    """Collect Compose ``environment:`` key->raw-value pairs from mapping or list shapes.
+
+    Mapping values are kept verbatim (coerced to ``str``; a YAML null stays
+    ``None``). A list ``KEY=value`` entry keeps ``value``; a bare ``KEY`` entry
+    maps to ``None`` (Compose forwards the host value unchanged).
+    """
 
     if isinstance(environment, Mapping):
-        for key in environment:
+        for key, value in environment.items():
             if isinstance(key, str):
-                keys.add(key)
+                pairs[key] = None if value is None else str(value)
         return
     if isinstance(environment, Sequence) and not isinstance(environment, str | bytes | bytearray):
         for item in environment:
             if not isinstance(item, str):
                 continue
-            name = item.split("=", 1)[0].strip()
-            if name:
-                keys.add(name)
+            name, separator, value = item.partition("=")
+            name = name.strip()
+            if not name:
+                continue
+            pairs[name] = value if separator else None
 
 
 def resolve_local_service_provider_environ(

--- a/src/awf/service/config.py
+++ b/src/awf/service/config.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import cast
 
+import yaml
 from sqlalchemy.engine import make_url
 
 from awf.common.config import (
@@ -60,6 +61,7 @@ __all__ = [
     "LOCAL_SERVICE_INCLUDED_COMPOSE_FILE",
     "ServiceSettings",
     "local_service_environ",
+    "local_service_worker_environment_keys",
     "resolve_local_service_compose_env_file",
     "resolve_local_service_provider_environ",
     "resolve_service_settings",
@@ -327,6 +329,73 @@ def local_service_environ(
     _populate_compose_postgres_password(merged)
     _populate_local_compose_defaults(merged)
     return merged
+
+
+def local_service_worker_environment_keys(
+    *, compose_file: Path | None = None
+) -> frozenset[str] | None:
+    """Return the env var NAMES the worker container is launched with.
+
+    The worker's secret-lease resolver only sees variables defined on the
+    local-service Compose ``environment:`` block (the worker service inherits the
+    shared ``&awf-environment`` anchor via ``<<: *awf-service``), NOT every
+    caller-shell export. Returns those mapping KEYS -- the real worker env
+    allowlist -- parsed from the canonical ``docker/compose/local-service.yml``.
+    ``None`` when the compose asset cannot be located/parsed (caller falls back
+    to the unrestricted merged view, preserving legacy behavior).
+    """
+
+    resolved = compose_file
+    if resolved is None:
+        resolved = _local_service_asset_path(LOCAL_SERVICE_INCLUDED_COMPOSE_FILE)
+    if resolved is None or not resolved.exists():
+        return None
+    try:
+        data = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return None
+    if not isinstance(data, Mapping):
+        return None
+
+    keys: set[str] = set()
+    services = data.get("services")
+    if isinstance(services, Mapping):
+        worker = services.get("worker")
+        if isinstance(worker, Mapping):
+            # Primary source: the worker's own ``environment`` block. PyYAML's
+            # SafeLoader expands ``<<: *awf-service`` so this already carries the
+            # ``&awf-environment`` anchor keys.
+            _collect_compose_environment_keys(worker.get("environment"), keys)
+    # Robust fallback that does not depend on merge-key expansion: union the
+    # ``environment`` keys from every top-level ``x-*`` extension template (the
+    # ``x-awf-service`` anchor the worker uses). This captures the anchor keys
+    # even if a loader leaves ``<<`` unexpanded. Intentionally do NOT walk
+    # arbitrary services (avoids pulling in postgres/console env keys the worker
+    # never receives).
+    for key, value in data.items():
+        if isinstance(key, str) and key.startswith("x-") and isinstance(value, Mapping):
+            _collect_compose_environment_keys(value.get("environment"), keys)
+
+    if not keys:
+        return None
+    return frozenset(keys)
+
+
+def _collect_compose_environment_keys(environment: object, keys: set[str]) -> None:
+    """Collect Compose ``environment:`` key names from mapping or list shapes."""
+
+    if isinstance(environment, Mapping):
+        for key in environment:
+            if isinstance(key, str):
+                keys.add(key)
+        return
+    if isinstance(environment, Sequence) and not isinstance(environment, str | bytes | bytearray):
+        for item in environment:
+            if not isinstance(item, str):
+                continue
+            name = item.split("=", 1)[0].strip()
+            if name:
+                keys.add(name)
 
 
 def resolve_local_service_provider_environ(

--- a/src/awf/service/environment.py
+++ b/src/awf/service/environment.py
@@ -449,6 +449,18 @@ def _strip_compose_inline_comment(raw_value: str) -> str:
     return raw_value
 
 
+def compose_expand_value(value: str, *, environ: Mapping[str, str]) -> str:
+    """Expand a Compose ``${VAR:-default}`` expression against ``environ``.
+
+    Public wrapper over the env-file value interpolator so callers outside this
+    module (e.g. the worker-environment materializer) can resolve a Compose
+    ``environment:`` value to what Docker Compose would inject, without reaching
+    into the private helper.
+    """
+
+    return _compose_expand_env_value(value, caller_environ=environ, values={})
+
+
 def _compose_expand_env_value(
     value: str,
     *,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shlex
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
@@ -526,9 +527,24 @@ def _is_postgres_database_url(database_url: str) -> bool:
     return False
 
 
-def _service_git_environment(host_home: Path, *, github_token: str | None = None) -> dict[str, str]:
-    """Git/SSH environment for service-worker host repository operations."""
+def _service_git_environment(
+    host_home: Path,
+    *,
+    github_token: str | None = None,
+    source_env: Mapping[str, str] | None = None,
+) -> dict[str, str]:
+    """Git/SSH environment for service-worker host repository operations.
 
+    ``source_env`` is the process environment the Bitbucket/SSH wiring inspects for
+    credentials and the agent socket. It defaults to ``os.environ`` — what the real
+    worker sees inside the service container (Compose-forwarded vars). Callers that
+    run from a *different* process context (e.g. ``awf profile doctor`` from the
+    operator shell) pass the worker's forwarded env explicitly so the
+    Bitbucket-conditional additions match what the worker would inject, rather than
+    silently reading the caller shell.
+    """
+
+    resolved_source: Mapping[str, str] = os.environ if source_env is None else source_env
     env = {"HOME": str(host_home)}
     _add_git_config_entries(env, (("safe.directory", "*"),))
     if github_token:
@@ -544,13 +560,13 @@ def _service_git_environment(host_home: Path, *, github_token: str | None = None
             ),
         )
     # Bitbucket git-over-HTTPS auth, host-scoped to bitbucket.org so the GitHub
-    # path above is byte-for-byte unchanged. Reads the live process environment
-    # (where ``BitbucketClient.from_env`` also reads its credentials) and never
-    # places the token in any returned env value — git invokes the helper, which
-    # reads the secret from the environment on demand.
-    apply_bitbucket_git_auth(env, os.environ)
+    # path above is byte-for-byte unchanged. Reads ``source_env`` (the live process
+    # environment by default, where ``BitbucketClient.from_env`` also reads its
+    # credentials) and never places the token in any returned env value — git
+    # invokes the helper, which reads the secret from the environment on demand.
+    apply_bitbucket_git_auth(env, resolved_source)
     ssh_command = ["ssh"]
-    if ssh_auth_sock := os.environ.get("SSH_AUTH_SOCK"):
+    if ssh_auth_sock := resolved_source.get("SSH_AUTH_SOCK"):
         env["SSH_AUTH_SOCK"] = ssh_auth_sock
         ssh_command.extend(["-o", f"IdentityAgent={ssh_auth_sock}"])
     ssh_config = host_home / ".ssh" / "config"

--- a/tests/unit/cli/test_profile_doctor_command.py
+++ b/tests/unit/cli/test_profile_doctor_command.py
@@ -1033,6 +1033,69 @@ def test_doctor_falls_back_to_merged_view_when_allowlist_unavailable(
     assert host_env["ANTHROPIC_API_KEY"] == "y"
 
 
+def test_doctor_mirrors_worker_git_env_into_host_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The doctor must mirror ALL worker-injected git env, not just the GH tokens.
+
+    ``build_worker_runtime`` calls ``_apply_service_git_environment(git_env)`` --
+    ``os.environ.update(git_env)`` -- BEFORE constructing its
+    ``LocalSecretLeaseMountResolver(host_env=os.environ)``. So the worker's real
+    lease env carries every key ``_service_git_environment`` injects after Compose
+    startup -- notably ``HOME`` (= ``host_home``) -- none of which live on the
+    Compose ``environment:`` allowlist. A ``provider: env`` lease satisfiable only
+    by such a worker-injected source (e.g. ``HOME``) provisioning would satisfy
+    must NOT be falsely reported as ``SECRET_LEASE_SOURCE_MISSING``, so the doctor
+    must forward the same ``git_env`` (overriding the allowlisted view, exactly as
+    ``os.environ.update`` does).
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    # The allowlisted view does not carry HOME; only the worker's git_env does.
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"ANTHROPIC_API_KEY": "y"},
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment_keys",
+        lambda: frozenset({"ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN"}),
+    )
+    host_home = tmp_path / "worker-host-home"
+    host_home.mkdir()
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(host_home),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    # HOME is injected by the worker's git_env even though it is not on the
+    # Compose allowlist, so the lease probe sees the same source the worker has.
+    assert host_env["HOME"] == str(host_home.expanduser().resolve())
+    # The allowlisted var still survives alongside the mirrored git_env.
+    assert host_env["ANTHROPIC_API_KEY"] == "y"
+
+
 def test_doctor_appears_in_profile_help() -> None:
     result = _runner.invoke(app, ["profile", "--help"])
     assert result.exit_code == 0

--- a/tests/unit/cli/test_profile_doctor_command.py
+++ b/tests/unit/cli/test_profile_doctor_command.py
@@ -1096,6 +1096,74 @@ def test_doctor_mirrors_worker_git_env_into_host_env(
     assert host_env["ANTHROPIC_API_KEY"] == "y"
 
 
+def test_doctor_mirrors_worker_injected_bitbucket_git_env(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Bitbucket-conditional git env is mirrored from the worker's forwarded env.
+
+    ``_service_git_environment`` adds ``GIT_TERMINAL_PROMPT`` and the bitbucket
+    ``GIT_CONFIG_*`` helper only when Bitbucket creds are visible in its
+    ``source_env``. The real worker reads its Compose-forwarded container env --
+    where ``BITBUCKET_API_TOKEN``/``BITBUCKET_EMAIL`` (both on the worker
+    ``environment:`` allowlist) arrive from ``docker/compose/.env`` -- so it injects
+    those keys. When the creds live ONLY in that env file and not the caller shell,
+    the doctor must feed the function the same allowlisted view (not the caller
+    os.environ) so the mirror includes the Bitbucket additions; otherwise a lease
+    satisfiable by those worker-injected keys is still falsely surfaced as
+    ``SECRET_LEASE_SOURCE_MISSING``.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    # Creds absent from the caller shell; present only in the merged Compose view.
+    monkeypatch.delenv("BITBUCKET_API_TOKEN", raising=False)
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"BITBUCKET_API_TOKEN": "bb_token", "BITBUCKET_EMAIL": "dev@example.com"},
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment_keys",
+        lambda: frozenset({"BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL"}),
+    )
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(tmp_path),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    # The worker would inject GIT_TERMINAL_PROMPT + the bitbucket helper from the
+    # forwarded creds; the mirror now reflects them despite the caller shell lacking
+    # the creds. The token never lands in any rendered git-config value (it stays in
+    # the BITBUCKET_API_TOKEN env entry the credential helper reads on demand).
+    assert host_env["GIT_TERMINAL_PROMPT"] == "0"
+    count = int(host_env["GIT_CONFIG_COUNT"])
+    config_keys = {host_env[f"GIT_CONFIG_KEY_{index}"] for index in range(count)}
+    config_values = {host_env[f"GIT_CONFIG_VALUE_{index}"] for index in range(count)}
+    assert "credential.https://bitbucket.org.helper" in config_keys
+    assert all("bb_token" not in value for value in config_values)
+
+
 def test_doctor_appears_in_profile_help() -> None:
     result = _runner.invoke(app, ["profile", "--help"])
     assert result.exit_code == 0

--- a/tests/unit/cli/test_profile_doctor_command.py
+++ b/tests/unit/cli/test_profile_doctor_command.py
@@ -296,10 +296,13 @@ def test_doctor_host_env_includes_service_compose_env_file_creds(
 def test_doctor_host_env_omits_token_when_settings_unset(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """No service token => the doctor forwards the shell env unchanged.
+    """No service token => the doctor does not inject a GH_TOKEN/GITHUB_TOKEN value.
 
-    A ``None`` ``settings.github_token`` must not inject empty GH_TOKEN/GITHUB_TOKEN
-    keys, which would otherwise mask a genuinely missing token source.
+    The worker container receives ``GH_TOKEN``/``GITHUB_TOKEN`` materialized as
+    ``""`` from Compose ``${...:-}`` when nothing is set, and the secret-lease
+    resolver treats an empty value as missing. A ``None`` ``settings.github_token``
+    must therefore leave them empty (not masked with a value), so a genuinely
+    missing token source is still surfaced as ``SECRET_LEASE_SOURCE_MISSING``.
     """
     captured: dict[str, object] = {}
 
@@ -317,12 +320,17 @@ def test_doctor_host_env_omits_token_when_settings_unset(
     )
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    # Pin the merged Compose env view so the absence assertion does not depend on
-    # a real docker/compose/.env that may carry GH_TOKEN/GITHUB_TOKEN; otherwise
-    # this guard would pass without the file and fail with it.
+    # Pin the merged Compose env view so the assertion does not depend on a real
+    # docker/compose/.env that may carry GH_TOKEN/GITHUB_TOKEN.
     monkeypatch.setattr(
         "awf.service.config.local_service_environ",
         lambda: {},
+    )
+    # The worker materializes GH_TOKEN/GITHUB_TOKEN as "" from Compose ${...:-}
+    # when nothing is set; model that empty materialized view.
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment",
+        lambda _merged_env: {"GH_TOKEN": "", "GITHUB_TOKEN": ""},
     )
     monkeypatch.setattr(
         "awf.service.config.resolve_service_settings",
@@ -339,8 +347,10 @@ def test_doctor_host_env_omits_token_when_settings_unset(
     assert result.exit_code == 0
     host_env = captured["host_env"]
     assert isinstance(host_env, dict)
-    assert "GH_TOKEN" not in host_env
-    assert "GITHUB_TOKEN" not in host_env
+    # A None service token must not mask a missing source: the tokens stay empty
+    # (treated as missing by the resolver), never populated with a value.
+    assert host_env["GH_TOKEN"] == ""
+    assert host_env["GITHUB_TOKEN"] == ""
 
 
 def test_doctor_forwards_configured_agent_runtime_image(
@@ -900,9 +910,15 @@ def test_doctor_drops_host_only_export_outside_worker_allowlist(
         "awf.service.config.local_service_environ",
         lambda: {"MY_CUSTOM_TOKEN": "x", "ANTHROPIC_API_KEY": "y"},
     )
+    # The materialized worker env only carries the worker ``environment:`` block
+    # keys, resolved from the merged view -- the host-only export is never on it.
     monkeypatch.setattr(
-        "awf.service.config.local_service_worker_environment_keys",
-        lambda: frozenset({"ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN"}),
+        "awf.service.config.local_service_worker_environment",
+        lambda merged_env: {
+            key: merged_env[key]
+            for key in ("ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN")
+            if key in merged_env
+        },
     )
     monkeypatch.setattr(
         "awf.service.config.resolve_service_settings",
@@ -958,8 +974,12 @@ def test_doctor_keeps_compose_env_allowlisted_var(
         },
     )
     monkeypatch.setattr(
-        "awf.service.config.local_service_worker_environment_keys",
-        lambda: frozenset({"BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL", "GH_TOKEN", "GITHUB_TOKEN"}),
+        "awf.service.config.local_service_worker_environment",
+        lambda merged_env: {
+            key: merged_env[key]
+            for key in ("BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL", "GH_TOKEN", "GITHUB_TOKEN")
+            if key in merged_env
+        },
     )
     monkeypatch.setattr(
         "awf.service.config.resolve_service_settings",
@@ -983,12 +1003,12 @@ def test_doctor_keeps_compose_env_allowlisted_var(
 def test_doctor_falls_back_to_merged_view_when_allowlist_unavailable(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """When the worker allowlist cannot be resolved, host_env keeps the merged view.
+    """When the materialized worker env cannot be resolved, host_env keeps the merged view.
 
     If the compose asset cannot be located/parsed,
-    ``local_service_worker_environment_keys`` returns ``None`` and the doctor
-    falls back to the unrestricted merged view -- preserving legacy behavior so
-    the preflight never crashes or over-fails.
+    ``local_service_worker_environment`` returns ``None`` and the doctor falls
+    back to the unrestricted merged view -- preserving legacy behavior so the
+    preflight never crashes or over-fails.
     """
     captured: dict[str, object] = {}
 
@@ -1009,8 +1029,8 @@ def test_doctor_falls_back_to_merged_view_when_allowlist_unavailable(
         lambda: {"MY_CUSTOM_TOKEN": "x", "ANTHROPIC_API_KEY": "y"},
     )
     monkeypatch.setattr(
-        "awf.service.config.local_service_worker_environment_keys",
-        lambda: None,
+        "awf.service.config.local_service_worker_environment",
+        lambda _merged_env: None,
     )
     monkeypatch.setattr(
         "awf.service.config.resolve_service_settings",
@@ -1063,14 +1083,18 @@ def test_doctor_mirrors_worker_git_env_into_host_env(
         "awf.common.git_remote.detect_repo_url_from_checkout",
         lambda _path: None,
     )
-    # The allowlisted view does not carry HOME; only the worker's git_env does.
+    # The materialized worker env does not carry HOME; only the worker's git_env does.
     monkeypatch.setattr(
         "awf.service.config.local_service_environ",
         lambda: {"ANTHROPIC_API_KEY": "y"},
     )
     monkeypatch.setattr(
-        "awf.service.config.local_service_worker_environment_keys",
-        lambda: frozenset({"ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN"}),
+        "awf.service.config.local_service_worker_environment",
+        lambda merged_env: {
+            key: merged_env[key]
+            for key in ("ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN")
+            if key in merged_env
+        },
     )
     host_home = tmp_path / "worker-host-home"
     host_home.mkdir()
@@ -1134,8 +1158,12 @@ def test_doctor_mirrors_worker_injected_bitbucket_git_env(
         lambda: {"BITBUCKET_API_TOKEN": "bb_token", "BITBUCKET_EMAIL": "dev@example.com"},
     )
     monkeypatch.setattr(
-        "awf.service.config.local_service_worker_environment_keys",
-        lambda: frozenset({"BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL"}),
+        "awf.service.config.local_service_worker_environment",
+        lambda merged_env: {
+            key: merged_env[key]
+            for key in ("BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL")
+            if key in merged_env
+        },
     )
     monkeypatch.setattr(
         "awf.service.config.resolve_service_settings",
@@ -1162,6 +1190,76 @@ def test_doctor_mirrors_worker_injected_bitbucket_git_env(
     config_values = {host_env[f"GIT_CONFIG_VALUE_{index}"] for index in range(count)}
     assert "credential.https://bitbucket.org.helper" in config_keys
     assert all("bb_token" not in value for value in config_values)
+
+
+def test_doctor_host_env_carries_materialized_compose_alias(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An aliased Compose default materialized by the worker reaches the lease host_env.
+
+    Regression for the PR #540 review note: the worker container receives
+    ``AWF_GITHUB_TOKEN`` populated from a host ``GH_TOKEN`` via
+    ``${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}``. The doctor must model
+    that materialized worker env -- not filter the pre-interpolation inputs -- so a
+    ``provider: env`` lease with ``ref: AWF_GITHUB_TOKEN`` provisioning satisfies is
+    not falsely reported as ``SECRET_LEASE_SOURCE_MISSING``.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    monkeypatch.delenv("AWF_GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    # Only GH_TOKEN is present in the merged Compose view -- the worker interpolates
+    # AWF_GITHUB_TOKEN/GITHUB_TOKEN from it.
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"GH_TOKEN": "ghp_alias"},
+    )
+
+    def _materialize(merged_env: dict[str, str]) -> dict[str, str]:
+        token = (
+            merged_env.get("AWF_GITHUB_TOKEN")
+            or merged_env.get("GH_TOKEN")
+            or merged_env.get("GITHUB_TOKEN")
+            or ""
+        )
+        return {"AWF_GITHUB_TOKEN": token, "GH_TOKEN": token, "GITHUB_TOKEN": token}
+
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment",
+        _materialize,
+    )
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(tmp_path),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    # The materialized alias reaches the lease probe even though its NAME is absent
+    # from the pre-interpolation host inputs (only GH_TOKEN was set).
+    assert host_env["AWF_GITHUB_TOKEN"] == "ghp_alias"
+    assert host_env["GITHUB_TOKEN"] == "ghp_alias"
+    assert host_env["GH_TOKEN"] == "ghp_alias"
 
 
 def test_doctor_appears_in_profile_help() -> None:

--- a/tests/unit/cli/test_profile_doctor_command.py
+++ b/tests/unit/cli/test_profile_doctor_command.py
@@ -869,6 +869,170 @@ def test_doctor_mirrors_cleared_docker_host_without_pinning_settings(
     assert docker_environ["DOCKER_CONFIG"] == "/svc/.docker"
 
 
+def test_doctor_drops_host_only_export_outside_worker_allowlist(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A host-only export not on the worker's env allowlist must NOT reach host_env.
+
+    The worker's ``LocalSecretLeaseMountResolver`` only sees variables on the
+    local-service Compose ``environment:`` block, not every caller-shell export.
+    A ``provider: env`` lease satisfiable only by a host-only variable (e.g.
+    ``MY_CUSTOM_TOKEN``) FAILS at provision with ``SECRET_LEASE_SOURCE_MISSING``,
+    so the doctor must drop it -- modelling host_env on the worker allowlist --
+    rather than falsely passing it from the over-inclusive merged shell view.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    # Merged view carries an allowlisted var and a host-only export outside it.
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"MY_CUSTOM_TOKEN": "x", "ANTHROPIC_API_KEY": "y"},
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment_keys",
+        lambda: frozenset({"ANTHROPIC_API_KEY", "GH_TOKEN", "GITHUB_TOKEN"}),
+    )
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(tmp_path),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    # Allowlisted var survives; the host-only export is dropped (matches the
+    # worker's provision-time SECRET_LEASE_SOURCE_MISSING).
+    assert host_env["ANTHROPIC_API_KEY"] == "y"
+    assert "MY_CUSTOM_TOKEN" not in host_env
+
+
+def test_doctor_keeps_compose_env_allowlisted_var(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An allowlisted var present only via the merged view must survive (no false negative).
+
+    PR #531 fixed a false negative where a var on the worker's Compose
+    ``environment:`` block but exported in the operator shell (not ``.env``) was
+    wrongly reported missing. The allowlist is a superset of ``.env`` for such
+    shell-exported allowlisted vars, so the doctor must keep them in host_env.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    # The merged view carries the bitbucket creds (shell-exported, allowlisted).
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {
+            "BITBUCKET_API_TOKEN": "bb_token",
+            "BITBUCKET_EMAIL": "dev@example.com",
+        },
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment_keys",
+        lambda: frozenset({"BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL", "GH_TOKEN", "GITHUB_TOKEN"}),
+    )
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(tmp_path),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    assert host_env["BITBUCKET_API_TOKEN"] == "bb_token"
+    assert host_env["BITBUCKET_EMAIL"] == "dev@example.com"
+
+
+def test_doctor_falls_back_to_merged_view_when_allowlist_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """When the worker allowlist cannot be resolved, host_env keeps the merged view.
+
+    If the compose asset cannot be located/parsed,
+    ``local_service_worker_environment_keys`` returns ``None`` and the doctor
+    falls back to the unrestricted merged view -- preserving legacy behavior so
+    the preflight never crashes or over-fails.
+    """
+    captured: dict[str, object] = {}
+
+    def _capture(*_args: object, **kwargs: object) -> dict:
+        captured.update(kwargs)
+        return _ok_report(str(tmp_path))
+
+    monkeypatch.setattr(
+        "awf.service.profile_doctor.collect_profile_doctor_report",
+        _capture,
+    )
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: None,
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"MY_CUSTOM_TOKEN": "x", "ANTHROPIC_API_KEY": "y"},
+    )
+    monkeypatch.setattr(
+        "awf.service.config.local_service_worker_environment_keys",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "awf.service.config.resolve_service_settings",
+        lambda: types.SimpleNamespace(
+            host_home=str(tmp_path),
+            github_token=None,
+            agent_runtime_image="awf-agent-runtime:latest",
+            docker_host="unix:///var/run/docker.sock",
+        ),
+    )
+
+    result = _runner.invoke(app, ["profile", "doctor", str(tmp_path)])
+
+    assert result.exit_code == 0
+    host_env = captured["host_env"]
+    assert isinstance(host_env, dict)
+    # Legacy behavior: the full merged view is preserved when the allowlist is
+    # unavailable (the doctor degrades safely rather than over-failing).
+    assert host_env["MY_CUSTOM_TOKEN"] == "x"
+    assert host_env["ANTHROPIC_API_KEY"] == "y"
+
+
 def test_doctor_appears_in_profile_help() -> None:
     result = _runner.invoke(app, ["profile", "--help"])
     assert result.exit_code == 0

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -1208,6 +1208,72 @@ def test_service_git_environment_unchanged_without_bitbucket_credentials(
     assert entries["credential.https://github.com.helper"] == "!gh auth git-credential"
 
 
+@pytest.mark.unit
+def test_service_git_environment_reads_bitbucket_and_ssh_from_source_env(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``source_env`` (not the caller os.environ) drives the Bitbucket/SSH wiring.
+
+    The real worker reads its Compose-forwarded container env; callers that run
+    from a different process context (``awf profile doctor``) pass that env via
+    ``source_env`` so the Bitbucket-conditional additions match the worker. Here
+    the creds and agent socket live ONLY in ``source_env`` and are absent from the
+    caller os.environ, yet the Bitbucket helper, GIT_TERMINAL_PROMPT, and the
+    SSH_AUTH_SOCK/GIT_SSH_COMMAND wiring are still emitted.
+    """
+    monkeypatch.delenv("BITBUCKET_API_TOKEN", raising=False)
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+
+    env = worker_mod._service_git_environment(
+        tmp_path / "host-home",
+        github_token="ghp_service_token",
+        source_env={
+            "BITBUCKET_API_TOKEN": "bb_token",
+            "BITBUCKET_EMAIL": "dev@example.com",
+            "SSH_AUTH_SOCK": "/run/host-services/ssh-auth.sock",
+        },
+    )
+
+    assert env["GIT_TERMINAL_PROMPT"] == "0"
+    count = int(env["GIT_CONFIG_COUNT"])
+    entries = {
+        env[f"GIT_CONFIG_KEY_{index}"]: env[f"GIT_CONFIG_VALUE_{index}"] for index in range(count)
+    }
+    assert "credential.https://bitbucket.org.helper" in entries
+    assert env["SSH_AUTH_SOCK"] == "/run/host-services/ssh-auth.sock"
+    assert "IdentityAgent=/run/host-services/ssh-auth.sock" in env["GIT_SSH_COMMAND"]
+
+
+@pytest.mark.unit
+def test_service_git_environment_source_env_overrides_caller_environ(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """An explicit ``source_env`` fully replaces os.environ for Bitbucket detection.
+
+    Bitbucket creds in the caller os.environ but absent from ``source_env`` must
+    NOT add the Bitbucket helper: the worker context modelled by ``source_env``
+    lacks them, so the doctor must not over-add keys the worker would not inject.
+    """
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "caller_token")
+    monkeypatch.setenv("BITBUCKET_EMAIL", "caller@example.com")
+
+    env = worker_mod._service_git_environment(
+        tmp_path / "host-home",
+        github_token="ghp_service_token",
+        source_env={},
+    )
+
+    assert "GIT_TERMINAL_PROMPT" not in env
+    count = int(env["GIT_CONFIG_COUNT"])
+    entries = {
+        env[f"GIT_CONFIG_KEY_{index}"]: env[f"GIT_CONFIG_VALUE_{index}"] for index in range(count)
+    }
+    assert not any("bitbucket.org" in key for key in entries)
+
+
 class _RecordingForgeClient:
     """Minimal ForgeClient stub that records aclose() calls."""
 

--- a/tests/unit/service/test_worker_environment_allowlist.py
+++ b/tests/unit/service/test_worker_environment_allowlist.py
@@ -153,17 +153,26 @@ def test_x_template_only_without_services_key(tmp_path: Path) -> None:
     )
 
 
-def test_ignores_non_string_and_empty_environment_entries(tmp_path: Path) -> None:
-    """Non-string keys/items and empty key names are skipped, not raised on."""
+def test_ignores_non_string_worker_environment_keys(tmp_path: Path) -> None:
+    """Non-string mapping keys on the worker block are skipped, not raised on."""
     compose_file = tmp_path / "local-service.yml"
-    # Mapping form with a non-string key alongside a valid one; the worker also
-    # carries a list-form is exercised in test_list_form_environment_supported.
     compose_file.write_text(
-        "services:\n"
-        "  worker:\n"
-        "    environment:\n"
-        "      GH_TOKEN: x\n"
-        "      123: numeric-key\n"
+        "services:\n  worker:\n    environment:\n      GH_TOKEN: x\n      123: numeric-key\n"
+    )
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys == frozenset({"GH_TOKEN"})
+
+
+def test_ignores_non_string_and_empty_list_entries_in_x_fallback(tmp_path: Path) -> None:
+    """Non-string list items and empty key names are skipped in the x-* fallback.
+
+    The fallback only runs when the worker block yields no keys, so this exercises
+    the list-form parser via an ``x-*`` template with no worker ``environment``.
+    """
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
         "x-awf-service:\n"
         "  environment:\n"
         "    - ANTHROPIC_API_KEY=value\n"
@@ -173,7 +182,38 @@ def test_ignores_non_string_and_empty_environment_entries(tmp_path: Path) -> Non
 
     keys = local_service_worker_environment_keys(compose_file=compose_file)
 
-    assert keys == frozenset({"GH_TOKEN", "ANTHROPIC_API_KEY"})
+    assert keys == frozenset({"ANTHROPIC_API_KEY"})
+
+
+def test_x_fallback_skipped_when_worker_environment_present(tmp_path: Path) -> None:
+    """An unrelated ``x-*`` env block must not widen the worker allowlist (PR #540).
+
+    Regression for the review note: the ``x-*`` fallback runs ONLY when the worker
+    block yields no keys (a loader that left ``<<`` unexpanded). When the worker's
+    ``environment`` already resolved via merge-key expansion, a future non-worker
+    extension template -- here ``x-debug-service`` -- must NOT leak its env keys
+    into the worker's secret-lease allowlist.
+    """
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
+        "x-awf-service: &awf-service\n"
+        "  environment: &awf-environment\n"
+        "    GH_TOKEN: ${GH_TOKEN:-}\n"
+        "x-debug-service:\n"
+        "  environment:\n"
+        "    DEBUG_ONLY_SECRET: ${DEBUG_ONLY_SECRET:-}\n"
+        "services:\n"
+        "  worker:\n"
+        "    <<: *awf-service\n"
+        '    command: sh -c "awf worker"\n'
+    )
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys is not None
+    assert "GH_TOKEN" in keys
+    # The unrelated x-debug-service env key never reaches the worker container.
+    assert "DEBUG_ONLY_SECRET" not in keys
 
 
 def test_real_local_service_yml_contains_expected_keys() -> None:

--- a/tests/unit/service/test_worker_environment_allowlist.py
+++ b/tests/unit/service/test_worker_environment_allowlist.py
@@ -1,0 +1,196 @@
+"""Tests for ``local_service_worker_environment_keys`` (issue #533).
+
+The doctor models its secret-lease ``host_env`` on the worker container's real
+env allowlist -- the KEYS of the worker service's Compose ``environment:`` block,
+NOT the bare caller shell. This guards that single-source-of-truth parser.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.service.config import local_service_worker_environment_keys
+
+pytestmark = pytest.mark.unit
+
+
+_ANCHORED_COMPOSE = """\
+name: awf-local-service
+
+x-awf-service: &awf-service
+  image: awf-control-plane:local
+  environment: &awf-environment
+    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+    BITBUCKET_API_TOKEN: ${BITBUCKET_API_TOKEN:-}
+    GH_TOKEN: ${GH_TOKEN:-}
+    AWF_AGENT_RUNTIME_IMAGE: ${AWF_AGENT_RUNTIME_IMAGE:-awf-agent-runtime:latest}
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_PASSWORD: secret
+  worker:
+    <<: *awf-service
+    command: sh -c "awf worker"
+  console:
+    image: awf-console:local
+    environment:
+      NODE_ENV: production
+"""
+
+
+def test_returns_worker_environment_keys_from_compose_file(tmp_path: Path) -> None:
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(_ANCHORED_COMPOSE)
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys is not None
+    # Worker inherits the &awf-environment anchor via ``<<: *awf-service``.
+    assert {
+        "ANTHROPIC_API_KEY",
+        "BITBUCKET_API_TOKEN",
+        "GH_TOKEN",
+        "AWF_AGENT_RUNTIME_IMAGE",
+    } <= keys
+    # Other services' env keys are NOT the worker's allowlist.
+    assert "POSTGRES_PASSWORD" not in keys
+    assert "NODE_ENV" not in keys
+
+
+def test_list_form_environment_supported(tmp_path: Path) -> None:
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
+        "services:\n"
+        "  worker:\n"
+        "    environment:\n"
+        "      - ANTHROPIC_API_KEY=value\n"
+        "      - GH_TOKEN\n"
+    )
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys is not None
+    assert {"ANTHROPIC_API_KEY", "GH_TOKEN"} <= keys
+
+
+def test_returns_none_when_compose_file_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.yml"
+
+    assert local_service_worker_environment_keys(compose_file=missing) is None
+
+
+def test_returns_none_on_malformed_yaml(tmp_path: Path) -> None:
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text("services: [unterminated\n")
+
+    assert local_service_worker_environment_keys(compose_file=compose_file) is None
+
+
+def test_returns_none_when_no_asset_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    # No explicit compose_file and no resolvable asset root -> None (caller then
+    # falls back to the unrestricted merged view, preserving legacy behavior).
+    monkeypatch.setattr(
+        "awf.service.config._local_service_asset_path",
+        lambda _path: None,
+    )
+
+    assert local_service_worker_environment_keys() is None
+
+
+def test_returns_none_on_unexpected_shape(tmp_path: Path) -> None:
+    # A worker with no environment block (and no x-* anchors) yields no keys.
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text("services:\n  worker:\n    command: sh -c 'true'\n")
+
+    assert local_service_worker_environment_keys(compose_file=compose_file) is None
+
+
+def test_returns_none_when_yaml_is_not_mapping(tmp_path: Path) -> None:
+    # A document that parses to a non-mapping (e.g. a list) yields no allowlist.
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text("- just\n- a\n- list\n")
+
+    assert local_service_worker_environment_keys(compose_file=compose_file) is None
+
+
+def test_unions_x_template_env_when_services_absent(tmp_path: Path) -> None:
+    """The x-* fallback supplies the allowlist even if the worker service is absent.
+
+    Mirrors a loader that leaves ``<<`` unexpanded: the robust fallback unions the
+    ``x-*`` extension template ``environment`` keys so the anchor keys are still
+    captured. Postgres env keys are excluded because only worker + x-* are walked.
+    """
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
+        "x-awf-service:\n"
+        "  environment:\n"
+        "    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}\n"
+        "    GH_TOKEN: ${GH_TOKEN:-}\n"
+        "services:\n"
+        "  postgres:\n"
+        "    environment:\n"
+        "      POSTGRES_PASSWORD: secret\n"
+    )
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys == frozenset({"ANTHROPIC_API_KEY", "GH_TOKEN"})
+
+
+def test_x_template_only_without_services_key(tmp_path: Path) -> None:
+    # No ``services`` mapping at all -> the x-* fallback is the sole source.
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
+        "x-awf-service:\n  environment:\n    GH_TOKEN: ${GH_TOKEN:-}\n",
+    )
+
+    assert local_service_worker_environment_keys(compose_file=compose_file) == frozenset(
+        {"GH_TOKEN"}
+    )
+
+
+def test_ignores_non_string_and_empty_environment_entries(tmp_path: Path) -> None:
+    """Non-string keys/items and empty key names are skipped, not raised on."""
+    compose_file = tmp_path / "local-service.yml"
+    # Mapping form with a non-string key alongside a valid one; the worker also
+    # carries a list-form is exercised in test_list_form_environment_supported.
+    compose_file.write_text(
+        "services:\n"
+        "  worker:\n"
+        "    environment:\n"
+        "      GH_TOKEN: x\n"
+        "      123: numeric-key\n"
+        "x-awf-service:\n"
+        "  environment:\n"
+        "    - ANTHROPIC_API_KEY=value\n"
+        "    - 456\n"
+        "    - =empty-name\n"
+    )
+
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert keys == frozenset({"GH_TOKEN", "ANTHROPIC_API_KEY"})
+
+
+def test_real_local_service_yml_contains_expected_keys() -> None:
+    """Guard the parse against future edits to the canonical compose file."""
+    repo_compose = Path(__file__).resolve().parents[3] / "docker/compose/local-service.yml"
+
+    keys = local_service_worker_environment_keys(compose_file=repo_compose)
+
+    assert keys is not None
+    assert {
+        "ANTHROPIC_API_KEY",
+        "BITBUCKET_API_TOKEN",
+        "BITBUCKET_EMAIL",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "AWF_AGENT_RUNTIME_IMAGE",
+    } <= keys
+    # The worker never receives the postgres/console service env keys.
+    assert "POSTGRES_PASSWORD" not in keys
+    assert "NODE_ENV" not in keys

--- a/tests/unit/service/test_worker_environment_allowlist.py
+++ b/tests/unit/service/test_worker_environment_allowlist.py
@@ -11,7 +11,10 @@ from pathlib import Path
 
 import pytest
 
-from awf.service.config import local_service_worker_environment_keys
+from awf.service.config import (
+    local_service_worker_environment,
+    local_service_worker_environment_keys,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -214,6 +217,106 @@ def test_x_fallback_skipped_when_worker_environment_present(tmp_path: Path) -> N
     assert "GH_TOKEN" in keys
     # The unrelated x-debug-service env key never reaches the worker container.
     assert "DEBUG_ONLY_SECRET" not in keys
+
+
+_ALIAS_COMPOSE = """\
+name: awf-local-service
+
+x-awf-service: &awf-service
+  image: awf-control-plane:local
+  environment: &awf-environment
+    AWF_SERVICE_NAME: awf
+    AWF_GITHUB_TOKEN: ${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}
+    GH_TOKEN: ${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}
+    GITHUB_TOKEN: ${AWF_GITHUB_TOKEN:-${GH_TOKEN:-${GITHUB_TOKEN:-}}}
+    ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+
+services:
+  worker:
+    <<: *awf-service
+    command: sh -c "awf worker"
+"""
+
+
+def test_materializes_aliased_default_from_host_alias(tmp_path: Path) -> None:
+    """An aliased Compose default is materialized from the host source it reads (PR #540).
+
+    The worker container receives ``AWF_GITHUB_TOKEN`` populated from ``GH_TOKEN``
+    via ``${AWF_GITHUB_TOKEN:-${GH_TOKEN:-...}}``, even though ``AWF_GITHUB_TOKEN``
+    is absent from the pre-interpolation inputs. A ``provider: env`` lease with
+    ``ref: AWF_GITHUB_TOKEN`` provisioning satisfies must therefore see the
+    materialized value, not be dropped as a missing input.
+    """
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(_ALIAS_COMPOSE)
+
+    materialized = local_service_worker_environment(
+        {"GH_TOKEN": "ghp_alias"}, compose_file=compose_file
+    )
+
+    assert materialized is not None
+    # All three GitHub aliases resolve from the single host GH_TOKEN, exactly as
+    # the worker container receives them.
+    assert materialized["AWF_GITHUB_TOKEN"] == "ghp_alias"
+    assert materialized["GH_TOKEN"] == "ghp_alias"
+    assert materialized["GITHUB_TOKEN"] == "ghp_alias"
+    # A literal value passes through; an unset optional resolves to empty string
+    # (the worker receives ``""``, which the secret-lease resolver treats as
+    # missing -- so keeping it does not weaken the signal).
+    assert materialized["AWF_SERVICE_NAME"] == "awf"
+    assert materialized["ANTHROPIC_API_KEY"] == ""
+
+
+def test_materializes_direct_value_from_merged_env(tmp_path: Path) -> None:
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(_ALIAS_COMPOSE)
+
+    materialized = local_service_worker_environment(
+        {"ANTHROPIC_API_KEY": "sk-real"}, compose_file=compose_file
+    )
+
+    assert materialized is not None
+    assert materialized["ANTHROPIC_API_KEY"] == "sk-real"
+
+
+def test_materialization_keys_match_allowlist(tmp_path: Path) -> None:
+    """The materialized env exposes exactly the worker allowlist KEYS."""
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(_ALIAS_COMPOSE)
+
+    materialized = local_service_worker_environment({}, compose_file=compose_file)
+    keys = local_service_worker_environment_keys(compose_file=compose_file)
+
+    assert materialized is not None
+    assert keys is not None
+    assert frozenset(materialized) == keys
+
+
+def test_materialization_returns_none_when_compose_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.yml"
+
+    assert local_service_worker_environment({}, compose_file=missing) is None
+
+
+def test_bare_list_entry_forwards_present_host_value_and_omits_unset(tmp_path: Path) -> None:
+    """A bare ``- KEY`` list entry forwards the host value, omitting it when unset.
+
+    Compose passes a bare environment entry through from the host unchanged and
+    leaves it unset in the container when the host does not export it.
+    """
+    compose_file = tmp_path / "local-service.yml"
+    compose_file.write_text(
+        "services:\n  worker:\n    environment:\n      - GH_TOKEN\n      - GITHUB_TOKEN\n"
+    )
+
+    materialized = local_service_worker_environment(
+        {"GH_TOKEN": "ghp_host"}, compose_file=compose_file
+    )
+
+    assert materialized is not None
+    assert materialized["GH_TOKEN"] == "ghp_host"
+    # GITHUB_TOKEN is not set on the host, so the worker never receives it.
+    assert "GITHUB_TOKEN" not in materialized
 
 
 def test_real_local_service_yml_contains_expected_keys() -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_dfee38d95dd64f9195f44a23` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Implement issue #533: make `awf profile doctor` model its `host_env` on the worker container's ACTUAL env allowlist (the compose `environment:` block), so a `provider: env` secret lease that is only satisfiable from a host-only shell export does NOT falsely pass doctor.

PROBLEM: In `src/awf/cli/profile_smoke_commands.py` the doctor builds `host_env = dict(local_service_environ())` (around line 99). `local_service_environ()` over-includes the full caller `os.environ`. But at provision time the worker's `LocalSecretLeaseMountResolver` only sees variables defined on the local-service Compose `environment:` block (plus explicit settings overrides), NOT every export in the operator shell. So a `provider: env` lease satisfied only by a host-only variable PASSES doctor but FAILS at provision with `SECRET_LEASE_SOURCE_MISSING`. Doctor must match what the worker actually receives.

APPROACH (specified — follow it carefully):
- Model the doctor's effective `host_env` for secret-lease evaluation on the worker container's real env allowlist: the compose `environment:` block the worker is launched with, plus explicit settings overrides (e.g. github_token → GH_TOKEN/GITHUB_TOKEN as already done), NOT the bare caller shell.
- Find the single source of truth for that allowlist (the compose generation / the worker's `raw_service_env` construction — see `src/awf/profiles/compose.py`, `src/awf/node/secret_mounts.py`, `src/awf/service/profile_doctor.py`) and reuse it. Do not duplicate the allowlist.
- CRITICAL: do NOT just narrow to a `.env`-only view. The deferral note warns a quick `.env`-only narrowing reintroduces the false-NEGATIVE that the original PR (#531) fixed (vars that ARE on the compose env but not in `.env`). The correct set is the worker's compose `environment:` allowlist (a superset of `.env` in the relevant cases).
- Net effect: a lease satisfiable only by a host-only export now surfaces as a doctor finding (matching the provision-time `SECRET_LEASE_SOURCE_MISSING`), while a lease satisfiable from the real worker env still passes.

REQUIREMENTS:
- Keep the non-secret-lease parts of the doctor (e.g. Docker host resolution from the merged view) working as today; only the secret-lease source evaluation should switch to the worker allowlist if those concerns are separable. If they share `host_env`, ensure the Docker-host resolution still sees what it needs.
- Full test coverage (~99% enforced): a host-only-export lease now fails doctor (matches provision); a compose-`environment:`-satisfied lease still passes; a `.env`-only var that the worker DOES receive still passes (no false negative); the Docker-host resolution path is unaffected.

SCOPE GUARDS:
- Do NOT modify `.github/workflows/**` or `.awf/workspace.yml`.
- Reuse the existing worker env allowlist source; do not invent a new one.
- Reference #533 in the PR. Full context is in the issue and the linked review thread.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes preflight secret-lease semantics (fewer false passes, more accurate alias handling); behavior is well-covered by tests but affects operator onboarding signals.
> 
> **Overview**
> Aligns **`awf profile doctor`** secret-lease checks with what the **local service worker** actually sees, instead of the full merged operator shell.
> 
> **Secret lease `host_env`** is built from a **materialized Compose worker environment** parsed from `docker/compose/local-service.yml` (`local_service_worker_environment`), with `${VAR:-...}` interpolation via new **`compose_expand_value`**, so aliased keys like `AWF_GITHUB_TOKEN` from `GH_TOKEN` match provisioning. Host-only exports **not** on the worker `environment:` block are **dropped** (fixes false passes vs `SECRET_LEASE_SOURCE_MISSING`). The doctor then **overlays** the same **`_service_git_environment`** keys the worker injects (`HOME`, Bitbucket git config, tokens), using optional **`source_env`** so Bitbucket creds from `.env` only are modeled correctly.
> 
> **Docker / agent image probes** still use the full **`merged_env`** from `local_service_environ`; only lease evaluation uses the restricted env. Falls back to merged env if compose parsing fails.
> 
> Adds unit tests for the allowlist parser, doctor wiring, and `_service_git_environment` `source_env` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 691cdcf7161f4352655675fecdb37e9d8c1769e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->