### PR TITLE
Forge detection at awf init, not host setup (#539)

### DIFF
--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -230,11 +230,18 @@ def _run_init_project_onboarding(
             typer.echo(f"error: {exc}", err=True)
             raise typer.Exit(code=1) from None
 
-    forge_block = _detect_project_forge_auth(
-        repository,
-        settings=settings,
-        service_env=service_env,
-    )
+    try:
+        forge_block = _detect_project_forge_auth(
+            repository,
+            settings=settings,
+            service_env=service_env,
+        )
+    except Exception:
+        # Forge auth is a diagnostic, never a gate: an unexpected error reading
+        # provider settings or an unusual git setup must downgrade to a neutral
+        # block rather than abort `awf init`. Preserves the "NEVER block"
+        # onboarding invariant unconditionally.
+        forge_block = _neutral_forge_block()
 
     mode = "guided" if effective_guided else "write" if should_write else "preview"
     payload = _init_project_onboarding_payload(

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -37,10 +37,17 @@ _ENV_COMMENT_KEY_IGNORE_WORDS = frozenset({"awf"})
 # Bitbucket env-auth contract verified at ``awf init`` for bitbucket.org repos
 # (issue #539). These names mirror the private constants in
 # ``awf.common.git_auth``; kept local so init_ops does not import private symbols.
+_BITBUCKET_TOKEN_ENV = "BITBUCKET_API_TOKEN"
+_BITBUCKET_EMAIL_ENV = "BITBUCKET_EMAIL"
+_BITBUCKET_AUTH_MODE_ENV = "BITBUCKET_AUTH_MODE"
+_BITBUCKET_BEARER_MODE = "bearer"
+# All three keys are *reported* (present/absent) for diagnostics, but only the
+# token (always) and email (default ``basic`` mode only) are actually *required* —
+# see :func:`_bitbucket_required_auth_keys`.
 _BITBUCKET_AUTH_ENV_KEYS: tuple[str, ...] = (
-    "BITBUCKET_API_TOKEN",
-    "BITBUCKET_EMAIL",
-    "BITBUCKET_AUTH_MODE",
+    _BITBUCKET_TOKEN_ENV,
+    _BITBUCKET_EMAIL_ENV,
+    _BITBUCKET_AUTH_MODE_ENV,
 )
 
 
@@ -537,17 +544,40 @@ def _detect_github_forge_auth(
     return auth, gh_present and readiness == "ok"
 
 
+def _bitbucket_required_auth_keys(env: Mapping[str, str]) -> tuple[str, ...]:
+    """Return the ``BITBUCKET_*`` env keys actually required for the configured mode.
+
+    Mirrors :func:`awf.common.git_auth.bitbucket_credentials_present`:
+    ``BITBUCKET_API_TOKEN`` is always required; ``BITBUCKET_EMAIL`` only in the
+    default ``basic`` mode (``BITBUCKET_AUTH_MODE=bearer`` authenticates with the
+    token alone). ``BITBUCKET_AUTH_MODE`` is an optional selector that defaults to
+    ``basic`` and is never itself required. Any unrecognized mode is treated
+    conservatively as ``basic`` (requiring the email).
+    """
+    mode = (env.get(_BITBUCKET_AUTH_MODE_ENV) or "basic").strip().lower()
+    if mode == _BITBUCKET_BEARER_MODE:
+        return (_BITBUCKET_TOKEN_ENV,)
+    return (_BITBUCKET_TOKEN_ENV, _BITBUCKET_EMAIL_ENV)
+
+
 def _detect_bitbucket_forge_auth(
     service_env: Mapping[str, str] | None,
 ) -> tuple[dict[str, object], bool]:
-    """Verify the three ``BITBUCKET_*`` env keys; name exactly which are missing.
+    """Verify the *required* ``BITBUCKET_*`` env keys; name exactly which are missing.
 
-    Never mentions gh — a bitbucket.org repo does not need the GitHub CLI. Falls
-    back to ``os.environ`` when the resolved service env is unavailable.
+    Mirrors the real auth contract (:func:`bitbucket_credentials_present`):
+    ``BITBUCKET_API_TOKEN`` is always required, ``BITBUCKET_EMAIL`` only in the
+    default ``basic`` auth mode, and ``BITBUCKET_AUTH_MODE`` is an optional selector
+    that is never itself required — so a token+email basic-mode workspace that omits
+    it is correctly reported as ``auth_ok`` rather than flagged as incomplete.
+    Presence of all three keys is still surfaced for diagnostics. Never mentions
+    gh — a bitbucket.org repo does not need the GitHub CLI. Falls back to
+    ``os.environ`` when the resolved service env is unavailable.
     """
     env = service_env if service_env is not None else os.environ
     present = {key: bool(env.get(key)) for key in _BITBUCKET_AUTH_ENV_KEYS}
-    missing = [key for key in _BITBUCKET_AUTH_ENV_KEYS if not present[key]]
+    required = _bitbucket_required_auth_keys(env)
+    missing = [key for key in required if not present[key]]
     auth: dict[str, object] = {"bitbucket_keys": present, "missing": missing}
     return auth, not missing
 
@@ -645,10 +675,9 @@ def _forge_guidance_lines(forge_block: Mapping[str, object]) -> list[str]:
             names = ", ".join(str(key) for key in missing)
             bitbucket_lines.append(f"  - Set the missing Bitbucket auth env in .env: {names}.")
         else:
-            bitbucket_lines.append(
-                "  - Bitbucket auth env present: "
-                "BITBUCKET_API_TOKEN, BITBUCKET_EMAIL, BITBUCKET_AUTH_MODE."
-            )
+            present_keys = _mapping_value(auth.get("bitbucket_keys"))
+            names = ", ".join(key for key in _BITBUCKET_AUTH_ENV_KEYS if present_keys.get(key))
+            bitbucket_lines.append(f"  - Bitbucket auth env present: {names}.")
         return bitbucket_lines
 
     if forge_block.get("host_detected"):

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -763,17 +763,28 @@ def _detect_project_forge_auth(
     readiness layer (issue #539). Reuses the existing detection seam
     (``detect_repo_url_from_checkout`` -> ``forge``); an explicit ``forge:`` pinned
     in an on-disk ``.awf/workspace.yml`` (via :func:`_explicit_project_forge`) is
-    honored over the URL host through ``concrete_forge_for_repo``. Missing matching
-    auth is reported as a WARNING and never blocks, preserving the invariant that
-    mocked smoke needs no live forge access. The returned dict is structured and
-    secret-free (the raw remote URL is reduced to its credential-free host).
+    honored over the URL host through ``concrete_forge_for_repo`` — and wins even
+    with no ``origin`` remote at all, so an already-onboarded repo pinning
+    ``forge: bitbucket``/``github`` still gets its forge-specific auth check instead
+    of the neutral no-remote block. Only a checkout with neither an ``origin`` remote
+    nor a concrete pin stays neutral. Missing matching auth is reported as a WARNING
+    and never blocks, preserving the invariant that mocked smoke needs no live forge
+    access. The returned dict is structured and secret-free (the raw remote URL is
+    reduced to its credential-free host).
     """
     from awf.common.forge import concrete_forge_for_repo, detect_forge_from_url
     from awf.common.git_remote import detect_repo_url_from_checkout
 
     repo_url = detect_repo_url_from_checkout(repository)
-    if repo_url is None:
-        # No ``origin`` remote: stay neutral, assume no forge, never block.
+    # Read the explicit ``forge:`` pin up front: documented precedence is explicit
+    # ``forge:`` > URL host > github, so a pinned profile wins even when there is no
+    # URL host. With no ``origin`` remote *and* no concrete pin we stay neutral, but
+    # a repo pinning ``forge: bitbucket``/``github`` must still get its forge-specific
+    # auth check rather than the neutral no-remote block that skips it (PR #541 review).
+    explicit_forge = _explicit_project_forge(repository)
+    if repo_url is None and explicit_forge not in ("bitbucket", "github"):
+        # No ``origin`` remote and no explicit forge pin: stay neutral, assume no
+        # forge, never block.
         return _neutral_forge_block()
 
     # When the caller could not resolve the Compose ``.env``-merged service env
@@ -796,11 +807,12 @@ def _detect_project_forge_auth(
         except (OSError, UnicodeDecodeError, ComposeEnvInterpolationError):
             service_env = None
 
-    explicit_forge = _explicit_project_forge(repository)
     forge = concrete_forge_for_repo(explicit_forge, repo_url)
     # ``host_detected`` distinguishes a recognized host from an unknown host
-    # (GHE/GitLab/self-hosted) that ``forge.py`` defaults to github.
-    host_detected = detect_forge_from_url(repo_url) is not None
+    # (GHE/GitLab/self-hosted) that ``forge.py`` defaults to github. With no
+    # ``origin`` URL to parse (a pinned-forge checkout) there is no host to
+    # recognize, so it stays ``False`` and ``host`` stays ``None``.
+    host_detected = repo_url is not None and detect_forge_from_url(repo_url) is not None
 
     if forge == "bitbucket":
         auth, auth_ok = _detect_bitbucket_forge_auth(service_env)
@@ -808,7 +820,7 @@ def _detect_project_forge_auth(
         auth, auth_ok = _detect_github_forge_auth(settings=settings, service_env=service_env)
 
     return {
-        "host": _redacted_remote_host(repo_url),
+        "host": _redacted_remote_host(repo_url) if repo_url is not None else None,
         "forge": forge,
         "host_detected": host_detected,
         "auth": auth,
@@ -851,6 +863,11 @@ def _forge_guidance_lines(forge_block: Mapping[str, object]) -> list[str]:
 
     if forge_block.get("host_detected"):
         github_lines = ["Detected forge: github."]
+    elif forge_block.get("host") is None:
+        # No ``origin`` URL host to recognize: github came from an explicit
+        # ``forge: github`` pin (a hostless checkout with no pin stays neutral and
+        # never reaches here), so it is not an unrecognized-host default.
+        github_lines = ["Detected forge: github (pinned in .awf/workspace.yml)."]
     else:
         github_lines = [
             f"Forge host {forge_block.get('host')!r} not recognized; defaulting to "

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -666,6 +666,21 @@ def _detect_project_forge_auth(
         # No ``origin`` remote: stay neutral, assume no forge, never block.
         return _neutral_forge_block()
 
+    # When the caller could not resolve the Compose ``.env``-merged service env
+    # (e.g. ``local_service_environ`` itself raised during onboarding collection,
+    # which runs after settings resolve), recompute it here so forge auth verifies
+    # the same merged view doctor/status use — otherwise a token present only in
+    # root ``.env`` is wrongly reported missing/unverified (PR #541 review).
+    # Guarded: a second failure degrades to ``None`` and the per-forge
+    # ``os.environ`` fallback, never aborting the diagnostic.
+    if service_env is None:
+        from awf.service.config import local_service_environ
+
+        try:
+            service_env = local_service_environ()
+        except (OSError, UnicodeDecodeError):
+            service_env = None
+
     explicit_forge = _explicit_project_forge(repository)
     forge = concrete_forge_for_repo(explicit_forge, repo_url)
     # ``host_detected`` distinguishes a recognized host from an unknown host

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -583,7 +583,11 @@ def _detect_bitbucket_forge_auth(
     ``os.environ`` when the resolved service env is unavailable.
     """
     env = service_env if service_env is not None else os.environ
-    present = {key: bool(env.get(key)) for key in _BITBUCKET_AUTH_ENV_KEYS}
+    # Strip before the presence check so a whitespace-only value is treated as
+    # absent, mirroring ``bitbucket_credentials_present`` (which strips token and
+    # email before testing). Otherwise a whitespace-only ``BITBUCKET_*`` value would
+    # report ``auth_ok`` with no missing keys while runtime auth still fails.
+    present = {key: bool((env.get(key) or "").strip()) for key in _BITBUCKET_AUTH_ENV_KEYS}
     required = _bitbucket_required_auth_keys(env)
     missing = [key for key in required if not present[key]]
     auth: dict[str, object] = {"bitbucket_keys": present, "missing": missing}

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -247,8 +247,10 @@ def _run_init_project_onboarding(
         # Forge auth is a diagnostic, never a gate: an unexpected error reading
         # provider settings or an unusual git setup must downgrade to a neutral
         # block rather than abort `awf init`. Preserves the "NEVER block"
-        # onboarding invariant unconditionally.
-        forge_block = _neutral_forge_block()
+        # onboarding invariant unconditionally. Use the detection-error block (not
+        # the no-origin neutral block) so guidance never claims the remote is
+        # missing when probing merely failed.
+        forge_block = _forge_detection_error_block()
 
     mode = "guided" if effective_guided else "write" if should_write else "preview"
     payload = _init_project_onboarding_payload(
@@ -521,6 +523,20 @@ def _neutral_forge_block() -> dict[str, object]:
     }
 
 
+def _forge_detection_error_block() -> dict[str, object]:
+    """Return the forge block used when forge detection raised unexpectedly.
+
+    Distinct from :func:`_neutral_forge_block` (the deliberate no-``origin``-remote
+    case): here an ``origin`` remote may well exist but probing failed for another
+    reason (an IO/config error reading provider settings, an unusual git setup).
+    Carries the same never-blocking shape but flags ``detection_error`` so the
+    guidance does not wrongly tell the user to add a remote that already exists.
+    """
+    block = _neutral_forge_block()
+    block["detection_error"] = True
+    return block
+
+
 def _detect_github_forge_auth(
     *, settings: Any, service_env: Mapping[str, str] | None
 ) -> tuple[dict[str, object], bool]:
@@ -675,6 +691,11 @@ def _forge_guidance_lines(forge_block: Mapping[str, object]) -> list[str]:
     """Return forge-scoped Next-step guidance lines (WARNING text never blocks)."""
     forge = forge_block.get("forge")
     if forge is None:
+        if forge_block.get("detection_error"):
+            return [
+                "Forge auth check could not run (an unexpected error occurred); this "
+                "never blocks onboarding. Re-run `awf init <path>` to retry.",
+            ]
         return [
             "No `origin` remote detected; forge auth check skipped. Add a git "
             "remote, then re-run `awf init <path>` to verify forge auth.",

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -530,6 +530,14 @@ def _detect_github_forge_auth(
     separately: a gh CLI installed but unauthenticated is ``gh_present=True`` with
     ``github_readiness="fail"``. Readiness degrades to ``"unknown"`` (never
     blocking) when local service settings are unavailable.
+
+    ``auth_ok`` tracks *authentication* only — the provider readiness signal,
+    which AWF's GitHub API operations actually depend on (the ``AWF_GITHUB_TOKEN``)
+    — and deliberately ignores ``gh_present``: a configured token with the ``gh``
+    CLI uninstalled is genuinely authenticated, so reporting ``auth_ok=False``
+    there would contradict the readiness signal (PR #541 review). The ``gh``
+    presence stays surfaced in ``auth`` and in the guidance lines as a separate,
+    advisory install hint, never folded into ``auth_ok``.
     """
     from awf.host_setup.system_checks import SetupCheckLevel, check_gh
 
@@ -541,7 +549,7 @@ def _detect_github_forge_auth(
         result = check_single_provider_readiness(settings, provider="github", environ=service_env)
         readiness = "ok" if result.get("ok") else "fail"
     auth: dict[str, object] = {"gh_present": gh_present, "github_readiness": readiness}
-    return auth, gh_present and readiness == "ok"
+    return auth, readiness == "ok"
 
 
 def _bitbucket_required_auth_keys(env: Mapping[str, str]) -> tuple[str, ...]:

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -40,7 +40,14 @@ _ENV_COMMENT_KEY_IGNORE_WORDS = frozenset({"awf"})
 _BITBUCKET_TOKEN_ENV = "BITBUCKET_API_TOKEN"
 _BITBUCKET_EMAIL_ENV = "BITBUCKET_EMAIL"
 _BITBUCKET_AUTH_MODE_ENV = "BITBUCKET_AUTH_MODE"
+_BITBUCKET_BASIC_MODE = "basic"
 _BITBUCKET_BEARER_MODE = "bearer"
+# The only modes ``BitbucketAuth.from_env`` accepts; anything else is rejected with
+# ``BITBUCKET_AUTH_NOT_CONFIGURED`` at runtime, so init must flag it as an auth
+# warning rather than report ``auth_ok`` (PR #541 review).
+_BITBUCKET_VALID_AUTH_MODES: frozenset[str] = frozenset(
+    {_BITBUCKET_BASIC_MODE, _BITBUCKET_BEARER_MODE}
+)
 # All three keys are *reported* (present/absent) for diagnostics, but only the
 # token (always) and email (default ``basic`` mode only) are actually *required* —
 # see :func:`_bitbucket_required_auth_keys`.
@@ -594,9 +601,14 @@ def _detect_bitbucket_forge_auth(
     default ``basic`` auth mode, and ``BITBUCKET_AUTH_MODE`` is an optional selector
     that is never itself required — so a token+email basic-mode workspace that omits
     it is correctly reported as ``auth_ok`` rather than flagged as incomplete.
-    Presence of all three keys is still surfaced for diagnostics. Never mentions
-    gh — a bitbucket.org repo does not need the GitHub CLI. Falls back to
-    ``os.environ`` when the resolved service env is unavailable.
+    An *invalid* mode (anything outside ``basic``/``bearer``, e.g. a typo like
+    ``bearrer``) is still an auth warning even with token and email both present:
+    ``BitbucketAuth.from_env`` rejects it with ``BITBUCKET_AUTH_NOT_CONFIGURED``, so
+    reporting ``auth_ok`` would tell operators auth is ready when every PR operation
+    will fail immediately (PR #541 review). Presence of all three keys is still
+    surfaced for diagnostics. Never mentions gh — a bitbucket.org repo does not need
+    the GitHub CLI. Falls back to ``os.environ`` when the resolved service env is
+    unavailable.
     """
     env = service_env if service_env is not None else os.environ
     # Strip before the presence check so a whitespace-only value is treated as
@@ -604,10 +616,16 @@ def _detect_bitbucket_forge_auth(
     # email before testing). Otherwise a whitespace-only ``BITBUCKET_*`` value would
     # report ``auth_ok`` with no missing keys while runtime auth still fails.
     present = {key: bool((env.get(key) or "").strip()) for key in _BITBUCKET_AUTH_ENV_KEYS}
+    mode = (env.get(_BITBUCKET_AUTH_MODE_ENV) or _BITBUCKET_BASIC_MODE).strip().lower()
+    invalid_mode = mode not in _BITBUCKET_VALID_AUTH_MODES
     required = _bitbucket_required_auth_keys(env)
     missing = [key for key in required if not present[key]]
-    auth: dict[str, object] = {"bitbucket_keys": present, "missing": missing}
-    return auth, not missing
+    auth: dict[str, object] = {
+        "bitbucket_keys": present,
+        "missing": missing,
+        "invalid_mode": invalid_mode,
+    }
+    return auth, not missing and not invalid_mode
 
 
 def _explicit_project_forge(repository: Path) -> str:
@@ -723,11 +741,17 @@ def _forge_guidance_lines(forge_block: Mapping[str, object]) -> list[str]:
     auth = _mapping_value(forge_block.get("auth"))
     if forge == "bitbucket":
         bitbucket_lines = ["Detected forge: bitbucket."]
+        invalid_mode = bool(auth.get("invalid_mode"))
+        if invalid_mode:
+            bitbucket_lines.append(
+                "  - BITBUCKET_AUTH_MODE is not 'basic' or 'bearer'; set a valid mode "
+                "in .env before Bitbucket PR operations (auth fails otherwise)."
+            )
         missing = _list_value(auth.get("missing"))
         if missing:
             names = ", ".join(str(key) for key in missing)
             bitbucket_lines.append(f"  - Set the missing Bitbucket auth env in .env: {names}.")
-        else:
+        elif not invalid_mode:
             present_keys = _mapping_value(auth.get("bitbucket_keys"))
             names = ", ".join(key for key in _BITBUCKET_AUTH_ENV_KEYS if present_keys.get(key))
             bitbucket_lines.append(f"  - Bitbucket auth env present: {names}.")

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -672,13 +672,18 @@ def _detect_project_forge_auth(
     # the same merged view doctor/status use — otherwise a token present only in
     # root ``.env`` is wrongly reported missing/unverified (PR #541 review).
     # Guarded: a second failure degrades to ``None`` and the per-forge
-    # ``os.environ`` fallback, never aborting the diagnostic.
+    # ``os.environ`` fallback, never aborting the diagnostic. Compose ``.env``
+    # merging can fail beyond file I/O (e.g. a ``${VAR:?}`` interpolation raises
+    # ``ComposeEnvInterpolationError``); those must degrade the same way so forge
+    # auth still runs via ``os.environ`` instead of bubbling into a generic
+    # ``detection_error`` block.
     if service_env is None:
         from awf.service.config import local_service_environ
+        from awf.service.environment import ComposeEnvInterpolationError
 
         try:
             service_env = local_service_environ()
-        except (OSError, UnicodeDecodeError):
+        except (OSError, UnicodeDecodeError, ComposeEnvInterpolationError):
             service_env = None
 
     explicit_forge = _explicit_project_forge(repository)

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -14,25 +14,117 @@ from typing import Any, cast
 import typer
 
 from awf.cli.common import OutputFormat, _emit, _list_value, _mapping_value
+
+# Local-service initialization helpers live in ``service_init_ops`` to keep
+# each first-party module under the maintainability line limit; re-exported
+# here (via ``__all__``) so existing importers and tests can keep referencing
+# them through ``awf.cli.init_ops``.
+from awf.cli.service_init_ops import (
+    _AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS,
+    _ENV_ASSIGNMENT_RE,
+    _ENV_COMMENT_KEY_IGNORE_WORDS,
+    _ENV_COMMENT_WORD_RE,
+    _add_env_migration_payload,
+    _add_init_env_overlay_keys,
+    _compose_root_env_file,
+    _docker_diagnostic_from_report,
+    _env_assignment_key,
+    _env_assignment_key_identity,
+    _env_assignment_line_with_canonical_key,
+    _env_assignment_line_with_key,
+    _env_comment_looks_key_specific,
+    _env_contents_have_multiline_values,
+    _env_context_has_file_header_marker,
+    _env_context_has_key_specific_comment,
+    _env_context_has_non_comment_note,
+    _env_context_is_single_adjacent_comment,
+    _env_context_looks_like_file_header,
+    _env_context_looks_like_section_header,
+    _env_seed_has_meaningful_leading_context,
+    _env_value_has_same_line_closing_quote,
+    _EnvSeedMergeError,
+    _init_display_path,
+    _init_env_error_payload,
+    _init_env_example_search_paths,
+    _init_env_overlay_source,
+    _init_env_warning,
+    _init_preflight_environ,
+    _is_local_service_compose_env_file,
+    _legacy_service_env_migration_allowed,
+    _merge_env_seed_contents,
+    _merge_env_seed_contents_with_overlay_keys,
+    _migrate_legacy_service_env_file,
+    _persist_console_host_port,
+    _replace_env_assignment_value,
+    _resolve_existing_service_env_file,
+    _resolve_service_compose_paths,
+    _resolve_service_env_files,
+    _resolve_service_runtime_env_files,
+    _resolve_state_directory,
+    _run_init_service_bootstrap,
+    _seed_env_file,
+    _service_compose_env_file,
+    _split_env_file_header_context,
+    _trusted_service_compose_env_file,
+    _trusted_service_compose_env_file_from_verified_paths,
+    resolve_existing_service_env_file,
+    resolve_service_compose_paths,
+    resolve_service_runtime_env_files,
+)
 from awf.service.smoke import _PROFILE_MARKER_PATHS as _PROJECT_PROFILE_MARKER_PATHS
 
-_AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS = (
-    "pyproject.toml",
-    "src/awf/__init__.py",
-    "compose.yaml",
-    "docker/compose/local-service.yml",
-)
-
-
-class _EnvSeedMergeError(ValueError):
-    """Raised when env seed merging cannot preserve dotenv semantics."""
-
-
-_ENV_ASSIGNMENT_RE = re.compile(r"\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=")
-
-_ENV_COMMENT_WORD_RE = re.compile(r"[a-z0-9]+")
-
-_ENV_COMMENT_KEY_IGNORE_WORDS = frozenset({"awf"})
+__all__ = [
+    "_AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS",
+    "_ENV_ASSIGNMENT_RE",
+    "_ENV_COMMENT_KEY_IGNORE_WORDS",
+    "_ENV_COMMENT_WORD_RE",
+    "_EnvSeedMergeError",
+    "_add_env_migration_payload",
+    "_add_init_env_overlay_keys",
+    "_compose_root_env_file",
+    "_docker_diagnostic_from_report",
+    "_env_assignment_key",
+    "_env_assignment_key_identity",
+    "_env_assignment_line_with_canonical_key",
+    "_env_assignment_line_with_key",
+    "_env_comment_looks_key_specific",
+    "_env_contents_have_multiline_values",
+    "_env_context_has_file_header_marker",
+    "_env_context_has_key_specific_comment",
+    "_env_context_has_non_comment_note",
+    "_env_context_is_single_adjacent_comment",
+    "_env_context_looks_like_file_header",
+    "_env_context_looks_like_section_header",
+    "_env_seed_has_meaningful_leading_context",
+    "_env_value_has_same_line_closing_quote",
+    "_init_display_path",
+    "_init_env_error_payload",
+    "_init_env_example_search_paths",
+    "_init_env_overlay_source",
+    "_init_env_warning",
+    "_init_preflight_environ",
+    "_is_local_service_compose_env_file",
+    "_legacy_service_env_migration_allowed",
+    "_merge_env_seed_contents",
+    "_merge_env_seed_contents_with_overlay_keys",
+    "_migrate_legacy_service_env_file",
+    "_persist_console_host_port",
+    "_replace_env_assignment_value",
+    "_resolve_existing_service_env_file",
+    "_resolve_service_compose_paths",
+    "_resolve_service_env_files",
+    "_resolve_service_runtime_env_files",
+    "_resolve_state_directory",
+    "_run_init_service_bootstrap",
+    "_seed_env_file",
+    "_service_compose_env_file",
+    "_split_env_file_header_context",
+    "_trusted_service_compose_env_file",
+    "_trusted_service_compose_env_file_from_verified_paths",
+    "resolve_existing_service_env_file",
+    "resolve_service_compose_paths",
+    "resolve_service_runtime_env_files",
+]
 
 # Bitbucket env-auth contract verified at ``awf init`` for bitbucket.org repos
 # (issue #539). These names mirror the private constants in
@@ -788,1028 +880,3 @@ def _existing_project_profile_path(repository: Path) -> Path | None:
         if candidate.is_file():
             return candidate
     return None
-
-
-def _resolve_state_directory(
-    env: Mapping[str, str],
-    *,
-    home_environ: Mapping[str, str] | None = None,
-) -> Path:
-    """Resolve the AWF host state directory matching the Compose default."""
-    raw = env.get("AWF_HOST_WORK_DIR") or ""
-    if raw:
-        return Path(raw).expanduser().resolve()
-    home_env = os.environ if home_environ is None else home_environ
-    home = home_env.get("HOME", "~")
-    return (Path(home) / ".awf" / "service").expanduser().resolve()
-
-
-def _resolve_service_compose_paths() -> tuple[Path, Path, Path]:
-    """Return the compose, env, and env seed source files used by service commands.
-
-    If the verified source checkout contains local Compose assets, return the
-    public root Compose entrypoint and root `.env` as absolute paths. The legacy
-    `docker/compose/.env` file is handled only by the migration helper.
-    """
-    from awf.service import bootstrap as bootstrap_mod
-    from awf.service.config import LOCAL_SERVICE_COMPOSE_ENV_FILE, LOCAL_SERVICE_COMPOSE_FILE
-
-    asset_root = bootstrap_mod.get_bootstrap_asset_root()
-    if asset_root is not None:
-        resolved_asset_root = asset_root.resolve()
-        compose_file = resolved_asset_root / LOCAL_SERVICE_COMPOSE_FILE
-        env_file = resolved_asset_root / LOCAL_SERVICE_COMPOSE_ENV_FILE
-        env_example = resolved_asset_root / ".env.example"
-        if bootstrap_mod.is_packaged_bootstrap_asset_root(resolved_asset_root):
-            return compose_file, Path(".env"), env_example
-        return compose_file, env_file, env_example
-
-    return LOCAL_SERVICE_COMPOSE_FILE, Path(".env"), Path(".env.example")
-
-
-def _resolve_existing_service_env_file(env_file: Path) -> Path:
-    """Return the existing env file service commands should read."""
-    if env_file.exists():
-        return env_file
-    root_env = _compose_root_env_file(env_file)
-    if root_env is not None and root_env.exists():
-        return root_env
-    return env_file
-
-
-def _resolve_service_env_files(
-    env_file: Path,
-    *,
-    trusted_compose_env_file: Path | None = None,
-) -> tuple[Path, Path | None]:
-    """Return the env read source and actual Compose env-file path."""
-    active_env_file = _resolve_existing_service_env_file(env_file)
-    return active_env_file, _service_compose_env_file(
-        active_env_file,
-        trusted_compose_env_file=trusted_compose_env_file,
-    )
-
-
-def _resolve_service_runtime_env_files(
-    compose_file: Path,
-    env_file: Path,
-    *,
-    paths_verified: bool = False,
-) -> tuple[Path, Path | None]:
-    """Return service env files using compose paths already verified upstream."""
-    return _resolve_service_env_files(
-        env_file,
-        trusted_compose_env_file=(
-            _trusted_service_compose_env_file_from_verified_paths(compose_file, env_file)
-            if paths_verified
-            else _trusted_service_compose_env_file(compose_file, env_file)
-        ),
-    )
-
-
-# Public, intentionally-stable names for the Compose env-resolution helpers above.
-# ``awf setup`` readiness must resolve the Compose env exactly as ``awf start``
-# does (so its port/work-dir probes match the real startup environment), so it
-# reuses these helpers across the module boundary. Exposing them without the
-# leading underscore makes that an explicit public contract: a rename or
-# signature change breaks at import/CI time rather than silently at the
-# ``setup`` call site. Existing in-module and sibling callers keep the
-# underscore-prefixed names as internal aliases.
-resolve_service_compose_paths = _resolve_service_compose_paths
-resolve_service_runtime_env_files = _resolve_service_runtime_env_files
-resolve_existing_service_env_file = _resolve_existing_service_env_file
-
-
-def _migrate_legacy_service_env_file(env_file: Path, env_example: Path) -> object | None:
-    """Migrate legacy compose env values into the canonical root env file."""
-    from awf.service.env_migration import (
-        default_legacy_compose_env_file,
-        migrate_legacy_compose_env_file,
-    )
-
-    canonical_env_file = env_file.expanduser()
-    if not _legacy_service_env_migration_allowed(canonical_env_file):
-        return None
-    legacy_env_file = default_legacy_compose_env_file(canonical_env_file)
-    if not legacy_env_file.exists():
-        return None
-    return migrate_legacy_compose_env_file(
-        canonical_env_file=canonical_env_file,
-        env_example_file=env_example,
-        legacy_env_file=legacy_env_file,
-    )
-
-
-def _legacy_service_env_migration_allowed(canonical_env_file: Path) -> bool:
-    """Return whether legacy Compose env migration is safe for this root."""
-
-    if canonical_env_file.name != ".env":
-        return False
-    root = canonical_env_file.parent if canonical_env_file.is_absolute() else Path.cwd()
-    return all((root / marker).is_file() for marker in _AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS)
-
-
-def _add_env_migration_payload(
-    payload: dict[str, object],
-    env_migration: object | None,
-) -> None:
-    """Attach secret-free env migration metadata when a migration occurred."""
-    if env_migration is None:
-        return
-    to_dict = getattr(env_migration, "to_dict", None)
-    if callable(to_dict):
-        payload["env_migration"] = to_dict()
-
-
-def _trusted_service_compose_env_file_from_verified_paths(
-    compose_file: Path,
-    env_file: Path,
-) -> Path | None:
-    """Return the Compose env path from already verified local-service paths."""
-    from awf.service.config import LOCAL_SERVICE_COMPOSE_FILE
-
-    if env_file == Path(".env"):
-        return env_file
-    resolved_compose_file = compose_file.expanduser().resolve()
-    resolved_env_file = env_file.expanduser().resolve()
-    if resolved_compose_file.parent != resolved_env_file.parent:
-        return None
-    if resolved_compose_file.name != LOCAL_SERVICE_COMPOSE_FILE.name:
-        return None
-    return env_file
-
-
-def _trusted_service_compose_env_file(compose_file: Path, env_file: Path) -> Path | None:
-    """Return the Compose env path from `_resolve_service_compose_paths`, if present."""
-    from awf.service.config import _is_local_service_compose_file_path
-
-    if not _is_local_service_compose_file_path(compose_file):
-        return None
-    if env_file == Path(".env"):
-        return env_file
-    if compose_file.expanduser().resolve().parent != env_file.expanduser().resolve().parent:
-        return None
-    return env_file
-
-
-def _service_compose_env_file(
-    active_env_file: Path,
-    *,
-    trusted_compose_env_file: Path | None = None,
-) -> Path | None:
-    """Return the env file that should be passed to Docker Compose, if any."""
-    if not active_env_file.exists():
-        return None
-    if trusted_compose_env_file is not None:
-        if (
-            active_env_file.expanduser().resolve()
-            == trusted_compose_env_file.expanduser().resolve()
-        ):
-            return active_env_file
-        return None
-    if _is_local_service_compose_env_file(active_env_file):
-        return active_env_file
-    return None
-
-
-def _is_local_service_compose_env_file(path: Path) -> bool:
-    """Return true for the verified local-service Compose env file."""
-    from awf.service.config import _is_local_service_compose_env_path
-
-    return _is_local_service_compose_env_path(path)
-
-
-def _init_env_error_payload(
-    *,
-    operation: str,
-    path: Path,
-    env_file: Path,
-    env_example: Path,
-    exc: Exception,
-) -> dict[str, str]:
-    """Return a machine-readable env seeding failure without env contents."""
-    return {
-        "operation": operation,
-        "path": _init_display_path(path),
-        "env_file": _init_display_path(env_file),
-        "env_example": _init_display_path(env_example),
-        "message": str(exc),
-    }
-
-
-def _compose_root_env_file(env_file: Path) -> Path | None:
-    """Return the root `.env` paired with a verified local Compose env file.
-
-    Relative env-file paths come from the no-asset-root fallback used outside an
-    AWF source checkout. They are intentionally not treated as local Compose
-    asset paths, which keeps root-env fallback and `--env-file` forwarding tied
-    to absolute paths resolved from the verified bootstrap asset root.
-    """
-    env_file = env_file.expanduser()
-    if not env_file.is_absolute():
-        return None
-    resolved_env_file = env_file.resolve()
-    if (
-        resolved_env_file.name == ".env"
-        and resolved_env_file.parent.name == "compose"
-        and resolved_env_file.parent.parent.name == "docker"
-    ):
-        return resolved_env_file.parent.parent.parent / ".env"
-    return None
-
-
-def _init_env_overlay_source(env_file: Path, env_example: Path) -> Path | None:
-    """Return the root `.env` overlay used when seeding compose env files."""
-    root_env = _compose_root_env_file(env_file)
-    if root_env is None or env_example == root_env or not root_env.exists():
-        return None
-    compose_example = env_file.with_name(".env.example")
-    root_example = root_env.with_name(".env.example")
-    if env_example not in (compose_example, root_example):
-        return None
-    return root_env
-
-
-def _env_assignment_key(line: str) -> str | None:
-    """Return the key from an env assignment line, ignoring comments."""
-    if line.lstrip().startswith("#"):
-        return None
-    match = _ENV_ASSIGNMENT_RE.match(line)
-    if match is None:
-        return None
-    return match.group("key")
-
-
-def _env_assignment_key_identity(key: str) -> str:
-    """Return the canonical key identity used for seed/overlay matching."""
-    return key.upper()
-
-
-def _env_assignment_line_with_key(line: str, key: str) -> str:
-    """Return a Compose env assignment line with the key spelling replaced."""
-    match = _ENV_ASSIGNMENT_RE.match(line)
-    if match is None:
-        return line
-    return f"{key}{line[match.end('key') :]}"
-
-
-def _env_assignment_line_with_canonical_key(line: str, canonical_key: str) -> str:
-    """Return ``line`` with its assignment key rewritten to ``canonical_key`` in place.
-
-    Unlike :func:`_env_assignment_line_with_key`, the leading ``export`` prefix and
-    any indentation before the key are preserved — only the key span is rewritten.
-    """
-    match = _ENV_ASSIGNMENT_RE.match(line)
-    if match is None:  # pragma: no cover - callers only pass matched assignment lines
-        return line
-    return f"{line[: match.start('key')]}{canonical_key}{line[match.end('key') :]}"
-
-
-def _replace_env_assignment_value(line: str, value: str) -> str:
-    """Return ``line`` (no trailing newline) with its assignment value set to ``value``.
-
-    Everything up to and including ``=`` is kept verbatim, so the key spelling and
-    any ``export`` prefix are preserved while the old value (and any same-line
-    trailing comment) is replaced.
-    """
-    match = _ENV_ASSIGNMENT_RE.match(line)
-    if match is None:  # pragma: no cover - callers only pass matched assignment lines
-        return line
-    return f"{line[: match.end()]}{value}"
-
-
-def _persist_console_host_port(env_file: Path, console_port: int) -> None:
-    """Persist ``AWF_CONSOLE_HOST_PORT=<console_port>`` into the active service env file.
-
-    Updates an existing assignment in place (preserving key spelling, an ``export``
-    prefix, and all unrelated lines/comments), appends a fresh assignment when the
-    key is absent, and creates the file (and parent dirs) when it does not yet exist.
-    ``AWF_CONSOLE_URL`` and every other key are left untouched.
-    """
-    value = str(console_port)
-    assignment = f"AWF_CONSOLE_HOST_PORT={value}"
-    if not env_file.exists():
-        env_file.parent.mkdir(parents=True, exist_ok=True)
-        env_file.write_text(f"{assignment}\n", encoding="utf-8")
-        return
-
-    text = env_file.read_text(encoding="utf-8")
-    target_identity = _env_assignment_key_identity("AWF_CONSOLE_HOST_PORT")
-    lines = text.splitlines(keepends=True)
-    updated = False
-    for index, line in enumerate(lines):
-        key = _env_assignment_key(line)
-        if key is None or _env_assignment_key_identity(key) != target_identity:
-            continue
-        body = line.rstrip("\r\n")
-        newline = line[len(body) :]
-        # Rewrite the key to the canonical uppercase spelling: Compose interpolates
-        # the case-sensitive ${AWF_CONSOLE_HOST_PORT} placeholder, so a preserved
-        # lowercase key would be ignored and the console would fall back to 3000.
-        canonical_body = _env_assignment_line_with_canonical_key(body, "AWF_CONSOLE_HOST_PORT")
-        lines[index] = f"{_replace_env_assignment_value(canonical_body, value)}{newline}"
-        updated = True
-    if updated:
-        # Update every matching assignment: later commands parse env files
-        # line-by-line and let later keys overwrite earlier ones, so leaving a
-        # stale trailing duplicate would persist the wrong console port.
-        env_file.write_text("".join(lines), encoding="utf-8")
-        return
-
-    if text and not text.endswith(("\n", "\r")):
-        text += "\n"
-    env_file.write_text(f"{text}{assignment}\n", encoding="utf-8")
-
-
-def _env_seed_has_meaningful_leading_context(lines: list[str]) -> bool:
-    """Return whether the seed owns the merged file header."""
-    for line in lines:
-        if _env_assignment_key(line) is not None:
-            return False
-        if line.strip():
-            return True
-    return False
-
-
-def _env_value_has_same_line_closing_quote(value: str, quote: str) -> bool:
-    """Return whether a quoted dotenv value closes on its assignment line."""
-    escaped = False
-    for char in value[1:]:
-        if quote == '"' and char == "\\" and not escaped:
-            escaped = True
-            continue
-        if char == quote and not escaped:
-            return True
-        escaped = False
-    return False
-
-
-def _env_contents_have_multiline_values(text: str) -> bool:
-    """Return true when dotenv assignments span physical lines."""
-    for line in text.splitlines(keepends=True):
-        key = _env_assignment_key(line)
-        if key is None:
-            continue
-        _assignment, _separator, value = line.partition("=")
-        stripped_value = value.lstrip()
-        if not stripped_value:
-            continue
-        quote = stripped_value[0]
-        line_without_newline = line.rstrip("\r\n")
-        trailing_backslashes = len(line_without_newline) - len(line_without_newline.rstrip("\\"))
-        if (
-            quote not in {"'", '"'}
-            and line.endswith(("\n", "\r"))
-            and trailing_backslashes % 2 == 1
-        ):
-            return True
-        if quote in {"'", '"'} and not _env_value_has_same_line_closing_quote(
-            stripped_value,
-            quote,
-        ):
-            return True
-    return False
-
-
-def _env_context_looks_like_file_header(lines: list[str]) -> bool:
-    """Return whether leading non-assignment lines look like a file header."""
-    comment_count = 0
-    for line in lines:
-        stripped = line.strip()
-        if stripped == "":
-            return True
-        if stripped.startswith("#"):
-            comment_count += 1
-    return comment_count > 1
-
-
-def _env_comment_looks_key_specific(line: str, key: str) -> bool:
-    """Return whether a comment appears to document one dotenv assignment key."""
-    stripped = line.strip()
-    if not stripped.startswith("#"):
-        return False
-    comment = stripped.lstrip("#").strip().lower()
-    if key.lower() in comment:
-        return True
-    key_words = [
-        word
-        for word in _ENV_COMMENT_WORD_RE.findall(key.lower())
-        if word not in _ENV_COMMENT_KEY_IGNORE_WORDS
-    ]
-    if not key_words:
-        return False
-    comment_words = set(_ENV_COMMENT_WORD_RE.findall(comment))
-    return all(word in comment_words for word in key_words)
-
-
-def _env_context_has_key_specific_comment(lines: list[str], key: str) -> bool:
-    """Return whether any context comment appears tied to the given key."""
-    return any(_env_comment_looks_key_specific(line, key) for line in lines)
-
-
-def _env_context_has_file_header_marker(lines: list[str]) -> bool:
-    """Return whether comments explicitly describe dotenv-file-level context."""
-    comments = [line.strip().lstrip("#").strip().lower() for line in lines]
-    return any(
-        ".env" in comment
-        or "dotenv" in comment
-        or "environment file" in comment
-        or "settings here" in comment
-        or "overrides here" in comment
-        for comment in comments
-    )
-
-
-def _split_env_file_header_context(
-    lines: list[str],
-    key: str,
-    *,
-    seed_has_leading_context: bool,
-) -> tuple[list[str], list[str]]:
-    """Split leading overlay comments into file-header and assignment context."""
-    if not _env_context_looks_like_file_header(lines):
-        return [], lines
-    last_blank_index: int | None = None
-    for index, line in enumerate(lines):
-        if line.strip() == "":
-            last_blank_index = index
-    if last_blank_index is not None:
-        return lines[: last_blank_index + 1], lines[last_blank_index + 1 :]
-
-    split_at: int | None = None
-    for index in range(len(lines) - 1, -1, -1):
-        stripped = lines[index].strip()
-        if not stripped.startswith("#"):
-            break
-        if _env_comment_looks_key_specific(lines[index], key):
-            split_at = index
-            break
-    if split_at is None:
-        if (
-            seed_has_leading_context
-            and len(lines) <= 2
-            and not _env_context_has_file_header_marker(lines)
-        ):
-            return [], lines
-        return lines, []
-    return lines[:split_at], lines[split_at:]
-
-
-def _env_context_looks_like_section_header(lines: list[str]) -> bool:
-    """Return whether non-assignment lines look like reusable section documentation."""
-    return sum(1 for line in lines if line.strip().startswith("#")) > 1
-
-
-def _env_context_is_single_adjacent_comment(lines: list[str]) -> bool:
-    """Return whether context is exactly one comment directly above an assignment."""
-    return len(lines) == 1 and lines[0].strip().startswith("#")
-
-
-def _env_context_has_non_comment_note(lines: list[str]) -> bool:
-    """Return whether context contains an operator note outside dotenv comments."""
-    return any(line.strip() and not line.strip().startswith("#") for line in lines)
-
-
-def _merge_env_seed_contents_with_overlay_keys(
-    seed_contents: bytes,
-    overlay_contents: bytes,
-) -> tuple[bytes, tuple[str, ...]]:
-    """Return merged env contents plus root-only keys appended from the overlay."""
-    try:
-        seed_text = seed_contents.decode("utf-8")
-        overlay_text = overlay_contents.decode("utf-8")
-    except UnicodeDecodeError as exc:
-        raise _EnvSeedMergeError("env seeding merge requires UTF-8 dotenv files") from exc
-
-    # This merge is deliberately line-oriented to preserve comments and ordering.
-    # Multi-line dotenv values are unsupported in seed and overlay files; keep
-    # template entries single-line unless this is replaced with a dotenv parser.
-    if _env_contents_have_multiline_values(seed_text) or _env_contents_have_multiline_values(
-        overlay_text
-    ):
-        raise _EnvSeedMergeError(
-            "unsupported multi-line dotenv values; env seeding merge only supports "
-            "single-line assignments"
-        )
-    seed_lines = seed_text.splitlines(keepends=True)
-    overlay_lines = overlay_text.splitlines(keepends=True)
-
-    overlay_assignments: dict[str, str] = {}
-    for line in overlay_lines:
-        key = _env_assignment_key(line)
-        if key is not None:
-            normalized_line = line if line.endswith(("\n", "\r")) else f"{line}\n"
-            overlay_assignments[_env_assignment_key_identity(key)] = _env_assignment_line_with_key(
-                normalized_line, key
-            )
-
-    seed_keys: set[str] = set()
-    for line in seed_lines:
-        key = _env_assignment_key(line)
-        if key is not None:
-            seed_keys.add(_env_assignment_key_identity(key))
-    seed_has_leading_context = _env_seed_has_meaningful_leading_context(seed_lines)
-
-    overlay_last_assignment_index: dict[str, int] = {}
-    for index, line in enumerate(overlay_lines):
-        key = _env_assignment_key(line)
-        if key is not None:
-            overlay_last_assignment_index[_env_assignment_key_identity(key)] = index
-
-    seed_leading_context: dict[str, list[str]] = {}
-    seed_final_context: list[str] = []
-    file_header_context: list[str] = []
-    overlay_only_lines: list[str] = []
-    overlay_only_keys: list[str] = []
-    pending_context: list[str] = []
-    duplicate_context: dict[str, list[str]] = {}
-    seen_overlay_assignment_keys: set[str] = set()
-    last_assignment_key: str | None = None
-    for index, line in enumerate(overlay_lines):
-        key = _env_assignment_key(line)
-        if key is None:
-            pending_context.append(line)
-            continue
-        key_identity = _env_assignment_key_identity(key)
-        first_overlay_assignment = last_assignment_key is None
-        if first_overlay_assignment and pending_context:
-            file_header_context, pending_context = _split_env_file_header_context(
-                pending_context,
-                key,
-                seed_has_leading_context=seed_has_leading_context,
-            )
-        context = [*duplicate_context.pop(key_identity, []), *pending_context]
-        context_has_key_specific_comment = _env_context_has_key_specific_comment(context, key)
-        if overlay_last_assignment_index.get(key_identity) == index:
-            if key_identity in seed_keys:
-                if (
-                    first_overlay_assignment
-                    and seed_has_leading_context
-                    and not context_has_key_specific_comment
-                    and (file_header_context or _env_context_is_single_adjacent_comment(context))
-                ):
-                    context = []
-                seed_leading_context[key_identity] = context
-            else:
-                overlay_only_lines.extend(context)
-                normalized_only_line = line if line.endswith(("\n", "\r")) else f"{line}\n"
-                overlay_only_lines.append(_env_assignment_line_with_key(normalized_only_line, key))
-                overlay_only_keys.append(key)
-        else:
-            if (
-                key_identity in seed_keys
-                or key_identity in seen_overlay_assignment_keys
-                or _env_context_looks_like_section_header(context)
-                or _env_context_is_single_adjacent_comment(context)
-                or _env_context_has_non_comment_note(context)
-            ):
-                duplicate_context.setdefault(key_identity, []).extend(context)
-        pending_context = []
-        seen_overlay_assignment_keys.add(key_identity)
-        last_assignment_key = key_identity
-    if pending_context and last_assignment_key is not None and last_assignment_key in seed_keys:
-        seed_final_context = pending_context
-    elif pending_context:
-        overlay_only_lines.extend(pending_context)
-
-    # Overlay file headers are kept only when the seed starts with assignments.
-    # If the seed has its own leading context, it owns the top of the merged file
-    # and overlay header comments are omitted to avoid duplicate file headers.
-    merged_lines: list[str] = [] if seed_has_leading_context else list(file_header_context)
-    emitted_seed_leading_context: set[str] = set()
-    for line in seed_lines:
-        key = _env_assignment_key(line)
-        if key is None:
-            merged_lines.append(line)
-            continue
-        key_identity = _env_assignment_key_identity(key)
-        if (
-            key_identity in seed_leading_context
-            and key_identity not in emitted_seed_leading_context
-        ):
-            merged_lines.extend(seed_leading_context[key_identity])
-            emitted_seed_leading_context.add(key_identity)
-        overlay_assignment = overlay_assignments.get(key_identity)
-        if overlay_assignment is None:
-            merged_lines.append(line)
-        else:
-            merged_lines.append(_env_assignment_line_with_key(overlay_assignment, key))
-
-    tail_lines = [*overlay_only_lines, *seed_final_context]
-    if tail_lines and merged_lines and not merged_lines[-1].endswith(("\n", "\r")):
-        merged_lines[-1] = f"{merged_lines[-1]}\n"
-    merged_lines.extend(tail_lines)
-
-    return "".join(merged_lines).encode("utf-8"), tuple(overlay_only_keys)
-
-
-def _merge_env_seed_contents(seed_contents: bytes, overlay_contents: bytes) -> bytes:
-    """Return compose-template env contents with root env assignments overlaid."""
-    merged_contents, _overlay_only_keys = _merge_env_seed_contents_with_overlay_keys(
-        seed_contents,
-        overlay_contents,
-    )
-    return merged_contents
-
-
-def _seed_env_file(
-    env_file: Path,
-    env_example: Path,
-    *,
-    env_overlay: Path | None = None,
-) -> tuple[str, dict[str, str] | None, tuple[str, ...]]:
-    """Seed an env file and return action, failure payload, and copied overlay keys."""
-    if env_file.exists():
-        return "kept_existing", None, ()
-
-    if not env_example.exists():
-        return "no_example", None, ()
-
-    try:
-        env_file.parent.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        return (
-            "write_failed",
-            _init_env_error_payload(
-                operation="create_parent_directory",
-                path=env_file.parent,
-                env_file=env_file,
-                env_example=env_example,
-                exc=exc,
-            ),
-            (),
-        )
-
-    try:
-        env_contents = env_example.read_bytes()
-    except OSError as exc:
-        return (
-            "write_failed",
-            _init_env_error_payload(
-                operation="read_example",
-                path=env_example,
-                env_file=env_file,
-                env_example=env_example,
-                exc=exc,
-            ),
-            (),
-        )
-
-    env_overlay_keys: tuple[str, ...] = ()
-    if env_overlay is not None and env_overlay.exists():
-        try:
-            overlay_contents = env_overlay.read_bytes()
-        except OSError as exc:
-            return (
-                "write_failed",
-                _init_env_error_payload(
-                    operation="read_overlay",
-                    path=env_overlay,
-                    env_file=env_file,
-                    env_example=env_example,
-                    exc=exc,
-                ),
-                (),
-            )
-        try:
-            env_contents, env_overlay_keys = _merge_env_seed_contents_with_overlay_keys(
-                env_contents,
-                overlay_contents,
-            )
-        except _EnvSeedMergeError as exc:
-            return (
-                "write_failed",
-                _init_env_error_payload(
-                    operation="merge_overlay",
-                    path=env_overlay,
-                    env_file=env_file,
-                    env_example=env_example,
-                    exc=exc,
-                ),
-                (),
-            )
-
-    env_file_created = False
-    try:
-        with env_file.open("xb") as handle:
-            env_file_created = True
-            handle.write(env_contents)
-    except FileExistsError:
-        return "kept_existing", None, ()
-    except OSError as exc:
-        if env_file_created:
-            try:
-                env_file.unlink()
-            except FileNotFoundError:
-                pass
-            except OSError:
-                pass
-        return (
-            "write_failed",
-            _init_env_error_payload(
-                operation="write_env",
-                path=env_file,
-                env_file=env_file,
-                env_example=env_example,
-                exc=exc,
-            ),
-            (),
-        )
-
-    return "wrote_from_example", None, env_overlay_keys
-
-
-def _init_display_path(path: Path | str) -> str:
-    """Return a stable human-readable init path from the launch directory."""
-    candidate = Path(path)
-    if not candidate.is_absolute():
-        return str(candidate)
-    try:
-        return os.path.relpath(candidate, Path.cwd())
-    except ValueError:
-        return str(candidate)
-
-
-def _init_env_warning(env_error: Mapping[str, str]) -> str:
-    """Return the pretty warning for an env seeding failure payload."""
-    operation = env_error["operation"]
-    message = env_error["message"]
-    env_file = env_error["env_file"]
-    env_example = env_error["env_example"]
-    if operation == "create_parent_directory":
-        parent = env_error["path"]
-        return f"  warning: could not create parent directory {parent} for {env_file}: {message}"
-    if operation == "read_example":
-        return f"  warning: could not read {env_example} while seeding {env_file}: {message}"
-    if operation == "read_overlay":
-        overlay = env_error["path"]
-        return (
-            f"  warning: could not read {overlay} while seeding {env_file} "
-            f"from {env_example}: {message}"
-        )
-    if operation == "merge_overlay":
-        overlay = env_error["path"]
-        return (
-            f"  warning: could not merge {overlay} while seeding {env_file} "
-            f"from {env_example}: {message}"
-        )
-    return f"  warning: could not write {env_file} from {env_example}: {message}"
-
-
-def _add_init_env_overlay_keys(
-    payload: dict[str, object],
-    env_overlay_keys: tuple[str, ...],
-) -> None:
-    """Add non-secret env overlay audit metadata to a JSON init payload."""
-    if env_overlay_keys:
-        payload["env_overlay_keys"] = list(env_overlay_keys)
-
-
-def _init_env_example_search_paths(env_file: Path, env_example: Path) -> tuple[Path, ...]:
-    """Return the env template paths that explain why init skipped seeding."""
-    search_paths: list[Path] = []
-    candidates = [env_file.with_name(".env.example"), env_example]
-    seen: set[Path] = set()
-    for candidate in candidates:
-        if candidate in seen:
-            continue
-        seen.add(candidate)
-        search_paths.append(candidate)
-    return tuple(search_paths)
-
-
-def _docker_diagnostic_from_report(report: object) -> object | None:
-    """Return the docker diagnostic entry from a readiness report if present."""
-    from typing import cast
-
-    diagnostics = getattr(report, "diagnostics", ())
-    for diagnostic in diagnostics:
-        if getattr(diagnostic, "id", None) == "docker":
-            return cast(object, diagnostic)
-    return None
-
-
-def _init_preflight_environ(
-    environ: Mapping[str, str],
-    *,
-    provider_secret_keys: frozenset[str],
-) -> dict[str, str]:
-    """Return init preflight env without provider credentials."""
-    secret_keys = {key.upper() for key in provider_secret_keys}
-    return {key: value for key, value in environ.items() if key.upper() not in secret_keys}
-
-
-def _run_init_service_bootstrap(
-    *,
-    write_env: bool,
-    timeout_seconds: float,
-    poll_interval_seconds: float,
-    skip_agent_runtime_build: bool,
-    providers: list[str],
-    fmt: OutputFormat,
-) -> None:
-    """Run local-service bootstrap with environment seeding and status output."""
-    from awf.common.config import Settings
-    from awf.service.bootstrap import (
-        ServiceBootstrapError,
-        ServiceBootstrapOptions,
-        run_service_bootstrap,
-    )
-    from awf.service.config import local_service_environ, resolve_service_settings
-    from awf.service.doctor import collect_doctor_report
-    from awf.service.provider_readiness import (
-        KNOWN_SECRET_ENV_KEYS,
-        ProviderReadinessError,
-        validate_provider_names,
-    )
-
-    try:
-        strict_providers = validate_provider_names(providers)
-    except ProviderReadinessError as exc:
-        typer.echo(f"error: {exc}", err=True)
-        raise typer.Exit(code=2) from exc
-
-    pretty = fmt == OutputFormat.pretty
-    compose_file, env_file, env_example = _resolve_service_compose_paths()
-    env_migration = _migrate_legacy_service_env_file(env_file, env_example) if write_env else None
-    env_action = "skipped"
-    env_error: dict[str, str] | None = None
-    env_overlay_keys: tuple[str, ...] = ()
-    if write_env:
-        env_action, env_error, env_overlay_keys = _seed_env_file(
-            env_file,
-            env_example,
-            env_overlay=_init_env_overlay_source(env_file, env_example),
-        )
-    active_env_file, compose_env_file = _resolve_service_runtime_env_files(
-        compose_file,
-        env_file,
-        paths_verified=True,
-    )
-
-    if pretty:
-        typer.echo("AWF init: local service bootstrap")
-        if write_env:
-            if env_migration is not None:
-                typer.echo(
-                    f"  migrated legacy docker/compose/.env into {_init_display_path(env_file)}"
-                )
-            if env_action == "write_failed" and env_error is not None:
-                typer.echo(_init_env_warning(env_error))
-            elif env_action == "kept_existing":
-                typer.echo(f"  kept existing {_init_display_path(env_file)}")
-            elif env_action == "wrote_from_example":
-                typer.echo(
-                    f"  wrote {_init_display_path(env_file)} from {_init_display_path(env_example)}"
-                )
-                if env_overlay_keys:
-                    typer.echo(
-                        "  added root .env keys to "
-                        f"{_init_display_path(env_file)}: {', '.join(env_overlay_keys)}"
-                    )
-            elif env_action == "no_example":
-                search_paths = ", ".join(
-                    _init_display_path(path)
-                    for path in _init_env_example_search_paths(env_file, env_example)
-                )
-                typer.echo(
-                    "  no env template found; skipped "
-                    f"{_init_display_path(env_file)} "
-                    f"creation (looked for {search_paths}; run `awf init` from "
-                    "the AWF repository root if you expected one)"
-                )
-
-    try:
-        service_env = local_service_environ(env_file=active_env_file)
-        preflight_env = _init_preflight_environ(
-            service_env,
-            provider_secret_keys=KNOWN_SECRET_ENV_KEYS,
-        )
-        settings = resolve_service_settings(
-            Settings(_env_file=active_env_file, github_token=None),
-            environ=preflight_env,
-        )
-
-        docker_report = asyncio.run(
-            collect_doctor_report(
-                settings,
-                strict_providers=frozenset(),
-                provider_environ=preflight_env,
-                environ=preflight_env,
-                compose_file=compose_file,
-                compose_env_file=compose_env_file,
-            )
-        )
-        docker_diag = _docker_diagnostic_from_report(docker_report)
-        docker_status = getattr(docker_diag, "status", None)
-        docker_unknown = docker_diag is None or docker_status is None
-        if docker_unknown or docker_status == "fail":
-            if docker_unknown:
-                message = "Docker availability could not be determined from the doctor report."
-                action = "Run `awf service doctor` to investigate the local environment."
-                reason = "DOCKER_DIAGNOSTIC_MISSING"
-            else:
-                message = getattr(docker_diag, "message", "Docker is not available.")
-                action = getattr(docker_diag, "action", "")
-                reason = getattr(docker_diag, "reason", "DOCKER_DAEMON_UNREACHABLE")
-            if pretty:
-                typer.echo(f"  docker: {message}")
-                if action:
-                    typer.echo(f"  action: {action}")
-                typer.echo("")
-                typer.echo("Docker is not available; cannot bootstrap local service.")
-            else:
-                docker_payload: dict[str, object] = {
-                    "status": "failed",
-                    "reason_code": reason,
-                    "message": message,
-                    "action": action,
-                    "env_action": env_action,
-                }
-                if env_error is not None:
-                    docker_payload["env_error"] = env_error
-                _add_init_env_overlay_keys(docker_payload, env_overlay_keys)
-                _add_env_migration_payload(docker_payload, env_migration)
-                _emit(docker_payload, fmt)
-            raise typer.Exit(code=1)
-
-        state_dir = _resolve_state_directory(service_env)
-        created = not state_dir.exists()
-        state_dir.mkdir(parents=True, exist_ok=True)
-    except typer.Exit:
-        raise
-    except Exception as exc:
-        if pretty:
-            typer.echo(f"error: could not collect local checks: {exc}", err=True)
-        else:
-            local_checks_payload: dict[str, object] = {
-                "status": "failed",
-                "reason_code": "BOOTSTRAP_LOCAL_CHECKS_FAILED",
-                "message": str(exc),
-                "env_action": env_action,
-            }
-            if env_error is not None:
-                local_checks_payload["env_error"] = env_error
-            _add_init_env_overlay_keys(local_checks_payload, env_overlay_keys)
-            _add_env_migration_payload(local_checks_payload, env_migration)
-            _emit(local_checks_payload, fmt)
-        raise typer.Exit(code=1) from exc
-
-    if pretty:
-        typer.echo(f"  state directory: {state_dir}")
-        typer.echo(f"  created: {'true' if created else 'false'}")
-
-    options = ServiceBootstrapOptions(
-        timeout_seconds=timeout_seconds,
-        poll_interval_seconds=poll_interval_seconds,
-        skip_agent_runtime_build=skip_agent_runtime_build,
-        strict_providers=frozenset(strict_providers),
-    )
-    try:
-        result = asyncio.run(
-            run_service_bootstrap(
-                settings,
-                options=options,
-                compose_file=compose_file,
-                env_file=compose_env_file,
-                service_environ=service_env,
-            ),
-        )
-    except KeyboardInterrupt:
-        raise typer.Exit(code=130) from None
-    except ServiceBootstrapError as exc:
-        payload = exc.to_dict()
-        if env_error is not None:
-            payload["env_error"] = env_error
-        _add_init_env_overlay_keys(payload, env_overlay_keys)
-        _add_env_migration_payload(payload, env_migration)
-        _emit(payload, fmt)
-        raise typer.Exit(code=1) from None
-
-    if pretty:
-        typer.echo("  bootstrap status: ok")
-        typer.echo("")
-        typer.echo("Next steps:")
-        # Service bootstrap is repo-agnostic (host/service level), so it cannot
-        # know the repo's forge: defer forge-scoped auth (GitHub token or the
-        # BITBUCKET_* env) to ``awf init <path>``, which detects the forge from the
-        # repo's git remote (issue #539).
-        typer.echo(
-            "  - Run `awf init <path>` to detect your repo's forge and verify the "
-            "matching auth (GitHub token or BITBUCKET_* env)."
-        )
-        typer.echo("  - Run `awf service status --format pretty` to verify readiness.")
-        typer.echo(
-            "  - Optional console: `npm --prefix apps/console run dev`, then open http://localhost:3000."
-        )
-        typer.echo("  - Run `awf init <path>` to onboard a project repository.")
-    else:
-        payload = result.to_dict()
-        payload["state_directory"] = str(state_dir)
-        payload["state_directory_created"] = created
-        payload["env_action"] = env_action
-        if env_error is not None:
-            payload["env_error"] = env_error
-        _add_init_env_overlay_keys(payload, env_overlay_keys)
-        _add_env_migration_payload(payload, env_migration)
-        _emit(payload, fmt)

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -34,6 +34,15 @@ _ENV_COMMENT_WORD_RE = re.compile(r"[a-z0-9]+")
 
 _ENV_COMMENT_KEY_IGNORE_WORDS = frozenset({"awf"})
 
+# Bitbucket env-auth contract verified at ``awf init`` for bitbucket.org repos
+# (issue #539). These names mirror the private constants in
+# ``awf.common.git_auth``; kept local so init_ops does not import private symbols.
+_BITBUCKET_AUTH_ENV_KEYS: tuple[str, ...] = (
+    "BITBUCKET_API_TOKEN",
+    "BITBUCKET_EMAIL",
+    "BITBUCKET_AUTH_MODE",
+)
+
 
 def _run_init_project_onboarding(
     path: Path,
@@ -101,6 +110,11 @@ def _run_init_project_onboarding(
     service_status: dict[str, object]
     doctor_report: DoctorReport | None
     doctor_error: str | None = None
+    # Captured to the outer scope so forge detection can still read them after the
+    # collection block — and degrade gracefully to ``None`` (auth signals become
+    # ``unknown``/skipped, never blocking) when the collection itself raises.
+    settings: Any = None
+    service_env: Mapping[str, str] | None = None
     try:
         settings = resolve_service_settings()
         service_env = local_service_environ()
@@ -216,6 +230,13 @@ def _run_init_project_onboarding(
             typer.echo(f"error: {exc}", err=True)
             raise typer.Exit(code=1) from None
 
+    forge_block = _detect_project_forge_auth(
+        repository,
+        preview=preview,
+        settings=settings,
+        service_env=service_env,
+    )
+
     mode = "guided" if effective_guided else "write" if should_write else "preview"
     payload = _init_project_onboarding_payload(
         preview=preview,
@@ -226,6 +247,7 @@ def _run_init_project_onboarding(
         local_checks_ready=local_checks_ready,
         guided=effective_guided,
         mode=mode,
+        forge=forge_block,
     )
 
     if fmt == OutputFormat.json:
@@ -341,8 +363,15 @@ def _init_project_onboarding_payload(
     local_checks_ready: bool,
     guided: bool,
     mode: str,
+    forge: Mapping[str, object] | None = None,
 ) -> dict[str, object]:
-    """Build the structured project-onboarding payload for pretty and JSON output."""
+    """Build the structured project-onboarding payload for pretty and JSON output.
+
+    ``forge`` carries the issue #539 forge detection + per-signal auth status. The
+    CLI ``awf init <PATH>`` path always supplies it; the lighter MCP
+    ``project_init`` contract (which reports doctor/readiness as ``not_checked``)
+    omits it, so it defaults to a neutral block here.
+    """
     payload = cast(dict[str, object], preview.to_dict())
     profile_exists = existing_profile_path is not None or written_path is not None
     payload.update(
@@ -354,6 +383,10 @@ def _init_project_onboarding_payload(
             "service_status": service_status,
             "doctor_status": doctor_status,
             "local_checks_ready": local_checks_ready,
+            # Forge detection + per-key/per-signal auth status lives in the JSON
+            # payload (not only the pretty echo) so ``--format json`` / ``--yes``
+            # callers can read it (issue #539).
+            "forge": dict(forge) if forge is not None else _neutral_forge_block(),
             "next_steps": _init_project_next_steps(
                 existing_profile_path=existing_profile_path,
                 written_path=written_path,
@@ -418,6 +451,13 @@ def _emit_init_project_onboarding_pretty(
         typer.echo("Smoke request payload (local-only, not submitted):")
         typer.echo(json.dumps(preview.smoke_request, indent=2, sort_keys=True, default=str))
 
+    # The onboarding payload always carries a forge block (at minimum the neutral
+    # no-remote block), so the forge-auth section is emitted unconditionally.
+    typer.echo("")
+    typer.echo("Forge auth:")
+    for line in _forge_guidance_lines(_mapping_value(payload.get("forge"))):
+        typer.echo(f"  {line}")
+
     typer.echo("")
     typer.echo("Suggested next steps:")
     for step in _list_value(payload.get("next_steps")):
@@ -433,6 +473,171 @@ def _emit_init_project_onboarding_pretty(
             "\nLocal prerequisites are not fully ready yet; profile onboarding can "
             "continue, but fix the issues above before creating or retrying workspaces."
         )
+
+
+def _redacted_remote_host(repo_url: str) -> str | None:
+    """Return the lowercased host of ``repo_url`` with any credentials stripped.
+
+    Never surfaces the raw remote URL: an ``https://user:token@host/...`` origin
+    can embed a secret, so only the credential-free host is reported for forge
+    diagnostics (issue #539; redaction is mandatory for any logged/persisted
+    value). Returns ``None`` when no host can be parsed (e.g. a bare ``owner/repo``
+    slug or a malformed URL).
+    """
+    from urllib.parse import urlsplit
+
+    scp = re.match(r"^[^/@\s]+@([^/:]+):", repo_url)
+    if scp is not None:
+        return scp.group(1).lower()
+    try:
+        host = urlsplit(repo_url).hostname
+    except ValueError:
+        return None
+    return host.lower() if host else None
+
+
+def _neutral_forge_block() -> dict[str, object]:
+    """Return the forge block used when no forge detection was performed."""
+    return {
+        "host": None,
+        "forge": None,
+        "host_detected": False,
+        "auth": None,
+        "auth_ok": True,
+        "level": "neutral",
+    }
+
+
+def _detect_github_forge_auth(
+    *, settings: Any, service_env: Mapping[str, str] | None
+) -> tuple[dict[str, object], bool]:
+    """Verify GitHub presence (gh) and auth (readiness) as two distinct signals.
+
+    Presence (``check_gh``) and auth (``provider_readiness``) are reported
+    separately: a gh CLI installed but unauthenticated is ``gh_present=True`` with
+    ``github_readiness="fail"``. Readiness degrades to ``"unknown"`` (never
+    blocking) when local service settings are unavailable.
+    """
+    from awf.host_setup.system_checks import SetupCheckLevel, check_gh
+
+    gh_present = check_gh().level is SetupCheckLevel.OK
+    readiness = "unknown"
+    if settings is not None:
+        from awf.service.provider_readiness import check_single_provider_readiness
+
+        result = check_single_provider_readiness(settings, provider="github", environ=service_env)
+        readiness = "ok" if result.get("ok") else "fail"
+    auth: dict[str, object] = {"gh_present": gh_present, "github_readiness": readiness}
+    return auth, gh_present and readiness == "ok"
+
+
+def _detect_bitbucket_forge_auth(
+    service_env: Mapping[str, str] | None,
+) -> tuple[dict[str, object], bool]:
+    """Verify the three ``BITBUCKET_*`` env keys; name exactly which are missing.
+
+    Never mentions gh — a bitbucket.org repo does not need the GitHub CLI. Falls
+    back to ``os.environ`` when the resolved service env is unavailable.
+    """
+    env = service_env if service_env is not None else os.environ
+    present = {key: bool(env.get(key)) for key in _BITBUCKET_AUTH_ENV_KEYS}
+    missing = [key for key in _BITBUCKET_AUTH_ENV_KEYS if not present[key]]
+    auth: dict[str, object] = {"bitbucket_keys": present, "missing": missing}
+    return auth, not missing
+
+
+def _detect_project_forge_auth(
+    repository: Path,
+    *,
+    preview: Any,
+    settings: Any,
+    service_env: Mapping[str, str] | None,
+) -> dict[str, object]:
+    """Detect the repo's forge from its origin remote and verify only matching auth.
+
+    Forge detection (GitHub vs Bitbucket) belongs at project onboarding, where the
+    repo's ``git remote`` is in scope — not at the repo-agnostic host/service
+    readiness layer (issue #539). Reuses the existing detection seam
+    (``detect_repo_url_from_checkout`` -> ``forge``); the explicit ``forge:`` in
+    ``.awf/workspace.yml`` is honored over the URL host for free via
+    ``concrete_forge_for_repo``. Missing matching auth is reported as a WARNING and
+    never blocks, preserving the invariant that mocked smoke needs no live forge
+    access. The returned dict is structured and secret-free (the raw remote URL is
+    reduced to its credential-free host).
+    """
+    from awf.common.forge import concrete_forge_for_repo, detect_forge_from_url
+    from awf.common.git_remote import detect_repo_url_from_checkout
+
+    repo_url = detect_repo_url_from_checkout(repository)
+    if repo_url is None:
+        # No ``origin`` remote: stay neutral, assume no forge, never block.
+        return _neutral_forge_block()
+
+    explicit_forge = getattr(getattr(preview.draft, "profile", None), "forge", "auto")
+    forge = concrete_forge_for_repo(explicit_forge, repo_url)
+    # ``host_detected`` distinguishes a recognized host from an unknown host
+    # (GHE/GitLab/self-hosted) that ``forge.py`` defaults to github.
+    host_detected = detect_forge_from_url(repo_url) is not None
+
+    if forge == "bitbucket":
+        auth, auth_ok = _detect_bitbucket_forge_auth(service_env)
+    else:
+        auth, auth_ok = _detect_github_forge_auth(settings=settings, service_env=service_env)
+
+    return {
+        "host": _redacted_remote_host(repo_url),
+        "forge": forge,
+        "host_detected": host_detected,
+        "auth": auth,
+        "auth_ok": auth_ok,
+        "level": "ok" if auth_ok else "warning",
+    }
+
+
+def _forge_guidance_lines(forge_block: Mapping[str, object]) -> list[str]:
+    """Return forge-scoped Next-step guidance lines (WARNING text never blocks)."""
+    forge = forge_block.get("forge")
+    if forge is None:
+        return [
+            "No `origin` remote detected; forge auth check skipped. Add a git "
+            "remote, then re-run `awf init <path>` to verify forge auth.",
+        ]
+    auth = _mapping_value(forge_block.get("auth"))
+    if forge == "bitbucket":
+        bitbucket_lines = ["Detected forge: bitbucket."]
+        missing = _list_value(auth.get("missing"))
+        if missing:
+            names = ", ".join(str(key) for key in missing)
+            bitbucket_lines.append(f"  - Set the missing Bitbucket auth env in .env: {names}.")
+        else:
+            bitbucket_lines.append(
+                "  - Bitbucket auth env present: "
+                "BITBUCKET_API_TOKEN, BITBUCKET_EMAIL, BITBUCKET_AUTH_MODE."
+            )
+        return bitbucket_lines
+
+    if forge_block.get("host_detected"):
+        github_lines = ["Detected forge: github."]
+    else:
+        github_lines = [
+            f"Forge host {forge_block.get('host')!r} not recognized; defaulting to "
+            "github. Set `forge:` in .awf/workspace.yml to override.",
+        ]
+    if auth.get("gh_present"):
+        github_lines.append("  - GitHub CLI (gh) is installed.")
+    else:
+        github_lines.append("  - Install the GitHub CLI (gh) for GitHub PR operations.")
+    readiness = auth.get("github_readiness")
+    if readiness == "ok":
+        github_lines.append("  - GitHub auth verified.")
+    elif readiness == "fail":
+        github_lines.append(
+            "  - GitHub auth not verified: set AWF_GITHUB_TOKEN "
+            '(e.g. `export AWF_GITHUB_TOKEN="$(gh auth token)"`).'
+        )
+    else:
+        github_lines.append("  - GitHub auth not checked (local service settings unavailable).")
+    return github_lines
 
 
 def _existing_project_profile_path(repository: Path) -> Path | None:
@@ -1444,7 +1649,14 @@ def _run_init_service_bootstrap(
         typer.echo("  bootstrap status: ok")
         typer.echo("")
         typer.echo("Next steps:")
-        typer.echo('  - export AWF_GITHUB_TOKEN="$(gh auth token)" so the worker can create PRs.')
+        # Service bootstrap is repo-agnostic (host/service level), so it cannot
+        # know the repo's forge: defer forge-scoped auth (GitHub token or the
+        # BITBUCKET_* env) to ``awf init <path>``, which detects the forge from the
+        # repo's git remote (issue #539).
+        typer.echo(
+            "  - Run `awf init <path>` to detect your repo's forge and verify the "
+            "matching auth (GitHub token or BITBUCKET_* env)."
+        )
         typer.echo("  - Run `awf service status --format pretty` to verify readiness.")
         typer.echo(
             "  - Optional console: `npm --prefix apps/console run dev`, then open http://localhost:3000."

--- a/src/awf/cli/init_ops.py
+++ b/src/awf/cli/init_ops.py
@@ -232,7 +232,6 @@ def _run_init_project_onboarding(
 
     forge_block = _detect_project_forge_auth(
         repository,
-        preview=preview,
         settings=settings,
         service_env=service_env,
     )
@@ -546,10 +545,39 @@ def _detect_bitbucket_forge_auth(
     return auth, not missing
 
 
+def _explicit_project_forge(repository: Path) -> str:
+    """Read the explicit ``forge:`` from an on-disk workspace profile, if any.
+
+    ``awf init`` builds its preview via ``preview_project_onboarding``, which
+    *drafts* a fresh profile (always ``forge: auto``) and never reads an existing
+    ``.awf/workspace.yml``. So the drafted preview cannot carry a pinned forge —
+    reading it would always yield ``"auto"`` and silently follow the origin URL
+    host. Re-running init on an already-onboarded repo that pins
+    ``forge: bitbucket``/``github`` must honor that override (precedence: explicit
+    ``forge:`` > URL host > github), so the on-disk value is read directly here.
+    Falls back to ``"auto"`` (defer to URL detection) when there is no profile, no
+    ``forge:`` key, or an unreadable/malformed file — this is a non-blocking
+    diagnostic, never a hard failure.
+    """
+    import yaml
+
+    profile_path = _existing_project_profile_path(repository)
+    if profile_path is None:
+        return "auto"
+    try:
+        raw = yaml.safe_load(profile_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError):
+        return "auto"
+    profile = raw.get("awf", raw) if isinstance(raw, dict) else None
+    if not isinstance(profile, dict):
+        return "auto"
+    forge = profile.get("forge", "auto")
+    return forge if isinstance(forge, str) else "auto"
+
+
 def _detect_project_forge_auth(
     repository: Path,
     *,
-    preview: Any,
     settings: Any,
     service_env: Mapping[str, str] | None,
 ) -> dict[str, object]:
@@ -558,12 +586,12 @@ def _detect_project_forge_auth(
     Forge detection (GitHub vs Bitbucket) belongs at project onboarding, where the
     repo's ``git remote`` is in scope — not at the repo-agnostic host/service
     readiness layer (issue #539). Reuses the existing detection seam
-    (``detect_repo_url_from_checkout`` -> ``forge``); the explicit ``forge:`` in
-    ``.awf/workspace.yml`` is honored over the URL host for free via
-    ``concrete_forge_for_repo``. Missing matching auth is reported as a WARNING and
-    never blocks, preserving the invariant that mocked smoke needs no live forge
-    access. The returned dict is structured and secret-free (the raw remote URL is
-    reduced to its credential-free host).
+    (``detect_repo_url_from_checkout`` -> ``forge``); an explicit ``forge:`` pinned
+    in an on-disk ``.awf/workspace.yml`` (via :func:`_explicit_project_forge`) is
+    honored over the URL host through ``concrete_forge_for_repo``. Missing matching
+    auth is reported as a WARNING and never blocks, preserving the invariant that
+    mocked smoke needs no live forge access. The returned dict is structured and
+    secret-free (the raw remote URL is reduced to its credential-free host).
     """
     from awf.common.forge import concrete_forge_for_repo, detect_forge_from_url
     from awf.common.git_remote import detect_repo_url_from_checkout
@@ -573,7 +601,7 @@ def _detect_project_forge_auth(
         # No ``origin`` remote: stay neutral, assume no forge, never block.
         return _neutral_forge_block()
 
-    explicit_forge = getattr(getattr(preview.draft, "profile", None), "forge", "auto")
+    explicit_forge = _explicit_project_forge(repository)
     forge = concrete_forge_for_repo(explicit_forge, repo_url)
     # ``host_detected`` distinguishes a recognized host from an unknown host
     # (GHE/GitLab/self-hosted) that ``forge.py`` defaults to github.

--- a/src/awf/cli/service_init_ops.py
+++ b/src/awf/cli/service_init_ops.py
@@ -1,0 +1,1061 @@
+"""Local-service initialization helpers for the AWF CLI.
+
+Split out of :mod:`awf.cli.init_ops` to keep each first-party module under the
+maintainability line limit. ``init_ops`` re-exports these names for backward
+compatibility, so importers and tests may reference either module.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import typer
+
+from awf.cli.common import OutputFormat, _emit
+
+_AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS = (
+    "pyproject.toml",
+    "src/awf/__init__.py",
+    "compose.yaml",
+    "docker/compose/local-service.yml",
+)
+
+
+class _EnvSeedMergeError(ValueError):
+    """Raised when env seed merging cannot preserve dotenv semantics."""
+
+
+_ENV_ASSIGNMENT_RE = re.compile(r"\s*(?:export\s+)?(?P<key>[A-Za-z_][A-Za-z0-9_]*)\s*=")
+
+_ENV_COMMENT_WORD_RE = re.compile(r"[a-z0-9]+")
+
+_ENV_COMMENT_KEY_IGNORE_WORDS = frozenset({"awf"})
+
+
+def _resolve_state_directory(
+    env: Mapping[str, str],
+    *,
+    home_environ: Mapping[str, str] | None = None,
+) -> Path:
+    """Resolve the AWF host state directory matching the Compose default."""
+    raw = env.get("AWF_HOST_WORK_DIR") or ""
+    if raw:
+        return Path(raw).expanduser().resolve()
+    home_env = os.environ if home_environ is None else home_environ
+    home = home_env.get("HOME", "~")
+    return (Path(home) / ".awf" / "service").expanduser().resolve()
+
+
+def _resolve_service_compose_paths() -> tuple[Path, Path, Path]:
+    """Return the compose, env, and env seed source files used by service commands.
+
+    If the verified source checkout contains local Compose assets, return the
+    public root Compose entrypoint and root `.env` as absolute paths. The legacy
+    `docker/compose/.env` file is handled only by the migration helper.
+    """
+    from awf.service import bootstrap as bootstrap_mod
+    from awf.service.config import LOCAL_SERVICE_COMPOSE_ENV_FILE, LOCAL_SERVICE_COMPOSE_FILE
+
+    asset_root = bootstrap_mod.get_bootstrap_asset_root()
+    if asset_root is not None:
+        resolved_asset_root = asset_root.resolve()
+        compose_file = resolved_asset_root / LOCAL_SERVICE_COMPOSE_FILE
+        env_file = resolved_asset_root / LOCAL_SERVICE_COMPOSE_ENV_FILE
+        env_example = resolved_asset_root / ".env.example"
+        if bootstrap_mod.is_packaged_bootstrap_asset_root(resolved_asset_root):
+            return compose_file, Path(".env"), env_example
+        return compose_file, env_file, env_example
+
+    return LOCAL_SERVICE_COMPOSE_FILE, Path(".env"), Path(".env.example")
+
+
+def _resolve_existing_service_env_file(env_file: Path) -> Path:
+    """Return the existing env file service commands should read."""
+    if env_file.exists():
+        return env_file
+    root_env = _compose_root_env_file(env_file)
+    if root_env is not None and root_env.exists():
+        return root_env
+    return env_file
+
+
+def _resolve_service_env_files(
+    env_file: Path,
+    *,
+    trusted_compose_env_file: Path | None = None,
+) -> tuple[Path, Path | None]:
+    """Return the env read source and actual Compose env-file path."""
+    active_env_file = _resolve_existing_service_env_file(env_file)
+    return active_env_file, _service_compose_env_file(
+        active_env_file,
+        trusted_compose_env_file=trusted_compose_env_file,
+    )
+
+
+def _resolve_service_runtime_env_files(
+    compose_file: Path,
+    env_file: Path,
+    *,
+    paths_verified: bool = False,
+) -> tuple[Path, Path | None]:
+    """Return service env files using compose paths already verified upstream."""
+    return _resolve_service_env_files(
+        env_file,
+        trusted_compose_env_file=(
+            _trusted_service_compose_env_file_from_verified_paths(compose_file, env_file)
+            if paths_verified
+            else _trusted_service_compose_env_file(compose_file, env_file)
+        ),
+    )
+
+
+# Public, intentionally-stable names for the Compose env-resolution helpers above.
+# ``awf setup`` readiness must resolve the Compose env exactly as ``awf start``
+# does (so its port/work-dir probes match the real startup environment), so it
+# reuses these helpers across the module boundary. Exposing them without the
+# leading underscore makes that an explicit public contract: a rename or
+# signature change breaks at import/CI time rather than silently at the
+# ``setup`` call site. Existing in-module and sibling callers keep the
+# underscore-prefixed names as internal aliases.
+resolve_service_compose_paths = _resolve_service_compose_paths
+resolve_service_runtime_env_files = _resolve_service_runtime_env_files
+resolve_existing_service_env_file = _resolve_existing_service_env_file
+
+
+def _migrate_legacy_service_env_file(env_file: Path, env_example: Path) -> object | None:
+    """Migrate legacy compose env values into the canonical root env file."""
+    from awf.service.env_migration import (
+        default_legacy_compose_env_file,
+        migrate_legacy_compose_env_file,
+    )
+
+    canonical_env_file = env_file.expanduser()
+    if not _legacy_service_env_migration_allowed(canonical_env_file):
+        return None
+    legacy_env_file = default_legacy_compose_env_file(canonical_env_file)
+    if not legacy_env_file.exists():
+        return None
+    return migrate_legacy_compose_env_file(
+        canonical_env_file=canonical_env_file,
+        env_example_file=env_example,
+        legacy_env_file=legacy_env_file,
+    )
+
+
+def _legacy_service_env_migration_allowed(canonical_env_file: Path) -> bool:
+    """Return whether legacy Compose env migration is safe for this root."""
+
+    if canonical_env_file.name != ".env":
+        return False
+    root = canonical_env_file.parent if canonical_env_file.is_absolute() else Path.cwd()
+    return all((root / marker).is_file() for marker in _AWF_SOURCE_ROOT_ENV_MIGRATION_MARKERS)
+
+
+def _add_env_migration_payload(
+    payload: dict[str, object],
+    env_migration: object | None,
+) -> None:
+    """Attach secret-free env migration metadata when a migration occurred."""
+    if env_migration is None:
+        return
+    to_dict = getattr(env_migration, "to_dict", None)
+    if callable(to_dict):
+        payload["env_migration"] = to_dict()
+
+
+def _trusted_service_compose_env_file_from_verified_paths(
+    compose_file: Path,
+    env_file: Path,
+) -> Path | None:
+    """Return the Compose env path from already verified local-service paths."""
+    from awf.service.config import LOCAL_SERVICE_COMPOSE_FILE
+
+    if env_file == Path(".env"):
+        return env_file
+    resolved_compose_file = compose_file.expanduser().resolve()
+    resolved_env_file = env_file.expanduser().resolve()
+    if resolved_compose_file.parent != resolved_env_file.parent:
+        return None
+    if resolved_compose_file.name != LOCAL_SERVICE_COMPOSE_FILE.name:
+        return None
+    return env_file
+
+
+def _trusted_service_compose_env_file(compose_file: Path, env_file: Path) -> Path | None:
+    """Return the Compose env path from `_resolve_service_compose_paths`, if present."""
+    from awf.service.config import _is_local_service_compose_file_path
+
+    if not _is_local_service_compose_file_path(compose_file):
+        return None
+    if env_file == Path(".env"):
+        return env_file
+    if compose_file.expanduser().resolve().parent != env_file.expanduser().resolve().parent:
+        return None
+    return env_file
+
+
+def _service_compose_env_file(
+    active_env_file: Path,
+    *,
+    trusted_compose_env_file: Path | None = None,
+) -> Path | None:
+    """Return the env file that should be passed to Docker Compose, if any."""
+    if not active_env_file.exists():
+        return None
+    if trusted_compose_env_file is not None:
+        if (
+            active_env_file.expanduser().resolve()
+            == trusted_compose_env_file.expanduser().resolve()
+        ):
+            return active_env_file
+        return None
+    if _is_local_service_compose_env_file(active_env_file):
+        return active_env_file
+    return None
+
+
+def _is_local_service_compose_env_file(path: Path) -> bool:
+    """Return true for the verified local-service Compose env file."""
+    from awf.service.config import _is_local_service_compose_env_path
+
+    return _is_local_service_compose_env_path(path)
+
+
+def _init_env_error_payload(
+    *,
+    operation: str,
+    path: Path,
+    env_file: Path,
+    env_example: Path,
+    exc: Exception,
+) -> dict[str, str]:
+    """Return a machine-readable env seeding failure without env contents."""
+    return {
+        "operation": operation,
+        "path": _init_display_path(path),
+        "env_file": _init_display_path(env_file),
+        "env_example": _init_display_path(env_example),
+        "message": str(exc),
+    }
+
+
+def _compose_root_env_file(env_file: Path) -> Path | None:
+    """Return the root `.env` paired with a verified local Compose env file.
+
+    Relative env-file paths come from the no-asset-root fallback used outside an
+    AWF source checkout. They are intentionally not treated as local Compose
+    asset paths, which keeps root-env fallback and `--env-file` forwarding tied
+    to absolute paths resolved from the verified bootstrap asset root.
+    """
+    env_file = env_file.expanduser()
+    if not env_file.is_absolute():
+        return None
+    resolved_env_file = env_file.resolve()
+    if (
+        resolved_env_file.name == ".env"
+        and resolved_env_file.parent.name == "compose"
+        and resolved_env_file.parent.parent.name == "docker"
+    ):
+        return resolved_env_file.parent.parent.parent / ".env"
+    return None
+
+
+def _init_env_overlay_source(env_file: Path, env_example: Path) -> Path | None:
+    """Return the root `.env` overlay used when seeding compose env files."""
+    root_env = _compose_root_env_file(env_file)
+    if root_env is None or env_example == root_env or not root_env.exists():
+        return None
+    compose_example = env_file.with_name(".env.example")
+    root_example = root_env.with_name(".env.example")
+    if env_example not in (compose_example, root_example):
+        return None
+    return root_env
+
+
+def _env_assignment_key(line: str) -> str | None:
+    """Return the key from an env assignment line, ignoring comments."""
+    if line.lstrip().startswith("#"):
+        return None
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    if match is None:
+        return None
+    return match.group("key")
+
+
+def _env_assignment_key_identity(key: str) -> str:
+    """Return the canonical key identity used for seed/overlay matching."""
+    return key.upper()
+
+
+def _env_assignment_line_with_key(line: str, key: str) -> str:
+    """Return a Compose env assignment line with the key spelling replaced."""
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    if match is None:
+        return line
+    return f"{key}{line[match.end('key') :]}"
+
+
+def _env_assignment_line_with_canonical_key(line: str, canonical_key: str) -> str:
+    """Return ``line`` with its assignment key rewritten to ``canonical_key`` in place.
+
+    Unlike :func:`_env_assignment_line_with_key`, the leading ``export`` prefix and
+    any indentation before the key are preserved — only the key span is rewritten.
+    """
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    if match is None:  # pragma: no cover - callers only pass matched assignment lines
+        return line
+    return f"{line[: match.start('key')]}{canonical_key}{line[match.end('key') :]}"
+
+
+def _replace_env_assignment_value(line: str, value: str) -> str:
+    """Return ``line`` (no trailing newline) with its assignment value set to ``value``.
+
+    Everything up to and including ``=`` is kept verbatim, so the key spelling and
+    any ``export`` prefix are preserved while the old value (and any same-line
+    trailing comment) is replaced.
+    """
+    match = _ENV_ASSIGNMENT_RE.match(line)
+    if match is None:  # pragma: no cover - callers only pass matched assignment lines
+        return line
+    return f"{line[: match.end()]}{value}"
+
+
+def _persist_console_host_port(env_file: Path, console_port: int) -> None:
+    """Persist ``AWF_CONSOLE_HOST_PORT=<console_port>`` into the active service env file.
+
+    Updates an existing assignment in place (preserving key spelling, an ``export``
+    prefix, and all unrelated lines/comments), appends a fresh assignment when the
+    key is absent, and creates the file (and parent dirs) when it does not yet exist.
+    ``AWF_CONSOLE_URL`` and every other key are left untouched.
+    """
+    value = str(console_port)
+    assignment = f"AWF_CONSOLE_HOST_PORT={value}"
+    if not env_file.exists():
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+        env_file.write_text(f"{assignment}\n", encoding="utf-8")
+        return
+
+    text = env_file.read_text(encoding="utf-8")
+    target_identity = _env_assignment_key_identity("AWF_CONSOLE_HOST_PORT")
+    lines = text.splitlines(keepends=True)
+    updated = False
+    for index, line in enumerate(lines):
+        key = _env_assignment_key(line)
+        if key is None or _env_assignment_key_identity(key) != target_identity:
+            continue
+        body = line.rstrip("\r\n")
+        newline = line[len(body) :]
+        # Rewrite the key to the canonical uppercase spelling: Compose interpolates
+        # the case-sensitive ${AWF_CONSOLE_HOST_PORT} placeholder, so a preserved
+        # lowercase key would be ignored and the console would fall back to 3000.
+        canonical_body = _env_assignment_line_with_canonical_key(body, "AWF_CONSOLE_HOST_PORT")
+        lines[index] = f"{_replace_env_assignment_value(canonical_body, value)}{newline}"
+        updated = True
+    if updated:
+        # Update every matching assignment: later commands parse env files
+        # line-by-line and let later keys overwrite earlier ones, so leaving a
+        # stale trailing duplicate would persist the wrong console port.
+        env_file.write_text("".join(lines), encoding="utf-8")
+        return
+
+    if text and not text.endswith(("\n", "\r")):
+        text += "\n"
+    env_file.write_text(f"{text}{assignment}\n", encoding="utf-8")
+
+
+def _env_seed_has_meaningful_leading_context(lines: list[str]) -> bool:
+    """Return whether the seed owns the merged file header."""
+    for line in lines:
+        if _env_assignment_key(line) is not None:
+            return False
+        if line.strip():
+            return True
+    return False
+
+
+def _env_value_has_same_line_closing_quote(value: str, quote: str) -> bool:
+    """Return whether a quoted dotenv value closes on its assignment line."""
+    escaped = False
+    for char in value[1:]:
+        if quote == '"' and char == "\\" and not escaped:
+            escaped = True
+            continue
+        if char == quote and not escaped:
+            return True
+        escaped = False
+    return False
+
+
+def _env_contents_have_multiline_values(text: str) -> bool:
+    """Return true when dotenv assignments span physical lines."""
+    for line in text.splitlines(keepends=True):
+        key = _env_assignment_key(line)
+        if key is None:
+            continue
+        _assignment, _separator, value = line.partition("=")
+        stripped_value = value.lstrip()
+        if not stripped_value:
+            continue
+        quote = stripped_value[0]
+        line_without_newline = line.rstrip("\r\n")
+        trailing_backslashes = len(line_without_newline) - len(line_without_newline.rstrip("\\"))
+        if (
+            quote not in {"'", '"'}
+            and line.endswith(("\n", "\r"))
+            and trailing_backslashes % 2 == 1
+        ):
+            return True
+        if quote in {"'", '"'} and not _env_value_has_same_line_closing_quote(
+            stripped_value,
+            quote,
+        ):
+            return True
+    return False
+
+
+def _env_context_looks_like_file_header(lines: list[str]) -> bool:
+    """Return whether leading non-assignment lines look like a file header."""
+    comment_count = 0
+    for line in lines:
+        stripped = line.strip()
+        if stripped == "":
+            return True
+        if stripped.startswith("#"):
+            comment_count += 1
+    return comment_count > 1
+
+
+def _env_comment_looks_key_specific(line: str, key: str) -> bool:
+    """Return whether a comment appears to document one dotenv assignment key."""
+    stripped = line.strip()
+    if not stripped.startswith("#"):
+        return False
+    comment = stripped.lstrip("#").strip().lower()
+    if key.lower() in comment:
+        return True
+    key_words = [
+        word
+        for word in _ENV_COMMENT_WORD_RE.findall(key.lower())
+        if word not in _ENV_COMMENT_KEY_IGNORE_WORDS
+    ]
+    if not key_words:
+        return False
+    comment_words = set(_ENV_COMMENT_WORD_RE.findall(comment))
+    return all(word in comment_words for word in key_words)
+
+
+def _env_context_has_key_specific_comment(lines: list[str], key: str) -> bool:
+    """Return whether any context comment appears tied to the given key."""
+    return any(_env_comment_looks_key_specific(line, key) for line in lines)
+
+
+def _env_context_has_file_header_marker(lines: list[str]) -> bool:
+    """Return whether comments explicitly describe dotenv-file-level context."""
+    comments = [line.strip().lstrip("#").strip().lower() for line in lines]
+    return any(
+        ".env" in comment
+        or "dotenv" in comment
+        or "environment file" in comment
+        or "settings here" in comment
+        or "overrides here" in comment
+        for comment in comments
+    )
+
+
+def _split_env_file_header_context(
+    lines: list[str],
+    key: str,
+    *,
+    seed_has_leading_context: bool,
+) -> tuple[list[str], list[str]]:
+    """Split leading overlay comments into file-header and assignment context."""
+    if not _env_context_looks_like_file_header(lines):
+        return [], lines
+    last_blank_index: int | None = None
+    for index, line in enumerate(lines):
+        if line.strip() == "":
+            last_blank_index = index
+    if last_blank_index is not None:
+        return lines[: last_blank_index + 1], lines[last_blank_index + 1 :]
+
+    split_at: int | None = None
+    for index in range(len(lines) - 1, -1, -1):
+        stripped = lines[index].strip()
+        if not stripped.startswith("#"):
+            break
+        if _env_comment_looks_key_specific(lines[index], key):
+            split_at = index
+            break
+    if split_at is None:
+        if (
+            seed_has_leading_context
+            and len(lines) <= 2
+            and not _env_context_has_file_header_marker(lines)
+        ):
+            return [], lines
+        return lines, []
+    return lines[:split_at], lines[split_at:]
+
+
+def _env_context_looks_like_section_header(lines: list[str]) -> bool:
+    """Return whether non-assignment lines look like reusable section documentation."""
+    return sum(1 for line in lines if line.strip().startswith("#")) > 1
+
+
+def _env_context_is_single_adjacent_comment(lines: list[str]) -> bool:
+    """Return whether context is exactly one comment directly above an assignment."""
+    return len(lines) == 1 and lines[0].strip().startswith("#")
+
+
+def _env_context_has_non_comment_note(lines: list[str]) -> bool:
+    """Return whether context contains an operator note outside dotenv comments."""
+    return any(line.strip() and not line.strip().startswith("#") for line in lines)
+
+
+def _merge_env_seed_contents_with_overlay_keys(
+    seed_contents: bytes,
+    overlay_contents: bytes,
+) -> tuple[bytes, tuple[str, ...]]:
+    """Return merged env contents plus root-only keys appended from the overlay."""
+    try:
+        seed_text = seed_contents.decode("utf-8")
+        overlay_text = overlay_contents.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise _EnvSeedMergeError("env seeding merge requires UTF-8 dotenv files") from exc
+
+    # This merge is deliberately line-oriented to preserve comments and ordering.
+    # Multi-line dotenv values are unsupported in seed and overlay files; keep
+    # template entries single-line unless this is replaced with a dotenv parser.
+    if _env_contents_have_multiline_values(seed_text) or _env_contents_have_multiline_values(
+        overlay_text
+    ):
+        raise _EnvSeedMergeError(
+            "unsupported multi-line dotenv values; env seeding merge only supports "
+            "single-line assignments"
+        )
+    seed_lines = seed_text.splitlines(keepends=True)
+    overlay_lines = overlay_text.splitlines(keepends=True)
+
+    overlay_assignments: dict[str, str] = {}
+    for line in overlay_lines:
+        key = _env_assignment_key(line)
+        if key is not None:
+            normalized_line = line if line.endswith(("\n", "\r")) else f"{line}\n"
+            overlay_assignments[_env_assignment_key_identity(key)] = _env_assignment_line_with_key(
+                normalized_line, key
+            )
+
+    seed_keys: set[str] = set()
+    for line in seed_lines:
+        key = _env_assignment_key(line)
+        if key is not None:
+            seed_keys.add(_env_assignment_key_identity(key))
+    seed_has_leading_context = _env_seed_has_meaningful_leading_context(seed_lines)
+
+    overlay_last_assignment_index: dict[str, int] = {}
+    for index, line in enumerate(overlay_lines):
+        key = _env_assignment_key(line)
+        if key is not None:
+            overlay_last_assignment_index[_env_assignment_key_identity(key)] = index
+
+    seed_leading_context: dict[str, list[str]] = {}
+    seed_final_context: list[str] = []
+    file_header_context: list[str] = []
+    overlay_only_lines: list[str] = []
+    overlay_only_keys: list[str] = []
+    pending_context: list[str] = []
+    duplicate_context: dict[str, list[str]] = {}
+    seen_overlay_assignment_keys: set[str] = set()
+    last_assignment_key: str | None = None
+    for index, line in enumerate(overlay_lines):
+        key = _env_assignment_key(line)
+        if key is None:
+            pending_context.append(line)
+            continue
+        key_identity = _env_assignment_key_identity(key)
+        first_overlay_assignment = last_assignment_key is None
+        if first_overlay_assignment and pending_context:
+            file_header_context, pending_context = _split_env_file_header_context(
+                pending_context,
+                key,
+                seed_has_leading_context=seed_has_leading_context,
+            )
+        context = [*duplicate_context.pop(key_identity, []), *pending_context]
+        context_has_key_specific_comment = _env_context_has_key_specific_comment(context, key)
+        if overlay_last_assignment_index.get(key_identity) == index:
+            if key_identity in seed_keys:
+                if (
+                    first_overlay_assignment
+                    and seed_has_leading_context
+                    and not context_has_key_specific_comment
+                    and (file_header_context or _env_context_is_single_adjacent_comment(context))
+                ):
+                    context = []
+                seed_leading_context[key_identity] = context
+            else:
+                overlay_only_lines.extend(context)
+                normalized_only_line = line if line.endswith(("\n", "\r")) else f"{line}\n"
+                overlay_only_lines.append(_env_assignment_line_with_key(normalized_only_line, key))
+                overlay_only_keys.append(key)
+        else:
+            if (
+                key_identity in seed_keys
+                or key_identity in seen_overlay_assignment_keys
+                or _env_context_looks_like_section_header(context)
+                or _env_context_is_single_adjacent_comment(context)
+                or _env_context_has_non_comment_note(context)
+            ):
+                duplicate_context.setdefault(key_identity, []).extend(context)
+        pending_context = []
+        seen_overlay_assignment_keys.add(key_identity)
+        last_assignment_key = key_identity
+    if pending_context and last_assignment_key is not None and last_assignment_key in seed_keys:
+        seed_final_context = pending_context
+    elif pending_context:
+        overlay_only_lines.extend(pending_context)
+
+    # Overlay file headers are kept only when the seed starts with assignments.
+    # If the seed has its own leading context, it owns the top of the merged file
+    # and overlay header comments are omitted to avoid duplicate file headers.
+    merged_lines: list[str] = [] if seed_has_leading_context else list(file_header_context)
+    emitted_seed_leading_context: set[str] = set()
+    for line in seed_lines:
+        key = _env_assignment_key(line)
+        if key is None:
+            merged_lines.append(line)
+            continue
+        key_identity = _env_assignment_key_identity(key)
+        if (
+            key_identity in seed_leading_context
+            and key_identity not in emitted_seed_leading_context
+        ):
+            merged_lines.extend(seed_leading_context[key_identity])
+            emitted_seed_leading_context.add(key_identity)
+        overlay_assignment = overlay_assignments.get(key_identity)
+        if overlay_assignment is None:
+            merged_lines.append(line)
+        else:
+            merged_lines.append(_env_assignment_line_with_key(overlay_assignment, key))
+
+    tail_lines = [*overlay_only_lines, *seed_final_context]
+    if tail_lines and merged_lines and not merged_lines[-1].endswith(("\n", "\r")):
+        merged_lines[-1] = f"{merged_lines[-1]}\n"
+    merged_lines.extend(tail_lines)
+
+    return "".join(merged_lines).encode("utf-8"), tuple(overlay_only_keys)
+
+
+def _merge_env_seed_contents(seed_contents: bytes, overlay_contents: bytes) -> bytes:
+    """Return compose-template env contents with root env assignments overlaid."""
+    merged_contents, _overlay_only_keys = _merge_env_seed_contents_with_overlay_keys(
+        seed_contents,
+        overlay_contents,
+    )
+    return merged_contents
+
+
+def _seed_env_file(
+    env_file: Path,
+    env_example: Path,
+    *,
+    env_overlay: Path | None = None,
+) -> tuple[str, dict[str, str] | None, tuple[str, ...]]:
+    """Seed an env file and return action, failure payload, and copied overlay keys."""
+    if env_file.exists():
+        return "kept_existing", None, ()
+
+    if not env_example.exists():
+        return "no_example", None, ()
+
+    try:
+        env_file.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return (
+            "write_failed",
+            _init_env_error_payload(
+                operation="create_parent_directory",
+                path=env_file.parent,
+                env_file=env_file,
+                env_example=env_example,
+                exc=exc,
+            ),
+            (),
+        )
+
+    try:
+        env_contents = env_example.read_bytes()
+    except OSError as exc:
+        return (
+            "write_failed",
+            _init_env_error_payload(
+                operation="read_example",
+                path=env_example,
+                env_file=env_file,
+                env_example=env_example,
+                exc=exc,
+            ),
+            (),
+        )
+
+    env_overlay_keys: tuple[str, ...] = ()
+    if env_overlay is not None and env_overlay.exists():
+        try:
+            overlay_contents = env_overlay.read_bytes()
+        except OSError as exc:
+            return (
+                "write_failed",
+                _init_env_error_payload(
+                    operation="read_overlay",
+                    path=env_overlay,
+                    env_file=env_file,
+                    env_example=env_example,
+                    exc=exc,
+                ),
+                (),
+            )
+        try:
+            env_contents, env_overlay_keys = _merge_env_seed_contents_with_overlay_keys(
+                env_contents,
+                overlay_contents,
+            )
+        except _EnvSeedMergeError as exc:
+            return (
+                "write_failed",
+                _init_env_error_payload(
+                    operation="merge_overlay",
+                    path=env_overlay,
+                    env_file=env_file,
+                    env_example=env_example,
+                    exc=exc,
+                ),
+                (),
+            )
+
+    env_file_created = False
+    try:
+        with env_file.open("xb") as handle:
+            env_file_created = True
+            handle.write(env_contents)
+    except FileExistsError:
+        return "kept_existing", None, ()
+    except OSError as exc:
+        if env_file_created:
+            try:
+                env_file.unlink()
+            except FileNotFoundError:
+                pass
+            except OSError:
+                pass
+        return (
+            "write_failed",
+            _init_env_error_payload(
+                operation="write_env",
+                path=env_file,
+                env_file=env_file,
+                env_example=env_example,
+                exc=exc,
+            ),
+            (),
+        )
+
+    return "wrote_from_example", None, env_overlay_keys
+
+
+def _init_display_path(path: Path | str) -> str:
+    """Return a stable human-readable init path from the launch directory."""
+    candidate = Path(path)
+    if not candidate.is_absolute():
+        return str(candidate)
+    try:
+        return os.path.relpath(candidate, Path.cwd())
+    except ValueError:
+        return str(candidate)
+
+
+def _init_env_warning(env_error: Mapping[str, str]) -> str:
+    """Return the pretty warning for an env seeding failure payload."""
+    operation = env_error["operation"]
+    message = env_error["message"]
+    env_file = env_error["env_file"]
+    env_example = env_error["env_example"]
+    if operation == "create_parent_directory":
+        parent = env_error["path"]
+        return f"  warning: could not create parent directory {parent} for {env_file}: {message}"
+    if operation == "read_example":
+        return f"  warning: could not read {env_example} while seeding {env_file}: {message}"
+    if operation == "read_overlay":
+        overlay = env_error["path"]
+        return (
+            f"  warning: could not read {overlay} while seeding {env_file} "
+            f"from {env_example}: {message}"
+        )
+    if operation == "merge_overlay":
+        overlay = env_error["path"]
+        return (
+            f"  warning: could not merge {overlay} while seeding {env_file} "
+            f"from {env_example}: {message}"
+        )
+    return f"  warning: could not write {env_file} from {env_example}: {message}"
+
+
+def _add_init_env_overlay_keys(
+    payload: dict[str, object],
+    env_overlay_keys: tuple[str, ...],
+) -> None:
+    """Add non-secret env overlay audit metadata to a JSON init payload."""
+    if env_overlay_keys:
+        payload["env_overlay_keys"] = list(env_overlay_keys)
+
+
+def _init_env_example_search_paths(env_file: Path, env_example: Path) -> tuple[Path, ...]:
+    """Return the env template paths that explain why init skipped seeding."""
+    search_paths: list[Path] = []
+    candidates = [env_file.with_name(".env.example"), env_example]
+    seen: set[Path] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        search_paths.append(candidate)
+    return tuple(search_paths)
+
+
+def _docker_diagnostic_from_report(report: object) -> object | None:
+    """Return the docker diagnostic entry from a readiness report if present."""
+
+    diagnostics = getattr(report, "diagnostics", ())
+    for diagnostic in diagnostics:
+        if getattr(diagnostic, "id", None) == "docker":
+            return cast(object, diagnostic)
+    return None
+
+
+def _init_preflight_environ(
+    environ: Mapping[str, str],
+    *,
+    provider_secret_keys: frozenset[str],
+) -> dict[str, str]:
+    """Return init preflight env without provider credentials."""
+    secret_keys = {key.upper() for key in provider_secret_keys}
+    return {key: value for key, value in environ.items() if key.upper() not in secret_keys}
+
+
+def _run_init_service_bootstrap(
+    *,
+    write_env: bool,
+    timeout_seconds: float,
+    poll_interval_seconds: float,
+    skip_agent_runtime_build: bool,
+    providers: list[str],
+    fmt: OutputFormat,
+) -> None:
+    """Run local-service bootstrap with environment seeding and status output."""
+    from awf.common.config import Settings
+    from awf.service.bootstrap import (
+        ServiceBootstrapError,
+        ServiceBootstrapOptions,
+        run_service_bootstrap,
+    )
+    from awf.service.config import local_service_environ, resolve_service_settings
+    from awf.service.doctor import collect_doctor_report
+    from awf.service.provider_readiness import (
+        KNOWN_SECRET_ENV_KEYS,
+        ProviderReadinessError,
+        validate_provider_names,
+    )
+
+    try:
+        strict_providers = validate_provider_names(providers)
+    except ProviderReadinessError as exc:
+        typer.echo(f"error: {exc}", err=True)
+        raise typer.Exit(code=2) from exc
+
+    pretty = fmt == OutputFormat.pretty
+    compose_file, env_file, env_example = _resolve_service_compose_paths()
+    env_migration = _migrate_legacy_service_env_file(env_file, env_example) if write_env else None
+    env_action = "skipped"
+    env_error: dict[str, str] | None = None
+    env_overlay_keys: tuple[str, ...] = ()
+    if write_env:
+        env_action, env_error, env_overlay_keys = _seed_env_file(
+            env_file,
+            env_example,
+            env_overlay=_init_env_overlay_source(env_file, env_example),
+        )
+    active_env_file, compose_env_file = _resolve_service_runtime_env_files(
+        compose_file,
+        env_file,
+        paths_verified=True,
+    )
+
+    if pretty:
+        typer.echo("AWF init: local service bootstrap")
+        if write_env:
+            if env_migration is not None:
+                typer.echo(
+                    f"  migrated legacy docker/compose/.env into {_init_display_path(env_file)}"
+                )
+            if env_action == "write_failed" and env_error is not None:
+                typer.echo(_init_env_warning(env_error))
+            elif env_action == "kept_existing":
+                typer.echo(f"  kept existing {_init_display_path(env_file)}")
+            elif env_action == "wrote_from_example":
+                typer.echo(
+                    f"  wrote {_init_display_path(env_file)} from {_init_display_path(env_example)}"
+                )
+                if env_overlay_keys:
+                    typer.echo(
+                        "  added root .env keys to "
+                        f"{_init_display_path(env_file)}: {', '.join(env_overlay_keys)}"
+                    )
+            elif env_action == "no_example":
+                search_paths = ", ".join(
+                    _init_display_path(path)
+                    for path in _init_env_example_search_paths(env_file, env_example)
+                )
+                typer.echo(
+                    "  no env template found; skipped "
+                    f"{_init_display_path(env_file)} "
+                    f"creation (looked for {search_paths}; run `awf init` from "
+                    "the AWF repository root if you expected one)"
+                )
+
+    try:
+        service_env = local_service_environ(env_file=active_env_file)
+        preflight_env = _init_preflight_environ(
+            service_env,
+            provider_secret_keys=KNOWN_SECRET_ENV_KEYS,
+        )
+        settings = resolve_service_settings(
+            Settings(_env_file=active_env_file, github_token=None),
+            environ=preflight_env,
+        )
+
+        docker_report = asyncio.run(
+            collect_doctor_report(
+                settings,
+                strict_providers=frozenset(),
+                provider_environ=preflight_env,
+                environ=preflight_env,
+                compose_file=compose_file,
+                compose_env_file=compose_env_file,
+            )
+        )
+        docker_diag = _docker_diagnostic_from_report(docker_report)
+        docker_status = getattr(docker_diag, "status", None)
+        docker_unknown = docker_diag is None or docker_status is None
+        if docker_unknown or docker_status == "fail":
+            if docker_unknown:
+                message = "Docker availability could not be determined from the doctor report."
+                action = "Run `awf service doctor` to investigate the local environment."
+                reason = "DOCKER_DIAGNOSTIC_MISSING"
+            else:
+                message = getattr(docker_diag, "message", "Docker is not available.")
+                action = getattr(docker_diag, "action", "")
+                reason = getattr(docker_diag, "reason", "DOCKER_DAEMON_UNREACHABLE")
+            if pretty:
+                typer.echo(f"  docker: {message}")
+                if action:
+                    typer.echo(f"  action: {action}")
+                typer.echo("")
+                typer.echo("Docker is not available; cannot bootstrap local service.")
+            else:
+                docker_payload: dict[str, object] = {
+                    "status": "failed",
+                    "reason_code": reason,
+                    "message": message,
+                    "action": action,
+                    "env_action": env_action,
+                }
+                if env_error is not None:
+                    docker_payload["env_error"] = env_error
+                _add_init_env_overlay_keys(docker_payload, env_overlay_keys)
+                _add_env_migration_payload(docker_payload, env_migration)
+                _emit(docker_payload, fmt)
+            raise typer.Exit(code=1)
+
+        state_dir = _resolve_state_directory(service_env)
+        created = not state_dir.exists()
+        state_dir.mkdir(parents=True, exist_ok=True)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        if pretty:
+            typer.echo(f"error: could not collect local checks: {exc}", err=True)
+        else:
+            local_checks_payload: dict[str, object] = {
+                "status": "failed",
+                "reason_code": "BOOTSTRAP_LOCAL_CHECKS_FAILED",
+                "message": str(exc),
+                "env_action": env_action,
+            }
+            if env_error is not None:
+                local_checks_payload["env_error"] = env_error
+            _add_init_env_overlay_keys(local_checks_payload, env_overlay_keys)
+            _add_env_migration_payload(local_checks_payload, env_migration)
+            _emit(local_checks_payload, fmt)
+        raise typer.Exit(code=1) from exc
+
+    if pretty:
+        typer.echo(f"  state directory: {state_dir}")
+        typer.echo(f"  created: {'true' if created else 'false'}")
+
+    options = ServiceBootstrapOptions(
+        timeout_seconds=timeout_seconds,
+        poll_interval_seconds=poll_interval_seconds,
+        skip_agent_runtime_build=skip_agent_runtime_build,
+        strict_providers=frozenset(strict_providers),
+    )
+    try:
+        result = asyncio.run(
+            run_service_bootstrap(
+                settings,
+                options=options,
+                compose_file=compose_file,
+                env_file=compose_env_file,
+                service_environ=service_env,
+            ),
+        )
+    except KeyboardInterrupt:
+        raise typer.Exit(code=130) from None
+    except ServiceBootstrapError as exc:
+        payload = exc.to_dict()
+        if env_error is not None:
+            payload["env_error"] = env_error
+        _add_init_env_overlay_keys(payload, env_overlay_keys)
+        _add_env_migration_payload(payload, env_migration)
+        _emit(payload, fmt)
+        raise typer.Exit(code=1) from None
+
+    if pretty:
+        typer.echo("  bootstrap status: ok")
+        typer.echo("")
+        typer.echo("Next steps:")
+        # Service bootstrap is repo-agnostic (host/service level), so it cannot
+        # know the repo's forge: defer forge-scoped auth (GitHub token or the
+        # BITBUCKET_* env) to ``awf init <path>``, which detects the forge from the
+        # repo's git remote (issue #539).
+        typer.echo(
+            "  - Run `awf init <path>` to detect your repo's forge and verify the "
+            "matching auth (GitHub token or BITBUCKET_* env)."
+        )
+        typer.echo("  - Run `awf service status --format pretty` to verify readiness.")
+        typer.echo(
+            "  - Optional console: `npm --prefix apps/console run dev`, then open http://localhost:3000."
+        )
+        typer.echo("  - Run `awf init <path>` to onboard a project repository.")
+    else:
+        payload = result.to_dict()
+        payload["state_directory"] = str(state_dir)
+        payload["state_directory_created"] = created
+        payload["env_action"] = env_action
+        if env_error is not None:
+            payload["env_error"] = env_error
+        _add_init_env_overlay_keys(payload, env_overlay_keys)
+        _add_env_migration_payload(payload, env_migration)
+        _emit(payload, fmt)

--- a/src/awf/host_setup/system_checks/__init__.py
+++ b/src/awf/host_setup/system_checks/__init__.py
@@ -266,11 +266,16 @@ def run_system_checks(
     compose_checks = (
         [check_compose(run=docker_runner)] if docker_check.data.get("available") else []
     )
+    # ``check_gh`` is intentionally NOT run here: GitHub-CLI presence is a
+    # forge-scoped concern that belongs at ``awf init <PATH>`` (project
+    # onboarding, where the repo's ``git remote`` reveals the forge), not at the
+    # repo-agnostic host/service readiness level. A Bitbucket-only host must see
+    # zero ``gh`` noise at ``awf setup`` (issue #539). ``check_gh`` is kept and
+    # re-exported because ``awf init`` reuses it for GitHub repos.
     return [
         docker_check,
         *compose_checks,
         check_git(),
-        check_gh(),
         check_python_runtime(),
         ports_check,
         postgres_port_check,

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -123,6 +123,39 @@ def test_detect_github_forge_auth_degrades_to_unknown_without_settings(
 
 
 @pytest.mark.unit
+def test_detect_github_forge_auth_ok_when_token_present_without_gh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured token authenticates even with the ``gh`` CLI uninstalled.
+
+    Regression for the misleading ``auth_ok: false`` (PR #541 review): AWF's
+    GitHub API operations rely on ``AWF_GITHUB_TOKEN`` (readiness), not the ``gh``
+    binary, so a present+valid token with ``gh`` absent is genuinely authenticated.
+    ``gh`` presence stays reported as a separate advisory signal but must not drag
+    ``auth_ok`` to ``False``.
+    """
+    from awf.host_setup.system_checks import SetupCheckLevel, SetupCheckResult
+
+    monkeypatch.setattr(
+        "awf.host_setup.system_checks.check_gh",
+        lambda **_kwargs: SetupCheckResult(
+            name="gh", level=SetupCheckLevel.WARNING, summary="missing", detail="missing"
+        ),
+    )
+    monkeypatch.setattr(
+        "awf.service.provider_readiness.check_single_provider_readiness",
+        lambda *_a, **_k: {"ok": True},
+    )
+
+    auth, auth_ok = init_ops._detect_github_forge_auth(  # noqa: SLF001
+        settings=object(), service_env=None
+    )
+
+    assert auth == {"gh_present": False, "github_readiness": "ok"}
+    assert auth_ok is True
+
+
+@pytest.mark.unit
 def test_detect_bitbucket_forge_auth_falls_back_to_os_environ(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -138,6 +138,53 @@ def test_detect_bitbucket_forge_auth_falls_back_to_os_environ(
 
 
 @pytest.mark.unit
+def test_explicit_project_forge_reads_pinned_value_from_disk(tmp_path: Path) -> None:
+    """A pinned ``forge:`` in an on-disk profile is read (not the drafted default)."""
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text("forge: bitbucket\n", encoding="utf-8")
+
+    assert init_ops._explicit_project_forge(tmp_path) == "bitbucket"  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_explicit_project_forge_reads_nested_awf_section(tmp_path: Path) -> None:
+    """The ``forge:`` under a top-level ``awf:`` mapping is honored too."""
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text("awf:\n  forge: github\n", encoding="utf-8")
+
+    assert init_ops._explicit_project_forge(tmp_path) == "github"  # noqa: SLF001
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "contents",
+    [
+        # No profile file at all is handled by the missing-path branch (see below).
+        "forge: 123\n",  # non-string forge value -> "auto"
+        "awf: not-a-mapping\n",  # awf section is not a mapping -> "auto"
+        "- just\n- a\n- list\n",  # top-level is not a mapping -> "auto"
+        "",  # empty file parses to ``None`` -> "auto"
+        ": : invalid : :\n",  # malformed YAML -> "auto"
+    ],
+)
+def test_explicit_project_forge_falls_back_to_auto(tmp_path: Path, contents: str) -> None:
+    """Missing key, wrong shape, or unreadable profile defers to URL detection."""
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text(contents, encoding="utf-8")
+
+    assert init_ops._explicit_project_forge(tmp_path) == "auto"  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_explicit_project_forge_returns_auto_without_profile(tmp_path: Path) -> None:
+    """No on-disk workspace profile defers to URL-host detection."""
+    assert init_ops._explicit_project_forge(tmp_path) == "auto"  # noqa: SLF001
+
+
+@pytest.mark.unit
 def test_forge_guidance_lines_cover_github_missing_gh_and_unknown_auth() -> None:
     lines = init_ops._forge_guidance_lines(  # noqa: SLF001
         {

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -197,6 +197,49 @@ def test_detect_bitbucket_forge_auth_unknown_mode_requires_email() -> None:
 
 
 @pytest.mark.unit
+def test_detect_bitbucket_forge_auth_invalid_mode_with_full_creds_is_not_ok() -> None:
+    """A misspelled auth mode is a warning even when token + email are both present.
+
+    ``BitbucketAuth.from_env`` rejects any mode outside ``basic``/``bearer`` with
+    ``BITBUCKET_AUTH_NOT_CONFIGURED``, so init must not report ``auth_ok`` for a
+    config the runtime client will refuse (PR #541 review).
+    """
+    auth, auth_ok = init_ops._detect_bitbucket_forge_auth(  # noqa: SLF001
+        {
+            "BITBUCKET_API_TOKEN": "tok",
+            "BITBUCKET_EMAIL": "e@x.com",
+            "BITBUCKET_AUTH_MODE": "bearrer",
+        }
+    )
+
+    assert auth["missing"] == []
+    assert auth["invalid_mode"] is True
+    assert auth_ok is False
+
+
+@pytest.mark.unit
+def test_forge_guidance_lines_bitbucket_invalid_mode_warns() -> None:
+    """Invalid Bitbucket auth mode surfaces a fix hint, not an auth-present line."""
+    lines = init_ops._forge_guidance_lines(  # noqa: SLF001
+        {
+            "forge": "bitbucket",
+            "auth": {
+                "bitbucket_keys": {
+                    "BITBUCKET_API_TOKEN": True,
+                    "BITBUCKET_EMAIL": True,
+                    "BITBUCKET_AUTH_MODE": True,
+                },
+                "missing": [],
+                "invalid_mode": True,
+            },
+        }
+    )
+
+    assert any("BITBUCKET_AUTH_MODE" in line and "basic" in line for line in lines)
+    assert not any("Bitbucket auth env present" in line for line in lines)
+
+
+@pytest.mark.unit
 def test_detect_bitbucket_forge_auth_whitespace_only_values_are_missing() -> None:
     """Whitespace-only ``BITBUCKET_*`` values are treated as absent.
 

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -126,14 +126,40 @@ def test_detect_github_forge_auth_degrades_to_unknown_without_settings(
 def test_detect_bitbucket_forge_auth_falls_back_to_os_environ(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When the resolved service env is unavailable, read ``os.environ``."""
+    """When the resolved service env is unavailable, read ``os.environ``.
+
+    Token + email with no ``BITBUCKET_AUTH_MODE`` is the valid default-basic
+    config, so the optional mode selector must not be reported as missing.
+    """
     monkeypatch.setenv("BITBUCKET_API_TOKEN", "tok")
     monkeypatch.setenv("BITBUCKET_EMAIL", "dev@example.com")
     monkeypatch.delenv("BITBUCKET_AUTH_MODE", raising=False)
 
     auth, auth_ok = init_ops._detect_bitbucket_forge_auth(None)  # noqa: SLF001
 
-    assert auth["missing"] == ["BITBUCKET_AUTH_MODE"]
+    assert auth["missing"] == []
+    assert auth_ok is True
+
+
+@pytest.mark.unit
+def test_detect_bitbucket_forge_auth_bearer_mode_needs_token_only() -> None:
+    """``BITBUCKET_AUTH_MODE=bearer`` authenticates with the token alone."""
+    auth, auth_ok = init_ops._detect_bitbucket_forge_auth(  # noqa: SLF001
+        {"BITBUCKET_API_TOKEN": "tok", "BITBUCKET_AUTH_MODE": "bearer"}
+    )
+
+    assert auth["missing"] == []
+    assert auth_ok is True
+
+
+@pytest.mark.unit
+def test_detect_bitbucket_forge_auth_unknown_mode_requires_email() -> None:
+    """An unrecognized auth mode is treated conservatively as ``basic``."""
+    auth, auth_ok = init_ops._detect_bitbucket_forge_auth(  # noqa: SLF001
+        {"BITBUCKET_API_TOKEN": "tok", "BITBUCKET_AUTH_MODE": "weird"}
+    )
+
+    assert auth["missing"] == ["BITBUCKET_EMAIL"]
     assert auth_ok is False
 
 

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -276,6 +276,41 @@ def test_detect_project_forge_auth_service_env_recompute_failure_is_neutral(
 
 
 @pytest.mark.unit
+def test_detect_project_forge_auth_recompute_interpolation_error_falls_back(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Compose interpolation error during recompute degrades to ``os.environ``.
+
+    ``local_service_environ`` merges the Compose ``.env``; a malformed interpolation
+    raises :class:`ComposeEnvInterpolationError` (a ``ValueError``). That must degrade
+    to the documented per-forge ``os.environ`` fallback like ``OSError`` does, not
+    bubble up into a generic ``detection_error`` block that skips forge auth.
+    """
+    from awf.service.environment import ComposeEnvInterpolationError
+
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _repo: "https://bitbucket.org/acme/widgets.git",
+    )
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "tok")
+    monkeypatch.setenv("BITBUCKET_EMAIL", "dev@example.com")
+
+    def _raise() -> dict[str, str]:
+        raise ComposeEnvInterpolationError("MISSING_VAR", "MISSING_VAR is required")
+
+    monkeypatch.setattr("awf.service.config.local_service_environ", _raise)
+
+    block = init_ops._detect_project_forge_auth(  # noqa: SLF001
+        tmp_path, settings=None, service_env=None
+    )
+
+    # Recompute failed; the per-forge ``os.environ`` fallback still verifies auth.
+    assert block["forge"] == "bitbucket"
+    assert block["auth_ok"] is True
+    assert "detection_error" not in block
+
+
+@pytest.mark.unit
 def test_explicit_project_forge_reads_pinned_value_from_disk(tmp_path: Path) -> None:
     """A pinned ``forge:`` in an on-disk profile is read (not the drafted default)."""
     awf_dir = tmp_path / ".awf"

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -281,6 +281,28 @@ def test_forge_guidance_lines_cover_github_missing_gh_and_unknown_auth() -> None
 
 
 @pytest.mark.unit
+def test_forge_guidance_lines_detection_error_does_not_claim_missing_remote() -> None:
+    """A detection-error block surfaces a retry hint, not the add-a-remote advice."""
+    lines = init_ops._forge_guidance_lines(  # noqa: SLF001
+        init_ops._forge_detection_error_block()  # noqa: SLF001
+    )
+
+    assert any("Forge auth check could not run" in line for line in lines)
+    assert not any("No `origin` remote detected" in line for line in lines)
+
+
+@pytest.mark.unit
+def test_forge_guidance_lines_no_origin_advises_adding_remote() -> None:
+    """The genuine no-origin neutral block still advises adding a git remote."""
+    lines = init_ops._forge_guidance_lines(  # noqa: SLF001
+        init_ops._neutral_forge_block()  # noqa: SLF001
+    )
+
+    assert any("No `origin` remote detected" in line for line in lines)
+    assert not any("Forge auth check could not run" in line for line in lines)
+
+
+@pytest.mark.unit
 def test_guided_project_onboarding_rejects_unknown_template(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
 ) -> None:

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -68,6 +68,91 @@ def test_project_onboarding_rejects_guided_json(
     assert "--guided cannot be used with --format json" in capsys.readouterr().err
 
 
+# --- Forge detection / auth helpers (issue #539) --------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("repo_url", "expected"),
+    [
+        ("git@github.com:acme/widgets.git", "github.com"),
+        ("https://user:token@bitbucket.org/acme/widgets.git", "bitbucket.org"),
+        ("ssh://git@gitlab.example.com:22/acme/widgets.git", "gitlab.example.com"),
+        # Bare ``owner/repo`` slug has no host.
+        ("acme/widgets", None),
+        # Malformed URL makes ``urlsplit`` raise ``ValueError`` -> ``None``.
+        ("https://[", None),
+    ],
+)
+def test_redacted_remote_host_strips_credentials_and_handles_unparseable(
+    repo_url: str, expected: str | None
+) -> None:
+    # An ``https://user:token@host/...`` origin must never surface its embedded
+    # credential; only the credential-free host is returned.
+    assert init_ops._redacted_remote_host(repo_url) == expected  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_detect_github_forge_auth_degrades_to_unknown_without_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Readiness is ``unknown`` (never blocking) when settings are unavailable."""
+    from awf.host_setup.system_checks import SetupCheckLevel, SetupCheckResult
+
+    monkeypatch.setattr(
+        "awf.host_setup.system_checks.check_gh",
+        lambda **_kwargs: SetupCheckResult(
+            name="gh", level=SetupCheckLevel.OK, summary="ok", detail="ok"
+        ),
+    )
+
+    def _readiness_must_not_run(*_a: object, **_k: object) -> dict[str, object]:
+        raise AssertionError("readiness must not run without settings")
+
+    monkeypatch.setattr(
+        "awf.service.provider_readiness.check_single_provider_readiness",
+        _readiness_must_not_run,
+    )
+
+    auth, auth_ok = init_ops._detect_github_forge_auth(  # noqa: SLF001
+        settings=None, service_env=None
+    )
+
+    assert auth == {"gh_present": True, "github_readiness": "unknown"}
+    assert auth_ok is False
+
+
+@pytest.mark.unit
+def test_detect_bitbucket_forge_auth_falls_back_to_os_environ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the resolved service env is unavailable, read ``os.environ``."""
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "tok")
+    monkeypatch.setenv("BITBUCKET_EMAIL", "dev@example.com")
+    monkeypatch.delenv("BITBUCKET_AUTH_MODE", raising=False)
+
+    auth, auth_ok = init_ops._detect_bitbucket_forge_auth(None)  # noqa: SLF001
+
+    assert auth["missing"] == ["BITBUCKET_AUTH_MODE"]
+    assert auth_ok is False
+
+
+@pytest.mark.unit
+def test_forge_guidance_lines_cover_github_missing_gh_and_unknown_auth() -> None:
+    lines = init_ops._forge_guidance_lines(  # noqa: SLF001
+        {
+            "forge": "github",
+            "host": "github.com",
+            "host_detected": True,
+            "auth": {"gh_present": False, "github_readiness": "unknown"},
+        }
+    )
+
+    assert "Detected forge: github." in lines
+    assert any("Install the GitHub CLI (gh)" in line for line in lines)
+    assert any("GitHub auth not checked" in line for line in lines)
+
+
 @pytest.mark.unit
 def test_guided_project_onboarding_rejects_unknown_template(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -218,6 +218,64 @@ def test_detect_bitbucket_forge_auth_whitespace_only_values_are_missing() -> Non
 
 
 @pytest.mark.unit
+def test_detect_project_forge_auth_recomputes_service_env_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A ``None`` service env is recomputed from the Compose ``.env``-merged view.
+
+    When onboarding collection leaves ``service_env`` unset (e.g.
+    ``local_service_environ`` raised after settings resolved), forge auth must still
+    verify the same merged view doctor/status use — not bare ``os.environ`` — so a
+    Bitbucket token present only in root ``.env`` is not wrongly reported missing.
+    """
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _repo: "https://bitbucket.org/acme/widgets.git",
+    )
+    # ``os.environ`` lacks the credentials; only the merged ``.env`` view carries them.
+    monkeypatch.delenv("BITBUCKET_API_TOKEN", raising=False)
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda: {"BITBUCKET_API_TOKEN": "tok", "BITBUCKET_EMAIL": "dev@example.com"},
+    )
+
+    block = init_ops._detect_project_forge_auth(  # noqa: SLF001
+        tmp_path, settings=None, service_env=None
+    )
+
+    assert block["forge"] == "bitbucket"
+    assert block["auth_ok"] is True
+    assert block["auth"]["missing"] == []  # type: ignore[index]
+
+
+@pytest.mark.unit
+def test_detect_project_forge_auth_service_env_recompute_failure_is_neutral(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed env recompute degrades to ``os.environ``, never raising out."""
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _repo: "https://bitbucket.org/acme/widgets.git",
+    )
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "tok")
+    monkeypatch.setenv("BITBUCKET_EMAIL", "dev@example.com")
+
+    def _raise() -> dict[str, str]:
+        raise OSError("env file unreadable")
+
+    monkeypatch.setattr("awf.service.config.local_service_environ", _raise)
+
+    block = init_ops._detect_project_forge_auth(  # noqa: SLF001
+        tmp_path, settings=None, service_env=None
+    )
+
+    # Recompute failed; the per-forge ``os.environ`` fallback still verifies auth.
+    assert block["forge"] == "bitbucket"
+    assert block["auth_ok"] is True
+
+
+@pytest.mark.unit
 def test_explicit_project_forge_reads_pinned_value_from_disk(tmp_path: Path) -> None:
     """A pinned ``forge:`` in an on-disk profile is read (not the drafted default)."""
     awf_dir = tmp_path / ".awf"

--- a/tests/unit/cli/test_init_ops_coverage_helpers.py
+++ b/tests/unit/cli/test_init_ops_coverage_helpers.py
@@ -197,6 +197,27 @@ def test_detect_bitbucket_forge_auth_unknown_mode_requires_email() -> None:
 
 
 @pytest.mark.unit
+def test_detect_bitbucket_forge_auth_whitespace_only_values_are_missing() -> None:
+    """Whitespace-only ``BITBUCKET_*`` values are treated as absent.
+
+    Mirrors ``bitbucket_credentials_present``, which strips token and email before
+    the presence check; otherwise a whitespace-only value would falsely report
+    ``auth_ok`` while runtime auth still fails.
+    """
+    auth, auth_ok = init_ops._detect_bitbucket_forge_auth(  # noqa: SLF001
+        {"BITBUCKET_API_TOKEN": "  ", "BITBUCKET_EMAIL": "\t"}
+    )
+
+    assert auth["bitbucket_keys"] == {
+        "BITBUCKET_API_TOKEN": False,
+        "BITBUCKET_EMAIL": False,
+        "BITBUCKET_AUTH_MODE": False,
+    }
+    assert auth["missing"] == ["BITBUCKET_API_TOKEN", "BITBUCKET_EMAIL"]
+    assert auth_ok is False
+
+
+@pytest.mark.unit
 def test_explicit_project_forge_reads_pinned_value_from_disk(tmp_path: Path) -> None:
     """A pinned ``forge:`` in an on-disk profile is read (not the drafted default)."""
     awf_dir = tmp_path / ".awf"

--- a/tests/unit/cli/test_init_parts/test_init_part_001.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_001.py
@@ -1225,7 +1225,11 @@ def test_init_without_path_runs_service_bootstrap(
     assert "AWF init: local service bootstrap" in result.output
     assert str(state_dir.resolve()) in result.output
     assert "awf service status" in result.output
-    assert "AWF_GITHUB_TOKEN" in result.output
+    # Service bootstrap is repo-agnostic: it no longer hard-codes the GitHub token
+    # export and instead defers forge-scoped auth to ``awf init <path>`` (issue
+    # #539).
+    assert "AWF_GITHUB_TOKEN" not in result.output
+    assert "BITBUCKET_* env" in result.output
     assert "awf init <path>" in result.output
     assert len(captured["bootstrap_calls"]) == 1
     assert captured["bootstrap_calls"][0]["env_file"] is None

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -140,13 +140,14 @@ def test_init_github_present_but_unauthenticated_reports_both_signals(
 
 
 @pytest.mark.unit
-def test_init_bitbucket_repo_verifies_trio_and_never_mentions_gh(
+def test_init_bitbucket_repo_names_only_required_missing_keys_and_never_mentions_gh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _stub_prereqs(monkeypatch)
     _stub_origin(monkeypatch, "git@bitbucket.org:acme/widgets.git")
     _forbid_check_gh(monkeypatch)
-    # Partial env: only the token is set, so EMAIL + AUTH_MODE must be named.
+    # Partial env: only the token is set. EMAIL is required in the default ``basic``
+    # mode, but AUTH_MODE is an optional selector and must NOT be named as missing.
     monkeypatch.setattr(
         "awf.service.config.local_service_environ",
         lambda *_a, **_k: {"BITBUCKET_API_TOKEN": "tok"},
@@ -162,17 +163,55 @@ def test_init_bitbucket_repo_verifies_trio_and_never_mentions_gh(
         "BITBUCKET_EMAIL": False,
         "BITBUCKET_AUTH_MODE": False,
     }
-    assert forge["auth"]["missing"] == ["BITBUCKET_EMAIL", "BITBUCKET_AUTH_MODE"]
+    assert forge["auth"]["missing"] == ["BITBUCKET_EMAIL"]
     assert forge["auth_ok"] is False
 
     pretty = _runner.invoke(app, ["init", str(tmp_path)])
     assert pretty.exit_code == 0, pretty.output
     assert "Detected forge: bitbucket." in pretty.output
-    assert "BITBUCKET_EMAIL, BITBUCKET_AUTH_MODE" in pretty.output
+    assert "BITBUCKET_EMAIL" in pretty.output
+    # The optional mode selector is never demanded as a missing key.
+    assert "BITBUCKET_AUTH_MODE" not in pretty.output
     # A bitbucket repo must see zero gh noise.
     assert "GitHub" not in pretty.output
     assert "gh auth" not in pretty.output
     assert "install gh" not in pretty.output.lower()
+
+
+@pytest.mark.unit
+def test_init_bitbucket_basic_mode_without_auth_mode_env_is_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Token + email but no ``BITBUCKET_AUTH_MODE`` is a valid default-basic config.
+
+    Regression for the false ``auth_ok: false`` warning: the auth-mode env defaults
+    to ``basic``, which only needs token + email, so omitting it must not flag the
+    workspace as incomplete (PR #541 review).
+    """
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://bitbucket.org/acme/widgets.git")
+    _forbid_check_gh(monkeypatch)
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda *_a, **_k: {
+            "BITBUCKET_API_TOKEN": "tok",
+            "BITBUCKET_EMAIL": "dev@example.com",
+        },
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "bitbucket"
+    assert forge["auth"]["missing"] == []
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "ok"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "Bitbucket auth env present" in pretty.output
+    # Only the keys that are actually present are listed — not the omitted selector.
+    assert "BITBUCKET_AUTH_MODE" not in pretty.output
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -227,6 +227,42 @@ def test_init_no_origin_remote_stays_neutral_and_never_blocks(
 
 
 @pytest.mark.unit
+def test_init_forge_detection_error_downgrades_to_neutral_and_never_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An unexpected error during forge auth detection must not abort onboarding.
+
+    The invariant is that forge auth issues never block project onboarding. If
+    the underlying detection raises (e.g. an IO/config error reading provider
+    settings, or an unusual git setup), ``awf init`` must downgrade to a neutral
+    forge block instead of propagating an unhandled exception.
+    """
+    _stub_prereqs(monkeypatch)
+
+    def _boom(_path: object) -> str:
+        raise RuntimeError("unexpected git failure")
+
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        _boom,
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] is None
+    assert forge["host"] is None
+    assert forge["host_detected"] is False
+    assert forge["auth"] is None
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "neutral"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert pretty.exit_code == 0, pretty.output
+
+
+@pytest.mark.unit
 def test_init_explicit_forge_override_wins_over_url_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -296,6 +296,84 @@ def test_init_no_origin_remote_stays_neutral_and_never_blocks(
 
 
 @pytest.mark.unit
+def test_init_no_origin_with_explicit_bitbucket_pin_honors_forge_auth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pinned ``forge: bitbucket`` is honored even with no ``origin`` remote.
+
+    Documented precedence is explicit ``forge:`` > URL host > github, so an
+    already-onboarded repo whose ``.awf/workspace.yml`` pins a concrete forge must
+    still get its forge-specific auth check — not the neutral no-remote block that
+    skips it (PR #541 review).
+    """
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, None)
+    _forbid_check_gh(monkeypatch)
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text("forge: bitbucket\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda *_a, **_k: {"BITBUCKET_API_TOKEN": "tok"},
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "bitbucket"
+    assert forge["host"] is None  # no origin URL to parse
+    assert forge["host_detected"] is False
+    # EMAIL is still required in the default basic mode, so this warns (never blocks).
+    assert forge["auth"]["missing"] == ["BITBUCKET_EMAIL"]
+    assert forge["auth_ok"] is False
+    assert forge["level"] == "warning"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert pretty.exit_code == 0, pretty.output
+    assert "Detected forge: bitbucket." in pretty.output
+    # The neutral "add a remote" guidance must NOT fire for a pinned profile.
+    assert "No `origin` remote detected" not in pretty.output
+
+
+@pytest.mark.unit
+def test_init_no_origin_with_explicit_github_pin_honors_forge_auth(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A pinned ``forge: github`` runs the GitHub auth check with no ``origin``.
+
+    With no URL host to recognize the guidance must not claim the host is
+    "not recognized; defaulting to github" (the forge was explicitly pinned), and
+    must run the readiness/gh checks rather than the neutral no-remote block.
+    """
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, None)
+    _stub_check_gh(monkeypatch, present=True)
+    _stub_github_readiness(monkeypatch, ok=True)
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text("forge: github\n", encoding="utf-8")
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "github"
+    assert forge["host"] is None
+    assert forge["host_detected"] is False
+    assert forge["auth"]["github_readiness"] == "ok"
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "ok"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert pretty.exit_code == 0, pretty.output
+    assert "Detected forge: github" in pretty.output
+    # A pinned forge is not an unrecognized-host default.
+    assert "not recognized" not in pretty.output
+    assert "No `origin` remote detected" not in pretty.output
+
+
+@pytest.mark.unit
 def test_init_forge_detection_error_downgrades_to_neutral_and_never_blocks(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -1,0 +1,310 @@
+"""CLI coverage for ``awf init`` forge detection + forge-scoped auth (issue #539).
+
+Forge detection (GitHub vs Bitbucket) and any ``gh`` requirement moved from the
+repo-agnostic host/service readiness layer to ``awf init <PATH>`` project
+onboarding, where the repo's ``git remote`` is in scope. These tests pin the
+detection branches (github / bitbucket / no-remote / explicit-override /
+unknown-host / present-but-unauthenticated) and the structured JSON contract.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+from awf.cli.main import app
+
+_runner = CliRunner()
+
+
+def _stub_prereqs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub local-service collection so onboarding reaches forge detection."""
+
+    async def _collect_service_status(_settings: object, **_kwargs: object) -> dict[str, object]:
+        return {
+            "service": "awf",
+            "status": "ok",
+            "checks": {},
+            "agent_readiness": {"status": "ok"},
+        }
+
+    async def _collect_doctor_report(_settings: object, **_kwargs: object) -> object:
+        return SimpleNamespace(status="ok", diagnostics=())
+
+    # A non-None settings object so the github branch exercises readiness; the
+    # readiness probe itself is stubbed per-test so it never shells out.
+    monkeypatch.setattr("awf.service.config.resolve_service_settings", lambda: object())
+    monkeypatch.setattr("awf.service.config.local_service_environ", lambda *_a, **_k: {})
+    monkeypatch.setattr("awf.service.status.collect_service_status", _collect_service_status)
+    monkeypatch.setattr("awf.service.doctor.collect_doctor_report", _collect_doctor_report)
+    monkeypatch.setattr(
+        "awf.service.doctor.render_doctor_pretty",
+        lambda report: f"AWF doctor: {getattr(report, 'status', 'unknown')}\n",
+    )
+
+
+def _stub_origin(monkeypatch: pytest.MonkeyPatch, repo_url: str | None) -> None:
+    monkeypatch.setattr(
+        "awf.common.git_remote.detect_repo_url_from_checkout",
+        lambda _path: repo_url,
+    )
+
+
+def _gh_result(level_ok: bool) -> Any:
+    from awf.host_setup.system_checks import SetupCheckLevel, SetupCheckResult
+
+    return SetupCheckResult(
+        name="gh",
+        level=SetupCheckLevel.OK if level_ok else SetupCheckLevel.WARNING,
+        summary="ok" if level_ok else "missing",
+        detail="ok",
+    )
+
+
+def _stub_check_gh(monkeypatch: pytest.MonkeyPatch, *, present: bool) -> None:
+    monkeypatch.setattr(
+        "awf.host_setup.system_checks.check_gh",
+        lambda **_kwargs: _gh_result(present),
+    )
+
+
+def _forbid_check_gh(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prove the bitbucket path never touches the GitHub CLI presence probe."""
+
+    def _boom(**_kwargs: object) -> Any:
+        raise AssertionError("check_gh must not run for a bitbucket repo")
+
+    monkeypatch.setattr("awf.host_setup.system_checks.check_gh", _boom)
+
+
+def _stub_github_readiness(monkeypatch: pytest.MonkeyPatch, *, ok: bool) -> None:
+    monkeypatch.setattr(
+        "awf.service.provider_readiness.check_single_provider_readiness",
+        lambda *_a, **_k: {"ok": ok},
+    )
+
+
+@pytest.mark.unit
+def test_init_github_repo_runs_gh_and_readiness_and_emits_github_steps(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://github.com/acme/widgets.git")
+    _stub_check_gh(monkeypatch, present=True)
+    _stub_github_readiness(monkeypatch, ok=True)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "github"
+    assert forge["host_detected"] is True
+    assert forge["host"] == "github.com"
+    assert forge["auth"]["gh_present"] is True
+    assert forge["auth"]["github_readiness"] == "ok"
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "ok"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert pretty.exit_code == 0, pretty.output
+    assert "Detected forge: github." in pretty.output
+    assert "GitHub CLI (gh)" in pretty.output
+
+
+@pytest.mark.unit
+def test_init_github_present_but_unauthenticated_reports_both_signals(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "git@github.com:acme/widgets.git")
+    _stub_check_gh(monkeypatch, present=True)
+    _stub_github_readiness(monkeypatch, ok=False)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output  # WARNING, never blocking
+    forge = json.loads(result.output)["forge"]
+    assert forge["auth"]["gh_present"] is True
+    assert forge["auth"]["github_readiness"] == "fail"
+    assert forge["auth_ok"] is False
+    assert forge["level"] == "warning"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "GitHub auth not verified" in pretty.output
+    assert "AWF_GITHUB_TOKEN" in pretty.output
+
+
+@pytest.mark.unit
+def test_init_bitbucket_repo_verifies_trio_and_never_mentions_gh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "git@bitbucket.org:acme/widgets.git")
+    _forbid_check_gh(monkeypatch)
+    # Partial env: only the token is set, so EMAIL + AUTH_MODE must be named.
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda *_a, **_k: {"BITBUCKET_API_TOKEN": "tok"},
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "bitbucket"
+    assert forge["auth"]["bitbucket_keys"] == {
+        "BITBUCKET_API_TOKEN": True,
+        "BITBUCKET_EMAIL": False,
+        "BITBUCKET_AUTH_MODE": False,
+    }
+    assert forge["auth"]["missing"] == ["BITBUCKET_EMAIL", "BITBUCKET_AUTH_MODE"]
+    assert forge["auth_ok"] is False
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert pretty.exit_code == 0, pretty.output
+    assert "Detected forge: bitbucket." in pretty.output
+    assert "BITBUCKET_EMAIL, BITBUCKET_AUTH_MODE" in pretty.output
+    # A bitbucket repo must see zero gh noise.
+    assert "GitHub" not in pretty.output
+    assert "gh auth" not in pretty.output
+    assert "install gh" not in pretty.output.lower()
+
+
+@pytest.mark.unit
+def test_init_bitbucket_repo_full_env_is_ok(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://bitbucket.org/acme/widgets.git")
+    _forbid_check_gh(monkeypatch)
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda *_a, **_k: {
+            "BITBUCKET_API_TOKEN": "tok",
+            "BITBUCKET_EMAIL": "dev@example.com",
+            "BITBUCKET_AUTH_MODE": "basic",
+        },
+    )
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "bitbucket"
+    assert forge["auth"]["missing"] == []
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "ok"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "Bitbucket auth env present" in pretty.output
+
+
+@pytest.mark.unit
+def test_init_no_origin_remote_stays_neutral_and_never_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, None)
+    _forbid_check_gh(monkeypatch)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] is None
+    assert forge["host"] is None
+    assert forge["host_detected"] is False
+    assert forge["auth"] is None
+    assert forge["level"] == "neutral"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "No `origin` remote detected" in pretty.output
+
+
+@pytest.mark.unit
+def test_init_explicit_forge_override_wins_over_url_host(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    # Origin host is github.com, but the workspace profile pins ``forge: bitbucket``.
+    _stub_origin(monkeypatch, "https://github.com/acme/widgets.git")
+    _forbid_check_gh(monkeypatch)
+    monkeypatch.setattr(
+        "awf.service.config.local_service_environ",
+        lambda *_a, **_k: {
+            "BITBUCKET_API_TOKEN": "tok",
+            "BITBUCKET_EMAIL": "dev@example.com",
+            "BITBUCKET_AUTH_MODE": "basic",
+        },
+    )
+
+    def _preview(_path: Path, **_kwargs: object) -> object:
+        return SimpleNamespace(
+            path=_path,
+            draft=SimpleNamespace(
+                template="generic",
+                profile=SimpleNamespace(forge="bitbucket"),
+            ),
+            smoke_request=None,
+            to_dict=lambda: {"path": str(_path), "draft": {"template": "generic"}},
+        )
+
+    monkeypatch.setattr("awf.profiles.onboarding.preview_project_onboarding", _preview)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    # Explicit ``forge:`` beats the github.com URL host.
+    assert forge["forge"] == "bitbucket"
+    assert forge["auth_ok"] is True
+
+
+@pytest.mark.unit
+def test_init_unknown_host_defaults_to_github_without_hard_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://gitlab.com/acme/widgets.git")
+    _stub_check_gh(monkeypatch, present=True)
+    _stub_github_readiness(monkeypatch, ok=True)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output  # unknown host does not hard-fail
+    forge = json.loads(result.output)["forge"]
+    assert forge["forge"] == "github"  # forge.py default for an unknown host
+    assert forge["host_detected"] is False
+    assert forge["host"] == "gitlab.com"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "not recognized" in pretty.output
+    assert "gitlab.com" in pretty.output
+
+
+@pytest.mark.unit
+def test_init_forge_block_present_on_write_yes_json_contract(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://github.com/acme/widgets.git")
+    _stub_check_gh(monkeypatch, present=True)
+    _stub_github_readiness(monkeypatch, ok=True)
+
+    result = _runner.invoke(
+        app,
+        ["init", str(tmp_path), "--write-profile", "--yes", "--format", "json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["mode"] == "write"
+    # The forge block + per-signal auth status travels in the JSON payload, not
+    # only the pretty echo.
+    assert payload["forge"]["forge"] == "github"
+    assert payload["forge"]["auth"]["github_readiness"] == "ok"

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -231,7 +231,14 @@ def test_init_explicit_forge_override_wins_over_url_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _stub_prereqs(monkeypatch)
-    # Origin host is github.com, but the workspace profile pins ``forge: bitbucket``.
+    # Origin host is github.com, but the on-disk workspace profile pins
+    # ``forge: bitbucket``. ``awf init`` drafts a fresh profile (always
+    # ``forge: auto``) and never reads this file into the preview, so the override
+    # must be read straight off disk — otherwise re-running init follows the
+    # github.com URL host and runs the wrong (GitHub) auth checks.
+    awf_dir = tmp_path / ".awf"
+    awf_dir.mkdir()
+    (awf_dir / "workspace.yml").write_text("forge: bitbucket\n", encoding="utf-8")
     _stub_origin(monkeypatch, "https://github.com/acme/widgets.git")
     _forbid_check_gh(monkeypatch)
     monkeypatch.setattr(
@@ -243,24 +250,11 @@ def test_init_explicit_forge_override_wins_over_url_host(
         },
     )
 
-    def _preview(_path: Path, **_kwargs: object) -> object:
-        return SimpleNamespace(
-            path=_path,
-            draft=SimpleNamespace(
-                template="generic",
-                profile=SimpleNamespace(forge="bitbucket"),
-            ),
-            smoke_request=None,
-            to_dict=lambda: {"path": str(_path), "draft": {"template": "generic"}},
-        )
-
-    monkeypatch.setattr("awf.profiles.onboarding.preview_project_onboarding", _preview)
-
     result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
 
     assert result.exit_code == 0, result.output
     forge = json.loads(result.output)["forge"]
-    # Explicit ``forge:`` beats the github.com URL host.
+    # Explicit on-disk ``forge:`` beats the github.com URL host.
     assert forge["forge"] == "bitbucket"
     assert forge["auth_ok"] is True
 

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -326,9 +326,16 @@ def test_init_forge_detection_error_downgrades_to_neutral_and_never_blocks(
     assert forge["auth"] is None
     assert forge["auth_ok"] is True
     assert forge["level"] == "neutral"
+    # The detection-error block is flagged distinctly from the no-origin case so
+    # guidance never claims a missing remote when probing merely failed.
+    assert forge["detection_error"] is True
 
     pretty = _runner.invoke(app, ["init", str(tmp_path)])
     assert pretty.exit_code == 0, pretty.output
+    # A detection failure must NOT tell the user to add a remote (the remote may
+    # well exist); it surfaces a generic retry hint instead.
+    assert "No `origin` remote detected" not in pretty.output
+    assert "Forge auth check could not run" in pretty.output
 
 
 @pytest.mark.unit

--- a/tests/unit/cli/test_init_parts/test_init_part_005.py
+++ b/tests/unit/cli/test_init_parts/test_init_part_005.py
@@ -140,6 +140,36 @@ def test_init_github_present_but_unauthenticated_reports_both_signals(
 
 
 @pytest.mark.unit
+def test_init_github_token_present_without_gh_is_authenticated(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A valid token with ``gh`` absent reports ``auth_ok``/``level=ok`` (PR #541).
+
+    AWF's GitHub API operations rely on ``AWF_GITHUB_TOKEN`` (readiness), not the
+    ``gh`` binary, so the top-level ``auth_ok`` must follow the readiness signal and
+    not be dragged to ``False`` by a missing CLI. The ``gh`` install hint is still
+    surfaced separately, but onboarding is not flagged as a warning.
+    """
+    _stub_prereqs(monkeypatch)
+    _stub_origin(monkeypatch, "https://github.com/acme/widgets.git")
+    _stub_check_gh(monkeypatch, present=False)
+    _stub_github_readiness(monkeypatch, ok=True)
+
+    result = _runner.invoke(app, ["init", str(tmp_path), "--format", "json"])
+
+    assert result.exit_code == 0, result.output
+    forge = json.loads(result.output)["forge"]
+    assert forge["auth"]["gh_present"] is False
+    assert forge["auth"]["github_readiness"] == "ok"
+    assert forge["auth_ok"] is True
+    assert forge["level"] == "ok"
+
+    pretty = _runner.invoke(app, ["init", str(tmp_path)])
+    assert "GitHub auth verified." in pretty.output
+    assert "Install the GitHub CLI (gh)" in pretty.output
+
+
+@pytest.mark.unit
 def test_init_bitbucket_repo_names_only_required_missing_keys_and_never_mentions_gh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/service/host_setup_system_checks_support.py
+++ b/tests/unit/service/host_setup_system_checks_support.py
@@ -32,8 +32,9 @@ def _stub_non_docker_checks_ok(monkeypatch: pytest.MonkeyPatch) -> None:
     def fake_ok(name: str) -> SetupCheckResult:
         return SetupCheckResult(name=name, level=SetupCheckLevel.OK, summary="ok", detail="ok")
 
+    # ``check_gh`` is no longer part of ``run_system_checks`` (issue #539): forge
+    # presence moved to ``awf init``, so it is not stubbed here.
     monkeypatch.setattr(system_checks, "check_git", lambda: fake_ok("git"))
-    monkeypatch.setattr(system_checks, "check_gh", lambda: fake_ok("gh"))
     monkeypatch.setattr(system_checks, "check_python_runtime", lambda: fake_ok("python"))
     monkeypatch.setattr(system_checks, "check_ports", lambda _port: fake_ok("ports"))
     monkeypatch.setattr(
@@ -86,7 +87,6 @@ def _patch_probes_capture_port(
     )
     monkeypatch.setattr(system_checks, "check_compose", lambda **_kwargs: fake_ok("compose"))
     monkeypatch.setattr(system_checks, "check_git", lambda: fake_ok("git"))
-    monkeypatch.setattr(system_checks, "check_gh", lambda: fake_ok("gh"))
     monkeypatch.setattr(system_checks, "check_python_runtime", lambda: fake_ok("python"))
     monkeypatch.setattr(system_checks, "check_ports", fake_ports)
     monkeypatch.setattr(
@@ -126,7 +126,6 @@ def _patch_probes_capture_postgres_port(
     )
     monkeypatch.setattr(system_checks, "check_compose", lambda **_kwargs: fake_ok("compose"))
     monkeypatch.setattr(system_checks, "check_git", lambda: fake_ok("git"))
-    monkeypatch.setattr(system_checks, "check_gh", lambda: fake_ok("gh"))
     monkeypatch.setattr(system_checks, "check_python_runtime", lambda: fake_ok("python"))
     monkeypatch.setattr(system_checks, "check_ports", lambda _port: fake_ok("ports"))
     monkeypatch.setattr(system_checks, "check_postgres_port", fake_postgres_port)
@@ -164,7 +163,6 @@ def _patch_probes_capture_disk_path(
     )
     monkeypatch.setattr(system_checks, "check_compose", lambda **_kwargs: fake_ok("compose"))
     monkeypatch.setattr(system_checks, "check_git", lambda: fake_ok("git"))
-    monkeypatch.setattr(system_checks, "check_gh", lambda: fake_ok("gh"))
     monkeypatch.setattr(system_checks, "check_python_runtime", lambda: fake_ok("python"))
     monkeypatch.setattr(system_checks, "check_ports", lambda _port: fake_ok("ports"))
     monkeypatch.setattr(

--- a/tests/unit/service/test_host_setup_system_checks_probes.py
+++ b/tests/unit/service/test_host_setup_system_checks_probes.py
@@ -426,6 +426,49 @@ def test_check_gh_warns_when_missing_and_ok_when_present() -> None:
     assert "BITBUCKET_AUTH_MODE" in missing.fix
 
 
+@pytest.mark.unit
+def test_run_system_checks_emits_no_gh_check_for_bitbucket_only_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Bitbucket-only host sees zero ``gh`` noise at ``awf setup`` (issue #539).
+
+    Forge presence moved to ``awf init <PATH>``; ``run_system_checks`` is the
+    repo-agnostic host/service readiness probe and must not enumerate a ``gh``
+    check even when ``check_gh`` would warn (no gh installed, Bitbucket auth in
+    the environment). The probe is asserted unstubbed so a regression that
+    re-adds ``check_gh`` to the ordered list is caught.
+    """
+    monkeypatch.setattr(
+        system_checks,
+        "check_docker",
+        lambda **_kwargs: SetupCheckResult(
+            name="docker",
+            level=SetupCheckLevel.OK,
+            summary="ok",
+            detail="ok",
+            data={"available": True},
+        ),
+    )
+    monkeypatch.setattr(
+        system_checks,
+        "check_compose",
+        lambda **_kwargs: SetupCheckResult(
+            name="compose", level=SetupCheckLevel.OK, summary="ok", detail="ok"
+        ),
+    )
+    _stub_non_docker_checks_ok(monkeypatch)
+
+    results = run_system_checks(
+        environ={
+            "BITBUCKET_API_TOKEN": "x",
+            "BITBUCKET_EMAIL": "dev@example.com",
+            "BITBUCKET_AUTH_MODE": "basic",
+        },
+    )
+
+    assert "gh" not in [r.name for r in results]
+
+
 # --- Python runtime -------------------------------------------------------
 
 
@@ -834,7 +877,6 @@ def test_run_system_checks_orders_and_wires_config(monkeypatch: pytest.MonkeyPat
     )
     monkeypatch.setattr(system_checks, "check_compose", lambda **_kwargs: fake_ok("compose"))
     monkeypatch.setattr(system_checks, "check_git", lambda: fake_ok("git"))
-    monkeypatch.setattr(system_checks, "check_gh", lambda: fake_ok("gh"))
     monkeypatch.setattr(system_checks, "check_python_runtime", lambda: fake_ok("python"))
 
     def fake_ports(port: int) -> SetupCheckResult:
@@ -859,7 +901,6 @@ def test_run_system_checks_orders_and_wires_config(monkeypatch: pytest.MonkeyPat
         "docker",
         "compose",
         "git",
-        "gh",
         "python",
         "ports",
         "postgres_port",
@@ -912,7 +953,6 @@ def test_run_system_checks_omits_compose_when_docker_binary_absent(
     assert names == [
         "docker",
         "git",
-        "gh",
         "python",
         "ports",
         "postgres_port",
@@ -985,7 +1025,6 @@ def test_run_system_checks_blocks_unresolvable_work_dir_user(
         "check_docker",
         "check_compose",
         "check_git",
-        "check_gh",
         "check_python_runtime",
         "check_shell_path",
         "check_local_capacity",


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a43d73c190c7483db313abeb` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Implement issue #539: move forge/provider detection to the `awf init` layer and remove the `gh` probe from host readiness.

PRINCIPLE (locked via engineering review): forge detection (GitHub vs Bitbucket) and any `gh` requirement belong at `awf init <PATH>` (project onboarding, where the repo's `git remote` is in scope), NOT at `awf setup` / `awf service doctor` (host/service level, repo-agnostic). The right abstraction already exists and MUST be reused — do not build new detection.

REUSE THESE (do not modify them):
- `src/awf/common/git_remote.py` `detect_repo_url_from_checkout(path)` — reads the `origin` remote URL, returns None when absent.
- `src/awf/common/forge.py` `RepoRef.from_url` — maps URL host to github|bitbucket, precedence: explicit `forge:` in workspace.yml > URL host > default github.
- existing `provider_readiness` for GitHub auth verification.
- `check_gh()` (keep it; reuse it at init for GitHub repos).

CHANGES:
1. `src/awf/host_setup/system_checks/__init__.py`: remove `check_gh()` from the `run_system_checks` list (around line 273). KEEP the `check_gh` function and its `__all__` export. Verify `build_setup_readiness_payload` (around line 364) does not enumerate a fixed `"gh"` key; if it does, drop it there too.
2. `src/awf/cli/init_ops.py`: at `awf init <PATH>` project onboarding, detect the forge via `detect_repo_url_from_checkout(PATH)` -> `forge.py`, then verify ONLY the matching auth:
   - GitHub: reuse `check_gh()` + `provider_readiness`.
   - Bitbucket: verify `BITBUCKET_API_TOKEN` + `BITBUCKET_EMAIL` + `BITBUCKET_AUTH_MODE` present in `.env`.
   Emit forge-scoped Next steps. DELETE the unconditional `export AWF_GITHUB_TOKEN="$(gh auth token)"` line (around line 1447) — replace with forge-scoped guidance.

EDGE CASES (cover all):
- No `origin` remote -> None -> neutral note, no forge assumption, NEVER block.
- Explicit `forge:` in workspace.yml -> honored over URL host (forge.py precedence).
- Unknown host (GHE / GitLab / self-hosted Bitbucket) -> forge.py default github; report detected host, do not hard-fail.
- GitHub repo, `gh` present but unauthenticated -> presence (check_gh) and auth (provider_readiness) are distinct; report both.
- Bitbucket repo, partial `BITBUCKET_*` -> name exactly which of the three keys is missing.
- `--format json` / `--yes` -> put `forge` + per-key auth status in the JSON payload, not only the pretty echo.
- Missing matching auth is NON-BLOCKING (WARNING level). This preserves the invariant that mocked smoke needs no live forge access.

TESTS (TDD, full coverage — this repo enforces ~99%):
- Host: `run_system_checks` output no longer contains a `gh` check; a Bitbucket-only env produces zero gh noise at `awf setup`. Update/retire the gh assertion in `tests/unit/service/test_host_setup_system_checks_probes.py`.
- Init: github-repo path runs check_gh + readiness and emits github Next steps; bitbucket-repo path verifies the trio and NEVER mentions gh; no-remote path stays neutral; explicit-`forge:` override honored; JSON contract carries `forge` + auth status.

SCOPE GUARDS:
- Do NOT modify `.github/workflows/**`, `.awf/workspace.yml`, `src/awf/common/forge.py`, or `src/awf/common/git_remote.py` (reuse only).
- Out of scope: GitLab support (forge.py supports github|bitbucket only); runtime/per-workspace forge logic (already correct).
- Keep the diff right-sized; explicit over clever; DRY (reuse the existing helpers, do not duplicate detection).

Reference #539 in the PR. The full spec is in the issue body.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes onboarding and auth diagnostic behavior across CLI paths; auth issues are non-blocking, but incorrect forge/env reporting could mislead operators before PR work.
> 
> **Overview**
> **Forge-scoped auth moves to project onboarding** (`awf init <path>`), and repo-agnostic host setup no longer probes the GitHub CLI.
> 
> `run_system_checks` drops `check_gh()` so Bitbucket-only hosts see no `gh` noise at `awf setup`; `check_gh` stays exported for reuse. Project init now detects forge from `origin` (plus explicit `forge:` in `.awf/workspace.yml`), runs GitHub (`gh` + provider readiness) or Bitbucket (`BITBUCKET_*`) checks only for the resolved forge, and adds a **`forge`** block to JSON and a **Forge auth:** section in pretty output—warnings never block onboarding. Service bootstrap next steps defer to `awf init <path>` instead of unconditionally suggesting `AWF_GITHUB_TOKEN`.
> 
> Local-service env/compose helpers are **extracted** to `service_init_ops.py` with re-exports from `init_ops` for compatibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb808c42b939dede7c5ce93ee5d7857ccc3d1a58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->