### PR TITLE
Centralize per-cycle task_tag fetch (#537)

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/ci_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/ci_ops.py
@@ -78,13 +78,16 @@ async def _run_ci_fix(
     )
     if head_result is not None:
         return cast(_GitPushResult, head_result)
+    # Resolve the workspace's optional Jira issue key once for this repair path
+    # and thread it into the commit sink so the cycle does not re-query the DB.
+    task_tag = await self._resolve_task_tag(workspace_id)
     prompt = fix_ci_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
         failures=failures,
         workspace_runtime_context=self._workspace_runtime_context,
         owned_paths=await _owned_paths_for_prompt(self, workspace_id),
-        task_tag=await self._resolve_task_tag(workspace_id),
+        task_tag=task_tag,
     )
     agent_run_err = None
     command_evidence: list[str] = []
@@ -115,6 +118,7 @@ async def _run_ci_fix(
             compose_project=compose_project,
             compose_file=compose_file,
             command_evidence=command_evidence,
+            task_tag=task_tag,
         )
     except ProtectedScopeDiffError as exc:
         return cast(

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -50,6 +50,7 @@ async def _address_thread(
     compose_file: Path,
     state: MonitorState | None = None,
     owned_paths: Sequence[str] | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> Verdict:
     from awf.runtime.pr_monitor_runner.helpers import (
         _defer_reason_state_key,
@@ -61,17 +62,23 @@ async def _address_thread(
         if owned_paths is not None
         else await _owned_paths_for_prompt(runner, workspace_id)
     )
-    # Resolve the workspace's optional Jira issue key once for this repair path
-    # and thread it into the downstream commit sink so the cycle does not re-query
-    # the DB for the same immutable value.
-    task_tag = await runner._resolve_task_tag(workspace_id)
+    # The workspace's optional Jira issue key is immutable, so resolve it once per
+    # repair cycle and thread it (alongside ``owned_paths``) into every item in the
+    # fix-cycle loops. Self-resolve only as a fallback for callers that pass nothing
+    # (the sentinel default), so a single comment-repair cycle with many threads
+    # opens one workspace lookup instead of one per item (#537).
+    resolved_task_tag = (
+        await runner._resolve_task_tag(workspace_id)
+        if isinstance(task_tag, _TaskTagUnset)
+        else task_tag
+    )
     prompt = address_thread_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
         thread=thread,
         workspace_runtime_context=runner._workspace_runtime_context,
         owned_paths=prompt_owned_paths,
-        task_tag=task_tag,
+        task_tag=resolved_task_tag,
     )
     result = await runner._invoke_cli_for_verdict_result(
         workspace_id=workspace_id,
@@ -80,7 +87,7 @@ async def _address_thread(
         compose_project=compose_project,
         compose_file=compose_file,
         state=state,
-        task_tag=task_tag,
+        task_tag=resolved_task_tag,
     )
     # Stash the agent's defer reason so the deferred-capture path can preserve it
     # in the filed tracking issue (the verdict alone loses that follow-up detail).
@@ -133,23 +140,30 @@ async def _address_review_comment_result(
     compose_file: Path,
     state: MonitorState | None = None,
     owned_paths: Sequence[str] | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> VerdictResult:
     prompt_owned_paths = (
         owned_paths
         if owned_paths is not None
         else await _owned_paths_for_prompt(runner, workspace_id)
     )
-    # Resolve the workspace's optional Jira issue key once for this repair path
-    # and thread it into the downstream commit sink so the cycle does not re-query
-    # the DB for the same immutable value.
-    task_tag = await runner._resolve_task_tag(workspace_id)
+    # The workspace's optional Jira issue key is immutable, so resolve it once per
+    # repair cycle and thread it (alongside ``owned_paths``) into every item in the
+    # fix-cycle loops. Self-resolve only as a fallback for callers that pass nothing
+    # (the sentinel default), so a single comment-repair cycle with many comments
+    # opens one workspace lookup instead of one per item (#537).
+    resolved_task_tag = (
+        await runner._resolve_task_tag(workspace_id)
+        if isinstance(task_tag, _TaskTagUnset)
+        else task_tag
+    )
     prompt = address_review_comment_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
         comment=comment,
         workspace_runtime_context=runner._workspace_runtime_context,
         owned_paths=prompt_owned_paths,
-        task_tag=task_tag,
+        task_tag=resolved_task_tag,
     )
     return await runner._invoke_cli_for_verdict_result(
         workspace_id=workspace_id,
@@ -158,7 +172,7 @@ async def _address_review_comment_result(
         compose_project=compose_project,
         compose_file=compose_file,
         state=state,
-        task_tag=task_tag,
+        task_tag=resolved_task_tag,
     )
 
 

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -17,6 +17,7 @@ from awf.runtime.monitor_prompts import (
     address_thread_prompt,
     ready_to_merge_comment,
 )
+from awf.runtime.pr_monitor_runner.constants import _TASK_TAG_UNSET, _TaskTagUnset
 from awf.runtime.pr_monitor_runner.types import ProviderRecoveryRetryError
 
 # Verdicts the CLI reply parser can produce. Kept as a type alias so
@@ -60,13 +61,17 @@ async def _address_thread(
         if owned_paths is not None
         else await _owned_paths_for_prompt(runner, workspace_id)
     )
+    # Resolve the workspace's optional Jira issue key once for this repair path
+    # and thread it into the downstream commit sink so the cycle does not re-query
+    # the DB for the same immutable value.
+    task_tag = await runner._resolve_task_tag(workspace_id)
     prompt = address_thread_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
         thread=thread,
         workspace_runtime_context=runner._workspace_runtime_context,
         owned_paths=prompt_owned_paths,
-        task_tag=await runner._resolve_task_tag(workspace_id),
+        task_tag=task_tag,
     )
     result = await runner._invoke_cli_for_verdict_result(
         workspace_id=workspace_id,
@@ -75,6 +80,7 @@ async def _address_thread(
         compose_project=compose_project,
         compose_file=compose_file,
         state=state,
+        task_tag=task_tag,
     )
     # Stash the agent's defer reason so the deferred-capture path can preserve it
     # in the filed tracking issue (the verdict alone loses that follow-up detail).
@@ -133,13 +139,17 @@ async def _address_review_comment_result(
         if owned_paths is not None
         else await _owned_paths_for_prompt(runner, workspace_id)
     )
+    # Resolve the workspace's optional Jira issue key once for this repair path
+    # and thread it into the downstream commit sink so the cycle does not re-query
+    # the DB for the same immutable value.
+    task_tag = await runner._resolve_task_tag(workspace_id)
     prompt = address_review_comment_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
         comment=comment,
         workspace_runtime_context=runner._workspace_runtime_context,
         owned_paths=prompt_owned_paths,
-        task_tag=await runner._resolve_task_tag(workspace_id),
+        task_tag=task_tag,
     )
     return await runner._invoke_cli_for_verdict_result(
         workspace_id=workspace_id,
@@ -148,6 +158,7 @@ async def _address_review_comment_result(
         compose_project=compose_project,
         compose_file=compose_file,
         state=state,
+        task_tag=task_tag,
     )
 
 
@@ -209,6 +220,7 @@ async def _invoke_cli_for_verdict_result(
     compose_project: str,
     compose_file: Path,
     state: MonitorState | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> VerdictResult:
     from awf.runtime.pr_monitor_runner.helpers import _parse_verdict_result
 
@@ -249,6 +261,7 @@ async def _invoke_cli_for_verdict_result(
         compose_file=compose_file,
         state=state,
         command_evidence=command_evidence,
+        task_tag=task_tag,
     )
 
     if agent_run_err is not None:

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -115,6 +115,7 @@ async def _address_review_comment(
     compose_file: Path,
     state: MonitorState | None = None,
     owned_paths: Sequence[str] | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> Verdict:
     result = await runner._address_review_comment_result(
         workspace_id=workspace_id,
@@ -125,6 +126,7 @@ async def _address_review_comment(
         compose_file=compose_file,
         state=state,
         owned_paths=owned_paths,
+        task_tag=task_tag,
     )
     return result.verdict
 

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -198,6 +198,7 @@ async def _invoke_cli_for_verdict(
     compose_project: str,
     compose_file: Path,
     state: MonitorState | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> Verdict:
     return (
         await runner._invoke_cli_for_verdict_result(
@@ -207,6 +208,7 @@ async def _invoke_cli_for_verdict(
             compose_project=compose_project,
             compose_file=compose_file,
             state=state,
+            task_tag=task_tag,
         )
     ).verdict
 

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -17,6 +17,24 @@ from awf.service.staleness import (
 
 _RETRYABLE_RECOVERY_TERMINAL_OPERATION_STATUSES = RETRYABLE_MONITOR_OPERATION_STATUSES
 
+
+class _TaskTagUnset:
+    """Sentinel type meaning "no ``task_tag`` was threaded by the caller".
+
+    ``task_tag`` is legitimately ``None`` when the workspace carries no Jira
+    issue key, so ``None`` cannot double as "not provided". A repair sink that
+    accepts a threaded tag uses an instance of this class as its default: when
+    the argument is still the sentinel the sink self-resolves the tag from the
+    DB (today's behavior); any other value (including ``None``) is used as-is.
+    """
+
+    __slots__ = ()
+
+
+# Module-level singleton used as the "not threaded" default. Compared by
+# ``isinstance(...)`` so the threaded path never depends on object identity.
+_TASK_TAG_UNSET = _TaskTagUnset()
+
 # Strong, unambiguous permanent markers. A fault carrying any of these is a
 # genuine credential/identity/repository failure that no amount of retrying can
 # fix, so the monitor fails fast. Deliberately does NOT include the broad

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -126,6 +126,12 @@ async def _run_fix_cycle(
     if head_result is not None:
         return cast(_GitPushResult, head_result)
     owned_paths = await _owned_paths_for_prompt_or_empty(self, workspace_id)
+    # The workspace's Jira issue key is immutable, so resolve it once for the whole
+    # repair cycle (alongside ``owned_paths``) and thread it into every per-item
+    # ``_address_thread`` / ``_address_review_comment_result`` call below. Without
+    # this each thread/comment — and each settle pass — would re-open a workspace
+    # lookup for the same value, the #537 regression in the busiest repair path.
+    task_tag = await self._resolve_task_tag(workspace_id)
 
     def _drop_pending_publish_state(item_id: str) -> None:
         publish_dependent_ids[:] = [
@@ -156,6 +162,7 @@ async def _run_fix_cycle(
                     compose_file=compose_file,
                     state=state,
                     owned_paths=owned_paths,
+                    task_tag=task_tag,
                 )
             except ProtectedScopeDiffError as exc:
                 for item_id in publish_dependent_ids:
@@ -257,6 +264,7 @@ async def _run_fix_cycle(
                     compose_file=compose_file,
                     state=state,
                     owned_paths=owned_paths,
+                    task_tag=task_tag,
                 )
             except ProtectedScopeDiffError as exc:
                 for item_id in publish_dependent_ids:

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -60,6 +60,9 @@ async def _run_operator_hint_cycle(
     if head_result is not None:
         return cast(_GitPushResult, head_result)
 
+    # Resolve the workspace's optional Jira issue key once for this repair path
+    # and thread it into the commit sink so the cycle does not re-query the DB.
+    task_tag = await self._resolve_task_tag(workspace_id)
     prompt = operator_hint_prompt(
         pr_number=pr_number,
         repo_slug=repo.slug(),
@@ -67,7 +70,7 @@ async def _run_operator_hint_cycle(
         directive=hint.directive,
         operation_id=hint.operation_id,
         workspace_runtime_context=self._workspace_runtime_context,
-        task_tag=await self._resolve_task_tag(workspace_id),
+        task_tag=task_tag,
     )
     try:
         verdict = await self._invoke_cli_for_verdict_result(
@@ -77,6 +80,7 @@ async def _run_operator_hint_cycle(
             compose_project=compose_project,
             compose_file=compose_file,
             state=state,
+            task_tag=task_tag,
         )
     except ProtectedScopeDiffError as exc:
         push_result = cast(

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -759,6 +759,7 @@ async def _run_sync_base(
                 workspace_id=workspace_id,
                 message=f"fix: resolve PR #{pr_number} base conflicts",
                 command_evidence=command_evidence,
+                task_tag=task_tag,
             )
         except _MonitorPolicyBlockedError as exc:
             return _GitPushResult(

--- a/src/awf/runtime/pr_monitor_runner/remote_repair.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair.py
@@ -56,6 +56,8 @@ from awf.runtime.pr_monitor_runner.constants import (
     _PROTECTED_SCOPE_REPAIR_FAILED_REASON,
     _REPAIR_START_HEAD_UNAVAILABLE_REASON,
     _REPAIR_WORKTREE_STATUS_FAILED_REASON,
+    _TASK_TAG_UNSET,
+    _TaskTagUnset,
 )
 from awf.runtime.pr_monitor_runner.git_utils import (
     git_worktree_command,
@@ -228,6 +230,7 @@ async def _commit_dirty_worktree(
     command_evidence: Sequence[str] = (),
     protected_scope_revert_remote_branch: str | None = None,
     remote_push_url: str | None = None,
+    task_tag: str | None | _TaskTagUnset = _TASK_TAG_UNSET,
 ) -> bool:
     """Commit dirty monitor-agent edits so PR feedback is not stranded.
 
@@ -308,9 +311,15 @@ async def _commit_dirty_worktree(
     # CI-fix commits link to the issue. Idempotent: a re-run never double-prefixes.
     # Truncate to [:72] after tagging for parity with every other AWF-authored
     # commit subject (executor agent/recovery commits, post-validation conformance).
-    message = commit_message_with_task_tag(message, await _resolve_task_tag(self, workspace_id))[
-        :72
-    ]
+    # The caller (a repair path) resolves ``task_tag`` once per monitor cycle and
+    # threads it in; fall back to a self-resolve only when nothing was threaded
+    # (the sentinel default), preserving behavior for callers that do not pass it.
+    resolved_task_tag = (
+        await _resolve_task_tag(self, workspace_id)
+        if isinstance(task_tag, _TaskTagUnset)
+        else task_tag
+    )
+    message = commit_message_with_task_tag(message, resolved_task_tag)[:72]
 
     commit = await self._deps.runner.run(
         git_worktree_command(worktree_path, "commit", "-m", message)

--- a/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
+++ b/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
@@ -19,9 +19,19 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.adapters.base import AgentRunResult
 from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.common.github_client import RepoRef
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
-from awf.runtime.pr_monitor import OperatorHint
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    OperatorHint,
+    PRStatus,
+    ReviewComment,
+    ReviewThread,
+)
 from awf.runtime.pr_monitor_runner import ci_ops, comments, operator_hints
 from awf.runtime.pr_monitor_runner import remote_ops as pr_remote_ops
 from awf.runtime.pr_monitor_runner import remote_repair as pr_remote_repair
@@ -29,6 +39,7 @@ from awf.runtime.pr_monitor_runner.comments import VerdictResult
 from awf.runtime.pr_monitor_runner.constants import _TASK_TAG_UNSET
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 from tests.postgres import postgres_test_engine
+from tests.shared.monitor_runner import DefaultMergeMethodGitHubClient
 from tests.unit.runtime._monitor_runner_fixtures import (
     FakeAdapter,
     RecordedSleep,
@@ -536,6 +547,173 @@ async def test_comment_paths_resolve_once_and_thread_to_invoke(
     assert resolve_calls == ["ws_cmt"]
     assert prompt_tags == ["CMT-5"]
     assert invoke_tags == ["CMT-5"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "entry",
+    ["_address_thread", "_address_review_comment_result"],
+)
+@pytest.mark.parametrize("threaded_tag", ["THREAD-9", None])
+async def test_comment_paths_thread_supplied_tag_skips_resolver(
+    entry: str,
+    threaded_tag: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A ``task_tag`` threaded from the fix cycle is forwarded verbatim — including a
+    real untagged ``None`` — to the prompt and commit sink without a per-item DB
+    self-resolve (the #537 hot-path fix). A self-resolve here would return the wrong
+    value, so the assertion both pins the no-DB contract and the forwarded value."""
+    resolve_calls: list[str] = []
+    prompt_tags: list[object] = []
+    invoke_tags: list[object] = []
+
+    async def _resolve_task_tag(workspace_id: str) -> str | None:
+        resolve_calls.append(workspace_id)
+        return "DB-NEVER-USED"
+
+    async def _invoke(**kwargs: object) -> VerdictResult:
+        invoke_tags.append(kwargs.get("task_tag"))
+        return VerdictResult(verdict="fix_committed")
+
+    def _prompt(**kwargs: object) -> str:
+        prompt_tags.append(kwargs.get("task_tag"))
+        return "PROMPT"
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    monkeypatch.setattr(comments, "address_review_comment_prompt", _prompt)
+
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _resolve_task_tag=_resolve_task_tag,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+
+    common_kwargs: dict[str, object] = {
+        "workspace_id": "ws_cmt",
+        "repo": _FAKE_REPO,
+        "pr_number": 3,
+        "compose_project": "proj",
+        "compose_file": Path("compose.yml"),
+        "owned_paths": ["src/"],
+        "task_tag": threaded_tag,
+    }
+    if entry == "_address_thread":
+        await comments._address_thread(
+            runner,
+            thread=SimpleNamespace(thread_id="t1"),
+            **common_kwargs,
+        )
+    else:
+        await comments._address_review_comment_result(
+            runner,
+            comment=SimpleNamespace(comment_id=11),
+            **common_kwargs,
+        )
+
+    assert resolve_calls == []
+    assert prompt_tags == [threaded_tag]
+    assert invoke_tags == [threaded_tag]
+
+
+class _EmptySettleResolveClient(DefaultMergeMethodGitHubClient):
+    """gh double: an empty settle status (burst settled) plus a no-op resolve.
+
+    Lets a multi-item ``_run_fix_cycle`` run end-to-end (address → settle → push →
+    resolve) so the per-cycle ``_resolve_task_tag`` call count can be asserted.
+    """
+
+    def __init__(self, runner: FakeCommandRunner) -> None:
+        super().__init__(runner)
+        self.resolved: list[str] = []
+
+    async def fetch_pr_status(
+        self, *, repo: RepoRef, pr_number: int, base_behind_count: int
+    ) -> PRStatus:
+        del repo, pr_number, base_behind_count
+        return PRStatus(
+            number=42,
+            head_sha="abc1234567890def",
+            mergeable=MergeableState.MERGEABLE,
+            check_state=CheckState.SUCCESS,
+            unresolved_inline_threads=(),
+            unresolved_review_comments=(),
+            base_behind_count=0,
+            merge_state_status=MergeStateStatus.CLEAN,
+        )
+
+    async def resolve_thread(self, *, thread_id: str) -> None:
+        self.resolved.append(thread_id)
+
+
+@pytest.mark.unit
+async def test_run_fix_cycle_resolves_task_tag_once_for_multiple_items(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The busiest repair path resolves ``task_tag`` exactly once per cycle (#537).
+
+    With two inline threads and two review comments in a single fix cycle, the tag
+    is hoisted alongside ``owned_paths`` and threaded into each per-item helper, so
+    the workspace is looked up once for the whole cycle — not once per item. The
+    two resolved threads confirm both item loops actually ran (so the single
+    resolve is not a trivial early-exit)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout="newsha\n")  # rev-parse HEAD
+    adapter = FakeAdapter()
+    for _ in range(4):  # 2 threads + 2 review comments
+        adapter.queue(stdout="Committed fix locally.")
+    threads = tuple(
+        ReviewThread(
+            thread_id=f"PRRT_{n}",
+            path="src/foo.py",
+            line=n,
+            body_excerpt="please adjust",
+            author="review-bot",
+        )
+        for n in (1, 2)
+    )
+    reviews = tuple(
+        ReviewComment(comment_id=cid, body_excerpt="tweak this", author="review-bot")
+        for cid in ("c11", "c12")
+    )
+    gh = _EmptySettleResolveClient(cmd)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+    # Spy the instance-bound resolver so every cycle-level + per-item lookup counts.
+    original_resolve = runner._resolve_task_tag
+    resolve_calls: list[str] = []
+
+    async def _counting_resolve(ws_id: str) -> str | None:
+        resolve_calls.append(ws_id)
+        return await original_resolve(ws_id)
+
+    runner._resolve_task_tag = _counting_resolve  # type: ignore[method-assign]
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=threads,
+        initial_reviews=reviews,
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert resolve_calls == [workspace_id]
+    assert gh.resolved == ["PRRT_1", "PRRT_2"]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
+++ b/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
@@ -283,6 +283,52 @@ async def test_invoke_cli_for_verdict_result_default_forwards_sentinel() -> None
     assert sink_task_tags == [_TASK_TAG_UNSET]
 
 
+def _verdict_wrapper_runner(invoke_tags: list[object]) -> SimpleNamespace:
+    async def _invoke(**kwargs: object) -> VerdictResult:
+        invoke_tags.append(kwargs.get("task_tag"))
+        return VerdictResult(verdict="fix_committed")
+
+    return SimpleNamespace(_invoke_cli_for_verdict_result=_invoke)
+
+
+@pytest.mark.unit
+async def test_invoke_cli_for_verdict_wrapper_forwards_explicit_tag() -> None:
+    """The verdict-only wrapper threads ``task_tag`` to the result helper."""
+    invoke_tags: list[object] = []
+    runner = _verdict_wrapper_runner(invoke_tags)
+
+    verdict = await comments._invoke_cli_for_verdict(
+        runner,
+        workspace_id="ws_1",
+        prompt="p",
+        commit_message="fix: x",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        task_tag="WRAP-9",
+    )
+
+    assert verdict == "fix_committed"
+    assert invoke_tags == ["WRAP-9"]
+
+
+@pytest.mark.unit
+async def test_invoke_cli_for_verdict_wrapper_default_forwards_sentinel() -> None:
+    """Omitting ``task_tag`` forwards the sentinel so the sink self-resolves."""
+    invoke_tags: list[object] = []
+    runner = _verdict_wrapper_runner(invoke_tags)
+
+    await comments._invoke_cli_for_verdict(
+        runner,
+        workspace_id="ws_1",
+        prompt="p",
+        commit_message="fix: x",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+    )
+
+    assert invoke_tags == [_TASK_TAG_UNSET]
+
+
 # --------------------------------------------------------------------------- #
 # 3. Each repair path resolves the tag once and threads the same value through.
 # --------------------------------------------------------------------------- #

--- a/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
+++ b/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
@@ -340,6 +340,54 @@ async def test_invoke_cli_for_verdict_wrapper_default_forwards_sentinel() -> Non
     assert invoke_tags == [_TASK_TAG_UNSET]
 
 
+def _review_comment_wrapper_runner(result_tags: list[object]) -> SimpleNamespace:
+    async def _result(**kwargs: object) -> VerdictResult:
+        result_tags.append(kwargs.get("task_tag"))
+        return VerdictResult(verdict="fix_committed")
+
+    return SimpleNamespace(_address_review_comment_result=_result)
+
+
+@pytest.mark.unit
+async def test_address_review_comment_wrapper_forwards_explicit_tag() -> None:
+    """The verdict-only review-comment wrapper threads ``task_tag`` to the result helper."""
+    result_tags: list[object] = []
+    runner = _review_comment_wrapper_runner(result_tags)
+
+    verdict = await comments._address_review_comment(
+        runner,
+        workspace_id="ws_1",
+        repo=_FAKE_REPO,
+        pr_number=3,
+        comment=SimpleNamespace(comment_id=11),
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        task_tag="WRAP-7",
+    )
+
+    assert verdict == "fix_committed"
+    assert result_tags == ["WRAP-7"]
+
+
+@pytest.mark.unit
+async def test_address_review_comment_wrapper_default_forwards_sentinel() -> None:
+    """Omitting ``task_tag`` forwards the sentinel so the result helper self-resolves."""
+    result_tags: list[object] = []
+    runner = _review_comment_wrapper_runner(result_tags)
+
+    await comments._address_review_comment(
+        runner,
+        workspace_id="ws_1",
+        repo=_FAKE_REPO,
+        pr_number=3,
+        comment=SimpleNamespace(comment_id=11),
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+    )
+
+    assert result_tags == [_TASK_TAG_UNSET]
+
+
 # --------------------------------------------------------------------------- #
 # 3. Each repair path resolves the tag once and threads the same value through.
 # --------------------------------------------------------------------------- #

--- a/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
+++ b/tests/unit/runtime/test_pr_monitor_task_tag_threading.py
@@ -1,0 +1,567 @@
+"""Tests for centralized per-cycle ``task_tag`` resolution (issue #537).
+
+``_resolve_task_tag`` used to open a fresh DB session on *every* call: each repair
+path resolved the tag once for its prompt and the shared
+``_commit_dirty_worktree`` sink re-resolved it a second time. These tests pin the
+new contract — each repair path resolves the tag exactly once per monitor cycle
+and threads that value into the commit sink — while guarding against any change to
+the tag value that reaches a commit/branch/PR.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters.base import AgentRunResult
+from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import OperatorHint
+from awf.runtime.pr_monitor_runner import ci_ops, comments, operator_hints
+from awf.runtime.pr_monitor_runner import remote_ops as pr_remote_ops
+from awf.runtime.pr_monitor_runner import remote_repair as pr_remote_repair
+from awf.runtime.pr_monitor_runner.comments import VerdictResult
+from awf.runtime.pr_monitor_runner.constants import _TASK_TAG_UNSET
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+_FAKE_REPO = SimpleNamespace(slug=lambda: "owner/repo")
+
+
+def _commit_message(cmd: FakeCommandRunner) -> str:
+    """Return the ``-m`` subject from the most recent ``git commit`` invocation."""
+    commit_calls = [call for call in cmd.calls if "commit" in call.args and "-m" in call.args]
+    assert commit_calls, "expected a git commit invocation"
+    args = commit_calls[-1].args
+    return str(args[args.index("-m") + 1])
+
+
+def _spy_resolver(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Spy the module-level ``_resolve_task_tag`` sink helper; record workspace ids."""
+    calls: list[str] = []
+    original = pr_remote_repair._resolve_task_tag
+
+    async def _spy(self: object, workspace_id: str) -> str | None:
+        calls.append(workspace_id)
+        return await original(self, workspace_id)
+
+    monkeypatch.setattr(pr_remote_repair, "_resolve_task_tag", _spy)
+    return calls
+
+
+# --------------------------------------------------------------------------- #
+# 1. The shared sink honors the threaded value without a DB round-trip.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_commit_dirty_worktree_threaded_tag_skips_resolver(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A threaded ``task_tag`` prefixes the subject and never re-queries the DB."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.task_tag = "ROW-1"  # would be used by a self-resolve; must be ignored
+        await session.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=" M file.py\n")  # status --porcelain (dirty)
+    cmd.queue_result(returncode=0)  # add -A
+    cmd.queue_result(returncode=1)  # diff --cached --quiet (staged)
+    cmd.queue_result(returncode=0)  # commit
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    (runner._worktrees_root / workspace_id).mkdir(parents=True, exist_ok=True)
+    resolver_calls = _spy_resolver(monkeypatch)
+
+    committed = await runner._commit_dirty_worktree(
+        workspace_id=workspace_id,
+        message="fix: dirty",
+        task_tag="PROJ-7",
+    )
+
+    assert committed is True
+    assert _commit_message(cmd) == "PROJ-7 fix: dirty"
+    assert resolver_calls == []
+
+
+@pytest.mark.unit
+async def test_commit_dirty_worktree_threaded_none_is_unprefixed_and_skips_resolver(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Threading ``None`` (a real untagged workspace) leaves the subject unprefixed."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.task_tag = "ROW-1"  # a self-resolve would wrongly prefix; must not run
+        await session.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=" M file.py\n")
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=1)
+    cmd.queue_result(returncode=0)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    (runner._worktrees_root / workspace_id).mkdir(parents=True, exist_ok=True)
+    resolver_calls = _spy_resolver(monkeypatch)
+
+    committed = await runner._commit_dirty_worktree(
+        workspace_id=workspace_id,
+        message="fix: dirty",
+        task_tag=None,
+    )
+
+    assert committed is True
+    assert _commit_message(cmd) == "fix: dirty"
+    assert resolver_calls == []
+
+
+@pytest.mark.unit
+async def test_commit_dirty_worktree_omitted_tag_self_resolves_once(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no threaded tag the sink self-resolves exactly once (backward compat)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.task_tag = "ROW-9"
+        await session.commit()
+
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=" M file.py\n")
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=1)
+    cmd.queue_result(returncode=0)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    (runner._worktrees_root / workspace_id).mkdir(parents=True, exist_ok=True)
+    resolver_calls = _spy_resolver(monkeypatch)
+
+    committed = await runner._commit_dirty_worktree(
+        workspace_id=workspace_id,
+        message="fix: dirty",
+    )
+
+    assert committed is True
+    assert _commit_message(cmd) == "ROW-9 fix: dirty"
+    assert resolver_calls == [workspace_id]
+
+
+@pytest.mark.unit
+async def test_commit_dirty_worktree_threaded_tag_truncated_to_72(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The threaded-tag path keeps the ``[:72]`` truncation parity of every AWF commit."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=" M file.py\n")
+    cmd.queue_result(returncode=0)
+    cmd.queue_result(returncode=1)
+    cmd.queue_result(returncode=0)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    (runner._worktrees_root / workspace_id).mkdir(parents=True, exist_ok=True)
+
+    long_subject = "fix: address PR review comment " + "x" * 80
+    committed = await runner._commit_dirty_worktree(
+        workspace_id=workspace_id,
+        message=long_subject,
+        task_tag="PROJ-123",
+    )
+
+    assert committed is True
+    message = _commit_message(cmd)
+    assert len(message) == 72
+    assert message == ("PROJ-123 " + long_subject)[:72]
+
+
+# --------------------------------------------------------------------------- #
+# 2. ``_invoke_cli_for_verdict_result`` forwards the tag to the sink verbatim.
+# --------------------------------------------------------------------------- #
+
+
+def _verdict_runner(sink_task_tags: list[object]) -> SimpleNamespace:
+    async def _suppress(workspace_id: str) -> bool:
+        return False
+
+    async def _adapter_run(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(returncode=0, stdout="AWF-VERDICT: FIXED: ok", stderr="")
+
+    async def _commit_dirty_worktree(**kwargs: object) -> bool:
+        sink_task_tags.append(kwargs.get("task_tag"))
+        return True
+
+    return SimpleNamespace(
+        _provider_recovery_suppresses_cli=_suppress,
+        _commit_dirty_worktree=_commit_dirty_worktree,
+        _deps=SimpleNamespace(adapter=SimpleNamespace(run=_adapter_run)),
+    )
+
+
+@pytest.mark.unit
+async def test_invoke_cli_for_verdict_result_forwards_explicit_tag() -> None:
+    sink_task_tags: list[object] = []
+    runner = _verdict_runner(sink_task_tags)
+
+    await comments._invoke_cli_for_verdict_result(
+        runner,
+        workspace_id="ws_1",
+        prompt="p",
+        commit_message="fix: x",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        task_tag="VERD-3",
+    )
+
+    assert sink_task_tags == ["VERD-3"]
+
+
+@pytest.mark.unit
+async def test_invoke_cli_for_verdict_result_default_forwards_sentinel() -> None:
+    sink_task_tags: list[object] = []
+    runner = _verdict_runner(sink_task_tags)
+
+    await comments._invoke_cli_for_verdict_result(
+        runner,
+        workspace_id="ws_1",
+        prompt="p",
+        commit_message="fix: x",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+    )
+
+    assert sink_task_tags == [_TASK_TAG_UNSET]
+
+
+# --------------------------------------------------------------------------- #
+# 3. Each repair path resolves the tag once and threads the same value through.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+async def test_run_ci_fix_resolves_once_and_threads_to_sink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_calls: list[str] = []
+    prompt_tags: list[object] = []
+    sink_tags: list[object] = []
+
+    async def _resolve_task_tag(workspace_id: str) -> str | None:
+        resolve_calls.append(workspace_id)
+        return "CI-7"
+
+    async def _pre_existing(**_kwargs: object) -> None:
+        return None
+
+    async def _suppress(workspace_id: str) -> bool:
+        return False
+
+    async def _head(**_kwargs: object) -> tuple[str, None]:
+        return "headsha", None
+
+    async def _adapter_run(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(returncode=0, stdout="", stderr="")
+
+    async def _owned_paths(_self: object, _workspace_id: str) -> list[str]:
+        return []
+
+    async def _commit_dirty_worktree(**kwargs: object) -> bool:
+        sink_tags.append(kwargs.get("task_tag"))
+        return True
+
+    async def _psb(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    def _fix_ci_prompt(**kwargs: object) -> str:
+        prompt_tags.append(kwargs.get("task_tag"))
+        return "PROMPT"
+
+    monkeypatch.setattr(ci_ops, "_owned_paths_for_prompt", _owned_paths)
+    monkeypatch.setattr(ci_ops, "fix_ci_prompt", _fix_ci_prompt)
+
+    self = SimpleNamespace(
+        _worktrees_root=tmp_path,
+        _workspace_runtime_context=None,
+        _resolve_task_tag=_resolve_task_tag,
+        _pre_existing_dirty_repair_worktree_result=_pre_existing,
+        _provider_recovery_suppresses_cli=_suppress,
+        _repair_operation_start_head_result=_head,
+        _commit_dirty_worktree=_commit_dirty_worktree,
+        _protected_scope_push_block=_psb,
+        _validated_git_push_result=_validated,
+        _deps=SimpleNamespace(adapter=SimpleNamespace(run=_adapter_run)),
+    )
+
+    await ci_ops._run_ci_fix(
+        self,
+        repo=_FAKE_REPO,
+        pr_number=1,
+        failures=(),
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+        workspace_id="ws_ci",
+        remote_branch="awf/ws_ci",
+    )
+
+    assert resolve_calls == ["ws_ci"]
+    assert prompt_tags == ["CI-7"]
+    assert sink_tags == ["CI-7"]
+
+
+@pytest.mark.unit
+async def test_run_operator_hint_cycle_resolves_once_and_threads_to_sink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_calls: list[str] = []
+    prompt_tags: list[object] = []
+    invoke_tags: list[object] = []
+
+    async def _resolve_task_tag(workspace_id: str) -> str | None:
+        resolve_calls.append(workspace_id)
+        return "HINT-2"
+
+    async def _pre_existing(**_kwargs: object) -> None:
+        return None
+
+    async def _head(**_kwargs: object) -> tuple[str, None]:
+        return "headsha", None
+
+    async def _invoke(**kwargs: object) -> VerdictResult:
+        invoke_tags.append(kwargs.get("task_tag"))
+        return VerdictResult(verdict="fix_committed")
+
+    async def _psb(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    async def _rev_parse_head(_worktree_path: Path) -> str:
+        return "pushedsha"
+
+    def _operator_hint_prompt(**kwargs: object) -> str:
+        prompt_tags.append(kwargs.get("task_tag"))
+        return "PROMPT"
+
+    monkeypatch.setattr(operator_hints, "operator_hint_prompt", _operator_hint_prompt)
+    monkeypatch.setattr(operator_hints, "mark_operator_hint_processed", lambda _state: None)
+
+    self = SimpleNamespace(
+        _worktrees_root=tmp_path,
+        _workspace_runtime_context=None,
+        _resolve_task_tag=_resolve_task_tag,
+        _pre_existing_dirty_repair_worktree_result=_pre_existing,
+        _repair_operation_start_head_result=_head,
+        _invoke_cli_for_verdict_result=_invoke,
+        _protected_scope_push_block=_psb,
+        _validated_git_push_result=_validated,
+        _rev_parse_head=_rev_parse_head,
+    )
+
+    state = SimpleNamespace(last_push_sha=None)
+    await operator_hints._run_operator_hint_cycle(
+        self,
+        workspace_id="ws_hint",
+        repo=_FAKE_REPO,
+        pr_number=2,
+        pr_head_sha="headsha",
+        hint=OperatorHint(reason="do x", directive="please fix"),
+        state=state,
+        remote_branch="awf/ws_hint",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+    )
+
+    assert resolve_calls == ["ws_hint"]
+    assert prompt_tags == ["HINT-2"]
+    assert invoke_tags == ["HINT-2"]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "entry",
+    ["_address_thread", "_address_review_comment_result"],
+)
+async def test_comment_paths_resolve_once_and_thread_to_invoke(
+    entry: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_calls: list[str] = []
+    prompt_tags: list[object] = []
+    invoke_tags: list[object] = []
+
+    async def _resolve_task_tag(workspace_id: str) -> str | None:
+        resolve_calls.append(workspace_id)
+        return "CMT-5"
+
+    async def _invoke(**kwargs: object) -> VerdictResult:
+        invoke_tags.append(kwargs.get("task_tag"))
+        return VerdictResult(verdict="fix_committed")
+
+    def _prompt(**kwargs: object) -> str:
+        prompt_tags.append(kwargs.get("task_tag"))
+        return "PROMPT"
+
+    monkeypatch.setattr(comments, "address_thread_prompt", _prompt)
+    monkeypatch.setattr(comments, "address_review_comment_prompt", _prompt)
+
+    runner = SimpleNamespace(
+        _workspace_runtime_context=None,
+        _resolve_task_tag=_resolve_task_tag,
+        _invoke_cli_for_verdict_result=_invoke,
+    )
+
+    common_kwargs: dict[str, object] = {
+        "workspace_id": "ws_cmt",
+        "repo": _FAKE_REPO,
+        "pr_number": 3,
+        "compose_project": "proj",
+        "compose_file": Path("compose.yml"),
+        "owned_paths": ["src/"],
+    }
+    if entry == "_address_thread":
+        await comments._address_thread(
+            runner,
+            thread=SimpleNamespace(thread_id="t1"),
+            **common_kwargs,
+        )
+    else:
+        await comments._address_review_comment_result(
+            runner,
+            comment=SimpleNamespace(comment_id=11),
+            **common_kwargs,
+        )
+
+    assert resolve_calls == ["ws_cmt"]
+    assert prompt_tags == ["CMT-5"]
+    assert invoke_tags == ["CMT-5"]
+
+
+@pytest.mark.unit
+async def test_run_sync_base_resolves_once_and_threads_to_sink(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    resolve_calls: list[str] = []
+    sink_tags: list[object] = []
+
+    class _FakeRunner:
+        def __init__(self, results: list[CommandResult]) -> None:
+            self._results = results
+            self.calls: list[list[str]] = []
+
+        async def run(self, args: list[str]) -> CommandResult:
+            self.calls.append(args)
+            return self._results.pop(0)
+
+    fake_runner = _FakeRunner(
+        [
+            CommandResult(returncode=0, stdout="", stderr=""),  # merge --abort
+            CommandResult(returncode=1, stdout="", stderr="conflict"),  # merge origin/base
+            CommandResult(returncode=0, stdout="UU src/foo.py\n", stderr=""),  # status
+        ]
+    )
+
+    async def _resolve_task_tag(workspace_id: str) -> str | None:
+        resolve_calls.append(workspace_id)
+        return "SYNC-4"
+
+    async def _fetch_base(**_kwargs: object) -> None:
+        return None
+
+    async def _suppress(workspace_id: str) -> bool:
+        return False
+
+    async def _adapter_run(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(returncode=0, stdout="", stderr="")
+
+    async def _commit_dirty_worktree(**kwargs: object) -> bool:
+        sink_tags.append(kwargs.get("task_tag"))
+        return True
+
+    async def _psb(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    runner = SimpleNamespace(
+        _worktrees_root=tmp_path,
+        _workspace_runtime_context="",
+        _resolve_task_tag=_resolve_task_tag,
+        _fetch_base=_fetch_base,
+        _provider_recovery_suppresses_cli=_suppress,
+        _commit_dirty_worktree=_commit_dirty_worktree,
+        _protected_scope_push_block=_psb,
+        _validated_git_push_result=_validated,
+        _deps=SimpleNamespace(runner=fake_runner, adapter=SimpleNamespace(run=_adapter_run)),
+    )
+
+    await pr_remote_ops._run_sync_base(
+        runner,
+        workspace_id="ws_sync",
+        repo=_FAKE_REPO,
+        pr_number=4,
+        base_branch="development",
+        remote_branch="awf/ws_sync",
+        compose_project="proj",
+        compose_file=Path("compose.yml"),
+    )
+
+    assert resolve_calls == ["ws_sync"]
+    assert sink_tags == ["SYNC-4"]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_b391ad74e69349fda9b1b8b2` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Implement issue #537: centralize the per-monitor-cycle workspace fetch so `task_tag` resolves once per cycle instead of a fresh DB session per repair path.

PROBLEM: `_resolve_task_tag` in `src/awf/runtime/pr_monitor_runner/remote_repair.py` (around line 210) opens a NEW DB session and fetches the full workspace row on EVERY call. It is called independently from `_commit_dirty_worktree`, `_run_ci_fix`, `_address_thread`, `_address_review_comment_result`, `_run_operator_hint_cycle`, and `_run_sync_base`. These paths are mutually exclusive within one monitor cycle, so the extra round-trips are not catastrophic, but they are inconsistent and wasteful.

THE PATTERN TO FOLLOW (already in the codebase): the pre-push validation path resolves the tag ONCE at the top of `_run_pre_push_validation_fix_pass` and threads it through rather than re-querying. Apply the same pattern: resolve `task_tag` (and ideally any other needed workspace fields) once per monitor cycle and thread it into the repair paths, eliminating the repeated per-operation `_resolve_task_tag` DB round-trips.

REQUIREMENTS:
- Resolve the workspace/task_tag once per cycle; thread it through to the six call sites. Keep the change DRY and explicit.
- Preserve exact behavior: the same task_tag value must reach each path it reaches today (no behavioral change to branch/PR/commit tagging).
- Handle the case where task_tag is None/absent unchanged.
- Right-sized diff. Do not restructure the monitor loop beyond what is needed to thread the value.
- Full test coverage (this repo enforces ~99%): assert the cycle resolves task_tag once and the repair paths receive the threaded value; assert no behavioral regression in tagging.

SCOPE GUARDS:
- Do NOT modify `.github/workflows/**` or `.awf/workspace.yml`.
- Keep changes within `src/awf/runtime/pr_monitor_runner/` and tests.
- Reference #537 in the PR. Full context is in the issue and the linked review thread.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same tagging semantics with fewer DB reads; extensive unit tests guard commit messages and resolve-once behavior.
> 
> **Overview**
> Fixes **#537** by resolving the workspace Jira `task_tag` **once per repair cycle** and passing it through prompts and `_commit_dirty_worktree`, instead of opening a new DB session on every prompt build and again on every dirty commit.
> 
> A **`_TaskTagUnset` sentinel** distinguishes “caller did not thread a tag” from a real **`None`** (untagged workspace). **`_commit_dirty_worktree`** and comment-repair helpers only self-resolve when the sentinel is still present; threaded values—including **`None`**—are used as-is.
> 
> **CI fix**, **comment fix cycle** (all threads/comments in the cycle), and **operator hint** paths hoist resolution at the top and thread the same value into verdict/commit flows. **`_run_sync_base`** threads its existing single resolve into the conflict commit path.
> 
> New unit tests lock in one resolve per cycle, no extra DB hits when a tag is threaded, and unchanged commit subject prefixing/truncation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8669a3d415d2c8b27936b14e787db281c1b2117b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Optimized task-tag resolution efficiency across repair cycles. Task tags are now resolved once per cycle and reused throughout CI fixes, review comment addressing, operator hints, and workspace synchronization, reducing redundant lookups.

* **Tests**
  * Added unit test coverage for task-tag threading behavior across repair operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->