### PR TITLE
feat: provision-time toolchain version-discovery probe (#535)

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3154,7 +3154,7 @@
               },
               "type": "array"
             },
-            "description": "Language toolchains the workspace needs, mapping a language identifier to the versions that must be available in the runtime/toolchain image, e.g. ``{\"java\": [\"17\", \"21\"]}``. Absent (the default empty mapping) means no toolchain requirement is declared. The runtime/toolchain image is expected to provide each declared version side by side (selected per-command via ``JAVA_HOME``/``update-alternatives``). A provision-time, in-container probe discovers the installed versions and the ``runtime_toolchain_findings`` lint seam yields a non-blocking ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is missing from the runtime image.",
+            "description": "Language toolchains the workspace needs, mapping a language identifier to the versions that must be available in the runtime/toolchain image, e.g. ``{\"java\": [\"17\", \"21\"]}``. Absent (the default empty mapping) means no toolchain requirement is declared. The runtime/toolchain image is expected to provide each declared version side by side; for Java these are selected per-command via ``JAVA_HOME``/``update-alternatives``, while other runtimes may use different resolution mechanisms. A provision-time, in-container probe discovers the installed versions and the ``runtime_toolchain_findings`` lint seam yields a non-blocking ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is missing from the runtime image.",
             "title": "Toolchains",
             "type": "object"
           }

--- a/openapi.json
+++ b/openapi.json
@@ -3154,7 +3154,7 @@
               },
               "type": "array"
             },
-            "description": "Language toolchains the workspace needs, mapping a language identifier to the versions that must be available in the runtime/toolchain image, e.g. ``{\"java\": [\"17\", \"21\"]}``. Absent (the default empty mapping) means no toolchain requirement is declared. The runtime/toolchain image is expected to provide each declared version side by side (selected per-command via ``JAVA_HOME``/``update-alternatives``). The ``runtime_toolchain_findings`` lint seam yields a ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is missing, but it requires a preflight that introspects the image to supply the discovered versions; that wiring does not exist yet, so the declaration is advisory.",
+            "description": "Language toolchains the workspace needs, mapping a language identifier to the versions that must be available in the runtime/toolchain image, e.g. ``{\"java\": [\"17\", \"21\"]}``. Absent (the default empty mapping) means no toolchain requirement is declared. The runtime/toolchain image is expected to provide each declared version side by side (selected per-command via ``JAVA_HOME``/``update-alternatives``). A provision-time, in-container probe discovers the installed versions and the ``runtime_toolchain_findings`` lint seam yields a non-blocking ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is missing from the runtime image.",
             "title": "Toolchains",
             "type": "object"
           }

--- a/src/awf/common/commands.py
+++ b/src/awf/common/commands.py
@@ -88,7 +88,16 @@ class AsyncioSubprocessRunner:
             stderr=asyncio.subprocess.PIPE,
             cwd=cwd,
         )
-        stdout_bytes, stderr_bytes = await proc.communicate(input=input_bytes)
+        try:
+            stdout_bytes, stderr_bytes = await proc.communicate(input=input_bytes)
+        except asyncio.CancelledError:
+            # A timeout wrapper (``asyncio.wait_for``) cancels this coroutine
+            # mid-``communicate``. Without explicit teardown the spawned process
+            # — e.g. a wedged ``docker compose exec`` client driving a toolchain
+            # probe — would be left orphaned and accumulate across workspaces.
+            # Terminate and reap it before propagating the cancellation.
+            await _terminate_process(proc, asyncio.create_task(proc.wait()))
+            raise
         assert proc.returncode is not None
         return CommandResult(
             returncode=proc.returncode,

--- a/src/awf/control/executor/constants.py
+++ b/src/awf/control/executor/constants.py
@@ -58,6 +58,8 @@ SETUP_DEPENDENCY_NETWORK_RETRY_EXHAUSTED_EVENT_TYPE = (
     "workspace.setup_dependency_network_retry_exhausted"
 )
 
+RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE = "workspace.runtime_toolchain_unavailable"
+
 _PR_MONITOR_ADOPTED_EVENT = "workspace.pr_monitor_adopted"
 
 _PR_MONITOR_ADOPTED_REASON_CODE = "PR_MONITOR_ADOPTED"

--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -373,6 +373,18 @@ async def execute(
                 details=setup_dependency_details,
             )
             return
+        try:
+            await self._record_runtime_toolchain_findings(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                profile=profile,
+            )
+        except Exception:
+            _log.exception(
+                "executor.runtime_toolchain_probe_record_failed",
+                workspace_id=workspace_id,
+            )
         profile_preflight = getattr(self._validation, "run_profile_tool_preflight", None)
         profile_preflight_result = (
             await profile_preflight(workspace_id=workspace_id, profile=profile)

--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -373,18 +373,12 @@ async def execute(
                 details=setup_dependency_details,
             )
             return
-        try:
-            await self._record_runtime_toolchain_findings(
-                workspace_id=workspace_id,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                profile=profile,
-            )
-        except Exception:
-            _log.exception(
-                "executor.runtime_toolchain_probe_record_failed",
-                workspace_id=workspace_id,
-            )
+        await self._record_runtime_toolchain_findings_safe(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            profile=profile,
+        )
         profile_preflight = getattr(self._validation, "run_profile_tool_preflight", None)
         profile_preflight_result = (
             await profile_preflight(workspace_id=workspace_id, profile=profile)

--- a/src/awf/control/executor/mixins.py
+++ b/src/awf/control/executor/mixins.py
@@ -53,6 +53,9 @@ class ExecutorDelegatesMixin:
         _monitor_handoff._record_setup_dependency_network_events
     )
     _record_runtime_toolchain_findings = _monitor_handoff._record_runtime_toolchain_findings
+    _record_runtime_toolchain_findings_safe = (
+        _monitor_handoff._record_runtime_toolchain_findings_safe
+    )
     _reject_unsupported_task_kind = _monitor_handoff._reject_unsupported_task_kind
     _dispatch_non_feature_task_kind = _monitor_handoff._dispatch_non_feature_task_kind
     _run_monitor_handoff_profile_setup = _monitor_handoff_setup._run_monitor_handoff_profile_setup

--- a/src/awf/control/executor/mixins.py
+++ b/src/awf/control/executor/mixins.py
@@ -52,6 +52,7 @@ class ExecutorDelegatesMixin:
     _record_setup_dependency_network_events = (
         _monitor_handoff._record_setup_dependency_network_events
     )
+    _record_runtime_toolchain_findings = _monitor_handoff._record_runtime_toolchain_findings
     _reject_unsupported_task_kind = _monitor_handoff._reject_unsupported_task_kind
     _dispatch_non_feature_task_kind = _monitor_handoff._dispatch_non_feature_task_kind
     _run_monitor_handoff_profile_setup = _monitor_handoff_setup._run_monitor_handoff_profile_setup

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -68,6 +68,7 @@ _record_executor_pr_audit_event = _monitor_handoff_audit._record_executor_pr_aud
 _record_setup_dependency_network_events = (
     _monitor_handoff_audit._record_setup_dependency_network_events
 )
+_record_runtime_toolchain_findings = _monitor_handoff_audit._record_runtime_toolchain_findings
 _ComposeInterpolationPreservingDumper = _companion_env._ComposeInterpolationPreservingDumper
 _ComposeStringKeySafeLoader = _companion_env._ComposeStringKeySafeLoader
 _atomic_write_text = _companion_env._atomic_write_text

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -69,6 +69,9 @@ _record_setup_dependency_network_events = (
     _monitor_handoff_audit._record_setup_dependency_network_events
 )
 _record_runtime_toolchain_findings = _monitor_handoff_audit._record_runtime_toolchain_findings
+_record_runtime_toolchain_findings_safe = (
+    _monitor_handoff_audit._record_runtime_toolchain_findings_safe
+)
 _ComposeInterpolationPreservingDumper = _companion_env._ComposeInterpolationPreservingDumper
 _ComposeStringKeySafeLoader = _companion_env._ComposeStringKeySafeLoader
 _atomic_write_text = _companion_env._atomic_write_text

--- a/src/awf/control/executor/monitor_handoff_audit.py
+++ b/src/awf/control/executor/monitor_handoff_audit.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any, cast
 
+from awf.common.logging import get_logger
 from awf.control.executor.constants import (
     _EXECUTOR_AUDIT_ACTOR,
+    RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE,
     SETUP_DEPENDENCY_NETWORK_RETRY_EVENT_TYPE,
     SETUP_DEPENDENCY_NETWORK_RETRY_EXHAUSTED_EVENT_TYPE,
 )
@@ -17,11 +19,14 @@ from awf.control.executor.logging_ops import (
 from awf.control.executor.metadata import _metadata_int
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
+from awf.profiles.models import RUNTIME_TOOLCHAIN_UNAVAILABLE
 from awf.runtime.validation import (
     SETUP_DEPENDENCY_NETWORK_RETRY,
     SETUP_DEPENDENCY_NETWORK_RETRY_EXHAUSTED,
     ValidationResult,
 )
+
+_log = get_logger(__name__)
 
 _UNSET_SOURCE_HEAD_SHA = object()
 
@@ -171,5 +176,62 @@ async def _record_setup_dependency_network_events(
                 event_type=event_type,
                 reason_code=reason_code,
                 payload=payload,
+            )
+        await session.commit()
+
+
+async def _record_runtime_toolchain_findings(
+    self: Any,
+    *,
+    workspace_id: str,
+    compose_project: str,
+    compose_file: Any,
+    profile: Any,
+) -> None:
+    """Probe the container for declared toolchains; record warnings (non-blocking).
+
+    Runs the provision-time toolchain probe via the validation runner and
+    appends one ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning event per finding. The
+    probe is strictly additive: any failure is swallowed here so it can never
+    affect provisioning or a state transition. Legacy ``_validation`` stubs that
+    predate the probe method are a no-op (the ``getattr`` returns ``None``).
+    """
+    probe = getattr(self._validation, "probe_runtime_toolchain_findings", None)
+    if not callable(probe):
+        return
+    try:
+        findings = await probe(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            profile=profile,
+        )
+    except Exception:
+        _log.exception(
+            "executor.runtime_toolchain_probe_failed",
+            workspace_id=workspace_id,
+        )
+        return
+    if not findings:
+        return
+
+    async with self._session_factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        if workspace is None:  # pragma: no cover - destroyed mid-flight
+            return
+        for finding in findings:
+            details = dict(finding.details)
+            await repo.add_event(
+                workspace,
+                event_type=RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE,
+                reason_code=RUNTIME_TOOLCHAIN_UNAVAILABLE,
+                payload={
+                    "language": details.get("language"),
+                    "version": details.get("version"),
+                    "available_versions": details.get("available_versions"),
+                    "path": finding.path,
+                    "message": finding.message,
+                },
             )
         await session.commit()

--- a/src/awf/control/executor/monitor_handoff_audit.py
+++ b/src/awf/control/executor/monitor_handoff_audit.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from awf.common.logging import get_logger
+from awf.common.redaction import redact_secrets
 from awf.control.executor.constants import (
     _EXECUTOR_AUDIT_ACTOR,
     RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE,
@@ -206,10 +207,15 @@ async def _record_runtime_toolchain_findings(
             compose_file=compose_file,
             profile=profile,
         )
-    except Exception:
-        _log.exception(
+    except Exception as exc:
+        # Non-blocking: this log entry is the only operator signal, so preserve
+        # the structured ``reason_code`` and emit a redacted error string rather
+        # than a raw traceback that could carry compose-exec stderr secrets.
+        _log.warning(
             "executor.runtime_toolchain_probe_failed",
             workspace_id=workspace_id,
+            reason_code=getattr(exc, "reason_code", None),
+            error=redact_secrets(str(exc))[:1000],
         )
         return
     if not findings:
@@ -258,8 +264,13 @@ async def _record_runtime_toolchain_findings_safe(
             compose_file=compose_file,
             profile=profile,
         )
-    except Exception:
-        _log.exception(
+    except Exception as exc:
+        # See ``_record_runtime_toolchain_findings``: keep the reason_code and a
+        # redacted error so the swallowed recorder defect stays diagnosable
+        # without leaking a raw traceback.
+        _log.warning(
             "executor.runtime_toolchain_probe_record_failed",
             workspace_id=workspace_id,
+            reason_code=getattr(exc, "reason_code", None),
+            error=redact_secrets(str(exc))[:1000],
         )

--- a/src/awf/control/executor/monitor_handoff_audit.py
+++ b/src/awf/control/executor/monitor_handoff_audit.py
@@ -235,3 +235,31 @@ async def _record_runtime_toolchain_findings(
                 },
             )
         await session.commit()
+
+
+async def _record_runtime_toolchain_findings_safe(
+    self: Any,
+    *,
+    workspace_id: str,
+    compose_project: str,
+    compose_file: Any,
+    profile: Any,
+) -> None:
+    """Double-guarded call-site wrapper for the runtime toolchain probe.
+
+    The recorder already swallows probe failures internally; this wrapper adds a
+    second guard so a defect in the recorder itself (or its DB write) can never
+    abort provisioning. Strictly additive: any exception is logged and dropped.
+    """
+    try:
+        await self._record_runtime_toolchain_findings(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            profile=profile,
+        )
+    except Exception:
+        _log.exception(
+            "executor.runtime_toolchain_probe_record_failed",
+            workspace_id=workspace_id,
+        )

--- a/src/awf/control/executor/monitor_handoff_setup.py
+++ b/src/awf/control/executor/monitor_handoff_setup.py
@@ -8,6 +8,7 @@ from typing import Any
 from awf.common.audit import redact_audit_text
 from awf.common.compose_exec import ComposeExecCleanupError, cleanup_failure_message
 from awf.common.logging import get_logger
+from awf.common.redaction import redact_secrets
 from awf.control.executor.constants import PR_MONITOR_SETUP_FAILED_REASON_CODE
 from awf.control.executor.helpers import _failure_reason_for_phase
 from awf.control.executor.logging_ops import (
@@ -216,10 +217,15 @@ async def _run_monitor_handoff_profile_setup(
                 compose_file=compose_file,
                 profile=profile,
             )
-        except Exception:
-            _log.exception(
+        except Exception as exc:
+            # Non-blocking probe/recorder failure: preserve the structured
+            # reason_code and a redacted error instead of a raw traceback that
+            # could carry compose-exec stderr secrets.
+            _log.warning(
                 "executor.monitor_handoff_runtime_toolchain_probe_record_failed",
                 workspace_id=workspace_id,
+                reason_code=getattr(exc, "reason_code", None),
+                error=redact_secrets(str(exc))[:1000],
             )
         return await _run_monitor_handoff_profile_preflight(
             self,

--- a/src/awf/control/executor/monitor_handoff_setup.py
+++ b/src/awf/control/executor/monitor_handoff_setup.py
@@ -203,6 +203,24 @@ async def _run_monitor_handoff_profile_setup(
         )
 
     if setup_result.all_passed:
+        # Mirror the ``execute`` path: probe the container for declared
+        # toolchains and record any ``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warnings
+        # after a green setup. The probe is strictly additive and non-blocking,
+        # so a recorder error is swallowed and never affects the handoff — but
+        # omitting it entirely would let adopted/release-PR workspaces silently
+        # miss the toolchain-availability warnings their executed peers get.
+        try:
+            await self._record_runtime_toolchain_findings(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                profile=profile,
+            )
+        except Exception:
+            _log.exception(
+                "executor.monitor_handoff_runtime_toolchain_probe_record_failed",
+                workspace_id=workspace_id,
+            )
         return await _run_monitor_handoff_profile_preflight(
             self,
             workspace_id=workspace_id,

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -78,8 +78,9 @@ class ProfileRuntime(BaseModel):
             "to the versions that must be available in the runtime/toolchain image, "
             'e.g. ``{"java": ["17", "21"]}``. Absent (the default empty mapping) '
             "means no toolchain requirement is declared. The runtime/toolchain image "
-            "is expected to provide each declared version side by side (selected "
-            "per-command via ``JAVA_HOME``/``update-alternatives``). A provision-time, "
+            "is expected to provide each declared version side by side; for Java these "
+            "are selected per-command via ``JAVA_HOME``/``update-alternatives``, while "
+            "other runtimes may use different resolution mechanisms. A provision-time, "
             "in-container probe discovers the installed versions and the "
             "``runtime_toolchain_findings`` lint seam yields a non-blocking "
             "``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is "

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -79,12 +79,11 @@ class ProfileRuntime(BaseModel):
             'e.g. ``{"java": ["17", "21"]}``. Absent (the default empty mapping) '
             "means no toolchain requirement is declared. The runtime/toolchain image "
             "is expected to provide each declared version side by side (selected "
-            "per-command via ``JAVA_HOME``/``update-alternatives``). The "
-            "``runtime_toolchain_findings`` lint seam yields a "
+            "per-command via ``JAVA_HOME``/``update-alternatives``). A provision-time, "
+            "in-container probe discovers the installed versions and the "
+            "``runtime_toolchain_findings`` lint seam yields a non-blocking "
             "``RUNTIME_TOOLCHAIN_UNAVAILABLE`` warning when a declared version is "
-            "missing, but it requires a preflight that introspects the image to "
-            "supply the discovered versions; that wiring does not exist yet, so the "
-            "declaration is advisory."
+            "missing from the runtime image."
         ),
     )
 

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -1,0 +1,179 @@
+"""Provision-time, in-container toolchain version discovery.
+
+A profile may declare ``runtime.toolchains`` (e.g. ``{"java": ["17", "21"]}``)
+to assert which language toolchain versions the runtime/toolchain image must
+provide. The pure lint seam :func:`awf.profiles.models.runtime_toolchain_findings`
+turns a discovered ``available`` mapping into ``RUNTIME_TOOLCHAIN_UNAVAILABLE``
+warnings, but it needs that mapping supplied by an image-introspecting probe.
+
+This module is that probe's *provider-neutral core*: a small per-language
+discovery registry plus the orchestration that runs each declared language's
+discovery command inside the workspace container, normalizes the discovered
+versions to the declared (major-version) granularity, and hands the result to
+the helper. It performs no I/O itself — the caller injects an
+``exec_in_container`` coroutine (the real one reuses the validation runner's
+tracked compose-exec path) — so it stays unit-testable.
+
+The probe is strictly additive and non-blocking. The ``available`` contract is
+the crux of avoiding false warnings:
+
+* probe infrastructure cannot exec into the container at all (the discovery
+  command raises, or returns non-zero — it is written to always exit 0 when the
+  container is reachable) -> ``available is None`` -> the helper stays globally
+  silent;
+* a declared language's tool is genuinely absent from a reachable image ->
+  that language maps to an empty set -> the helper warns every declared version;
+* a declared language with no registered discovery strategy is treated as
+  satisfied (no false warning for a not-yet-supported language).
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+from awf.profiles.models import (
+    ProfileLintFinding,
+    WorkspaceProfile,
+    runtime_toolchain_findings,
+)
+
+
+@dataclass(frozen=True)
+class ProbeExecResult:
+    """Result of running a discovery command inside the workspace container."""
+
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+# A coroutine that execs an argv inside the workspace container and returns its
+# result. Injected by the caller so this module performs no I/O of its own.
+ExecInContainer = Callable[[list[str]], Awaitable[ProbeExecResult]]
+
+
+@dataclass(frozen=True)
+class ToolchainDiscoveryStrategy:
+    """How to discover every installed version of one language's toolchain."""
+
+    command: tuple[str, ...]
+    parse: Callable[[str], set[str]]
+
+
+# Enumerate *all* installed JDKs, not just the default ``java -version`` reports.
+# Reading each ``/usr/lib/jvm/*/release`` yields ``JAVA_VERSION="17.0.9"`` lines;
+# ``update-alternatives --list java`` adds the registered JDK paths as a
+# fallback. The trailing ``true`` guarantees exit 0 whenever the container is
+# reachable, so a non-zero return unambiguously signals probe-infra failure.
+_JAVA_DISCOVERY_COMMAND = (
+    "sh",
+    "-c",
+    "cat /usr/lib/jvm/*/release 2>/dev/null; update-alternatives --list java 2>/dev/null; true",
+)
+
+# ``JAVA_VERSION="17.0.9"`` from release files (quotes optional).
+_JAVA_RELEASE_VERSION_RE = re.compile(r'JAVA_VERSION="?([0-9][0-9._]*)"?')
+# ``openjdk version "17.0.9"`` style output.
+_JAVA_QUOTED_VERSION_RE = re.compile(r'version "([0-9][0-9._]*)"')
+# JDK major embedded in a jvm directory / alternatives path, e.g.
+# ``/usr/lib/jvm/java-17-openjdk-amd64/bin/java`` or ``temurin-21-jdk``.
+_JAVA_PATH_MAJOR_RE = re.compile(
+    r"(?:java|jdk|jre|openjdk|temurin|zulu|corretto|graalvm|semeru)-(\d+)"
+)
+_LEADING_INT_RE = re.compile(r"\d+")
+
+
+def _leading_int(component: str) -> str | None:
+    """Return the leading integer of ``component`` (e.g. ``"0_392" -> "0"``)."""
+    match = _LEADING_INT_RE.match(component.strip())
+    if match is None:
+        return None
+    return str(int(match.group()))
+
+
+def _normalize_java_version(raw: str) -> str | None:
+    """Normalize a discovered Java version to its declared major granularity.
+
+    Declared versions are coarse majors (``"17"``, ``"21"``) while installed
+    versions are fine (``"17.0.9"``). Map each discovered version to the major
+    so a declared ``"17"`` is satisfied by an installed ``17.0.9`` without a
+    false warning, and a declared ``"23"`` against only 17/21 still warns:
+
+    * modern ``17.0.9`` / ``21`` -> leading numeric major (``"17"`` / ``"21"``);
+    * legacy ``1.8.0_392`` -> ``"8"`` (first component ``1`` -> use the second);
+    * unparseable input -> ``None`` (dropped by the caller).
+    """
+    cleaned = raw.strip().strip('"').strip()
+    if not cleaned:
+        return None
+    parts = cleaned.split(".")
+    first = _leading_int(parts[0])
+    if first is None:
+        return None
+    if first == "1" and len(parts) >= 2:
+        return _leading_int(parts[1])
+    return first
+
+
+def _parse_java_versions(output: str) -> set[str]:
+    """Parse discovery output into the set of installed Java major versions."""
+    versions: set[str] = set()
+    for pattern in (_JAVA_RELEASE_VERSION_RE, _JAVA_QUOTED_VERSION_RE, _JAVA_PATH_MAJOR_RE):
+        for raw in pattern.findall(output):
+            normalized = _normalize_java_version(raw)
+            if normalized is not None:
+                versions.add(normalized)
+    return versions
+
+
+# Per-language discovery registry. node/python/go/rust/cpp slot in here later by
+# adding a discovery command + parser; the orchestration below is language-agnostic.
+_TOOLCHAIN_DISCOVERY: dict[str, ToolchainDiscoveryStrategy] = {
+    "java": ToolchainDiscoveryStrategy(
+        command=_JAVA_DISCOVERY_COMMAND,
+        parse=_parse_java_versions,
+    ),
+}
+
+
+async def probe_runtime_toolchains(
+    *,
+    profile: WorkspaceProfile,
+    exec_in_container: ExecInContainer,
+) -> tuple[ProfileLintFinding, ...]:
+    """Discover installed toolchain versions and return any availability findings.
+
+    Builds the ``available`` mapping demanded by
+    :func:`runtime_toolchain_findings` by running each declared language's
+    discovery command in the container, then returns the helper's findings. See
+    the module docstring for the ``available`` contract that keeps probe-infra
+    failures globally silent while still warning on genuinely-absent tools.
+    """
+    if not profile.runtime.toolchains:
+        return ()
+
+    available: dict[str, set[str]] = {}
+    for language in profile.runtime.toolchains:
+        strategy = _TOOLCHAIN_DISCOVERY.get(language)
+        if strategy is None:
+            # No discovery for this language yet: treat the declared versions as
+            # satisfied so an unsupported language never produces a false warning.
+            available[language] = set(profile.runtime.toolchains[language])
+            continue
+        try:
+            result = await exec_in_container(list(strategy.command))
+        except Exception:
+            # Cannot exec into the container at all -> probe-infra failure ->
+            # stay globally silent rather than warn on missing introspection.
+            return runtime_toolchain_findings(profile, None)
+        if result.returncode != 0:
+            # The discovery command always exits 0 when reachable, so a non-zero
+            # return means the container/compose-exec is unreachable -> silent.
+            return runtime_toolchain_findings(profile, None)
+        # Reachable image: an empty parse means the tool is genuinely absent, so
+        # the helper warns every declared version for this language.
+        available[language] = strategy.parse(result.stdout)
+
+    return runtime_toolchain_findings(profile, available)

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -79,8 +79,11 @@ _JAVA_RELEASE_VERSION_RE = re.compile(r'JAVA_VERSION="?([0-9][0-9._]*)"?')
 _JAVA_QUOTED_VERSION_RE = re.compile(r'version "([0-9][0-9._]*)"')
 # JDK major embedded in a jvm directory / alternatives path, e.g.
 # ``/usr/lib/jvm/java-17-openjdk-amd64/bin/java`` or ``temurin-21-jdk``.
+# Capture dotted/underscored versions too so legacy RHEL-style paths like
+# ``java-1.8.0-openjdk-amd64`` yield ``1.8.0`` (normalized to ``8``) rather
+# than a bare ``1`` that cannot be resolved to its real major.
 _JAVA_PATH_MAJOR_RE = re.compile(
-    r"(?:java|jdk|jre|openjdk|temurin|zulu|corretto|graalvm|semeru)-(\d+)"
+    r"(?:java|jdk|jre|openjdk|temurin|zulu|corretto|graalvm|semeru)-([0-9][0-9._]*)"
 )
 _LEADING_INT_RE = re.compile(r"\d+")
 

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -69,12 +69,18 @@ class ToolchainDiscoveryStrategy:
 # Enumerate *all* installed JDKs, not just the default ``java -version`` reports.
 # Reading each ``/usr/lib/jvm/*/release`` yields ``JAVA_VERSION="17.0.9"`` lines;
 # ``update-alternatives --list java`` adds the registered JDK paths as a
-# fallback. The trailing ``true`` guarantees exit 0 whenever the container is
-# reachable, so a non-zero return unambiguously signals probe-infra failure.
+# fallback. Common official images (eclipse-temurin, amazoncorretto) instead
+# install the JDK under ``$JAVA_HOME`` (e.g. ``/opt/java/openjdk``) outside
+# ``/usr/lib/jvm`` and register no alternatives, so also read ``$JAVA_HOME/release``
+# and fall back to ``java -version`` (which prints to stderr, hence ``2>&1``) —
+# otherwise such an image parses empty and is wrongly reported as missing java.
+# The trailing ``true`` guarantees exit 0 whenever the container is reachable, so
+# a non-zero return unambiguously signals probe-infra failure.
 _JAVA_DISCOVERY_COMMAND = (
     "sh",
     "-c",
-    "cat /usr/lib/jvm/*/release 2>/dev/null; update-alternatives --list java 2>/dev/null; true",
+    'cat /usr/lib/jvm/*/release "$JAVA_HOME/release" 2>/dev/null; '
+    "update-alternatives --list java 2>/dev/null; java -version 2>&1; true",
 )
 
 # ``JAVA_VERSION="17.0.9"`` from release files (quotes optional).

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -60,6 +60,10 @@ class ToolchainDiscoveryStrategy:
 
     command: tuple[str, ...]
     parse: Callable[[str], set[str]]
+    # Map a *declared* version string to the same granularity ``parse`` emits, so a
+    # finer declared version (the schema accepts dotted forms like ``1.8`` / ``11.0.2``)
+    # can be matched against the discovered majors. Returns ``None`` if unparseable.
+    normalize: Callable[[str], str | None]
 
 
 # Enumerate *all* installed JDKs, not just the default ``java -version`` reports.
@@ -137,6 +141,7 @@ _TOOLCHAIN_DISCOVERY: dict[str, ToolchainDiscoveryStrategy] = {
     "java": ToolchainDiscoveryStrategy(
         command=_JAVA_DISCOVERY_COMMAND,
         parse=_parse_java_versions,
+        normalize=_normalize_java_version,
     ),
 }
 
@@ -177,6 +182,17 @@ async def probe_runtime_toolchains(
             return runtime_toolchain_findings(profile, None)
         # Reachable image: an empty parse means the tool is genuinely absent, so
         # the helper warns every declared version for this language.
-        available[language] = strategy.parse(result.stdout)
+        discovered = strategy.parse(result.stdout)
+        # ``discovered`` holds majors (``17``), but the helper compares declared
+        # strings exactly and the schema accepts finer dotted declarations (``1.8``,
+        # ``11.0.2``). Add each declared version whose normalized major is present so
+        # an installed ``11.0.2`` satisfies a declared ``11.0.2`` instead of warning,
+        # keeping the discovered majors too so bare-major declarations still match.
+        satisfied = {
+            version
+            for version in profile.runtime.toolchains[language]
+            if strategy.normalize(version) in discovered
+        }
+        available[language] = discovered | satisfied
 
     return runtime_toolchain_findings(profile, available)

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -173,13 +173,19 @@ async def probe_runtime_toolchains(
         try:
             result = await exec_in_container(list(strategy.command))
         except Exception:
-            # Cannot exec into the container at all -> probe-infra failure ->
-            # stay globally silent rather than warn on missing introspection.
-            return runtime_toolchain_findings(profile, None)
-        if result.returncode != 0:
-            # The discovery command always exits 0 when reachable, so a non-zero
-            # return means the container/compose-exec is unreachable -> silent.
-            return runtime_toolchain_findings(profile, None)
+            result = None
+        # The discovery command always exits 0 when the container is reachable, so
+        # an exception or a non-zero return both signal a probe-infra failure for
+        # this language. If nothing has been probed yet the container is wholly
+        # unreachable -> stay globally silent (available is None). But once an
+        # earlier language has probed cleanly the container *is* reachable, so
+        # preserve those accurate findings and treat only this language as
+        # satisfied (silent for it) instead of discarding the partial results.
+        if result is None or result.returncode != 0:
+            if not available:
+                return runtime_toolchain_findings(profile, None)
+            available[language] = set(profile.runtime.toolchains[language])
+            continue
         # Reachable image: an empty parse means the tool is genuinely absent, so
         # the helper warns every declared version for this language.
         discovered = strategy.parse(result.stdout)

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -178,12 +178,17 @@ def _declared_version_satisfied(
     equals it or refines it at a component boundary — ``"1.8"`` by an installed
     ``1.8.0``, ``"11.0.2"`` by an installed ``11.0.2`` — never merely by a sibling
     patch on the same major, so a declared ``"11.0.2"`` is *not* satisfied by an
-    installed ``11.0.1``.
+    installed ``11.0.1``. Legacy JDK release strings join the update level with an
+    underscore (``1.8.0_392``), so that too counts as a refining boundary —
+    ``"1.8.0"`` is satisfied by an installed ``1.8.0_392``.
     """
     if "." not in version:
         major = normalize(version)
         return major is not None and major in discovered_majors
-    return any(exact == version or exact.startswith(f"{version}.") for exact in discovered_exact)
+    return any(
+        exact == version or exact.startswith(f"{version}.") or exact.startswith(f"{version}_")
+        for exact in discovered_exact
+    )
 
 
 # Per-language discovery registry. node/python/go/rust/cpp slot in here later by

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -60,9 +60,14 @@ class ToolchainDiscoveryStrategy:
 
     command: tuple[str, ...]
     parse: Callable[[str], set[str]]
+    # Parse discovery output into the *exact* installed version strings (e.g.
+    # ``17.0.9`` / ``1.8.0``), not coarsened to majors. Used to honour the
+    # patch-level intent of a dotted declaration (``11.0.2``) so a sibling patch on
+    # the same major (``11.0.1``) does not silence it.
+    parse_exact: Callable[[str], set[str]]
     # Map a *declared* version string to the same granularity ``parse`` emits, so a
-    # finer declared version (the schema accepts dotted forms like ``1.8`` / ``11.0.2``)
-    # can be matched against the discovered majors. Returns ``None`` if unparseable.
+    # bare-major declaration (``17``) matches a discovered major regardless of patch.
+    # Returns ``None`` if unparseable.
     normalize: Callable[[str], str | None]
 
 
@@ -141,12 +146,53 @@ def _parse_java_versions(output: str) -> set[str]:
     return versions
 
 
+def _parse_java_exact_versions(output: str) -> set[str]:
+    """Parse discovery output into the set of *exact* installed Java versions.
+
+    Unlike :func:`_parse_java_versions` (which coarsens to majors), this keeps the
+    full discovered version string — ``17.0.9`` from ``JAVA_VERSION="17.0.9"``,
+    ``1.8.0`` from a legacy ``java-1.8.0-openjdk`` path — so a patch-precise
+    declaration (``11.0.2``) can be matched against the installed patch rather than
+    merely its major. Each raw capture is stripped of surrounding quotes/whitespace.
+    """
+    exact: set[str] = set()
+    for pattern in (_JAVA_RELEASE_VERSION_RE, _JAVA_QUOTED_VERSION_RE, _JAVA_PATH_MAJOR_RE):
+        # Each pattern's capture group is digit-led and quote-free, so the raw match
+        # is already a clean version string (just trim any incidental whitespace).
+        exact.update(raw.strip() for raw in pattern.findall(output))
+    return exact
+
+
+def _declared_version_satisfied(
+    version: str,
+    discovered_majors: set[str],
+    discovered_exact: set[str],
+    normalize: Callable[[str], str | None],
+) -> bool:
+    """Decide whether one declared toolchain version is satisfied by discovery.
+
+    A *bare-major* declaration (no dot, e.g. ``"17"`` / ``"21"``) matches by major,
+    so an installed ``17.0.9`` satisfies ``"17"`` regardless of patch level. A
+    *dotted* declaration carries patch-level intent the operator must be warned
+    about when unmet: it is satisfied only by an exact discovered version that
+    equals it or refines it at a component boundary — ``"1.8"`` by an installed
+    ``1.8.0``, ``"11.0.2"`` by an installed ``11.0.2`` — never merely by a sibling
+    patch on the same major, so a declared ``"11.0.2"`` is *not* satisfied by an
+    installed ``11.0.1``.
+    """
+    if "." not in version:
+        major = normalize(version)
+        return major is not None and major in discovered_majors
+    return any(exact == version or exact.startswith(f"{version}.") for exact in discovered_exact)
+
+
 # Per-language discovery registry. node/python/go/rust/cpp slot in here later by
 # adding a discovery command + parser; the orchestration below is language-agnostic.
 _TOOLCHAIN_DISCOVERY: dict[str, ToolchainDiscoveryStrategy] = {
     "java": ToolchainDiscoveryStrategy(
         command=_JAVA_DISCOVERY_COMMAND,
         parse=_parse_java_versions,
+        parse_exact=_parse_java_exact_versions,
         normalize=_normalize_java_version,
     ),
 }
@@ -195,15 +241,21 @@ async def probe_runtime_toolchains(
         # Reachable image: an empty parse means the tool is genuinely absent, so
         # the helper warns every declared version for this language.
         discovered = strategy.parse(result.stdout)
-        # ``discovered`` holds majors (``17``), but the helper compares declared
-        # strings exactly and the schema accepts finer dotted declarations (``1.8``,
-        # ``11.0.2``). Add each declared version whose normalized major is present so
-        # an installed ``11.0.2`` satisfies a declared ``11.0.2`` instead of warning,
-        # keeping the discovered majors too so bare-major declarations still match.
+        discovered_exact = strategy.parse_exact(result.stdout)
+        # ``discovered`` holds majors (``17``); the helper compares declared strings
+        # exactly and the schema accepts both bare majors (``17``) and finer dotted
+        # declarations (``1.8``, ``11.0.2``). A bare-major declaration is satisfied by
+        # any installed patch on that major, but a dotted declaration carries
+        # patch-level intent: match it only against an exact discovered version that
+        # equals or refines it, so an installed ``11.0.1`` does *not* silence a
+        # declared ``11.0.2``. Keep the discovered majors in ``available`` so
+        # bare-major declarations still match (and surface as ``available_versions``).
         satisfied = {
             version
             for version in profile.runtime.toolchains[language]
-            if strategy.normalize(version) in discovered
+            if _declared_version_satisfied(
+                version, discovered, discovered_exact, strategy.normalize
+            )
         }
         available[language] = discovered | satisfied
 

--- a/src/awf/runtime/toolchain_probe.py
+++ b/src/awf/runtime/toolchain_probe.py
@@ -17,10 +17,11 @@ tracked compose-exec path) — so it stays unit-testable.
 The probe is strictly additive and non-blocking. The ``available`` contract is
 the crux of avoiding false warnings:
 
-* probe infrastructure cannot exec into the container at all (the discovery
-  command raises, or returns non-zero — it is written to always exit 0 when the
-  container is reachable) -> ``available is None`` -> the helper stays globally
-  silent;
+* probe infrastructure cannot exec into the container at all (the exec raises
+  ``OSError``, or the command returns non-zero — it is written to always exit 0
+  when the container is reachable) -> ``available is None`` -> the helper stays
+  globally silent. Any *other* exception out of the injected exec is an
+  unexpected programmer error and is left to propagate, not swallowed;
 * a declared language's tool is genuinely absent from a reachable image ->
   that language maps to an empty set -> the helper warns every declared version;
 * a declared language with no registered discovery strategy is treated as
@@ -229,10 +230,18 @@ async def probe_runtime_toolchains(
             continue
         try:
             result = await exec_in_container(list(strategy.command))
-        except Exception:
+        except OSError:
+            # The injected exec_in_container already translates the operational
+            # failures it expects (e.g. a wedged exec -> rc 124) into a non-zero
+            # ProbeExecResult, so the only exception that still signals genuine
+            # probe-infra failure here is the container exec being unable to spawn
+            # at all (OSError: missing binary, spawn failure, ...). Swallow that as
+            # a probe miss, but let any other exception — a programmer error in the
+            # exec path — propagate rather than silently suppressing
+            # RUNTIME_TOOLCHAIN_UNAVAILABLE findings.
             result = None
         # The discovery command always exits 0 when the container is reachable, so
-        # an exception or a non-zero return both signal a probe-infra failure for
+        # an OSError or a non-zero return both signal a probe-infra failure for
         # this language. If nothing has been probed yet the container is wholly
         # unreachable -> stay globally silent (available is None). But once an
         # earlier language has probed cleanly the container *is* reachable, so

--- a/src/awf/runtime/validation_runner.py
+++ b/src/awf/runtime/validation_runner.py
@@ -35,6 +35,7 @@ from awf.profiles.models import (
     ProfileCommand,
     ProfileCoverage,
     ProfileHealthCheck,
+    ProfileLintFinding,
     WorkspaceProfile,
 )
 from awf.runtime.alembic_validation import (
@@ -44,6 +45,7 @@ from awf.runtime.alembic_validation import (
     validate_alembic_migration_chain,
 )
 from awf.runtime.logs import LogStore
+from awf.runtime.toolchain_probe import ProbeExecResult, probe_runtime_toolchains
 from awf.runtime.validation_coverage import (
     _alembic_policy_missing_worktree_metadata,
     _compose_exec_timed_out,
@@ -319,6 +321,43 @@ class ValidationRunner:
             metadata=metadata,
         )
         return ValidationResult(commands=[result])
+
+    async def probe_runtime_toolchain_findings(
+        self,
+        *,
+        workspace_id: str,
+        compose_project: str,
+        compose_file: Path,
+        profile: WorkspaceProfile,
+    ) -> tuple[ProfileLintFinding, ...]:
+        """Discover declared toolchain versions in the container; return findings.
+
+        Provision-time, non-blocking probe: when the profile declares
+        ``runtime.toolchains``, exec the per-language discovery commands inside
+        the agent container (reusing the tracked compose-exec path) and run the
+        pure ``runtime_toolchain_findings`` helper over the discovered versions.
+        Skips entirely (zero exec) when no toolchains are declared.
+        """
+        del workspace_id
+        if not profile.runtime.toolchains:
+            return ()
+
+        async def _exec(cli_args: list[str]) -> ProbeExecResult:
+            invocation = build_tracked_compose_exec(
+                compose_project=compose_project,
+                compose_file=compose_file,
+                cli_args=cli_args,
+                source="toolchain_probe",
+                label="toolchain_probe",
+            )
+            result = await self._runner.run(invocation.args)
+            return ProbeExecResult(
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+
+        return await probe_runtime_toolchains(profile=profile, exec_in_container=_exec)
 
     async def run_profile_phases(
         self,

--- a/src/awf/runtime/validation_runner.py
+++ b/src/awf/runtime/validation_runner.py
@@ -140,6 +140,11 @@ DB_REFRESH_PHASE = "db_refresh"
 # that runs the probe, so the exec is bounded and the tracked process tree torn
 # down on timeout (the failure stays silent — see ``probe_runtime_toolchains``).
 _TOOLCHAIN_PROBE_TIMEOUT_SECONDS = 30.0
+# Wall timeout for the post-timeout cleanup exec. ``cleanup_compose_exec_invocation``
+# runs another ``docker compose exec`` via ``runner.run`` with no internal wall
+# timeout, so a wedged Docker daemon would let the cleanup itself hang the probe
+# (and the handoff) forever — bound it too, and give up cleanup rather than block.
+_TOOLCHAIN_PROBE_CLEANUP_TIMEOUT_SECONDS = 30.0
 _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_LIMIT = 1000
 _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_SCAN_LIMIT = 4 * _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_LIMIT
 _SETUP_DEPENDENCY_NETWORK_COMMAND_LIMIT = 500
@@ -370,11 +375,17 @@ class ValidationRunner:
                 # language instead of warning falsely.
                 # Cleanup already logs any failure; the probe must stay strictly
                 # non-blocking, so swallow a cleanup error rather than propagate.
-                with suppress(ComposeExecCleanupError):
-                    await cleanup_compose_exec_invocation(
-                        self._runner,
-                        invocation,
-                        workspace_id=workspace_id,
+                # The cleanup is itself an unbounded ``docker compose exec``, so a
+                # wedged daemon could hang it forever — bound it with its own short
+                # wall timeout and abandon cleanup rather than stall the handoff.
+                with suppress(ComposeExecCleanupError, TimeoutError):
+                    await asyncio.wait_for(
+                        cleanup_compose_exec_invocation(
+                            self._runner,
+                            invocation,
+                            workspace_id=workspace_id,
+                        ),
+                        timeout=_TOOLCHAIN_PROBE_CLEANUP_TIMEOUT_SECONDS,
                     )
                 return ProbeExecResult(
                     returncode=124,

--- a/src/awf/runtime/validation_runner.py
+++ b/src/awf/runtime/validation_runner.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import re
 import time
+from contextlib import suppress
 from dataclasses import replace
 from pathlib import Path
 
@@ -25,6 +26,7 @@ from awf.common.commands import (
     CommandResult,
 )
 from awf.common.compose_exec import (
+    ComposeExecCleanupError,
     build_tracked_compose_exec,
     cleanup_compose_exec_invocation,
     cleanup_compose_exec_invocation_after_cancellation,
@@ -133,6 +135,11 @@ SETUP_DEPENDENCY_NETWORK_RETRY_EXHAUSTED = "SETUP_DEPENDENCY_NETWORK_RETRY_EXHAU
 SETUP_DEPENDENCY_NETWORK_METADATA_KEY = "setup_dependency_network"
 DB_GENERATED_SETUP_PHASE = "db_generated_setup"
 DB_REFRESH_PHASE = "db_refresh"
+# Wall timeout for the non-blocking provision-time toolchain discovery exec. A
+# wedged ``docker compose exec`` must never stall the execute()/monitor handoff
+# that runs the probe, so the exec is bounded and the tracked process tree torn
+# down on timeout (the failure stays silent — see ``probe_runtime_toolchains``).
+_TOOLCHAIN_PROBE_TIMEOUT_SECONDS = 30.0
 _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_LIMIT = 1000
 _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_SCAN_LIMIT = 4 * _SETUP_DEPENDENCY_NETWORK_DIAGNOSTIC_LIMIT
 _SETUP_DEPENDENCY_NETWORK_COMMAND_LIMIT = 500
@@ -338,7 +345,6 @@ class ValidationRunner:
         pure ``runtime_toolchain_findings`` helper over the discovered versions.
         Skips entirely (zero exec) when no toolchains are declared.
         """
-        del workspace_id
         if not profile.runtime.toolchains:
             return ()
 
@@ -350,7 +356,38 @@ class ValidationRunner:
                 source="toolchain_probe",
                 label="toolchain_probe",
             )
-            result = await self._runner.run(invocation.args)
+            try:
+                result = await asyncio.wait_for(
+                    self._runner.run(invocation.args),
+                    timeout=_TOOLCHAIN_PROBE_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                # The default runner waits on ``proc.communicate()`` with no wall
+                # timeout, so a wedged ``docker compose exec`` would otherwise stall
+                # this non-blocking probe (and the handoff that runs it) forever.
+                # Tear the tracked in-container process tree down, then report a
+                # probe-infra failure (non-zero) so the helper stays silent for this
+                # language instead of warning falsely.
+                # Cleanup already logs any failure; the probe must stay strictly
+                # non-blocking, so swallow a cleanup error rather than propagate.
+                with suppress(ComposeExecCleanupError):
+                    await cleanup_compose_exec_invocation(
+                        self._runner,
+                        invocation,
+                        workspace_id=workspace_id,
+                    )
+                return ProbeExecResult(
+                    returncode=124,
+                    stdout="",
+                    stderr=f"toolchain probe timed out after {_TOOLCHAIN_PROBE_TIMEOUT_SECONDS}s",
+                )
+            except asyncio.CancelledError:
+                await cleanup_compose_exec_invocation_after_cancellation(
+                    self._runner,
+                    invocation,
+                    workspace_id=workspace_id,
+                )
+                raise
             return ProbeExecResult(
                 returncode=result.returncode,
                 stdout=result.stdout,

--- a/tests/unit/common/test_command_watchdogs.py
+++ b/tests/unit/common/test_command_watchdogs.py
@@ -123,6 +123,42 @@ async def test_asyncio_runner_cancellation_terminates_subprocess(tmp_path: Path)
 
 
 @pytest.mark.unit
+async def test_asyncio_runner_plain_run_terminates_subprocess_on_cancellation(
+    tmp_path: Path,
+) -> None:
+    runner = AsyncioSubprocessRunner()
+    pid_file = tmp_path / "child.pid"
+
+    task = asyncio.create_task(
+        runner.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import os,pathlib,sys,time;"
+                    "pathlib.Path(sys.argv[1]).write_text(str(os.getpid()));"
+                    "time.sleep(30)"
+                ),
+                str(pid_file),
+            ],
+        )
+    )
+    pid = await _wait_for_pid_file(pid_file)
+
+    try:
+        # A timeout wrapper (``asyncio.wait_for``) cancels ``run`` mid-flight;
+        # the spawned process must be reaped, not left orphaned.
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert not _pid_exists(pid)
+    finally:
+        if _pid_exists(pid):
+            os.kill(pid, signal.SIGKILL)
+
+
+@pytest.mark.unit
 async def test_asyncio_runner_ignores_child_that_closes_stdin_early() -> None:
     runner = AsyncioSubprocessRunner()
     stdout: list[str] = []

--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
@@ -105,8 +105,9 @@ def _allow_monitor_handoff_runtime_ownership_repair(monkeypatch: pytest.MonkeyPa
 class _OkSetupValidation:
     """Validation runner whose setup/pre_agent phase always passes."""
 
-    def __init__(self) -> None:
+    def __init__(self, trace: list[str] | None = None) -> None:
         self.calls: list[tuple[str, ...]] = []
+        self._trace = trace
 
     async def run_profile_phases(
         self,
@@ -115,6 +116,8 @@ class _OkSetupValidation:
         **_kwargs: Any,
     ) -> ValidationResult:
         self.calls.append(phase_names)
+        if self._trace is not None:
+            self._trace.append("run_profile_phases")
         return ValidationResult()
 
 
@@ -805,19 +808,24 @@ class TestHandoffSetupRunsToolchainProbe:
         # The monitor-handoff setup path must mirror ``execute`` and probe the
         # container for declared toolchains after a green setup, so adopted /
         # release-PR workspaces still surface RUNTIME_TOOLCHAIN_UNAVAILABLE
-        # warnings. The probe runs before the profile preflight returns.
+        # warnings. The probe runs after a green setup (run_profile_phases plus
+        # the dependency-network recorder) and before the profile preflight
+        # returns; the ordered trace below pins that sequence so the probe can
+        # never silently move ahead of profile setup.
         toolchain_calls: list[tuple[str, str]] = []
-        validation = _OkSetupValidation()
+        trace: list[str] = []
+        validation = _OkSetupValidation(trace=trace)
 
         class _Executor:
             _validation = validation
 
             async def _record_setup_dependency_network_events(self, **_kwargs: Any) -> None:
-                return None
+                trace.append("record_setup_dependency_network_events")
 
             async def _record_runtime_toolchain_findings(
                 self, *, workspace_id: str, compose_project: str, **_kwargs: Any
             ) -> None:
+                trace.append("record_runtime_toolchain_findings")
                 toolchain_calls.append((workspace_id, compose_project))
 
         ok = await _run_monitor_handoff_profile_setup(
@@ -832,6 +840,14 @@ class TestHandoffSetupRunsToolchainProbe:
         assert ok is True
         assert validation.calls == [("setup", "pre_agent")]
         assert toolchain_calls == [("ws-toolchain", "awf_x")]
+        # The probe must run strictly after the green setup completes, not just
+        # "eventually": run_profile_phases first, then the dependency-network
+        # recorder, then the toolchain recorder.
+        assert trace == [
+            "run_profile_phases",
+            "record_setup_dependency_network_events",
+            "record_runtime_toolchain_findings",
+        ]
 
     @pytest.mark.unit
     async def test_setup_swallows_toolchain_recorder_error(
@@ -851,7 +867,8 @@ class TestHandoffSetupRunsToolchainProbe:
 
         monkeypatch.setattr(monitor_handoff_setup_module, "_log", _Logger())
 
-        validation = _OkSetupValidation()
+        trace: list[str] = []
+        validation = _OkSetupValidation(trace=trace)
 
         class _RecorderError(RuntimeError):
             reason_code = "TOOLCHAIN_RECORDER_BROKE"
@@ -860,9 +877,10 @@ class TestHandoffSetupRunsToolchainProbe:
             _validation = validation
 
             async def _record_setup_dependency_network_events(self, **_kwargs: Any) -> None:
-                return None
+                trace.append("record_setup_dependency_network_events")
 
             async def _record_runtime_toolchain_findings(self, **_kwargs: Any) -> None:
+                trace.append("record_runtime_toolchain_findings")
                 raise _RecorderError("recorder unavailable ghp_FAKESECRET0000000")
 
         ok = await _run_monitor_handoff_profile_setup(
@@ -875,6 +893,13 @@ class TestHandoffSetupRunsToolchainProbe:
         )
 
         assert ok is True
+        # Even on the swallowed-error path the probe must fire only after the
+        # green setup completes, never ahead of run_profile_phases.
+        assert trace == [
+            "run_profile_phases",
+            "record_setup_dependency_network_events",
+            "record_runtime_toolchain_findings",
+        ]
         assert [event for event, _ in log_calls] == [
             "executor.monitor_handoff_runtime_toolchain_probe_record_failed"
         ]

--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
@@ -796,6 +796,84 @@ class TestHandoffProfilePreflightAndSetupReraise:
         assert exc_info.value is escaping
 
 
+class TestHandoffSetupRunsToolchainProbe:
+    @pytest.mark.unit
+    async def test_setup_records_toolchain_findings_after_green_setup(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        # The monitor-handoff setup path must mirror ``execute`` and probe the
+        # container for declared toolchains after a green setup, so adopted /
+        # release-PR workspaces still surface RUNTIME_TOOLCHAIN_UNAVAILABLE
+        # warnings. The probe runs before the profile preflight returns.
+        toolchain_calls: list[tuple[str, str]] = []
+        validation = _OkSetupValidation()
+
+        class _Executor:
+            _validation = validation
+
+            async def _record_setup_dependency_network_events(self, **_kwargs: Any) -> None:
+                return None
+
+            async def _record_runtime_toolchain_findings(
+                self, *, workspace_id: str, compose_project: str, **_kwargs: Any
+            ) -> None:
+                toolchain_calls.append((workspace_id, compose_project))
+
+        ok = await _run_monitor_handoff_profile_setup(
+            _Executor(),
+            workspace_id="ws-toolchain",
+            profile=object(),
+            compose_project="awf_x",
+            compose_file=tmp_path / "compose.yml",
+            worktree_path=tmp_path,
+        )
+
+        assert ok is True
+        assert validation.calls == [("setup", "pre_agent")]
+        assert toolchain_calls == [("ws-toolchain", "awf_x")]
+
+    @pytest.mark.unit
+    async def test_setup_swallows_toolchain_recorder_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The toolchain probe is strictly additive: a recorder error is logged
+        # and swallowed so the handoff still proceeds to the profile preflight
+        # and returns success.
+        log_events: list[str] = []
+
+        class _Logger:
+            def exception(self, event: str, **_kwargs: Any) -> None:
+                log_events.append(event)
+
+        monkeypatch.setattr(monitor_handoff_setup_module, "_log", _Logger())
+
+        validation = _OkSetupValidation()
+
+        class _Executor:
+            _validation = validation
+
+            async def _record_setup_dependency_network_events(self, **_kwargs: Any) -> None:
+                return None
+
+            async def _record_runtime_toolchain_findings(self, **_kwargs: Any) -> None:
+                raise RuntimeError("recorder unavailable")
+
+        ok = await _run_monitor_handoff_profile_setup(
+            _Executor(),
+            workspace_id="ws-toolchain-boom",
+            profile=object(),
+            compose_project="awf_x",
+            compose_file=tmp_path / "compose.yml",
+            worktree_path=tmp_path,
+        )
+
+        assert ok is True
+        assert log_events == ["executor.monitor_handoff_runtime_toolchain_probe_record_failed"]
+
+
 class TestSyncReleasePrHandoffRemainingBranches:
     @pytest.mark.unit
     async def test_release_handoff_skips_when_worktree_missing(

--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_017.py
@@ -841,16 +841,20 @@ class TestHandoffSetupRunsToolchainProbe:
     ) -> None:
         # The toolchain probe is strictly additive: a recorder error is logged
         # and swallowed so the handoff still proceeds to the profile preflight
-        # and returns success.
-        log_events: list[str] = []
+        # and returns success. The swallowed failure must preserve the structured
+        # reason_code and redact secrets instead of dumping a raw traceback.
+        log_calls: list[tuple[str, dict[str, Any]]] = []
 
         class _Logger:
-            def exception(self, event: str, **_kwargs: Any) -> None:
-                log_events.append(event)
+            def warning(self, event: str, **kwargs: Any) -> None:
+                log_calls.append((event, kwargs))
 
         monkeypatch.setattr(monitor_handoff_setup_module, "_log", _Logger())
 
         validation = _OkSetupValidation()
+
+        class _RecorderError(RuntimeError):
+            reason_code = "TOOLCHAIN_RECORDER_BROKE"
 
         class _Executor:
             _validation = validation
@@ -859,7 +863,7 @@ class TestHandoffSetupRunsToolchainProbe:
                 return None
 
             async def _record_runtime_toolchain_findings(self, **_kwargs: Any) -> None:
-                raise RuntimeError("recorder unavailable")
+                raise _RecorderError("recorder unavailable ghp_FAKESECRET0000000")
 
         ok = await _run_monitor_handoff_profile_setup(
             _Executor(),
@@ -871,7 +875,13 @@ class TestHandoffSetupRunsToolchainProbe:
         )
 
         assert ok is True
-        assert log_events == ["executor.monitor_handoff_runtime_toolchain_probe_record_failed"]
+        assert [event for event, _ in log_calls] == [
+            "executor.monitor_handoff_runtime_toolchain_probe_record_failed"
+        ]
+        _, kwargs = log_calls[0]
+        assert kwargs["reason_code"] == "TOOLCHAIN_RECORDER_BROKE"
+        assert "ghp_FAKESECRET0000000" not in kwargs["error"]
+        assert "<redacted>" in kwargs["error"]
 
 
 class TestSyncReleasePrHandoffRemainingBranches:

--- a/tests/unit/control/test_executor_runtime_toolchain_probe.py
+++ b/tests/unit/control/test_executor_runtime_toolchain_probe.py
@@ -1,0 +1,322 @@
+"""Executor wiring for the provision-time toolchain-availability probe.
+
+Covers ``_record_runtime_toolchain_findings`` (emit one warning event per
+finding; legacy-stub and best-effort no-ops) and the non-blocking guarded call
+site in ``execution_flow.execute`` (probe findings never fail provisioning; a
+recorder error is swallowed).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters import registry as _registry  # noqa: F401 - populates adapter registry
+from awf.common.commands import FakeCommandRunner
+from awf.control.executor import ExecutorConfig, WorkspaceExecutor
+from awf.control.executor.constants import RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
+from awf.control.executor.monitor_handoff_audit import _record_runtime_toolchain_findings
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.node.compose_manager import ComposeManager
+from awf.profiles.models import (
+    RUNTIME_TOOLCHAIN_UNAVAILABLE,
+    ProfileLintFinding,
+    ProfileLintSeverity,
+)
+from awf.runtime.pr_creator import PullRequestCreator
+from awf.runtime.validation import ValidationRunner
+from tests.unit.control.test_executor_parts.test_executor_part_005 import (
+    _TEMPLATE,
+    _queue_pre_push_diagnostics,
+    _queue_validation_head,
+    _seed_ready_workspace,
+    factory,
+    fake,
+)
+
+_IMPORTED_FIXTURES = (factory, fake)
+
+
+def _java_finding(version: str) -> ProfileLintFinding:
+    return ProfileLintFinding(
+        reason_code=RUNTIME_TOOLCHAIN_UNAVAILABLE,
+        message=f"runtime image does not provide java toolchain version {version}",
+        path="runtime.toolchains.java",
+        severity=ProfileLintSeverity.warning,
+        details={"language": "java", "version": version, "available_versions": ["17"]},
+    )
+
+
+class _FindingsValidation:
+    """Validation double whose probe returns canned toolchain findings."""
+
+    def __init__(self, findings: tuple[ProfileLintFinding, ...]) -> None:
+        self._findings = findings
+        self.calls: list[str] = []
+
+    async def probe_runtime_toolchain_findings(
+        self, *, workspace_id: str, **_kwargs: Any
+    ) -> tuple[ProfileLintFinding, ...]:
+        self.calls.append(workspace_id)
+        return self._findings
+
+
+class TestRecordRuntimeToolchainFindings:
+    @pytest.mark.unit
+    async def test_emits_one_warning_event_per_finding(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+        validation = _FindingsValidation((_java_finding("21"), _java_finding("23")))
+
+        class _Executor:
+            _session_factory = factory
+            _validation = validation
+
+        await _record_runtime_toolchain_findings(
+            _Executor(),
+            workspace_id=ws_id,
+            compose_project="awf_x",
+            compose_file=Path("/tmp/compose.yml"),
+            profile=object(),
+        )
+
+        assert validation.calls == [ws_id]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            # The probe is non-blocking: status is unchanged.
+            assert ws.status == WorkspaceStatus.ready.value
+            events = [
+                e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
+            ]
+            assert [e.payload["version"] for e in events] == ["21", "23"]
+            assert all(e.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE for e in events)
+            assert events[0].payload["language"] == "java"
+            assert events[0].payload["available_versions"] == ["17"]
+            assert events[0].payload["path"] == "runtime.toolchains.java"
+
+    @pytest.mark.unit
+    async def test_no_findings_records_nothing(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+
+        class _Executor:
+            _session_factory = factory
+            _validation = _FindingsValidation(())
+
+        await _record_runtime_toolchain_findings(
+            _Executor(),
+            workspace_id=ws_id,
+            compose_project="awf_x",
+            compose_file=Path("/tmp/compose.yml"),
+            profile=object(),
+        )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert [
+                e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
+            ] == []
+
+    @pytest.mark.unit
+    async def test_legacy_validation_without_probe_is_noop(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+
+        class _LegacyValidation:
+            """No ``probe_runtime_toolchain_findings`` attribute at all."""
+
+        class _Executor:
+            _session_factory = factory
+            _validation = _LegacyValidation()
+
+        await _record_runtime_toolchain_findings(
+            _Executor(),
+            workspace_id=ws_id,
+            compose_project="awf_x",
+            compose_file=Path("/tmp/compose.yml"),
+            profile=object(),
+        )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.ready.value
+
+    @pytest.mark.unit
+    async def test_probe_exception_is_swallowed(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        ws_id = await _seed_ready_workspace(factory)
+
+        class _ExplodingValidation:
+            async def probe_runtime_toolchain_findings(self, **_kwargs: Any) -> Any:
+                raise RuntimeError("probe blew up ghp_FAKESECRET0000000")
+
+        class _Executor:
+            _session_factory = factory
+            _validation = _ExplodingValidation()
+
+        # Must not raise.
+        await _record_runtime_toolchain_findings(
+            _Executor(),
+            workspace_id=ws_id,
+            compose_project="awf_x",
+            compose_file=Path("/tmp/compose.yml"),
+            profile=object(),
+        )
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.ready.value
+            assert [
+                e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
+            ] == []
+
+
+def _make_handoff_executor(
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monitor: Any,
+) -> WorkspaceExecutor:
+    compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+    validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+    pr = PullRequestCreator(fake)
+    return WorkspaceExecutor(
+        session_factory=factory,
+        runner=fake,
+        compose=compose,
+        validation=validation,
+        pr_creator=pr,
+        config=ExecutorConfig(
+            worktrees_root=tmp_path / "work" / "worktrees",
+            compose_projects_root=tmp_path / "work" / "compose",
+            default_models={
+                AgentRuntime.codex: "gpt-5",
+                AgentRuntime.claude_code: "sonnet",
+                AgentRuntime.gemini: "gemini-2.5-pro",
+            },
+        ),
+        pr_monitor=monitor,
+    )
+
+
+class _CompletingMonitor:
+    def __init__(self, factory: async_sessionmaker[AsyncSession]) -> None:
+        self._factory = factory
+        self.calls: list[str] = []
+
+    async def run(self, *, workspace_id: str, compose_project: str, compose_file: Path) -> None:
+        del compose_project, compose_file
+        self.calls.append(workspace_id)
+        async with self._factory() as s:
+            ws = await WorkspaceRepository(s).get(workspace_id)
+            assert ws is not None
+            await WorkspaceRepository(s).transition(
+                ws, to=WorkspaceStatus.completed, reason_code="STUB_MERGE"
+            )
+            await s.commit()
+
+
+def _queue_happy_execute(fake: FakeCommandRunner, ws_id: str) -> None:
+    fake.queue_result(returncode=0)  # adapter
+    fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")  # current branch
+    fake.queue_result(returncode=0)  # git add
+    fake.queue_result(returncode=0, stdout="f\n")  # diff --cached
+    fake.queue_result(returncode=0)  # git commit
+    fake.queue_result(returncode=0, stdout="1\n")  # rev-list count
+    fake.queue_result(returncode=0)  # merge-base --is-ancestor ok
+    _queue_validation_head(fake)
+    fake.queue_result(returncode=0)  # validation cmd
+    _queue_pre_push_diagnostics(fake)
+    fake.queue_result(returncode=0)  # push
+    fake.queue_result(
+        returncode=0,
+        stdout="https://github.com/dimileeh/aira-web/pull/7777\n",
+    )
+
+
+class TestExecuteGuardedProbeCall:
+    @pytest.mark.unit
+    async def test_probe_findings_recorded_without_blocking_provisioning(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # A reachable image missing a declared toolchain version surfaces a
+        # warning event mid-execute, yet provisioning proceeds to completion.
+        monitor = _CompletingMonitor(factory)
+        executor = _make_handoff_executor(fake, factory, tmp_path, monitor)
+
+        async def _probe(**_kwargs: Any) -> tuple[ProfileLintFinding, ...]:
+            return (_java_finding("21"),)
+
+        monkeypatch.setattr(executor._validation, "probe_runtime_toolchain_findings", _probe)
+
+        ws_id = await _seed_ready_workspace(
+            factory,
+            compose_file_path=str(tmp_path / "rendered" / "compose.yml"),
+        )
+        _queue_happy_execute(fake, ws_id)
+
+        await executor.execute(ws_id)
+
+        assert monitor.calls == [ws_id]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value
+            toolchain_events = [
+                e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
+            ]
+            assert len(toolchain_events) == 1
+            assert toolchain_events[0].payload["version"] == "21"
+            assert toolchain_events[0].reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE
+
+    @pytest.mark.unit
+    async def test_recorder_failure_is_swallowed_and_provisioning_proceeds(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The call site double-guards: even if the recorder itself raises, the
+        # workspace still hands off to the monitor and completes.
+        monitor = _CompletingMonitor(factory)
+        executor = _make_handoff_executor(fake, factory, tmp_path, monitor)
+
+        async def _boom(**_kwargs: Any) -> None:
+            raise RuntimeError("recorder unavailable")
+
+        monkeypatch.setattr(executor, "_record_runtime_toolchain_findings", _boom)
+
+        ws_id = await _seed_ready_workspace(
+            factory,
+            compose_file_path=str(tmp_path / "rendered" / "compose.yml"),
+        )
+        _queue_happy_execute(fake, ws_id)
+
+        await executor.execute(ws_id)
+
+        assert monitor.calls == [ws_id]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.completed.value

--- a/tests/unit/control/test_executor_runtime_toolchain_probe.py
+++ b/tests/unit/control/test_executor_runtime_toolchain_probe.py
@@ -92,9 +92,14 @@ class TestRecordRuntimeToolchainFindings:
             assert ws is not None
             # The probe is non-blocking: status is unchanged.
             assert ws.status == WorkspaceStatus.ready.value
-            events = [
-                e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE
-            ]
+            # ``ws.events`` is ordered only by ``occurred_at``; events written
+            # together can share a timestamp, so sort on the monotonic
+            # ``event_order`` (the canonical insertion tiebreak) for a
+            # backend-independent, deterministic assertion on emission order.
+            events = sorted(
+                (e for e in ws.events if e.event_type == RUNTIME_TOOLCHAIN_UNAVAILABLE_EVENT_TYPE),
+                key=lambda e: e.event_order,
+            )
             assert [e.payload["version"] for e in events] == ["21", "23"]
             assert all(e.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE for e in events)
             assert events[0].payload["language"] == "java"

--- a/tests/unit/control/test_executor_runtime_toolchain_probe.py
+++ b/tests/unit/control/test_executor_runtime_toolchain_probe.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import structlog
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.adapters import registry as _registry  # noqa: F401 - populates adapter registry
@@ -166,22 +167,36 @@ class TestRecordRuntimeToolchainFindings:
     ) -> None:
         ws_id = await _seed_ready_workspace(factory)
 
+        class _ProbeError(RuntimeError):
+            reason_code = "RUNTIME_TOOLCHAIN_PROBE_BROKE"
+
         class _ExplodingValidation:
             async def probe_runtime_toolchain_findings(self, **_kwargs: Any) -> Any:
-                raise RuntimeError("probe blew up ghp_FAKESECRET0000000")
+                raise _ProbeError("probe blew up ghp_FAKESECRET0000000")
 
         class _Executor:
             _session_factory = factory
             _validation = _ExplodingValidation()
 
         # Must not raise.
-        await _record_runtime_toolchain_findings(
-            _Executor(),
-            workspace_id=ws_id,
-            compose_project="awf_x",
-            compose_file=Path("/tmp/compose.yml"),
-            profile=object(),
-        )
+        with structlog.testing.capture_logs() as captured:
+            await _record_runtime_toolchain_findings(
+                _Executor(),
+                workspace_id=ws_id,
+                compose_project="awf_x",
+                compose_file=Path("/tmp/compose.yml"),
+                profile=object(),
+            )
+
+        # The swallowed failure is the only operator signal: it must preserve the
+        # structured reason_code and never leak the compose-exec stderr secret as
+        # a raw traceback.
+        entry = next(e for e in captured if e["event"] == "executor.runtime_toolchain_probe_failed")
+        assert entry["log_level"] == "warning"
+        assert entry["reason_code"] == "RUNTIME_TOOLCHAIN_PROBE_BROKE"
+        assert "ghp_FAKESECRET0000000" not in entry["error"]
+        assert "<redacted>" in entry["error"]
+        assert "exc_info" not in entry
 
         async with factory() as s:
             ws = await WorkspaceRepository(s).get(ws_id)

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -18,7 +18,9 @@ from awf.profiles.models import (
     WorkspaceProfile,
 )
 from awf.runtime.toolchain_probe import (
+    _TOOLCHAIN_DISCOVERY,
     ProbeExecResult,
+    ToolchainDiscoveryStrategy,
     _normalize_java_version,
     _parse_java_versions,
     probe_runtime_toolchains,
@@ -178,6 +180,70 @@ class TestProbeRuntimeToolchains:
 
         assert findings == ()
         assert spy.calls == []
+
+    async def test_later_language_probe_failure_keeps_earlier_findings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Register a second discovery strategy so the multi-language orchestration
+        # path is exercised: java probes cleanly (warning that 21 is missing), then
+        # the second language's probe returns non-zero. A per-language infra
+        # failure must not discard java's accurate finding, nor warn for the failed
+        # language (whose installed versions are unknown).
+        monkeypatch.setitem(
+            _TOOLCHAIN_DISCOVERY,
+            "node",
+            ToolchainDiscoveryStrategy(
+                command=("sh", "-c", "true"),
+                parse=lambda _output: set(),
+                normalize=lambda version: version,
+            ),
+        )
+        profile = _profile_with_toolchains({"java": ["17", "21"], "node": ["20"]})
+        spy = _SpyExec(
+            [
+                ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr=""),
+                ProbeExecResult(returncode=1, stdout="", stderr="boom"),
+            ]
+        )
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        # Only java's genuine "21 missing" warning survives; node stays silent.
+        assert [(f.details["language"], f.details["version"]) for f in findings] == [("java", "21")]
+        assert len(spy.calls) == 2
+
+    async def test_later_language_probe_exception_keeps_earlier_findings(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Same as above but the second language's probe *raises* mid-loop: java's
+        # finding is still preserved and the failed language stays silent.
+        monkeypatch.setitem(
+            _TOOLCHAIN_DISCOVERY,
+            "node",
+            ToolchainDiscoveryStrategy(
+                command=("sh", "-c", "boom"),
+                parse=lambda _output: set(),
+                normalize=lambda version: version,
+            ),
+        )
+        profile = _profile_with_toolchains({"java": ["17", "21"], "node": ["20"]})
+
+        class _OneGoodThenRaise:
+            def __init__(self) -> None:
+                self.calls: list[list[str]] = []
+
+            async def __call__(self, cli_args: list[str]) -> ProbeExecResult:
+                self.calls.append(cli_args)
+                if len(self.calls) == 1:
+                    return ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")
+                raise RuntimeError("cannot exec into container")
+
+        spy = _OneGoodThenRaise()
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert [(f.details["language"], f.details["version"]) for f in findings] == [("java", "21")]
+        assert len(spy.calls) == 2
 
     async def test_unprobed_language_alongside_probed_java(self) -> None:
         # Java is probed (and satisfied); the unsupported language is treated as

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -1,0 +1,198 @@
+"""Unit tests for the provision-time toolchain version-discovery probe.
+
+These cover the pure orchestration core in
+``awf.runtime.toolchain_probe.probe_runtime_toolchains`` and its java
+normalization/parse helpers. The ``available`` contract is the crux: probe-infra
+failure (exception or non-zero return) stays globally silent, while a reachable
+but tool-less image warns. The probe never runs an exec when no toolchains are
+declared or for a language with no registered strategy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.profiles.models import (
+    RUNTIME_TOOLCHAIN_UNAVAILABLE,
+    ProfileLintSeverity,
+    WorkspaceProfile,
+)
+from awf.runtime.toolchain_probe import (
+    ProbeExecResult,
+    _normalize_java_version,
+    _parse_java_versions,
+    probe_runtime_toolchains,
+)
+
+
+def _profile_with_toolchains(toolchains: dict[str, list[str]]) -> WorkspaceProfile:
+    return WorkspaceProfile.model_validate(
+        {"name": "toolchain-profile", "runtime": {"toolchains": toolchains}}
+    )
+
+
+class _SpyExec:
+    """Records the argvs it was asked to run and returns queued results."""
+
+    def __init__(self, results: list[ProbeExecResult] | None = None) -> None:
+        self.calls: list[list[str]] = []
+        self._results = list(results or [])
+        self.raise_exc: BaseException | None = None
+
+    async def __call__(self, cli_args: list[str]) -> ProbeExecResult:
+        self.calls.append(cli_args)
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        if self._results:
+            return self._results.pop(0)
+        return ProbeExecResult(returncode=0, stdout="", stderr="")
+
+
+_RELEASE_17 = 'JAVA_VERSION="17.0.9"\n'
+_RELEASE_21 = 'JAVA_VERSION="21.0.1"\n'
+
+
+@pytest.mark.unit
+class TestProbeRuntimeToolchains:
+    async def test_no_toolchains_declared_skips_probe(self) -> None:
+        profile = _profile_with_toolchains({})
+        spy = _SpyExec()
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+        assert spy.calls == []
+
+    async def test_all_declared_versions_present_no_findings(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17 + _RELEASE_21, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+        assert len(spy.calls) == 1
+
+    async def test_only_one_version_present_warns_missing(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert len(findings) == 1
+        finding = findings[0]
+        assert finding.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE
+        assert finding.severity == ProfileLintSeverity.warning
+        assert finding.path == "runtime.toolchains.java"
+        assert finding.details["language"] == "java"
+        assert finding.details["version"] == "21"
+
+    async def test_probe_exec_exception_is_silent(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        spy = _SpyExec()
+        spy.raise_exc = RuntimeError("cannot exec into container")
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        # Probe-infra failure -> available=None -> globally silent.
+        assert findings == ()
+        assert len(spy.calls) == 1
+
+    async def test_probe_returncode_nonzero_is_silent(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        spy = _SpyExec([ProbeExecResult(returncode=1, stdout="", stderr="boom")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
+    async def test_tool_absent_empty_set_warns_all(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        # Reachable image (rc=0) but no JDK installed -> empty parse -> warns both.
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout="", stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        warned = sorted(f.details["version"] for f in findings)
+        assert warned == ["17", "21"]
+
+    async def test_installed_17_0_9_satisfies_declared_17(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
+    async def test_declared_23_with_only_17_21_installed_warns(self) -> None:
+        profile = _profile_with_toolchains({"java": ["17", "21", "23"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17 + _RELEASE_21, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert [f.details["version"] for f in findings] == ["23"]
+
+    async def test_unprobed_language_does_not_warn(self) -> None:
+        # A language with no registered discovery strategy is treated as
+        # satisfied so it never produces a false warning — and no exec runs.
+        profile = _profile_with_toolchains({"python": ["3.12"]})
+        spy = _SpyExec()
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+        assert spy.calls == []
+
+    async def test_unprobed_language_alongside_probed_java(self) -> None:
+        # Java is probed (and satisfied); the unsupported language is treated as
+        # satisfied without an exec of its own.
+        profile = _profile_with_toolchains({"java": ["17"], "python": ["3.12"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+        # Only java triggers an exec.
+        assert len(spy.calls) == 1
+
+
+@pytest.mark.unit
+class TestNormalizeJavaVersion:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("17.0.9", "17"),
+            ("21", "21"),
+            ("21.0.1", "21"),
+            ("1.8.0_392", "8"),
+            ("1.8", "8"),
+            ('"17.0.9"', "17"),
+            ("08", "8"),
+            ("", None),
+            ("   ", None),
+            ("not-a-version", None),
+        ],
+    )
+    def test_normalize(self, raw: str, expected: str | None) -> None:
+        assert _normalize_java_version(raw) == expected
+
+
+@pytest.mark.unit
+class TestParseJavaVersions:
+    def test_parses_release_and_alternatives_output(self) -> None:
+        output = (
+            'JAVA_VERSION="17.0.9"\n'
+            "IMPLEMENTOR=Eclipse Adoptium\n"
+            'JAVA_VERSION="21.0.1"\n'
+            "/usr/lib/jvm/java-17-openjdk-amd64/bin/java\n"
+            "/usr/lib/jvm/temurin-21-jdk-amd64/bin/java\n"
+        )
+
+        assert _parse_java_versions(output) == {"17", "21"}
+
+    def test_parses_quoted_java_version_line(self) -> None:
+        output = 'openjdk version "17.0.9" 2023-10-17\n'
+
+        assert _parse_java_versions(output) == {"17"}
+
+    def test_empty_output_is_empty_set(self) -> None:
+        assert _parse_java_versions("") == set()

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -18,6 +18,7 @@ from awf.profiles.models import (
     WorkspaceProfile,
 )
 from awf.runtime.toolchain_probe import (
+    _JAVA_DISCOVERY_COMMAND,
     _TOOLCHAIN_DISCOVERY,
     ProbeExecResult,
     ToolchainDiscoveryStrategy,
@@ -306,3 +307,25 @@ class TestParseJavaVersions:
 
     def test_empty_output_is_empty_set(self) -> None:
         assert _parse_java_versions("") == set()
+
+    def test_parses_java_version_stderr_style_output(self) -> None:
+        # ``java -version`` fallback (merged via ``2>&1``) for images that install
+        # the JDK under ``$JAVA_HOME`` outside ``/usr/lib/jvm`` with no alternatives.
+        output = 'openjdk version "21.0.1" 2023-10-17\nOpenJDK Runtime Environment\n'
+
+        assert _parse_java_versions(output) == {"21"}
+
+
+@pytest.mark.unit
+class TestJavaDiscoveryCommand:
+    def test_command_reads_java_home_and_falls_back_to_java_version(self) -> None:
+        # Regression: images that install the JDK under ``$JAVA_HOME`` (e.g.
+        # eclipse-temurin's ``/opt/java/openjdk``) outside ``/usr/lib/jvm`` and
+        # register no update-alternatives must still be discovered, not reported
+        # as missing java.
+        script = _JAVA_DISCOVERY_COMMAND[-1]
+        assert '"$JAVA_HOME/release"' in script
+        assert "java -version 2>&1" in script
+        # The trailing ``true`` still guarantees exit 0 when the container is
+        # reachable, preserving the probe-infra-failure contract.
+        assert script.rstrip().endswith("true")

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -23,6 +23,7 @@ from awf.runtime.toolchain_probe import (
     ProbeExecResult,
     ToolchainDiscoveryStrategy,
     _normalize_java_version,
+    _parse_java_exact_versions,
     _parse_java_versions,
     probe_runtime_toolchains,
 )
@@ -136,6 +137,29 @@ class TestProbeRuntimeToolchains:
 
         assert findings == ()
 
+    async def test_dotted_declared_11_0_2_warns_when_only_sibling_patch_installed(self) -> None:
+        # Regression for PRRT_kwDOSJAM6s6JD_5P: a dotted declaration carries
+        # patch-level intent, so a *different* patch on the same major (11.0.1) must
+        # NOT silence a declared 11.0.2 — the missing exact patch still warns, with
+        # the discovered major surfaced in available_versions.
+        profile = _profile_with_toolchains({"java": ["11.0.2"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout='JAVA_VERSION="11.0.1"\n', stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert [f.details["version"] for f in findings] == ["11.0.2"]
+        assert findings[0].details["available_versions"] == ["11"]
+
+    async def test_bare_major_11_satisfied_by_any_installed_patch(self) -> None:
+        # A bare-major declaration stays coarse: an installed 11.0.1 satisfies a
+        # declared "11" regardless of patch (contrast the dotted case above).
+        profile = _profile_with_toolchains({"java": ["11"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout='JAVA_VERSION="11.0.1"\n', stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
     async def test_legacy_dotted_declared_1_8_satisfied_by_installed_jdk8(self) -> None:
         profile = _profile_with_toolchains({"java": ["1.8"]})
         spy = _SpyExec(
@@ -196,6 +220,7 @@ class TestProbeRuntimeToolchains:
             ToolchainDiscoveryStrategy(
                 command=("sh", "-c", "true"),
                 parse=lambda _output: set(),
+                parse_exact=lambda _output: set(),
                 normalize=lambda version: version,
             ),
         )
@@ -224,6 +249,7 @@ class TestProbeRuntimeToolchains:
             ToolchainDiscoveryStrategy(
                 command=("sh", "-c", "boom"),
                 parse=lambda _output: set(),
+                parse_exact=lambda _output: set(),
                 normalize=lambda version: version,
             ),
         )
@@ -314,6 +340,23 @@ class TestParseJavaVersions:
         output = 'openjdk version "21.0.1" 2023-10-17\nOpenJDK Runtime Environment\n'
 
         assert _parse_java_versions(output) == {"21"}
+
+
+@pytest.mark.unit
+class TestParseJavaExactVersions:
+    def test_keeps_full_patch_versions_not_just_majors(self) -> None:
+        # Unlike _parse_java_versions, the exact parser preserves patch granularity
+        # (and the legacy dotted path) so patch-precise declarations can be matched.
+        output = (
+            'JAVA_VERSION="17.0.9"\n'
+            'JAVA_VERSION="11.0.2"\n'
+            "/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java\n"
+        )
+
+        assert _parse_java_exact_versions(output) == {"17.0.9", "11.0.2", "1.8.0"}
+
+    def test_empty_output_is_empty_set(self) -> None:
+        assert _parse_java_exact_versions("") == set()
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -189,6 +189,13 @@ class TestParseJavaVersions:
 
         assert _parse_java_versions(output) == {"17", "21"}
 
+    def test_parses_legacy_dotted_jvm_path(self) -> None:
+        # RHEL-style legacy JDK 8 directories embed ``1.8.0`` in the path; the
+        # path regex must capture the dotted version so it normalizes to ``8``.
+        output = "/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java\n"
+
+        assert _parse_java_versions(output) == {"8"}
+
     def test_parses_quoted_java_version_line(self) -> None:
         output = 'openjdk version "17.0.9" 2023-10-17\n'
 

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -90,15 +90,29 @@ class TestProbeRuntimeToolchains:
         assert finding.details["language"] == "java"
         assert finding.details["version"] == "21"
 
-    async def test_probe_exec_exception_is_silent(self) -> None:
+    async def test_probe_exec_oserror_is_silent(self) -> None:
         profile = _profile_with_toolchains({"java": ["17", "21"]})
         spy = _SpyExec()
-        spy.raise_exc = RuntimeError("cannot exec into container")
+        # OSError models the only operational probe-infra failure the exec itself
+        # raises (container exec cannot spawn — missing binary, etc.).
+        spy.raise_exc = OSError("cannot exec into container")
 
         findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
 
         # Probe-infra failure -> available=None -> globally silent.
         assert findings == ()
+        assert len(spy.calls) == 1
+
+    async def test_probe_exec_unexpected_exception_propagates(self) -> None:
+        # A non-OSError out of the injected exec is a programmer bug, not an
+        # expected probe miss: it must surface instead of being downgraded into a
+        # silent suppression of RUNTIME_TOOLCHAIN_UNAVAILABLE findings.
+        profile = _profile_with_toolchains({"java": ["17", "21"]})
+        spy = _SpyExec()
+        spy.raise_exc = RuntimeError("regression in the exec path")
+
+        with pytest.raises(RuntimeError, match="regression in the exec path"):
+            await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
         assert len(spy.calls) == 1
 
     async def test_probe_returncode_nonzero_is_silent(self) -> None:
@@ -255,8 +269,9 @@ class TestProbeRuntimeToolchains:
     async def test_later_language_probe_exception_keeps_earlier_findings(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Same as above but the second language's probe *raises* mid-loop: java's
-        # finding is still preserved and the failed language stays silent.
+        # Same as above but the second language's probe *raises* an operational
+        # OSError mid-loop: java's finding is still preserved and the failed
+        # language stays silent.
         monkeypatch.setitem(
             _TOOLCHAIN_DISCOVERY,
             "node",
@@ -277,7 +292,7 @@ class TestProbeRuntimeToolchains:
                 self.calls.append(cli_args)
                 if len(self.calls) == 1:
                     return ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")
-                raise RuntimeError("cannot exec into container")
+                raise OSError("cannot exec into container")
 
         spy = _OneGoodThenRaise()
 

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -176,6 +176,20 @@ class TestProbeRuntimeToolchains:
 
         assert findings == ()
 
+    async def test_dotted_declared_1_8_0_satisfied_by_legacy_underscore_patch(self) -> None:
+        # Regression for PRRT_kwDOSJAM6s6JENkD: legacy JDK release strings join the
+        # update level with an underscore (``1.8.0_392``), which is a refining
+        # boundary just like a dot — a declared ``1.8.0`` must be satisfied by an
+        # installed ``1.8.0_392`` rather than warning RUNTIME_TOOLCHAIN_UNAVAILABLE.
+        profile = _profile_with_toolchains({"java": ["1.8.0"]})
+        spy = _SpyExec(
+            [ProbeExecResult(returncode=0, stdout='openjdk version "1.8.0_392"\n', stderr="")]
+        )
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
     async def test_dotted_declared_absent_still_warns(self) -> None:
         # A finer dotted declaration whose major is missing still warns, and the
         # warning surfaces the discovered majors in available_versions.

--- a/tests/unit/runtime/test_toolchain_probe.py
+++ b/tests/unit/runtime/test_toolchain_probe.py
@@ -123,6 +123,43 @@ class TestProbeRuntimeToolchains:
 
         assert findings == ()
 
+    async def test_dotted_declared_11_0_2_satisfied_by_installed_11_0_2(self) -> None:
+        # The schema accepts finer dotted declarations; an installed 11.0.2 must
+        # satisfy a declared "11.0.2" rather than warning against discovered "11".
+        profile = _profile_with_toolchains({"java": ["11.0.2"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout='JAVA_VERSION="11.0.2"\n', stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
+    async def test_legacy_dotted_declared_1_8_satisfied_by_installed_jdk8(self) -> None:
+        profile = _profile_with_toolchains({"java": ["1.8"]})
+        spy = _SpyExec(
+            [
+                ProbeExecResult(
+                    returncode=0,
+                    stdout="/usr/lib/jvm/java-1.8.0-openjdk-amd64/bin/java\n",
+                    stderr="",
+                )
+            ]
+        )
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert findings == ()
+
+    async def test_dotted_declared_absent_still_warns(self) -> None:
+        # A finer dotted declaration whose major is missing still warns, and the
+        # warning surfaces the discovered majors in available_versions.
+        profile = _profile_with_toolchains({"java": ["23.0.1"]})
+        spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17, stderr="")])
+
+        findings = await probe_runtime_toolchains(profile=profile, exec_in_container=spy)
+
+        assert [f.details["version"] for f in findings] == ["23.0.1"]
+        assert findings[0].details["available_versions"] == ["17"]
+
     async def test_declared_23_with_only_17_21_installed_warns(self) -> None:
         profile = _profile_with_toolchains({"java": ["17", "21", "23"]})
         spy = _SpyExec([ProbeExecResult(returncode=0, stdout=_RELEASE_17 + _RELEASE_21, stderr="")])

--- a/tests/unit/runtime/test_validation_runner_toolchain_probe.py
+++ b/tests/unit/runtime/test_validation_runner_toolchain_probe.py
@@ -2,18 +2,22 @@
 
 Verify the runner method reuses the tracked compose-exec path (tagged
 ``source="toolchain_probe"``), returns the pure helper's findings, skips
-entirely without a declaration, and stays silent when the in-container probe
-command is unreachable (non-zero return).
+entirely without a declaration, stays silent when the in-container probe
+command is unreachable (non-zero return), and — when ``docker compose exec``
+wedges — times out, tears down the tracked process tree, and stays silent
+rather than stalling the non-blocking handoff probe indefinitely.
 """
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
 
-from awf.common.commands import FakeCommandRunner
+from awf.common.commands import CommandResult, FakeCommandRunner
 from awf.profiles.models import RUNTIME_TOOLCHAIN_UNAVAILABLE, WorkspaceProfile
+from awf.runtime import validation_runner as validation_runner_module
 from awf.runtime.validation_runner import ValidationRunner
 
 
@@ -25,6 +29,37 @@ def _profile_with_toolchains(toolchains: dict[str, list[str]]) -> WorkspaceProfi
 
 def _runner(fake: FakeCommandRunner, tmp_path: Path) -> ValidationRunner:
     return ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+
+class _WedgedProbeRunner:
+    """Hangs on the probe exec; answers the targeted cleanup call.
+
+    Models a wedged ``docker compose exec``: the discovery exec never returns,
+    while the tracked cleanup invocation responds with ``cleanup_returncode``.
+    """
+
+    def __init__(self, *, cleanup_returncode: int) -> None:
+        self.calls: list[list[str]] = []
+        self.exec_started = asyncio.Event()
+        self._cleanup_returncode = cleanup_returncode
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        input_bytes: bytes | None = None,
+        cwd: str | None = None,
+    ) -> CommandResult:
+        self.calls.append(list(args))
+        if "awf-cleanup" in args:
+            return CommandResult(
+                returncode=self._cleanup_returncode,
+                stdout="awf cleanup: killed" if self._cleanup_returncode == 0 else "",
+                stderr="" if self._cleanup_returncode == 0 else "still alive",
+            )
+        self.exec_started.set()
+        await asyncio.sleep(3600)  # pragma: no cover - cancelled by timeout
+        raise AssertionError("wedged exec should never return")  # pragma: no cover
 
 
 @pytest.mark.unit
@@ -78,3 +113,63 @@ class TestProbeRuntimeToolchainFindings:
         )
 
         assert findings == ()
+
+    async def test_probe_times_out_and_cleans_up(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A wedged ``docker compose exec`` must not stall the non-blocking probe.
+        monkeypatch.setattr(validation_runner_module, "_TOOLCHAIN_PROBE_TIMEOUT_SECONDS", 0.05)
+        fake = _WedgedProbeRunner(cleanup_returncode=0)
+        runner = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+        findings = await runner.probe_runtime_toolchain_findings(
+            workspace_id="ws-1",
+            compose_project="awf_ws1",
+            compose_file=tmp_path / "compose.yml",
+            profile=_profile_with_toolchains({"java": ["17", "21"]}),
+        )
+
+        # Globally silent (first language timed out) and the tracked process tree
+        # was torn down via the targeted cleanup invocation.
+        assert findings == ()
+        assert any("awf-exec" in call for call in fake.calls)
+        assert any("awf-cleanup" in call for call in fake.calls)
+
+    async def test_probe_timeout_swallows_cleanup_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A failed cleanup after a timeout must never propagate out of the
+        # strictly non-blocking probe.
+        monkeypatch.setattr(validation_runner_module, "_TOOLCHAIN_PROBE_TIMEOUT_SECONDS", 0.05)
+        fake = _WedgedProbeRunner(cleanup_returncode=1)
+        runner = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+        findings = await runner.probe_runtime_toolchain_findings(
+            workspace_id="ws-1",
+            compose_project="awf_ws1",
+            compose_file=tmp_path / "compose.yml",
+            profile=_profile_with_toolchains({"java": ["17", "21"]}),
+        )
+
+        assert findings == ()
+        assert any("awf-cleanup" in call for call in fake.calls)
+
+    async def test_probe_cleans_up_on_cancellation(self, tmp_path: Path) -> None:
+        fake = _WedgedProbeRunner(cleanup_returncode=0)
+        runner = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+        task = asyncio.ensure_future(
+            runner.probe_runtime_toolchain_findings(
+                workspace_id="ws-1",
+                compose_project="awf_ws1",
+                compose_file=tmp_path / "compose.yml",
+                profile=_profile_with_toolchains({"java": ["17"]}),
+            )
+        )
+        await fake.exec_started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Cancellation still tears the tracked process tree down.
+        assert any("awf-cleanup" in call for call in fake.calls)

--- a/tests/unit/runtime/test_validation_runner_toolchain_probe.py
+++ b/tests/unit/runtime/test_validation_runner_toolchain_probe.py
@@ -62,6 +62,32 @@ class _WedgedProbeRunner:
         raise AssertionError("wedged exec should never return")  # pragma: no cover
 
 
+class _WedgedCleanupProbeRunner:
+    """Hangs on BOTH the probe exec and the targeted cleanup exec.
+
+    Models a wedged Docker daemon where even the post-timeout cleanup
+    ``docker compose exec`` never returns, so the cleanup must be bounded by its
+    own wall timeout or it would stall the non-blocking probe indefinitely.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+        self.cleanup_started = asyncio.Event()
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        input_bytes: bytes | None = None,
+        cwd: str | None = None,
+    ) -> CommandResult:
+        self.calls.append(list(args))
+        if "awf-cleanup" in args:
+            self.cleanup_started.set()
+        await asyncio.sleep(3600)  # pragma: no cover - cancelled by timeout
+        raise AssertionError("wedged exec should never return")  # pragma: no cover
+
+
 @pytest.mark.unit
 class TestProbeRuntimeToolchainFindings:
     async def test_probe_builds_compose_exec_and_returns_findings(self, tmp_path: Path) -> None:
@@ -152,6 +178,33 @@ class TestProbeRuntimeToolchainFindings:
         )
 
         assert findings == ()
+        assert any("awf-cleanup" in call for call in fake.calls)
+
+    async def test_probe_bounds_wedged_cleanup(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A wedged Docker daemon makes even the post-timeout cleanup exec hang;
+        # the cleanup's own wall timeout must keep the probe non-blocking.
+        monkeypatch.setattr(validation_runner_module, "_TOOLCHAIN_PROBE_TIMEOUT_SECONDS", 0.05)
+        monkeypatch.setattr(
+            validation_runner_module, "_TOOLCHAIN_PROBE_CLEANUP_TIMEOUT_SECONDS", 0.05
+        )
+        fake = _WedgedCleanupProbeRunner()
+        runner = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+        findings = await asyncio.wait_for(
+            runner.probe_runtime_toolchain_findings(
+                workspace_id="ws-1",
+                compose_project="awf_ws1",
+                compose_file=tmp_path / "compose.yml",
+                profile=_profile_with_toolchains({"java": ["17", "21"]}),
+            ),
+            timeout=5,
+        )
+
+        # Silent, and the bounded cleanup was attempted before being abandoned.
+        assert findings == ()
+        assert fake.cleanup_started.is_set()
         assert any("awf-cleanup" in call for call in fake.calls)
 
     async def test_probe_cleans_up_on_cancellation(self, tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_validation_runner_toolchain_probe.py
+++ b/tests/unit/runtime/test_validation_runner_toolchain_probe.py
@@ -1,0 +1,80 @@
+"""``ValidationRunner.probe_runtime_toolchain_findings`` integration tests.
+
+Verify the runner method reuses the tracked compose-exec path (tagged
+``source="toolchain_probe"``), returns the pure helper's findings, skips
+entirely without a declaration, and stays silent when the in-container probe
+command is unreachable (non-zero return).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.common.commands import FakeCommandRunner
+from awf.profiles.models import RUNTIME_TOOLCHAIN_UNAVAILABLE, WorkspaceProfile
+from awf.runtime.validation_runner import ValidationRunner
+
+
+def _profile_with_toolchains(toolchains: dict[str, list[str]]) -> WorkspaceProfile:
+    return WorkspaceProfile.model_validate(
+        {"name": "toolchain-profile", "runtime": {"toolchains": toolchains}}
+    )
+
+
+def _runner(fake: FakeCommandRunner, tmp_path: Path) -> ValidationRunner:
+    return ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
+
+
+@pytest.mark.unit
+class TestProbeRuntimeToolchainFindings:
+    async def test_probe_builds_compose_exec_and_returns_findings(self, tmp_path: Path) -> None:
+        fake = FakeCommandRunner()
+        # Reachable image (rc=0) with only JDK 17 installed; declares 17+21.
+        fake.queue_result(returncode=0, stdout='JAVA_VERSION="17.0.9"\n')
+        runner = _runner(fake, tmp_path)
+
+        findings = await runner.probe_runtime_toolchain_findings(
+            workspace_id="ws-1",
+            compose_project="awf_ws1",
+            compose_file=tmp_path / "compose.yml",
+            profile=_profile_with_toolchains({"java": ["17", "21"]}),
+        )
+
+        assert [f.details["version"] for f in findings] == ["21"]
+        assert all(f.reason_code == RUNTIME_TOOLCHAIN_UNAVAILABLE for f in findings)
+        # Reused the tracked compose-exec path tagged for the probe.
+        assert len(fake.calls) == 1
+        argv = fake.calls[0].args
+        assert argv[:3] == ["docker", "compose", "-p"]
+        assert "awf_ws1" in argv
+        assert "agent" in argv
+
+    async def test_probe_skips_without_toolchains(self, tmp_path: Path) -> None:
+        fake = FakeCommandRunner()
+        runner = _runner(fake, tmp_path)
+
+        findings = await runner.probe_runtime_toolchain_findings(
+            workspace_id="ws-1",
+            compose_project="awf_ws1",
+            compose_file=tmp_path / "compose.yml",
+            profile=_profile_with_toolchains({}),
+        )
+
+        assert findings == ()
+        assert fake.calls == []
+
+    async def test_probe_silent_on_runner_nonzero(self, tmp_path: Path) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=1, stderr="exec failed")
+        runner = _runner(fake, tmp_path)
+
+        findings = await runner.probe_runtime_toolchain_findings(
+            workspace_id="ws-1",
+            compose_project="awf_ws1",
+            compose_file=tmp_path / "compose.yml",
+            profile=_profile_with_toolchains({"java": ["17", "21"]}),
+        )
+
+        assert findings == ()


### PR DESCRIPTION
## Wire provision-time toolchain version-discovery (#535)

Wires the existing pure helper `runtime_toolchain_findings` (#527 item 6) into a real production preflight so a profile declaring `toolchains: {java: ["17","21"]}` actually surfaces `RUNTIME_TOOLCHAIN_UNAVAILABLE` warnings when the runtime image lacks a declared version.

**Design (locked via `/plan-eng-review`):** a provision-time, in-container probe — the workspace container is already running, so the data is truthful and no extra launch is needed. New `src/awf/runtime/toolchain_probe.py` discovers installed versions; the executor's `execute()` flow records findings as **non-blocking** warning events (wrapped in `try/except` so a probe failure can never affect provisioning or a state transition).

**Note for review:** this PR was salvaged from AWF workspace `ws_fd235320` after a benign post-validation conformance-report git failure (`infrastructure_failure`) that fired *after* `AGENT_RUN_OK`. The work is complete; the executor touches are the necessary wiring to surface findings through the real validation orchestration, and `openapi.json` is regenerated. Full CI (sharded pytest + coverage) is the authoritative gate.

Closes #535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches executor provisioning/handoff paths and compose-exec timeouts; failures are designed to be non-blocking but incorrect probe logic could emit false warnings or miss real gaps.
> 
> **Overview**
> **Provision-time in-container toolchain discovery** turns declared `runtime.toolchains` into real `RUNTIME_TOOLCHAIN_UNAVAILABLE` warnings instead of advisory-only docs. New `toolchain_probe` runs per-language discovery (Java first) via injected compose exec, compares installed vs declared versions (major vs patch-aware matching), and feeds the existing `runtime_toolchain_findings` helper.
> 
> **Executor wiring** runs the probe after successful profile setup on both `execute()` and PR monitor handoff, persisting one `workspace.runtime_toolchain_unavailable` event per finding. Probe and recorder failures are swallowed with redacted logs so provisioning and handoff never block.
> 
> **ValidationRunner** adds `probe_runtime_toolchain_findings` using tracked `docker compose exec` with 30s exec/cleanup timeouts and teardown on timeout or cancellation. **AsyncioSubprocessRunner** now terminates subprocesses when `communicate` is cancelled (e.g. wedged exec). OpenAPI/profile field descriptions updated to describe the live probe behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1773d5f6908f8e383f936109c4589d24e74ebd87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Runtime toolchain discovery for Java with automatic version detection inside workspaces
  * Non-blocking warnings when declared toolchain versions are unavailable

* **Bug Fixes**
  * Improved subprocess lifecycle management to prevent orphaned processes during task cancellation

* **Documentation**
  * Updated API documentation to reflect new toolchain discovery and warning behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->