### PR TITLE
Fix #573: dirty-tree guard ignores untracked .claude/agent-memory/ (both guard sites)

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/remote_repair.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair.py
@@ -85,6 +85,9 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorPolicyBlockedError,
     _ProtectedScopeRollbackDeltaEvidence,
 )
+from awf.runtime.validation_worktree import (
+    is_under_agent_runtime_root,
+)
 
 
 async def _pre_existing_dirty_repair_worktree_result(
@@ -124,7 +127,18 @@ async def _pre_existing_dirty_repair_worktree_result(
     if not status.stdout.strip():
         return None
 
-    paths = sorted(_changed_paths_from_porcelain(status.stdout))
+    # AWF-agent-runtime artifacts (reviewer subagent memory) written into the
+    # repair worktree are not part of the PR, so drop UNTRACKED memory paths
+    # before deciding the worktree is dirty. Tracked-modified memory (and every
+    # other path) stays visible/blocking. If nothing else remains, the worktree
+    # is effectively clean — return None, same as the empty-status path above.
+    all_paths = _changed_paths_from_porcelain(status.stdout)
+    untracked = set(_untracked_paths_from_porcelain(status.stdout))
+    paths = sorted(
+        path for path in all_paths if not (path in untracked and is_under_agent_runtime_root(path))
+    )
+    if not paths:
+        return None
     _log.warning(
         "monitor.repair_worktree_pre_existing_dirty",
         workspace_id=workspace_id,

--- a/src/awf/runtime/pr_monitor_runner/remote_repair.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair.py
@@ -99,8 +99,15 @@ async def _pre_existing_dirty_repair_worktree_result(
 ) -> _GitPushResult | None:
     if not worktree_path.exists():
         return None
+    # ``--untracked-files=all`` is load-bearing here: with git's default
+    # ``normal`` mode a *fully*-untracked ``.claude/`` (no tracked content under
+    # it) collapses all the way to a single ``?? .claude/`` entry, which is NOT
+    # under the ``.claude/agent-memory/`` ignored root and would therefore stay
+    # in ``paths`` and refuse repair in the common case this guard unblocks.
+    # Enumerating leaf paths lets the agent-runtime filter below see and drop the
+    # memory files. Mirrors ``check_validation_worktree_clean``.
     status = await self._deps.runner.run(
-        git_worktree_command(worktree_path, "status", "--porcelain")
+        git_worktree_command(worktree_path, "status", "--porcelain", "--untracked-files=all")
     )
     if not status.ok:
         stderr = status.stderr[:400]

--- a/src/awf/runtime/validation_worktree.py
+++ b/src/awf/runtime/validation_worktree.py
@@ -107,6 +107,7 @@ def _resolve_head_sha(result: CommandResult, *, ref: str) -> tuple[str | None, s
 def _is_under_ignored_path(path: str, ignored_paths: set[str]) -> bool:
     """Return whether `path` should be treated as part of an ignored root."""
     normalized_path = _normalize_porcelain_path(path)
+    path_is_dir_entry = path.endswith("/")
     for ignored_path in ignored_paths:
         # Normalize the ignored root too: roots may carry a trailing slash
         # (e.g. ``.claude/agent-memory/``), and git collapses a fully-untracked
@@ -114,7 +115,16 @@ def _is_under_ignored_path(path: str, ignored_paths: set[str]) -> bool:
         # matches the root itself as well as its descendants, while keeping the
         # sibling ``.claude/agent-memory-archive/`` excluded.
         normalized_ignored = _normalize_porcelain_path(ignored_path)
-        if normalized_path == normalized_ignored:
+        # The exemption is scoped to the ignored *directory* and its descendants.
+        # ``git status --untracked-files=all`` reports a regular file named exactly
+        # ``.claude/agent-memory`` (no trailing slash) as ``?? .claude/agent-memory``
+        # — a distinct path that must stay visible. Only suppress the equality case
+        # for an actual directory entry: the incoming path carries a trailing slash
+        # (git's collapsed root form / the empty-dir snapshot), or the ignored root
+        # itself was stored without one (a genuinely-ignored entry, file or dir alike).
+        if normalized_path == normalized_ignored and (
+            path_is_dir_entry or not ignored_path.endswith("/")
+        ):
             return True
         if normalized_path.startswith(f"{normalized_ignored}/"):
             return True

--- a/src/awf/runtime/validation_worktree.py
+++ b/src/awf/runtime/validation_worktree.py
@@ -384,7 +384,11 @@ async def check_validation_worktree_clean(
     )
     empty_untracked_dirs = _snapshot_empty_untracked_dirs(
         worktree_path=worktree_path,
-        ignored_paths=ignored_paths,
+        # The snapshot appends its results unfiltered below, so it must skip the
+        # AWF-agent-runtime roots itself — an empty ``.claude/agent-memory/<agent>/``
+        # (created before any file is written) would otherwise surface the root
+        # and its parents as dirty, escaping the unconditional suppression above.
+        ignored_paths=(*ignored_paths, *AWF_AGENT_RUNTIME_IGNORED_ROOTS),
     )
     # Ignored roots only suppress untracked or ignored artifacts; tracked files
     # below those roots must stay visible so cleanup can restore them.

--- a/src/awf/runtime/validation_worktree.py
+++ b/src/awf/runtime/validation_worktree.py
@@ -17,6 +17,9 @@ from awf.runtime.git_porcelain import (
     untracked_paths_from_porcelain as _untracked_paths_from_porcelain,
 )
 from awf.runtime.validation_worktree_constants import (
+    AWF_AGENT_RUNTIME_IGNORED_ROOTS as _AWF_AGENT_RUNTIME_IGNORED_ROOTS,
+)
+from awf.runtime.validation_worktree_constants import (
     VALIDATION_INFRASTRUCTURE_ERROR as _VALIDATION_INFRASTRUCTURE_ERROR,
 )
 from awf.runtime.validation_worktree_constants import (
@@ -37,6 +40,7 @@ VALIDATION_WORKTREE_PRE_EXISTING_DIRTY: str = _VALIDATION_WORKTREE_PRE_EXISTING_
 VALIDATION_WORKTREE_SIDE_EFFECTS_CLEANED: str = _VALIDATION_WORKTREE_SIDE_EFFECTS_CLEANED
 VALIDATION_WORKTREE_STATUS_FAILED: str = _VALIDATION_WORKTREE_STATUS_FAILED
 VALIDATION_INFRASTRUCTURE_ERROR: str = _VALIDATION_INFRASTRUCTURE_ERROR
+AWF_AGENT_RUNTIME_IGNORED_ROOTS: tuple[str, ...] = _AWF_AGENT_RUNTIME_IGNORED_ROOTS
 
 GitRunner = Callable[[list[str]], Awaitable[CommandResult]]
 
@@ -111,6 +115,11 @@ def _is_under_ignored_path(path: str, ignored_paths: set[str]) -> bool:
         if not ignored_path.endswith("/") and normalized_path.startswith(f"{ignored_path}/"):
             return True
     return False
+
+
+def is_under_agent_runtime_root(path: str) -> bool:
+    """Return whether ``path`` is an AWF-agent-runtime artifact root/descendant."""
+    return _is_under_ignored_path(path, set(AWF_AGENT_RUNTIME_IGNORED_ROOTS))
 
 
 def _untracked_cleanup_parent_dirs(path: str, ignored_paths: set[str]) -> tuple[str, ...]:
@@ -359,6 +368,11 @@ async def check_validation_worktree_clean(
     ignored_paths_to_ignore = (
         {_normalize_porcelain_path(path) for path in ignored_paths} if ignore_all_ignored else set()
     )
+    # AWF-agent-runtime artifacts (reviewer subagent memory) never belong to the
+    # PR, so suppress them as untracked/ignored UNCONDITIONALLY — independent of
+    # the target repo's .gitignore and of the ``ignore_all_ignored`` flag. Only
+    # untracked entries are suppressed below; tracked memory stays visible.
+    ignored_paths_to_ignore |= set(AWF_AGENT_RUNTIME_IGNORED_ROOTS)
     changed_paths = _changed_paths_from_porcelain(status_stdout)
     untracked_paths_from_status = _untracked_paths_from_porcelain(
         status_stdout,

--- a/src/awf/runtime/validation_worktree.py
+++ b/src/awf/runtime/validation_worktree.py
@@ -108,11 +108,15 @@ def _is_under_ignored_path(path: str, ignored_paths: set[str]) -> bool:
     """Return whether `path` should be treated as part of an ignored root."""
     normalized_path = _normalize_porcelain_path(path)
     for ignored_path in ignored_paths:
-        if normalized_path == ignored_path:
+        # Normalize the ignored root too: roots may carry a trailing slash
+        # (e.g. ``.claude/agent-memory/``), and git collapses a fully-untracked
+        # directory to that exact root entry. Comparing normalized-to-normalized
+        # matches the root itself as well as its descendants, while keeping the
+        # sibling ``.claude/agent-memory-archive/`` excluded.
+        normalized_ignored = _normalize_porcelain_path(ignored_path)
+        if normalized_path == normalized_ignored:
             return True
-        if ignored_path.endswith("/") and normalized_path.startswith(ignored_path):
-            return True
-        if not ignored_path.endswith("/") and normalized_path.startswith(f"{ignored_path}/"):
+        if normalized_path.startswith(f"{normalized_ignored}/"):
             return True
     return False
 

--- a/src/awf/runtime/validation_worktree_constants.py
+++ b/src/awf/runtime/validation_worktree_constants.py
@@ -7,3 +7,13 @@ VALIDATION_WORKTREE_PRE_EXISTING_DIRTY = "VALIDATION_WORKTREE_PRE_EXISTING_DIRTY
 VALIDATION_WORKTREE_SIDE_EFFECTS_CLEANED = "VALIDATION_WORKTREE_SIDE_EFFECTS_CLEANED"
 VALIDATION_WORKTREE_STATUS_FAILED = "VALIDATION_WORKTREE_STATUS_FAILED"
 VALIDATION_INFRASTRUCTURE_ERROR = "VALIDATION_INFRASTRUCTURE_ERROR"
+
+# AWF-agent-runtime artifact roots that reviewer subagents
+# (bug-hunter/bug-validator/bug-judge) write into a worktree. Untracked
+# artifacts under these roots never belong to the PR, so the dirty-tree
+# guards suppress them unconditionally. Kept to EXACTLY .claude/agent-memory/
+# — NOT all of .claude/ (settings etc. can be legitimate project files). The
+# trailing slash is load-bearing: it makes both the `_is_under_ignored_path`
+# matcher and a raw ``str.startswith`` correctly exclude the sibling
+# ``.claude/agent-memory-archive/``.
+AWF_AGENT_RUNTIME_IGNORED_ROOTS: tuple[str, ...] = (".claude/agent-memory/",)

--- a/tests/unit/runtime/test_agent_runtime_memory_guard.py
+++ b/tests/unit/runtime/test_agent_runtime_memory_guard.py
@@ -1,0 +1,161 @@
+"""Tests for AWF-agent-runtime ``.claude/agent-memory/`` dirty-tree suppression.
+
+Reviewer subagents (bug-hunter/bug-validator/bug-judge) write their memory into
+``.claude/agent-memory/<agent>/`` inside the validation worktree. Those untracked
+artifacts are never part of the PR, so the dirty-tree guard must treat them as
+clean — unconditionally, without depending on the target repo's ``.gitignore``.
+Tracked memory (some users commit theirs) must stay fully visible. See #573.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from awf.common.commands import CommandResult
+from awf.runtime.validation_worktree import check_validation_worktree_clean
+
+
+def _git(worktree: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a real git command in a temporary worktree."""
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_real_worktree(tmp_path: Path) -> Path:
+    """Create a real git repo with a single tracked commit."""
+    worktree = tmp_path / "worktree"
+    worktree.mkdir(parents=True, exist_ok=True)
+    _git(worktree, "init", "-q")
+    _git(worktree, "config", "user.email", "awf@example.com")
+    _git(worktree, "config", "user.name", "AWF Test")
+    (worktree / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+    _git(worktree, "add", "tracked.py")
+    _git(worktree, "commit", "-qm", "initial")
+    return worktree
+
+
+def _real_run_git(worktree: Path):
+    """Return an async ``run_git`` bound to a real worktree."""
+
+    async def run_git(args: list[str]) -> CommandResult:
+        proc = subprocess.run(
+            ["git", "-C", str(worktree), *args],
+            capture_output=True,
+            text=True,
+        )
+        return CommandResult(
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
+
+    return run_git
+
+
+def _write(worktree: Path, relative: str, content: str = "memory\n") -> None:
+    """Create a file (and parents) under the worktree."""
+    target = worktree / relative
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(content, encoding="utf-8")
+
+
+@pytest.mark.unit
+async def test_untracked_agent_memory_only_is_clean(tmp_path: Path) -> None:
+    """Untracked agent-memory alone makes the tree clean (the #573 fix).
+
+    Runs with the default ``ignore_all_ignored=False`` to prove the suppression
+    is unconditional and not gated on that flag.
+    """
+    worktree = _init_real_worktree(tmp_path)
+    _write(worktree, ".claude/agent-memory/bug-validator/notes.md")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is True
+    assert check.paths == ()
+    assert check.untracked_paths == ()
+
+
+@pytest.mark.unit
+async def test_untracked_agent_memory_plus_real_file_reports_only_real(tmp_path: Path) -> None:
+    """A real untracked artifact still trips the guard; memory is suppressed."""
+    worktree = _init_real_worktree(tmp_path)
+    _write(worktree, ".claude/agent-memory/bug-hunter/x.md")
+    _write(worktree, "src/foo.py", "print('x')\n")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is False
+    assert "src/foo.py" in check.untracked_paths
+    assert not any("agent-memory" in path for path in check.paths)
+    assert not any("agent-memory" in path for path in check.untracked_paths)
+
+
+@pytest.mark.unit
+async def test_tracked_modified_agent_memory_still_dirty(tmp_path: Path) -> None:
+    """Tracked (committed) memory that is modified stays visible/blocking."""
+    worktree = _init_real_worktree(tmp_path)
+    _write(worktree, ".claude/agent-memory/notes.md", "original\n")
+    _git(worktree, "add", ".claude/agent-memory/notes.md")
+    _git(worktree, "commit", "-qm", "commit memory")
+    (worktree / ".claude" / "agent-memory" / "notes.md").write_text("modified\n", encoding="utf-8")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is False
+    assert ".claude/agent-memory/notes.md" in check.paths
+
+
+@pytest.mark.unit
+async def test_sibling_prefix_directory_is_not_suppressed(tmp_path: Path) -> None:
+    """``.claude/agent-memory-archive/`` shares a prefix but is a different root."""
+    worktree = _init_real_worktree(tmp_path)
+    _write(worktree, ".claude/agent-memory-archive/x.md")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is False
+    assert ".claude/agent-memory-archive/x.md" in check.untracked_paths
+
+
+@pytest.mark.unit
+async def test_nested_agent_memory_paths_all_suppressed(tmp_path: Path) -> None:
+    """Deeply nested untracked memory paths are all treated as clean."""
+    worktree = _init_real_worktree(tmp_path)
+    _write(worktree, ".claude/agent-memory/bug-hunter/notes.md")
+    _write(worktree, ".claude/agent-memory/bug-judge/a/b.md")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is True
+    assert check.paths == ()
+    assert check.untracked_paths == ()
+
+
+@pytest.mark.unit
+async def test_gitignored_agent_memory_unchanged(tmp_path: Path) -> None:
+    """A target repo that already gitignores agent-memory keeps working."""
+    worktree = _init_real_worktree(tmp_path)
+    (worktree / ".gitignore").write_text(".claude/agent-memory/\n", encoding="utf-8")
+    _git(worktree, "add", ".gitignore")
+    _git(worktree, "commit", "-qm", "ignore agent memory")
+    _write(worktree, ".claude/agent-memory/bug-validator/notes.md")
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(
+        run_git=run_git, worktree_path=worktree, ignore_all_ignored=True
+    )
+
+    assert check.clean is True

--- a/tests/unit/runtime/test_agent_runtime_memory_guard.py
+++ b/tests/unit/runtime/test_agent_runtime_memory_guard.py
@@ -145,6 +145,26 @@ async def test_nested_agent_memory_paths_all_suppressed(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+async def test_empty_untracked_agent_memory_dir_is_clean(tmp_path: Path) -> None:
+    """An empty agent-memory directory (no file yet) is still suppressed.
+
+    The agent runtime can create ``.claude/agent-memory/<agent>/`` before it
+    writes any file. git status omits empty directories, so the empty-dir
+    snapshot is what surfaces them — and it must honour the AWF runtime roots,
+    or the parents (``.claude/agent-memory/``, ``.claude/``) get reported dirty.
+    """
+    worktree = _init_real_worktree(tmp_path)
+    (worktree / ".claude" / "agent-memory" / "bug-hunter").mkdir(parents=True)
+    run_git = _real_run_git(worktree)
+
+    check = await check_validation_worktree_clean(run_git=run_git, worktree_path=worktree)
+
+    assert check.clean is True
+    assert check.paths == ()
+    assert check.untracked_paths == ()
+
+
+@pytest.mark.unit
 async def test_gitignored_agent_memory_unchanged(tmp_path: Path) -> None:
     """A target repo that already gitignores agent-memory keeps working."""
     worktree = _init_real_worktree(tmp_path)

--- a/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
+++ b/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
@@ -1,0 +1,120 @@
+"""Tests for ``.claude/agent-memory/`` suppression in the repair dirty-tree guard.
+
+The repair guard (``_pre_existing_dirty_repair_worktree_result``) refuses to
+start agent repair from a dirty worktree. Untracked AWF-agent-runtime memory
+written by reviewer subagents must not count as dirty (the #573 fix), while a
+real dirty path — or tracked-modified memory — must still block. See #573.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor_runner.constants import (
+    _PRE_EXISTING_DIRTY_WORKTREE_REASON,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+async def _run_guard(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    *,
+    status_stdout: str,
+):
+    """Invoke the repair dirty-tree guard with a canned ``git status`` stdout."""
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=status_stdout)
+    workspace_id = await seed_monitoring_workspace(factory)
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    return await runner._pre_existing_dirty_repair_worktree_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        operation_type="comment_repair",
+    )
+
+
+@pytest.mark.unit
+async def test_untracked_agent_memory_only_returns_none(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """Untracked memory paths (file or collapsed dir form) are not blocking."""
+    result = await _run_guard(
+        factory,
+        tmp_path,
+        status_stdout=(
+            "?? .claude/agent-memory/bug-validator/notes.md\n?? .claude/agent-memory/bug-hunter/\n"
+        ),
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
+async def test_untracked_agent_memory_plus_real_path_blocks_with_real_path(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """A real dirty path still blocks; the memory path is filtered out."""
+    result = await _run_guard(
+        factory,
+        tmp_path,
+        status_stdout="?? .claude/agent-memory/x.md\n M src/awf/foo.py\n",
+    )
+
+    assert result is not None
+    assert result.failed is True
+    assert result.reason_code == _PRE_EXISTING_DIRTY_WORKTREE_REASON
+    assert result.details["paths"] == ["src/awf/foo.py"]
+
+
+@pytest.mark.unit
+async def test_tracked_modified_agent_memory_blocks(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """Tracked-modified memory (not an ``??`` line) stays visible/blocking."""
+    result = await _run_guard(
+        factory,
+        tmp_path,
+        status_stdout=" M .claude/agent-memory/notes.md\n",
+    )
+
+    assert result is not None
+    assert result.failed is True
+    assert result.reason_code == _PRE_EXISTING_DIRTY_WORKTREE_REASON
+    assert result.details["paths"] == [".claude/agent-memory/notes.md"]
+
+
+@pytest.mark.unit
+async def test_empty_status_returns_none(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """An empty status is not blocking — unchanged behavior."""
+    result = await _run_guard(factory, tmp_path, status_stdout="")
+
+    assert result is None

--- a/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
+++ b/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
@@ -77,6 +77,25 @@ async def test_untracked_agent_memory_only_returns_none(
 
 
 @pytest.mark.unit
+async def test_untracked_agent_memory_collapsed_root_returns_none(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """A collapsed untracked-root entry (``.claude/agent-memory/``) is not blocking.
+
+    Plain ``git status --porcelain`` (the repair guard's status mode) collapses a
+    fully-untracked ``.claude/agent-memory`` directory to a single
+    ``?? .claude/agent-memory/`` line. That root entry must still be suppressed.
+    """
+    result = await _run_guard(
+        factory,
+        tmp_path,
+        status_stdout="?? .claude/agent-memory/\n",
+    )
+
+    assert result is None
+
+
+@pytest.mark.unit
 async def test_untracked_agent_memory_plus_real_path_blocks_with_real_path(
     factory: async_sessionmaker[AsyncSession], tmp_path: Path
 ) -> None:

--- a/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
+++ b/tests/unit/runtime/test_agent_runtime_memory_repair_guard.py
@@ -39,9 +39,10 @@ async def _run_guard(
     tmp_path: Path,
     *,
     status_stdout: str,
+    cmd: FakeCommandRunner | None = None,
 ):
     """Invoke the repair dirty-tree guard with a canned ``git status`` stdout."""
-    cmd = FakeCommandRunner()
+    cmd = cmd or FakeCommandRunner()
     cmd.queue_result(returncode=0, stdout=status_stdout)
     workspace_id = await seed_monitoring_workspace(factory)
     worktree = tmp_path / "worktrees" / workspace_id
@@ -82,9 +83,9 @@ async def test_untracked_agent_memory_collapsed_root_returns_none(
 ) -> None:
     """A collapsed untracked-root entry (``.claude/agent-memory/``) is not blocking.
 
-    Plain ``git status --porcelain`` (the repair guard's status mode) collapses a
-    fully-untracked ``.claude/agent-memory`` directory to a single
-    ``?? .claude/agent-memory/`` line. That root entry must still be suppressed.
+    Even though the guard requests ``--untracked-files=all`` (which normally
+    enumerates leaf files), a collapsed ``?? .claude/agent-memory/`` root entry
+    must still be suppressed if git ever reports it that way.
     """
     result = await _run_guard(
         factory,
@@ -127,6 +128,35 @@ async def test_tracked_modified_agent_memory_blocks(
     assert result.failed is True
     assert result.reason_code == _PRE_EXISTING_DIRTY_WORKTREE_REASON
     assert result.details["paths"] == [".claude/agent-memory/notes.md"]
+
+
+@pytest.mark.unit
+async def test_status_requests_all_untracked_files(
+    factory: async_sessionmaker[AsyncSession], tmp_path: Path
+) -> None:
+    """The guard must inspect untracked files in ``all`` mode.
+
+    Plain ``git status --porcelain`` (``--untracked-files=normal``) collapses a
+    *fully*-untracked ``.claude/`` directory all the way to a single
+    ``?? .claude/`` entry when nothing under ``.claude`` is tracked. That parent
+    entry is not under the ``.claude/agent-memory/`` ignored root, so the filter
+    would leave it in ``paths`` and refuse repair in the common case this guard
+    is meant to unblock (a target repo that tracks nothing under ``.claude``).
+    Requesting ``--untracked-files=all`` forces git to enumerate the leaf
+    memory files so they are suppressed. See PR #575.
+    """
+    cmd = FakeCommandRunner()
+    await _run_guard(
+        factory,
+        tmp_path,
+        status_stdout="?? .claude/agent-memory/bug-hunter/notes.md\n",
+        cmd=cmd,
+    )
+
+    assert cmd.calls, "guard never ran git status"
+    status_args = cmd.calls[0].args
+    assert "status" in status_args
+    assert "--untracked-files=all" in status_args
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_005.py
@@ -341,7 +341,7 @@ async def test_execute_ci_repair_start_failures_are_terminal(
     assert state.iter_count == 0
     assert adapter.calls == []
     assert [call.args for call in cmd.calls] == [
-        _git_worktree_command(worktree, "status", "--porcelain")
+        _git_worktree_command(worktree, "status", "--porcelain", "--untracked-files=all")
     ]
     async with factory() as s:
         workspace = await WorkspaceRepository(s).get(workspace_id)
@@ -404,7 +404,7 @@ async def test_execute_comment_repair_pre_existing_dirty_worktree_is_terminal(
     assert adapter.calls == []
     assert "T_dirty_start" not in state.threads_addressed_ids
     assert [call.args for call in cmd.calls] == [
-        _git_worktree_command(worktree, "status", "--porcelain")
+        _git_worktree_command(worktree, "status", "--porcelain", "--untracked-files=all")
     ]
     async with factory() as s:
         workspace = await WorkspaceRepository(s).get(workspace_id)
@@ -463,7 +463,7 @@ async def test_execute_ci_repair_missing_operation_start_head_is_terminal(
     assert state.iter_count == 0
     assert adapter.calls == []
     assert [call.args for call in cmd.calls] == [
-        _git_worktree_command(worktree, "status", "--porcelain"),
+        _git_worktree_command(worktree, "status", "--porcelain", "--untracked-files=all"),
         _git_worktree_command(worktree, "rev-parse", "HEAD"),
     ]
     async with factory() as s:
@@ -528,7 +528,7 @@ async def test_execute_comment_repair_missing_operation_start_head_is_terminal(
     assert adapter.calls == []
     assert "T_missing_start" not in state.threads_addressed_ids
     assert [call.args for call in cmd.calls] == [
-        _git_worktree_command(worktree, "status", "--porcelain"),
+        _git_worktree_command(worktree, "status", "--porcelain", "--untracked-files=all"),
         _git_worktree_command(worktree, "rev-parse", "HEAD"),
     ]
     async with factory() as s:

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_011.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_011.py
@@ -136,5 +136,5 @@ async def test_ci_fix_refuses_pre_existing_dirty_worktree_before_agent(
     }
     assert adapter.calls == []
     assert [call.args for call in cmd.calls] == [
-        _git_worktree_command(worktree, "status", "--porcelain")
+        _git_worktree_command(worktree, "status", "--porcelain", "--untracked-files=all")
     ]

--- a/tests/unit/runtime/test_validation_worktree.py
+++ b/tests/unit/runtime/test_validation_worktree.py
@@ -66,9 +66,15 @@ def test_is_under_agent_runtime_root_matches_collapsed_root_directory() -> None:
     trailing slash, so without normalizing it the root entry itself fails to
     match while its descendants match — defeating the suppression. The sibling
     ``.claude/agent-memory-archive/`` must still NOT be suppressed.
+
+    The exemption is scoped to the ``.claude/agent-memory/`` *directory* and its
+    descendants. A regular *file* spelled exactly ``.claude/agent-memory`` (which
+    ``git status --untracked-files=all`` reports without a trailing slash) is a
+    distinct path that must stay visible, not be silently dropped as if it were
+    the ignored directory root.
     """
     assert validation_worktree.is_under_agent_runtime_root(".claude/agent-memory/") is True
-    assert validation_worktree.is_under_agent_runtime_root(".claude/agent-memory") is True
+    assert validation_worktree.is_under_agent_runtime_root(".claude/agent-memory") is False
     assert (
         validation_worktree.is_under_agent_runtime_root(".claude/agent-memory/bug-hunter/notes.md")
         is True

--- a/tests/unit/runtime/test_validation_worktree.py
+++ b/tests/unit/runtime/test_validation_worktree.py
@@ -58,6 +58,28 @@ def test_validation_worktree_cleanup_helpers_handle_defensive_path_edges() -> No
 
 
 @pytest.mark.unit
+def test_is_under_agent_runtime_root_matches_collapsed_root_directory() -> None:
+    """A collapsed untracked-root entry (``.claude/agent-memory/``) must match.
+
+    Plain ``git status --porcelain`` collapses a fully-untracked directory to a
+    single ``?? .claude/agent-memory/`` line. The ignored root is stored with a
+    trailing slash, so without normalizing it the root entry itself fails to
+    match while its descendants match — defeating the suppression. The sibling
+    ``.claude/agent-memory-archive/`` must still NOT be suppressed.
+    """
+    assert validation_worktree.is_under_agent_runtime_root(".claude/agent-memory/") is True
+    assert validation_worktree.is_under_agent_runtime_root(".claude/agent-memory") is True
+    assert (
+        validation_worktree.is_under_agent_runtime_root(".claude/agent-memory/bug-hunter/notes.md")
+        is True
+    )
+    assert (
+        validation_worktree.is_under_agent_runtime_root(".claude/agent-memory-archive/x.md")
+        is False
+    )
+
+
+@pytest.mark.unit
 def test_empty_dir_snapshot_helpers_tolerate_iterdir_errors(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e8e8a0819393448b99403abe` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix issue #573: the AWF pre-validation dirty-tree guard fails an otherwise-healthy `monitoring_pr` workspace with `infrastructure_failure` ("Validation worktree has pre-existing uncommitted changes; refusing to run AWF-owned validation from a dirty tree. Dirty paths: .claude/agent-memory/bug-validator/") when a reviewer subagent (bug-hunter / bug-validator / bug-judge) writes its memory under `.claude/agent-memory/<agent>/` into the validation (or repair) worktree AND the target repo's .gitignore does not cover that path. Those memory files are AWF-agent-runtime artifacts, not part of the PR; the PR's code is fine. Two guard sites hit it: src/awf/runtime/validation_worktree.py (~line 410) and src/awf/runtime/pr_monitor_runner/remote_repair.py (~line 139).

=== LOCKED DESIGN (do exactly this; do NOT widen scope) ===

Make BOTH dirty-tree guards treat `.claude/agent-memory/` as an ignorable AWF-agent-runtime root, but ONLY when it appears as an UNTRACKED artifact. TRACKED files under `.claude/agent-memory/` MUST stay fully visible — some users deliberately commit their agent memories, and we must not silently swallow tracked/committed memory. This is the SAME "ignored roots only suppress untracked/ignored artifacts; tracked files below those roots must stay visible" semantic already documented at src/awf/runtime/validation_worktree.py:371-377.

Concretely:

1. Add ONE shared constant for the ignorable AWF-agent-runtime root(s), e.g.
   `AWF_AGENT_RUNTIME_IGNORED_ROOTS = (".claude/agent-memory/",)`, in a sensible shared home under
   `src/awf/runtime/` (e.g. alongside validation_worktree.py, imported by remote_repair.py). Keep it to
   EXACTLY `.claude/agent-memory/` — do NOT broaden to all of `.claude/` (other `.claude/` paths such as
   settings can be legitimate project files).

2. Validation guard (src/awf/runtime/validation_worktree.py, the check that builds `paths`/`untracked_paths`
   ~lines 360-413 and raises VALIDATION_WORKTREE_PRE_EXISTING_DIRTY): fold `.claude/agent-memory/` into the
   set that suppresses UNTRACKED/ignored artifacts (the `ignored_paths_to_ignore` consumed at lines 373-377),
   UNCONDITIONALLY — independent of the target repo's .gitignore and independent of which adapter ran.
   Preserve the existing rule that TRACKED files under an ignored root stay visible.

3. Repair guard (src/awf/runtime/pr_monitor_runner/remote_repair.py, ~lines 124-150, reason
   `_PRE_EXISTING_DIRTY_WORKTREE_REASON`): this guard uses `_changed_paths_from_porcelain(status.stdout)` and
   has NO scratch-path mechanism. Filter UNTRACKED `.claude/agent-memory/` paths out of the dirty `paths` set
   before deciding the worktree is dirty. KEEP tracked-modified memory (and every other path) visible/blocking.
   If after filtering there are no remaining dirty paths, the guard must return None (not blocking), same as the
   empty-status path at lines 124-125.

DO NOT:
- Do NOT add `.claude/agent-memory/` (or anything) to any `.gitignore` — not in this repo, not in any target
  repo, not a "managed gitignore". The whole point of #573 is to be robust WITHOUT depending on the target
  repo's .gitignore, and without preventing users from committing their memories.
- Do NOT use the per-adapter `runtime_scratch_paths` mechanism (src/awf/adapters/base.py:184). Rejected on
  purpose: it only reaches the validation guard (the repair guard does not consult it), and the reviewer
  subagents are Claude-Code regardless of the primary coding adapter, so per-adapter attribution is fragile.
  Leave src/awf/adapters/** unchanged.
- Do NOT change any reason code or message for the genuinely-dirty case (a real untracked non-memory artifact,
  or a tracked modification, must still fail exactly as today).
- Do NOT broaden the ignored root beyond `.claude/agent-memory/`.

=== EDGE CASES (cover all) ===
- Untracked `.claude/agent-memory/bug-validator/...` only -> tree is CLEAN, validation/repair proceeds (the #573 fix).
- User who COMMITS memories: tracked `.claude/agent-memory/...` file, clean -> not dirty (unchanged). Tracked
  `.claude/agent-memory/...` file MODIFIED -> STILL visible/dirty (respect their versioned content; do not suppress).
- Untracked `.claude/agent-memory/...` PLUS a real untracked non-memory artifact (e.g. untracked `src/foo.py`)
  -> STILL dirty (only the memory paths are suppressed; the real artifact is reported).
- gitignored `.claude/agent-memory/` (target repo already ignores it) -> unchanged behavior (still clean).
- Nested paths: `.claude/agent-memory/bug-hunter/notes.md`, `.claude/agent-memory/bug-judge/...` -> all suppressed (untracked).
- Sibling that merely shares a string prefix (e.g. `.claude/agent-memory-archive/`) MUST NOT be suppressed -
  match the directory root, not a raw string prefix.

=== TESTS (TDD, strict ~99% coverage; the CI coverage gate is exact) ===
- validation_worktree guard: untracked agent-memory -> clean; untracked agent-memory + real untracked file ->
  dirty (real file reported); tracked-modified agent-memory -> dirty; sibling `.claude/agent-memory-archive/`
  -> dirty; gitignored case unchanged.
- remote_repair guard: untracked agent-memory only -> returns None (not blocking); untracked agent-memory +
  real dirty path -> blocks with the real path; tracked-modified memory -> blocks; empty status -> None (unchanged).
- If any existing test locks the OLD behavior specifically for `.claude/agent-memory/` (i.e. asserts it makes
  the tree dirty), AMEND it to the new contract — do not weaken unrelated dirty-tree assertions.

=== SCOPE GUARDS ===
- Owned paths: `src/awf/runtime/**`, `tests/**`.
- Do NOT modify `.github/workflows/**`, `.awf/workspace.yml`, `src/awf/adapters/**`, or any `.gitignore`.
- Reference #573 in the PR. Run ruff + mypy clean; keep the OpenAPI/contract gates green.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when validation and repair are allowed to start based on worktree cleanliness; scope is limited to untracked agent-memory, but incorrect path matching could hide real dirt or still block valid runs.
> 
> **Overview**
> Fixes **#573**: monitoring/validation no longer fails with `PRE_EXISTING_DIRTY_WORKTREE` / `VALIDATION_WORKTREE_PRE_EXISTING_DIRTY` when reviewer subagents leave **untracked** files under `.claude/agent-memory/`, without relying on the target repo’s `.gitignore`.
> 
> Introduces shared **`AWF_AGENT_RUNTIME_IGNORED_ROOTS`** (only `.claude/agent-memory/`) and **`is_under_agent_runtime_root`**, with tighter **`_is_under_ignored_path`** handling (normalized roots, collapsed directory entries, and excluding `.claude/agent-memory-archive/`). The **validation** guard always treats untracked paths under that root as non-dirty and skips empty-dir snapshots there; **tracked** changes under agent-memory still block.
> 
> The **repair** pre-start guard now runs `git status --porcelain --untracked-files=all`, drops untracked agent-memory paths from the dirty set, and treats memory-only dirt as clean (same as an empty status). Real dirty paths and tracked-modified memory still fail unchanged.
> 
> New unit tests cover validation and repair guards plus updated monitor-runner expectations for `--untracked-files=all`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd89feac8756a89109f8c1159d995b15f7d17b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->