### PR TITLE
Fix #574: adopt-pr handoff provisions the toolchain (run profile setup before monitoring_pr)

### DIFF
--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_013.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_013.py
@@ -550,6 +550,15 @@ class TestExecutorMonitorHandoffSetup:
         # PR_ADOPTION_SKIP_AGENT must skip only the AGENT RUN, never profile setup,
         # so setup runs *before* that transition (while still ``running``) and the
         # toolchain is present when the monitor later runs pre-push validation.
+        #
+        # NB: ``auto_merge=True`` here reflects the typical real-world configuration
+        # for ``existing_github_pr`` adoptions; it is NOT a code-path branch. The
+        # executor never reads ``workspace.auto_merge`` in the sync_feature_pr
+        # dispatch chain — the existing_github_pr handoff is selected solely by the
+        # presence of ``pr_adoption`` in ``task_policy``. The distinct value this
+        # test adds over test_sync_feature_pr_handoff_runs_profile_setup_before_monitor
+        # is asserting the workspace *status* at setup time (via
+        # _StatusAtSetupValidation), not the auto_merge flag.
         monitor_runs: list[str] = []
         validation = _StatusAtSetupValidation(factory)
         ws_id = await _seed_ready(

--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_013.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_013.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from awf.common.bitbucket_client import BITBUCKET_AUTH_NOT_CONFIGURED, BitbucketClientError
 from awf.common.commands import FakeCommandRunner
 from awf.control.executor.constants import (
+    _PR_ADOPTION_SKIP_AGENT_REASON_CODE,
     PR_MONITOR_SETUP_FAILED_REASON_CODE,
     SETUP_DEPENDENCY_NETWORK_RETRY_EVENT_TYPE,
     SETUP_DEPENDENCY_NETWORK_RETRY_EXHAUSTED_EVENT_TYPE,
@@ -153,6 +154,42 @@ class _CancellingHandoffSetupValidation:
             )
             await session.commit()
         return ValidationResult()
+
+
+class _StatusAtSetupValidation(_RecordingValidation):
+    """Records the workspace status observed at the moment profile setup runs.
+
+    Locks the #574 ordering invariant: the ``existing_github_pr`` adoption must
+    run the profile ``("setup", "pre_agent")`` phase *while the workspace is
+    still ``running``* — i.e. before the ``PR_ADOPTION_SKIP_AGENT``
+    (``validating``) transition — so the lint/test toolchain is installed before
+    the monitor's first comment-repair runs pre-push validation. Reordering
+    setup after the skip-agent transition (or dropping it) reintroduces #574's
+    ``PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING`` death.
+    """
+
+    def __init__(self, factory: async_sessionmaker[AsyncSession]) -> None:
+        super().__init__()
+        self._factory = factory
+        self.status_at_setup: list[str] = []
+
+    async def run_profile_phases(
+        self,
+        *,
+        workspace_id: str,
+        phase_names: tuple[str, ...],
+        **kwargs: Any,
+    ) -> ValidationResult:
+        if phase_names == ("setup", "pre_agent"):
+            async with self._factory() as session:
+                workspace = await WorkspaceRepository(session).get(workspace_id)
+                assert workspace is not None
+                self.status_at_setup.append(workspace.status)
+        return await super().run_profile_phases(
+            workspace_id=workspace_id,
+            phase_names=phase_names,
+            **kwargs,
+        )
 
 
 class _ProfilePreflightFailureValidation(_RecordingValidation):
@@ -497,6 +534,79 @@ class TestExecutorMonitorHandoffSetup:
             ws = await WorkspaceRepository(s).get(ws_id)
             assert ws is not None
             assert ws.status == WorkspaceStatus.monitoring_pr.value
+
+    @pytest.mark.unit
+    async def test_sync_feature_pr_adoption_runs_setup_before_skip_agent_transition(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        # Regression for #574: an adopt-pr (auto_merge=True) monitor died
+        # infrastructure_failure / PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING on its
+        # first comment-repair because the existing_github_pr handoff transitioned
+        # running -> validating (PR_ADOPTION_SKIP_AGENT) -> monitoring_pr WITHOUT
+        # running the profile setup phase that installs the toolchain.
+        # PR_ADOPTION_SKIP_AGENT must skip only the AGENT RUN, never profile setup,
+        # so setup runs *before* that transition (while still ``running``) and the
+        # toolchain is present when the monitor later runs pre-push validation.
+        monitor_runs: list[str] = []
+        validation = _StatusAtSetupValidation(factory)
+        ws_id = await _seed_ready(
+            factory,
+            task_kind="sync_feature_pr",
+            auto_merge=True,
+            task_policy={
+                "pr_adoption": {
+                    "repo_slug": "x/y",
+                    "pr_number": 42,
+                    "pr_url": "https://github.com/x/y/pull/42",
+                    "head_ref": "feature/existing",
+                    "base_ref": "development",
+                    "head_sha": "h" * 40,
+                    "base_sha": "b" * 40,
+                }
+            },
+        )
+
+        class _Monitor:
+            async def run(
+                self, *, workspace_id: str, compose_project: str, compose_file: Path
+            ) -> None:
+                del compose_project, compose_file
+                monitor_runs.append(workspace_id)
+
+        executor = _make_executor(
+            fake,
+            factory,
+            tmp_path,
+            validation=validation,
+            pr_monitor_factory=lambda *_args, **_kwargs: _Monitor(),
+        )
+
+        await executor.execute(ws_id)
+
+        # Setup ran exactly once, for the ("setup","pre_agent") phases...
+        assert validation.calls == [("setup", "pre_agent")]
+        # ...while the workspace was still ``running`` — i.e. *before* the
+        # PR_ADOPTION_SKIP_AGENT -> validating transition (the #574 ordering
+        # invariant). If setup is reordered after the skip-agent transition or
+        # dropped, this records ``validating`` / nothing and the test fails.
+        assert validation.status_at_setup == [WorkspaceStatus.running.value]
+        assert monitor_runs == [ws_id]
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            # PR_ADOPTION_SKIP_AGENT is still emitted (only the AGENT RUN is
+            # skipped) and lands strictly after the setup call ran.
+            skip_agent_events = [
+                event
+                for event in ws.events
+                if event.reason_code == _PR_ADOPTION_SKIP_AGENT_REASON_CODE
+            ]
+            assert len(skip_agent_events) == 1
+            assert skip_agent_events[0].payload["source"] == "existing_github_pr"
 
     @pytest.mark.unit
     async def test_sync_feature_pr_handoff_bitbucket_auth_error_preserves_reason_code(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_f49ae93f44b44e569083585e` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix issue #574: an `adopt-pr` PR monitor (auto-merge) dies `infrastructure_failure` / `PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING` the FIRST time it makes a comment-repair edit, because the adopt-pr handoff never provisions the target repo's lint/test toolchain. Confirmed on ws_5ced4d7d and ws_625aaf17302640c785e03b2a (adopt-pr monitor on aira-agent).

=== ROOT CAUSE (confirmed via the live event timeline) ===
The adopt-pr path (`source: existing_github_pr`) in `src/awf/control/executor/monitor_handoff_sync.py` —
function `_handoff_sync_feature_pr_monitor` (around line 499; the existing_github_pr adoption transitions are at
~lines 630-647) — provisions the base runtime and then transitions straight:
    running -> validating (reason `PR_ADOPTION_SKIP_AGENT`) -> monitoring_pr
WITHOUT ever running the profile `setup` phase. The event timeline for ws_625aaf17 shows NO setup phase event at
all (PROVISIONING_COMPLETE -> EXECUTOR_CLAIMED -> PR_MONITOR_ADOPTED -> PR_ADOPTION_SKIP_AGENT -> monitoring_pr ->
PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING). `PR_ADOPTION_SKIP_AGENT` conflates "skip the AGENT RUN" (correct: an adopted
existing PR has no fresh coding task) with "skip PROFILE SETUP" (wrong: the `setup` phase is what installs the
toolchain). Pre-push validation later runs the profile `("post_agent","validate")` phases
(`src/awf/runtime/pr_monitor_runner/pre_push_validation.py:503`), every command returns 127 (command-not-found), the
`_pure_toolchain_missing_failure` path sets reason `PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING`, which is terminal ->
the monitor dies.

A normal `workspace create` AND the `sync_feature_pr` / `sync_release_pr` handoffs all run the profile `setup`
phase. adopt-pr is the one path that builds a REPAIR-CAPABLE monitor without provisioning its toolchain.

=== LOCKED DESIGN: eager provisioning at adoption (owner decision) ===
Make the adopt-pr (`existing_github_pr`) handoff RUN the profile `setup` (+ `pre_agent`) phase BEFORE transitioning
to `monitoring_pr`, so the toolchain is installed and present when the monitor later runs pre-push validation for a
comment-repair. Reuse the EXISTING helper `_run_monitor_handoff_profile_setup`
(`src/awf/control/executor/monitor_handoff_setup.py`, which runs `run_profile_phases(phase_names=("setup","pre_agent"))`
and already has the toolchain-probe + failure handling) — do NOT write a parallel setup path.

Concretely:
1. First REPRODUCE/CONFIRM the gap: a test (or trace) showing the existing_github_pr adoption reaches monitoring_pr
   without the `setup` phase running. (The event timeline proves it; lock it with a test.)
2. In the existing_github_pr adoption flow (`_handoff_sync_feature_pr_monitor` / the existing_github_pr branch in
   monitor_handoff_sync.py), invoke `_run_monitor_handoff_profile_setup(workspace_id, profile, compose_project,
   compose_file, worktree_path)` AFTER the runtime is provisioned and the profile is resolved, and BEFORE the
   `PR_ADOPTION_SKIP_AGENT` -> `monitoring_pr` transitions. Keep `PR_ADOPTION_SKIP_AGENT` semantics: it still means
   "no agent RUN", but setup now runs.
3. Setup-failure handling: if the setup phase genuinely fails (network / install error), the workspace must fail with
   the existing `PR_MONITOR_SETUP_FAILED` (infrastructure_failure) path that `_run_monitor_handoff_profile_setup`
   already drives — do NOT proceed to monitoring_pr with a half-provisioned env, and do NOT swallow it.
4. Idempotency / no double-setup: do NOT run setup where it already ran. The `release_pr_sync` path
   (`_handoff_sync_release_pr_monitor`, calls `_build_handoff_pr_monitor(..., run_profile_setup=False)` ~line 357)
   intentionally skips setup because the originating workspace already provisioned it — leave that behavior unchanged.
   Verify the `sync_feature_pr` rebuild path (`_build_handoff_pr_monitor`, run_profile_setup default True) is not made
   to run setup twice.

DO NOT implement graceful-degradation / skip-validation (rejected): the toolchain MUST be provisioned, not the
validation skipped. Leave the `pre_push_validation` terminal classification of TOOLCHAIN_MISSING AS-IS — after this
fix, a setup-able adopt-pr monitor never reaches it.

=== EDGE CASES (cover all) ===
- adopt-pr (existing_github_pr) of a repo with a real setup phase -> setup runs at adoption -> later comment-repair's
  pre-push validation has the toolchain -> no TOOLCHAIN_MISSING (the fix).
- adopt-pr of a repo whose profile has NO setup commands -> run_profile_phases is a no-op (all_passed) -> proceeds (no
  regression, no crash); the monitor simply has nothing to install.
- setup phase fails (e.g. dependency network failure) -> PR_MONITOR_SETUP_FAILED / SETUP_DEPENDENCY_NETWORK_FAILURE
  (infrastructure_failure), NOT silently continuing.
- release_pr_sync adoption -> setup NOT re-run (run_profile_setup=False preserved).
- sync_feature_pr rebuild -> setup runs exactly once (no double-run).

=== TESTS (TDD, strict ~99% coverage; the CI coverage gate is exact) ===
- The existing_github_pr adoption invokes the profile setup phase (assert `_run_monitor_handoff_profile_setup` /
  `run_profile_phases(("setup","pre_agent"))` is called) before the monitoring_pr transition; PR_ADOPTION_SKIP_AGENT
  is still emitted.
- Setup success -> transitions to monitoring_pr. Setup failure -> PR_MONITOR_SETUP_FAILED, does NOT reach monitoring_pr.
- release_pr_sync path still does NOT run setup (regression guard).
- No-op profile (no setup commands) -> adoption still succeeds.
- Update any existing test asserting the OLD "adopt-pr skips setup" behavior to the new contract.

=== SCOPE GUARDS ===
- Owned paths: `src/awf/control/executor/**`, `tests/**`.
- Do NOT modify `.github/workflows/**`, `.awf/workspace.yml`, or the pre_push_validation terminal classification.
- Reference #574 in the PR. Run ruff + mypy clean; keep the OpenAPI/contract gates green.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in executor error-path coverage; no production behavior modified in this diff.
> 
> **Overview**
> Adds a **regression test for #574** so `existing_github_pr` adopt-pr handoffs cannot again reach `monitoring_pr` without provisioning the profile toolchain in the right order.
> 
> Introduces `_StatusAtSetupValidation` to record workspace status when `("setup", "pre_agent")` runs, plus `test_sync_feature_pr_adoption_runs_setup_before_skip_agent_transition`, which requires setup to run **once while the workspace is still `running`**—before the `PR_ADOPTION_SKIP_AGENT` → `validating` transition—and still expects a single skip-agent event with `source: existing_github_pr` and a successful handoff to `monitoring_pr`. Also imports `_PR_ADOPTION_SKIP_AGENT_REASON_CODE` for that assertion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bbc2eab9fa160a6c9b3d563febe4a01c53d2f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->