### PR TITLE
Fix #579: normalize host-local OLLAMA_HOST to host.docker.internal (launcher + preflight parity)

### DIFF
--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -120,9 +120,23 @@ def _ollama_base_url_prelude() -> str:
     — else the agent would collapse to the scheme default port 80 while AWF probed
     ``:11434``). A port-less host (a sidecar service name like ``ollama-sidecar``, or
     the bare default-host form) inherits Ollama's default daemon port (11434); a value
-    that already carries a port is left intact. An explicit
-    ``AWF_OPENCODE_OLLAMA_BASE_URL`` still wins over ``OLLAMA_HOST``; with neither set
-    we fall back to the default.
+    that already carries a port is left intact.
+
+    A host-local connection target -- IPv4 loopback (``127.0.0.0/8``), IPv6 loopback
+    (``[::1]``), ``localhost``, or the IPv4/IPv6 unspecified addresses (``0.0.0.0`` /
+    ``[::]``) -- is then translated to the Docker host gateway
+    (``host.docker.internal``), keeping the resolved port and dropping any userinfo:
+    inside the agent container such an address points at the container *itself*, not
+    the host Ollama daemon (issue #579). This mirrors the Python source of truth
+    ``provider_readiness_helpers._normalize_host_local_host`` so launch and preflight
+    resolve the same daemon. Routable hosts (a LAN IP, the configured hostname, a
+    Compose service name, the gateway aliases) pass through unchanged. The ``127.*``
+    shell glob is intentionally looser than the Python ``ipaddress`` check -- no real
+    loopback hostname literally starts ``127.`` -- and the parity test asserts the two
+    agree over the representative table.
+
+    An explicit ``AWF_OPENCODE_OLLAMA_BASE_URL`` still wins over ``OLLAMA_HOST``; with
+    neither set we fall back to the default.
     """
     return (
         '__awf_ollama_host="${AWF_OPENCODE_OLLAMA_BASE_URL:-}"\n'
@@ -152,6 +166,43 @@ def _ollama_base_url_prelude() -> str:
         "    *:*) : ;;\n"
         "    '') : ;;\n"
         '    *) __awf_ollama_authority="$__awf_ollama_authority:11434" ;;\n'
+        "  esac\n"
+        # Translate a host-local authority (loopback / unspecified / ``localhost``) to
+        # the Docker host gateway so the agent container reaches the *host* Ollama
+        # daemon rather than itself (issue #579). Recompute host:port from the
+        # port-defaulted authority (``##*@`` drops userinfo), split bracketed IPv6
+        # ``[..]:port`` and plain ``host:port``, strip IPv6 brackets, then rewrite a
+        # host-local host to ``host.docker.internal`` keeping the resolved port and
+        # dropping userinfo. Mirrors ``_normalize_host_local_host`` on the Python side.
+        '  __awf_ollama_hostport="${__awf_ollama_authority##*@}"\n'
+        '  case "$__awf_ollama_hostport" in\n'
+        "    '['*']:'*)\n"
+        '      __awf_ollama_hl_port="${__awf_ollama_hostport##*]:}"\n'
+        "      __awf_ollama_hl_host=\"${__awf_ollama_hostport%%']:'*}\"\n"
+        "      __awf_ollama_hl_host=\"${__awf_ollama_hl_host#'['}\"\n"
+        "      ;;\n"
+        "    '['*']')\n"
+        "      __awf_ollama_hl_host=\"${__awf_ollama_hostport#'['}\"\n"
+        "      __awf_ollama_hl_host=\"${__awf_ollama_hl_host%']'}\"\n"
+        "      __awf_ollama_hl_port=\n"
+        "      ;;\n"
+        "    *:*)\n"
+        '      __awf_ollama_hl_host="${__awf_ollama_hostport%:*}"\n'
+        '      __awf_ollama_hl_port="${__awf_ollama_hostport##*:}"\n'
+        "      ;;\n"
+        "    *)\n"
+        '      __awf_ollama_hl_host="$__awf_ollama_hostport"\n'
+        "      __awf_ollama_hl_port=\n"
+        "      ;;\n"
+        "  esac\n"
+        '  case "$__awf_ollama_hl_host" in\n'
+        "    localhost|0.0.0.0|::|::1|127.*)\n"
+        '      if [ -n "$__awf_ollama_hl_port" ]; then\n'
+        '        __awf_ollama_authority="host.docker.internal:$__awf_ollama_hl_port"\n'
+        "      else\n"
+        '        __awf_ollama_authority="host.docker.internal"\n'
+        "      fi\n"
+        "      ;;\n"
         "  esac\n"
         '  __awf_ollama_host="$__awf_ollama_scheme://$__awf_ollama_authority$__awf_ollama_path"\n'
         '  __awf_ollama_host="${__awf_ollama_host%/}"\n'

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -195,8 +195,12 @@ def _ollama_base_url_prelude() -> str:
         "      __awf_ollama_hl_port=\n"
         "      ;;\n"
         "  esac\n"
+        # ``localhost`` is matched case-insensitively (POSIX bracket expansion, no
+        # bashism) because the Python side lowercases the host (``urlsplit().hostname``
+        # plus ``host.lower() == "localhost"``), so a value like ``http://LocalHost``
+        # must normalize on both sides or launch and preflight disagree on the daemon.
         '  case "$__awf_ollama_hl_host" in\n'
-        "    localhost|0.0.0.0|::|::1|127.*)\n"
+        "    [Ll][Oo][Cc][Aa][Ll][Hh][Oo][Ss][Tt]|0.0.0.0|::|::1|127.*)\n"
         '      if [ -n "$__awf_ollama_hl_port" ]; then\n'
         '        __awf_ollama_authority="host.docker.internal:$__awf_ollama_hl_port"\n'
         "      else\n"

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -178,12 +178,12 @@ def _ollama_base_url_prelude() -> str:
         '  case "$__awf_ollama_hostport" in\n'
         "    '['*']:'*)\n"
         '      __awf_ollama_hl_port="${__awf_ollama_hostport##*]:}"\n'
-        "      __awf_ollama_hl_host=\"${__awf_ollama_hostport%%']:'*}\"\n"
+        '      __awf_ollama_hl_host="${__awf_ollama_hostport%%]:*}"\n'
         "      __awf_ollama_hl_host=\"${__awf_ollama_hl_host#'['}\"\n"
         "      ;;\n"
         "    '['*']')\n"
         "      __awf_ollama_hl_host=\"${__awf_ollama_hostport#'['}\"\n"
-        "      __awf_ollama_hl_host=\"${__awf_ollama_hl_host%']'}\"\n"
+        '      __awf_ollama_hl_host="${__awf_ollama_hl_host%]}"\n'
         "      __awf_ollama_hl_port=\n"
         "      ;;\n"
         "    *:*)\n"

--- a/src/awf/adapters/opencode.py
+++ b/src/awf/adapters/opencode.py
@@ -133,7 +133,10 @@ def _ollama_base_url_prelude() -> str:
     Compose service name, the gateway aliases) pass through unchanged. The ``127.*``
     shell glob is intentionally looser than the Python ``ipaddress`` check -- no real
     loopback hostname literally starts ``127.`` -- and the parity test asserts the two
-    agree over the representative table.
+    agree over the representative table. An expanded/uncompressed IPv6 loopback or
+    unspecified literal (``0:0:0:0:0:0:0:1``, ``[0000:...:0001]``, ``0::1``) is first
+    canonicalized to ``::1`` / ``::`` so it normalizes like the Python ``ipaddress``
+    check rather than leaking through as a routable host.
 
     An explicit ``AWF_OPENCODE_OLLAMA_BASE_URL`` still wins over ``OLLAMA_HOST``; with
     neither set we fall back to the default.
@@ -193,6 +196,49 @@ def _ollama_base_url_prelude() -> str:
         "    *)\n"
         '      __awf_ollama_hl_host="$__awf_ollama_hostport"\n'
         "      __awf_ollama_hl_port=\n"
+        "      ;;\n"
+        "  esac\n"
+        # Canonicalize an expanded/uncompressed IPv6 loopback (``::1``) or unspecified
+        # (``::``) literal to its compressed form so the host-local case below catches
+        # it. The Python source of truth uses ``ipaddress.ip_address()``, which treats
+        # every textual form (``0:0:0:0:0:0:0:1``, ``[0000:...:0001]``, ``0::1``) as
+        # loopback/unspecified, but a literal glob would only see ``::1``/``::`` -- so a
+        # valid expanded form would launch against the agent container while the worker
+        # probed the host gateway (issue #579). Collapse the single ``::`` position-
+        # preservingly into one zero group, strip each group's leading zeros, then the
+        # host is host-local iff every group but the last is all-zero and the last group
+        # is ``0`` (unspecified) or ``1`` (loopback). Mirrors ``_normalize_host_local_host``.
+        '  case "$__awf_ollama_hl_host" in\n'
+        "    *.* | *%*) : ;;\n"
+        "    *::*::*) : ;;\n"
+        "    *:*)\n"
+        '      __awf_ip6="$__awf_ollama_hl_host"\n'
+        '      case "$__awf_ip6" in\n'
+        '        ::) __awf_ip6="0" ;;\n'
+        '        ::*) __awf_ip6="0:${__awf_ip6#::}" ;;\n'
+        '        *::) __awf_ip6="${__awf_ip6%::}:0" ;;\n'
+        '        *::*) __awf_ip6="${__awf_ip6%%::*}:0:${__awf_ip6##*::}" ;;\n'
+        "      esac\n"
+        '      __awf_ip6_last="${__awf_ip6##*:}"\n'
+        '      case "$__awf_ip6" in\n'
+        '        *:*) __awf_ip6_prefix="${__awf_ip6%:*}" ;;\n'
+        "        *) __awf_ip6_prefix= ;;\n"
+        "      esac\n"
+        "      while : ; do\n"
+        '        case "$__awf_ip6_last" in\n'
+        '          0?*) __awf_ip6_last="${__awf_ip6_last#0}" ;;\n'
+        "          *) break ;;\n"
+        "        esac\n"
+        "      done\n"
+        '      case "$__awf_ip6_prefix" in\n'
+        "        *[!0:]*) : ;;\n"
+        "        *)\n"
+        '          case "$__awf_ip6_last" in\n'
+        "            '' | 0) __awf_ollama_hl_host=\"::\" ;;\n"
+        '            1) __awf_ollama_hl_host="::1" ;;\n'
+        "          esac\n"
+        "          ;;\n"
+        "      esac\n"
         "      ;;\n"
         "  esac\n"
         # ``localhost`` is matched case-insensitively (POSIX bracket expansion, no

--- a/src/awf/service/provider_readiness_helpers.py
+++ b/src/awf/service/provider_readiness_helpers.py
@@ -638,8 +638,68 @@ def _opencode_ollama_host_probe_deferrable(
     return _is_cloud_model(model) and _opencode_ollama_credentials_present(environ, host_home)
 
 
+# The Docker host-gateway alias the agent container uses to reach the *host*
+# Ollama daemon. A host-local connection target (loopback / unspecified address,
+# ``localhost``) inside the agent container resolves to the container itself, not
+# the host, so such a target is normalized to this gateway before it is used —
+# mirrored in the OpenCode launcher prelude (``_ollama_base_url_prelude``) so launch
+# and preflight resolve the same daemon (issue #579).
+_HOST_GATEWAY = "host.docker.internal"
+
+
+def _normalize_host_local_host(host: str) -> str:
+    """Translate a host-local Ollama host to the Docker host gateway.
+
+    Single source of truth for the host-local set the shell launcher prelude
+    mirrors: IPv4 loopback (``127.0.0.0/8``), IPv6 loopback (``::1``),
+    ``localhost``, the IPv4/IPv6 unspecified addresses (``0.0.0.0`` / ``::``) all
+    map to ``host.docker.internal`` — inside the agent container they would
+    otherwise resolve to the container itself rather than the host Ollama daemon.
+    Everything else passes through unchanged: a routable LAN IP, a Compose service
+    DNS name (e.g. ``ollama-sidecar``), the configured host's own hostname, and the
+    gateway aliases (``host.docker.internal`` / ``gateway.docker.internal``) — none
+    of which point the agent at itself.
+    """
+
+    bare = host.strip()
+    # ``urlsplit().hostname`` is already unbracketed, but normalize defensively so
+    # a caller passing a bracketed IPv6 literal (``[::1]``) compares correctly.
+    if bare.startswith("[") and bare.endswith("]"):
+        bare = bare[1:-1]
+    if bare.lower() == "localhost":
+        return _HOST_GATEWAY
+    try:
+        address = ipaddress.ip_address(bare)
+    except ValueError:
+        # A DNS name (Compose service, the configured hostname) is not host-local.
+        return host
+    if address.is_loopback or address.is_unspecified:
+        return _HOST_GATEWAY
+    return host
+
+
+def _normalize_host_local_authority(parts: SplitResult) -> SplitResult:
+    """Rebuild *parts* netloc as the host gateway when its host is host-local.
+
+    When ``parts.hostname`` normalizes to the host gateway, rebuild the authority as
+    ``host.docker.internal[:port]`` — keeping the resolved port and **dropping any
+    userinfo** (the gateway needs no credentials; cf. the #577 userinfo strip).
+    A non-host-local authority is returned unchanged so the #577 userinfo-port
+    behavior survives for routable hosts.
+    """
+
+    host = parts.hostname
+    if not host:
+        return parts
+    normalized = _normalize_host_local_host(host)
+    if normalized == host:
+        return parts
+    netloc = normalized if parts.port is None else f"{normalized}:{parts.port}"
+    return parts._replace(netloc=netloc)
+
+
 def _parse_ollama_base_url(environ: Mapping[str, str]) -> SplitResult:
-    """Resolve and parse the Ollama base URL, normalizing malformed input.
+    """Resolve and parse the Ollama base URL, normalizing malformed and host-local input.
 
     Both the worker reachability classifier and the probe/pull URL builder need the
     *same* resolution of ``AWF_OPENCODE_OLLAMA_BASE_URL`` / ``OLLAMA_HOST`` (falling
@@ -650,6 +710,12 @@ def _parse_ollama_base_url(environ: Mapping[str, str]) -> SplitResult:
     the ``host.docker.internal`` default exactly once — host-reachable, never a crash
     during readiness — instead of escaping as a ``ValueError`` from whichever caller
     happens to touch the offending attribute first.
+
+    After the port is defaulted (``_default_ollama_port``), a host-local authority
+    (loopback / unspecified / ``localhost``) is translated to the Docker host gateway
+    (``_normalize_host_local_authority``) so this single resolution point — shared by
+    ``_ollama_api_urls`` and ``_ollama_url_host_reachable_from_worker`` — sees the same
+    daemon the OpenCode launcher prelude resolves (issue #579).
     """
 
     raw = (
@@ -672,7 +738,7 @@ def _parse_ollama_base_url(environ: Mapping[str, str]) -> SplitResult:
             raise ValueError("missing Ollama host")
     except ValueError:
         parts = urlsplit(DEFAULT_OLLAMA_OPENAI_BASE_URL)
-    return _default_ollama_port(parts)
+    return _normalize_host_local_authority(_default_ollama_port(parts))
 
 
 def _default_ollama_port(parts: SplitResult) -> SplitResult:
@@ -752,21 +818,17 @@ def _ollama_api_urls(environ: Mapping[str, str], api_path: str) -> tuple[str, ..
     return (primary,)
 
 
-# Hostnames that resolve to the host the worker runs on (Docker host gateway
-# aliases and localhost). An Ollama base URL pointing at one of these — or any
-# loopback IP — is reachable from the worker; anything else (a workspace Compose
-# service DNS name, a routable LAN IP) is not. ``0.0.0.0`` is a valid Ollama bind
-# address (``OLLAMA_HOST=0.0.0.0:11434``) that, as a *connection* target, routes
-# to the loopback just like ``localhost``; classify it reachable so a broken
-# host-bound daemon is still caught at create time rather than silently skipped
-# (``ip_address("0.0.0.0").is_loopback`` is ``False`` — the unspecified address is
-# not a loopback IP — so it would otherwise fall through to the conservative skip).
+# Hostnames that resolve to the host the worker runs on — the Docker host-gateway
+# aliases. An Ollama base URL pointing at one of these is reachable from the worker;
+# anything else (a workspace Compose service DNS name, a routable LAN IP) is not.
+# Host-local connection targets (``localhost``, ``127.0.0.0/8``, ``0.0.0.0``, ``::1``,
+# ``::``) are no longer listed here: ``_parse_ollama_base_url`` normalizes them to
+# ``host.docker.internal`` upstream (issue #579), so they reach the classifier already
+# rewritten to the gateway and a plain membership test suffices.
 _WORKER_HOST_REACHABLE_HOSTNAMES = frozenset(
     {
         "host.docker.internal",
         "gateway.docker.internal",
-        "localhost",
-        "0.0.0.0",
     }
 )
 
@@ -776,27 +838,19 @@ def _ollama_url_host_reachable_from_worker(environ: Mapping[str, str]) -> bool:
 
     The worker runs off ``awf_net`` and cannot reach a workspace Compose service
     DNS name (e.g. ``http://ollama-sidecar:11434``). Mirror ``_ollama_api_urls``'s
-    URL resolution, then classify the host: the Docker host gateway aliases,
-    ``localhost``, and loopback IPs are host-reachable; any other DNS name (a
-    Compose service) or routable IP is not. A missing/blank/garbled value resolves
-    to the ``host.docker.internal`` default and is therefore host-reachable (no
-    crash). The skip is conservative: a non-host-reachable URL defers the model
-    probe to the agent container rather than risk a false ``OLLAMA_MODEL_PROBE_FAILED``.
+    URL resolution, then classify the host with a pure membership test: only the
+    Docker host-gateway aliases are host-reachable. ``_parse_ollama_base_url``
+    normalizes every host-local target (``localhost``, loopback / unspecified IPs)
+    to ``host.docker.internal`` and resolves a missing/blank/garbled value to that
+    same gateway default, so a host-local or garbled URL is classified reachable
+    without a separate loopback branch or empty-host guard here, and any other DNS
+    name (a Compose service) or routable IP is not. The skip is conservative: a
+    non-host-reachable URL defers the model probe to the agent container rather than
+    risk a false ``OLLAMA_MODEL_PROBE_FAILED``.
     """
 
-    # ``_parse_ollama_base_url`` normalizes a malformed value (unbalanced IPv6
-    # brackets, non-numeric port) to the ``host.docker.internal`` default, which is
-    # host-reachable — so a garbled URL is treated like any other garbled value
-    # (host-reachable, never a crash) without a guard here.
-    host = (_parse_ollama_base_url(environ).hostname or "").lower()
-    if not host:
-        return True
-    if host in _WORKER_HOST_REACHABLE_HOSTNAMES:
-        return True
-    try:
-        return ipaddress.ip_address(host).is_loopback
-    except ValueError:
-        return False
+    host = _parse_ollama_base_url(environ).hostname
+    return (host or "").lower() in _WORKER_HOST_REACHABLE_HOSTNAMES
 
 
 def overlay_profile_ollama_base_url(

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -992,6 +992,10 @@ class TestOpenCodeAdapter:
 
     @pytest.mark.unit
     @pytest.mark.parametrize(
+        "env_var",
+        ["OLLAMA_HOST", "AWF_OPENCODE_OLLAMA_BASE_URL"],
+    )
+    @pytest.mark.parametrize(
         "ollama_host",
         [
             "127.0.0.1:11434",
@@ -1008,7 +1012,7 @@ class TestOpenCodeAdapter:
         ],
     )
     async def test_launch_prelude_matches_python_preflight_resolution(
-        self, ollama_host: str
+        self, ollama_host: str, env_var: str
     ) -> None:
         """Parity anchor: the shell launcher prelude and the Python worker preflight
         must resolve the *same* daemon (host + port) for every representative input.
@@ -1017,8 +1021,11 @@ class TestOpenCodeAdapter:
         hosts pass through unchanged. Running the actual prelude under ``sh`` against
         ``_parse_ollama_base_url`` is what keeps the two implementations honest — any
         sh-specific bracketed-IPv6/userinfo bug, or a drift between the host-local sets,
-        surfaces as a host/port mismatch here."""
-        env = {"OLLAMA_HOST": ollama_host}
+        surfaces as a host/port mismatch here. Both env keys are exercised because the
+        prelude (and ``_parse_ollama_base_url``) prefer ``AWF_OPENCODE_OLLAMA_BASE_URL``
+        over ``OLLAMA_HOST`` while sharing the downstream normalization, so a regression
+        specific to the preferred branch must also surface as a mismatch."""
+        env = {env_var: ollama_host}
         resolved = await self._resolve_ollama_base_url(env)
         shell_parts = urlsplit(resolved)
         python_parts = provider_readiness_helpers._parse_ollama_base_url(env)

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -964,6 +964,11 @@ class TestOpenCodeAdapter:
             ("127.5.5.5:11434", "http://host.docker.internal:11434/v1"),
             ("localhost", "http://host.docker.internal:11434/v1"),
             ("http://localhost:11434", "http://host.docker.internal:11434/v1"),
+            # ``localhost`` is host-local regardless of case: the Python preflight
+            # lowercases the host, so the shell launcher must match every casing too
+            # or the two disagree on the daemon.
+            ("http://LocalHost:11434", "http://host.docker.internal:11434/v1"),
+            ("LOCALHOST:11434", "http://host.docker.internal:11434/v1"),
             ("http://[::]:11434", "http://host.docker.internal:11434/v1"),
             ("http://[::1]", "http://host.docker.internal:11434/v1"),
             ("http://[::1]:11434", "http://host.docker.internal:11434/v1"),
@@ -991,6 +996,7 @@ class TestOpenCodeAdapter:
         [
             "127.0.0.1:11434",
             "http://localhost",
+            "http://LocalHost:11434",
             "0.0.0.0:11434",
             "http://[::1]:11434",
             "[::]:11434",

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -972,6 +972,13 @@ class TestOpenCodeAdapter:
             ("http://[::]:11434", "http://host.docker.internal:11434/v1"),
             ("http://[::1]", "http://host.docker.internal:11434/v1"),
             ("http://[::1]:11434", "http://host.docker.internal:11434/v1"),
+            # An expanded/uncompressed IPv6 loopback or unspecified literal is
+            # canonicalized to the host gateway like ``::1`` / ``::`` -- the Python
+            # ``ipaddress`` check treats every textual form alike, so the shell must
+            # too (issue #579).
+            ("http://[0:0:0:0:0:0:0:1]:11434", "http://host.docker.internal:11434/v1"),
+            ("http://[0::1]:11434", "http://host.docker.internal:11434/v1"),
+            ("http://[0:0:0:0:0:0:0:0]:11434", "http://host.docker.internal:11434/v1"),
             # A userinfo-bearing host-local value drops the credentials too.
             ("http://user:pass@127.0.0.1:11434", "http://host.docker.internal:11434/v1"),
         ],
@@ -1004,6 +1011,16 @@ class TestOpenCodeAdapter:
             "0.0.0.0:11434",
             "http://[::1]:11434",
             "[::]:11434",
+            # Expanded/uncompressed IPv6 loopback and unspecified literals must
+            # resolve the same daemon on both sides: the Python preflight uses
+            # ``ipaddress.ip_address()`` (every textual form is loopback/unspecified),
+            # so the shell prelude must canonicalize them too or launch keeps the
+            # IPv6 loopback while the worker probes the gateway (issue #579).
+            "http://[0:0:0:0:0:0:0:1]:11434",
+            "http://[0000:0000:0000:0000:0000:0000:0000:0001]:11434",
+            "http://[0::1]:11434",
+            "http://[0:0:0:0:0:0:0:0]:11434",
+            "http://[0::]:11434",
             "host.docker.internal:11434",
             "ollama-sidecar:11434",
             "192.168.1.10:11434",

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -17,6 +17,7 @@ import inspect
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import pytest
 import structlog
@@ -47,6 +48,7 @@ from awf.adapters.opencode import (
 from awf.common.commands import CommandResult, FakeCommandRunner
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.db.enums import AgentRuntime
+from awf.service import provider_readiness_helpers
 
 _PROMPT = "Add a one-line docstring to src/module/__init__.py."
 _LONG_PROMPT = "Review this oversized PR comment.\n" + ("x" * 140_000)
@@ -902,7 +904,9 @@ class TestOpenCodeAdapter:
             ("http://ollama-sidecar", "http://ollama-sidecar:11434/v1"),
             ("ollama-sidecar", "http://ollama-sidecar:11434/v1"),
             ("https://ollama-sidecar/v1", "https://ollama-sidecar:11434/v1"),
-            ("http://[::1]/v1", "http://[::1]:11434/v1"),
+            # An IPv6 loopback literal is host-local: it is translated to the Docker
+            # host gateway (issue #579), keeping the defaulted daemon port.
+            ("http://[::1]/v1", "http://host.docker.internal:11434/v1"),
             # A port-less value carrying userinfo credentials still inherits the
             # default daemon port (11434): the colon in ``user:pass`` is part of
             # the credentials, not a port, so it must not suppress defaulting.
@@ -910,9 +914,12 @@ class TestOpenCodeAdapter:
                 "http://user:pass@ollama.local/v1",
                 "http://user:pass@ollama.local:11434/v1",
             ),
+            # A host-local host drops userinfo and normalizes to the host gateway:
+            # the gateway needs no credentials and the agent must reach the host
+            # daemon, not itself.
             (
                 "http://user:pass@[::1]/v1",
-                "http://user:pass@[::1]:11434/v1",
+                "http://host.docker.internal:11434/v1",
             ),
             # Userinfo with an explicit port is left intact.
             (
@@ -946,10 +953,22 @@ class TestOpenCodeAdapter:
             ("http://ollama-sidecar", "http://ollama-sidecar:11434/v1"),
             ("https://ollama-sidecar/v1", "https://ollama-sidecar:11434/v1"),
             ("ollama.local", "http://ollama.local:11434/v1"),
-            ("0.0.0.0", "http://0.0.0.0:11434/v1"),
-            # IPv6 literals: bracket form, with and without a port.
-            ("http://[::1]", "http://[::1]:11434/v1"),
-            ("http://[::1]:11434", "http://[::1]:11434/v1"),
+            # Host-local connection targets are translated to the Docker host gateway
+            # (issue #579) so the agent reaches the host Ollama daemon, not itself.
+            # The IPv4/IPv6 unspecified addresses, IPv4 loopback (any ``127.*``),
+            # ``localhost``, and the IPv6 loopback all normalize to the gateway with
+            # the resolved/defaulted daemon port kept.
+            ("0.0.0.0", "http://host.docker.internal:11434/v1"),
+            ("0.0.0.0:11434", "http://host.docker.internal:11434/v1"),
+            ("127.0.0.1:11434", "http://host.docker.internal:11434/v1"),
+            ("127.5.5.5:11434", "http://host.docker.internal:11434/v1"),
+            ("localhost", "http://host.docker.internal:11434/v1"),
+            ("http://localhost:11434", "http://host.docker.internal:11434/v1"),
+            ("http://[::]:11434", "http://host.docker.internal:11434/v1"),
+            ("http://[::1]", "http://host.docker.internal:11434/v1"),
+            ("http://[::1]:11434", "http://host.docker.internal:11434/v1"),
+            # A userinfo-bearing host-local value drops the credentials too.
+            ("http://user:pass@127.0.0.1:11434", "http://host.docker.internal:11434/v1"),
         ],
     )
     async def test_launch_prelude_mirrors_ollama_host(
@@ -965,6 +984,43 @@ class TestOpenCodeAdapter:
         """With neither variable set the prelude keeps the default daemon URL."""
         resolved = await self._resolve_ollama_base_url({})
         assert resolved == "http://host.docker.internal:11434/v1"
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "ollama_host",
+        [
+            "127.0.0.1:11434",
+            "http://localhost",
+            "0.0.0.0:11434",
+            "http://[::1]:11434",
+            "[::]:11434",
+            "host.docker.internal:11434",
+            "ollama-sidecar:11434",
+            "192.168.1.10:11434",
+            "ollama.local",
+            "http://user:pass@127.0.0.1:11434",
+        ],
+    )
+    async def test_launch_prelude_matches_python_preflight_resolution(
+        self, ollama_host: str
+    ) -> None:
+        """Parity anchor: the shell launcher prelude and the Python worker preflight
+        must resolve the *same* daemon (host + port) for every representative input.
+
+        Host-local targets normalize to ``host.docker.internal`` on both sides; routable
+        hosts pass through unchanged. Running the actual prelude under ``sh`` against
+        ``_parse_ollama_base_url`` is what keeps the two implementations honest — any
+        sh-specific bracketed-IPv6/userinfo bug, or a drift between the host-local sets,
+        surfaces as a host/port mismatch here."""
+        env = {"OLLAMA_HOST": ollama_host}
+        resolved = await self._resolve_ollama_base_url(env)
+        shell_parts = urlsplit(resolved)
+        python_parts = provider_readiness_helpers._parse_ollama_base_url(env)
+
+        assert (shell_parts.hostname, shell_parts.port) == (
+            python_parts.hostname,
+            python_parts.port,
+        )
 
     @pytest.mark.unit
     async def test_default_opencode_invocation_omits_variant_without_effort(self) -> None:

--- a/tests/unit/control/test_executor_ollama_model.py
+++ b/tests/unit/control/test_executor_ollama_model.py
@@ -326,12 +326,15 @@ async def test_ensure_derives_urls_from_profile_ollama_base_url(
     the worker process env: a profile that sets ``AWF_OPENCODE_OLLAMA_BASE_URL``
     for the agent points at a different daemon than the worker, and AWF must
     probe/pull the daemon the agent will actually reach. Both daemons are
-    host-reachable loopback hosts so the #569 worker-skip does not apply and the
-    URL-derivation wiring is still exercised."""
+    worker-reachable host-gateway aliases so the #569 worker-skip does not apply and
+    the URL-derivation wiring is still exercised; the two distinct aliases are used
+    rather than two ``127.*`` loopback hosts because host-local targets now both
+    normalize to ``host.docker.internal`` (issue #579), which would make the
+    profile-vs-worker daemon indistinguishable here."""
     workspace_id = await _seed_running(factory)
     executor = _make_executor(factory, tmp_path)
 
-    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://127.0.0.2:11434")
+    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://host.docker.internal:11434")
 
     seen: dict[str, Any] = {}
 
@@ -351,7 +354,7 @@ async def test_ensure_derives_urls_from_profile_ollama_base_url(
                 "name": "ollama-profile-daemon",
                 "runtime": {
                     "environment": {
-                        "AWF_OPENCODE_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
+                        "AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434",
                     }
                 },
             },
@@ -359,9 +362,9 @@ async def test_ensure_derives_urls_from_profile_ollama_base_url(
     )
 
     assert proceed is True
-    assert any("127.0.0.1:11434" in url for url in seen["tags_urls"])
-    assert any("127.0.0.1:11434" in url for url in seen["pull_urls"])
-    assert all("127.0.0.2" not in url for url in seen["tags_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["tags_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["pull_urls"])
+    assert all("host.docker.internal" not in url for url in seen["tags_urls"])
 
 
 @pytest.mark.unit
@@ -371,12 +374,14 @@ async def test_ensure_without_resolved_profile_uses_worker_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Without a resolved profile the preflight falls back to the worker env so
-    the existing single-daemon behavior is preserved. The worker daemon is a
-    host-reachable loopback host so the #569 worker-skip does not apply."""
+    the existing single-daemon behavior is preserved. The worker daemon is the
+    worker-reachable host gateway so the #569 worker-skip does not apply;
+    ``gateway.docker.internal`` (not the default ``host.docker.internal``) proves the
+    explicit worker-env value drives the probe."""
     workspace_id = await _seed_running(factory)
     executor = _make_executor(factory, tmp_path)
 
-    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://127.0.0.1:11434")
+    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://gateway.docker.internal:11434")
 
     seen: dict[str, Any] = {}
 
@@ -392,7 +397,7 @@ async def test_ensure_without_resolved_profile_uses_worker_env(
     )
 
     assert proceed is True
-    assert any("127.0.0.1:11434" in url for url in seen["tags_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["tags_urls"])
 
 
 @pytest.mark.unit
@@ -404,12 +409,15 @@ async def test_ensure_profile_ollama_host_overrides_worker_base_url(
     """A profile that declares only ``OLLAMA_HOST`` must win over a stale worker
     ``AWF_OPENCODE_OLLAMA_BASE_URL``: ``_ollama_api_urls`` prefers the base URL,
     so the worker value would otherwise shadow the profile-selected daemon and
-    AWF would probe/pull the wrong host. Both daemons are host-reachable loopback
-    hosts so the #569 worker-skip does not apply."""
+    AWF would probe/pull the wrong host. Both daemons are worker-reachable
+    host-gateway aliases so the #569 worker-skip does not apply; the two distinct
+    aliases are used rather than two ``127.*`` loopback hosts because host-local
+    targets now both normalize to ``host.docker.internal`` (issue #579), which would
+    make the profile-vs-worker daemon indistinguishable here."""
     workspace_id = await _seed_running(factory)
     executor = _make_executor(factory, tmp_path)
 
-    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://127.0.0.2:11434")
+    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://host.docker.internal:11434")
 
     seen: dict[str, Any] = {}
 
@@ -429,7 +437,7 @@ async def test_ensure_profile_ollama_host_overrides_worker_base_url(
                 "name": "ollama-profile-daemon",
                 "runtime": {
                     "environment": {
-                        "OLLAMA_HOST": "http://127.0.0.1:11434",
+                        "OLLAMA_HOST": "http://gateway.docker.internal:11434",
                     }
                 },
             },
@@ -437,10 +445,10 @@ async def test_ensure_profile_ollama_host_overrides_worker_base_url(
     )
 
     assert proceed is True
-    assert any("127.0.0.1:11434" in url for url in seen["tags_urls"])
-    assert any("127.0.0.1:11434" in url for url in seen["pull_urls"])
-    assert all("127.0.0.2" not in url for url in seen["tags_urls"])
-    assert all("127.0.0.2" not in url for url in seen["pull_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["tags_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["pull_urls"])
+    assert all("host.docker.internal" not in url for url in seen["tags_urls"])
+    assert all("host.docker.internal" not in url for url in seen["pull_urls"])
 
 
 @pytest.mark.unit
@@ -455,12 +463,14 @@ async def test_ensure_expands_profile_ollama_placeholder_against_environ(
     Docker Compose host-env substitution, but the worker-side probe does not pass
     through Compose — so a literal ``${OLLAMA_URL}`` would otherwise be probed as
     ``http://${OLLAMA_URL}/api/tags`` and block/fail the workspace before launch.
-    The resolved daemon is a host-reachable loopback host so the #569 worker-skip
-    does not apply and the placeholder-expansion wiring is still exercised."""
+    The resolved daemon is the worker-reachable host gateway so the #569 worker-skip
+    does not apply and the placeholder-expansion wiring is still exercised;
+    ``gateway.docker.internal`` is used rather than a ``127.*`` loopback host because
+    host-local targets now normalize to ``host.docker.internal`` (issue #579)."""
     workspace_id = await _seed_running(factory)
     executor = _make_executor(factory, tmp_path)
 
-    monkeypatch.setenv("OLLAMA_URL", "http://127.0.0.1:11434")
+    monkeypatch.setenv("OLLAMA_URL", "http://gateway.docker.internal:11434")
 
     seen: dict[str, Any] = {}
 
@@ -488,8 +498,8 @@ async def test_ensure_expands_profile_ollama_placeholder_against_environ(
     )
 
     assert proceed is True
-    assert any("127.0.0.1:11434" in url for url in seen["tags_urls"])
-    assert any("127.0.0.1:11434" in url for url in seen["pull_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["tags_urls"])
+    assert any("gateway.docker.internal:11434" in url for url in seen["pull_urls"])
     assert all("${" not in url for url in seen["tags_urls"])
     assert all("${" not in url for url in seen["pull_urls"])
 

--- a/tests/unit/control/test_executor_ollama_model.py
+++ b/tests/unit/control/test_executor_ollama_model.py
@@ -365,6 +365,7 @@ async def test_ensure_derives_urls_from_profile_ollama_base_url(
     assert any("gateway.docker.internal:11434" in url for url in seen["tags_urls"])
     assert any("gateway.docker.internal:11434" in url for url in seen["pull_urls"])
     assert all("host.docker.internal" not in url for url in seen["tags_urls"])
+    assert all("host.docker.internal" not in url for url in seen["pull_urls"])
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_ollama_model_pull.py
+++ b/tests/unit/service/test_ollama_model_pull.py
@@ -838,15 +838,19 @@ def test_opencode_ollama_host_probe_deferrable(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("environ", "expected"),
     [
-        # Host gateway / loopback hosts are reachable from the worker.
+        # The Docker host-gateway aliases are reachable from the worker. Host-local
+        # connection targets (``localhost``, ``127.0.0.0/8``, ``::1``, ``0.0.0.0``,
+        # ``::``) are normalized to ``host.docker.internal`` by ``_parse_ollama_base_url``
+        # (issue #579), so they reach the classifier already rewritten to the gateway
+        # and classify reachable through the same pure membership test.
         ({"AWF_OPENCODE_OLLAMA_BASE_URL": "http://host.docker.internal:11434"}, True),
         ({"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434"}, True),
         ({"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"}, True),
         ({"OLLAMA_HOST": "http://127.0.0.1:11434"}, True),
         ({"OLLAMA_HOST": "http://[::1]:11434"}, True),
-        # ``0.0.0.0`` is a valid Ollama bind address that, as a connection target,
-        # routes to the loopback like ``localhost`` — reachable from the worker even
-        # though it is not itself a loopback IP (``is_loopback`` is ``False``).
+        # ``0.0.0.0`` / ``::`` are the unspecified addresses; as a *connection* target
+        # they route to the host loopback, so they normalize to the gateway upstream
+        # and classify reachable like ``localhost``.
         ({"OLLAMA_HOST": "http://0.0.0.0:11434"}, True),
         ({"AWF_OPENCODE_OLLAMA_BASE_URL": "0.0.0.0:11434"}, True),
         # A bare host:port without scheme still classifies on the hostname.

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
@@ -56,16 +56,20 @@ def _unexpected_subprocess(args: list[str], **_kwargs: object) -> Any:
 def _ollama_ok(url: str, *, timeout: float) -> Any:
     assert timeout > 0
     # Answer both a non-worker-reachable DNS host (``ollama.local``) and the
-    # worker-reachable ``localhost`` so callers that need the create-time daemon
-    # probe to actually run can point at a host that is not deferred away.
+    # worker-reachable host gateway (``gateway.docker.internal``) so callers that
+    # need the create-time daemon probe to actually run can point at a host that is
+    # not deferred away. ``gateway.docker.internal`` is used rather than ``localhost``
+    # because a host-local target now normalizes to ``host.docker.internal`` (issue
+    # #579) — which carries a ``localhost`` probe fallback — whereas the gateway alias
+    # resolves to a single probe URL, keeping these single-URL assertions intact.
     if url in {
         "http://ollama.local:11434/api/version",
-        "http://localhost:11434/api/version",
+        "http://gateway.docker.internal:11434/api/version",
     }:
         return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
     if url in {
         "http://ollama.local:11434/api/tags",
-        "http://localhost:11434/api/tags",
+        "http://gateway.docker.internal:11434/api/tags",
     }:
         return SimpleNamespace(
             status_code=200,
@@ -273,9 +277,10 @@ def test_selected_provider_preflight_maps_agents_to_effective_models(
     (home / ".gemini").mkdir()
     (home / ".config" / "opencode").mkdir(parents=True)
     env = {
-        # ``localhost`` is worker-reachable so the OpenCode create-time daemon probe
-        # runs for the ``:cloud`` model rather than being deferred as non-reachable.
-        "AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1",
+        # ``gateway.docker.internal`` is worker-reachable so the OpenCode create-time
+        # daemon probe runs for the ``:cloud`` model rather than being deferred as
+        # non-reachable.
+        "AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1",
         "CURSOR_API_KEY": "cursor_secret",
         "XAI_API_KEY": "xai-selected-grok-secret",
     }
@@ -534,16 +539,16 @@ def test_selected_opencode_preflight_cloud_model_absent_from_tags_is_non_blockin
     (home / ".config" / "opencode").mkdir(parents=True)
     urls: list[str] = []
 
-    # ``localhost`` is worker-reachable, so the create-time daemon probe runs and
+    # ``gateway.docker.internal`` is worker-reachable, so the create-time daemon probe runs and
     # exercises the cloud-absent-from-tags disposition. (A ``:cloud`` model at a
     # daemon URL the worker cannot reach defers instead — see
     # ``test_selected_opencode_preflight_cloud_model_with_creds_non_worker_reachable_url_defers``.)
     def _http_get(url: str, *, timeout: float) -> Any:
         assert timeout > 0
         urls.append(url)
-        if url == "http://localhost:11434/api/version":
+        if url == "http://gateway.docker.internal:11434/api/version":
             return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
-        if url == "http://localhost:11434/api/tags":
+        if url == "http://gateway.docker.internal:11434/api/tags":
             return SimpleNamespace(
                 status_code=200,
                 text='{"models":[{"name":"other-model:latest"}]}',
@@ -554,7 +559,7 @@ def test_selected_opencode_preflight_cloud_model_absent_from_tags_is_non_blockin
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/kimi-k2.6:cloud"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_runtime_cli_ok("opencode"),
         http_get=_http_get,
     )
@@ -569,8 +574,8 @@ def test_selected_opencode_preflight_cloud_model_absent_from_tags_is_non_blockin
     assert result["blocks_launch"] is False
     # Preflight never pulls — only the cheap version + tags probes run.
     assert urls == [
-        "http://localhost:11434/api/version",
-        "http://localhost:11434/api/tags",
+        "http://gateway.docker.internal:11434/api/version",
+        "http://gateway.docker.internal:11434/api/tags",
     ]
 
 
@@ -581,14 +586,14 @@ def test_selected_opencode_preflight_absent_non_cloud_model_is_pull_pending(
     home = tmp_path / "home"
     (home / ".config" / "opencode").mkdir(parents=True)
 
-    # ``localhost`` is worker-reachable, so the create-time daemon probe runs (the
+    # ``gateway.docker.internal`` is worker-reachable, so the create-time daemon probe runs (the
     # #569 host-unreachable skip does not apply); a sidecar DNS name is covered by
     # ``test_selected_opencode_preflight_local_model_non_worker_reachable_url_defers``.
     def _http_get(url: str, *, timeout: float) -> Any:
         assert timeout > 0
-        if url == "http://localhost:11434/api/version":
+        if url == "http://gateway.docker.internal:11434/api/version":
             return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
-        if url == "http://localhost:11434/api/tags":
+        if url == "http://gateway.docker.internal:11434/api/tags":
             return SimpleNamespace(
                 status_code=200,
                 text='{"models":[{"name":"other-model:latest"}]}',
@@ -599,7 +604,7 @@ def test_selected_opencode_preflight_absent_non_cloud_model_is_pull_pending(
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/llama4:70b"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_runtime_cli_ok("opencode"),
         http_get=_http_get,
     )
@@ -618,13 +623,13 @@ def test_selected_opencode_preflight_blocks_when_daemon_unreachable(
     home = tmp_path / "home"
     (home / ".config" / "opencode").mkdir(parents=True)
 
-    # A worker-reachable URL (``localhost``) whose daemon is down still blocks: the
+    # A worker-reachable URL (``gateway.docker.internal``) whose daemon is down still blocks: the
     # #569 skip only defers a daemon URL the worker cannot reach at all.
     def _http_get(url: str, *, timeout: float) -> Any:
         assert timeout > 0
-        if url == "http://localhost:11434/api/version":
+        if url == "http://gateway.docker.internal:11434/api/version":
             return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
-        if url == "http://localhost:11434/api/tags":
+        if url == "http://gateway.docker.internal:11434/api/tags":
             raise httpx.ConnectError("connection refused")
         raise AssertionError(f"unexpected Ollama probe URL: {url}")
 
@@ -632,7 +637,7 @@ def test_selected_opencode_preflight_blocks_when_daemon_unreachable(
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/llama4:70b"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_runtime_cli_ok("opencode"),
         http_get=_http_get,
     )
@@ -650,13 +655,14 @@ def test_selected_opencode_preflight_authless_local_model_reachable_daemon_allow
     # ``ollama/``-prefixed model is served by the host daemon, whose /api/tags
     # and /api/pull need no OpenCode/Ollama Cloud credential. With the daemon
     # reachable the strict auth gate is waived (carve-out symmetric to
-    # OPENCODE_NON_OLLAMA_PROVIDER_SELECTED) so admission can proceed. ``localhost``
-    # is worker-reachable, so the daemon probe runs rather than the #569 skip.
+    # OPENCODE_NON_OLLAMA_PROVIDER_SELECTED) so admission can proceed.
+    # ``gateway.docker.internal`` is worker-reachable, so the daemon probe runs rather
+    # than the #569 skip.
     def _http_get(url: str, *, timeout: float) -> Any:
         assert timeout > 0
-        if url == "http://localhost:11434/api/version":
+        if url == "http://gateway.docker.internal:11434/api/version":
             return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
-        if url == "http://localhost:11434/api/tags":
+        if url == "http://gateway.docker.internal:11434/api/tags":
             return SimpleNamespace(
                 status_code=200,
                 text='{"models":[{"name":"llama4:70b"}]}',
@@ -667,7 +673,7 @@ def test_selected_opencode_preflight_authless_local_model_reachable_daemon_allow
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/llama4:70b"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_runtime_cli_ok("opencode"),
         http_get=_http_get,
     )
@@ -696,9 +702,9 @@ def test_selected_opencode_preflight_authless_local_absent_model_is_pull_pending
     # reachable, so the carve-out daemon probe runs rather than the #569 skip.
     def _http_get(url: str, *, timeout: float) -> Any:
         assert timeout > 0
-        if url == "http://localhost:11434/api/version":
+        if url == "http://gateway.docker.internal:11434/api/version":
             return SimpleNamespace(status_code=200, text='{"version":"0.1.0"}')
-        if url == "http://localhost:11434/api/tags":
+        if url == "http://gateway.docker.internal:11434/api/tags":
             return SimpleNamespace(
                 status_code=200,
                 text='{"models":[{"name":"other-model:latest"}]}',
@@ -709,7 +715,7 @@ def test_selected_opencode_preflight_authless_local_absent_model_is_pull_pending
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/llama4:70b"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_runtime_cli_ok("opencode"),
         http_get=_http_get,
     )
@@ -749,7 +755,7 @@ def test_selected_opencode_preflight_authless_cloud_model_still_requires_creds(
 def test_selected_opencode_preflight_authless_local_model_unreachable_daemon_blocks(
     tmp_path: Path,
 ) -> None:
-    # Authless local model at a worker-reachable URL (``localhost``) whose daemon is
+    # Authless local model at a worker-reachable URL (``gateway.docker.internal``) whose daemon is
     # down: the waiver is conditional on daemon reachability, so with no credential
     # present this still blocks with OPENCODE_OLLAMA_AUTH_MISSING. Only the cheap
     # /api/version probe runs before the gate falls through. (A daemon URL the worker
@@ -766,7 +772,7 @@ def test_selected_opencode_preflight_authless_local_model_unreachable_daemon_blo
         _settings(tmp_path),
         agent="opencode",
         task_policy={"agent_model": "ollama/llama4:70b"},
-        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434/v1"},
+        environ={"AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434/v1"},
         run_subprocess=_unexpected_subprocess,
         http_get=_http_get,
     )
@@ -774,7 +780,7 @@ def test_selected_opencode_preflight_authless_local_model_unreachable_daemon_blo
     assert result["auth_status"] == "fail"
     assert result["reason_code"] == "OPENCODE_OLLAMA_AUTH_MISSING"
     assert result["blocks_launch"] is True
-    assert seen == ["http://localhost:11434/api/version"]
+    assert seen == ["http://gateway.docker.internal:11434/api/version"]
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_010.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_010.py
@@ -6,6 +6,8 @@ first-party file line limit (see ``test_core_decomposition_maintainability``).
 
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import pytest
 
 import awf.service.provider_readiness as provider_readiness
@@ -37,29 +39,56 @@ def test_ollama_url_helpers_preserve_host_gateway_fallback_port() -> None:
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("env", "expected_primary"),
+    ("env", "expected"),
     [
-        # A port-less host inherits Ollama's daemon port (11434) so the worker probe
-        # resolves the same daemon as the OpenCode launcher prelude — not the scheme
-        # default (port 80).
-        ({"OLLAMA_HOST": "localhost"}, "http://localhost:11434/api/version"),
-        ({"OLLAMA_HOST": "0.0.0.0"}, "http://0.0.0.0:11434/api/version"),
-        ({"OLLAMA_HOST": "ollama-sidecar"}, "http://ollama-sidecar:11434/api/version"),
+        # A host-local port-less host both inherits Ollama's daemon port (11434) and
+        # normalizes to the Docker host gateway (issue #579), so the worker resolves
+        # the same daemon as the OpenCode launcher prelude — and the normalized
+        # ``host.docker.internal`` host gains the ``localhost`` fallback in
+        # ``_ollama_api_urls``, yielding two probe URLs.
+        (
+            {"OLLAMA_HOST": "localhost"},
+            (
+                "http://host.docker.internal:11434/api/version",
+                "http://localhost:11434/api/version",
+            ),
+        ),
+        (
+            {"OLLAMA_HOST": "0.0.0.0"},
+            (
+                "http://host.docker.internal:11434/api/version",
+                "http://localhost:11434/api/version",
+            ),
+        ),
+        # A port-less IPv6 loopback literal normalizes to the gateway and defaults
+        # the port too.
+        (
+            {"OLLAMA_HOST": "http://[::1]"},
+            (
+                "http://host.docker.internal:11434/api/version",
+                "http://localhost:11434/api/version",
+            ),
+        ),
+        # Non-host-local port-less hosts keep their host and resolve to a single URL
+        # (no ``localhost`` fallback): a Compose service name and a routable hostname.
+        (
+            {"OLLAMA_HOST": "ollama-sidecar"},
+            ("http://ollama-sidecar:11434/api/version",),
+        ),
         (
             {"AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.local/v1"},
-            "http://ollama.local:11434/api/version",
+            ("http://ollama.local:11434/api/version",),
         ),
-        # A port-less IPv6 literal re-brackets and defaults the port too.
-        ({"OLLAMA_HOST": "http://[::1]"}, "http://[::1]:11434/api/version"),
     ],
 )
 def test_ollama_url_helpers_default_portless_host_to_daemon_port(
-    env: dict[str, str], expected_primary: str
+    env: dict[str, str], expected: tuple[str, ...]
 ) -> None:
     """A port-less ``OLLAMA_HOST`` / ``AWF_OPENCODE_OLLAMA_BASE_URL`` must resolve to
     Ollama's daemon port (11434), mirroring the OpenCode launcher prelude, so the
-    worker probe/pull does not hit port 80 while the agent talks to 11434."""
-    assert provider_readiness_helpers._ollama_version_urls(env) == (expected_primary,)
+    worker probe/pull does not hit port 80 while the agent talks to 11434. A
+    host-local host additionally normalizes to ``host.docker.internal``."""
+    assert provider_readiness_helpers._ollama_version_urls(env) == expected
 
 
 @pytest.mark.unit
@@ -71,6 +100,80 @@ def test_ollama_url_helpers_default_portless_host_gateway_to_daemon_port() -> No
         "http://host.docker.internal:11434/api/version",
         "http://localhost:11434/api/version",
     )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host",
+    [
+        # IPv4 loopback (any ``127.0.0.0/8``), the IPv4/IPv6 unspecified addresses,
+        # ``localhost`` (case-insensitive), and the IPv6 loopback are all host-local
+        # connection targets translated to the Docker host gateway (issue #579). The
+        # bracketed IPv6 form is normalized defensively even though ``urlsplit``
+        # already unbrackets ``.hostname``.
+        "127.0.0.1",
+        "127.5.5.5",
+        "0.0.0.0",
+        "localhost",
+        "LocalHost",
+        "::1",
+        "::",
+        "[::1]",
+    ],
+)
+def test_normalize_host_local_host_maps_host_local_to_gateway(host: str) -> None:
+    assert provider_readiness_helpers._normalize_host_local_host(host) == "host.docker.internal"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "host",
+    [
+        # A Compose service DNS name, a routable LAN IP, the configured host's own
+        # hostname, and the gateway aliases themselves are not host-local — they do
+        # not point the agent container at itself, so they pass through unchanged.
+        "ollama-sidecar",
+        "192.168.1.10",
+        "ollama.local",
+        "host.docker.internal",
+        "gateway.docker.internal",
+    ],
+)
+def test_normalize_host_local_host_passes_through_routable(host: str) -> None:
+    assert provider_readiness_helpers._normalize_host_local_host(host) == host
+
+
+@pytest.mark.unit
+def test_normalize_host_local_authority_rebuilds_host_local_keeping_port() -> None:
+    """A host-local authority rebuilds to the gateway, keeping the resolved port and
+    dropping userinfo (the host gateway needs no credentials)."""
+    normalized = provider_readiness_helpers._normalize_host_local_authority(
+        urlsplit("http://user:pass@127.0.0.1:11434/v1")
+    )
+    assert normalized.hostname == "host.docker.internal"
+    assert normalized.port == 11434
+    assert normalized.username is None
+
+
+@pytest.mark.unit
+def test_normalize_host_local_authority_rebuilds_host_local_without_port() -> None:
+    """Defensive: a host-local authority with no port (``_default_ollama_port`` always
+    supplies one upstream) rebuilds to the bare gateway host."""
+    normalized = provider_readiness_helpers._normalize_host_local_authority(
+        urlsplit("http://localhost/v1")
+    )
+    assert normalized.netloc == "host.docker.internal"
+    assert normalized.port is None
+
+
+@pytest.mark.unit
+def test_normalize_host_local_authority_passes_through_non_host_local_and_hostless() -> None:
+    """A non-host-local authority and a hostless authority are returned unchanged so
+    the #577 userinfo-port behavior survives for routable hosts."""
+    routable = urlsplit("http://user:pass@ollama.local:11434/v1")
+    assert provider_readiness_helpers._normalize_host_local_authority(routable) is routable
+    hostless = urlsplit("http://")
+    assert provider_readiness_helpers._normalize_host_local_authority(hostless) is hostless
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_retry.py
+++ b/tests/unit/service/test_workspace_retry.py
@@ -100,10 +100,14 @@ async def test_create_preflight_probes_profile_ollama_daemon(
     probe so admission targets the same daemon the executor's pre-agent step
     reaches — not the worker env's daemon (regression for PRRT_kwDOSJAM6s6JU0zF).
 
-    Both URLs are worker-reachable loopback hosts so the create-time daemon probe
-    actually runs for the ``:cloud`` model: a non-worker-reachable sidecar URL now
-    defers the probe to the agent container (PRRT_kwDOSJAM6s6JV_Rl), which would
-    leave nothing to assert the overlay against."""
+    Both URLs are worker-reachable host-gateway aliases so the create-time daemon
+    probe actually runs for the ``:cloud`` model: a non-worker-reachable sidecar URL
+    now defers the probe to the agent container (PRRT_kwDOSJAM6s6JV_Rl), which would
+    leave nothing to assert the overlay against. The two distinct gateway aliases are
+    used rather than ``localhost`` / ``127.0.0.1`` because host-local targets now both
+    normalize to ``host.docker.internal`` (issue #579), which would make the
+    profile-vs-worker daemon indistinguishable here; ``gateway.docker.internal`` is
+    worker-reachable and not collapsed by that normalization."""
     settings = _settings_with_host_home(tmp_path)
 
     payload = _request(provider_readiness_override=False).model_dump(mode="python")
@@ -115,7 +119,7 @@ async def test_create_preflight_probes_profile_ollama_daemon(
             "name": "ollama-profile-host",
             "runtime": {
                 "environment": {
-                    "AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434",
+                    "AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434",
                 },
             },
         },
@@ -135,7 +139,7 @@ async def test_create_preflight_probes_profile_ollama_daemon(
             settings=settings,
             provider_environ={
                 "OLLAMA_API_KEY": "ollama_secret",
-                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
+                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://host.docker.internal:11434",
             },
             run_subprocess=_docker_ok,
             http_get=_capturing_http_get,
@@ -144,8 +148,8 @@ async def test_create_preflight_probes_profile_ollama_daemon(
     preflight = workspace.task_policy["provider_readiness_preflight"]
     assert preflight["provider"] == "opencode"
     assert probed, "expected the create-time readiness probe to hit the Ollama daemon"
-    assert all("localhost:11434" in url for url in probed)
-    assert all("127.0.0.1" not in url for url in probed)
+    assert all("gateway.docker.internal:11434" in url for url in probed)
+    assert all("host.docker.internal" not in url for url in probed)
 
 
 async def test_create_with_provider_readiness_override_records_policy_and_event(
@@ -282,10 +286,13 @@ async def test_retry_preflight_probes_source_profile_ollama_daemon(
     pre-agent step reaches — not the worker env's daemon (regression for
     PRRT_kwDOSJAM6s6JU4FX).
 
-    Both URLs are worker-reachable loopback hosts so the retry daemon probe
+    Both URLs are worker-reachable host-gateway aliases so the retry daemon probe
     actually runs for the ``:cloud`` model: a non-worker-reachable sidecar URL now
     defers the probe to the agent container (PRRT_kwDOSJAM6s6JV_Rl), which would
-    leave nothing to assert the overlay against."""
+    leave nothing to assert the overlay against. The two distinct gateway aliases are
+    used rather than ``localhost`` / ``127.0.0.1`` because host-local targets now both
+    normalize to ``host.docker.internal`` (issue #579), which would make the
+    source-profile-vs-retry-env daemon indistinguishable here."""
     settings = _settings_with_host_home(tmp_path)
 
     payload = _request(provider_readiness_override=False).model_dump(mode="python")
@@ -297,7 +304,7 @@ async def test_retry_preflight_probes_source_profile_ollama_daemon(
             "name": "ollama-profile-host",
             "runtime": {
                 "environment": {
-                    "AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434",
+                    "AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434",
                 },
             },
         },
@@ -311,7 +318,7 @@ async def test_retry_preflight_probes_source_profile_ollama_daemon(
             settings=settings,
             provider_environ={
                 "OLLAMA_API_KEY": "ollama_secret",
-                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://localhost:11434",
+                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://gateway.docker.internal:11434",
             },
             run_subprocess=_docker_ok,
             http_get=_ollama_ok,
@@ -332,15 +339,15 @@ async def test_retry_preflight_probes_source_profile_ollama_daemon(
             settings=settings,
             provider_environ={
                 "OLLAMA_API_KEY": "ollama_secret",
-                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://127.0.0.1:11434",
+                "AWF_OPENCODE_OLLAMA_BASE_URL": "http://host.docker.internal:11434",
             },
             run_subprocess=_docker_ok,
             http_get=_capturing_http_get,
         )
 
     assert probed, "expected the retry readiness probe to hit the Ollama daemon"
-    assert all("localhost:11434" in url for url in probed)
-    assert all("127.0.0.1" not in url for url in probed)
+    assert all("gateway.docker.internal:11434" in url for url in probed)
+    assert all("host.docker.internal" not in url for url in probed)
 
 
 async def test_retry_with_provider_readiness_override_records_source_and_target(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_14abdf47c2a04cdf9d985b79` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `high`).


### Task
Fix issue #579 (deferred from PR #577). BUG: when the local-service environment inherits a host Ollama value like OLLAMA_HOST=http://127.0.0.1:11434, localhost, or 0.0.0.0, the OpenCode launcher prelude in src/awf/adapters/opencode.py exports that same loopback/unspecified address into the agent container as AWF_OPENCODE_OLLAMA_BASE_URL. But the workspace compose network only reaches the host daemon via host.docker.internal, so a loopback/unspecified address points at the AGENT CONTAINER ITSELF, not the host Ollama daemon — preflight can reject a working host-Ollama setup, or the agent fails later against its own container.

=== LOCKED DESIGN (engineering review; owner-approved) ===
Normalize host-local Ollama addresses to the Docker host-gateway (host.docker.internal) BEFORE they are used, MIRRORED in BOTH the shell launcher prelude AND the Python worker preflight, with a PARITY TEST that asserts the two implementations agree. (Chosen over a Python-only single-source because the codebase already mirrors launch<->preflight logic in shell + Python by design — see the opencode.py:113-125 docstring "so launch and preflight always agree"; keep that pattern.)

HOST-LOCAL SET to normalize -> host.docker.internal (preserving the port):
- IPv4 loopback 127.0.0.0/8  (any 127.x.x.x, e.g. 127.0.0.1)
- IPv6 loopback ::1  (bracketed: [::1])
- localhost
- IPv4 unspecified 0.0.0.0
- IPv6 unspecified ::  (bracketed: [::])
Do NOT normalize: the configured host's own hostname, routable LAN IPs, Compose service DNS names (e.g. ollama-sidecar), or host.docker.internal/gateway.docker.internal themselves — those pass through unchanged.

1. SHELL prelude (src/awf/adapters/opencode.py, the `_opencode_ollama_base_url_prelude`-style snippet ~lines 127-167):
   After the existing userinfo-strip + port-default logic computes the authority, translate a host-local HOST part
   (the host portion of the authority, after stripping userinfo and port) to host.docker.internal while KEEPING the
   resolved port. Handle bracketed IPv6 ([::1], [::]) and the 127.* range. The result still flows through the existing
   scheme/port/`/v1` normalization. Keep AWF_OPENCODE_OLLAMA_BASE_URL precedence over OLLAMA_HOST and the default
   fallback unchanged.

2. PYTHON preflight (src/awf/service/provider_readiness_helpers.py): apply the SAME host-local -> host.docker.internal
   normalization in the Ollama base-URL resolution used by the worker probe/pull + the host-reachability classification
   (`_parse_ollama_base_url` / `_ollama_api_urls` / `_ollama_url_host_reachable_from_worker` /
   `_WORKER_HOST_REACHABLE_HOSTNAMES`), so the worker and the launcher resolve the SAME daemon URL. Define the host-local
   set + the host-gateway target as a single Python source of truth (constant/helper) that the Python side uses; the
   shell mirrors it.

3. PARITY TEST: a test that runs the shell prelude (e.g. via `sh -c`) and the Python normalization over a shared table
   of representative inputs (127.0.0.1:11434, http://localhost, 0.0.0.0:11434, http://[::1]:11434, [::]:11434,
   host.docker.internal:11434, ollama-sidecar:11434, a routable LAN IP, a port-less host, a user:pass@ userinfo case)
   and asserts they produce the SAME normalized AWF_OPENCODE_OLLAMA_BASE_URL / resolved host. This is what keeps the two
   implementations honest.

=== EDGE CASES (cover all) ===
- OLLAMA_HOST=http://127.0.0.1:11434  -> AWF_OPENCODE_OLLAMA_BASE_URL=http://host.docker.internal:11434/v1 (port kept).
- OLLAMA_HOST=localhost (port-less) -> host.docker.internal:11434/v1 (default port applied, host normalized).
- OLLAMA_HOST=0.0.0.0:11434 -> host.docker.internal:11434/v1.
- OLLAMA_HOST=http://[::1]:11434 and [::]:11434 -> host.docker.internal:11434/v1 (IPv6 loopback/unspecified).
- OLLAMA_HOST with userinfo (http://user:pass@127.0.0.1:11434) -> userinfo stripped + host normalized -> host.docker.internal:11434/v1 (the #577 userinfo fix stays correct).
- A Compose service (http://ollama-sidecar:11434) -> UNCHANGED (not host-local); worker still skips its probe per #569.
- A routable LAN IP / the configured host hostname -> UNCHANGED.
- host.docker.internal / gateway.docker.internal -> UNCHANGED (already host-gateway).
- AWF_OPENCODE_OLLAMA_BASE_URL set (wins over OLLAMA_HOST) with a host-local host -> ALSO normalized.
- Missing/blank/garbled -> existing host.docker.internal default behavior, no crash.

=== TESTS (TDD, strict ~99% coverage; the CI coverage gate is exact) ===
- The parity test above (shell == Python over the input table).
- Launcher: each host-local input -> exported base URL uses host.docker.internal with the right port + /v1; non-host-local inputs pass through.
- Preflight: host-local input resolves/probes host.docker.internal; classification + reachability consistent with the launcher.
- AMEND the existing 0.0.0.0 / ::1 pass-through regression tests in the adapter tests (test_adapters.py and any provider_readiness tests that lock the OLD pass-through behavior) to the NEW normalize-to-host.docker.internal contract — update them, do not delete the coverage.

=== SCOPE GUARDS ===
- Owned paths: `src/awf/adapters/**`, `src/awf/service/**`, `tests/**`.
- Do NOT modify `.github/workflows/**` or `.awf/workspace.yml`. Keep the #577 userinfo-port fix intact. Do NOT broaden beyond the host-local set above.
- Reference #579 in the PR. Run ruff + mypy clean; keep the OpenAPI/contract gates green.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared Ollama URL resolution for agent launch and worker probes; incorrect host-local matching could misroute agents or skip probes, but behavior is heavily parametrized and parity-tested.
> 
> **Overview**
> Fixes **#579**: when `OLLAMA_HOST` or `AWF_OPENCODE_OLLAMA_BASE_URL` uses loopback, `localhost`, or unspecified addresses (`0.0.0.0` / `::`), the OpenCode agent container was targeting **itself** instead of the host Ollama daemon.
> 
> **Worker preflight** (`provider_readiness_helpers`) adds `_normalize_host_local_host` / `_normalize_host_local_authority` and applies them in `_parse_ollama_base_url` after port defaulting, rewriting host-local authorities to `host.docker.internal` (port kept, userinfo dropped). Worker reachability now treats only `host.docker.internal` / `gateway.docker.internal` as host-reachable, since loopback inputs are normalized upstream.
> 
> **Shell launcher prelude** (`_ollama_base_url_prelude` in `opencode.py`) mirrors the same rules, including expanded IPv6 loopback/unspecified literals and case-insensitive `localhost`.
> 
> A **parity test** runs the real shell prelude against `_parse_ollama_base_url` so launch and preflight stay aligned. Existing tests are updated from old pass-through loopback expectations to the gateway contract; profile-vs-worker daemon tests use distinct gateway aliases instead of `127.*` pairs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c2136883c7727bf3bd0a90c8aa6323d82446a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Ollama daemon host connectivity for containerized deployments. Localhost and loopback address references now correctly normalize to the Docker host gateway, improving daemon reachability from containers running within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->