### PR TITLE
[codex] Add transient retry for PR creation

### DIFF
--- a/plans/PRRT_kwDOSJAM6s6JuSPr_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6JuSPr_PLAN.md
@@ -1,0 +1,10 @@
+# PRRT_kwDOSJAM6s6JuSPr Duplicate Lookup Plan
+
+## Scope
+Fix PR creator duplicate-PR reconciliation so a failed `gh pr list` lookup is not treated as a genuine empty result.
+
+## Steps
+1. Add a focused regression test for duplicate `gh pr create` plus failed reconciliation lookup.
+2. Update `src/awf/runtime/pr_creator.py` to distinguish failed lookup details from not-found lookup details on duplicate errors.
+3. Run the narrow affected test(s) only; AWF/GitHub own broad validation after this agent phase.
+4. Record validation outcome in `plans/PRRT_kwDOSJAM6s6JuSPr_VALIDATION.md`.

--- a/plans/PRRT_kwDOSJAM6s6JuSPr_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6JuSPr_VALIDATION.md
@@ -1,0 +1,17 @@
+# PRRT_kwDOSJAM6s6JuSPr Duplicate Lookup Validation
+
+## Plan Check
+- Added focused duplicate-PR regression coverage for a failed reconciliation lookup followed by a successful retry.
+- Added focused coverage for the terminal case where duplicate reconciliation lookups are exhausted.
+- Updated `src/awf/runtime/pr_creator.py` so duplicate lookup failures retry within the existing PR-create retry budget and report `duplicate_lookup_failed` when exhausted.
+
+## Evidence
+- Confirmed the new retry regression failed before the production change:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_duplicate_pr_create_retries_failed_lookup -q`
+- Passed focused runtime tests:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_duplicate_pr_create_retries_failed_lookup tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_duplicate_pr_create_reports_exhausted_lookup_failure tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_duplicate_pr_create_error_reconciles_existing_pr -q`
+- Passed targeted lint:
+  `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_creator.py tests/unit/runtime/test_pr_creator.py`
+
+## Broad Validation
+Full AWF/GitHub validation is managed after agent completion; it was not run during this focused fix cycle.

--- a/plans/PRRT_kwDOSJAM6s6JuWDH_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6JuWDH_PLAN.md
@@ -1,0 +1,19 @@
+# PRRT_kwDOSJAM6s6JuWDH Plan
+
+## Problem Statement and Scope
+
+GitHub PR creation can lose retry evidence when a retry eventually returns an empty PR URL. The fix is limited to preserving structured retry details on that terminal error path.
+
+## Requirements Checklist
+
+- Verify the inline review against the current `src/awf/runtime/pr_creator.py` implementation.
+- Add a focused regression test for transient GitHub PR creation failure followed by an empty URL.
+- Preserve accumulated `failures` and `reconcile_lookups` in the raised `PullRequestError.details`.
+- Run only targeted validation for the changed behavior; full AWF/GitHub validation remains managed after agent completion.
+
+## Implementation Steps
+
+1. Add a failing unit test in `tests/unit/runtime/test_pr_creator.py`.
+2. Update the GitHub empty-URL terminal path in `src/awf/runtime/pr_creator.py` to attach `_github_pr_create_details(...)`.
+3. Re-run the focused unit test.
+4. Record validation evidence in `plans/PRRT_kwDOSJAM6s6JuWDH_VALIDATION.md`.

--- a/plans/PRRT_kwDOSJAM6s6JuWDH_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6JuWDH_VALIDATION.md
@@ -1,0 +1,21 @@
+# PRRT_kwDOSJAM6s6JuWDH Validation
+
+Plan reference: `plans/PRRT_kwDOSJAM6s6JuWDH_PLAN.md`
+
+## Requirement Status
+
+- Verify the inline review against the current implementation: Complete. The GitHub retry-loop empty-URL path raised `PullRequestError` without `details`.
+- Add a focused regression test: Complete. Added `test_github_transient_pr_create_failure_then_empty_url_preserves_retry_details`.
+- Preserve accumulated retry evidence: Complete. The empty-URL GitHub terminal path now attaches `_github_pr_create_details(...)` with failures and reconcile lookups.
+- Run focused validation only: Complete. Full AWF/GitHub validation remains managed by AWF after agent completion.
+
+## Evidence
+
+- Changed `src/awf/runtime/pr_creator.py`.
+- Changed `tests/unit/runtime/test_pr_creator.py`.
+- Confirmed the new regression failed before the implementation change:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_transient_pr_create_failure_then_empty_url_preserves_retry_details -q`
+- Passed after the fix:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_creator.py::TestPushAndOpen::test_github_transient_pr_create_failure_then_empty_url_preserves_retry_details -q`
+- Passed targeted suite:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_creator.py -q`

--- a/plans/PR_CREATE_TRANSIENT_RETRY_PLAN.md
+++ b/plans/PR_CREATE_TRANSIENT_RETRY_PLAN.md
@@ -1,0 +1,34 @@
+# Add Redundant PR Creation For Transient GitHub Failures
+
+## Summary
+
+Feature workspaces can validate and push successfully, then fail during
+`gh pr create` when GitHub returns a transient GraphQL/network error. The pushed
+branch is left for a human to salvage. Add bounded retry and same-repo PR
+reconciliation to the executor PR-open path so transient forge failures do not
+strand completed work.
+
+## Implementation Plan
+
+- Keep the normal happy path as a single `gh pr create` call.
+- Add shared GitHub transient classification for API/CLI errors and reuse it
+  from both PR monitor retries and feature PR creation.
+- After a transient or duplicate-PR create failure, run a same-repo open-PR
+  lookup scoped by head branch and base branch.
+- If the lookup finds a matching PR, return it as the PR result and continue the
+  existing executor handoff.
+- If no PR is found, retry transient create failures with a small exponential
+  backoff budget; deterministic errors still fail immediately.
+- Include retry/reconciliation metadata in PR audit evidence and final failure
+  evidence without changing the downstream executor state machine.
+
+## Validation Plan
+
+- Add focused PR creator tests for transient retry success, transient
+  reconciliation, duplicate reconciliation, fork-collision rejection, and
+  deterministic no-retry behavior.
+- Add/adjust executor tests so PR-create failure evidence carries retry metadata
+  when retry exhaustion occurs while existing exact evidence remains unchanged
+  for ordinary deterministic failures.
+- Run targeted PR creator/executor tests plus `ruff` and `mypy` on touched
+  Python files.

--- a/plans/PR_CREATE_TRANSIENT_RETRY_VALIDATION.md
+++ b/plans/PR_CREATE_TRANSIENT_RETRY_VALIDATION.md
@@ -1,0 +1,22 @@
+# PR Create Transient Retry Validation
+
+## Commands Run
+
+- `uv run --python 3.12 --extra dev python -m pytest tests/unit/runtime/test_pr_creator.py tests/unit/control/test_executor_parts/test_executor_part_005.py::TestFailurePaths::test_transient_pr_create_exhaustion_records_retry_evidence tests/unit/common/test_github_client_parts/test_github_client_part_001.py::TestListOpenPullRequestsForBranch tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py::test_transient_github_error_classifier_keeps_auth_errors_terminal -q`
+- `uv run --python 3.12 --extra dev ruff check src/awf/common/github_transient.py src/awf/runtime/pr_creator.py src/awf/runtime/pr_monitor_runner/constants.py src/awf/control/executor/pr_open_step.py src/awf/control/executor/execution_flow.py tests/unit/runtime/test_pr_creator.py tests/unit/control/test_executor_parts/test_executor_part_005.py`
+- `uv run --python 3.12 --extra dev mypy src/awf/common/github_transient.py src/awf/runtime/pr_creator.py src/awf/runtime/pr_monitor_runner/constants.py src/awf/control/executor/pr_open_step.py src/awf/control/executor/execution_flow.py`
+
+## Results
+
+- Targeted pytest: `43 passed`.
+- Ruff: passed.
+- Mypy: passed on touched source files.
+
+## Coverage Notes
+
+- Covered transient `gh pr create` retry success.
+- Covered transient `gh pr create` reconciliation with a same-repo open PR.
+- Covered duplicate/already-exists reconciliation.
+- Covered fork PR collision rejection.
+- Covered deterministic GitHub create failure without retry/lookup.
+- Covered executor audit evidence for exhausted transient PR creation.

--- a/src/awf/common/github_transient.py
+++ b/src/awf/common/github_transient.py
@@ -1,0 +1,65 @@
+"""Shared GitHub transient-failure classification helpers."""
+
+from __future__ import annotations
+
+NON_TRANSIENT_GITHUB_ERROR_MARKERS = (
+    "bad credentials",
+    "not logged in",
+    "please run gh auth login",
+    "not found",
+    "could not resolve to a repository",
+    "could not resolve to a node",
+)
+
+TRANSIENT_GITHUB_ERROR_MARKERS = (
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+    "500 internal server",
+    "502 bad gateway",
+    "503 service unavailable",
+    "504 gateway timeout",
+    "bad gateway",
+    "gateway timeout",
+    "internal server error",
+    "returned error: 500",
+    "returned error: 502",
+    "returned error: 503",
+    "returned error: 504",
+    "service unavailable",
+    "temporarily unavailable",
+    "try again",
+    "timed out",
+    "timeout",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "tls handshake timeout",
+    "network",
+    "eof",
+    "rate limit",
+    "secondary rate limit",
+    "abuse detection",
+    "something went wrong",
+    "could not resolve host",
+    "temporary failure in name resolution",
+    "name or service not known",
+    "could not resolve proxy",
+)
+
+AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = (
+    "http 401",
+    "requires authentication",
+)
+
+
+def is_transient_github_error_text(*, operation: str, stderr: str) -> bool:
+    """Return whether a GitHub CLI/API failure looks transient."""
+
+    text = f"{operation}\n{stderr}".lower()
+    if any(marker in text for marker in NON_TRANSIENT_GITHUB_ERROR_MARKERS):
+        return False
+    if any(marker in text for marker in TRANSIENT_GITHUB_ERROR_MARKERS):
+        return True
+    return any(marker in text for marker in AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS)

--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -1408,6 +1408,7 @@ async def execute(
             pr_number=persisted.pr_number,
             pr_url=persisted.pr_url,
             source_head_sha=pr.head_sha,
+            evidence=pr.open_metadata,
         )
         # Resolve which monitor (if any) to hand off to. Pre-constructed
         # ``pr_monitor`` wins (tests); otherwise the factory builds one

--- a/src/awf/control/executor/pr_open_step.py
+++ b/src/awf/control/executor/pr_open_step.py
@@ -168,6 +168,13 @@ async def push_and_open_pr(
                 pr_url=ws.pr_url,
                 source_head_sha=exc.head_sha,
             )
+        evidence = {
+            "operation": exc.operation,
+            "returncode": exc.returncode,
+            "error_message": exc.stderr.strip() or "<no output>",
+        }
+        if exc.details is not None:
+            evidence["details"] = exc.details
         await self._record_executor_pr_audit_event(
             workspace_id,
             event_type=(
@@ -185,11 +192,7 @@ async def push_and_open_pr(
             pr_number=_extract_pr_number(ws.pr_url) if ws.pr_url else None,
             pr_url=ws.pr_url,
             source_head_sha=exc.head_sha,
-            evidence={
-                "operation": exc.operation,
-                "returncode": exc.returncode,
-                "error_message": exc.stderr.strip() or "<no output>",
-            },
+            evidence=evidence,
         )
         await self._mark_failed(
             workspace_id=workspace_id,

--- a/src/awf/runtime/pr_creator.py
+++ b/src/awf/runtime/pr_creator.py
@@ -18,14 +18,23 @@ call (``gh pr create`` for GitHub, the REST API for Bitbucket).
 
 from __future__ import annotations
 
+import asyncio
 import re
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 
 from awf.common.commands import AsyncCommandRunner
 from awf.common.forge import ForgeClient
 from awf.common.git_identity import git_safe_directory_config_args
-from awf.common.github_client import GitHubClientError, RepoRef
+from awf.common.github_client import (
+    BranchOpenPullRequest,
+    GitHubClientError,
+    PullRequestMetadataError,
+    RepoRef,
+    list_open_pull_requests_for_branch,
+)
+from awf.common.github_transient import is_transient_github_error_text
 from awf.common.logging import get_logger
 
 _log = get_logger(__name__)
@@ -43,6 +52,11 @@ _URL_CREDENTIAL_PATTERN = re.compile(r"(https?://)[^/@\s]+(?::[^/@\s]+)?@")
 # exceed log-backend payload limits.
 _MAX_DIAGNOSTIC_COMMITS = 50
 _HEADS_REF_PREFIX = "refs/heads/"
+_PR_CREATE_TRANSIENT_MAX_RETRIES = 3
+_PR_CREATE_TRANSIENT_INITIAL_BACKOFF_SECONDS = 5.0
+_PR_CREATE_TRANSIENT_MAX_BACKOFF_SECONDS = 30.0
+
+_Sleep = Callable[[float], Awaitable[None]]
 
 
 def _redact_credentials(text: str) -> str:
@@ -56,11 +70,88 @@ def _short_branch_name(branch_name: str) -> str:
     return branch_name.removeprefix(_HEADS_REF_PREFIX)
 
 
+def _is_duplicate_pull_request_error(exc: GitHubClientError) -> bool:
+    return exc.returncode == 1 and "already exists" in exc.stderr.lower()
+
+
+def _short_error(text: str) -> str:
+    cleaned = text.strip() or "<no output>"
+    return cleaned[:1000]
+
+
+def _github_pr_create_failure_detail(
+    exc: GitHubClientError,
+    *,
+    attempt: int,
+    transient: bool,
+    duplicate: bool,
+) -> dict[str, object]:
+    return {
+        "attempt": attempt,
+        "operation": exc.operation,
+        "returncode": exc.returncode,
+        "error_message": _short_error(exc.stderr),
+        "transient": transient,
+        "duplicate": duplicate,
+        "will_retry": False,
+    }
+
+
+def _branch_open_pr_metadata(pr: BranchOpenPullRequest) -> dict[str, object]:
+    metadata: dict[str, object] = {
+        "number": pr.number,
+        "url": pr.url,
+        "head_ref": pr.head_ref,
+        "head_repo_slug": pr.head_repo_slug,
+    }
+    if pr.head_sha is not None:
+        metadata["head_sha"] = pr.head_sha
+    return metadata
+
+
+def _github_pr_create_details(
+    *,
+    strategy: str,
+    attempts: int,
+    max_retries: int,
+    failures: list[dict[str, object]],
+    lookups: list[dict[str, object]],
+    matched_pr: dict[str, object] | None = None,
+) -> dict[str, object]:
+    details: dict[str, object] = {
+        "strategy": strategy,
+        "attempts": attempts,
+        "retry_count": max(attempts - 1, 0),
+        "max_retries": max_retries,
+        "failures": list(failures),
+        "reconcile_lookups": list(lookups),
+    }
+    if matched_pr is not None:
+        details["matched_pr"] = matched_pr
+    return details
+
+
+def _pull_request_error_from_github(
+    exc: GitHubClientError,
+    *,
+    head_sha: str | None,
+    details: dict[str, object] | None = None,
+) -> PullRequestError:
+    return PullRequestError(
+        operation=exc.operation,
+        returncode=exc.returncode,
+        stderr=exc.stderr,
+        head_sha=head_sha,
+        details=details,
+    )
+
+
 @dataclass(frozen=True)
 class PullRequestResult:
     url: str
     branch: str
     head_sha: str | None = None
+    open_metadata: dict[str, object] | None = None
 
 
 class PullRequestError(Exception):
@@ -74,11 +165,13 @@ class PullRequestError(Exception):
         stderr: str,
         head_sha: str | None = None,
         reason_code: str | None = None,
+        details: dict[str, object] | None = None,
     ) -> None:
         self.operation = operation
         self.returncode = returncode
         self.stderr = stderr
         self.head_sha = head_sha
+        self.details = details
         # Forge clients that carry an actionable reason code (e.g.
         # ``BitbucketClientError`` with auth / rate-limit / transport codes)
         # propagate it here so the executor records the specific doctor
@@ -94,8 +187,28 @@ class PullRequestError(Exception):
 class PullRequestCreator:
     """Pushes a feature branch and opens a PR via an injected ``ForgeClient``."""
 
-    def __init__(self, runner: AsyncCommandRunner) -> None:
+    def __init__(
+        self,
+        runner: AsyncCommandRunner,
+        *,
+        pr_create_transient_max_retries: int = _PR_CREATE_TRANSIENT_MAX_RETRIES,
+        pr_create_transient_initial_backoff_seconds: float = (
+            _PR_CREATE_TRANSIENT_INITIAL_BACKOFF_SECONDS
+        ),
+        pr_create_transient_max_backoff_seconds: float = _PR_CREATE_TRANSIENT_MAX_BACKOFF_SECONDS,
+        sleep: _Sleep = asyncio.sleep,
+    ) -> None:
         self._runner = runner
+        self._pr_create_transient_max_retries: int = max(pr_create_transient_max_retries, 0)
+        self._pr_create_transient_initial_backoff_seconds: float = max(
+            pr_create_transient_initial_backoff_seconds,
+            0.0,
+        )
+        self._pr_create_transient_max_backoff_seconds: float = max(
+            pr_create_transient_max_backoff_seconds,
+            0.0,
+        )
+        self._sleep: _Sleep = sleep
 
     async def push_and_open(
         self,
@@ -201,6 +314,16 @@ class PullRequestCreator:
 
         repo = RepoRef.from_url(remote_url or repo_url)
         try:
+            if repo.forge == "github":
+                return await self._create_github_pull_request_with_redundancy(
+                    forge_client=forge_client,
+                    repo=repo,
+                    base_branch=base_branch,
+                    branch_name=branch_name,
+                    title=title,
+                    body=body,
+                    head_sha=head_sha,
+                )
             url = await forge_client.create_pull_request(
                 repo=repo,
                 base=base_branch,
@@ -208,6 +331,8 @@ class PullRequestCreator:
                 title=title,
                 body=body,
             )
+        except PullRequestError:
+            raise
         except GitHubClientError as exc:
             # Preserve the structured returncode + already-redacted stderr +
             # operation (never ``str(exc)``, which could leak unredacted output);
@@ -244,6 +369,222 @@ class PullRequestCreator:
 
         _log.info("pr.created", branch=branch_name, url=url)
         return PullRequestResult(url=url, branch=branch_name, head_sha=head_sha)
+
+    async def _create_github_pull_request_with_redundancy(
+        self,
+        *,
+        forge_client: ForgeClient,
+        repo: RepoRef,
+        base_branch: str,
+        branch_name: str,
+        title: str,
+        body: str,
+        head_sha: str | None,
+    ) -> PullRequestResult:
+        failures: list[dict[str, object]] = []
+        lookups: list[dict[str, object]] = []
+        attempt = 0
+
+        while True:
+            attempt += 1
+            try:
+                url = await forge_client.create_pull_request(
+                    repo=repo,
+                    base=base_branch,
+                    head=branch_name,
+                    title=title,
+                    body=body,
+                )
+            except GitHubClientError as exc:
+                duplicate = _is_duplicate_pull_request_error(exc)
+                transient = is_transient_github_error_text(
+                    operation=exc.operation,
+                    stderr=exc.stderr,
+                )
+                failure = _github_pr_create_failure_detail(
+                    exc,
+                    attempt=attempt,
+                    transient=transient,
+                    duplicate=duplicate,
+                )
+                failures.append(failure)
+                if not transient and not duplicate:
+                    raise _pull_request_error_from_github(
+                        exc,
+                        head_sha=head_sha,
+                        details=_github_pr_create_details(
+                            strategy="failed",
+                            attempts=attempt,
+                            max_retries=self._pr_create_transient_max_retries,
+                            failures=failures,
+                            lookups=lookups,
+                        ),
+                    ) from exc
+
+                existing_pr, lookup_detail = await self._lookup_same_repo_open_pr(
+                    repo=repo,
+                    branch_name=branch_name,
+                    base_branch=base_branch,
+                )
+                lookups.append(lookup_detail)
+                if existing_pr is not None:
+                    metadata = _github_pr_create_details(
+                        strategy=(
+                            "reconciled_after_duplicate"
+                            if duplicate
+                            else "reconciled_after_transient"
+                        ),
+                        attempts=attempt,
+                        max_retries=self._pr_create_transient_max_retries,
+                        failures=failures,
+                        lookups=lookups,
+                        matched_pr=_branch_open_pr_metadata(existing_pr),
+                    )
+                    _log.info(
+                        "pr_creator.github_pr_create_reconciled",
+                        repo=repo.slug(),
+                        branch=branch_name,
+                        base_branch=base_branch,
+                        attempt=attempt,
+                        pr_url=existing_pr.url,
+                        pr_number=existing_pr.number,
+                        strategy=metadata["strategy"],
+                    )
+                    return PullRequestResult(
+                        url=existing_pr.url,
+                        branch=existing_pr.head_ref or branch_name,
+                        head_sha=existing_pr.head_sha or head_sha,
+                        open_metadata=metadata,
+                    )
+
+                if duplicate:
+                    raise _pull_request_error_from_github(
+                        exc,
+                        head_sha=head_sha,
+                        details=_github_pr_create_details(
+                            strategy="duplicate_lookup_missed",
+                            attempts=attempt,
+                            max_retries=self._pr_create_transient_max_retries,
+                            failures=failures,
+                            lookups=lookups,
+                        ),
+                    ) from exc
+
+                if attempt > self._pr_create_transient_max_retries:
+                    details = _github_pr_create_details(
+                        strategy="transient_retry_exhausted",
+                        attempts=attempt,
+                        max_retries=self._pr_create_transient_max_retries,
+                        failures=failures,
+                        lookups=lookups,
+                    )
+                    _log.warning(
+                        "pr_creator.github_pr_create_retry_exhausted",
+                        repo=repo.slug(),
+                        branch=branch_name,
+                        base_branch=base_branch,
+                        attempt=attempt,
+                        max_retries=self._pr_create_transient_max_retries,
+                        error=failure["error_message"],
+                    )
+                    raise _pull_request_error_from_github(
+                        exc,
+                        head_sha=head_sha,
+                        details=details,
+                    ) from exc
+
+                wait_seconds = self._pr_create_retry_wait_seconds(attempt)
+                failure["will_retry"] = True
+                failure["wait_seconds"] = wait_seconds
+                _log.warning(
+                    "pr_creator.github_pr_create_retrying",
+                    repo=repo.slug(),
+                    branch=branch_name,
+                    base_branch=base_branch,
+                    attempt=attempt,
+                    max_retries=self._pr_create_transient_max_retries,
+                    wait_seconds=wait_seconds,
+                    error=failure["error_message"],
+                )
+                if wait_seconds > 0:
+                    await self._sleep(wait_seconds)
+                continue
+
+            if not url:
+                raise PullRequestError(
+                    operation="create_pull_request (no URL)",
+                    returncode=0,
+                    stderr="forge returned an empty PR URL",
+                    head_sha=head_sha,
+                )
+            open_metadata = (
+                _github_pr_create_details(
+                    strategy="created_after_retry",
+                    attempts=attempt,
+                    max_retries=self._pr_create_transient_max_retries,
+                    failures=failures,
+                    lookups=lookups,
+                )
+                if failures
+                else None
+            )
+            _log.info("pr.created", branch=branch_name, url=url, attempts=attempt)
+            return PullRequestResult(
+                url=url,
+                branch=branch_name,
+                head_sha=head_sha,
+                open_metadata=open_metadata,
+            )
+
+    async def _lookup_same_repo_open_pr(
+        self,
+        *,
+        repo: RepoRef,
+        branch_name: str,
+        base_branch: str,
+    ) -> tuple[BranchOpenPullRequest | None, dict[str, object]]:
+        try:
+            candidates = await list_open_pull_requests_for_branch(
+                runner=self._runner,
+                repo=repo,
+                branch_name=branch_name,
+                base_branch=base_branch,
+            )
+        except PullRequestMetadataError as exc:
+            lookup_failure_detail: dict[str, object] = {
+                "status": "failed",
+                "reason_code": exc.reason_code,
+                "message": exc.message[:500],
+            }
+            _log.warning(
+                "pr_creator.github_pr_create_reconcile_lookup_failed",
+                repo=repo.slug(),
+                branch=branch_name,
+                base_branch=base_branch,
+                reason_code=exc.reason_code,
+                error=exc.message[:500],
+            )
+            return None, lookup_failure_detail
+
+        repo_slug = repo.slug().lower()
+        same_repo = [
+            candidate for candidate in candidates if candidate.head_repo_slug.lower() == repo_slug
+        ]
+        lookup_detail: dict[str, object] = {
+            "status": "found" if same_repo else "not_found",
+            "candidate_count": len(candidates),
+            "same_repo_count": len(same_repo),
+            "fork_collision_count": len(candidates) - len(same_repo),
+        }
+        if not same_repo:
+            return None, lookup_detail
+        match = same_repo[0]
+        lookup_detail["matched_pr"] = _branch_open_pr_metadata(match)
+        return match, lookup_detail
+
+    def _pr_create_retry_wait_seconds(self, retry_number: int) -> float:
+        wait = self._pr_create_transient_initial_backoff_seconds * (2 ** (retry_number - 1))
+        return float(min(wait, self._pr_create_transient_max_backoff_seconds))
 
     async def _log_pre_push_diagnostics(
         self,

--- a/src/awf/runtime/pr_creator.py
+++ b/src/awf/runtime/pr_creator.py
@@ -540,6 +540,13 @@ class PullRequestCreator:
                     returncode=0,
                     stderr="forge returned an empty PR URL",
                     head_sha=head_sha,
+                    details=_github_pr_create_details(
+                        strategy="failed",
+                        attempts=attempt,
+                        max_retries=self._pr_create_transient_max_retries,
+                        failures=failures,
+                        lookups=lookups,
+                    ),
                 )
             open_metadata = (
                 _github_pr_create_details(

--- a/src/awf/runtime/pr_creator.py
+++ b/src/awf/runtime/pr_creator.py
@@ -457,12 +457,36 @@ class PullRequestCreator:
                         open_metadata=metadata,
                     )
 
+                lookup_failed = lookup_detail.get("status") == "failed"
+                if duplicate and lookup_failed and attempt <= self._pr_create_transient_max_retries:
+                    wait_seconds = self._pr_create_retry_wait_seconds(attempt)
+                    failure["will_retry"] = True
+                    failure["wait_seconds"] = wait_seconds
+                    _log.warning(
+                        "pr_creator.github_pr_create_duplicate_lookup_retrying",
+                        repo=repo.slug(),
+                        branch=branch_name,
+                        base_branch=base_branch,
+                        attempt=attempt,
+                        max_retries=self._pr_create_transient_max_retries,
+                        wait_seconds=wait_seconds,
+                        reason_code=lookup_detail.get("reason_code"),
+                        error=failure["error_message"],
+                    )
+                    if wait_seconds > 0:
+                        await self._sleep(wait_seconds)
+                    continue
+
                 if duplicate:
                     raise _pull_request_error_from_github(
                         exc,
                         head_sha=head_sha,
                         details=_github_pr_create_details(
-                            strategy="duplicate_lookup_missed",
+                            strategy=(
+                                "duplicate_lookup_failed"
+                                if lookup_failed
+                                else "duplicate_lookup_missed"
+                            ),
                             attempts=attempt,
                             max_retries=self._pr_create_transient_max_retries,
                             failures=failures,

--- a/src/awf/runtime/pr_creator.py
+++ b/src/awf/runtime/pr_creator.py
@@ -606,8 +606,8 @@ class PullRequestCreator:
         lookup_detail["matched_pr"] = _branch_open_pr_metadata(match)
         return match, lookup_detail
 
-    def _pr_create_retry_wait_seconds(self, retry_number: int) -> float:
-        wait = self._pr_create_transient_initial_backoff_seconds * (2 ** (retry_number - 1))
+    def _pr_create_retry_wait_seconds(self, attempt: int) -> float:
+        wait = self._pr_create_transient_initial_backoff_seconds * (2 ** (attempt - 1))
         return float(min(wait, self._pr_create_transient_max_backoff_seconds))
 
     async def _log_pre_push_diagnostics(

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 
 import re
 
+from awf.common.github_transient import (
+    AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
+    NON_TRANSIENT_GITHUB_ERROR_MARKERS,
+    TRANSIENT_GITHUB_ERROR_MARKERS,
+)
 from awf.db.enums import OperationStatus, WorkspaceStatus
 from awf.runtime.pr_monitor_operations import RETRYABLE_MONITOR_OPERATION_STATUSES
 from awf.service.staleness import (
@@ -43,51 +48,8 @@ _TASK_TAG_UNSET = _TaskTagUnset()
 # on a valid token (#515) and is handled as bounded-retryable below. These strong
 # markers are checked first in ``_is_transient_github_client_error`` and win, so a
 # 401 combined with e.g. ``Bad credentials`` still fails fast.
-_NON_TRANSIENT_GITHUB_ERROR_MARKERS = (
-    "bad credentials",
-    "not logged in",
-    "please run gh auth login",
-    "not found",
-    "could not resolve to a repository",
-    "could not resolve to a node",
-)
-
-_TRANSIENT_GITHUB_ERROR_MARKERS = (
-    "http 500",
-    "http 502",
-    "http 503",
-    "http 504",
-    "500 internal server",
-    "502 bad gateway",
-    "503 service unavailable",
-    "504 gateway timeout",
-    "bad gateway",
-    "gateway timeout",
-    "internal server error",
-    "returned error: 500",
-    "returned error: 502",
-    "returned error: 503",
-    "returned error: 504",
-    "service unavailable",
-    "temporarily unavailable",
-    "try again",
-    "timed out",
-    "timeout",
-    "connection reset",
-    "connection refused",
-    "connection aborted",
-    "tls handshake timeout",
-    "network",
-    "eof",
-    "rate limit",
-    "secondary rate limit",
-    "abuse detection",
-    "something went wrong",
-    "could not resolve host",
-    "temporary failure in name resolution",
-    "name or service not known",
-    "could not resolve proxy",
-)
+_NON_TRANSIENT_GITHUB_ERROR_MARKERS = NON_TRANSIENT_GITHUB_ERROR_MARKERS
+_TRANSIENT_GITHUB_ERROR_MARKERS = TRANSIENT_GITHUB_ERROR_MARKERS
 
 # Ambiguous auth blips: a bare ``HTTP 401`` / ``Requires authentication`` with no
 # strong permanent marker is a recoverable transient on the GitHub *API* client
@@ -100,10 +62,7 @@ _TRANSIENT_GITHUB_ERROR_MARKERS = (
 # substring), which must fail fast rather than be bounded-retried. They are
 # therefore deliberately kept out of ``_TRANSIENT_GITHUB_ERROR_MARKERS`` so
 # ``_is_transient_base_fetch_error`` never matches them.
-_AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = (
-    "http 401",
-    "requires authentication",
-)
+_AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS
 
 _GITHUB_TRANSIENT_RETRY_REASON = "GITHUB_TRANSIENT_RETRY"
 

--- a/tests/unit/control/test_executor_parts/test_executor_part_005.py
+++ b/tests/unit/control/test_executor_parts/test_executor_part_005.py
@@ -903,6 +903,57 @@ class TestFailurePaths:
         assert "https://[redacted]@github.com/org/repo" in repr(pr_events[0].payload)
 
     @pytest.mark.unit
+    async def test_transient_pr_create_exhaustion_records_retry_evidence(
+        self,
+        executor: WorkspaceExecutor,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        executor._pr_creator = PullRequestCreator(  # noqa: SLF001
+            fake,
+            pr_create_transient_max_retries=0,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        ws_id = await _seed_ready_workspace(factory)
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout=f"awf/{ws_id}\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="f\n")
+        fake.queue_result(returncode=0)
+        fake.queue_result(returncode=0, stdout="1\n")
+        fake.queue_result(returncode=0)
+        _queue_validation_head(fake)
+        fake.queue_result(returncode=0)
+        _queue_pre_push_diagnostics(fake, head="pushed-head")
+        fake.queue_result(returncode=0)
+        fake.queue_result(
+            returncode=1,
+            stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+        )
+        fake.queue_result(returncode=0, stdout="[]")
+
+        await executor.execute(ws_id)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            pr_events = await WorkspaceEventRepository(s).list(
+                workspace_id=ws_id,
+                event_type="workspace.audit.pr_created",
+                limit=10,
+            )
+
+        assert len(pr_events) == 1
+        evidence = pr_events[0].payload["evidence"]
+        assert evidence["operation"] == "gh pr create"
+        assert evidence["returncode"] == 1
+        assert evidence["details"]["strategy"] == "transient_retry_exhausted"
+        assert evidence["details"]["attempts"] == 1
+        assert evidence["details"]["max_retries"] == 0
+        assert evidence["details"]["reconcile_lookups"][0]["status"] == "not_found"
+
+    @pytest.mark.unit
     async def test_agent_makes_no_changes_marks_failed(
         self,
         executor: WorkspaceExecutor,

--- a/tests/unit/runtime/test_pr_creator.py
+++ b/tests/unit/runtime/test_pr_creator.py
@@ -282,6 +282,89 @@ class TestPushAndOpen:
         assert len([call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]) == 1
 
     @pytest.mark.unit
+    async def test_github_duplicate_pr_create_retries_failed_lookup(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        duplicate_error = (
+            'a pull request for branch "awf/ws_x" into branch "development" already exists'
+        )
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(returncode=1, stderr=duplicate_error)
+        runner.queue_result(returncode=1, stderr="gh api timeout")
+        runner.queue_result(returncode=1, stderr=duplicate_error)
+        runner.queue_result(
+            returncode=0,
+            stdout=_open_pr_list_payload(number=89, branch="awf/ws_x"),
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        result = await creator.push_and_open(
+            worktree_path=_WORKTREE,
+            branch_name="awf/ws_x",
+            base_branch="development",
+            title="t",
+            body="b",
+            forge_client=GitHubClient(runner),
+            repo_url=_GH_REPO_URL,
+        )
+
+        assert result.url == "https://github.com/dimileeh/aira-agent/pull/89"
+        assert result.open_metadata is not None
+        assert result.open_metadata["strategy"] == "reconciled_after_duplicate"
+        lookups = result.open_metadata["reconcile_lookups"]
+        assert isinstance(lookups, list)
+        assert lookups[0]["status"] == "failed"
+        assert lookups[0]["reason_code"] == "OPEN_PR_LOOKUP_FAILED"
+        assert lookups[1]["status"] == "found"
+        failures = result.open_metadata["failures"]
+        assert isinstance(failures, list)
+        assert failures[0]["will_retry"] is True
+        create_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]
+        list_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "list"]]
+        assert len(create_calls) == 2
+        assert len(list_calls) == 2
+
+    @pytest.mark.unit
+    async def test_github_duplicate_pr_create_reports_exhausted_lookup_failure(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "awf/ws_x" into branch "development" already exists',
+        )
+        runner.queue_result(returncode=1, stderr="gh api timeout")
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_max_retries=0,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        with pytest.raises(PullRequestError) as exc:
+            await creator.push_and_open(
+                worktree_path=_WORKTREE,
+                branch_name="awf/ws_x",
+                base_branch="development",
+                title="t",
+                body="b",
+                forge_client=GitHubClient(runner),
+                repo_url=_GH_REPO_URL,
+            )
+
+        assert exc.value.details is not None
+        assert exc.value.details["strategy"] == "duplicate_lookup_failed"
+        lookups = exc.value.details["reconcile_lookups"]
+        assert isinstance(lookups, list)
+        assert lookups[0]["status"] == "failed"
+        assert lookups[0]["reason_code"] == "OPEN_PR_LOOKUP_FAILED"
+        failures = exc.value.details["failures"]
+        assert isinstance(failures, list)
+        assert failures[0]["will_retry"] is False
+
+    @pytest.mark.unit
     async def test_github_transient_pr_create_ignores_fork_pr_collision(self) -> None:
         runner = FakeCommandRunner()
         _queue_pre_push_diagnostics(runner)

--- a/tests/unit/runtime/test_pr_creator.py
+++ b/tests/unit/runtime/test_pr_creator.py
@@ -20,7 +20,7 @@ from awf.common.bitbucket_client import (
     BitbucketClientError,
 )
 from awf.common.commands import FakeCommandRunner
-from awf.common.github_client import GitHubClient, RepoRef
+from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.runtime.pr_creator import PullRequestCreator, PullRequestError
 
 _WORKTREE = Path("/fake/worktree")
@@ -85,6 +85,29 @@ class _FakeForgeClient:
         if self._error is not None:
             raise self._error
         return self._url
+
+
+class _SequencedForgeClient:
+    """Returns or raises one queued PR-create outcome per call."""
+
+    def __init__(self, outcomes: list[str | Exception]) -> None:
+        self._outcomes = list(outcomes)
+        self.calls: list[dict[str, object]] = []
+
+    async def create_pull_request(
+        self,
+        *,
+        repo: RepoRef,
+        base: str,
+        head: str,
+        title: str,
+        body: str,
+    ) -> str:
+        self.calls.append({"repo": repo, "base": base, "head": head, "title": title, "body": body})
+        outcome = self._outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
 
 
 class _RaisingForgeClient:
@@ -208,6 +231,53 @@ class TestPushAndOpen:
         list_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "list"]]
         assert len(create_calls) == 2
         assert len(list_calls) == 1
+
+    @pytest.mark.unit
+    async def test_github_transient_pr_create_failure_then_empty_url_preserves_retry_details(
+        self,
+    ) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(returncode=0, stdout="[]")  # reconcile lookup: none
+        forge = _SequencedForgeClient(
+            [
+                GitHubClientError(
+                    operation="gh pr create",
+                    returncode=1,
+                    stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+                ),
+                "",
+            ]
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_max_retries=1,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        with pytest.raises(PullRequestError) as exc:
+            await creator.push_and_open(
+                worktree_path=_WORKTREE,
+                branch_name="awf/ws_x",
+                base_branch="development",
+                title="t",
+                body="b",
+                forge_client=forge,
+                repo_url=_GH_REPO_URL,
+            )
+
+        assert "no URL" in exc.value.operation
+        assert exc.value.details is not None
+        assert exc.value.details["strategy"] == "failed"
+        assert exc.value.details["attempts"] == 2
+        assert exc.value.details["retry_count"] == 1
+        failures = exc.value.details["failures"]
+        assert isinstance(failures, list)
+        assert failures[0]["will_retry"] is True
+        lookups = exc.value.details["reconcile_lookups"]
+        assert isinstance(lookups, list)
+        assert lookups[0]["status"] == "not_found"
 
     @pytest.mark.unit
     async def test_github_transient_pr_create_reconciles_existing_same_repo_pr(self) -> None:

--- a/tests/unit/runtime/test_pr_creator.py
+++ b/tests/unit/runtime/test_pr_creator.py
@@ -9,6 +9,7 @@ Bitbucket and error paths use a recording/​raising fake forge client.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,28 @@ def _queue_pre_push_diagnostics(runner: FakeCommandRunner) -> None:
     runner.queue_result(returncode=0, stdout="abc123def4567890\n")  # rev-parse HEAD
     runner.queue_result(returncode=0, stdout="awf/ws_xyz\n")  # current branch
     runner.queue_result(returncode=0, stdout="abc123 some work\n")  # ahead-of-base
+
+
+def _open_pr_list_payload(
+    *,
+    number: int = 42,
+    repo_slug: str = "dimileeh/aira-agent",
+    branch: str = "awf/ws_x",
+    head_sha: str = "f" * 40,
+) -> str:
+    owner, repo = repo_slug.split("/", 1)
+    return json.dumps(
+        [
+            {
+                "number": number,
+                "url": f"https://github.com/{repo_slug}/pull/{number}",
+                "headRefName": branch,
+                "headRefOid": head_sha,
+                "headRepository": {"name": repo, "nameWithOwner": repo_slug},
+                "headRepositoryOwner": {"login": owner},
+            }
+        ]
+    )
 
 
 class _FakeForgeClient:
@@ -146,6 +169,185 @@ class TestPushAndOpen:
         assert "gh: auth token expired" in exc.value.stderr
         # GitHubClientError carries no reason_code, so the wrapper leaves it None.
         assert exc.value.reason_code is None
+
+    @pytest.mark.unit
+    async def test_github_transient_pr_create_failure_retries_then_succeeds(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+        )
+        runner.queue_result(returncode=0, stdout="[]")  # reconcile lookup: none
+        runner.queue_result(
+            returncode=0,
+            stdout="https://github.com/dimileeh/aira-agent/pull/42\n",
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_max_retries=1,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        result = await creator.push_and_open(
+            worktree_path=_WORKTREE,
+            branch_name="awf/ws_x",
+            base_branch="development",
+            title="t",
+            body="b",
+            forge_client=GitHubClient(runner),
+            repo_url=_GH_REPO_URL,
+        )
+
+        assert result.url == "https://github.com/dimileeh/aira-agent/pull/42"
+        assert result.open_metadata is not None
+        assert result.open_metadata["strategy"] == "created_after_retry"
+        assert result.open_metadata["attempts"] == 2
+        create_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]
+        list_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "list"]]
+        assert len(create_calls) == 2
+        assert len(list_calls) == 1
+
+    @pytest.mark.unit
+    async def test_github_transient_pr_create_reconciles_existing_same_repo_pr(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+        )
+        runner.queue_result(
+            returncode=0,
+            stdout=_open_pr_list_payload(number=77, branch="awf/ws_x", head_sha="a" * 40),
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        result = await creator.push_and_open(
+            worktree_path=_WORKTREE,
+            branch_name="awf/ws_x",
+            base_branch="development",
+            title="t",
+            body="b",
+            forge_client=GitHubClient(runner),
+            repo_url=_GH_REPO_URL,
+        )
+
+        assert result.url == "https://github.com/dimileeh/aira-agent/pull/77"
+        assert result.head_sha == "a" * 40
+        assert result.open_metadata is not None
+        assert result.open_metadata["strategy"] == "reconciled_after_transient"
+        assert result.open_metadata["matched_pr"] == {
+            "number": 77,
+            "url": "https://github.com/dimileeh/aira-agent/pull/77",
+            "head_ref": "awf/ws_x",
+            "head_repo_slug": "dimileeh/aira-agent",
+            "head_sha": "a" * 40,
+        }
+        create_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]
+        assert len(create_calls) == 1
+
+    @pytest.mark.unit
+    async def test_github_duplicate_pr_create_error_reconciles_existing_pr(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "awf/ws_x" into branch "development" already exists',
+        )
+        runner.queue_result(
+            returncode=0,
+            stdout=_open_pr_list_payload(number=88, branch="awf/ws_x"),
+        )
+
+        creator = PullRequestCreator(runner)
+        result = await creator.push_and_open(
+            worktree_path=_WORKTREE,
+            branch_name="awf/ws_x",
+            base_branch="development",
+            title="t",
+            body="b",
+            forge_client=GitHubClient(runner),
+            repo_url=_GH_REPO_URL,
+        )
+
+        assert result.url == "https://github.com/dimileeh/aira-agent/pull/88"
+        assert result.open_metadata is not None
+        assert result.open_metadata["strategy"] == "reconciled_after_duplicate"
+        assert len([call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]) == 1
+
+    @pytest.mark.unit
+    async def test_github_transient_pr_create_ignores_fork_pr_collision(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+        )
+        runner.queue_result(
+            returncode=0,
+            stdout=_open_pr_list_payload(
+                number=99,
+                repo_slug="fork/aira-agent",
+                branch="awf/ws_x",
+            ),
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_max_retries=0,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        with pytest.raises(PullRequestError) as exc:
+            await creator.push_and_open(
+                worktree_path=_WORKTREE,
+                branch_name="awf/ws_x",
+                base_branch="development",
+                title="t",
+                body="b",
+                forge_client=GitHubClient(runner),
+                repo_url=_GH_REPO_URL,
+            )
+
+        assert exc.value.details is not None
+        assert exc.value.details["strategy"] == "transient_retry_exhausted"
+        lookups = exc.value.details["reconcile_lookups"]
+        assert isinstance(lookups, list)
+        assert lookups[0]["fork_collision_count"] == 1
+        assert lookups[0]["same_repo_count"] == 0
+
+    @pytest.mark.unit
+    async def test_github_deterministic_pr_create_failure_does_not_retry_or_lookup(self) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(returncode=1, stderr="Bad credentials")
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        with pytest.raises(PullRequestError) as exc:
+            await creator.push_and_open(
+                worktree_path=_WORKTREE,
+                branch_name="awf/ws_x",
+                base_branch="development",
+                title="t",
+                body="b",
+                forge_client=GitHubClient(runner),
+                repo_url=_GH_REPO_URL,
+            )
+
+        assert exc.value.details is not None
+        assert exc.value.details["strategy"] == "failed"
+        assert not any(call.args[:3] == ["gh", "pr", "list"] for call in runner.calls)
+        assert len([call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]) == 1
 
     @pytest.mark.unit
     async def test_opens_pr_on_bitbucket_via_forge_client(self) -> None:


### PR DESCRIPTION
## Summary
- add bounded retry and same-repo reconciliation around transient GitHub `gh pr create` failures
- share GitHub transient markers between the PR monitor and feature PR creator
- surface retry/reconciliation details in existing PR audit evidence

## Validation
- `uv run --python 3.12 --extra dev python -m pytest tests/unit/runtime/test_pr_creator.py tests/unit/control/test_executor_parts/test_executor_part_005.py::TestFailurePaths::test_transient_pr_create_exhaustion_records_retry_evidence tests/unit/common/test_github_client_parts/test_github_client_part_001.py::TestListOpenPullRequestsForBranch tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py::test_transient_github_error_classifier_keeps_auth_errors_terminal -q`
- `uv run --python 3.12 --extra dev ruff check src/awf/common/github_transient.py src/awf/runtime/pr_creator.py src/awf/runtime/pr_monitor_runner/constants.py src/awf/control/executor/pr_open_step.py src/awf/control/executor/execution_flow.py tests/unit/runtime/test_pr_creator.py tests/unit/control/test_executor_parts/test_executor_part_005.py`
- `uv run --python 3.12 --extra dev mypy src/awf/common/github_transient.py src/awf/runtime/pr_creator.py src/awf/runtime/pr_monitor_runner/constants.py src/awf/control/executor/pr_open_step.py src/awf/control/executor/execution_flow.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core post-validation push/PR-open behavior for GitHub workspaces; misclassification could retry auth failures or reconcile the wrong PR, though deterministic errors still fail fast and fork PRs are filtered.
> 
> **Overview**
> Adds **bounded retry and same-repo PR reconciliation** when GitHub `gh pr create` fails transiently or reports a duplicate, so validated pushes are less likely to strand without a PR.
> 
> **`PullRequestCreator`** routes GitHub opens through `_create_github_pull_request_with_redundancy`: classify errors via shared **`is_transient_github_error_text`**, run **`gh pr list`** reconciliation (same-repo only; fork collisions ignored), exponential backoff retries, and structured **`open_metadata` / `PullRequestError.details`** (`strategy`, `failures`, `reconcile_lookups`). Follow-ups preserve retry evidence on **empty URL** failures and **retry duplicate reconciliation** when lookup fails (`duplicate_lookup_failed` when exhausted).
> 
> **`github_transient.py`** centralizes transient/non-transient markers; the PR monitor constants module re-exports them. The executor records retry/reconciliation metadata on **successful** PR audit events and forwards **`details`** on **failed** PR-create audits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25a95bd22738c8afccf1bdb938d6028e764d512c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->