### PR TITLE
feat(console): surface protected-file pause (blocked) state in the web console (WS-3)

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -1,0 +1,21 @@
+# TODOS
+
+## Up-front owned_paths ergonomics (reduce protected-file pause friction)
+
+- **What:** Help orchestrators declare the right `owned_paths` *before* a workspace spends tokens —
+  e.g., AWF suggests likely-needed protected paths at dispatch based on task intent, or fails fast
+  before expensive work when the task obviously needs a protected file.
+- **Why:** The "protected-file violation → pause for operator" feature (see
+  `~/.claude/plans/cached-baking-haven.md`) is *recovery*: it preserves work and lets the operator
+  approve/revert. But if agents *commonly* edit protected dep/config files, the pause becomes a
+  human-approval queue. Up-front declaration is the complementary *prevention* that keeps the pause
+  rare (reserved for genuine surprises).
+- **Pros:** Cuts the approval-queue friction; fewer expensive runs that pause; better DX for
+  orchestrators (the assistant included — forgetting `owned_paths` is the original pain).
+- **Cons:** Heuristics for "likely-needed protected paths" can be wrong (false suggestions); a
+  fail-fast gate risks blocking legitimate exploratory work. Distinct effort from the pause feature.
+- **Context:** Surfaced by codex during the `/plan-eng-review` outside-voice pass on the pause
+  feature. Prevention vs recovery — deliberately kept OUT of the pause feature's scope so it ships
+  focused. Revisit if the pause/approval queue becomes noisy in practice.
+- **Depends on / blocked by:** Independent of the pause feature, but most useful *after* it ships
+  (you'll know the real pause frequency).

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -25,6 +25,7 @@ compactDuration,
 compactId,
 fallbackLifecycleStages,
 formatDateTime,
+normalizeLifecycle,
 relativeTime,
 statusGlyph,
 statusTone,
@@ -908,7 +909,9 @@ export function LifecycleRail({
 }) {
   const terminal = status === "failed" || status === "cancelled";
   const stages: WorkspaceLifecycleStage[] =
-    lifecycle.length > 0 ? lifecycle : fallbackLifecycleStages(status, terminalSourceStage);
+    lifecycle.length > 0
+      ? normalizeLifecycle(status, lifecycle)
+      : fallbackLifecycleStages(status, terminalSourceStage);
   return (
     <Panel title="Lifecycle" icon={<GitPullRequest size={16} aria-hidden />}>
       <div className="grid gap-2 md:grid-cols-4 xl:grid-cols-8">

--- a/apps/console/components/console-dashboard-overview.tsx
+++ b/apps/console/components/console-dashboard-overview.tsx
@@ -36,8 +36,10 @@ useState
 
 import { formatAgentLabel,formatAgentTitle } from "@/lib/agent-format";
 import { copyTextToClipboard } from "@/lib/clipboard";
+import { blockedAgeSeconds, blockedSince } from "@/lib/blocked-format";
 import { summarizeVisibleCoordinationWarnings } from "@/lib/coordination-format";
 import {
+compactDuration,
 compactId,
 formatDateTime,
 lifecycleStages,
@@ -244,7 +246,7 @@ export function FleetHealthStrip({ kpis }: { kpis: FleetKpi[] }) {
           some values show the last snapshot — live data may be stale
         </div>
       ) : null}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-8">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4 xl:grid-cols-9">
         {kpis.map((kpi) => (
           <KpiStat
             key={kpi.id}
@@ -673,6 +675,11 @@ export function WorkspaceList({
       {items.map((item) => {
         const recoveryBadge = formatRecoveryBadge(item.recovery, item.status);
         const coordinationSummary = summarizeVisibleCoordinationWarnings(item.coordination_warnings, item.status);
+        // Blocked-age proxy for the list: the overview response carries no
+        // block_state, so derive "blocked for N" from the blocked transition
+        // event (or updated_at). The inspector shows the precise blocked_at.
+        const blockedFor =
+          item.status === "blocked" ? blockedAgeSeconds(blockedSince(item)) : null;
         return (
           <div
             key={item.workspace_id}
@@ -759,6 +766,15 @@ export function WorkspaceList({
                   <span className="inline-flex h-6 max-w-full items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 text-[11px] font-medium text-amber-900">
                     <AlertCircle size={12} aria-hidden />
                     <span className="truncate">Stale running</span>
+                  </span>
+                ) : null}
+                {item.status === "blocked" ? (
+                  <span
+                    data-testid={`workspace-blocked-age-${item.workspace_id}`}
+                    className="inline-flex h-6 max-w-full items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-2 text-[11px] font-medium text-amber-900"
+                  >
+                    <AlertCircle size={12} aria-hidden />
+                    <span className="truncate">Blocked for {compactDuration(blockedFor)}</span>
                   </span>
                 ) : null}
                 {recoveryBadge ? (

--- a/apps/console/components/console-dashboard-shared.tsx
+++ b/apps/console/components/console-dashboard-shared.tsx
@@ -88,6 +88,7 @@ export function fallbackResourceSaturation(
       validating: saturation.workspace_counts?.validating ?? 0,
       pushing: saturation.workspace_counts?.pushing ?? 0,
       monitoring_pr: saturation.workspace_counts?.monitoring_pr ?? 0,
+      blocked: saturation.workspace_counts?.blocked ?? 0,
       destroying: saturation.workspace_counts?.destroying ?? 0,
       completed: saturation.workspace_counts?.completed ?? 0,
       failed: saturation.workspace_counts?.failed ?? 0,

--- a/apps/console/components/console-dashboard-workspace-detail.tsx
+++ b/apps/console/components/console-dashboard-workspace-detail.tsx
@@ -31,8 +31,15 @@ hasConformanceArtifact,
 hasPlanArtifact,
 PLAN_ARTIFACT_NAME
 } from "@/lib/artifact-format";
+import {
+blockedAgeSeconds,
+blockedSince,
+formatBlockedResolutionCommands
+} from "@/lib/blocked-format";
+import { copyTextToClipboard } from "@/lib/clipboard";
 import { summarizeVisibleCoordinationWarnings } from "@/lib/coordination-format";
 import {
+compactDuration,
 compactId,
 fallbackLlmUsage,
 formatCostWithPricing,
@@ -530,6 +537,7 @@ export function WorkspaceSummary({
         <ProviderReadinessPreflightBlock
           preflight={workspace?.provider_readiness_preflight ?? overview.provider_readiness_preflight ?? null}
         />
+        <BlockedViolationBlock workspace={workspace} overview={overview} />
         {recovery && overview.status !== "completed" ? (
           <RecoveryCallout recovery={recovery} status={overview.status} />
         ) : null}
@@ -967,6 +975,123 @@ export function ProviderReadinessPreflightBlock({
           override: {preflight.override_reason}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+// Operator-pause inspector block: for a `blocked` workspace (protected quality-gate
+// violation), surfaces the violating path(s) and the two ready-to-run `guide`
+// resolution commands. Reads the full GET's `block_state`; degrades to a
+// loading/unavailable line when only the overview snapshot is available.
+export function BlockedViolationBlock({
+  workspace,
+  overview,
+}: {
+  workspace: Workspace | null;
+  overview: WorkspaceOverview;
+}) {
+  if (overview.status !== "blocked") {
+    return null;
+  }
+  const blockState = workspace?.block_state ?? null;
+  const violations = blockState?.violations ?? [];
+  const commands = formatBlockedResolutionCommands(overview.workspace_id, violations);
+  // Prefer the authoritative blocked_at; fall back to the overview proxy while the
+  // full workspace fetch is still in flight (overview-only render).
+  const ageSeconds = blockedAgeSeconds(blockState?.blocked_at ?? blockedSince(overview));
+
+  return (
+    <div
+      data-testid="blocked-violation-block"
+      className="rounded-md border border-attention-border bg-attention-soft p-3 text-sm text-attention-text"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2 font-semibold">
+          <Ban size={14} aria-hidden />
+          <span className="truncate">
+            Awaiting operator — {blockState?.block_reason_code ?? "protected-file violation"}
+          </span>
+        </div>
+        <span className="mono rounded-md border border-attention-border bg-surface px-2 py-0.5 text-[11px] text-attention-text">
+          blocked for {compactDuration(ageSeconds)}
+        </span>
+      </div>
+      {blockState ? (
+        <>
+          <div className="mt-2 grid gap-2 text-xs sm:grid-cols-3">
+            <Fact label="Block type" value={blockState.block_type ?? "—"} />
+            <Fact label="Resume phase" value={blockState.block_resume_phase ?? "—"} />
+            <Fact label="Blocked at" value={formatDateTime(blockState.blocked_at)} />
+          </div>
+          {violations.length > 0 ? (
+            <div className="mt-3 grid gap-1">
+              <div className="label-caps">Protected violations</div>
+              <ul className="grid gap-1">
+                {violations.map((violation, index) => (
+                  <li
+                    key={`${violation.path ?? "violation"}-${index}`}
+                    data-testid="blocked-violation-row"
+                    className="rounded-md border border-attention-border bg-surface px-2 py-1 text-xs"
+                  >
+                    <span className="mono break-all text-fg-strong">
+                      {violation.path ?? "(unknown path)"}
+                    </span>
+                    <span className="text-attention-text">
+                      {" · "}
+                      {violation.protected_pattern ?? "protected"}
+                      {violation.section ? ` · ${violation.section}` : ""}
+                      {violation.reason ? ` · ${violation.reason}` : ""}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <div className="mt-3 text-xs text-attention-text">
+              No specific violation paths were recorded.
+            </div>
+          )}
+          <div className="mt-3 grid gap-2">
+            <div className="label-caps">Resolve</div>
+            <BlockedCommand label="Approve & keep" command={commands.grantCommand} />
+            <BlockedCommand label="Revert" command={commands.revertCommand} />
+          </div>
+        </>
+      ) : (
+        <div className="mt-2 text-xs text-attention-text">
+          Block details are loading or unavailable — open the workspace to load the full record.
+        </div>
+      )}
+    </div>
+  );
+}
+
+// A single copy-able guide command. The async copy works in both secure and
+// plain-HTTP (Tailscale) contexts via the shared clipboard helper.
+function BlockedCommand({ label, command }: { label: string; command: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="grid gap-1">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] font-medium text-attention-text">{label}</span>
+        <button
+          type="button"
+          onClick={async () => {
+            if (await copyTextToClipboard(command)) {
+              setCopied(true);
+              window.setTimeout(() => setCopied(false), 1500);
+            }
+          }}
+          className="inline-flex h-6 items-center gap-1 rounded-md border border-attention-border bg-surface px-2 text-[11px] text-attention-text transition hover:bg-surface-2"
+          aria-label={`Copy command: ${label}`}
+        >
+          <ClipboardCheck size={11} aria-hidden />
+          {copied ? "copied" : "copy"}
+        </button>
+      </div>
+      <code className="mono block overflow-x-auto whitespace-pre rounded-md border border-attention-border bg-surface px-2 py-1 text-[11px] text-fg-strong">
+        {command}
+      </code>
     </div>
   );
 }

--- a/apps/console/components/console-dashboard.tsx
+++ b/apps/console/components/console-dashboard.tsx
@@ -839,6 +839,18 @@ const searchParams = useSearchParams();
         stale: saturationStale,
       },
       {
+        // Protected-file pause: a `blocked` workspace is awaiting an operator
+        // guide decision while it still holds its slot + stack. It counts inside
+        // Active (server-side, via active_total) but deliberately NOT inside
+        // Running (running+validating+pushing, the PR #598 contract) — it is
+        // halted, not executing.
+        id: "blocked",
+        label: "Awaiting operator",
+        value: counts ? (counts.blocked ?? 0) : dash,
+        tone: counts?.blocked ? "warn" : undefined,
+        stale: saturationStale,
+      },
+      {
         id: "queued",
         label: "Queued",
         value: queued ?? dash,

--- a/apps/console/lib/blocked-format.test.mjs
+++ b/apps/console/lib/blocked-format.test.mjs
@@ -75,7 +75,7 @@ test("formatBlockedResolutionCommands builds grant and revert commands from the 
   ]);
   assert.equal(
     grantCommand,
-    "awf workspace guide ws_abc123 --grant '.github/workflows/ci.yml' --reason '<why>'",
+    "awf workspace guide ws_abc123 --grant '.github/workflows/ci.yml' --approve-policy-downgrade --reason '<why>'",
   );
   assert.equal(
     revertCommand,
@@ -85,7 +85,7 @@ test("formatBlockedResolutionCommands builds grant and revert commands from the 
 
 test("formatBlockedResolutionCommands uses a placeholder when there are no violations", () => {
   const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", []);
-  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --approve-policy-downgrade --reason '<why>'");
   assert.equal(revertCommand, "awf workspace guide ws_abc123 --directive 'revert <path>; <alternative>'");
 });
 
@@ -93,13 +93,13 @@ test("formatBlockedResolutionCommands treats an empty/whitespace path as missing
   const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
     { path: "   " },
   ]);
-  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --approve-policy-downgrade --reason '<why>'");
   assert.equal(revertCommand, "awf workspace guide ws_abc123 --directive 'revert <path>; <alternative>'");
 });
 
 test("formatBlockedResolutionCommands tolerates a null violations list", () => {
   const { grantCommand } = formatBlockedResolutionCommands("ws_abc123", null);
-  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --approve-policy-downgrade --reason '<why>'");
 });
 
 test("formatBlockedResolutionCommands escapes a single quote in the path so the shell command stays valid", () => {
@@ -110,7 +110,7 @@ test("formatBlockedResolutionCommands escapes a single quote in the path so the 
   ]);
   assert.equal(
     grantCommand,
-    "awf workspace guide ws_abc123 --grant 'it'\\''s/config.yml' --reason '<why>'",
+    "awf workspace guide ws_abc123 --grant 'it'\\''s/config.yml' --approve-policy-downgrade --reason '<why>'",
   );
   assert.equal(
     revertCommand,

--- a/apps/console/lib/blocked-format.test.mjs
+++ b/apps/console/lib/blocked-format.test.mjs
@@ -117,3 +117,48 @@ test("formatBlockedResolutionCommands escapes a single quote in the path so the 
     "awf workspace guide ws_abc123 --directive 'revert it'\\''s/config.yml; <alternative>'",
   );
 });
+
+test("formatBlockedResolutionCommands grants and reverts every recorded violation path", () => {
+  // The resume path requires ALL recorded violations to be granted, so a
+  // multi-violation pause must emit one --grant per path (and revert each).
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    { path: "pyproject.toml" },
+    { path: ".github/workflows/ci.yml" },
+  ]);
+  assert.equal(
+    grantCommand,
+    "awf workspace guide ws_abc123 --grant 'pyproject.toml' --grant '.github/workflows/ci.yml' --approve-policy-downgrade --reason '<why>'",
+  );
+  assert.equal(
+    revertCommand,
+    "awf workspace guide ws_abc123 --directive 'revert pyproject.toml; revert .github/workflows/ci.yml; <alternative>'",
+  );
+});
+
+test("formatBlockedResolutionCommands de-duplicates repeated violation paths", () => {
+  const { grantCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    { path: "pyproject.toml" },
+    { path: "   " },
+    { path: "pyproject.toml" },
+  ]);
+  assert.equal(
+    grantCommand,
+    "awf workspace guide ws_abc123 --grant 'pyproject.toml' --approve-policy-downgrade --reason '<why>'",
+  );
+});
+
+test("formatBlockedResolutionCommands escapes glob metacharacters in the grant path only", () => {
+  // `--grant` is applied as an fnmatch glob, so a literal path with `*?[` must be
+  // escaped to target the exact file; the revert directive is free text and stays literal.
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    { path: "config[1].yml" },
+  ]);
+  assert.equal(
+    grantCommand,
+    "awf workspace guide ws_abc123 --grant 'config[[]1].yml' --approve-policy-downgrade --reason '<why>'",
+  );
+  assert.equal(
+    revertCommand,
+    "awf workspace guide ws_abc123 --directive 'revert config[1].yml; <alternative>'",
+  );
+});

--- a/apps/console/lib/blocked-format.test.mjs
+++ b/apps/console/lib/blocked-format.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  blockedAgeSeconds,
+  blockedSince,
+  formatBlockedResolutionCommands,
+} from "./blocked-format.ts";
+
+test("blockedSince prefers last_event.occurred_at when the workspace entered blocked", () => {
+  assert.equal(
+    blockedSince({
+      updated_at: "2026-06-18T10:00:00.000Z",
+      last_event: { new_state: "blocked", occurred_at: "2026-06-18T09:30:00.000Z" },
+    }),
+    "2026-06-18T09:30:00.000Z",
+  );
+});
+
+test("blockedSince falls back to updated_at when the last event is not the block transition", () => {
+  assert.equal(
+    blockedSince({
+      updated_at: "2026-06-18T10:00:00.000Z",
+      last_event: { new_state: "monitoring_pr", occurred_at: "2026-06-18T09:30:00.000Z" },
+    }),
+    "2026-06-18T10:00:00.000Z",
+  );
+});
+
+test("blockedSince falls back to updated_at when the block event has no timestamp", () => {
+  assert.equal(
+    blockedSince({
+      updated_at: "2026-06-18T10:00:00.000Z",
+      last_event: { new_state: "blocked", occurred_at: null },
+    }),
+    "2026-06-18T10:00:00.000Z",
+  );
+});
+
+test("blockedSince falls back to updated_at when there is no last event", () => {
+  assert.equal(
+    blockedSince({ updated_at: "2026-06-18T10:00:00.000Z", last_event: null }),
+    "2026-06-18T10:00:00.000Z",
+  );
+});
+
+test("blockedSince returns null when neither a block event nor updated_at is present", () => {
+  assert.equal(blockedSince({ updated_at: null, last_event: null }), null);
+});
+
+test("blockedAgeSeconds returns elapsed seconds against an injected clock", () => {
+  const now = Date.parse("2026-06-18T10:05:00.000Z");
+  assert.equal(blockedAgeSeconds("2026-06-18T10:00:00.000Z", now), 300);
+});
+
+test("blockedAgeSeconds clamps a future timestamp to zero", () => {
+  const now = Date.parse("2026-06-18T10:00:00.000Z");
+  assert.equal(blockedAgeSeconds("2026-06-18T10:05:00.000Z", now), 0);
+});
+
+test("blockedAgeSeconds returns null for a missing or unparseable timestamp", () => {
+  assert.equal(blockedAgeSeconds(null, Date.parse("2026-06-18T10:00:00.000Z")), null);
+  assert.equal(blockedAgeSeconds("not-a-date", Date.parse("2026-06-18T10:00:00.000Z")), null);
+});
+
+test("formatBlockedResolutionCommands builds grant and revert commands from the first violating path", () => {
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    {
+      path: ".github/workflows/ci.yml",
+      protected_pattern: ".github/**",
+      section: "ci",
+      line: null,
+      reason: "protected quality gate",
+    },
+  ]);
+  assert.equal(
+    grantCommand,
+    "awf workspace guide ws_abc123 --grant '.github/workflows/ci.yml' --reason '<why>'",
+  );
+  assert.equal(
+    revertCommand,
+    "awf workspace guide ws_abc123 --directive 'revert .github/workflows/ci.yml; <alternative>'",
+  );
+});
+
+test("formatBlockedResolutionCommands uses a placeholder when there are no violations", () => {
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", []);
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+  assert.equal(revertCommand, "awf workspace guide ws_abc123 --directive 'revert <path>; <alternative>'");
+});
+
+test("formatBlockedResolutionCommands treats an empty/whitespace path as missing", () => {
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    { path: "   " },
+  ]);
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+  assert.equal(revertCommand, "awf workspace guide ws_abc123 --directive 'revert <path>; <alternative>'");
+});
+
+test("formatBlockedResolutionCommands tolerates a null violations list", () => {
+  const { grantCommand } = formatBlockedResolutionCommands("ws_abc123", null);
+  assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
+});

--- a/apps/console/lib/blocked-format.test.mjs
+++ b/apps/console/lib/blocked-format.test.mjs
@@ -101,3 +101,19 @@ test("formatBlockedResolutionCommands tolerates a null violations list", () => {
   const { grantCommand } = formatBlockedResolutionCommands("ws_abc123", null);
   assert.equal(grantCommand, "awf workspace guide ws_abc123 --grant '<path>' --reason '<why>'");
 });
+
+test("formatBlockedResolutionCommands escapes a single quote in the path so the shell command stays valid", () => {
+  // Git filenames may legally contain a single quote; without escaping it would
+  // break the single-quoted shell argument and could inject extra tokens.
+  const { grantCommand, revertCommand } = formatBlockedResolutionCommands("ws_abc123", [
+    { path: "it's/config.yml" },
+  ]);
+  assert.equal(
+    grantCommand,
+    "awf workspace guide ws_abc123 --grant 'it'\\''s/config.yml' --reason '<why>'",
+  );
+  assert.equal(
+    revertCommand,
+    "awf workspace guide ws_abc123 --directive 'revert it'\\''s/config.yml; <alternative>'",
+  );
+});

--- a/apps/console/lib/blocked-format.ts
+++ b/apps/console/lib/blocked-format.ts
@@ -61,7 +61,11 @@ export function formatBlockedResolutionCommands(
 ): BlockedResolutionCommands {
   const path = shellSingleQuote(firstViolationPath(violations));
   return {
-    grantCommand: `awf workspace guide ${workspaceId} --grant '${path}' --reason '${REASON_PLACEHOLDER}'`,
+    // The guide service rejects a grant that covers a recorded block violation
+    // unless `--approve-policy-downgrade` is set (controls_guide.py): the grant
+    // always targets the recorded violation path, so the flag is mandatory for
+    // the command to actually unblock — include it so the copied command works.
+    grantCommand: `awf workspace guide ${workspaceId} --grant '${path}' --approve-policy-downgrade --reason '${REASON_PLACEHOLDER}'`,
     revertCommand: `awf workspace guide ${workspaceId} --directive 'revert ${path}; ${ALTERNATIVE_PLACEHOLDER}'`,
   };
 }

--- a/apps/console/lib/blocked-format.ts
+++ b/apps/console/lib/blocked-format.ts
@@ -59,14 +59,22 @@ export function formatBlockedResolutionCommands(
   workspaceId: string,
   violations: readonly Pick<WorkspaceBlockViolation, "path">[] | null | undefined,
 ): BlockedResolutionCommands {
-  const path = shellSingleQuote(firstViolationPath(violations));
+  // Cover EVERY recorded violation, not just the first: the blocked resume only
+  // suppresses violations covered by active grants, and the preserved-commit guard
+  // requires all recorded block_violations to be granted, so a single-path command
+  // would fail to unblock a multi-violation pause.
+  const paths = violationPaths(violations);
+  const grants = paths
+    .map((path) => `--grant '${shellSingleQuote(globEscape(path))}'`)
+    .join(" ");
+  const reverts = paths.map((path) => `revert ${shellSingleQuote(path)}`).join("; ");
   return {
     // The guide service rejects a grant that covers a recorded block violation
-    // unless `--approve-policy-downgrade` is set (controls_guide.py): the grant
-    // always targets the recorded violation path, so the flag is mandatory for
-    // the command to actually unblock — include it so the copied command works.
-    grantCommand: `awf workspace guide ${workspaceId} --grant '${path}' --approve-policy-downgrade --reason '${REASON_PLACEHOLDER}'`,
-    revertCommand: `awf workspace guide ${workspaceId} --directive 'revert ${path}; ${ALTERNATIVE_PLACEHOLDER}'`,
+    // unless `--approve-policy-downgrade` is set (controls_guide.py): the grants
+    // target the recorded violation paths, so the flag is mandatory for the command
+    // to actually unblock — include it so the copied command works.
+    grantCommand: `awf workspace guide ${workspaceId} ${grants} --approve-policy-downgrade --reason '${REASON_PLACEHOLDER}'`,
+    revertCommand: `awf workspace guide ${workspaceId} --directive '${reverts}; ${ALTERNATIVE_PLACEHOLDER}'`,
   };
 }
 
@@ -79,14 +87,28 @@ function shellSingleQuote(value: string): string {
   return value.replace(/'/g, "'\\''");
 }
 
-function firstViolationPath(
+// `--grant` is applied as an fnmatch path glob by the guide gate (controls_guide.py),
+// so a literal violation path containing glob metacharacters (`*`, `?`, `[`) would
+// match the wrong files. Escape each the fnmatch way (wrap in a character class) so
+// the grant targets exactly the recorded file. Mirrors Python's glob.escape. Applied
+// to grants only — the revert directive is free text, not a glob.
+function globEscape(value: string): string {
+  return value.replace(/([*?[])/g, "[$1]");
+}
+
+// All distinct, non-empty violation paths in recorded order, or the placeholder when
+// none are available so the command stays copy-able.
+function violationPaths(
   violations: readonly Pick<WorkspaceBlockViolation, "path">[] | null | undefined,
-): string {
+): string[] {
+  const seen = new Set<string>();
+  const paths: string[] = [];
   for (const violation of violations ?? []) {
     const candidate = violation.path?.trim();
-    if (candidate) {
-      return candidate;
+    if (candidate && !seen.has(candidate)) {
+      seen.add(candidate);
+      paths.push(candidate);
     }
   }
-  return PATH_PLACEHOLDER;
+  return paths.length > 0 ? paths : [PATH_PLACEHOLDER];
 }

--- a/apps/console/lib/blocked-format.ts
+++ b/apps/console/lib/blocked-format.ts
@@ -59,11 +59,20 @@ export function formatBlockedResolutionCommands(
   workspaceId: string,
   violations: readonly Pick<WorkspaceBlockViolation, "path">[] | null | undefined,
 ): BlockedResolutionCommands {
-  const path = firstViolationPath(violations);
+  const path = shellSingleQuote(firstViolationPath(violations));
   return {
     grantCommand: `awf workspace guide ${workspaceId} --grant '${path}' --reason '${REASON_PLACEHOLDER}'`,
     revertCommand: `awf workspace guide ${workspaceId} --directive 'revert ${path}; ${ALTERNATIVE_PLACEHOLDER}'`,
   };
+}
+
+// The violating path is interpolated inside single-quoted shell arguments above.
+// Git filenames may legally contain a single quote (e.g. `it's/config.yml`), which
+// would break the quoting and let extra shell tokens slip in when an operator copies
+// the command. Escape it the POSIX way: close the quote, emit a literal quote, reopen
+// (`'` -> `'\''`). The `<path>` placeholder has no quote, so this is a no-op for it.
+function shellSingleQuote(value: string): string {
+  return value.replace(/'/g, "'\\''");
 }
 
 function firstViolationPath(

--- a/apps/console/lib/blocked-format.ts
+++ b/apps/console/lib/blocked-format.ts
@@ -1,0 +1,79 @@
+import type { WorkspaceBlockViolation } from "@/lib/types";
+
+// Pure helpers for the `blocked` (protected-file pause) surface. Mirrors the
+// per-concern `lib/*-format.ts` convention so the age + resolution-command logic
+// is node:test-covered without a browser. No backend behaviour lives here — these
+// only read the fields WS-1/WS-2 already expose.
+
+// Operator-fillable placeholders woven into the ready-to-run guide commands. The
+// path is auto-filled from the recorded violation; the justification and the
+// revert alternative are the operator's to supply.
+const PATH_PLACEHOLDER = "<path>";
+const REASON_PLACEHOLDER = "<why>";
+const ALTERNATIVE_PLACEHOLDER = "<alternative>";
+
+export interface BlockedResolutionCommands {
+  /** Approve-and-keep: record a scoped grant for the violating path. */
+  grantCommand: string;
+  /** Revert the protected change and steer the agent to an alternative. */
+  revertCommand: string;
+}
+
+// Best-effort "blocked since" timestamp for the overview/list surface, which does
+// NOT carry the precise `block_state.blocked_at` (only the full GET does). Prefer
+// the recorded `blocked` state-transition event; otherwise fall back to
+// `updated_at`. The inspector uses the authoritative `block_state.blocked_at`.
+export function blockedSince(
+  overview: {
+    updated_at: string | null;
+    last_event: { new_state: string | null; occurred_at: string | null } | null;
+  },
+): string | null {
+  const event = overview.last_event;
+  if (event && event.new_state === "blocked" && event.occurred_at) {
+    return event.occurred_at;
+  }
+  return overview.updated_at ?? null;
+}
+
+// Elapsed seconds since a blocked workspace paused, for the "Blocked for N"
+// indicators. Returns null when the source timestamp is missing/unparseable so
+// `compactDuration` renders a dash rather than a misleading age. `now` is
+// injectable so the conversion stays deterministically unit-testable.
+export function blockedAgeSeconds(since: string | null, now: number = Date.now()): number | null {
+  if (!since) {
+    return null;
+  }
+  const started = new Date(since).getTime();
+  if (Number.isNaN(started)) {
+    return null;
+  }
+  return Math.max(0, (now - started) / 1000);
+}
+
+// Build the two ready-to-run `awf workspace guide` commands an operator pastes to
+// resolve a pre-PR protected-file pause. The violating path is taken from the
+// first recorded violation (operators address them one at a time); a placeholder
+// is substituted when no path is available so the command stays copy-able.
+export function formatBlockedResolutionCommands(
+  workspaceId: string,
+  violations: readonly Pick<WorkspaceBlockViolation, "path">[] | null | undefined,
+): BlockedResolutionCommands {
+  const path = firstViolationPath(violations);
+  return {
+    grantCommand: `awf workspace guide ${workspaceId} --grant '${path}' --reason '${REASON_PLACEHOLDER}'`,
+    revertCommand: `awf workspace guide ${workspaceId} --directive 'revert ${path}; ${ALTERNATIVE_PLACEHOLDER}'`,
+  };
+}
+
+function firstViolationPath(
+  violations: readonly Pick<WorkspaceBlockViolation, "path">[] | null | undefined,
+): string {
+  for (const violation of violations ?? []) {
+    const candidate = violation.path?.trim();
+    if (candidate) {
+      return candidate;
+    }
+  }
+  return PATH_PLACEHOLDER;
+}

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -8,6 +8,7 @@ import {
   formatCostWithPricing,
   formatUsageProvenance,
   lifecycleStages,
+  normalizeLifecycle,
   pickWorkspaceLogStreams,
   renderLogEntries,
   statusGlyph,
@@ -114,6 +115,65 @@ test("lifecycleStages includes blocked as an in-flight stage before monitoring_p
   assert.ok(lifecycleStages.indexOf("blocked") < lifecycleStages.indexOf("monitoring_pr"));
   // blocked stays a non-terminal stage, so it must not appear after completed.
   assert.ok(lifecycleStages.indexOf("blocked") < lifecycleStages.indexOf("completed"));
+});
+
+// The backend lifecycle omits `blocked`, so a real blocked workspace arrives with no
+// active stage. normalizeLifecycle injects the active pause so the rail surfaces it.
+function stage(name, status) {
+  return { stage: name, started_at: null, ended_at: null, duration_seconds: null, status };
+}
+
+test("normalizeLifecycle injects an active blocked stage for a real blocked workspace", () => {
+  // Mirrors the backend for a pause from validating: stages it left are completed,
+  // downstream pending, and (since blocked isn't a lifecycle stage) nothing active.
+  const backend = [
+    stage("requested", "completed"),
+    stage("provisioning", "completed"),
+    stage("ready", "completed"),
+    stage("running", "completed"),
+    stage("validating", "completed"),
+    stage("pushing", "pending"),
+    stage("monitoring_pr", "pending"),
+    stage("completed", "pending"),
+  ];
+
+  const result = normalizeLifecycle("blocked", backend);
+  const rendered = result.map((s) => [s.stage, s.status]);
+
+  // blocked is inserted at its canonical position (after pushing, before monitoring_pr)
+  // and is the single active stage; the backend stages are untouched.
+  assert.deepEqual(rendered, [
+    ["requested", "completed"],
+    ["provisioning", "completed"],
+    ["ready", "completed"],
+    ["running", "completed"],
+    ["validating", "completed"],
+    ["pushing", "pending"],
+    ["blocked", "active"],
+    ["monitoring_pr", "pending"],
+    ["completed", "pending"],
+  ]);
+  assert.equal(result.filter((s) => s.status === "active").length, 1);
+});
+
+test("normalizeLifecycle is a no-op for a non-blocked workspace", () => {
+  const backend = [stage("running", "active"), stage("validating", "pending")];
+  assert.equal(normalizeLifecycle("running", backend), backend);
+});
+
+test("normalizeLifecycle is idempotent when a blocked stage is already present", () => {
+  const backend = [stage("validating", "completed"), stage("blocked", "active")];
+  assert.equal(normalizeLifecycle("blocked", backend), backend);
+});
+
+test("normalizeLifecycle appends blocked when no later stage is present to anchor it", () => {
+  const backend = [stage("requested", "completed"), stage("running", "completed")];
+  const rendered = normalizeLifecycle("blocked", backend).map((s) => [s.stage, s.status]);
+  assert.deepEqual(rendered, [
+    ["requested", "completed"],
+    ["running", "completed"],
+    ["blocked", "active"],
+  ]);
 });
 
 test("formatUsageProvenance maps ccusage source and reason codes to friendly labels", () => {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -7,8 +7,11 @@ import {
   fallbackLlmUsage,
   formatCostWithPricing,
   formatUsageProvenance,
+  lifecycleStages,
   pickWorkspaceLogStreams,
   renderLogEntries,
+  statusGlyph,
+  statusTone,
   toneFillClass,
 } from "./format.ts";
 
@@ -78,6 +81,21 @@ test("fallbackLifecycleStages preserves active non-terminal status", () => {
   assert.equal(stages.running, "completed");
   assert.equal(stages.validating, "active");
   assert.equal(stages.pushing, "pending");
+});
+
+test("statusTone marks a blocked workspace as warn (operator attention)", () => {
+  assert.equal(statusTone("blocked"), "warn");
+});
+
+test("statusGlyph renders the pause glyph for a blocked workspace", () => {
+  assert.equal(statusGlyph("blocked"), "⏸");
+});
+
+test("lifecycleStages includes blocked as an in-flight stage before monitoring_pr", () => {
+  assert.ok(lifecycleStages.includes("blocked"));
+  assert.ok(lifecycleStages.indexOf("blocked") < lifecycleStages.indexOf("monitoring_pr"));
+  // blocked stays a non-terminal stage, so it must not appear after completed.
+  assert.ok(lifecycleStages.indexOf("blocked") < lifecycleStages.indexOf("completed"));
 });
 
 test("formatUsageProvenance maps ccusage source and reason codes to friendly labels", () => {

--- a/apps/console/lib/format.test.mjs
+++ b/apps/console/lib/format.test.mjs
@@ -83,6 +83,24 @@ test("fallbackLifecycleStages preserves active non-terminal status", () => {
   assert.equal(stages.pushing, "pending");
 });
 
+test("fallbackLifecycleStages does not claim execution stages completed for a blocked workspace", () => {
+  // `blocked` can be entered from running/validating/pushing but sits at a fixed
+  // position in the linear list; without the real lifecycle the fallback must not
+  // falsely render a later execution stage (e.g. pushing) as completed.
+  const stages = Object.fromEntries(
+    fallbackLifecycleStages("blocked").map((stage) => [stage.stage, stage.status]),
+  );
+
+  assert.equal(stages.requested, "completed");
+  assert.equal(stages.provisioning, "completed");
+  assert.equal(stages.ready, "completed");
+  assert.equal(stages.running, "pending");
+  assert.equal(stages.validating, "pending");
+  assert.equal(stages.pushing, "pending");
+  assert.equal(stages.blocked, "active");
+  assert.equal(stages.monitoring_pr, "pending");
+});
+
 test("statusTone marks a blocked workspace as warn (operator attention)", () => {
   assert.equal(statusTone("blocked"), "warn");
 });

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -26,6 +26,11 @@ export const lifecycleStages: WorkspaceStatus[] = [
   "running",
   "validating",
   "pushing",
+  // `blocked` is the non-terminal operator-pause state (protected-file violation).
+  // It sits just before monitoring_pr — the push→monitor boundary where both the
+  // pre-PR and post-PR pauses cluster — so the status filter and fallback progress
+  // bar treat it as in-flight, not terminal.
+  "blocked",
   "monitoring_pr",
   "completed",
 ];
@@ -377,7 +382,14 @@ export function statusTone(status: string): StatusTone {
   if (status === "failed" || status === "destroyed" || status === "error" || status === "dead") {
     return "bad";
   }
-  if (status === "cancelled" || status === "destroying" || status === "unhealthy") {
+  // `blocked` is operator-attention (awaiting a guide decision), distinct from the
+  // `info` in-flight states and the `bad` failure states.
+  if (
+    status === "cancelled" ||
+    status === "destroying" ||
+    status === "unhealthy" ||
+    status === "blocked"
+  ) {
     return "warn";
   }
   if (
@@ -418,6 +430,10 @@ export function statusGlyph(status: string): string {
       return "✕";
     case "cancelled":
       return "⊘";
+    case "blocked":
+      // Pause glyph — a distinct shape (used nowhere else) so the operator-pause
+      // state reads as "halted, awaiting you" without relying on color alone.
+      return "⏸";
     case "destroying":
       return "◌";
     case "monitoring_pr":

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -75,6 +75,37 @@ export function fallbackLifecycleStages(
   });
 }
 
+// The backend lifecycle (`LIFECYCLE_STAGES`, workspace_observability.py) omits the
+// non-terminal `blocked` pause. So a real blocked workspace arrives with its linear
+// stages and NO active stage: the stage it paused at is marked `completed` once left,
+// and `blocked` isn't a lifecycle stage, so `_stage_summary` never marks anything
+// active. Inject a synthetic active `blocked` stage at its canonical position (after
+// `pushing`) so the operator sees the workspace is paused awaiting them, instead of a
+// rail with no active step. No-op unless the workspace is blocked and the supplied
+// lifecycle lacks a blocked stage (idempotent + safe for every other status).
+export function normalizeLifecycle(
+  status: WorkspaceStatus,
+  lifecycle: WorkspaceLifecycleStage[],
+): WorkspaceLifecycleStage[] {
+  if (status !== "blocked" || lifecycle.some((stage) => stage.stage === "blocked")) {
+    return lifecycle;
+  }
+  const blockedStage: WorkspaceLifecycleStage = {
+    stage: "blocked",
+    started_at: null,
+    ended_at: null,
+    duration_seconds: null,
+    status: "active",
+  };
+  const blockedOrder = lifecycleStages.indexOf("blocked");
+  const insertAt = lifecycle.findIndex(
+    (stage) => lifecycleStages.indexOf(stage.stage as WorkspaceStatus) > blockedOrder,
+  );
+  return insertAt === -1
+    ? [...lifecycle, blockedStage]
+    : [...lifecycle.slice(0, insertAt), blockedStage, ...lifecycle.slice(insertAt)];
+}
+
 export function fallbackLlmUsage(
   usage?: Partial<LlmUsageSummary> | null,
 ): LlmUsageSummary {

--- a/apps/console/lib/format.ts
+++ b/apps/console/lib/format.ts
@@ -43,6 +43,13 @@ export function fallbackLifecycleStages(
   const terminal = status === "failed" || status === "cancelled";
   const terminalSourceIndex = lifecycleStages.indexOf(terminalSourceStage as WorkspaceStatus);
   const completedThroughIndex = terminal ? Math.max(-1, terminalSourceIndex) : activeIndex - 1;
+  // `blocked` can be entered from running/validating/pushing, but it sits at a
+  // fixed position (after `pushing`) in this linear list. Without the real
+  // lifecycle data we can't tell which execution stage it paused at, so we must
+  // NOT claim the execution stages completed (a validating-time pause would
+  // otherwise falsely render `pushing` as done). Stages before execution
+  // (requested/provisioning/ready) are still safely "completed".
+  const executionStartIndex = lifecycleStages.indexOf("running");
 
   return lifecycleStages.map((stage, index): WorkspaceLifecycleStage => {
     let stageStatus: WorkspaceLifecycleStage["status"];
@@ -50,6 +57,8 @@ export function fallbackLifecycleStages(
       stageStatus = index <= completedThroughIndex ? "completed" : "terminal_skipped";
     } else if (stage === status) {
       stageStatus = "active";
+    } else if (status === "blocked" && index >= executionStartIndex) {
+      stageStatus = "pending";
     } else if (index < activeIndex) {
       stageStatus = "completed";
     } else {

--- a/apps/console/lib/recovery-format.test.mjs
+++ b/apps/console/lib/recovery-format.test.mjs
@@ -109,3 +109,33 @@ test("reverse timeline detection identifies backward workspace transitions", () 
     false,
   );
 });
+
+test("blocked entries and resumes are not flagged as reverse transitions", () => {
+  // Post-PR pause: a higher lifecycle index (monitoring_pr) moving into blocked.
+  assert.equal(
+    isReverseWorkspaceTransition({
+      event_type: "workspace.state_changed",
+      old_state: "monitoring_pr",
+      new_state: "blocked",
+    }),
+    false,
+  );
+  // Pre-PR resume: blocked stepping back to an earlier execution stage.
+  assert.equal(
+    isReverseWorkspaceTransition({
+      event_type: "workspace.state_changed",
+      old_state: "blocked",
+      new_state: "validating",
+    }),
+    false,
+  );
+  // A genuine regression that does not involve blocked is still detected.
+  assert.equal(
+    isReverseWorkspaceTransition({
+      event_type: "workspace.state_changed",
+      old_state: "pushing",
+      new_state: "running",
+    }),
+    true,
+  );
+});

--- a/apps/console/lib/recovery-format.ts
+++ b/apps/console/lib/recovery-format.ts
@@ -62,6 +62,14 @@ export function isReverseWorkspaceTransition(
   if (event.event_type !== "workspace.state_changed") {
     return false;
   }
+  // `blocked` is a non-linear operator pause: it is entered from any execution
+  // stage (incl. monitoring_pr, a higher lifecycle index) and resumes back to an
+  // earlier one. Those entries/exits are expected, not regressions, so a
+  // lifecycle-index comparison would mislabel them as backward "step-back" moves.
+  // Never flag a transition into or out of `blocked` as reverse.
+  if (event.old_state === "blocked" || event.new_state === "blocked") {
+    return false;
+  }
   const oldIndex = lifecycleStageIndex(event.old_state);
   const newIndex = lifecycleStageIndex(event.new_state);
   return oldIndex >= 0 && newIndex >= 0 && oldIndex > newIndex;

--- a/apps/console/lib/types.ts
+++ b/apps/console/lib/types.ts
@@ -6,6 +6,7 @@ export type WorkspaceStatus =
   | "validating"
   | "pushing"
   | "monitoring_pr"
+  | "blocked"
   | "completed"
   | "failed"
   | "cancelled"
@@ -458,6 +459,27 @@ export interface ProfileSecurity {
   host_home_auth_mounts: HostHomeAuthMountPolicy;
 }
 
+// A single protected-file violation recorded when a workspace paused (blocked).
+// Mirrors `WorkspaceBlockViolationResponse` (api/schemas.py) exactly.
+export interface WorkspaceBlockViolation {
+  path: string | null;
+  protected_pattern: string | null;
+  section: string | null;
+  line: number | null;
+  reason: string | null;
+}
+
+// Operator-facing block details surfaced while a workspace is `blocked`. Mirrors
+// `WorkspaceBlockStateResponse` (api/schemas.py); only on the full GET response.
+export interface WorkspaceBlockState {
+  block_type: string | null;
+  block_reason_code: string | null;
+  block_resume_phase: string | null;
+  block_epoch: number;
+  blocked_at: string | null;
+  violations: WorkspaceBlockViolation[];
+}
+
 export interface Workspace {
   id: string;
   status: WorkspaceStatus;
@@ -506,6 +528,7 @@ export interface Workspace {
   pr_number?: number | null;
   failure_reason: string | null;
   failure_message: string | null;
+  block_state?: WorkspaceBlockState | null;
   secret_leases: WorkspaceSecretLease[];
   policy_findings: PolicyFinding[];
   egress_audit: WorkspaceEgressAudit | null;
@@ -650,6 +673,7 @@ export interface WorkspaceSaturationCounts {
   validating: number;
   pushing: number;
   monitoring_pr: number;
+  blocked: number;
   destroying: number;
   completed: number;
   failed: number;

--- a/apps/console/lib/workspace-operator-controls.test.mjs
+++ b/apps/console/lib/workspace-operator-controls.test.mjs
@@ -30,6 +30,16 @@ test("control eligibility remonitor requires PR-monitorable workspace", () => {
   );
 });
 
+test("control eligibility cancel stays available for a blocked (operator-paused) workspace", () => {
+  // A blocked workspace holds its slot + warm stack awaiting an operator decision;
+  // cancel is the manual capacity-reclaim lever (state machine allows blocked →
+  // cancelled), so the operator can abandon it instead of being forced to resolve.
+  assertControl({ overview: overview({ status: "blocked" }) }, "cancel", {
+    enabled: true,
+    reason: null,
+  });
+});
+
 test("control eligibility refresh targets merge candidate or stale context", () => {
   assertControl(
     {

--- a/apps/console/lib/workspace-operator-controls.ts
+++ b/apps/console/lib/workspace-operator-controls.ts
@@ -54,6 +54,11 @@ const cancellableStatuses = new Set([
   "validating",
   "pushing",
   "monitoring_pr",
+  // A paused (blocked) workspace holds its execution slot + warm stack while it
+  // awaits an operator decision. Cancel stays the manual capacity-reclaim lever
+  // (the state machine allows blocked → cancelled), so the operator can abandon a
+  // workspace that should not be resumed instead of being forced to grant/revert.
+  "blocked",
 ]);
 
 const terminalOperationStatuses = new Set(["succeeded", "failed", "cancelled", "canceled"]);

--- a/apps/console/tests/dashboard-blocked.spec.ts
+++ b/apps/console/tests/dashboard-blocked.spec.ts
@@ -61,7 +61,7 @@ test("inspector shows the protected violation and both guide resolution commands
 
   // Both ready-to-run guide commands, pre-filled with the workspace id + path.
   await expect(block).toContainText(
-    "awf workspace guide ws_blocked1 --grant '.github/workflows/ci.yml' --reason '<why>'",
+    "awf workspace guide ws_blocked1 --grant '.github/workflows/ci.yml' --approve-policy-downgrade --reason '<why>'",
   );
   await expect(block).toContainText(
     "awf workspace guide ws_blocked1 --directive 'revert .github/workflows/ci.yml; <alternative>'",

--- a/apps/console/tests/dashboard-blocked.spec.ts
+++ b/apps/console/tests/dashboard-blocked.spec.ts
@@ -1,0 +1,336 @@
+import { expect, type Page, test } from "@playwright/test";
+
+// Protected-file pause (blocked) console surfacing:
+//  - the blocked workspace renders the pause glyph + a "Blocked for …" badge;
+//  - the "Awaiting operator" KPI counts blocked, lands in Active, and is EXCLUDED
+//    from Running (running+validating+pushing only — the PR #598 contract);
+//  - the inspector shows the protected violation(s) + the two guide commands.
+
+const now = "2026-06-18T12:00:00.000Z";
+const blockedAt = "2026-06-18T11:00:00.000Z";
+
+test.beforeEach(async ({ page }) => {
+  await mockAwfApi(page);
+});
+
+test("blocked workspace renders the pause badge and a blocked-for indicator", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const card = page.getByTestId("workspace-card-ws_blocked1");
+  await expect(card).toBeVisible();
+  // Badge glyph + label (glyph proves status is not conveyed by color alone).
+  await expect(card.getByText("blocked", { exact: true })).toBeVisible();
+  await expect(card.getByText("⏸")).toBeVisible();
+  // Blocked-age indicator.
+  await expect(page.getByTestId("workspace-blocked-age-ws_blocked1")).toContainText("Blocked for");
+});
+
+test("Awaiting operator KPI counts blocked; Active includes it but Running excludes it", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  // running:2 + validating:1 + pushing:1 => 4 (blocked NOT folded in — PR #598).
+  const runningKpi = kpiCard(page, "Running");
+  await expect(runningKpi.locator(".kpi-value")).toHaveText("4");
+
+  // blocked:2 surfaced as its own KPI.
+  const awaitingKpi = kpiCard(page, "Awaiting operator");
+  await expect(awaitingKpi.locator(".kpi-value")).toHaveText("2");
+
+  // Active is the server-side active_total (includes blocked).
+  const activeKpi = kpiCard(page, "Active");
+  await expect(activeKpi.locator(".kpi-value")).toHaveText("6");
+});
+
+test("inspector shows the protected violation and both guide resolution commands", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  await openInspector(page, "ws_blocked1");
+
+  const block = page.getByTestId("blocked-violation-block");
+  await expect(block).toBeVisible();
+  await expect(block).toContainText("Awaiting operator");
+  await expect(block).toContainText("PROTECTED_QUALITY_GATE_VIOLATION");
+
+  // Violation path + classification.
+  const violation = page.getByTestId("blocked-violation-row").first();
+  await expect(violation).toContainText(".github/workflows/ci.yml");
+  await expect(violation).toContainText(".github/**");
+
+  // Both ready-to-run guide commands, pre-filled with the workspace id + path.
+  await expect(block).toContainText(
+    "awf workspace guide ws_blocked1 --grant '.github/workflows/ci.yml' --reason '<why>'",
+  );
+  await expect(block).toContainText(
+    "awf workspace guide ws_blocked1 --directive 'revert .github/workflows/ci.yml; <alternative>'",
+  );
+});
+
+function kpiCard(page: Page, label: string) {
+  return page
+    .getByText(label, { exact: true })
+    .locator("..")
+    .filter({ has: page.locator(".kpi-value") });
+}
+
+async function openInspector(page: Page, workspaceId: string) {
+  const title = page.getByTestId(`workspace-title-${workspaceId}`);
+  await title.waitFor({ state: "visible" });
+  const box = await title.boundingBox();
+  if (!box) {
+    throw new Error(`Workspace title ${workspaceId} did not produce a clickable box`);
+  }
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+  await expect(page.locator("h2", { hasText: "Protected CI tweak" }).first()).toBeVisible();
+}
+
+async function waitForConsoleReady(page: Page) {
+  await expect(page.locator("header").filter({ hasText: "AWF Console" })).toBeVisible();
+  await expect(page.getByText("API: ok")).toBeVisible();
+}
+
+async function mockAwfApi(page: Page) {
+  await page.route("**/api/awf/**", async (route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    if (path === "/api/awf/health") {
+      await fulfillJson(route, { status: "ok" });
+      return;
+    }
+    if (path === "/api/awf/workspaces/overview") {
+      await fulfillJson(route, listEnvelope([blockedOverview()]));
+      return;
+    }
+    if (path === "/api/awf/workspaces/ws_blocked1") {
+      await fulfillJson(route, blockedWorkspace());
+      return;
+    }
+    if (path === "/api/awf/workspaces/ws_blocked1/runtime") {
+      await fulfillJson(route, { status: "blocked" });
+      return;
+    }
+    if (
+      path === "/api/awf/workspaces/ws_blocked1/events" ||
+      path === "/api/awf/workspaces/ws_blocked1/operations" ||
+      path === "/api/awf/workspaces/ws_blocked1/logs"
+    ) {
+      await fulfillJson(route, listEnvelope([]));
+      return;
+    }
+    if (path.startsWith("/api/awf/workspaces/ws_blocked1/stream")) {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "text/event-stream; charset=utf-8", "cache-control": "no-cache" },
+        body: `data: ${JSON.stringify({ type: "connected", workspace_id: "ws_blocked1" })}\n\n`,
+      });
+      return;
+    }
+    if (path === "/api/awf/metrics/resources/saturation") {
+      await fulfillJson(route, resourceSaturation());
+      return;
+    }
+    if (path === "/api/awf/metrics/workspaces/summary") {
+      await fulfillJson(route, workspaceReliability());
+      return;
+    }
+    if (path === "/api/awf/merge-queue") {
+      await fulfillJson(route, listEnvelope([]));
+      return;
+    }
+    if (path === "/api/awf/metrics/failures/summary") {
+      await fulfillJson(route, { total_failures: 0, window_hours: 24, taxonomy: [], latest_examples: [] });
+      return;
+    }
+
+    await fulfillJson(route, { detail: { message: `unmocked ${path}` } }, 404);
+  });
+}
+
+async function fulfillJson(route: Parameters<Parameters<Page["route"]>[1]>[0], body: unknown, status = 200) {
+  await route.fulfill({ status, headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+}
+
+function listEnvelope<T>(items: T[]) {
+  return { items, next_cursor: null, has_more: false };
+}
+
+function blockedOverview() {
+  return {
+    workspace_id: "ws_blocked1",
+    task_id: "task_blocked1",
+    title: "Protected CI tweak",
+    task_prompt: "edit ci",
+    repo_url: "https://github.com/test/repo",
+    base_branch: "main",
+    branch_name: "awf/ws_blocked1",
+    agent: "codex",
+    agent_model: "gpt-5-codex",
+    agent_effort: "high",
+    agent_model_source: "default",
+    agent_effort_source: "default",
+    network_posture: "restricted",
+    lifecycle: [],
+    llm_usage: null,
+    pricing: null,
+    recovery: null,
+    coordination_warnings: [],
+    provider_readiness_preflight: null,
+    status: "blocked",
+    subphase: null,
+    last_activity_at: blockedAt,
+    last_log_at: blockedAt,
+    is_stale_running: false,
+    current_phase: "validating",
+    active_operation: null,
+    last_event: {
+      id: "evt_block",
+      workspace_id: "ws_blocked1",
+      event_type: "workspace.state_changed",
+      old_state: "validating",
+      new_state: "blocked",
+      reason_code: "PROTECTED_QUALITY_GATE_VIOLATION",
+      payload: null,
+      occurred_at: blockedAt,
+    },
+    pr_url: null,
+    pr_number: null,
+    failure_reason: null,
+    failure_message: null,
+    created_at: "2026-06-18T10:00:00.000Z",
+    updated_at: blockedAt,
+  };
+}
+
+function blockedWorkspace() {
+  return {
+    ...blockedOverview(),
+    id: "ws_blocked1",
+    version: 4,
+    block_state: {
+      block_type: "pre_pr_protected_quality_gate",
+      block_reason_code: "PROTECTED_QUALITY_GATE_VIOLATION",
+      block_resume_phase: "validating",
+      block_epoch: 1,
+      blocked_at: blockedAt,
+      violations: [
+        {
+          path: ".github/workflows/ci.yml",
+          protected_pattern: ".github/**",
+          section: "ci",
+          line: 12,
+          reason: "protected quality gate file",
+        },
+      ],
+    },
+  };
+}
+
+function resourceSaturation() {
+  return {
+    generated_at: now,
+    workspace_counts: {
+      by_status: { running: 2, validating: 1, pushing: 1, monitoring_pr: 0, blocked: 2 },
+      active_total: 6,
+      requested: 0,
+      provisioning: 0,
+      ready: 0,
+      running: 2,
+      validating: 1,
+      pushing: 1,
+      monitoring_pr: 0,
+      blocked: 2,
+      destroying: 0,
+      completed: 0,
+      failed: 0,
+      cancelled: 0,
+      destroyed: 0,
+    },
+    worker: { max_concurrent_provisions: 2, max_concurrent_executions: 4 },
+    local_capacity: { cpu_cores: 8, memory_gb: 32, source: "docker", reason_code: null, detail: null },
+    resource_defaults: { steady_cpu: 1, steady_memory_gb: 2, peak_cpu: 2, peak_memory_gb: 4 },
+    reserved_resources: {
+      active_workspace_count: 6,
+      steady_cpu: 6,
+      steady_memory_gb: 12,
+      peak_cpu: 12,
+      peak_memory_gb: 24,
+      disk_mb: 10240,
+      dind_slots: 0,
+    },
+    capacity: {
+      steady_cpu: { limit: null, reserved: 6, available: 2, available_after_next_default: 1, reason_code: null },
+      peak_cpu: { limit: null, reserved: 12, available: 4, available_after_next_default: 2, reason_code: null },
+      steady_memory_gb: { limit: null, reserved: 12, available: 20, available_after_next_default: 18, reason_code: null },
+      peak_memory_gb: { limit: null, reserved: 24, available: 8, available_after_next_default: 4, reason_code: null },
+      disk_mb: { limit: null, reserved: 10240, available: 1048576, available_after_next_default: 1038336, reason_code: null },
+      dind_slots: { limit: null, reserved: 0, available: null, available_after_next_default: null, reason_code: null },
+      pressure_reasons: [],
+    },
+    allocated_resources: {
+      active_workspace_count: 0,
+      steady_cpu: 0,
+      steady_memory_gb: 0,
+      peak_cpu: 0,
+      peak_memory_gb: 0,
+      disk_mb: 0,
+      dind_slots: 0,
+    },
+    allocated_capacity: {
+      steady_cpu: { limit: null, reserved: 0, available: 8, available_after_next_default: 6, reason_code: null },
+      peak_cpu: { limit: null, reserved: 0, available: 16, available_after_next_default: 12, reason_code: null },
+      steady_memory_gb: { limit: null, reserved: 0, available: 32, available_after_next_default: 28, reason_code: null },
+      peak_memory_gb: { limit: null, reserved: 0, available: 32, available_after_next_default: 28, reason_code: null },
+      disk_mb: { limit: null, reserved: 0, available: 1060864, available_after_next_default: 1049600, reason_code: null },
+      dind_slots: { limit: null, reserved: 0, available: null, available_after_next_default: null, reason_code: null },
+      pressure_reasons: [],
+    },
+    capacity_queue: {
+      queued_workspace_count: 0,
+      oldest_workspace_id: null,
+      oldest_wait_seconds: null,
+      planned_resources: { steady_cpu: 0, steady_memory_gb: 0, peak_cpu: 0, peak_memory_gb: 0, disk_mb: 0, dind_slots: 0 },
+      blocked_reason_counts: {},
+    },
+    concurrency: {
+      provision: { limit: 2, in_use: 0, queued: 0, available: 2 },
+      execution: { limit: 4, in_use: 4, queued: 0, available: 0 },
+    },
+    disk: {
+      path: "/workspace",
+      checked_path: "/workspace",
+      total_bytes: 107374182400,
+      used_bytes: 21474836480,
+      free_bytes: 85899345920,
+      percent_free: 80,
+      threshold_bytes: 10737418240,
+      ok: true,
+      status: "ok",
+      reason: "healthy",
+      detail: null,
+    },
+    admission: { ok: true, status: "ok", reason: "healthy", detail: null },
+  };
+}
+
+function workspaceReliability() {
+  return {
+    generated_at: now,
+    window_start: now,
+    since_hours: 24,
+    status_counts: { running: 2, validating: 1, pushing: 1, blocked: 2 },
+    failure_reason_counts: {},
+    active_count: 6,
+    destroying_count: 0,
+    completed_count: 0,
+    failed_count: 0,
+    cancelled_count: 0,
+    destroyed_count: 0,
+    cleanup_failure_count: 0,
+    stuck_count: 0,
+    actionable_reason_count: 0,
+    unactionable_reason_count: 0,
+  };
+}

--- a/apps/console/tests/dashboard-running-kpi.spec.ts
+++ b/apps/console/tests/dashboard-running-kpi.spec.ts
@@ -18,8 +18,23 @@ test("Running KPI sums running, validating, and pushing workspaces", async ({ pa
   const runningKpi = page.getByText("Running", { exact: true }).locator("..").filter({ has: page.locator(".kpi-value") });
   await expect(runningKpi).toBeVisible();
 
-  // running:2 + validating:1 + pushing:1 => 4
+  // running:2 + validating:1 + pushing:1 => 4 (blocked:1 is NOT folded in).
   await expect(runningKpi.locator(".kpi-value")).toHaveText("4");
+});
+
+test("a blocked workspace lands in Active but never in the Running KPI", async ({ page }) => {
+  await page.goto("/");
+  await waitForConsoleReady(page);
+
+  const kpi = (label: string) =>
+    page.getByText(label, { exact: true }).locator("..").filter({ has: page.locator(".kpi-value") });
+
+  // Running stays running+validating+pushing — blocked must not regress it.
+  await expect(kpi("Running").locator(".kpi-value")).toHaveText("4");
+  // Active is active_total, which includes the blocked workspace.
+  await expect(kpi("Active").locator(".kpi-value")).toHaveText("5");
+  // The dedicated Awaiting operator KPI reflects the blocked count.
+  await expect(kpi("Awaiting operator").locator(".kpi-value")).toHaveText("1");
 });
 
 async function waitForConsoleReady(page: Page) {
@@ -78,8 +93,9 @@ function resourceSaturation() {
         validating: 1,
         pushing: 1,
         monitoring_pr: 0,
+        blocked: 1,
       },
-      active_total: 4,
+      active_total: 5,
       requested: 0,
       provisioning: 0,
       ready: 0,
@@ -87,6 +103,7 @@ function resourceSaturation() {
       validating: 1,
       pushing: 1,
       monitoring_pr: 0,
+      blocked: 1,
       destroying: 0,
       completed: 0,
       failed: 0,

--- a/apps/console/tests/theme-accessibility.spec.ts
+++ b/apps/console/tests/theme-accessibility.spec.ts
@@ -142,6 +142,10 @@ test("mobile theme screenshots cover dashboard, workspace, and logs views", asyn
   // copy-id button overlaps that button's centre, so click the title box
   // directly (above the copy-id control) to land on the open-details button.
   const cardTitle = page.getByTestId(`workspace-title-${workspaceId}`);
+  // The fleet-health strip carries enough KPIs that the first card can sit below
+  // the mobile fold; scroll it into view so the raw-coordinate click below (used
+  // to dodge the overlapping copy-id control) lands inside the viewport.
+  await cardTitle.scrollIntoViewIfNeeded();
   const titleBox = await cardTitle.boundingBox();
   if (!titleBox) {
     throw new Error(`Workspace title ${workspaceId} did not produce a clickable box`);

--- a/plans/PROTECTED_FILE_PAUSE_CONSOLE_WS3_VALIDATION.md
+++ b/plans/PROTECTED_FILE_PAUSE_CONSOLE_WS3_VALIDATION.md
@@ -1,0 +1,94 @@
+# Validation — protected-file pause: CONSOLE + hardening slice (WS-3 of 3)
+
+Plan: `docs/awf-plans/ws_fd877d96989f4218a517a679.md`
+Workspace: `ws_fd877d96989f4218a517a679`
+
+## What shipped (console-only surfacing; no backend behaviour changed)
+
+1. **Status rendering** — `lib/format.ts`: `blocked` added to `lifecycleStages`
+   (before `monitoring_pr`, non-terminal), `statusTone("blocked") → "warn"`,
+   `statusGlyph("blocked") → "⏸"` (a shape used nowhere else, so the pause state is
+   never color-only). `lib/types.ts`: `"blocked"` added to the `WorkspaceStatus`
+   union; `blocked: number` added to `WorkspaceSaturationCounts`; new
+   `WorkspaceBlockViolation` / `WorkspaceBlockState` interfaces mirroring
+   `api/schemas.py`; `block_state?` added to `Workspace`. Saturation fallback mapper
+   (`console-dashboard-shared.tsx`) carries `blocked`.
+2. **Fleet KPI** — `console-dashboard.tsx` `fleetKpis`: new **"Awaiting operator"**
+   KPI = `counts.blocked ?? 0` (warn tone), placed after "Monitoring PR". The
+   **Running** KPI expression is untouched (`running + validating + pushing`, the
+   PR #598 contract); `blocked` lands in **Active** server-side via `active_total`.
+   `FleetHealthStrip` grid widened `xl:grid-cols-8 → xl:grid-cols-9`.
+3. **Blocked-age** — `lib/blocked-format.ts` (new pure helpers): `blockedSince`
+   (list proxy: `last_event.occurred_at` when `new_state==="blocked"`, else
+   `updated_at`), `blockedAgeSeconds` (deterministic, injectable clock). The list
+   renders a "Blocked for N" badge; the inspector uses the precise
+   `block_state.blocked_at`.
+4. **Inspector** — `console-dashboard-workspace-detail.tsx` `BlockedViolationBlock`:
+   for a `blocked` workspace, shows reason code / block type / resume phase /
+   blocked-at, the violation list (path · pattern · section · reason), and the two
+   copy-able guide commands from `formatBlockedResolutionCommands`
+   (`--grant '<path>' --reason '<why>'` and `--directive 'revert <path>; <alternative>'`).
+   Degrades to a "details loading/unavailable" line when `block_state` is absent
+   (overview-only render).
+
+## Tests added/extended (TDD — written before implementation)
+
+- `lib/format.test.mjs` — `blocked` tone/glyph/lifecycle.
+- `lib/blocked-format.test.mjs` (new) — `blockedSince`, `blockedAgeSeconds`,
+  `formatBlockedResolutionCommands` (incl. null/empty-path placeholder).
+- `tests/dashboard-blocked.spec.ts` (new) — blocked badge (⏸) + "Blocked for"
+  indicator; "Awaiting operator" KPI counts blocked, in Active but NOT Running;
+  inspector shows the violation path + both guide commands.
+- `tests/dashboard-running-kpi.spec.ts` — added `blocked` to the fixture; asserts
+  Running stays `running+validating+pushing` while Active grows.
+- `tests/theme-accessibility.spec.ts` — the mobile inspector-open step now scrolls
+  the first card into view before its raw-coordinate click; the required 9th KPI
+  ("Awaiting operator") lengthens the mobile fleet strip enough to push the first
+  card below the fold otherwise. Pure test-robustness change; no app behaviour.
+
+## Focused checks run locally (AWF/CI owns the broad gates)
+
+- `npm --prefix apps/console run test` → 191 pass / 0 fail.
+- `npm --prefix apps/console run typecheck` → clean.
+- `npm --prefix apps/console run lint` → clean.
+- `npx playwright test` (full console browser suite) → 48 pass / 0 fail.
+
+Per the workspace contract, the full Python suite, coverage gate, OpenAPI drift
+gate and console CI job are owned by AWF + GitHub CI after agent completion; they
+were not run here.
+
+## Item 5 — hardening check-first matrix (no duplicate tests added)
+
+The backend authorization-abuse surface is already covered by WS-1/WS-2; this slice
+reads its fields only and adds **no** backend tests (avoiding the protected-file
+trap and keeping the diff console-scoped). Verified existing coverage:
+
+- **Grant `../` traversal / absolute / empty rejected** — `_canonicalize_grant_path`
+  (`controls_guide.py:373-386`) + `test_guide_blocked_rejects_unsafe_grant_path`,
+  `test_canonicalize_grant_path_strips_leading_dot_slash`,
+  `test_canonicalize_grant_path_rejects_empty_after_normalization`.
+- **Directory-wide grant** — `test_directory_grant_suppresses_nested_weakening_workflow`,
+  `test_directory_grant_without_ack_does_not_suppress`,
+  `test_wildcard_grant_does_not_authorize_non_matching_workflow`
+  (`test_quality_gates_parts/test_quality_gates_grants.py`).
+- **Grants rejected on non-blocked / `monitoring_pr`** —
+  `test_guide_grants_rejected_on_monitoring_pr`.
+- **Operator-identity binding (no agent self-grant)** — `operator` is set by the
+  control plane, never from workspace input (`controls_guide.py:406-407`
+  docstring; route passes `payload.operator` from the operator API call, not the
+  agent). Enforced by `test_guide_blocked_grant_same_key_different_operator_conflicts`
+  and `test_guide_blocked_grant_same_operator_whitespace_replays`; a grant also
+  requires a reason (`test_guide_blocked_grant_requires_reason`) and the
+  policy-downgrade ack (`test_guide_blocked_weakening_grant_requires_ack`).
+- **Symlinked protected file** — not a reachable vector at this layer. The quality
+  gate classifies **git-diff path strings**: a tracked symlink appears in the diff
+  as its own path (a symlink blob), and content edited *through* a symlink shows up
+  in the diff as a change to the real protected path, which the pattern matcher
+  flags. There is no string-level seam where a symlink stands in for a protected
+  path, so no focused test is warranted; `_canonicalize_grant_path` independently
+  fails closed on `..`/absolute paths.
+- **Egress to the guide/grant endpoint** — the guide control lives behind the
+  operator REST/MCP surface; the agent runtime runs unprivileged with the profile's
+  restricted egress posture and holds no control-plane API token, so it cannot
+  reach `POST /v1/workspaces/{id}/controls/guide`. This is owned by the
+  profile/network-posture layer (WS-1/WS-2) and unchanged here.

--- a/tests/unit/service/test_support_bundle.py
+++ b/tests/unit/service/test_support_bundle.py
@@ -29,9 +29,24 @@ from awf.service.config import ServiceSettings
 from awf.service.support_bundle import (
     BUNDLE_FILENAME_PREFIX,
     ISSUE_TEMPLATE_PATH,
+    _credential_ref_kind,
     collect_support_bundle,
     write_support_bundle,
 )
+
+
+@pytest.mark.unit
+def test_credential_ref_kind_classifies_backend_schemes() -> None:
+    # Recognized credential backends map to stable labels used in the support
+    # bundle; an unrecognized scheme (or a bare value with no scheme) must fall
+    # through to "unknown" so the bundle never mislabels a backend it does not
+    # understand, and an absent reference stays None.
+    assert _credential_ref_kind("keyring://aws/access-key") == "keyring"
+    assert _credential_ref_kind("env://AWS_ACCESS_KEY") == "env_ref"
+    assert _credential_ref_kind("plain-file:///etc/awf/secret") == "plain_file"
+    assert _credential_ref_kind("vault://prod/db") == "unknown"
+    assert _credential_ref_kind("no-scheme-here") == "unknown"
+    assert _credential_ref_kind(None) is None
 
 
 def _settings(

--- a/tests/unit/service/test_usage_store.py
+++ b/tests/unit/service/test_usage_store.py
@@ -74,6 +74,15 @@ def test_provider_ccusage_source_unknown_returns_none() -> None:
 
 
 @pytest.mark.unit
+def test_accumulate_usage_returns_none_when_no_metric_is_reported() -> None:
+    # No accumulated history, no run delta, and no fallback means the workspace
+    # has not produced a single trustworthy usage sample yet. accumulate_usage
+    # must report None rather than fabricating a zeroed snapshot, so downstream
+    # cost/usage surfaces can distinguish "nothing reported" from "reported zero".
+    assert accumulate_usage(None, None, fallback=None) is None
+
+
+@pytest.mark.unit
 def test_provider_ccusage_source_cursor_is_unsupported_until_ccusage_adds_source() -> None:
     """Cursor remains unsupported until ccusage exposes a source name."""
     assert provider_ccusage_source(AgentRuntime.cursor) is None


### PR DESCRIPTION
## Summary

Final slice (WS-3) of the **protected-file violation → pause-for-operator** feature: surfaces the
`blocked` ("awaiting operator decision") state in the AWF web console. The backend is already merged
(WS-1 #601, WS-2 #609); this is console-only and reads existing API fields — no backend change.

- **Status rendering** (`apps/console/lib/format.ts`, `lib/types.ts`): `blocked` added to
  `lifecycleStages` (non-terminal, before `monitoring_pr`), `statusTone: warn`, `statusGlyph: ⏸`
  (shape, never color-only); `WorkspaceStatus` type entry.
- **"Awaiting operator" fleet KPI** (`console-dashboard.tsx`) counting `blocked` — counts in **Active**
  but **NOT** folded into the **Running** KPI (keeps the #598 semantics intact).
- **Blocked-age**: new pure `lib/blocked-format.ts` (`blockedSince`, `blockedAgeSeconds`,
  `formatBlockedResolutionCommands`); the list shows a "Blocked for N" badge.
- **Inspector** (`console-dashboard-workspace-detail.tsx`): for a `blocked` workspace, shows the
  protected violation(s) + the ready-to-run resolution commands (`guide --grant` / `guide --directive`).
- **Tests**: `blocked-format.test.mjs` (node:test), `dashboard-blocked.spec.ts` (Playwright),
  updated `dashboard-running-kpi.spec.ts` (asserts `blocked` is in Active, not Running).

## Provenance

Salvaged from AWF workspace `ws_fd877d96` — the console work was complete and committed, but the AWF
executor failed twice on infrastructure quirks (the protected-file guard, which only hard-fails because
the pause feature isn't bootstrapped into the running control plane yet; then a dirty-tree because the
plan artifact landed in `apps/console/docs/awf-plans/`, which the root-anchored `.gitignore` doesn't
cover). The console code is unaffected — this PR is that committed work, validated by CI here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and formatting over existing API fields; no auth, data, or server behavior changes. KPI semantics are explicitly preserved (blocked excluded from Running).
> 
> **Overview**
> **Console-only (WS-3):** surfaces the existing `blocked` protected-file pause in the AWF web console—no backend changes.
> 
> The console now treats **`blocked`** as a first-class in-flight status: warn tone, **⏸** glyph, lifecycle stage (with **`normalizeLifecycle`** when the API omits it), and safer fallback progress when lifecycle data is missing. Types and saturation fallbacks add **`block_state`** / violation shapes and a **`blocked`** count.
> 
> Fleet UX adds an **"Awaiting operator"** KPI (warn when &gt; 0); **`blocked`** stays in **Active** via `active_total` but is **not** folded into **Running** (still `running+validating+pushing`). The fleet KPI grid widens to nine columns.
> 
> Workspace list cards show **Blocked for N** (proxy from block transition / `updated_at`). The inspector adds **`BlockedViolationBlock`**: violation details plus copyable **`awf workspace guide`** grant/revert commands from new **`lib/blocked-format.ts`** (multi-path grants, shell/glob escaping). **Cancel** remains enabled for blocked workspaces; **`blocked`** transitions are excluded from reverse “step-back” timeline warnings.
> 
> Coverage: node tests, Playwright (`dashboard-blocked`, running KPI), mobile scroll fix for accessibility; **`TODOS.md`** notes future `owned_paths` ergonomics; tiny unrelated Python unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429961407f3213ac109dc0b4216f1137ef8a51bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for "blocked" workspace status with visual pause indicator and amber "Blocked for…" duration badge.
  * Introduced "Awaiting operator" fleet KPI metric to track blocked workspaces.
  * Enhanced workspace inspector to display violation details and two copyable operator resolution commands when a workspace is blocked.
  * Improved blocked workspace age calculation and formatting.

* **Tests**
  * Added comprehensive test coverage for blocked workspace rendering and KPI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->