### PR TITLE
[codex] Harden GitHub transient retry handling

### DIFF
--- a/plans/GITHUB_OPERATION_RETRY_REDUNDANCY_PLAN.md
+++ b/plans/GITHUB_OPERATION_RETRY_REDUNDANCY_PLAN.md
@@ -1,0 +1,27 @@
+# GitHub Operation Retry And Redundancy Plan
+
+## Summary
+
+Fix AWF's GitHub retry gap where `gh pr create` can fail with GitHub's
+GraphQL `HTTP 400 ... Please try resubmitting` response and be treated as a
+deterministic failure. Keep retries bounded and call-site aware so mutating
+GitHub operations do not duplicate side effects.
+
+## Implementation
+
+- Classify GitHub API/GraphQL failures containing `try resubmitting` as
+  transient, while keeping generic HTTP 400, auth, missing repo, invalid branch,
+  and no-commits errors deterministic.
+- Preserve the existing feature PR creation retry/reconcile path and add direct
+  regression coverage for the malformed GraphQL 400 text.
+- Add the same bounded retry and same-repo reconciliation behavior to release PR
+  creation, with structured log evidence for attempts, wait times, lookups, and
+  exhaustion.
+- Rely on the shared classifier for PR monitor GitHub retry helpers; do not add
+  blind low-level retries inside `GitHubClient`.
+
+## Validation
+
+- Targeted unit tests for the classifier, feature PR creation, release PR sync,
+  PR monitor transient retry, and executor PR-open evidence.
+- `ruff` and `mypy` on touched common/runtime files.

--- a/plans/GITHUB_OPERATION_RETRY_REDUNDANCY_VALIDATION.md
+++ b/plans/GITHUB_OPERATION_RETRY_REDUNDANCY_VALIDATION.md
@@ -1,0 +1,20 @@
+# GitHub Operation Retry And Redundancy Validation
+
+## Commands
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/common/test_github_transient.py tests/unit/runtime/test_pr_creator.py tests/unit/runtime/test_release_pr_sync.py tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py tests/unit/control/test_executor_parts/test_executor_part_005.py -q`
+  - Result: `104 passed`
+- `uv run --python 3.12 --extra dev ruff check src/awf/common/github_transient.py src/awf/runtime/release_pr_sync.py src/awf/runtime/pr_monitor_runner/helpers.py tests/unit/common/test_github_transient.py tests/unit/runtime/test_pr_creator.py tests/unit/runtime/test_release_pr_sync.py tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py tests/unit/control/test_executor_parts/test_executor_part_005.py`
+  - Result: passed
+- `uv run --python 3.12 --extra dev mypy src/awf/common/github_transient.py src/awf/runtime/release_pr_sync.py src/awf/runtime/pr_monitor_runner/helpers.py`
+  - Result: passed
+
+## Notes
+
+- The exact GitHub GraphQL malformed-request response with `Please try
+  resubmitting` is now classified as transient only when GitHub API/GraphQL
+  context is present.
+- Feature PR creation, release PR creation, and PR monitor GitHub retry paths all
+  have focused coverage for the new classification.
+- Deterministic errors such as bad credentials and generic malformed HTTP 400
+  responses remain non-transient.

--- a/src/awf/common/github_transient.py
+++ b/src/awf/common/github_transient.py
@@ -53,6 +53,19 @@ AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = (
     "requires authentication",
 )
 
+GITHUB_RESUBMIT_TRANSIENT_MARKERS = (
+    "please try resubmitting",
+    "try resubmitting",
+)
+
+GITHUB_API_CONTEXT_MARKERS = (
+    "api.github.com",
+    "github api",
+    "graphql",
+    "gh api",
+    "gh pr create",
+)
+
 
 def is_transient_github_error_text(*, operation: str, stderr: str) -> bool:
     """Return whether a GitHub CLI/API failure looks transient."""
@@ -60,6 +73,10 @@ def is_transient_github_error_text(*, operation: str, stderr: str) -> bool:
     text = f"{operation}\n{stderr}".lower()
     if any(marker in text for marker in NON_TRANSIENT_GITHUB_ERROR_MARKERS):
         return False
+    if any(marker in text for marker in GITHUB_RESUBMIT_TRANSIENT_MARKERS) and any(
+        marker in text for marker in GITHUB_API_CONTEXT_MARKERS
+    ):
+        return True
     if any(marker in text for marker in TRANSIENT_GITHUB_ERROR_MARKERS):
         return True
     return any(marker in text for marker in AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS)

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 
 from awf.common.github_transient import (
-    AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
     NON_TRANSIENT_GITHUB_ERROR_MARKERS,
     TRANSIENT_GITHUB_ERROR_MARKERS,
 )
@@ -50,19 +49,6 @@ _TASK_TAG_UNSET = _TaskTagUnset()
 # 401 combined with e.g. ``Bad credentials`` still fails fast.
 _NON_TRANSIENT_GITHUB_ERROR_MARKERS = NON_TRANSIENT_GITHUB_ERROR_MARKERS
 _TRANSIENT_GITHUB_ERROR_MARKERS = TRANSIENT_GITHUB_ERROR_MARKERS
-
-# Ambiguous auth blips: a bare ``HTTP 401`` / ``Requires authentication`` with no
-# strong permanent marker is a recoverable transient on the GitHub *API* client
-# path (a GraphQL blip on a valid token, #515). The strong markers above are
-# checked first and win, so a genuine bad-credentials 401 still fails fast.
-#
-# These markers apply ONLY to ``_is_transient_github_client_error``, never to raw
-# git base-fetch stderr: git's smart-HTTP transport surfaces genuine credential
-# failures as ``error: RPC failed; HTTP 401`` (a contiguous ``HTTP 401``
-# substring), which must fail fast rather than be bounded-retried. They are
-# therefore deliberately kept out of ``_TRANSIENT_GITHUB_ERROR_MARKERS`` so
-# ``_is_transient_base_fetch_error`` never matches them.
-_AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS
 
 _GITHUB_TRANSIENT_RETRY_REASON = "GITHUB_TRANSIENT_RETRY"
 

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -27,6 +27,7 @@ from awf.common.bitbucket_client import (
     BitbucketClientError,
 )
 from awf.common.github_client import GitHubClientError
+from awf.common.github_transient import is_transient_github_error_text
 from awf.control.quality_gates import QualityGateViolation
 from awf.control.state_machine import WorkspaceStateMachine
 from awf.db.enums import (
@@ -89,7 +90,6 @@ from awf.runtime.pr_monitor_runner.comments import (
     VerdictResult,
 )
 from awf.runtime.pr_monitor_runner.constants import (
-    _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
     _AUTHORIZATION_BEARER_RE,
     _AWF_VERDICT,
     _BASE_FETCH_RETRY_COUNT_KEY_PREFIX,
@@ -650,14 +650,7 @@ def _redact_and_truncate_forge_error(value: str, *, limit: int = 400) -> str:
 def _is_transient_github_client_error(exc: GitHubClientError) -> bool:
     """Classify GitHub/gh failures that should keep the monitor polling."""
 
-    text = f"{exc.operation}\n{exc.stderr}".lower()
-    if any(marker in text for marker in _NON_TRANSIENT_GITHUB_ERROR_MARKERS):
-        return False
-    if any(marker in text for marker in _TRANSIENT_GITHUB_ERROR_MARKERS):
-        return True
-    # Ambiguous auth blips are transient only on the GitHub API client path (#515);
-    # ``_is_transient_base_fetch_error`` deliberately does not consult them.
-    return any(marker in text for marker in _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS)
+    return is_transient_github_error_text(operation=exc.operation, stderr=exc.stderr)
 
 
 def _is_transient_bitbucket_client_error(exc: BitbucketClientError) -> bool:

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -23,6 +23,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
+from awf.common.audit import redact_audit_text
 from awf.common.commands import AsyncCommandRunner
 from awf.common.forge import ForgeClient
 from awf.common.github_client import (
@@ -273,7 +274,11 @@ async def _lookup_release_pr_after_create_failure(
             # carry it into the reconcile-lookup record so the retry/audit metadata
             # keeps the policy-relevant failure semantics (reason codes flow end-to-end).
             "reason_code": exc.reason_code,
-            "error_message": exc.message.strip(),
+            # ``exc.message`` is raw ``gh pr list`` stderr — unlike
+            # ``GitHubClientError.stderr`` it is *not* redacted at construction, so
+            # redact it here before it lands in ``reconcile_lookups`` and the
+            # retry/exhausted logs (no-secret logging rule).
+            "error_message": redact_audit_text(exc.message.strip()),
         }
     return number, {"status": "found" if number is not None else "not_found", "number": number}
 

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -19,6 +19,8 @@ Generic AWF core behaviour — no hard-coded repositories or branch names.
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 
 from awf.common.commands import AsyncCommandRunner
@@ -31,6 +33,7 @@ from awf.common.github_client import (
     list_open_pull_requests_for_branch,
     parse_github_pull_request_url,
 )
+from awf.common.github_transient import is_transient_github_error_text
 from awf.common.logging import get_logger
 
 _log = get_logger(__name__)
@@ -42,6 +45,11 @@ NO_CHANGES_REASON_CODE = "NO_CHANGES_TO_SYNC"
 # ``gh pr view`` and parses github.com-only PR URLs. Mirrors
 # ``OPEN_PR_RESOLVER_FORGE_NOT_SUPPORTED`` and ``PR_ADOPTION_METADATA_FETCH_GITHUB_ONLY``.
 RELEASE_SYNC_FORGE_NOT_SUPPORTED_REASON_CODE = "RELEASE_SYNC_FORGE_NOT_SUPPORTED"
+_RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES = 3
+_RELEASE_PR_CREATE_TRANSIENT_INITIAL_BACKOFF_SECONDS = 5.0
+_RELEASE_PR_CREATE_TRANSIENT_MAX_BACKOFF_SECONDS = 30.0
+
+SleepFn = Callable[[float], Awaitable[None]]
 
 
 def ensure_release_sync_forge_supported(
@@ -178,6 +186,31 @@ def _is_duplicate_pull_request_error(exc: GitHubClientError) -> bool:
     return exc.returncode == 1 and "already exists" in exc.stderr.lower()
 
 
+def _release_pr_create_retry_wait_seconds(attempt: int) -> float:
+    wait_seconds = min(
+        _RELEASE_PR_CREATE_TRANSIENT_INITIAL_BACKOFF_SECONDS * (2 ** max(0, attempt - 1)),
+        _RELEASE_PR_CREATE_TRANSIENT_MAX_BACKOFF_SECONDS,
+    )
+    return float(wait_seconds)
+
+
+def _release_pr_create_failure_detail(
+    exc: GitHubClientError,
+    *,
+    attempt: int,
+    transient: bool,
+    duplicate: bool,
+) -> dict[str, object]:
+    return {
+        "operation": exc.operation,
+        "returncode": exc.returncode,
+        "attempt": attempt,
+        "transient": transient,
+        "duplicate": duplicate,
+        "error_message": exc.stderr.strip(),
+    }
+
+
 async def _find_open_same_repo_pr_number(
     *,
     runner: AsyncCommandRunner,
@@ -204,6 +237,169 @@ async def _find_open_same_repo_pr_number(
     return same_repo_existing[0].number if same_repo_existing else None
 
 
+async def _lookup_release_pr_after_create_failure(
+    *,
+    runner: AsyncCommandRunner,
+    repo: RepoRef,
+    source_branch: str,
+    target_branch: str,
+) -> tuple[int | None, dict[str, object]]:
+    try:
+        number = await _find_open_same_repo_pr_number(
+            runner=runner,
+            repo=repo,
+            source_branch=source_branch,
+            target_branch=target_branch,
+        )
+    except GitHubClientError as exc:
+        return None, {
+            "status": "failed",
+            "operation": exc.operation,
+            "returncode": exc.returncode,
+            "error_message": exc.stderr.strip(),
+        }
+    return number, {"status": "found" if number is not None else "not_found", "number": number}
+
+
+async def _create_release_pr_with_redundancy(
+    *,
+    runner: AsyncCommandRunner,
+    gh: ForgeClient,
+    repo: RepoRef,
+    source_branch: str,
+    target_branch: str,
+    title: str,
+    body: str,
+    sleep: SleepFn,
+) -> tuple[int, bool]:
+    failures: list[dict[str, object]] = []
+    lookups: list[dict[str, object]] = []
+    attempt = 0
+
+    while True:
+        attempt += 1
+        try:
+            pr_url = await gh.create_pull_request(
+                repo=repo,
+                base=target_branch,
+                head=source_branch,
+                title=title,
+                body=body,
+            )
+        except GitHubClientError as exc:
+            if exc.returncode == 0:
+                raise ReleasePrSyncError(
+                    reason_code="RELEASE_SYNC_PR_URL_INVALID",
+                    message=f"gh pr create returned no parseable PR URL: {exc.stderr!r}",
+                    detail={"source_branch": source_branch, "target_branch": target_branch},
+                ) from exc
+
+            duplicate = _is_duplicate_pull_request_error(exc)
+            transient = is_transient_github_error_text(
+                operation=exc.operation,
+                stderr=exc.stderr,
+            )
+            failure = _release_pr_create_failure_detail(
+                exc,
+                attempt=attempt,
+                transient=transient,
+                duplicate=duplicate,
+            )
+            failures.append(failure)
+            if not transient and not duplicate:
+                raise
+
+            existing_number, lookup_detail = await _lookup_release_pr_after_create_failure(
+                runner=runner,
+                repo=repo,
+                source_branch=source_branch,
+                target_branch=target_branch,
+            )
+            lookups.append(lookup_detail)
+            if existing_number is not None:
+                _log.info(
+                    "release_pr_sync.create_reconciled",
+                    repo=repo.slug(),
+                    source_branch=source_branch,
+                    target_branch=target_branch,
+                    attempt=attempt,
+                    pr_number=existing_number,
+                    transient=transient,
+                    duplicate=duplicate,
+                    failures=failures,
+                    reconcile_lookups=lookups,
+                )
+                return existing_number, False
+
+            retry_lookup_failure = duplicate and lookup_detail.get("status") == "failed"
+            if not transient and not retry_lookup_failure:
+                raise
+            if attempt > _RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES:
+                _log.warning(
+                    "release_pr_sync.create_retry_exhausted",
+                    repo=repo.slug(),
+                    source_branch=source_branch,
+                    target_branch=target_branch,
+                    attempt=attempt,
+                    max_retries=_RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES,
+                    failures=failures,
+                    reconcile_lookups=lookups,
+                )
+                raise
+
+            wait_seconds = _release_pr_create_retry_wait_seconds(attempt)
+            failure["will_retry"] = True
+            failure["wait_seconds"] = wait_seconds
+            _log.warning(
+                "release_pr_sync.create_retrying",
+                repo=repo.slug(),
+                source_branch=source_branch,
+                target_branch=target_branch,
+                attempt=attempt,
+                max_retries=_RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES,
+                wait_seconds=wait_seconds,
+                transient=transient,
+                duplicate=duplicate,
+                failures=failures,
+                reconcile_lookups=lookups,
+            )
+            if wait_seconds > 0:
+                await sleep(wait_seconds)
+            continue
+
+        try:
+            parsed_repo, pr_number = parse_github_pull_request_url(pr_url)
+        except ValueError as exc:
+            raise ReleasePrSyncError(
+                reason_code="RELEASE_SYNC_PR_URL_INVALID",
+                message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
+                detail={"source_branch": source_branch, "target_branch": target_branch},
+            ) from exc
+        if parsed_repo.slug().lower() != repo.slug().lower():
+            raise ReleasePrSyncError(
+                reason_code="RELEASE_SYNC_PR_REPO_MISMATCH",
+                message=f"gh pr create returned a PR URL for a different repository: {pr_url!r}",
+                detail={
+                    "expected_repo": repo.slug(),
+                    "parsed_repo": parsed_repo.slug(),
+                    "source_branch": source_branch,
+                    "target_branch": target_branch,
+                },
+            )
+        if failures:
+            _log.info(
+                "release_pr_sync.create_succeeded_after_retry",
+                repo=repo.slug(),
+                source_branch=source_branch,
+                target_branch=target_branch,
+                attempt=attempt,
+                pr_number=pr_number,
+                failures=failures,
+                reconcile_lookups=lookups,
+            )
+        return pr_number, True
+
+
 async def find_or_create_release_pr(
     *,
     runner: AsyncCommandRunner,
@@ -213,6 +409,7 @@ async def find_or_create_release_pr(
     target_branch: str,
     title: str,
     body: str,
+    sleep: SleepFn | None = None,
 ) -> tuple[PullRequestAdoptionMetadata, bool]:
     """Reuse an open ``source→target`` PR if present, else create one.
 
@@ -230,7 +427,6 @@ async def find_or_create_release_pr(
         target_branch=target_branch,
     )
 
-    repo_slug = repo.slug()
     existing_number = await _find_open_same_repo_pr_number(
         runner=runner,
         repo=repo,
@@ -241,68 +437,16 @@ async def find_or_create_release_pr(
         pr_number = existing_number
         created = False
     else:
-        try:
-            pr_url = await gh.create_pull_request(
-                repo=repo,
-                base=target_branch,
-                head=source_branch,
-                title=title,
-                body=body,
-            )
-        except GitHubClientError as exc:
-            if exc.returncode == 0:
-                # ``gh`` exited 0 but printed no parseable PR URL. GitHubClient
-                # signals exactly this case with returncode=0 (real gh failures
-                # carry the non-zero exit code). Surface it with the release-sync
-                # reason code rather than leaking the raw gh error, preserving the
-                # RELEASE_SYNC_PR_URL_INVALID contract downstream callers rely on.
-                raise ReleasePrSyncError(
-                    reason_code="RELEASE_SYNC_PR_URL_INVALID",
-                    message=f"gh pr create returned no parseable PR URL: {exc.stderr!r}",
-                    detail={"source_branch": source_branch, "target_branch": target_branch},
-                ) from exc
-            # TOCTOU: the list above can race a concurrent sync run or a human
-            # opening the same source→target PR before this create. GitHub
-            # rejects the duplicate with a recognisable "already exists" error,
-            # so only then re-check and adopt the now-existing PR instead of
-            # failing the workspace. Any other failure (auth, network, branch
-            # protection) re-raises immediately with its original context
-            # rather than being masked by a second, unrelated list call.
-            if not _is_duplicate_pull_request_error(exc):
-                raise
-            raced_number = await _find_open_same_repo_pr_number(
-                runner=runner,
-                repo=repo,
-                source_branch=source_branch,
-                target_branch=target_branch,
-            )
-            if raced_number is None:
-                raise
-            pr_number = raced_number
-            created = False
-        else:
-            try:
-                parsed_repo, pr_number = parse_github_pull_request_url(pr_url)
-            except ValueError as exc:
-                raise ReleasePrSyncError(
-                    reason_code="RELEASE_SYNC_PR_URL_INVALID",
-                    message=f"gh pr create returned an unparseable PR URL: {pr_url!r}",
-                    detail={"source_branch": source_branch, "target_branch": target_branch},
-                ) from exc
-            if parsed_repo.slug().lower() != repo_slug.lower():
-                raise ReleasePrSyncError(
-                    reason_code="RELEASE_SYNC_PR_REPO_MISMATCH",
-                    message=(
-                        f"gh pr create returned a PR URL for a different repository: {pr_url!r}"
-                    ),
-                    detail={
-                        "expected_repo": repo_slug,
-                        "parsed_repo": parsed_repo.slug(),
-                        "source_branch": source_branch,
-                        "target_branch": target_branch,
-                    },
-                )
-            created = True
+        pr_number, created = await _create_release_pr_with_redundancy(
+            runner=runner,
+            gh=gh,
+            repo=repo,
+            source_branch=source_branch,
+            target_branch=target_branch,
+            title=title,
+            body=body,
+            sleep=sleep or asyncio.sleep,
+        )
     metadata = await fetch_pull_request_adoption_metadata(
         runner=runner,
         repo=repo,

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -269,6 +269,10 @@ async def _lookup_release_pr_after_create_failure(
             "status": "failed",
             "operation": "gh pr list",
             "returncode": detail.get("returncode"),
+            # ``reason_code`` lives on the exception itself, not inside ``detail``;
+            # carry it into the reconcile-lookup record so the retry/audit metadata
+            # keeps the policy-relevant failure semantics (reason codes flow end-to-end).
+            "reason_code": exc.reason_code,
             "error_message": exc.message.strip(),
         }
     return number, {"status": "found" if number is not None else "not_found", "number": number}

--- a/src/awf/runtime/release_pr_sync.py
+++ b/src/awf/runtime/release_pr_sync.py
@@ -28,6 +28,7 @@ from awf.common.forge import ForgeClient
 from awf.common.github_client import (
     GitHubClientError,
     PullRequestAdoptionMetadata,
+    PullRequestMetadataError,
     RepoRef,
     fetch_pull_request_adoption_metadata,
     list_open_pull_requests_for_branch,
@@ -257,6 +258,18 @@ async def _lookup_release_pr_after_create_failure(
             "operation": exc.operation,
             "returncode": exc.returncode,
             "error_message": exc.stderr.strip(),
+        }
+    except PullRequestMetadataError as exc:
+        # ``gh pr list`` (via ``list_open_pull_requests_for_branch``) raises this
+        # rather than ``GitHubClientError``. Treat it as a failed lookup so the
+        # bounded create-retry / duplicate-lookup-retry loop still runs instead
+        # of letting it escape and bypass the retry path entirely.
+        detail = exc.detail or {}
+        return None, {
+            "status": "failed",
+            "operation": "gh pr list",
+            "returncode": detail.get("returncode"),
+            "error_message": exc.message.strip(),
         }
     return number, {"status": "found" if number is not None else "not_found", "number": number}
 

--- a/tests/unit/common/test_github_transient.py
+++ b/tests/unit/common/test_github_transient.py
@@ -1,0 +1,44 @@
+"""Regression coverage for shared GitHub transient-failure classification."""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.common.github_transient import is_transient_github_error_text
+
+
+@pytest.mark.unit
+def test_malformed_graphql_resubmit_error_is_transient() -> None:
+    assert is_transient_github_error_text(
+        operation="gh pr create",
+        stderr=(
+            "pull request create failed: HTTP 400: We received a malformed request "
+            "from your client. Sorry about that. Please try resubmitting your "
+            "request and contact us if the problem persists. "
+            "(https://api.github.com/graphql)"
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_generic_malformed_http_400_without_resubmit_guidance_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="HTTP 400: malformed request",
+    )
+
+
+@pytest.mark.unit
+def test_resubmit_wording_without_github_api_context_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="local validator",
+        stderr="malformed payload; please try resubmitting",
+    )
+
+
+@pytest.mark.unit
+def test_deterministic_github_auth_error_wins_over_resubmit_wording() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr="Bad credentials. Please try resubmitting your request.",
+    )

--- a/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_007.py
+++ b/tests/unit/control/test_executor_error_paths_parts/test_executor_error_paths_part_007.py
@@ -1210,7 +1210,12 @@ class TestSyncReleasePrHandoff:
         fake.queue_result(returncode=0)  # post-setup git fetch
         fake.queue_result(returncode=0, stdout="2\n")  # post-setup git rev-list --count
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> no existing PR
-        fake.queue_result(returncode=1, stderr="gh: API rate limit exceeded")  # gh pr create fails
+        # A *non-transient* gh pr create error (issue #PRRT retry hardening) must
+        # fail cleanly on the first attempt — no bounded retry, no reconcile lookup
+        # — so it surfaces as RELEASE_SYNC_GITHUB_ERROR before the monitor runs.
+        # A transient error (e.g. a rate limit) would instead be retried; that path
+        # is covered by test_release_pr_sync's exhaustion test.
+        fake.queue_result(returncode=1, stderr="gh: Bad credentials")  # gh pr create fails
 
         ws_id = await _seed_ready(
             factory,

--- a/tests/unit/control/test_executor_parts/test_executor_part_005.py
+++ b/tests/unit/control/test_executor_parts/test_executor_part_005.py
@@ -928,7 +928,12 @@ class TestFailurePaths:
         fake.queue_result(returncode=0)
         fake.queue_result(
             returncode=1,
-            stderr='Post "https://api.github.com/graphql": dial tcp: i/o timeout',
+            stderr=(
+                "pull request create failed: HTTP 400: We received a malformed request "
+                "from your client. Sorry about that. Please try resubmitting your "
+                "request and contact us if the problem persists. "
+                "(https://api.github.com/graphql)"
+            ),
         )
         fake.queue_result(returncode=0, stdout="[]")
 

--- a/tests/unit/runtime/test_pr_creator.py
+++ b/tests/unit/runtime/test_pr_creator.py
@@ -233,6 +233,55 @@ class TestPushAndOpen:
         assert len(list_calls) == 1
 
     @pytest.mark.unit
+    async def test_github_malformed_graphql_resubmit_pr_create_retries_then_succeeds(
+        self,
+    ) -> None:
+        runner = FakeCommandRunner()
+        _queue_pre_push_diagnostics(runner)
+        runner.queue_result(returncode=0)  # push succeeds
+        runner.queue_result(
+            returncode=1,
+            stderr=(
+                "pull request create failed: HTTP 400: We received a malformed request "
+                "from your client. Sorry about that. Please try resubmitting your "
+                "request and contact us if the problem persists. "
+                "(https://api.github.com/graphql)"
+            ),
+        )
+        runner.queue_result(returncode=0, stdout="[]")  # reconcile lookup: none
+        runner.queue_result(
+            returncode=0,
+            stdout="https://github.com/dimileeh/aira-agent/pull/42\n",
+        )
+
+        creator = PullRequestCreator(
+            runner,
+            pr_create_transient_max_retries=1,
+            pr_create_transient_initial_backoff_seconds=0,
+        )
+        result = await creator.push_and_open(
+            worktree_path=_WORKTREE,
+            branch_name="awf/ws_x",
+            base_branch="development",
+            title="t",
+            body="b",
+            forge_client=GitHubClient(runner),
+            repo_url=_GH_REPO_URL,
+        )
+
+        assert result.url == "https://github.com/dimileeh/aira-agent/pull/42"
+        assert result.open_metadata is not None
+        assert result.open_metadata["strategy"] == "created_after_retry"
+        failures = result.open_metadata["failures"]
+        assert isinstance(failures, list)
+        assert failures[0]["transient"] is True
+        assert failures[0]["will_retry"] is True
+        create_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "create"]]
+        list_calls = [call for call in runner.calls if call.args[:3] == ["gh", "pr", "list"]]
+        assert len(create_calls) == 2
+        assert len(list_calls) == 1
+
+    @pytest.mark.unit
     async def test_github_transient_pr_create_failure_then_empty_url_preserves_retry_details(
         self,
     ) -> None:

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -165,6 +165,50 @@ async def test_github_transient_401_retries_with_backoff_then_exhausts(
 
 
 @pytest.mark.unit
+async def test_github_malformed_graphql_resubmit_retries(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    sleep_fn = RecordedSleep()
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+    )
+    exc = GitHubClientError(
+        operation="gh api graphql",
+        returncode=1,
+        stderr=(
+            "HTTP 400: We received a malformed request from your client. "
+            "Sorry about that. Please try resubmitting your request and contact us "
+            "if the problem persists. (https://api.github.com/graphql)"
+        ),
+    )
+    state = MonitorState()
+
+    retried = await runner._wait_after_transient_github_error(
+        exc,
+        workspace_id=workspace_id,
+        pr_number=42,
+        context="fetch_pr_status",
+        state=state,
+        monitor_log=None,
+    )
+
+    assert retried is True
+    assert sleep_fn.calls == [5]
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+        retrying = _events(ws, "monitor.github_transient_error_retrying")
+        assert len(retrying) == 1
+        assert retrying[0].payload["context"] == "fetch_pr_status"
+
+
+@pytest.mark.unit
 async def test_bitbucket_transient_403_retries_with_backoff_then_exhausts(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -433,14 +433,112 @@ class TestFindOrCreateReleasePr:
         ]
 
     @pytest.mark.unit
-    async def test_non_duplicate_create_failure_reraises_without_recheck(self) -> None:
-        # A create failure that is not a duplicate-PR rejection (auth, network,
-        # branch protection, HTTP 5xx) is not a lost race. It must surface the
-        # original gh error immediately, without a second `gh pr list` whose own
-        # failure could mask the real cause.
+    async def test_transient_create_failure_retries_then_succeeds(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
         fake.queue_result(returncode=1, stderr="HTTP 500 from GitHub")  # gh pr create -> fails
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list recheck -> none
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # gh pr view
+        gh = GitHubClient(fake)
+        slept: list[float] = []
+
+        async def _record_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+            sleep=_record_sleep,
+        )
+
+        assert created is True
+        assert metadata.number == 321
+        assert slept == [5.0]
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_malformed_graphql_resubmit_create_failure_retries_then_succeeds(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(
+            returncode=1,
+            stderr=(
+                "pull request create failed: HTTP 400: We received a malformed request "
+                "from your client. Sorry about that. Please try resubmitting your "
+                "request and contact us if the problem persists. "
+                "(https://api.github.com/graphql)"
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list recheck -> none
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # gh pr view
+        gh = GitHubClient(fake)
+
+        async def _no_sleep(_seconds: float) -> None:
+            return None
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+            sleep=_no_sleep,
+        )
+
+        assert created is True
+        assert metadata.number == 321
+        assert len([c for c in fake.calls if c.args[:3] == ["gh", "pr", "create"]]) == 2
+
+    @pytest.mark.unit
+    async def test_transient_create_failure_reconciles_existing_pr(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=1, stderr="HTTP 503 from GitHub")  # gh pr create -> fails
+        fake.queue_result(returncode=0, stdout=_open_pr_list_payload(number=77))
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=77))  # gh pr view
+        gh = GitHubClient(fake)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+        )
+
+        assert created is False
+        assert metadata.number == 77
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_deterministic_create_failure_reraises_without_recheck(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=1, stderr="Bad credentials")  # gh pr create -> fails
         gh = GitHubClient(fake)
 
         with pytest.raises(GitHubClientError) as exc:
@@ -455,7 +553,7 @@ class TestFindOrCreateReleasePr:
             )
 
         assert exc.value.operation == "gh pr create"
-        # Only the initial list + the failed create ran: no re-check, no view.
+        # Only the initial list + the failed create ran: no retry, re-check, or view.
         assert [c.args[:3] for c in fake.calls] == [
             ["gh", "pr", "list"],
             ["gh", "pr", "create"],

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -14,6 +14,7 @@ import pytest
 from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import GitHubClient, GitHubClientError, RepoRef
 from awf.runtime.release_pr_sync import (
+    _RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES,
     NO_CHANGES_REASON_CODE,
     ReleasePrSyncError,
     ReleasePrSyncNoOp,
@@ -627,6 +628,53 @@ class TestFindOrCreateReleasePr:
             ["gh", "pr", "list"],
             ["gh", "pr", "view"],
         ]
+
+    @pytest.mark.unit
+    async def test_transient_create_failure_retry_exhausted_reraises(self) -> None:
+        # Four consecutive transient create failures whose reconcile lookups find
+        # nothing must exhaust the bounded retry loop
+        # (``attempt > _RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES``) and re-raise the
+        # original gh error rather than looping forever. Mirrors the feature-PR
+        # exhaustion guard in ``test_pr_creator.py``.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        for _ in range(_RELEASE_PR_CREATE_TRANSIENT_MAX_RETRIES + 1):
+            fake.queue_result(returncode=1, stderr="HTTP 500 from GitHub")  # gh pr create
+            fake.queue_result(returncode=0, stdout="[]")  # reconcile gh pr list -> none
+        gh = GitHubClient(fake)
+        slept: list[float] = []
+
+        async def _record_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        with pytest.raises(GitHubClientError) as exc:
+            await find_or_create_release_pr(
+                runner=fake,
+                gh=gh,
+                repo=_REPO,
+                source_branch="development",
+                target_branch="main",
+                title="t",
+                body="b",
+                sleep=_record_sleep,
+            )
+
+        assert exc.value.operation == "gh pr create"
+        # One initial list + four (create, reconcile-list) attempts; no `gh pr view`.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+        ]
+        # Backoff before the 2nd/3rd/4th attempts only — the exhausting attempt
+        # re-raises before sleeping.
+        assert slept == [5.0, 10.0, 20.0]
 
     @pytest.mark.unit
     async def test_deterministic_create_failure_reraises_without_recheck(self) -> None:

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -535,6 +535,100 @@ class TestFindOrCreateReleasePr:
         ]
 
     @pytest.mark.unit
+    async def test_transient_create_failure_recheck_list_error_retries_then_succeeds(
+        self,
+    ) -> None:
+        # The post-create reconcile ``gh pr list`` itself fails. That call raises
+        # ``PullRequestMetadataError`` (not ``GitHubClientError``); the lookup must
+        # treat it as a failed reconcile so the bounded transient-retry loop still
+        # runs instead of letting the metadata error escape.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(returncode=1, stderr="HTTP 500 from GitHub")  # gh pr create -> fails
+        fake.queue_result(
+            returncode=1, stderr="HTTP 502 from GitHub"
+        )  # gh pr list recheck -> errors
+        fake.queue_result(returncode=0, stdout="https://github.com/o/r/pull/321\n")
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=321))  # gh pr view
+        gh = GitHubClient(fake)
+        slept: list[float] = []
+
+        async def _record_sleep(seconds: float) -> None:
+            slept.append(seconds)
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+            sleep=_record_sleep,
+        )
+
+        assert created is True
+        assert metadata.number == 321
+        assert slept == [5.0]
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
+    async def test_duplicate_create_failure_recheck_list_error_retries_lookup(self) -> None:
+        # A duplicate (non-transient) create failure whose reconcile ``gh pr list``
+        # errors must still drive the duplicate-lookup retry: the
+        # ``PullRequestMetadataError`` is caught as a failed lookup rather than
+        # escaping and bypassing the retry path.
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
+        fake.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "development" into branch "main" already exists',
+        )  # gh pr create -> duplicate rejected
+        fake.queue_result(
+            returncode=1, stderr="HTTP 500 from GitHub"
+        )  # gh pr list recheck -> errors
+        fake.queue_result(
+            returncode=1,
+            stderr='a pull request for branch "development" into branch "main" already exists',
+        )  # gh pr create (retry) -> still duplicate
+        fake.queue_result(returncode=0, stdout=_open_pr_list_payload(number=88))  # recheck -> found
+        fake.queue_result(returncode=0, stdout=_adoption_payload(number=88))  # gh pr view
+        gh = GitHubClient(fake)
+
+        async def _no_sleep(_seconds: float) -> None:
+            return None
+
+        metadata, created = await find_or_create_release_pr(
+            runner=fake,
+            gh=gh,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+            title="t",
+            body="b",
+            sleep=_no_sleep,
+        )
+
+        assert created is False
+        assert metadata.number == 88
+        # First recheck errors (caught, not escaped) -> the duplicate-lookup retry
+        # re-runs create, whose recheck then adopts the raced PR.
+        assert [c.args[:3] for c in fake.calls] == [
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "create"],
+            ["gh", "pr", "list"],
+            ["gh", "pr", "view"],
+        ]
+
+    @pytest.mark.unit
     async def test_deterministic_create_failure_reraises_without_recheck(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -782,6 +782,34 @@ class TestFindOrCreateReleasePr:
         assert detail["reason_code"] == "OPEN_PR_LOOKUP_FAILED"
         assert detail["returncode"] == 1
 
+    @pytest.mark.unit
+    async def test_lookup_failure_detail_redacts_credentials_in_message(self) -> None:
+        # ``gh pr list`` stderr reaches ``_lookup_release_pr_after_create_failure``
+        # via ``PullRequestMetadataError.message``, which — unlike
+        # ``GitHubClientError.stderr`` — is *not* redacted at construction. The
+        # failed-lookup detail is stored in ``reconcile_lookups`` and emitted by
+        # the retry/exhausted logs, so credentials in the message must be redacted
+        # before they land in the detail (no-secret logging rule).
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=1,
+            stderr="fatal: unable to access https://x-access-token:ghs_supersecret@github.com/o/r",
+        )
+
+        number, detail = await _lookup_release_pr_after_create_failure(
+            runner=fake,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+        )
+
+        assert number is None
+        assert detail["status"] == "failed"
+        error_message = detail["error_message"]
+        assert isinstance(error_message, str)
+        assert "ghs_supersecret" not in error_message
+        assert "[redacted]" in error_message
+
 
 class TestPrepareReleasePrSync:
     @pytest.mark.unit

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -19,6 +19,7 @@ from awf.runtime.release_pr_sync import (
     ReleasePrSyncError,
     ReleasePrSyncNoOp,
     ReleasePrSyncResult,
+    _lookup_release_pr_after_create_failure,
     count_commits_ahead,
     find_or_create_release_pr,
     prepare_release_pr_sync,
@@ -759,6 +760,27 @@ class TestFindOrCreateReleasePr:
             )
 
         assert all(c.args[:3] != ["gh", "pr", "view"] for c in fake.calls)
+
+    @pytest.mark.unit
+    async def test_lookup_failure_detail_preserves_reason_code(self) -> None:
+        # When the reconcile ``gh pr list`` fails it raises
+        # ``PullRequestMetadataError``; the failed-lookup detail must carry the
+        # exception's ``reason_code`` so retry/audit metadata keeps the
+        # policy-relevant failure semantics (reason codes flow end-to-end).
+        fake = FakeCommandRunner()
+        fake.queue_result(returncode=1, stderr="HTTP 502 from GitHub")  # gh pr list -> errors
+
+        number, detail = await _lookup_release_pr_after_create_failure(
+            runner=fake,
+            repo=_REPO,
+            source_branch="development",
+            target_branch="main",
+        )
+
+        assert number is None
+        assert detail["status"] == "failed"
+        assert detail["reason_code"] == "OPEN_PR_LOOKUP_FAILED"
+        assert detail["returncode"] == 1
 
 
 class TestPrepareReleasePrSync:


### PR DESCRIPTION
## Summary

- Treat GitHub GraphQL/API `please try resubmitting` failures as transient without making generic HTTP 400 errors retryable.
- Route PR monitor GitHub transient checks through the shared classifier.
- Add bounded retry and same-repo reconciliation to release PR creation, matching the feature PR creation safety model.

## Root Cause

AWF already had retry/reconciliation for feature PR creation, but GitHub's malformed GraphQL 400 response was not classified as transient, so the retry path was skipped and pushed work could be stranded after `gh pr create` failed.

## Validation

- `uv run --python 3.12 --extra dev pytest tests/unit/common/test_github_transient.py tests/unit/runtime/test_pr_creator.py tests/unit/runtime/test_release_pr_sync.py tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py tests/unit/control/test_executor_parts/test_executor_part_005.py -q` (`104 passed`)
- `uv run --python 3.12 --extra dev ruff check src/awf/common/github_transient.py src/awf/runtime/release_pr_sync.py src/awf/runtime/pr_monitor_runner/helpers.py tests/unit/common/test_github_transient.py tests/unit/runtime/test_pr_creator.py tests/unit/runtime/test_release_pr_sync.py tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py tests/unit/control/test_executor_parts/test_executor_part_005.py`
- `uv run --python 3.12 --extra dev mypy src/awf/common/github_transient.py src/awf/runtime/release_pr_sync.py src/awf/runtime/pr_monitor_runner/helpers.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when `gh pr create` retries and adds release-PR create loops; bounded retries plus same-repo reconciliation limit duplicate-PR risk, but mutating GitHub paths and executor failure semantics are still sensitive.
> 
> **Overview**
> Fixes a gap where GitHub’s malformed GraphQL **HTTP 400 … Please try resubmitting** response was treated as permanent, so `gh pr create` could fail without using existing retry/reconcile logic.
> 
> **Shared classifier** (`is_transient_github_error_text`): marks “try resubmitting” as transient only when GitHub API/GraphQL context is present; generic HTTP 400, bad credentials, and similar errors stay non-retryable.
> 
> **PR monitor** routes GitHub transient checks through that shared helper instead of duplicating marker logic locally.
> 
> **Release PR creation** gains the same bounded exponential backoff, post-failure same-repo `gh pr list` reconciliation, and structured logging as feature PR creation—including handling `PullRequestMetadataError` on reconcile lookups and redacting secrets in lookup failure details.
> 
> Adds plan/validation notes and unit/executor tests for the new classification and release-sync retry paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0739aa0d381077e0a874416a5e878620a8d49fd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GitHub transient error handling with automatic retry logic and PR reconciliation for improved reliability during temporary API issues.

* **New Features**
  * Added redundancy and retry mechanisms for release PR creation operations.

* **Documentation**
  * Added operational guides for GitHub retry and redundancy behavior.

* **Tests**
  * Added comprehensive test coverage for GitHub error classification and retry scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->