### PR TITLE
feat: #612 slice 1/3 — recovering workspace status foundation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -11160,6 +11160,10 @@
             "title": "Ready",
             "type": "integer"
           },
+          "recovering": {
+            "title": "Recovering",
+            "type": "integer"
+          },
           "requested": {
             "title": "Requested",
             "type": "integer"
@@ -11184,6 +11188,7 @@
           "pushing",
           "monitoring_pr",
           "blocked",
+          "recovering",
           "destroying",
           "completed",
           "failed",
@@ -11314,6 +11319,7 @@
           "pushing",
           "monitoring_pr",
           "blocked",
+          "recovering",
           "completed",
           "failed",
           "cancelled",

--- a/src/awf/api/routes/metrics.py
+++ b/src/awf/api/routes/metrics.py
@@ -236,6 +236,7 @@ class WorkspaceSaturationCountsResponse(BaseModel):
     pushing: int
     monitoring_pr: int
     blocked: int
+    recovering: int
     destroying: int
     completed: int
     failed: int

--- a/src/awf/cli/service_commands.py
+++ b/src/awf/cli/service_commands.py
@@ -61,6 +61,7 @@ class GCStatusFilter(StrEnum):
     pushing = "pushing"
     monitoring_pr = "monitoring_pr"
     blocked = "blocked"
+    recovering = "recovering"
     completed = "completed"
     failed = "failed"
     cancelled = "cancelled"

--- a/src/awf/control/state_machine.py
+++ b/src/awf/control/state_machine.py
@@ -44,6 +44,11 @@ _RAW_TRANSITIONS: dict[WorkspaceStatus, frozenset[WorkspaceStatus]] = {
             # A protected quality-gate violation pauses the run for an operator
             # decision instead of terminally failing (pre-PR block).
             WorkspaceStatus.blocked,
+            # A transient provider failure mid-run diverts into the auto-healing
+            # ``recovering`` pause instead of terminally failing, so the warm
+            # stack + worktree + execution claim survive the provider cooldown
+            # (#612). This is the only entry edge into ``recovering`` in slice 1.
+            WorkspaceStatus.recovering,
             WorkspaceStatus.failed,
             WorkspaceStatus.cancelled,
         }
@@ -82,6 +87,21 @@ _RAW_TRANSITIONS: dict[WorkspaceStatus, frozenset[WorkspaceStatus]] = {
             WorkspaceStatus.validating,
             WorkspaceStatus.pushing,
             WorkspaceStatus.monitoring_pr,
+            WorkspaceStatus.failed,
+            WorkspaceStatus.cancelled,
+        }
+    ),
+    # A recovering workspace auto-heals: after the provider cooldown the worker
+    # resumes it in place (``running``); if the retry budget is exhausted or the
+    # failure is non-retryable it re-fails (``failed``); or an operator cancels
+    # it (``cancelled``). Like ``blocked`` it is non-terminal, keeps its warm
+    # stack + execution claim while paused, and never jumps straight to
+    # ``completed``/``destroying``. Unlike ``blocked`` it does NOT resume into
+    # ``validating``/``pushing``/``monitoring_pr`` — the auto-retry re-invokes the
+    # agent from the ``running`` phase (#612).
+    WorkspaceStatus.recovering: frozenset(
+        {
+            WorkspaceStatus.running,
             WorkspaceStatus.failed,
             WorkspaceStatus.cancelled,
         }

--- a/src/awf/control/worker/constants.py
+++ b/src/awf/control/worker/constants.py
@@ -39,11 +39,15 @@ _REQUESTED_ADMISSION_SLOT_STATUSES: tuple[WorkspaceStatus, ...] = (
     WorkspaceStatus.monitoring_pr,
     # A blocked workspace keeps its warm stack, so it holds the host-port lock.
     WorkspaceStatus.blocked,
+    # A recovering workspace keeps its warm stack while it auto-retries across
+    # the provider cooldown, so it holds the host-port lock too (#612).
+    WorkspaceStatus.recovering,
 )
 """Workspace statuses where the workspace holds an admission slot (e.g. a host-port lock).
 
-Deliberately excludes ``blocked`` from ``_ACTIVE_EXECUTION_STATUSES`` and
-``_RUNTIME_HEALTH_SCAN_STATUSES`` (above): a paused ``blocked`` workspace must be
+Deliberately excludes ``blocked`` and ``recovering`` from
+``_ACTIVE_EXECUTION_STATUSES`` and ``_RUNTIME_HEALTH_SCAN_STATUSES`` (above): a
+paused ``blocked`` (operator) or ``recovering`` (auto-retry) workspace must be
 preserve-not-reap, so it stays out of the stale-execution reaping / health-scan
 sets while still holding its admission slot here."""
 

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -53,6 +53,21 @@ class WorkspaceStatus(StrEnum):
     self-approve. See ``src/awf/control/quality_gates.py`` and the worker resume
     path. This is NOT terminal and must not fold into the "Running" KPI."""
 
+    recovering = "recovering"
+    """Non-terminal, AUTO-healing pause for an in-flight provider retry (#612).
+
+    Entered (pre-PR) when an agent run hits a *transient* provider failure (e.g.
+    an idle-timeout) that is retryable and still has retry budget: instead of
+    terminally failing and discarding the spent work, the workspace pauses here
+    with its worktree, warm stack, and execution claim preserved across the
+    provider cooldown, then resumes itself in place — no operator action. It is
+    the same KIND of pause as ``blocked`` (non-terminal, holds an execution slot,
+    keeps a warm stack) and shares its status accounting, but it is NOT
+    operator-facing: there is no ``guide``/grant, required-PR, or block-state
+    projection — it auto-resumes once ``now >= provider_cooldown_not_before``.
+    This is NOT terminal and must not fold into the "Running" KPI. Nothing enters
+    this status yet — #612 slice 2 wires the failure-fork divert."""
+
     completed = "completed"
     failed = "failed"
     cancelled = "cancelled"

--- a/src/awf/db/repositories/base.py
+++ b/src/awf/db/repositories/base.py
@@ -63,6 +63,11 @@ ACTIVE_OWNED_PATH_OVERLAP_STATUSES: Final[tuple[str, ...]] = (
     # also keeps its warm compose stack and bound host ports, so this status
     # flows into HOST_PORT_CONFLICT_STATUSES below via the splat.
     WorkspaceStatus.blocked.value,
+    # A recovering workspace likewise keeps its worktree + warm stack + bound
+    # host ports while it auto-retries across the provider cooldown (#612), so it
+    # holds the same owned-path/host-port occupancy (and flows into
+    # HOST_PORT_CONFLICT_STATUSES below via the splat).
+    WorkspaceStatus.recovering.value,
 )
 HOST_PORT_CONFLICT_STATUSES: Final[tuple[str, ...]] = (
     *ACTIVE_OWNED_PATH_OVERLAP_STATUSES,
@@ -104,6 +109,9 @@ ALLOCATED_RESOURCE_RESERVATION_STATUSES: Final[tuple[str, ...]] = (
     WorkspaceStatus.monitoring_pr.value,
     # A blocked workspace holds its reservation while paused (keep-warm).
     WorkspaceStatus.blocked.value,
+    # A recovering workspace holds its reservation while it auto-retries across
+    # the provider cooldown (keep-warm, #612).
+    WorkspaceStatus.recovering.value,
     WorkspaceStatus.destroying.value,
 )
 DEFAULT_IDEMPOTENCY_REPLAY_KEY_LIMIT: Final[int] = 4096

--- a/src/awf/service/controls_helpers.py
+++ b/src/awf/service/controls_helpers.py
@@ -788,4 +788,10 @@ def _is_active(status_value: WorkspaceStatus) -> bool:
         # while the row stays ``blocked`` pointing at removed resources, and
         # ``blocked`` cannot transition directly to ``destroying``.
         WorkspaceStatus.blocked,
+        # ``recovering`` is the auto-healing provider-retry pause (#612) — the
+        # same kind of non-terminal hold (warm stack + worktree + execution
+        # claim) that also cannot transition directly to ``destroying``. It must
+        # classify as active for the identical reason, so stop/destroy route it
+        # through ``cancelled`` and the force guard applies.
+        WorkspaceStatus.recovering,
     }

--- a/src/awf/service/gc_classify.py
+++ b/src/awf/service/gc_classify.py
@@ -56,6 +56,10 @@ PROTECTED_WORKSPACE_GC_STATUSES = frozenset(
         # A blocked workspace is paused awaiting an operator decision with its
         # worktree + warm stack preserved; never GC-reap it.
         WorkspaceStatus.blocked.value,
+        # A recovering workspace is paused auto-retrying across the provider
+        # cooldown with its worktree + warm stack preserved; never GC-reap it
+        # (#612).
+        WorkspaceStatus.recovering.value,
         WorkspaceStatus.destroying.value,
     }
 )

--- a/src/awf/service/metrics.py
+++ b/src/awf/service/metrics.py
@@ -92,6 +92,10 @@ EXECUTION_IN_USE_STATUSES = frozenset(
         # A blocked workspace keeps its warm stack + execution claim while it
         # awaits an operator decision, so it still holds an execution slot.
         WorkspaceStatus.blocked.value,
+        # A recovering workspace keeps its warm stack + execution claim during
+        # the provider cooldown while it auto-retries in place, so it still holds
+        # an execution slot (#612).
+        WorkspaceStatus.recovering.value,
     }
 )
 EXECUTION_QUEUE_STATUSES = frozenset({WorkspaceStatus.ready.value})

--- a/src/awf/service/metrics_capacity.py
+++ b/src/awf/service/metrics_capacity.py
@@ -112,6 +112,10 @@ EXECUTION_IN_USE_STATUSES = frozenset(
         # A blocked workspace keeps its warm stack + execution claim while it
         # awaits an operator decision, so it still holds an execution slot.
         WorkspaceStatus.blocked.value,
+        # A recovering workspace keeps its warm stack + execution claim during
+        # the provider cooldown while it auto-retries in place, so it still holds
+        # an execution slot (#612).
+        WorkspaceStatus.recovering.value,
     }
 )
 EXECUTION_QUEUE_STATUSES = frozenset({WorkspaceStatus.ready.value})

--- a/src/awf/service/metrics_resources.py
+++ b/src/awf/service/metrics_resources.py
@@ -630,6 +630,12 @@ async def _count_stuck_workspaces(
         .where(
             ~Workspace.status.in_(TERMINAL_WORKSPACE_STATUSES),
             Workspace.status != WorkspaceStatus.destroying.value,
+            # ``recovering`` is an intentional auto-retry pause (#612): it holds
+            # its warm stack across the provider cooldown and resumes itself, so
+            # a workspace older than 2×SLA while paused here is not "stuck".
+            # Mirror the SLO ``_count_stuck_detailed`` exclusion so the
+            # reliability ``stuck_count`` stays consistent.
+            Workspace.status != WorkspaceStatus.recovering.value,
             Workspace.created_at < cutoff,
             Workspace.failure_reason.is_(None),
         )

--- a/src/awf/service/metrics_resources.py
+++ b/src/awf/service/metrics_resources.py
@@ -822,6 +822,7 @@ def _workspace_saturation_counts(status_counts: dict[str, int]) -> WorkspaceSatu
         pushing=status_counts[WorkspaceStatus.pushing.value],
         monitoring_pr=status_counts[WorkspaceStatus.monitoring_pr.value],
         blocked=status_counts[WorkspaceStatus.blocked.value],
+        recovering=status_counts[WorkspaceStatus.recovering.value],
         destroying=status_counts[WorkspaceStatus.destroying.value],
         completed=status_counts[WorkspaceStatus.completed.value],
         failed=status_counts[WorkspaceStatus.failed.value],

--- a/src/awf/service/metrics_slo.py
+++ b/src/awf/service/metrics_slo.py
@@ -269,6 +269,10 @@ async def _count_stuck_detailed(
             ~Workspace.status.in_(TERMINAL_WORKSPACE_STATUSES),
             Workspace.status != WorkspaceStatus.destroying.value,
             Workspace.status != WorkspaceStatus.monitoring_pr.value,
+            # ``recovering`` is an intentional auto-retry pause (#612): it holds
+            # its warm stack across the provider cooldown and resumes itself, so
+            # a workspace older than 2×SLA while paused here is not "stuck".
+            Workspace.status != WorkspaceStatus.recovering.value,
             Workspace.created_at < cutoff,
         )
     )

--- a/src/awf/service/metrics_types.py
+++ b/src/awf/service/metrics_types.py
@@ -136,6 +136,7 @@ class WorkspaceSaturationCounts:
     pushing: int
     monitoring_pr: int
     blocked: int
+    recovering: int
     destroying: int
     completed: int
     failed: int

--- a/src/awf/service/orphan_resources.py
+++ b/src/awf/service/orphan_resources.py
@@ -74,6 +74,10 @@ ACTIVE_WORKSPACE_STATUSES = frozenset(
         # in gc_classify). It must classify as active here so the orphan reaper
         # never tears down the warm stack this state exists to keep.
         WorkspaceStatus.blocked.value,
+        # A recovering workspace is paused auto-retrying across the provider
+        # cooldown with its worktree + warm stack preserved (#612); it must
+        # classify as active for the same reason — never reap the warm stack.
+        WorkspaceStatus.recovering.value,
         WorkspaceStatus.destroying.value,
     }
 )

--- a/src/awf/service/overlap_graph.py
+++ b/src/awf/service/overlap_graph.py
@@ -41,6 +41,11 @@ RUNNING_WORKSPACE_STATUSES: Final[tuple[str, ...]] = (
     # the workspaces they are about to grant/resume or start related work
     # against. It maps to the "running" node queue state via the splat below.
     WorkspaceStatus.blocked.value,
+    # A recovering workspace stays paused with its worktree and owned paths held
+    # (keep-warm) while it auto-retries across the provider cooldown (#612), so
+    # it must surface in the advisory graph for the same reason. It also maps to
+    # the "running" node queue state via the splat below.
+    WorkspaceStatus.recovering.value,
 )
 ACTIVE_OVERLAP_GRAPH_STATUSES: Final[tuple[str, ...]] = (
     *QUEUED_WORKSPACE_STATUSES,

--- a/tests/unit/api/test_metrics_capacity.py
+++ b/tests/unit/api/test_metrics_capacity.py
@@ -1002,3 +1002,34 @@ async def test_resource_saturation_endpoint_explains_disk_admission_denial(
     assert body["admission"]["status"] == "blocked"
     assert body["admission"]["reason"] == "INSUFFICIENT_DISK"
     assert "free disk" in body["admission"]["detail"].lower()
+
+
+@pytest.mark.unit
+def test_saturation_counts_response_carries_recovering() -> None:
+    # The auto-healing provider-retry pause (#612) gets its own per-status
+    # saturation count, mirroring ``blocked``. The response model maps it by
+    # name from the ``WorkspaceSaturationCounts`` dataclass (``from_attributes``).
+    from awf.service.metrics_types import WorkspaceSaturationCounts
+
+    counts = WorkspaceSaturationCounts(
+        by_status={WorkspaceStatus.recovering.value: 2},
+        active_total=2,
+        requested=0,
+        provisioning=0,
+        ready=0,
+        running=0,
+        validating=0,
+        pushing=0,
+        monitoring_pr=0,
+        blocked=0,
+        recovering=2,
+        destroying=0,
+        completed=0,
+        failed=0,
+        cancelled=0,
+        destroyed=0,
+    )
+    response = metrics_route.WorkspaceSaturationCountsResponse.model_validate(counts)
+    assert response.recovering == 2
+    assert response.active_total == 2
+    assert response.model_dump()["recovering"] == 2

--- a/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
+++ b/tests/unit/api/test_workspaces_parts/test_workspaces_part_007.py
@@ -940,6 +940,24 @@ class TestListWorkspaces:
         assert {r["status"] for r in results} == {"ready"}
 
     @pytest.mark.unit
+    async def test_filters_by_recovering_status(
+        self, client: AsyncClient, engine: AsyncEngine
+    ) -> None:
+        # ``recovering`` is the auto-healing provider-retry pause (#612). It is a
+        # plain string status, so the ``status=recovering`` list filter must be
+        # accepted and the status round-trips in the response body.
+        recovering_id = await _create_workspace(client, task_title="recovering")
+        await _create_workspace(client, task_title="still requested")
+        await _set_workspace_status(engine, recovering_id, WorkspaceStatus.recovering)
+
+        response = await client.get("/v1/workspaces", params={"status": "recovering"})
+
+        assert response.status_code == 200
+        results = response.json()
+        assert [r["id"] for r in results] == [recovering_id]
+        assert {r["status"] for r in results} == {"recovering"}
+
+    @pytest.mark.unit
     async def test_filters_by_agent(self, client: AsyncClient) -> None:
         await _create_workspace(client, task_title="codex", agent="codex")
         claude_id = await _create_workspace(

--- a/tests/unit/cli/test_cli_parts/test_cli_part_002.py
+++ b/tests/unit/cli/test_cli_parts/test_cli_part_002.py
@@ -579,6 +579,30 @@ class TestWorkspaceList:
         ]
 
     @pytest.mark.unit
+    def test_recovering_status_flag_passed(self) -> None:
+        # ``recovering`` is the auto-healing provider-retry pause (#612); the
+        # ``--status`` option is typed ``list[WorkspaceStatus]`` so the new enum
+        # value parses and forwards as ``status=recovering`` without error.
+        response = _mock_response(status_code=200, payload=[])
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "list",
+                    "--status",
+                    "recovering",
+                ],
+            )
+
+        assert result.exit_code == 0
+        kwargs = mock.call_args.kwargs
+        assert kwargs["params"] == [
+            ("limit", 50),
+            ("status", "recovering"),
+        ]
+
+    @pytest.mark.unit
     def test_pretty_prints_separators_between_items(self) -> None:
         response = _mock_response(
             status_code=200,

--- a/tests/unit/control/test_recovering_status_membership.py
+++ b/tests/unit/control/test_recovering_status_membership.py
@@ -1,0 +1,160 @@
+"""Status-set membership invariants for the non-terminal ``recovering`` status.
+
+A ``recovering`` workspace is paused mid-run after a *transient provider failure*
+(e.g. an idle-timeout) while it auto-heals across the provider cooldown. Unlike
+``blocked`` (which awaits an operator decision), ``recovering`` resumes itself —
+but it is the **same KIND** of pause: non-terminal, keeps its worktree + warm
+stack + execution claim. So it gets the same status accounting as ``blocked``.
+
+The rule this test pins (#612 slice 1): ``recovering`` is a member of every
+status set that already contains ``blocked``, and is absent from every set
+``blocked`` is deliberately absent from (stuck-detection / terminal /
+preserve-not-reap scans). It must:
+
+- count as execution-in-use / allocated / admission-slot-holding (keep-warm),
+- be GC-protected and orphan-active (never reaped — the warm stack is the point),
+- hold its owned paths + host ports (overlap/port-conflict),
+- surface in the advisory overlap graph as a "running" node,
+- be present in the per-status saturation counts and ``active_total``,
+
+while it must NOT:
+
+- be terminal,
+- be scanned for stale-execution reaping or runtime-health (which would tear it
+  down or fail it — the held claim is the durable lease),
+- count toward SLO stuck-detection (an intentional auto-retry pause is not stuck),
+- fold into the running/validating/pushing "Running" KPI execution set.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.control.worker.constants import (
+    _ACTIVE_EXECUTION_STATUSES,
+    _REQUESTED_ADMISSION_SLOT_STATUSES,
+    _RUNTIME_HEALTH_SCAN_STATUSES,
+)
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories.base import (
+    ACTIVE_OWNED_PATH_OVERLAP_STATUSES,
+    ALLOCATED_RESOURCE_RESERVATION_STATUSES,
+    HOST_PORT_CONFLICT_STATUSES,
+)
+from awf.service.gc_classify import (
+    PROTECTED_WORKSPACE_GC_STATUSES,
+    TERMINAL_WORKSPACE_GC_STATUSES,
+)
+from awf.service.metrics import EXECUTION_IN_USE_STATUSES, TERMINAL_WORKSPACE_STATUSES
+from awf.service.metrics_capacity import (
+    EXECUTION_IN_USE_STATUSES as CAPACITY_EXECUTION_IN_USE_STATUSES,
+)
+from awf.service.metrics_slo import (
+    EXECUTION_IN_USE_STATUSES as SLO_EXECUTION_IN_USE_STATUSES,
+)
+from awf.service.orphan_resources import (
+    ACTIVE_WORKSPACE_STATUSES as ORPHAN_ACTIVE_WORKSPACE_STATUSES,
+)
+from awf.service.orphan_resources import (
+    KNOWN_WORKSPACE_STATUSES as ORPHAN_KNOWN_WORKSPACE_STATUSES,
+)
+from awf.service.overlap_graph import (
+    ACTIVE_OVERLAP_GRAPH_STATUSES,
+    RUNNING_WORKSPACE_STATUSES,
+    _queue_state_for_status,
+)
+
+_RECOVERING = WorkspaceStatus.recovering
+
+
+@pytest.mark.unit
+class TestRecoveringKeepWarmMembership:
+    """A recovering workspace holds its slot/reservation/stack while paused."""
+
+    def test_in_execution_in_use(self) -> None:
+        assert _RECOVERING.value in EXECUTION_IN_USE_STATUSES
+        assert _RECOVERING.value in CAPACITY_EXECUTION_IN_USE_STATUSES
+
+    def test_in_allocated_reservation_statuses(self) -> None:
+        assert _RECOVERING.value in ALLOCATED_RESOURCE_RESERVATION_STATUSES
+
+    def test_in_admission_slot_statuses(self) -> None:
+        assert _RECOVERING in _REQUESTED_ADMISSION_SLOT_STATUSES
+
+    def test_in_protected_gc_statuses(self) -> None:
+        assert _RECOVERING.value in PROTECTED_WORKSPACE_GC_STATUSES
+
+    def test_in_orphan_resource_active_statuses(self) -> None:
+        # The orphan-resource scanner keeps its own active/known status sets; if
+        # ``recovering`` were omitted, the workspace row would be filtered out of
+        # the id view, its containers/networks/volumes/worktree would classify as
+        # ``missing``, and the reaper could delete the preserved warm stack.
+        assert _RECOVERING.value in ORPHAN_ACTIVE_WORKSPACE_STATUSES
+        assert _RECOVERING.value in ORPHAN_KNOWN_WORKSPACE_STATUSES
+
+    def test_in_owned_path_and_host_port_statuses(self) -> None:
+        # It keeps its worktree (owned paths) and warm compose stack (host ports)
+        # while paused, so a concurrent overlapping create/retry must still treat
+        # both as occupied.
+        assert _RECOVERING.value in ACTIVE_OWNED_PATH_OVERLAP_STATUSES
+        assert _RECOVERING.value in HOST_PORT_CONFLICT_STATUSES
+
+    def test_in_overlap_graph_running_statuses(self) -> None:
+        assert _RECOVERING.value in RUNNING_WORKSPACE_STATUSES
+        assert _RECOVERING.value in ACTIVE_OVERLAP_GRAPH_STATUSES
+
+    def test_overlap_graph_queue_state_is_running(self) -> None:
+        assert _queue_state_for_status(_RECOVERING.value) == "running"
+
+
+@pytest.mark.unit
+class TestRecoveringNotTerminalNotReaped:
+    """A recovering workspace is preserve-not-reap and never terminal."""
+
+    def test_not_terminal_metrics(self) -> None:
+        assert _RECOVERING.value not in TERMINAL_WORKSPACE_STATUSES
+
+    def test_not_terminal_gc(self) -> None:
+        assert _RECOVERING.value not in TERMINAL_WORKSPACE_GC_STATUSES
+
+    def test_not_in_active_execution_scan(self) -> None:
+        # Absence here is what makes recovery_stale preserve-not-reap it.
+        assert _RECOVERING not in _ACTIVE_EXECUTION_STATUSES
+
+    def test_not_in_runtime_health_scan(self) -> None:
+        assert _RECOVERING not in _RUNTIME_HEALTH_SCAN_STATUSES
+
+    def test_not_in_slo_execution_in_use(self) -> None:
+        # The SLO stuck-detection execution set deliberately excludes intentional
+        # pauses (it omits ``blocked`` too): an auto-retry pause is not "stuck".
+        assert _RECOVERING.value not in SLO_EXECUTION_IN_USE_STATUSES
+
+
+@pytest.mark.unit
+class TestRecoveringSaturationCount:
+    """``recovering`` is exposed as its own per-status saturation count."""
+
+    def test_recovering_in_saturation_counts(self) -> None:
+        from awf.service.metrics_resources import _workspace_saturation_counts
+
+        status_counts = {status.value: 0 for status in WorkspaceStatus}
+        status_counts[_RECOVERING.value] = 3
+        counts = _workspace_saturation_counts(status_counts)
+        assert counts.recovering == 3
+        # A recovering workspace is non-terminal, so it counts toward active_total.
+        assert counts.active_total == 3
+        assert counts.by_status[_RECOVERING.value] == 3
+
+
+@pytest.mark.unit
+class TestRecoveringRunningKpiSeparation:
+    """``recovering`` is its own state, not folded into the Running KPI set."""
+
+    def test_running_kpi_set_excludes_recovering(self) -> None:
+        # The console "Running" KPI counts running + validating + pushing only.
+        running_kpi_set = {
+            WorkspaceStatus.running.value,
+            WorkspaceStatus.validating.value,
+            WorkspaceStatus.pushing.value,
+        }
+        assert _RECOVERING.value not in running_kpi_set

--- a/tests/unit/control/test_state_machine.py
+++ b/tests/unit/control/test_state_machine.py
@@ -40,6 +40,10 @@ class TestValidTransitions:
             (WorkspaceStatus.running, WorkspaceStatus.validating),
             (WorkspaceStatus.running, WorkspaceStatus.monitoring_pr),
             (WorkspaceStatus.running, WorkspaceStatus.blocked),
+            # A transient provider failure mid-run diverts into the auto-healing
+            # ``recovering`` pause instead of terminally failing (#612 slice 2
+            # wires the divert; the edge is declared here in slice 1).
+            (WorkspaceStatus.running, WorkspaceStatus.recovering),
             (WorkspaceStatus.running, WorkspaceStatus.failed),
             (WorkspaceStatus.running, WorkspaceStatus.cancelled),
             # Worker-restart salvage can rewind an abandoned active phase so
@@ -63,6 +67,14 @@ class TestValidTransitions:
             (WorkspaceStatus.blocked, WorkspaceStatus.monitoring_pr),
             (WorkspaceStatus.blocked, WorkspaceStatus.failed),
             (WorkspaceStatus.blocked, WorkspaceStatus.cancelled),
+            # A recovering workspace auto-resumes after the provider cooldown
+            # (-> running), re-fails when the retry budget is exhausted or the
+            # failure is non-retryable (-> failed), or an operator cancels it
+            # (-> cancelled). Like blocked, it never jumps straight to
+            # completed/destroying.
+            (WorkspaceStatus.recovering, WorkspaceStatus.running),
+            (WorkspaceStatus.recovering, WorkspaceStatus.failed),
+            (WorkspaceStatus.recovering, WorkspaceStatus.cancelled),
             # A protected-scope violation during the PR monitor pauses the PR
             # owner for an operator decision instead of failing (post-PR block).
             (WorkspaceStatus.monitoring_pr, WorkspaceStatus.blocked),
@@ -110,6 +122,20 @@ class TestInvalidTransitions:
             (WorkspaceStatus.blocked, WorkspaceStatus.completed),
             (WorkspaceStatus.blocked, WorkspaceStatus.destroying),
             (WorkspaceStatus.blocked, WorkspaceStatus.blocked),
+            # recovering is non-terminal and auto-healing: it may only resume
+            # (-> running) or terminate (-> failed/cancelled). It cannot jump to
+            # completed/destroying, self-loop, or resume into any phase other
+            # than running. The validating/pushing -> recovering entry edges are
+            # deferred to slice 2 (the only divert fork runs in ``running``), so
+            # they must stay rejected here.
+            (WorkspaceStatus.recovering, WorkspaceStatus.completed),
+            (WorkspaceStatus.recovering, WorkspaceStatus.destroying),
+            (WorkspaceStatus.recovering, WorkspaceStatus.recovering),
+            (WorkspaceStatus.recovering, WorkspaceStatus.monitoring_pr),
+            (WorkspaceStatus.recovering, WorkspaceStatus.validating),
+            (WorkspaceStatus.recovering, WorkspaceStatus.pushing),
+            (WorkspaceStatus.validating, WorkspaceStatus.recovering),
+            (WorkspaceStatus.pushing, WorkspaceStatus.recovering),
             # Cannot self-transition.
             (WorkspaceStatus.running, WorkspaceStatus.running),
             # monitoring_pr exits to completed/failed/cancelled (and now blocked
@@ -159,6 +185,7 @@ class TestTerminalDetection:
             WorkspaceStatus.validating,
             WorkspaceStatus.pushing,
             WorkspaceStatus.blocked,
+            WorkspaceStatus.recovering,
             WorkspaceStatus.completed,  # terminal *for the attempt*, but workspace can still destroy
             WorkspaceStatus.failed,
             WorkspaceStatus.cancelled,
@@ -194,6 +221,7 @@ class TestTerminalDetection:
             WorkspaceStatus.pushing,
             WorkspaceStatus.monitoring_pr,
             WorkspaceStatus.blocked,
+            WorkspaceStatus.recovering,
         ],
     )
     def test_not_callback_terminal(self, state: WorkspaceStatus) -> None:

--- a/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_part_002.py
+++ b/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_part_002.py
@@ -575,6 +575,32 @@ async def test_destroy_rejects_active_workspace_without_force_before_cleanup(
 
 
 @pytest.mark.unit
+async def test_destroy_rejects_recovering_workspace_without_force_before_cleanup(
+    session: AsyncSession,
+) -> None:
+    # A ``recovering`` workspace is a non-terminal auto-retry pause that holds a
+    # warm stack + worktree + execution claim and cannot transition directly to
+    # ``destroying`` (#612). Like ``blocked`` it must classify as active, so a
+    # force-less destroy is refused before any cleanup runs — otherwise the row
+    # would be torn down while still pointing at live resources.
+    workspace = await _workspace(session, status=WorkspaceStatus.recovering)
+    cleaner = RecordingCleaner()
+    service, _stopper, _cleaner = _service(session, cleaner=cleaner)
+
+    with pytest.raises(ActiveWorkspaceDestroyError) as exc_info:
+        await service.destroy_workspace(
+            workspace.id,
+            force=False,
+            remove_volumes=True,
+            remove_worktree=True,
+        )
+
+    assert exc_info.value.error_code == "WORKSPACE_ACTIVE"
+    assert cleaner.calls == []
+    assert await _operations(session, workspace.id) == []
+
+
+@pytest.mark.unit
 async def test_destroy_already_cancelled_workspace_runs_cleanup_and_records_destroy_contract(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/service/test_metrics_parts/test_metrics_part_003.py
+++ b/tests/unit/service/test_metrics_parts/test_metrics_part_003.py
@@ -507,6 +507,30 @@ async def test_workspace_reliability_reports_stuck_count(
 
 
 @pytest.mark.unit
+async def test_recovering_excluded_from_reliability_stuck_count(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    # ``recovering`` is an intentional auto-retry pause (#612): even an
+    # active row past the 2×SLA cutoff with no failure_reason must not be
+    # reported as a stuck workspace by /v1/metrics/reliability. This mirrors
+    # the same exclusion applied to the SLO ``_count_stuck_detailed`` query.
+    from awf.service.metrics import summarize_workspace_reliability
+
+    now = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
+    settings = Settings(_env_file=None, agent_wall_timeout_seconds=3600)
+    await create_workspace(
+        session_factory,
+        status=WorkspaceStatus.recovering,
+        updated_at=now - timedelta(hours=2),
+        created_at=now - timedelta(hours=3),
+    )
+
+    summary = await summarize_workspace_reliability(session_factory, settings=settings, now=now)
+
+    assert summary.stuck_count == 0
+
+
+@pytest.mark.unit
 async def test_workspace_reliability_reports_cleanup_failure_reason_code_coverage(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:

--- a/tests/unit/service/test_metrics_parts/test_metrics_part_003.py
+++ b/tests/unit/service/test_metrics_parts/test_metrics_part_003.py
@@ -943,6 +943,43 @@ async def test_stuck_state_splits_by_reason_code_presence(
 
 
 @pytest.mark.unit
+async def test_recovering_excluded_from_stuck_detection(
+    session_factory: async_sessionmaker[AsyncSession],
+) -> None:
+    # ``recovering`` is an intentional auto-retry pause (#612): even past the
+    # 2×SLA cutoff it must not surface as stuck_running/stuck_with_reason. This
+    # guards the actual ``_count_stuck_detailed`` query, not just the unused
+    # SLO ``EXECUTION_IN_USE_STATUSES`` set.
+    from awf.service.metrics import summarize_slo_metrics_for_session
+
+    now = datetime(2026, 4, 28, 12, 0, tzinfo=UTC)
+    settings = Settings(_env_file=None, agent_wall_timeout_seconds=3600)
+    await create_workspace(
+        session_factory,
+        status=WorkspaceStatus.recovering,
+        created_at=now - timedelta(hours=3),
+        updated_at=now - timedelta(hours=2),
+    )
+    await create_workspace(
+        session_factory,
+        status=WorkspaceStatus.recovering,
+        created_at=now - timedelta(hours=3),
+        updated_at=now - timedelta(hours=2),
+        failure_reason="idle_timeout",
+    )
+
+    async with session_factory() as session:
+        summary = await summarize_slo_metrics_for_session(
+            session,
+            settings=settings,
+            now=now,
+        )
+
+    assert summary.stuck_running_count == 0
+    assert summary.stuck_with_reason_count == 0
+
+
+@pytest.mark.unit
 async def test_recovery_metrics_from_operations(
     session_factory: async_sessionmaker[AsyncSession],
 ) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_15eafd8eb8c049d8aa8b9dc3` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `xhigh`).


### Task
Implement SLICE 1 of 3 for AWF issue #612 (in-place provider retry). Read the locked plan first: `plans/PROVIDER_INPLACE_RETRY_PLAN.md` (it has the full design + the architecture decisions D1-D5 + tasks T1-T9). This slice is the FOUNDATION only.

SLICE 1 SCOPE = the new `recovering` workspace status + its state machine + accounting + API/CLI exposure. Python ONLY. NO behavior change (nothing ENTERS recovering yet — that's slice 2) and NO console work (that's slice 3).

The decisive guidance: **mirror EXACTLY how the existing `WorkspaceStatus.blocked` status was added** (the protected-file-pause feature, recently shipped). `recovering` is the same KIND of status as `blocked` — non-terminal, holds an execution slot, keeps a warm stack — so it gets the same accounting treatment. First grep the codebase for every site that special-cases `blocked` and add the parallel `recovering` handling. Differences from blocked: `recovering` is AUTO-healing (resumes after a cooldown, no operator action) whereas `blocked` awaits an operator — so it must NOT inherit blocked's operator-facing semantics (no guide/grant/required-pr handling); it's purely an in-flight auto-retry state.

Implement (task T1 in the plan):
1. Add `WorkspaceStatus.recovering` to the enum (src/awf/db/enums.py). Check whether `blocked` needed a DB migration when it was added; if the status column is a plain string, none is needed — mirror whatever `blocked` did.
2. State machine (src/awf/control/state_machine.py): add transitions `running → recovering` and `recovering → {running, failed, cancelled}`. (validating/pushing → recovering may also be valid mirrors of where blocked is reachable — match the blocked reachability set where the semantics hold.)
3. Status accounting: `recovering` ∈ active_total ∧ EXECUTION_IN_USE_STATUSES (holds a slot — prevents container over-subscription), NOT terminal, NOT the "Running" KPI. Add the per-status field in `WorkspaceSaturationCountsResponse` (mirror the `blocked` field added by the pause feature, cf PR #598/#601).
4. Mirror every other `blocked` special-casing site for `recovering` where the non-terminal/holds-a-slot semantics match: metrics, capacity, gc_classify, orphan_resources, overlap_graph, claims, manager, workspaces_response, etc. (the plan notes a ~17-file blast radius). Grep `WorkspaceStatus.blocked` / `"blocked"` / `.blocked` to find them.
5. API/CLI: `awf workspace list --status recovering` accepted; the status round-trips in responses.

DO NOT in this slice: change the executor failure fork, add any resume path, touch the console (apps/console), or add dedup. Those are slices 2 and 3.

VERIFICATION (T1): unit tests for every new state-machine transition; a parametrized status-bucket test asserting `recovering` ∈ active ∧ slot-holding ∧ NOT Running-KPI ∧ NOT terminal (mirror the blocked bucket test); an API/CLI filter test for `--status recovering`. Keep the full suite green; do NOT lower the 99% coverage gate.

SCOPE (owned paths): src/awf + tests. Do NOT modify protected quality-gate files (pyproject.toml, .github/workflows/, .awf/, .coveragerc, setup.cfg) or apps/console.

In the PR: title "feat: #612 slice 1/3 — `recovering` workspace status foundation"; body says "Part of #612" (NOT "Fixes #612" — the issue stays open until all 3 slices merge). Summarize what landed + that no workspace enters `recovering` yet.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Foundation-only enum and accounting changes with broad but parallel `blocked` mirroring; no executor or failure-fork behavior ships yet, so production workspace flows are unchanged until slice 2.
> 
> **Overview**
> **Slice 1 of #612** adds a new non-terminal **`recovering`** workspace status for future in-place provider auto-retry. Nothing enters this state in this PR; slice 2 will wire the failure divert.
> 
> The status is modeled like **`blocked`** for keep-warm semantics: it holds execution slots, admission/host-port locks, owned-path overlap, GC/orphan protection, and counts in **`active_total`** / saturation metrics with its own **`recovering`** field. It stays out of stale-execution reaping, runtime health scans, the Running KPI, and stuck/SLO detection (intentional cooldown pause).
> 
> The **state machine** declares **`running → recovering`** and **`recovering → {running, failed, cancelled}`** only (no entry from validating/pushing yet). Stop/destroy treats **`recovering`** as active like **`blocked`**.
> 
> **OpenAPI**, metrics responses, CLI **`--status recovering`**, and workspace list filtering are updated. Tests cover transitions, status-set membership, API/CLI filters, destroy guards, and stuck-count exclusions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4560d26953fa7559f7424cfcb154dec996395fde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->