### PR TITLE
Harden mirror hooks repair against worktree races

### DIFF
--- a/plans/MIRROR_HOOKS_REPAIR_RACE_HARDENING_PLAN.md
+++ b/plans/MIRROR_HOOKS_REPAIR_RACE_HARDENING_PLAN.md
@@ -1,0 +1,27 @@
+# Mirror Hooks Repair Race Hardening
+
+## Summary
+Harden AWF's mirror hooks-path repair after a PR monitor failed post-validation with
+`MIRROR_HOOKS_PATH_POISONED` while another workspace was removing/pruning a worktree
+on the same mirror. The fix extends PR #614 by serializing mirror repair with the
+same per-mirror lock used for worktree add/remove/prune, preserving fail-closed
+behavior for real surviving hooks-path poisoning, and recording actionable repair
+evidence when repair still fails.
+
+## Implementation
+- Make `repair_mirror_hooks_path()` acquire the shared mirror lock before reading
+  or mutating mirror/worktree Git metadata.
+- Treat disappearing linked-worktree metadata as stale mirror metadata: skip it,
+  prune under the same lock, and run one follow-up repair scan.
+- Keep repair strict when a `core.hooksPath` remains after repair or Git config
+  commands fail for non-stale reasons.
+- Add a shared PR-monitor evidence helper for mirror repair failures and use it in
+  pre-push validation paths so workspace events/logs include operation, returncode,
+  stdout, stderr, stage, and mirror path.
+
+## Validation
+- Add focused Git manager coverage for mirror-lock serialization and disappearing
+  linked-worktree metadata.
+- Add PR monitor coverage proving post-validation repair failure details are exposed
+  in result details.
+- Run targeted pytest, ruff, and mypy on touched files.

--- a/plans/MIRROR_HOOKS_REPAIR_RACE_HARDENING_VALIDATION.md
+++ b/plans/MIRROR_HOOKS_REPAIR_RACE_HARDENING_VALIDATION.md
@@ -1,0 +1,14 @@
+# Mirror Hooks Repair Race Hardening Validation
+
+## Commands
+- `uv run --python 3.12 --extra dev pytest tests/unit/node/test_git_manager_mirror_hooks_repair.py tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py -q`
+  - Result: passed, `47 passed in 12.07s`.
+- `uv run --python 3.12 --extra dev ruff check src/awf/node/git_manager.py src/awf/runtime/pr_monitor_runner/mirror_hooks.py src/awf/runtime/pr_monitor_runner/pre_push_validation.py src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py src/awf/runtime/pr_monitor_runner/comments.py src/awf/runtime/pr_monitor_runner/ci_ops.py src/awf/runtime/pr_monitor_runner/remote_ops.py src/awf/runtime/pr_monitor_runner/remote_repair.py src/awf/runtime/pr_monitor_runner/remote_repair_protected.py tests/unit/node/test_git_manager_mirror_hooks_repair.py tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py`
+  - Result: passed.
+- `uv run --python 3.12 --extra dev mypy src/awf/node/git_manager.py src/awf/runtime/pr_monitor_runner/mirror_hooks.py src/awf/runtime/pr_monitor_runner/pre_push_validation.py src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py src/awf/runtime/pr_monitor_runner/comments.py src/awf/runtime/pr_monitor_runner/ci_ops.py src/awf/runtime/pr_monitor_runner/remote_ops.py src/awf/runtime/pr_monitor_runner/remote_repair.py src/awf/runtime/pr_monitor_runner/remote_repair_protected.py`
+  - Result: passed, no issues in 9 source files.
+
+## Coverage Notes
+- Added Git manager coverage proving mirror hooks repair waits on the shared mirror lock.
+- Added Git manager coverage proving disappearing linked-worktree metadata is pruned and retried once.
+- Extended PR monitor pre-push validation coverage so mirror repair failures preserve operation, return code, stderr, stdout, stage, and mirror path details.

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -1140,7 +1140,7 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
                 ),
                 reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
             )
-        return repaired or retry_repaired or True
+        return repaired or retry_repaired
 
 
 async def verify_head_object_exists(worktree_path: Path) -> bool:

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -1121,9 +1121,25 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
             return repaired
 
         await _run_git_worktree_prune(mirror_path)
-        retry_repaired, _retry_stale_worktree_metadata = await _repair_mirror_hooks_path_once(
+        retry_repaired, retry_stale_worktree_metadata = await _repair_mirror_hooks_path_once(
             mirror_path
         )
+        if retry_stale_worktree_metadata:
+            # Prune clears dead metadata races, but unreadable linked-worktree
+            # metadata (e.g. a permission-denied gitdir back-reference of a live
+            # worktree) survives. Its ``config.worktree`` was skipped on both
+            # passes, so a poisoned ``core.hooksPath`` may still be present. Fail
+            # closed rather than letting the monitor proceed on an unverified mirror.
+            raise GitOperationError(
+                operation="mirror.worktree_metadata_stale",
+                returncode=1,
+                stdout="",
+                stderr=(
+                    "linked-worktree metadata still stale after worktree prune at "
+                    f"{mirror_path}; cannot guarantee core.hooksPath repair of worktree config"
+                ),
+                reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+            )
         return repaired or retry_repaired or True
 
 

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -116,6 +116,29 @@ async def _run_git_config(
     )
 
 
+async def _run_git_worktree_prune(mirror_path: Path) -> None:
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        "--git-dir",
+        str(mirror_path),
+        "worktree",
+        "prune",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=git_env_without_object_lookup_overrides(),
+    )
+    stdout_bytes, stderr_bytes = await proc.communicate()
+    assert proc.returncode is not None
+    if proc.returncode != 0:
+        raise GitOperationError(
+            operation="mirror.worktree_prune",
+            returncode=proc.returncode,
+            stdout=stdout_bytes.decode("utf-8", errors="replace"),
+            stderr=stderr_bytes.decode("utf-8", errors="replace"),
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        )
+
+
 async def _probe_hooks_path_config(
     *,
     git_args: tuple[str, ...],
@@ -995,6 +1018,12 @@ def _linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
         ) from exc
 
 
+def _is_stale_linked_worktree_metadata_error(exc: GitOperationError) -> bool:
+    return exc.operation == "worktree.hooks_path_probe" and exc.stderr.startswith(
+        "cannot read linked-worktree gitdir back-reference at "
+    )
+
+
 def _chown_targets(targets: tuple[_ChownTarget, ...], uid: int, gid: int) -> None:
     seen: set[tuple[Path, bool, bool]] = set()
     for target in targets:
@@ -1011,12 +1040,7 @@ def _chown_targets(targets: tuple[_ChownTarget, ...], uid: int, gid: int) -> Non
             os.chown(target.path, uid, gid)
 
 
-async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
-    """Remove poisoned ``core.hooksPath`` values from mirror and worktree config.
-
-    Returns ``True`` if repair was needed and succeeded, ``False`` if no repair
-    was needed. Raises ``GitOperationError`` if the probe or unset fails.
-    """
+async def _repair_mirror_hooks_path_once(mirror_path: Path) -> tuple[bool, bool]:
     repaired = await _repair_hooks_path_config(
         git_args=("--git-dir", str(mirror_path)),
         config_scope_args=("--local",),
@@ -1024,16 +1048,27 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
         operation_prefix="mirror",
     )
 
+    stale_worktree_metadata = False
     worktrees_dir = mirror_path / "worktrees"
-    linked_worktree_dirs = (
-        sorted(path for path in worktrees_dir.iterdir() if path.is_dir())
-        if worktrees_dir.exists()
-        else []
-    )
+    if worktrees_dir.exists():
+        try:
+            linked_worktree_dirs = sorted(path for path in worktrees_dir.iterdir() if path.is_dir())
+        except OSError:
+            linked_worktree_dirs = []
+            stale_worktree_metadata = True
+    else:
+        linked_worktree_dirs = []
     worktree_config_enabled: bool | None = None
     for linked_worktree_dir in linked_worktree_dirs:
-        worktree_path = _linked_worktree_path_from_git_dir(linked_worktree_dir)
+        try:
+            worktree_path = _linked_worktree_path_from_git_dir(linked_worktree_dir)
+        except GitOperationError as exc:
+            if not _is_stale_linked_worktree_metadata_error(exc):
+                raise
+            stale_worktree_metadata = True
+            continue
         if not worktree_path.exists():
+            stale_worktree_metadata = True
             continue
         repaired = (
             await _repair_hooks_path_config(
@@ -1070,7 +1105,26 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
             )
             or repaired
         )
-    return repaired
+    return repaired, stale_worktree_metadata
+
+
+async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
+    """Remove poisoned ``core.hooksPath`` values from mirror and worktree config.
+
+    Returns ``True`` if repair was needed and succeeded, ``False`` if no repair
+    was needed. Raises ``GitOperationError`` if the probe or unset fails.
+    """
+    lock = GitManager._lock_for_mirror(mirror_path)
+    async with lock:
+        repaired, stale_worktree_metadata = await _repair_mirror_hooks_path_once(mirror_path)
+        if not stale_worktree_metadata:
+            return repaired
+
+        await _run_git_worktree_prune(mirror_path)
+        retry_repaired, _retry_stale_worktree_metadata = await _repair_mirror_hooks_path_once(
+            mirror_path
+        )
+        return repaired or retry_repaired or True
 
 
 async def verify_head_object_exists(worktree_path: Path) -> bool:

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -1000,12 +1000,27 @@ def _linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
         if not git_file.is_absolute():
             git_file = linked_git_dir / git_file
         return git_file.resolve().parent
-    except OSError as exc:
+    except FileNotFoundError as exc:
+        # The back-reference file is gone (ENOENT): the linked worktree was
+        # removed out from under us, i.e. genuinely stale metadata that
+        # ``git worktree prune`` can safely clear.
         raise GitOperationError(
             operation="worktree.hooks_path_probe",
             returncode=1,
             stdout="",
             stderr=f"cannot read linked-worktree gitdir back-reference at {metadata_gitdir}",
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        ) from exc
+    except OSError as exc:
+        # The back-reference exists but is unreadable (e.g. permission denied):
+        # this is a live worktree we merely cannot inspect, not stale metadata.
+        # Surface a non-stale error so repair fails closed instead of pruning —
+        # ``git worktree prune`` would delete the live worktree's admin files.
+        raise GitOperationError(
+            operation="worktree.hooks_path_probe",
+            returncode=1,
+            stdout="",
+            stderr=f"cannot access linked-worktree gitdir back-reference at {metadata_gitdir}",
             reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
         ) from exc
     except RuntimeError as exc:
@@ -1125,11 +1140,12 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
             mirror_path
         )
         if retry_stale_worktree_metadata:
-            # Prune clears dead metadata races, but unreadable linked-worktree
-            # metadata (e.g. a permission-denied gitdir back-reference of a live
-            # worktree) survives. Its ``config.worktree`` was skipped on both
-            # passes, so a poisoned ``core.hooksPath`` may still be present. Fail
-            # closed rather than letting the monitor proceed on an unverified mirror.
+            # Prune clears dead metadata races, but stale metadata that survives
+            # the prune (e.g. an unreadable ``worktrees`` directory, or a missing
+            # gitdir back-reference prune cannot reap) leaves a worktree whose
+            # ``config.worktree`` was skipped on both passes, so a poisoned
+            # ``core.hooksPath`` may still be present. Fail closed rather than
+            # letting the monitor proceed on an unverified mirror.
             raise GitOperationError(
                 operation="mirror.worktree_metadata_stale",
                 returncode=1,

--- a/src/awf/runtime/pr_monitor_runner/ci_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/ci_ops.py
@@ -46,6 +46,7 @@ from awf.runtime.pr_monitor_runner.constants import (
 )
 from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
 from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.remote_ops import (
     AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE,
     _GitPushResult,
@@ -248,11 +249,16 @@ async def _run_ci_fix(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="before_ci_fix_agent",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.ci_fix_mirror_hooks_path_repair_failed",
                 workspace_id=workspace_id,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                error_type=exc.__class__.__name__,
+                **repair_details,
             )
             return _GitPushResult(
                 pushed=False,
@@ -260,6 +266,7 @@ async def _run_ci_fix(
                 returncode=1,
                 stderr="could not repair poisoned mirror hooks path before CI fix agent launch",
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                details=repair_details,
             )
     try:
         result = await self._deps.adapter.run(
@@ -287,12 +294,17 @@ async def _run_ci_fix(
             try:
                 await repair_mirror_hooks_path(mirror_path)
             except (GitOperationError, OSError) as repair_exc:
+                repair_details = mirror_hooks_repair_failure_details(
+                    repair_exc,
+                    repair_stage="after_ci_fix_agent_exception",
+                    mirror_path=mirror_path,
+                    extra={"original_error_type": exc.__class__.__name__},
+                )
                 _log.warning(
                     "monitor.ci_fix_post_agent_mirror_hooks_path_repair_failed",
                     workspace_id=workspace_id,
                     reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                    error_type=repair_exc.__class__.__name__,
-                    original_error_type=exc.__class__.__name__,
+                    **repair_details,
                 )
                 return _GitPushResult(
                     pushed=False,
@@ -300,6 +312,7 @@ async def _run_ci_fix(
                     returncode=1,
                     stderr="could not repair poisoned mirror hooks path",
                     reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                    details=repair_details,
                 )
         post_agent_err = exc
 

--- a/src/awf/runtime/pr_monitor_runner/comments.py
+++ b/src/awf/runtime/pr_monitor_runner/comments.py
@@ -31,6 +31,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _TASK_TAG_UNSET,
     _TaskTagUnset,
 )
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.types import (
     ProviderRecoveryRetryError,
     _MonitorAgentRuntimeOwnershipRepairFailedError,
@@ -289,11 +290,16 @@ async def _invoke_cli_for_verdict_result(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="before_comment_agent",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.mirror_hooks_path_repair_failed",
                 workspace_id=workspace_id,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                error_type=exc.__class__.__name__,
+                **repair_details,
             )
             raise _MonitorMirrorHooksPathRepairFailedError() from exc
     agent_run_err = None
@@ -325,11 +331,16 @@ async def _invoke_cli_for_verdict_result(
             try:
                 await repair_mirror_hooks_path(mirror_path)
             except (GitOperationError, OSError) as exc:
+                repair_details = mirror_hooks_repair_failure_details(
+                    exc,
+                    repair_stage="after_comment_agent_exception",
+                    mirror_path=mirror_path,
+                )
                 _log.warning(
                     "monitor.mirror_hooks_path_repair_failed",
                     workspace_id=workspace_id,
                     reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                    error_type=exc.__class__.__name__,
+                    **repair_details,
                 )
                 raise _MonitorMirrorHooksPathRepairFailedError() from exc
         await runner._commit_dirty_worktree(

--- a/src/awf/runtime/pr_monitor_runner/mirror_hooks.py
+++ b/src/awf/runtime/pr_monitor_runner/mirror_hooks.py
@@ -1,0 +1,41 @@
+"""Mirror hooks-path repair diagnostics for PR monitor operations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from awf.node.git_manager import GitOperationError
+
+_EVIDENCE_TEXT_LIMIT = 1000
+
+
+def mirror_hooks_repair_failure_details(
+    exc: BaseException,
+    *,
+    repair_stage: str,
+    mirror_path: Path | None = None,
+    extra: dict[str, object] | None = None,
+) -> dict[str, object]:
+    """Return structured, bounded evidence for a failed mirror hooks repair."""
+    details: dict[str, object] = {
+        "mirror_hooks_repair_failed": True,
+        "repair_stage": repair_stage,
+        "error_type": exc.__class__.__name__,
+    }
+    if mirror_path is not None:
+        details["mirror_path"] = str(mirror_path)
+    if isinstance(exc, GitOperationError):
+        details.update(
+            {
+                "repair_reason_code": exc.reason_code,
+                "git_operation": exc.operation,
+                "git_returncode": exc.returncode,
+                "stderr": exc.stderr[:_EVIDENCE_TEXT_LIMIT],
+                "stdout": exc.stdout[:_EVIDENCE_TEXT_LIMIT],
+            }
+        )
+    else:
+        details["error"] = str(exc)[:_EVIDENCE_TEXT_LIMIT]
+    if extra:
+        details.update(extra)
+    return details

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
@@ -44,6 +44,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _PROTECTED_SCOPE_REPAIR_FAILED_REASON,
 )
 from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.pre_push_validation_constants import (
     _PRE_PUSH_DIRTY_FINALIZE_DELTA_UNAVAILABLE_REASON,
     _PRE_PUSH_DIRTY_FINALIZE_UNOWNED_DELTA_REASON,
@@ -642,11 +643,17 @@ async def _post_pre_push_validation_mirror_hooks_repair_result(
     try:
         await repair_mirror_hooks_path(mirror_path)
     except (GitOperationError, OSError) as exc:
+        repair_details = mirror_hooks_repair_failure_details(
+            exc,
+            repair_stage="post_pre_push_validation",
+            mirror_path=mirror_path,
+            extra={"post_validation_mirror_repair_failed": True},
+        )
         _log.warning(
             "monitor.post_pre_push_validation_mirror_hooks_path_repair_failed",
             workspace_id=workspace_id,
             reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-            error_type=exc.__class__.__name__,
+            **repair_details,
         )
         return _PrePushValidationResult(
             passed=False,
@@ -654,7 +661,7 @@ async def _post_pre_push_validation_mirror_hooks_repair_result(
             workspace_head_sha=workspace_head_sha,
             reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
             message="could not repair poisoned mirror hooks path after pre-push validation",
-            extra_details={"post_validation_mirror_repair_failed": True},
+            extra_details=repair_details,
         )
     return None
 
@@ -692,11 +699,16 @@ async def _run_pre_push_validation(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="before_pre_push_validation",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.mirror_hooks_path_repair_failed",
                 workspace_id=workspace_id,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                error_type=exc.__class__.__name__,
+                **repair_details,
             )
             return _PrePushValidationResult(
                 passed=False,
@@ -704,6 +716,7 @@ async def _run_pre_push_validation(
                 workspace_head_sha=workspace_head_sha,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
                 message="could not repair poisoned mirror hooks path before pre-push validation",
+                extra_details=repair_details,
             )
 
     head_object_exists = await verify_head_object_exists(worktree_path)

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py
@@ -46,6 +46,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _PROTECTED_SCOPE_REPAIR_FAILED_REASON,
 )
 from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.path_parsing import _changed_paths_from_name_status_z
 from awf.runtime.pr_monitor_runner.pre_push_validation_constants import (
     _PRE_PUSH_VALIDATION_INFRASTRUCTURE_FAILED_REASON,
@@ -412,12 +413,17 @@ async def _repair_pre_push_validation_fix_mirror_hooks(
     try:
         await repair_mirror_hooks_path(mirror_path)
     except (GitOperationError, OSError) as exc:
+        repair_details = mirror_hooks_repair_failure_details(
+            exc,
+            repair_stage="pre_push_validation_fix_pass",
+            mirror_path=mirror_path,
+            extra={"pass_number": pass_number},
+        )
         _log.warning(
             "monitor.mirror_hooks_path_repair_failed",
             workspace_id=workspace_id,
-            pass_number=pass_number,
             reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-            error_type=exc.__class__.__name__,
+            **repair_details,
         )
         return _MIRROR_HOOKS_PATH_POISONED_REASON
     return None

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -38,6 +38,7 @@ from awf.runtime.pr_monitor_runner.constants import (
     _REPAIR_DIRTY_COMMIT_FAILED_REASON,
     _SYNC_BASE_RESOLVABLE_STALE_REASONS,
 )
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.pre_push_validation_constants import (
     _PRE_PUSH_DIRTY_FINALIZE_DELTA_UNAVAILABLE_REASON,
     _PRE_PUSH_DIRTY_FINALIZE_UNOWNED_DELTA_REASON,
@@ -571,11 +572,17 @@ async def _git_push_result(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="before_git_push",
+                mirror_path=mirror_path,
+                extra={"phase": "git_push"},
+            )
             _log.warning(
                 "monitor.push_mirror_hooks_path_repair_failed",
                 workspace_id=worktree_path.name,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                error_type=exc.__class__.__name__,
+                **repair_details,
             )
             return _GitPushResult(
                 pushed=False,
@@ -583,7 +590,7 @@ async def _git_push_result(
                 returncode=1,
                 stderr="could not repair poisoned mirror hooks path before git push",
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                details={"phase": "git_push"},
+                details=repair_details,
             )
     git_env = git_env_without_object_lookup_overrides()
     r = await runner._deps.runner.run(
@@ -818,11 +825,16 @@ async def _run_sync_base(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="before_sync_base_merge",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.sync_base_mirror_hooks_path_repair_failed",
                 workspace_id=workspace_id,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                error_type=exc.__class__.__name__,
+                **repair_details,
             )
             return _GitPushResult(
                 pushed=False,
@@ -830,6 +842,7 @@ async def _run_sync_base(
                 returncode=1,
                 stderr="could not repair poisoned mirror hooks path before sync-base merge",
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                details=repair_details,
             )
     merge_args: tuple[str, ...] = ("merge", "--no-edit", f"origin/{base_branch}")
     if task_tag:
@@ -886,11 +899,16 @@ async def _run_sync_base(
             try:
                 await repair_mirror_hooks_path(mirror_path)
             except (GitOperationError, OSError) as exc:
+                repair_details = mirror_hooks_repair_failure_details(
+                    exc,
+                    repair_stage="before_sync_base_agent",
+                    mirror_path=mirror_path,
+                )
                 _log.warning(
                     "monitor.sync_base_mirror_hooks_path_repair_failed",
                     workspace_id=workspace_id,
                     reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                    error_type=exc.__class__.__name__,
+                    **repair_details,
                 )
                 return _GitPushResult(
                     pushed=False,
@@ -898,6 +916,7 @@ async def _run_sync_base(
                     returncode=1,
                     stderr="could not repair poisoned mirror hooks path before sync-base agent launch",
                     reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                    details=repair_details,
                 )
         try:
             result = await runner._deps.adapter.run(
@@ -925,12 +944,17 @@ async def _run_sync_base(
                 try:
                     await repair_mirror_hooks_path(mirror_path)
                 except (GitOperationError, OSError) as repair_exc:
+                    repair_details = mirror_hooks_repair_failure_details(
+                        repair_exc,
+                        repair_stage="after_sync_base_agent_exception",
+                        mirror_path=mirror_path,
+                        extra={"original_error_type": exc.__class__.__name__},
+                    )
                     _log.warning(
                         "monitor.sync_base_post_agent_mirror_hooks_path_repair_failed",
                         workspace_id=workspace_id,
                         reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
-                        error_type=repair_exc.__class__.__name__,
-                        original_error_type=exc.__class__.__name__,
+                        **repair_details,
                     )
                     return _GitPushResult(
                         pushed=False,
@@ -938,6 +962,7 @@ async def _run_sync_base(
                         returncode=1,
                         stderr="could not repair poisoned mirror hooks path after sync-base agent failure",
                         reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                        details=repair_details,
                     )
             post_agent_err = exc
 

--- a/src/awf/runtime/pr_monitor_runner/remote_repair.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair.py
@@ -68,6 +68,7 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _untracked_paths_from_porcelain,
 )
 from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.path_parsing import (
     _changed_paths_from_name_status_z,
 )
@@ -838,24 +839,15 @@ async def _commit_dirty_worktree(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
-            log_kwargs: dict[str, object] = {
-                "workspace_id": workspace_id,
-                "reason_code": _MIRROR_HOOKS_PATH_POISONED_REASON,
-                "error_type": exc.__class__.__name__,
-            }
-            if isinstance(exc, GitOperationError):
-                log_kwargs.update(
-                    {
-                        "repair_reason_code": exc.reason_code,
-                        "git_operation": exc.operation,
-                        "git_returncode": exc.returncode,
-                        "stderr": exc.stderr[:1000],
-                    }
-                )
-            else:
-                log_kwargs["error"] = str(exc)
+            log_kwargs = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="commit_dirty_worktree",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.mirror_hooks_path_repair_failed",
+                workspace_id=workspace_id,
+                reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
                 **log_kwargs,
             )
             raise _MonitorMirrorHooksPathRepairFailedError() from exc

--- a/src/awf/runtime/pr_monitor_runner/remote_repair_protected.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_repair_protected.py
@@ -82,6 +82,7 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _untracked_paths_from_porcelain_z,
 )
 from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.mirror_hooks import mirror_hooks_repair_failure_details
 from awf.runtime.pr_monitor_runner.remote_ops import (
     _GitPushResult,
     _ProtectedScopePushBlock,
@@ -844,10 +845,16 @@ async def _repair_protected_scope_changes_before_commit(
         try:
             await repair_mirror_hooks_path(mirror_path)
         except (GitOperationError, OSError) as exc:
+            repair_details = mirror_hooks_repair_failure_details(
+                exc,
+                repair_stage="protected_scope_repair",
+                mirror_path=mirror_path,
+            )
             _log.warning(
                 "monitor.protected_scope_repair_mirror_hooks_path_repair_failed",
                 workspace_id=workspace_id,
                 reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+                **repair_details,
             )
             raise _MonitorMirrorHooksPathRepairFailedError() from exc
 

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -825,7 +825,10 @@ def test_linked_worktree_path_from_git_dir_wraps_metadata_read_error(
 
     assert raised.value.operation == "worktree.hooks_path_probe"
     assert raised.value.reason_code == "MIRROR_HOOKS_PATH_REPAIR_FAILED"
-    assert "cannot read linked-worktree gitdir back-reference" in raised.value.stderr
+    # A non-ENOENT OSError (permission denied) is a live-but-unreadable worktree,
+    # not a removal race, so the probe surfaces the fail-closed "cannot access"
+    # wording rather than the stale "cannot read" sentinel reserved for ENOENT.
+    assert "cannot access linked-worktree gitdir back-reference" in raised.value.stderr
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_git_manager_mirror_hooks_repair.py
+++ b/tests/unit/node/test_git_manager_mirror_hooks_repair.py
@@ -148,7 +148,9 @@ class TestRepairMirrorHooksPath:
         monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
         monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
 
-        assert await git_module.repair_mirror_hooks_path(mirror) is True
+        # Both scan passes report nothing to repair, so the corrected contract
+        # returns ``False`` even though stale metadata was pruned between them.
+        assert await git_module.repair_mirror_hooks_path(mirror) is False
         assert prune_calls == 1
         assert repair_calls == 2
 

--- a/tests/unit/node/test_git_manager_mirror_hooks_repair.py
+++ b/tests/unit/node/test_git_manager_mirror_hooks_repair.py
@@ -85,6 +85,71 @@ class TestRepairMirrorHooksPath:
         assert check.returncode != 0
 
     @pytest.mark.unit
+    async def test_repair_waits_for_shared_mirror_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        started = False
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            nonlocal started
+            started = True
+            return False
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        lock = git_module.GitManager._lock_for_mirror(mirror)  # noqa: SLF001
+        await lock.acquire()
+        task = asyncio.create_task(git_module.repair_mirror_hooks_path(mirror))
+        try:
+            await asyncio.sleep(0)
+            assert started is False
+            assert task.done() is False
+        finally:
+            lock.release()
+
+        assert await task is False
+        assert started is True
+
+    @pytest.mark.unit
+    async def test_prunes_and_retries_when_linked_worktree_metadata_disappears(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        linked_git_dir = mirror / "worktrees" / "workspace"
+        linked_git_dir.mkdir(parents=True)
+        repair_calls = 0
+        prune_calls = 0
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            nonlocal repair_calls
+            repair_calls += 1
+            return False
+
+        async def _run_git_worktree_prune(path: Path) -> None:
+            nonlocal prune_calls
+            prune_calls += 1
+            assert path == mirror
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
+
+        assert await git_module.repair_mirror_hooks_path(mirror) is True
+        assert prune_calls == 1
+        assert repair_calls == 2
+
+    @pytest.mark.unit
     async def test_removes_include_exposing_poisoned_hooks_path(self, tmp_path: Path) -> None:
         mirror = tmp_path / "mirror.git"
         mirror.mkdir()

--- a/tests/unit/node/test_git_manager_mirror_hooks_repair.py
+++ b/tests/unit/node/test_git_manager_mirror_hooks_repair.py
@@ -189,6 +189,105 @@ class TestRepairMirrorHooksPath:
         assert raised.value.operation == "mirror.worktree_metadata_stale"
 
     @pytest.mark.unit
+    async def test_run_git_worktree_prune_raises_when_prune_subprocess_fails(
+        self, tmp_path: Path
+    ) -> None:
+        # A path that is not a git directory makes ``git worktree prune`` exit
+        # non-zero, which must surface as a repair failure rather than being
+        # swallowed.
+        not_a_mirror = tmp_path / "not-a-git-dir"
+        not_a_mirror.mkdir()
+
+        with pytest.raises(git_module.GitOperationError) as raised:
+            await git_module._run_git_worktree_prune(not_a_mirror)
+
+        assert raised.value.operation == "mirror.worktree_prune"
+        assert raised.value.returncode != 0
+        assert raised.value.reason_code == "MIRROR_HOOKS_PATH_REPAIR_FAILED"
+
+    @pytest.mark.unit
+    async def test_fails_closed_when_worktrees_dir_is_unreadable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        worktrees_dir = mirror / "worktrees"
+        worktrees_dir.mkdir()
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            return False
+
+        async def _run_git_worktree_prune(path: Path) -> None:
+            assert path == mirror
+
+        real_iterdir = Path.iterdir
+
+        def _iterdir(self: Path):  # type: ignore[no-untyped-def]
+            if self == worktrees_dir:
+                raise OSError("permission denied scanning worktrees")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
+        monkeypatch.setattr(Path, "iterdir", _iterdir)
+
+        # An unreadable ``worktrees`` directory persists across the prune retry,
+        # so a poisoned worktree ``core.hooksPath`` cannot be verified-clean and
+        # repair must fail closed.
+        with pytest.raises(git_module.GitOperationError) as raised:
+            await git_module.repair_mirror_hooks_path(mirror)
+
+        assert raised.value.operation == "mirror.worktree_metadata_stale"
+        assert raised.value.reason_code == "MIRROR_HOOKS_PATH_REPAIR_FAILED"
+
+    @pytest.mark.unit
+    async def test_propagates_non_stale_linked_worktree_probe_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        linked_git_dir = mirror / "worktrees" / "workspace"
+        linked_git_dir.mkdir(parents=True)
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            return False
+
+        probe_error = git_module.GitOperationError(
+            operation="worktree.hooks_path_probe",
+            returncode=1,
+            stdout="",
+            stderr="fatal: some other probe failure",
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        )
+
+        def _linked_worktree_path_from_git_dir(_path: Path) -> Path:
+            raise probe_error
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        monkeypatch.setattr(
+            git_module,
+            "_linked_worktree_path_from_git_dir",
+            _linked_worktree_path_from_git_dir,
+        )
+
+        # A probe error that is not the stale-metadata sentinel is a genuine
+        # failure and must propagate instead of being treated as stale metadata.
+        with pytest.raises(git_module.GitOperationError) as raised:
+            await git_module.repair_mirror_hooks_path(mirror)
+
+        assert raised.value is probe_error
+
+    @pytest.mark.unit
     async def test_removes_include_exposing_poisoned_hooks_path(self, tmp_path: Path) -> None:
         mirror = tmp_path / "mirror.git"
         mirror.mkdir()

--- a/tests/unit/node/test_git_manager_mirror_hooks_repair.py
+++ b/tests/unit/node/test_git_manager_mirror_hooks_repair.py
@@ -141,6 +141,9 @@ class TestRepairMirrorHooksPath:
             nonlocal prune_calls
             prune_calls += 1
             assert path == mirror
+            # Real ``git worktree prune`` removes the dead linked-worktree metadata,
+            # so the retry pass no longer reports it as stale.
+            shutil.rmtree(linked_git_dir)
 
         monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
         monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
@@ -148,6 +151,40 @@ class TestRepairMirrorHooksPath:
         assert await git_module.repair_mirror_hooks_path(mirror) is True
         assert prune_calls == 1
         assert repair_calls == 2
+
+    @pytest.mark.unit
+    async def test_fails_closed_when_stale_metadata_survives_retry(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        linked_git_dir = mirror / "worktrees" / "workspace"
+        linked_git_dir.mkdir(parents=True)
+        prune_calls = 0
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            return False
+
+        async def _run_git_worktree_prune(path: Path) -> None:
+            nonlocal prune_calls
+            prune_calls += 1
+            # Prune cannot clear metadata that stays unreadable (e.g. a
+            # permission-denied gitdir back-reference of a live worktree).
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
+
+        with pytest.raises(git_module.GitOperationError) as raised:
+            await git_module.repair_mirror_hooks_path(mirror)
+
+        assert prune_calls == 1
+        assert raised.value.reason_code == "MIRROR_HOOKS_PATH_REPAIR_FAILED"
+        assert raised.value.operation == "mirror.worktree_metadata_stale"
 
     @pytest.mark.unit
     async def test_removes_include_exposing_poisoned_hooks_path(self, tmp_path: Path) -> None:

--- a/tests/unit/node/test_git_manager_mirror_hooks_repair.py
+++ b/tests/unit/node/test_git_manager_mirror_hooks_repair.py
@@ -175,8 +175,8 @@ class TestRepairMirrorHooksPath:
         async def _run_git_worktree_prune(path: Path) -> None:
             nonlocal prune_calls
             prune_calls += 1
-            # Prune cannot clear metadata that stays unreadable (e.g. a
-            # permission-denied gitdir back-reference of a live worktree).
+            # Prune cannot clear metadata whose gitdir back-reference stays
+            # missing (the empty linked-worktree dir survives the prune).
 
         monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
         monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
@@ -286,6 +286,53 @@ class TestRepairMirrorHooksPath:
             await git_module.repair_mirror_hooks_path(mirror)
 
         assert raised.value is probe_error
+
+    @pytest.mark.unit
+    async def test_unreadable_live_worktree_gitdir_fails_closed_without_prune(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        mirror.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", str(mirror)],
+            check=True,
+            capture_output=True,
+        )
+        linked_git_dir = mirror / "worktrees" / "workspace"
+        linked_git_dir.mkdir(parents=True)
+        gitdir_ref = linked_git_dir / "gitdir"
+        gitdir_ref.write_text(str(tmp_path / "live-worktree" / ".git"), encoding="utf-8")
+        prune_calls = 0
+
+        async def _repair_hooks_path_config(**_kwargs: object) -> bool:
+            return False
+
+        async def _run_git_worktree_prune(path: Path) -> None:
+            nonlocal prune_calls
+            prune_calls += 1
+
+        real_read_text = Path.read_text
+
+        def _read_text(self: Path, *args: object, **kwargs: object) -> str:
+            if self == gitdir_ref:
+                raise PermissionError("unable to read gitdir file (Permission denied)")
+            return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(git_module, "_repair_hooks_path_config", _repair_hooks_path_config)
+        monkeypatch.setattr(git_module, "_run_git_worktree_prune", _run_git_worktree_prune)
+        monkeypatch.setattr(Path, "read_text", _read_text)
+
+        # A permission-denied gitdir back-reference belongs to a live worktree we
+        # merely cannot inspect; it is NOT stale metadata. Pruning it would delete
+        # the live worktree's admin files, so repair must fail closed and never
+        # reach ``git worktree prune``.
+        with pytest.raises(git_module.GitOperationError) as raised:
+            await git_module.repair_mirror_hooks_path(mirror)
+
+        assert prune_calls == 0
+        assert raised.value.operation == "worktree.hooks_path_probe"
+        assert raised.value.reason_code == "MIRROR_HOOKS_PATH_REPAIR_FAILED"
+        assert "cannot access linked-worktree gitdir back-reference" in raised.value.stderr
 
     @pytest.mark.unit
     async def test_removes_include_exposing_poisoned_hooks_path(self, tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py
@@ -424,6 +424,12 @@ async def test_pre_push_validation_fails_closed_on_git_mirror_hooks_repair_failu
 
     assert result.passed is False
     assert result.reason_code == "MIRROR_HOOKS_PATH_POISONED"
+    assert result.extra_details is not None
+    assert result.extra_details["repair_stage"] == "before_pre_push_validation"
+    assert result.extra_details["git_operation"] == "mirror.hooks_path_repair"
+    assert result.extra_details["git_returncode"] == 1
+    assert result.extra_details["stderr"] == "failed"
+    assert result.extra_details["mirror_hooks_repair_failed"] is True
 
 
 @pytest.mark.unit
@@ -542,7 +548,7 @@ async def test_pre_push_validation_fails_closed_when_post_validation_mirror_repa
             raise GitOperationError(
                 operation="mirror.hooks_path_repair",
                 returncode=1,
-                stdout="",
+                stdout="repair stdout",
                 stderr="failed",
                 reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
             )
@@ -562,6 +568,13 @@ async def test_pre_push_validation_fails_closed_when_post_validation_mirror_repa
 
     assert result.passed is False
     assert result.reason_code == _MIRROR_HOOKS_PATH_POISONED_REASON
+    assert result.extra_details is not None
+    assert result.extra_details["post_validation_mirror_repair_failed"] is True
+    assert result.extra_details["repair_stage"] == "post_pre_push_validation"
+    assert result.extra_details["git_operation"] == "mirror.hooks_path_repair"
+    assert result.extra_details["git_returncode"] == 1
+    assert result.extra_details["stderr"] == "failed"
+    assert result.extra_details["stdout"] == "repair stdout"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_022.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_022.py
@@ -154,11 +154,15 @@ async def test_commit_dirty_worktree_preserves_mirror_hooks_repair_failure_detai
             {
                 "workspace_id": workspace_id,
                 "reason_code": "MIRROR_HOOKS_PATH_POISONED",
+                "mirror_hooks_repair_failed": True,
+                "repair_stage": "commit_dirty_worktree",
                 "error_type": "GitOperationError",
+                "mirror_path": str(tmp_path / "mirrors" / "test.git"),
                 "repair_reason_code": "MIRROR_HOOKS_PATH_REPAIR_FAILED",
                 "git_operation": "mirror.hooks_path_repair",
                 "git_returncode": 1,
                 "stderr": "fatal: config unset failed",
+                "stdout": "",
             },
         )
     ]

--- a/tests/unit/runtime/test_pr_monitor_sync_base_operation_start_head.py
+++ b/tests/unit/runtime/test_pr_monitor_sync_base_operation_start_head.py
@@ -1024,6 +1024,14 @@ async def test_run_sync_base_fails_closed_when_post_agent_mirror_hooks_repair_fa
         returncode=1,
         stderr="could not repair poisoned mirror hooks path after sync-base agent failure",
         reason_code=_MIRROR_HOOKS_PATH_POISONED_REASON,
+        details={
+            "mirror_hooks_repair_failed": True,
+            "repair_stage": "after_sync_base_agent_exception",
+            "error_type": "OSError",
+            "mirror_path": str(tmp_path / "mirror.git"),
+            "error": "could not repair hooks",
+            "original_error_type": "ComposeExecCleanupError",
+        },
     )
     assert events == [
         "git:merge --abort",


### PR DESCRIPTION
## Summary
- serialize `repair_mirror_hooks_path()` with the same per-mirror lock used for worktree add/remove/prune
- tolerate disappearing linked-worktree metadata by pruning under the lock and retrying one repair scan
- add structured mirror-repair failure evidence across PR-monitor repair paths

## Root Cause
PR #614 added fail-closed mirror hooks repair, but the repair function itself did not acquire the shared mirror lock. A PR-monitor post-validation repair could scan linked-worktree metadata while another workspace was removing/pruning a worktree on the same mirror, then fail closed with only a generic `MIRROR_HOOKS_PATH_POISONED` message.

## Validation
- `uv run --python 3.12 --extra dev pytest tests/unit/node/test_git_manager_mirror_hooks_repair.py tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py -q`
- `uv run --python 3.12 --extra dev ruff check src/awf/node/git_manager.py src/awf/runtime/pr_monitor_runner/mirror_hooks.py src/awf/runtime/pr_monitor_runner/pre_push_validation.py src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py src/awf/runtime/pr_monitor_runner/comments.py src/awf/runtime/pr_monitor_runner/ci_ops.py src/awf/runtime/pr_monitor_runner/remote_ops.py src/awf/runtime/pr_monitor_runner/remote_repair.py src/awf/runtime/pr_monitor_runner/remote_repair_protected.py tests/unit/node/test_git_manager_mirror_hooks_repair.py tests/unit/runtime/test_pr_monitor_pre_push_validation_edges.py`
- `uv run --python 3.12 --extra dev mypy src/awf/node/git_manager.py src/awf/runtime/pr_monitor_runner/mirror_hooks.py src/awf/runtime/pr_monitor_runner/pre_push_validation.py src/awf/runtime/pr_monitor_runner/pre_push_validation_fix_pass.py src/awf/runtime/pr_monitor_runner/comments.py src/awf/runtime/pr_monitor_runner/ci_ops.py src/awf/runtime/pr_monitor_runner/remote_ops.py src/awf/runtime/pr_monitor_runner/remote_repair.py src/awf/runtime/pr_monitor_runner/remote_repair_protected.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared mirror locking and git worktree metadata handling on a path many monitor operations depend on; mistakes could block pushes or mis-classify live vs stale worktrees, but behavior stays fail-closed with expanded tests.
> 
> **Overview**
> Fixes false **`MIRROR_HOOKS_PATH_POISONED`** failures when PR monitor mirror hooks repair races concurrent worktree remove/prune on the same bare mirror.
> 
> **`repair_mirror_hooks_path()`** now runs under **`GitManager._lock_for_mirror`**, matching worktree add/remove/prune. Repair is split into a single scan (`_repair_mirror_hooks_path_once`); if linked-worktree metadata looks stale (missing gitdir back-reference, missing worktree path, unreadable `worktrees` listing), it runs **`git worktree prune`** once and rescans. **ENOENT** on the gitdir back-reference is treated as stale; **other OS errors** (e.g. permission denied) fail closed **without** prune so live worktrees are not destroyed. If stale metadata survives the retry, repair raises **`mirror.worktree_metadata_stale`** instead of proceeding.
> 
> PR monitor paths that call mirror repair now use **`mirror_hooks_repair_failure_details`** so logs and push/validation results carry stage, mirror path, git operation, return code, and bounded stdout/stderr. Focused unit tests cover lock ordering, prune/retry, and fail-closed edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f7467822ae1689a361c1af37d097f1969d80f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->