### PR TITLE
Release: sync development → main (actions/checkout v7, #626)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
@@ -79,7 +79,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
@@ -143,7 +143,7 @@ jobs:
           echo "python-coverage-shards result: ${{ needs.python-coverage-shards.result }}"
           exit 1
 
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
@@ -194,7 +194,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
       manifest_generated: ${{ steps.build.outputs.manifest_generated }}
     steps:
       - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-tags: true
           # This is the most release-sensitive checkout in the repo (it builds
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout source
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           # Match the build job and ci.yml: do not persist GITHUB_TOKEN in
           # .git/config for the artifact-verification smoke checkout.

--- a/tests/unit/test_ci_workflow_full_coverage.py
+++ b/tests/unit/test_ci_workflow_full_coverage.py
@@ -440,7 +440,7 @@ def test_required_ci_gate_rolls_up_full_coverage_and_required_jobs() -> None:
 @pytest.mark.parametrize(
     ("action", "ref"),
     [
-        ("actions/checkout", "v6"),
+        ("actions/checkout", "v7"),
         ("astral-sh/setup-uv", "v8"),
         ("actions/upload-artifact", "v7"),
         ("actions/download-artifact", "v8"),

--- a/tests/unit/test_publish_workflow_release_artifacts.py
+++ b/tests/unit/test_publish_workflow_release_artifacts.py
@@ -74,7 +74,7 @@ def _uploaded_paths(job: dict[str, Any]) -> set[str]:
 @pytest.mark.parametrize(
     ("action", "ref"),
     [
-        ("actions/checkout", "v6"),
+        ("actions/checkout", "v7"),
         ("astral-sh/setup-uv", "v8"),
         ("actions/upload-artifact", "v7"),
         ("actions/download-artifact", "v8"),


### PR DESCRIPTION
Promote the merged `development` backlog to `main`. Delta since the last release (#650):

- **#626** — bump `actions/checkout` v6.0.3 → v7.0.0 (Dependabot; SHA-pinned, `# v7.0.0`) + the SHA-pin guard-test expectation `v6` → `v7` to match. v7.0.0 only moves the action runtime to Node 24 — no API/behavior change; ran green in CI on development.

Mechanical release sync — no new feature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only dependency bump with unchanged checkout inputs; v7.0.0 is described as a Node 24 runtime update without API/behavior changes.
> 
> **Overview**
> Bumps **`actions/checkout`** from **v6.0.3** to **v7.0.0** everywhere it is used, still **SHA-pinned** with the `# v7.0.0` comment.
> 
> **CI** (`ci.yml`): all five checkout steps (lint, coverage shards, full coverage, console, release-artifacts) now use the new pin; `persist-credentials: false` is unchanged.
> 
> **Publish** (`publish.yml`): checkout in **build** and **installer-smoke** is updated the same way.
> 
> **Tests**: the workflow SHA-pin guards expect **`actions/checkout` → `v7`** instead of `v6` in `test_ci_workflow_full_coverage.py` and `test_publish_workflow_release_artifacts.py`.
> 
> No application or workflow logic changes beyond the action version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92c3bb63593e1088b86fa00a8586e70f5d93ff52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->