### PR TITLE
fix: bounded grace before HUMAN_WAIT on transient required-CI absence (#655)

### DIFF
--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -235,6 +235,18 @@ class PRStatus:
     exist → do NOT skip the pending-checks wait"), so a forgotten populate can
     never enable an unsafe no-CI merge. Consumed only by ``decide`` gate 6 in
     combination with ``MonitorConfig.require_ci``."""
+    awaiting_required_checks_grace_active: bool = False
+    """Within the bounded grace window for required CI that is expected but
+    absent on the current head (#655).
+
+    Time-derived and set by the RUNNER (``decide`` stays pure), exactly like
+    ``no_checks_observed`` is populated upstream. ``True`` means the head first
+    showed "required CI expected but absent" recently enough that the new
+    pre-gate-9 gate defers to a bounded ``WaitForCI`` instead of pinging a human;
+    once the per-head grace expires the runner flips it ``False`` and gate 9
+    escalates. The default ``False`` means "escalate immediately" — so a
+    forgotten populate reverts to pre-#655 behavior (a possibly-premature ping),
+    never an unsafe merge."""
     changed_paths: tuple[str, ...] = ()
     closed: bool = False
     merged: bool = False
@@ -397,6 +409,20 @@ class MonitorConfig:
     exceeded this age. This is observability only; pending checks still
     block merge through the ordinary WaitForCI path."""
 
+    awaiting_required_checks_grace_seconds: float = 600.0
+    """Grace window for required CI that is expected but absent on the current
+    head before escalating to a human (#655).
+
+    Right after a monitor push the forge has not started CI on the new head yet,
+    so the head shows an empty check set while branch protection reports
+    ``BLOCKED`` (the required context is absent). Within this window ``decide``
+    defers to a bounded ``WaitForCI`` instead of a premature ``NotifyHuman``;
+    once it expires a head that genuinely never gets CI escalates as before. The
+    default (600s) covers the observed ≈5.5-min CI-start lag with margin. Used by
+    the RUNNER to derive ``PRStatus.awaiting_required_checks_grace_active``, not
+    by ``decide`` directly. Set ``<= 0`` to disable the grace (escalate
+    immediately, pre-#655 behavior)."""
+
     max_no_progress_sync_base_attempts: int = 3
     """Abort or move to still-actionable review feedback after this many
     consecutive no-op SyncBase attempts for the same PR snapshot. This
@@ -472,7 +498,11 @@ class SyncBase:
 class WaitForCI:
     """CI still running; sleep poll_interval then re-decide. Does NOT bump iter_count."""
 
-    reason: Literal["pending_checks", "unknown_mergeable_state"] = "pending_checks"
+    reason: Literal[
+        "pending_checks",
+        "unknown_mergeable_state",
+        "awaiting_required_checks",
+    ] = "pending_checks"
 
 
 @dataclass(frozen=True)
@@ -922,6 +952,19 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
         NotifyHuman. Deferred BOT feedback does not block — bots
         can't themselves mark threads resolved, so their deferred
         nits would linger forever.
+    8b. Required CI expected-but-ABSENT on the current head within the
+        grace window (#655) → bounded WaitForCI("awaiting_required_checks").
+        Right after a monitor push the forge has not started CI on the new
+        head yet, so the head shows an empty check set
+        (``no_checks_observed``) while branch protection reports
+        BLOCKED/HAS_HOOKS (the required context is missing). Without this
+        gate ``decide`` falls through to gate 9 and posts a premature human
+        ping that the monitor self-recovers from once CI lands. The runner
+        sets ``awaiting_required_checks_grace_active`` per head, so once the
+        window expires this gate stops matching and gate 9 escalates. Safety
+        hinge: it fires ONLY when checks are ABSENT — a genuine human-gate
+        block (checks PRESENT + BLOCKED) leaves ``no_checks_observed`` False
+        and escalates immediately via gate 9.
     9.  ``merge_state_status`` BLOCKED / HAS_HOOKS → NotifyHuman. These
         protected states can represent missing approval or branch-protection
         hooks even when there is no unresolved review thread to address.
@@ -1164,6 +1207,34 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     )
     if has_blocking_feedback:
         return NotifyHuman()
+
+    # 8b. Bounded grace before HUMAN_WAIT on transient required-CI absence (#655).
+    # Right after a monitor push the forge has not started CI on the new head
+    # yet, so the head shows an empty check set (``no_checks_observed``) while
+    # branch protection reports BLOCKED/HAS_HOOKS (the required context is
+    # absent). Defer to a bounded WaitForCI while the runner-set per-head grace
+    # window is active, instead of pinging a human that the monitor would
+    # self-recover from once CI lands. Safety hinge: this fires ONLY when checks
+    # are ABSENT — a genuine human-gate block (checks PRESENT + BLOCKED) leaves
+    # ``no_checks_observed`` False, so the gate is skipped and gate 9 escalates
+    # immediately. ``check_state != FAILURE`` is defensive (gate 5 already
+    # returned on FAILURE above); once the grace expires the runner flips the
+    # flag False and gate 9 takes over.
+    if (
+        config.require_ci
+        and status.no_checks_observed
+        and status.merge_state_status
+        in (
+            MergeStateStatus.BLOCKED,
+            MergeStateStatus.HAS_HOOKS,
+        )
+        # Defensive/redundant: gate 5 above already returns on FAILURE, so mypy
+        # narrows ``check_state`` to exclude it here. Kept explicit so a future
+        # gate reordering can't silently steal the FAILURE path into this wait.
+        and status.check_state != CheckState.FAILURE  # type: ignore[comparison-overlap]
+        and status.awaiting_required_checks_grace_active
+    ):
+        return WaitForCI(reason="awaiting_required_checks")
 
     # 9. GitHub may report BLOCKED / HAS_HOOKS because required approval,
     # protected hooks, or maintainer-controlled review state has not cleared.

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -498,6 +498,57 @@ def _stale_pending_check_warning_key(
     )
 
 
+def _awaiting_required_checks_first_seen_key(head_sha: str) -> str:
+    """Reserved ``MonitorState.threads_addressed_ids`` key carrying the first
+    poll time (epoch float string) the given head showed "required CI expected
+    but absent" (#655). One key per ``head_sha`` so each monitor push gets its
+    own grace window; stale keys for old heads linger harmlessly, like the
+    stale-pending and reviewer-settle markers."""
+    return f"__awf_awaiting_required_checks_first_seen__:{head_sha}"
+
+
+def _awaiting_required_checks_grace(
+    status: PRStatus,
+    state: MonitorState,
+    config: MonitorConfig,
+    *,
+    now: datetime,
+) -> tuple[bool, bool]:
+    """Return ``(grace_active, state_changed)`` for the transient required-CI gap.
+
+    Tracks, per ``head_sha``, the first poll time the head showed required CI
+    expected-but-absent (``config.require_ci`` and ``status.no_checks_observed``)
+    and reports whether that first observation is still within
+    ``config.awaiting_required_checks_grace_seconds``. A new ``head_sha`` starts a
+    fresh window (its key is absent → first observation again).
+
+    ``state_changed`` is ``True`` only when this call recorded a new first-seen
+    marker, signalling the caller to persist ``state`` — mandatory, because the
+    runner reloads ``state`` from the DB every poll, so an unpersisted marker
+    would re-read as absent forever and the window would never expire.
+
+    Returns ``(False, False)`` and records nothing when the condition does not
+    apply (``require_ci`` off, checks present, or the grace disabled with
+    ``grace_seconds <= 0``)."""
+    if not (config.require_ci and status.no_checks_observed):
+        return (False, False)
+    grace_seconds = config.awaiting_required_checks_grace_seconds
+    if grace_seconds <= 0:
+        return (False, False)
+    key = _awaiting_required_checks_first_seen_key(status.head_sha)
+    raw = state.threads_addressed_ids.get(key)
+    now_ts = _as_utc(now).timestamp()
+    if raw is None:
+        state.mark_addressed(key, f"{now_ts:.6f}")
+        return (True, True)  # first observation → within grace
+    try:
+        first_seen = float(raw)
+    except (TypeError, ValueError):
+        state.mark_addressed(key, f"{now_ts:.6f}")
+        return (True, True)
+    return (now_ts - first_seen < grace_seconds, False)
+
+
 def _notify_human_reason(status: PRStatus, state: MonitorState) -> str | None:
     if status.blocking_reviews:
         return "a merge-blocking changes-requested review remains unresolved"

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -240,13 +240,10 @@ async def _execute(
             workspace_id=workspace_id,
             action="check_wait",
             requested_action="wait_for_ci",
-            reason=(
-                "CI checks are still pending."
-                if action.reason == "pending_checks"
-                else "Required CI has not started on the new head yet."
-                if action.reason == "awaiting_required_checks"
-                else "GitHub has not reported a stable mergeable state."
-            ),
+            reason={
+                "pending_checks": "CI checks are still pending.",
+                "awaiting_required_checks": "Required CI has not started on the new head yet.",
+            }.get(action.reason, "GitHub has not reported a stable mergeable state."),
             reason_code="CHECK_WAIT",
             pr_number=pr_number,
             status=status,

--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -243,6 +243,8 @@ async def _execute(
             reason=(
                 "CI checks are still pending."
                 if action.reason == "pending_checks"
+                else "Required CI has not started on the new head yet."
+                if action.reason == "awaiting_required_checks"
                 else "GitHub has not reported a stable mergeable state."
             ),
             reason_code="CHECK_WAIT",

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -56,21 +56,19 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _redact_and_truncate_forge_error,
 )
 from awf.runtime.pr_monitor_runner.logging import _log
+from awf.runtime.pr_monitor_runner.merge_methods import (
+    _MERGE_METHOD_MISMATCH_REASON,
+    _merge_completion_marker,
+    _merge_method_mismatch_message,
+    _merge_method_preflight_rejection_reason,
+    _merge_method_rejection_method,
+    _resolve_effective_merge_methods,
+)
 from awf.runtime.pr_monitor_runner.types import (
     BaseBehindCountError,
     BaseFetchError,
 )
 from awf.service.merge_queue import MergeQueueBlocker
-
-# ``fast_forward`` is intentionally LAST so squash stays the default and the
-# GitHub precedence (squash > merge > rebase) is unchanged: it only ever wins on a
-# repo/branch policy that allows no other method (e.g. a fast-forward-only Bitbucket
-# repo, which previously wedged on a spurious MERGE_METHOD_MISMATCH — issue #448).
-# AWF preference wins among allowed strategies; Bitbucket's ``default_merge_strategy``
-# is ignored, uniform with GitHub.
-_MERGE_METHOD_PREFERENCE = ("squash", "merge", "rebase", "fast_forward")
-_KNOWN_MERGE_METHODS = frozenset(_MERGE_METHOD_PREFERENCE)
-_MERGE_METHOD_MISMATCH_REASON = "MERGE_METHOD_MISMATCH"
 
 # Bitbucket reason codes whose merge attempt is still in flight server-side rather
 # than a deterministic failure: the 409 already-in-progress signal and the exhausted
@@ -113,109 +111,6 @@ class _MergeAttemptResult:
         if not self.notification_reason:  # pragma: no cover
             raise RuntimeError("method-blocker merge attempt result has no reason")
         return self.notification_reason
-
-
-def _effective_merge_methods(
-    *,
-    repo_methods: tuple[str, ...],
-    branch_methods: tuple[str, ...] | None,
-) -> tuple[str, ...]:
-    """Intersect repo and branch merge policies in AWF preference order."""
-    repo_allowed = {method for method in repo_methods if method in _KNOWN_MERGE_METHODS}
-    branch_allowed = (
-        None
-        if branch_methods is None
-        else {method for method in branch_methods if method in _KNOWN_MERGE_METHODS}
-    )
-    allowed = repo_allowed if branch_allowed is None else repo_allowed.intersection(branch_allowed)
-    return tuple(method for method in _MERGE_METHOD_PREFERENCE if method in allowed)
-
-
-async def _resolve_effective_merge_methods(
-    self: Any,
-    *,
-    repo: RepoRef,
-    base_branch: str,
-) -> tuple[str, ...]:
-    """Fetch repository and base-branch policy before selecting merge methods.
-
-    ``self`` is the ``PullRequestMonitorRunner`` instance; this follows the
-    extract-to-module-function pattern used throughout this module.
-    """
-    repo_methods = await self._deps.gh.fetch_repo_merge_methods(repo=repo)
-    branch_methods = await self._deps.gh.fetch_branch_pull_request_allowed_merge_methods(
-        repo=repo,
-        branch=base_branch,
-    )
-    return _effective_merge_methods(repo_methods=repo_methods, branch_methods=branch_methods)
-
-
-def _merge_method_rejection_method(exc: GitHubClientError) -> str | None:
-    """Return the merge method explicitly rejected by GitHub, when known."""
-    # GitHubClientError stores redacted stderr. These policy phrases contain no
-    # secret-like material, so redaction should preserve the classifier signal.
-    text = exc.stderr.lower()
-    if (
-        "squash merges are not allowed" in text
-        or "merge method squash merging is not allowed" in text
-    ):
-        return "squash"
-    if (
-        "merge commits are not allowed" in text
-        or "merge method merge commit is not allowed" in text
-    ):
-        return "merge"
-    if "rebase merges are not allowed" in text or "merge method rebase is not allowed" in text:
-        return "rebase"
-    return None
-
-
-def _merge_error_supports_method_alternative(exc: GitHubClientError) -> bool:
-    """Detect GitHub merge failures that can be retried with another method."""
-    return _merge_method_rejection_method(exc) is not None
-
-
-def _merge_method_mismatch_message(
-    *,
-    base_branch: str,
-    attempted_method: str | None,
-    effective_methods: tuple[str, ...],
-    detail: str | None = None,
-) -> str:
-    """Build the human-facing merge-method mismatch notification."""
-    allowed = ", ".join(effective_methods) if effective_methods else "none"
-    attempted = attempted_method or "none"
-    suffix = f" GitHub reported: {detail}" if detail else ""
-    return (
-        "MERGE_METHOD_MISMATCH: AWF could not merge this PR because no merge "
-        f"method succeeded for base branch {base_branch!r}. "
-        f"attempted={attempted}; effective_allowed={allowed}.{suffix}"
-    )[:2000]
-
-
-def _merge_method_preflight_rejection_reason(exc: GitHubClientError) -> str:
-    """Build an operator-facing reason for merge-method policy preflight failures.
-
-    Only called with ``GitHubClientError``; ``BitbucketClientError`` has no
-    ``stderr`` attribute and is handled separately by
-    ``_bitbucket_merge_rejection_reason``.
-    """
-    detail = " ".join(_redact_and_truncate_forge_error(exc.stderr).split())[:240]
-    if detail:
-        return f"GitHub rejected merge-method preflight: {detail}"
-    return "GitHub rejected merge-method preflight"
-
-
-def _merge_completion_marker(
-    *,
-    merge_sha: str | None,
-    head_sha: str,
-) -> str:
-    """Return the non-empty marker used to record a completed PR merge."""
-    normalized_merge_sha = merge_sha.strip() if merge_sha else None
-    if normalized_merge_sha:
-        return normalized_merge_sha
-    return head_sha
 
 
 async def _record_empty_effective_merge_methods_blocker(

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
 from typing import Any, cast
@@ -39,6 +40,7 @@ from awf.runtime.pr_monitor_runner.gates import (
     _NonCheckReviewerSettleDecision,
 )
 from awf.runtime.pr_monitor_runner.helpers import (
+    _awaiting_required_checks_grace,
     _bitbucket_merge_rejection_reason,
     _clear_transient_base_fetch_retry_state,
     _clear_transient_forge_retry_state,
@@ -861,6 +863,29 @@ async def handle_merge_action(
                         state=state,
                     ):
                         pre_merge_state_changed = True
+                    # #656: decorate the freshly fetched status with the same
+                    # per-head required-CI-start grace the outer loop applies
+                    # before ``decide`` (runner.py). This recheck fetches a NEW
+                    # status that can show the transient empty-checks + BLOCKED
+                    # CI-start gap (the head changed during the settle window, or
+                    # GitHub recomputed mergeability); without the decoration
+                    # ``decide`` sees the default
+                    # ``awaiting_required_checks_grace_active=False``, gate 8b is
+                    # skipped, and the monitor pages a human prematurely before
+                    # the next outer poll can recover. Persisting the first-seen
+                    # marker is mandatory for the same reason as in the outer
+                    # loop: the runner reloads ``state`` from the DB every poll,
+                    # so an unpersisted marker would re-read as absent forever and
+                    # a genuine never-CI head would never escalate past the grace.
+                    grace_active, grace_state_changed = _awaiting_required_checks_grace(
+                        checked_status, state, self._config, now=datetime.now(UTC)
+                    )
+                    if grace_state_changed:
+                        pre_merge_state_changed = True
+                    checked_status = replace(
+                        checked_status,
+                        awaiting_required_checks_grace_active=grace_active,
+                    )
                     if pre_merge_state_changed:
                         await self._persist_state(workspace_id, state)
                     checked_action = decide(checked_status, state, self._config)

--- a/src/awf/runtime/pr_monitor_runner/merge_methods.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_methods.py
@@ -1,0 +1,128 @@
+"""Merge-method policy resolution, classification, and messaging helpers.
+
+Extracted from ``merge_loop`` so that module stays within the first-party
+line limit (``test_first_party_code_files_stay_under_line_limit``). These are
+the pure (and one ``self``-taking) helpers that decide which merge method to
+use, classify forge rejections, and build operator-facing messages; the merge
+action orchestration that calls them lives in ``merge_loop``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from awf.common.github_client import GitHubClientError, RepoRef
+from awf.runtime.pr_monitor_runner.helpers import _redact_and_truncate_forge_error
+
+# ``fast_forward`` is intentionally LAST so squash stays the default and the
+# GitHub precedence (squash > merge > rebase) is unchanged: it only ever wins on a
+# repo/branch policy that allows no other method (e.g. a fast-forward-only Bitbucket
+# repo, which previously wedged on a spurious MERGE_METHOD_MISMATCH — issue #448).
+# AWF preference wins among allowed strategies; Bitbucket's ``default_merge_strategy``
+# is ignored, uniform with GitHub.
+_MERGE_METHOD_PREFERENCE = ("squash", "merge", "rebase", "fast_forward")
+_KNOWN_MERGE_METHODS = frozenset(_MERGE_METHOD_PREFERENCE)
+_MERGE_METHOD_MISMATCH_REASON = "MERGE_METHOD_MISMATCH"
+
+
+def _effective_merge_methods(
+    *,
+    repo_methods: tuple[str, ...],
+    branch_methods: tuple[str, ...] | None,
+) -> tuple[str, ...]:
+    """Intersect repo and branch merge policies in AWF preference order."""
+    repo_allowed = {method for method in repo_methods if method in _KNOWN_MERGE_METHODS}
+    branch_allowed = (
+        None
+        if branch_methods is None
+        else {method for method in branch_methods if method in _KNOWN_MERGE_METHODS}
+    )
+    allowed = repo_allowed if branch_allowed is None else repo_allowed.intersection(branch_allowed)
+    return tuple(method for method in _MERGE_METHOD_PREFERENCE if method in allowed)
+
+
+async def _resolve_effective_merge_methods(
+    self: Any,
+    *,
+    repo: RepoRef,
+    base_branch: str,
+) -> tuple[str, ...]:
+    """Fetch repository and base-branch policy before selecting merge methods.
+
+    ``self`` is the ``PullRequestMonitorRunner`` instance; this follows the
+    extract-to-module-function pattern used throughout this module.
+    """
+    repo_methods = await self._deps.gh.fetch_repo_merge_methods(repo=repo)
+    branch_methods = await self._deps.gh.fetch_branch_pull_request_allowed_merge_methods(
+        repo=repo,
+        branch=base_branch,
+    )
+    return _effective_merge_methods(repo_methods=repo_methods, branch_methods=branch_methods)
+
+
+def _merge_method_rejection_method(exc: GitHubClientError) -> str | None:
+    """Return the merge method explicitly rejected by GitHub, when known."""
+    # GitHubClientError stores redacted stderr. These policy phrases contain no
+    # secret-like material, so redaction should preserve the classifier signal.
+    text = exc.stderr.lower()
+    if (
+        "squash merges are not allowed" in text
+        or "merge method squash merging is not allowed" in text
+    ):
+        return "squash"
+    if (
+        "merge commits are not allowed" in text
+        or "merge method merge commit is not allowed" in text
+    ):
+        return "merge"
+    if "rebase merges are not allowed" in text or "merge method rebase is not allowed" in text:
+        return "rebase"
+    return None
+
+
+def _merge_error_supports_method_alternative(exc: GitHubClientError) -> bool:
+    """Detect GitHub merge failures that can be retried with another method."""
+    return _merge_method_rejection_method(exc) is not None
+
+
+def _merge_method_mismatch_message(
+    *,
+    base_branch: str,
+    attempted_method: str | None,
+    effective_methods: tuple[str, ...],
+    detail: str | None = None,
+) -> str:
+    """Build the human-facing merge-method mismatch notification."""
+    allowed = ", ".join(effective_methods) if effective_methods else "none"
+    attempted = attempted_method or "none"
+    suffix = f" GitHub reported: {detail}" if detail else ""
+    return (
+        "MERGE_METHOD_MISMATCH: AWF could not merge this PR because no merge "
+        f"method succeeded for base branch {base_branch!r}. "
+        f"attempted={attempted}; effective_allowed={allowed}.{suffix}"
+    )[:2000]
+
+
+def _merge_method_preflight_rejection_reason(exc: GitHubClientError) -> str:
+    """Build an operator-facing reason for merge-method policy preflight failures.
+
+    Only called with ``GitHubClientError``; ``BitbucketClientError`` has no
+    ``stderr`` attribute and is handled separately by
+    ``_bitbucket_merge_rejection_reason``.
+    """
+    detail = " ".join(_redact_and_truncate_forge_error(exc.stderr).split())[:240]
+    if detail:
+        return f"GitHub rejected merge-method preflight: {detail}"
+    return "GitHub rejected merge-method preflight"
+
+
+def _merge_completion_marker(
+    *,
+    merge_sha: str | None,
+    head_sha: str,
+) -> str:
+    """Return the non-empty marker used to record a completed PR merge."""
+    normalized_merge_sha = merge_sha.strip() if merge_sha else None
+    if normalized_merge_sha:
+        return normalized_merge_sha
+    return head_sha

--- a/src/awf/runtime/pr_monitor_runner/runner.py
+++ b/src/awf/runtime/pr_monitor_runner/runner.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,7 @@ from awf.runtime.pr_monitor_runner.config import (
 )
 from awf.runtime.pr_monitor_runner.constants import _GIT_BASE_BEHIND_FAILED_REASON
 from awf.runtime.pr_monitor_runner.helpers import (
+    _awaiting_required_checks_grace,
     _clear_transient_base_fetch_retry_state,
     _clear_transient_forge_retry_state,
     _infer_service_work_dir,
@@ -354,6 +357,17 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                     remote_branch=remote_branch,
                     monitor_log=monitor_log,
                 )
+                # #655: derive the per-head grace flag for the transient
+                # required-CI-absent window. Persisting the first-seen marker is
+                # mandatory: run() reloads ``state`` from the DB every poll, so an
+                # unpersisted marker would re-read as absent forever and a genuine
+                # never-CI head would never escalate past the grace.
+                grace_active, grace_state_changed = _awaiting_required_checks_grace(
+                    status, state, self._config, now=datetime.now(UTC)
+                )
+                if grace_state_changed:
+                    await self._persist_state(workspace_id, state)
+                status = replace(status, awaiting_required_checks_grace_active=grace_active)
                 action = decide(status, state, self._config)
                 try:
                     terminal = await self._execute(

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -153,11 +153,22 @@ def pr_payload(
     merge_state_status: str = "CLEAN",
     check_state: str = "SUCCESS",
     check_contexts: list[dict] | None = None,
+    check_contexts_total_count: int | None = None,
     threads: list[dict] | None = None,
     reviews: list[dict] | None = None,
     comments: list[dict] | None = None,
 ) -> str:
-    """Build a GraphQL-like PR payload for monitor status helpers."""
+    """Build a GraphQL-like PR payload for monitor status helpers.
+
+    ``check_contexts_total_count`` sets the rollup ``contexts.totalCount`` that
+    drives ``PRStatus.no_checks_observed`` (a present-but-empty rollup reports
+    ``totalCount == 0`` — the transient post-push CI-start window). When left
+    ``None`` the key is omitted, preserving the legacy ``no_checks_observed=False``
+    shape for existing callers.
+    """
+    contexts: dict[str, object] = {"nodes": check_contexts or []}
+    if check_contexts_total_count is not None:
+        contexts["totalCount"] = check_contexts_total_count
     return json.dumps(
         {
             "data": {
@@ -179,7 +190,7 @@ def pr_payload(
                                     "commit": {
                                         "statusCheckRollup": {
                                             "state": check_state,
-                                            "contexts": {"nodes": check_contexts or []},
+                                            "contexts": contexts,
                                         },
                                         "committedDate": committed_date,
                                     }

--- a/tests/unit/runtime/test_pr_monitor_awaiting_required_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_awaiting_required_checks.py
@@ -1,0 +1,390 @@
+"""Bounded grace before HUMAN_WAIT on transient required-CI absence (#655).
+
+Right after a monitor push the forge has not started CI on the new head yet, so
+the head shows an EMPTY check set (``no_checks_observed=True``) while branch
+protection reports ``merge_state_status == BLOCKED`` (the required context is
+absent). The empty rollup parses to a non-PENDING ``check_state`` so the pending
+gate misses it, and ``decide`` used to escalate ``NotifyHuman`` immediately — a
+premature human ping the monitor self-recovers from once CI lands.
+
+The runner derives a per-head grace flag
+(``_awaiting_required_checks_grace`` →
+``PRStatus.awaiting_required_checks_grace_active``); ``decide`` defers to a
+bounded ``WaitForCI("awaiting_required_checks")`` while the window is active and
+escalates only after it expires. These tests lock the runner timing helper and
+the end-to-end loop wiring (the pure ``decide`` matrix lives in
+``test_pr_monitor_require_ci.py``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+import structlog
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.enums import OperationType
+from awf.db.repositories import OperationRepository, WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorConfig,
+    MonitorState,
+    PRStatus,
+)
+from awf.runtime.pr_monitor_runner.helpers import (
+    _awaiting_required_checks_first_seen_key,
+    _awaiting_required_checks_grace,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    pr_payload,
+    seed_monitoring_workspace,
+)
+
+_NOW = datetime(2026, 6, 22, 8, 30, 0, tzinfo=UTC)
+
+
+def _status(
+    *,
+    head_sha: str = "head1",
+    no_checks_observed: bool = True,
+    check_state: CheckState = CheckState.SUCCESS,
+    merge_state_status: MergeStateStatus = MergeStateStatus.BLOCKED,
+) -> PRStatus:
+    return PRStatus(
+        number=7,
+        head_sha=head_sha,
+        mergeable=MergeableState.MERGEABLE,
+        check_state=check_state,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=merge_state_status,
+        no_checks_observed=no_checks_observed,
+    )
+
+
+# ── B. Runner timing-helper unit tests (no DB) ─────────────────────────────
+
+
+class TestAwaitingRequiredChecksGrace:
+    @pytest.mark.unit
+    def test_first_observation_records_marker_and_is_within_grace(self) -> None:
+        state = MonitorState()
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(), state, MonitorConfig(), now=_NOW
+        )
+
+        assert (active, changed) == (True, True)
+        key = _awaiting_required_checks_first_seen_key("head1")
+        assert key in state.threads_addressed_ids
+        assert float(state.threads_addressed_ids[key]) == pytest.approx(_NOW.timestamp())
+        # The first record must be reported as a change so the runner persists it.
+        assert key in state.changed_thread_ids()
+
+    @pytest.mark.unit
+    def test_same_head_within_grace_stays_active_without_rerecording(self) -> None:
+        state = MonitorState()
+        config = MonitorConfig()
+        _awaiting_required_checks_grace(_status(), state, config, now=_NOW)
+        first_value = state.threads_addressed_ids[_awaiting_required_checks_first_seen_key("head1")]
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(), state, config, now=_NOW + timedelta(seconds=300)
+        )
+
+        assert (active, changed) == (True, False)
+        # The marker is untouched on a within-grace re-poll.
+        assert (
+            state.threads_addressed_ids[_awaiting_required_checks_first_seen_key("head1")]
+            == first_value
+        )
+
+    @pytest.mark.unit
+    def test_same_head_after_grace_flips_inactive(self) -> None:
+        state = MonitorState()
+        config = MonitorConfig()
+        _awaiting_required_checks_grace(_status(), state, config, now=_NOW)
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(),
+            state,
+            config,
+            now=_NOW + timedelta(seconds=config.awaiting_required_checks_grace_seconds),
+        )
+
+        assert (active, changed) == (False, False)
+
+    @pytest.mark.unit
+    def test_new_head_resets_window(self) -> None:
+        state = MonitorState()
+        config = MonitorConfig()
+        # Old head observed long ago and now expired.
+        _awaiting_required_checks_grace(_status(head_sha="old"), state, config, now=_NOW)
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(head_sha="new"),
+            state,
+            config,
+            now=_NOW + timedelta(seconds=10_000),
+        )
+
+        assert (active, changed) == (True, True)
+        new_key = _awaiting_required_checks_first_seen_key("new")
+        assert float(state.threads_addressed_ids[new_key]) == pytest.approx(
+            (_NOW + timedelta(seconds=10_000)).timestamp()
+        )
+
+    @pytest.mark.unit
+    def test_require_ci_false_records_nothing(self) -> None:
+        state = MonitorState()
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(), state, MonitorConfig(require_ci=False), now=_NOW
+        )
+
+        assert (active, changed) == (False, False)
+        assert state.threads_addressed_ids == {}
+
+    @pytest.mark.unit
+    def test_checks_present_records_nothing(self) -> None:
+        state = MonitorState()
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(no_checks_observed=False), state, MonitorConfig(), now=_NOW
+        )
+
+        assert (active, changed) == (False, False)
+        assert state.threads_addressed_ids == {}
+
+    @pytest.mark.unit
+    def test_non_positive_grace_disables_and_records_nothing(self) -> None:
+        state = MonitorState()
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(),
+            state,
+            MonitorConfig(awaiting_required_checks_grace_seconds=0),
+            now=_NOW,
+        )
+
+        assert (active, changed) == (False, False)
+        assert state.threads_addressed_ids == {}
+
+    @pytest.mark.unit
+    def test_corrupt_marker_is_rerecorded_within_grace(self) -> None:
+        state = MonitorState()
+        key = _awaiting_required_checks_first_seen_key("head1")
+        state.threads_addressed_ids[key] = "not-a-float"
+
+        active, changed = _awaiting_required_checks_grace(
+            _status(), state, MonitorConfig(), now=_NOW
+        )
+
+        assert (active, changed) == (True, True)
+        assert float(state.threads_addressed_ids[key]) == pytest.approx(_NOW.timestamp())
+
+
+# ── C. Runner integration tests (full loop wiring + loop.py message) ────────
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.fixture
+def cmd() -> FakeCommandRunner:
+    return FakeCommandRunner()
+
+
+@pytest.fixture
+def adapter() -> FakeAdapter:
+    return FakeAdapter()
+
+
+@pytest.fixture
+def sleep_fn() -> RecordedSleep:
+    return RecordedSleep()
+
+
+def _absent_ci_blocked_payload() -> str:
+    # A present-but-empty rollup (totalCount == 0) with a non-PENDING state is the
+    # transient post-push CI-start window: no_checks_observed=True, BLOCKED.
+    return pr_payload(
+        check_state="SUCCESS",
+        check_contexts=[],
+        check_contexts_total_count=0,
+        merge_state_status="BLOCKED",
+    )
+
+
+class TestAwaitingRequiredChecksRunner:
+    @pytest.mark.unit
+    async def test_within_grace_waits_for_ci_and_records_marker(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=_absent_ci_blocked_payload())
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            max_outer_iterations=1,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        actions = [r["action"] for r in captured if r.get("event") == "monitor.action"]
+        assert actions == ["WaitForCI"]
+        assert sleep_fn.calls == [60]
+        # The transient gap must NOT page a human.
+        assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            # First-seen marker persisted so the window can actually expire.
+            assert _awaiting_required_checks_first_seen_key("abc1234567890def") in (
+                ws.monitor_threads_addressed or {}
+            )
+            operations = await OperationRepository(s).list_all(
+                workspace_id=ws_id,
+                operation_type=OperationType.monitor_state,
+                limit=20,
+            )
+        wait_ops = [
+            op
+            for op in operations
+            if isinstance(op.payload, dict) and op.payload.get("reason_code") == "CHECK_WAIT"
+        ]
+        assert len(wait_ops) == 1
+        payload = wait_ops[0].payload
+        assert payload is not None
+        assert payload["wait_reason"] == "awaiting_required_checks"
+        assert payload["reason"] == "Required CI has not started on the new head yet."
+
+    @pytest.mark.unit
+    async def test_grace_expired_escalates_to_notify_human(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        # Pre-seed an EXPIRED first-seen marker for the current head: observed
+        # longer ago than the default 600s grace.
+        expired_epoch = (datetime.now(UTC) - timedelta(seconds=700)).timestamp()
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get_for_update(ws_id)
+            assert ws is not None
+            ws.monitor_threads_addressed = {
+                _awaiting_required_checks_first_seen_key("abc1234567890def"): (
+                    f"{expired_epoch:.6f}"
+                )
+            }
+            await s.commit()
+
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=_absent_ci_blocked_payload())
+        cmd.queue_result(returncode=0)  # gh pr comment (human notification)
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            max_outer_iterations=1,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        actions = [r["action"] for r in captured if r.get("event") == "monitor.action"]
+        assert actions == ["NotifyHuman"]
+        # The expired head genuinely never got CI → a human comment IS posted.
+        assert any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
+
+    @pytest.mark.unit
+    async def test_new_head_gets_its_own_grace_window(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await seed_monitoring_workspace(factory)
+        # Two polls with DIFFERENT head SHAs: each push reopens the CI-start gap,
+        # so each head must wait within its own fresh grace window.
+        for head_sha in ("abc1234567890def", "def4567890abcdef0"):
+            cmd.queue_result(returncode=0)  # git fetch origin <base>
+            cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+            cmd.queue_result(
+                returncode=0,
+                stdout=pr_payload(
+                    head_sha=head_sha,
+                    check_state="SUCCESS",
+                    check_contexts=[],
+                    check_contexts_total_count=0,
+                    merge_state_status="BLOCKED",
+                ),
+            )
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            max_outer_iterations=2,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        actions = [r["action"] for r in captured if r.get("event") == "monitor.action"]
+        assert actions == ["WaitForCI", "WaitForCI"]
+        assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+        markers = ws.monitor_threads_addressed or {}
+        assert _awaiting_required_checks_first_seen_key("abc1234567890def") in markers
+        assert _awaiting_required_checks_first_seen_key("def4567890abcdef0") in markers

--- a/tests/unit/runtime/test_pr_monitor_awaiting_required_checks.py
+++ b/tests/unit/runtime/test_pr_monitor_awaiting_required_checks.py
@@ -388,3 +388,63 @@ class TestAwaitingRequiredChecksRunner:
         markers = ws.monitor_threads_addressed or {}
         assert _awaiting_required_checks_first_seen_key("abc1234567890def") in markers
         assert _awaiting_required_checks_first_seen_key("def4567890abcdef0") in markers
+
+    @pytest.mark.unit
+    async def test_pre_merge_recheck_applies_grace_instead_of_paging_human(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+        cmd: FakeCommandRunner,
+        adapter: FakeAdapter,
+        sleep_fn: RecordedSleep,
+        tmp_path: Path,
+    ) -> None:
+        # #656 (PRRT_kwDOSJAM6s6LPoZx): the outer poll observed an all-green head
+        # and chose Merge, but during the pre-merge settle window the freshly
+        # fetched status shows the transient empty-checks + BLOCKED CI-start gap
+        # (the head changed, or GitHub recomputed mergeability). The recheck
+        # ``decide`` must apply the same per-head required-CI grace as the outer
+        # loop; otherwise ``awaiting_required_checks_grace_active`` stays its
+        # default False, gate 8b is skipped, and the monitor pages a human
+        # prematurely before the next outer poll can recover.
+        ws_id = await seed_monitoring_workspace(factory)
+        # Outer poll: all green -> Merge.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=pr_payload())
+        # Pre-merge settle recheck: transient required-CI-absent + BLOCKED gap.
+        cmd.queue_result(returncode=0)  # git fetch origin <base>
+        cmd.queue_result(returncode=0, stdout="0\n")  # base-behind
+        cmd.queue_result(returncode=0, stdout=_absent_ci_blocked_payload())
+        runner = make_runner(
+            factory=factory,
+            cmd=cmd,
+            adapter=adapter,
+            sleep_fn=sleep_fn,
+            worktrees_root=tmp_path / "worktrees",
+            pre_merge_settle_seconds=90,
+            max_outer_iterations=1,
+        )
+
+        with structlog.testing.capture_logs() as captured:
+            await runner.run(
+                workspace_id=ws_id,
+                compose_project="proj",
+                compose_file=tmp_path / "compose.yml",
+            )
+
+        actions = [r["action"] for r in captured if r.get("event") == "monitor.action"]
+        # The recheck defers to the bounded grace wait, NOT a premature human ping.
+        assert actions == ["Merge", "WaitForCI"]
+        assert not any(call.args[:3] == ["gh", "pr", "comment"] for call in cmd.calls)
+        assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+        # 90s pre-merge settle, then the 60s poll-interval grace wait.
+        assert sleep_fn.calls == [90, 60]
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+        # The recheck persisted the first-seen marker so the grace window can
+        # actually expire on a head that genuinely never gets CI.
+        assert _awaiting_required_checks_first_seen_key("abc1234567890def") in (
+            ws.monitor_threads_addressed or {}
+        )

--- a/tests/unit/runtime/test_pr_monitor_merge_method_classifier.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_method_classifier.py
@@ -7,11 +7,13 @@ import pytest
 from awf.common.audit import redact_audit_text
 from awf.common.github_client import GitHubClientError
 from awf.runtime.pr_monitor_runner.merge_loop import (
+    _MergeAttemptOutcome,
+    _MergeAttemptResult,
+)
+from awf.runtime.pr_monitor_runner.merge_methods import (
     _effective_merge_methods,
     _merge_error_supports_method_alternative,
     _merge_method_rejection_method,
-    _MergeAttemptOutcome,
-    _MergeAttemptResult,
 )
 
 

--- a/tests/unit/runtime/test_pr_monitor_require_ci.py
+++ b/tests/unit/runtime/test_pr_monitor_require_ci.py
@@ -19,6 +19,7 @@ from awf.runtime.pr_monitor import (
     MergeStateStatus,
     MonitorConfig,
     MonitorState,
+    NotifyHuman,
     PRStatus,
     ReportCiFailure,
     WaitForCI,
@@ -33,6 +34,7 @@ def _status(
     mergeable: MergeableState = MergeableState.MERGEABLE,
     merge_state_status: MergeStateStatus = MergeStateStatus.CLEAN,
     ci_failures: tuple[CheckFailure, ...] = (),
+    awaiting_required_checks_grace_active: bool = False,
 ) -> PRStatus:
     return PRStatus(
         number=7,
@@ -45,6 +47,7 @@ def _status(
         merge_state_status=merge_state_status,
         ci_failures=ci_failures,
         no_checks_observed=no_checks_observed,
+        awaiting_required_checks_grace_active=awaiting_required_checks_grace_active,
     )
 
 
@@ -114,3 +117,172 @@ def test_require_ci_true_default_no_checks_waits_regression() -> None:
     )
     assert isinstance(action, WaitForCI)
     assert action.reason == "pending_checks"
+
+
+# ── #655: bounded grace before HUMAN_WAIT on transient required-CI absence ──
+#
+# Right after a monitor push, the new head has NO checks yet
+# (``no_checks_observed=True``) and branch protection reports
+# ``merge_state_status == BLOCKED`` because the required ``ci-required`` context
+# is absent. The empty rollup parses to a non-PENDING ``check_state`` (SUCCESS /
+# NEUTRAL), so gate 6 misses it and ``decide`` used to fall straight through to
+# gate 9 (``BLOCKED → NotifyHuman``) — a premature human ping that the monitor
+# self-recovers from once CI lands. The new gate defers to a bounded
+# ``WaitForCI`` while the runner-set grace flag is active, escalating only after
+# the grace expires. The safety hinge: it fires ONLY when checks are ABSENT, so a
+# genuine human-gate block (checks present + BLOCKED) still escalates immediately.
+
+
+@pytest.mark.unit
+def test_within_grace_absent_ci_blocked_waits() -> None:
+    # A.1: within-grace, required CI absent, BLOCKED → bounded WaitForCI.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "awaiting_required_checks"
+
+
+@pytest.mark.unit
+def test_grace_expired_absent_ci_blocked_notifies_human() -> None:
+    # A.2: grace expired (flag False) → gate 9 escalates as before.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=False,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
+@pytest.mark.unit
+def test_within_grace_absent_ci_has_hooks_waits() -> None:
+    # A.3: HAS_HOOKS is the other member of the merge-state tuple — also deferred.
+    action = decide(
+        status=_status(
+            check_state=CheckState.NEUTRAL,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.HAS_HOOKS,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "awaiting_required_checks"
+
+
+@pytest.mark.unit
+def test_checks_present_human_gate_notifies_human_immediately() -> None:
+    # A.4 (safety hinge): checks PRESENT but BLOCKED on a real human gate
+    # (no_checks_observed=False). The grace flag is irrelevant — the new gate is
+    # skipped and gate 9 escalates immediately, even within the window.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=False,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
+@pytest.mark.unit
+def test_require_ci_false_absent_ci_blocked_unchanged() -> None:
+    # A.5: require_ci=False + absent checks + BLOCKED → the new gate is skipped
+    # (require_ci is False) and gate 9 escalates exactly as before.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(require_ci=False),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
+@pytest.mark.unit
+def test_pending_checks_still_routes_to_gate_6() -> None:
+    # A.6: ordering preserved — PENDING fires gate 6 before the new gate, even
+    # with the grace flag set and a BLOCKED merge state.
+    action = decide(
+        status=_status(
+            check_state=CheckState.PENDING,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "pending_checks"
+
+
+@pytest.mark.unit
+def test_failure_still_routes_to_gate_5() -> None:
+    # A.7: FAILURE fires gate 5 (ReportCiFailure); the new gate must not steal it
+    # even within grace with checks absent and BLOCKED.
+    action = decide(
+        status=_status(
+            check_state=CheckState.FAILURE,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, ReportCiFailure)
+
+
+@pytest.mark.unit
+def test_unknown_merge_state_still_routes_to_gate_6() -> None:
+    # A.8: UNKNOWN mergeable/merge_state hits gate 6's unknown branch before the
+    # new gate, which only matches BLOCKED/HAS_HOOKS.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.UNKNOWN,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "unknown_mergeable_state"
+
+
+@pytest.mark.unit
+def test_grace_flag_does_not_block_clean_green_merge() -> None:
+    # A.9 (regression): the grace flag only matters on BLOCKED/HAS_HOOKS. A clean,
+    # all-green PR still merges even when the flag is left True.
+    action = decide(
+        status=_status(
+            check_state=CheckState.SUCCESS,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.CLEAN,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, Merge)


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a24b765fd11e4803aa387918` (agent: `claude_code`, model: `claude-opus-4-8`, effort: `xhigh`).


### Task
Fix issue #655 in agent-workspace-fabric: the PR monitor posts a premature HUMAN_WAIT during the transient window after it pushes a new head, before the forge has started CI on that head.

ROOT CAUSE (confirmed): src/awf/runtime/pr_monitor.py::decide() is pure/time-agnostic. Gate 6 (WaitForCI, ~line 1074) only fires when status.check_state == CheckState.PENDING. Right after a monitor push, the new head has NO checks yet (status.no_checks_observed == True, not PENDING), so gate 6 misses it; branch protection reports merge_state_status == BLOCKED (required ci-required absent); decide() falls through to gate 9 (`if status.merge_state_status in (BLOCKED, HAS_HOOKS): return NotifyHuman()`, ~line 1172) and posts "needs human attention". The monitor then self-recovers once CI lands and merges. Every self-repair push creates a fresh head with this CI-start gap, so a self-recovering PR emits a premature ping per head. Evidence (PR #654): repair head pushed 08:28:42; CI on it started 08:34:18 (5.5-min lag); NotifyHuman posted 08:34:36 in the gap; CI passed 08:54; merged 08:56 — the ping was never needed.

THE FIX (locked via engineering review — grace-then-escalate; HOLD SCOPE, do exactly this):

Treat "merge BLOCKED + required CI expected-but-absent on the current head" as a BOUNDED WaitForCI within a grace window, escalating NotifyHuman only AFTER the grace expires. This silences the normal CI-start lag but still surfaces a head that genuinely never gets CI (the dev->main CI-trigger gotcha, which needs a human / empty-commit re-trigger).

decide() is pure (no `now`), so the RUNNER computes the time-derived grace flag and decide() consumes a precomputed boolean — exactly how it already consumes no_checks_observed and how the stale-pending-check machinery (pr_monitor_runner/provider_ops.py::_record_stale_pending_check_warnings, MonitorConfig.stale_pending_check_warning_seconds) tracks per-(head,check) timing.

1. CONFIG (src/awf/runtime/pr_monitor.py, MonitorConfig): add `awaiting_required_checks_grace_seconds: float = 600.0` (covers the observed 5.5-min CI-start lag with margin).

2. RUNNER (pr_monitor_runner/loop.py and/or provider_ops.py, beside the stale-pending machinery): track, per head_sha, the first poll time the head showed "required CI expected but absent" (config.require_ci and status.no_checks_observed). Compute a boolean `awaiting_required_checks_grace_active = (now - first_absent_seen < awaiting_required_checks_grace_seconds)`. A NEW head_sha resets the window (each push gets its own grace). Surface the boolean to decide() following the existing precomputed-signal pattern (a MonitorState field or a runner-set field on the status snapshot — your call, match how no_checks_observed is threaded).

3. decide() — add a NEW gate immediately BEFORE the existing gate 9 (the BLOCKED/HAS_HOOKS NotifyHuman):
   if (config.require_ci and status.no_checks_observed and status.merge_state_status in (BLOCKED, HAS_HOOKS) and status.check_state != CheckState.FAILURE and <grace active>): return WaitForCI(reason="awaiting_required_checks")
   Leave gate 9 unchanged; it is reached once the grace expires OR whenever checks are present.

SAFETY HINGE (must hold): the new gate defers ONLY when checks are ABSENT (no_checks_observed). When checks are PRESENT but merge is BLOCKED on a genuine human gate (required approval, protected hook, unresolved thread), no_checks_observed is False, the new gate does not apply, and gate 9 escalates IMMEDIATELY — unchanged.

DO NOT: touch the protected-file work (#652/#653); change gates 1-8; change the stale-pending-check WARNING (it stays warning-only); add an active CI re-trigger (out of scope).

TESTS:
- decide() unit (pure function): within-grace absent-CI BLOCKED -> WaitForCI(reason="awaiting_required_checks"); grace-expired -> NotifyHuman; BLOCKED with checks PRESENT (no_checks_observed False, a human gate) -> NotifyHuman immediately; require_ci=False + no checks -> unchanged; PENDING -> gate 6; FAILURE -> gate 5; UNKNOWN mergeable/merge_state -> gate 6 UNKNOWN branch.
- runner unit: first-absent-seen timestamp recorded per head; the grace boolean flips after the threshold; a new head_sha resets the window; require_ci=False never records.
- pr_monitor decide tests live under tests/unit/runtime/test_pr_monitor_parts/ and tests/unit/runtime/test_pr_monitor_*.py; runner tests under tests/unit/runtime/ and tests/integration/runtime/. Keep the full suite green at the 99% coverage gate.

PR: title "fix: bounded grace before HUMAN_WAIT on transient required-CI absence (#655)"; body explains the root cause + the absent-vs-present-checks safety hinge; state that it Fixes #655. Commit before exiting; the AWF monitor handles the PR. Do not address review comments or merge the PR yourself.

Optimize for: the smallest correct diff. The new gate must defer ONLY the transient absent-CI case and never weaken immediate escalation for a real human-gate block.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor merge/human-escalation timing on BLOCKED states, but only for the absent-check transient case; incorrect grace logic could delay real blockers or page too early, though the no_checks_observed hinge limits scope.
> 
> **Overview**
> Fixes **premature human pings** right after the monitor pushes a new head, when branch protection shows **BLOCKED/HAS_HOOKS** but the forge has not started required CI yet (authoritative **empty** check rollup).
> 
> Adds a **per-head grace window** (default 600s, configurable via `awaiting_required_checks_grace_seconds`): the runner records first-seen time in monitor state, sets `PRStatus.awaiting_required_checks_grace_active`, and **`decide`** gate **8b** returns `WaitForCI(reason="awaiting_required_checks")` instead of falling through to `NotifyHuman`. After grace expires, behavior matches pre-#655 escalation. The gate applies only when **`require_ci`**, **`no_checks_observed`**, and merge state is BLOCKED/HAS_HOOKS—**checks present + BLOCKED** still escalates immediately.
> 
> Wiring includes the main poll loop, a dedicated wait message in `loop.py`, and the **pre-merge recheck** path so a fresh status during settle gets the same grace decoration and persisted markers.
> 
> **Refactor:** merge-method policy helpers move from `merge_loop` into new `merge_methods.py` (line-limit hygiene); behavior unchanged aside from import paths.
> 
> **Tests** cover `decide` matrix, grace helper timing, runner integration, and pre-merge recheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b8e696c0f57baefbc19c1d01a9a66b4ee223d49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->