### PR TITLE
fix: route absent-rollup PENDING through the required-CI grace (#660)

### DIFF
--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -1178,8 +1178,28 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     # (require_ci=False) AND the forge authoritatively reported zero checks
     # (no_checks_observed); the signal defaults False so a forgotten populate
     # never bypasses this gate.
-    if status.check_state == CheckState.PENDING and (
-        config.require_ci or not status.no_checks_observed
+    #
+    # #660 carve-out: the ABSENT-PENDING shape (a fresh head whose required
+    # ``ci-required`` context never started, surfacing as the null status
+    # rollup: ``check_state == PENDING`` AND ``no_checks_observed == True``)
+    # under ``require_ci == True`` on a BLOCKED/HAS_HOOKS merge state must NOT
+    # be parked here forever. Let it fall through to gate 8b, which owns the
+    # required-CI grace window for absent checks (grace active → bounded
+    # WaitForCI; grace expired → gate 9 → NotifyHuman). The GENUINE-PENDING
+    # shape (real checks present and running, ``no_checks_observed == False``)
+    # keeps waiting here — the #469 "require_ci=True waits forever for
+    # genuinely pending checks" contract is preserved. The carve-out is scoped
+    # to BLOCKED/HAS_HOOKS so an absent-PENDING head on a CLEAN state still
+    # waits here (no grace gate would catch it; merging a PENDING head blind
+    # is forbidden).
+    if (
+        status.check_state == CheckState.PENDING
+        and (config.require_ci or not status.no_checks_observed)
+        and not (
+            config.require_ci
+            and status.no_checks_observed
+            and status.merge_state_status in (MergeStateStatus.BLOCKED, MergeStateStatus.HAS_HOOKS)
+        )
     ):
         return WaitForCI(reason="pending_checks")
     if (

--- a/tests/unit/runtime/test_pr_monitor_require_ci.py
+++ b/tests/unit/runtime/test_pr_monitor_require_ci.py
@@ -220,13 +220,102 @@ def test_require_ci_false_absent_ci_blocked_unchanged() -> None:
 
 @pytest.mark.unit
 def test_pending_checks_still_routes_to_gate_6() -> None:
-    # A.6: ordering preserved — PENDING fires gate 6 before the new gate, even
-    # with the grace flag set and a BLOCKED merge state.
+    # A.6: ordering preserved — the GENUINE-PENDING shape (real checks present
+    # and running, ``no_checks_observed=False``) still fires gate 6 before the
+    # required-CI grace gate, even with the grace flag set and a BLOCKED merge
+    # state. This pins the #469 contract that genuinely pending required checks
+    # wait forever at gate 6. The ABSENT-PENDING shape
+    # (``no_checks_observed=True``) is covered separately by the
+    # #660 absent-PENDING tests below — it no longer parks at gate 6.
+    action = decide(
+        status=_status(
+            check_state=CheckState.PENDING,
+            no_checks_observed=False,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "pending_checks"
+
+
+# ── #660: route the ABSENT-PENDING shape through the required-CI grace ──
+#
+# The null-rollup shape reports ``check_state == PENDING`` together with
+# ``no_checks_observed == True``. Gate 6 used to intercept this under
+# ``require_ci=True`` and poll forever, defeating #656's "a head that
+# genuinely never gets CI still surfaces HUMAN_WAIT after the grace"
+# guarantee. The fix carves ONLY the ABSENT-PENDING + BLOCKED/HAS_HOOKS shape
+# out of gate 6 so it falls through to gate 8b (grace active → bounded
+# WaitForCI; grace expired → gate 9 → NotifyHuman). The GENUINE-PENDING shape
+# (A.6 above) is untouched.
+
+
+@pytest.mark.unit
+def test_absent_pending_grace_expired_routes_to_notify_human() -> None:
+    # The bug fix: ABSENT-PENDING (null rollup) + BLOCKED + require_ci, grace
+    # EXPIRED → NotifyHuman (was WaitForCI("pending_checks") forever).
     action = decide(
         status=_status(
             check_state=CheckState.PENDING,
             no_checks_observed=True,
             merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=False,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
+@pytest.mark.unit
+def test_absent_pending_within_grace_routes_to_awaiting_required_checks() -> None:
+    # Same ABSENT-PENDING shape, grace ACTIVE → bounded WaitForCI within the
+    # required-CI grace window (gate 8b), not the gate-6 forever wait.
+    action = decide(
+        status=_status(
+            check_state=CheckState.PENDING,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.BLOCKED,
+            awaiting_required_checks_grace_active=True,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, WaitForCI)
+    assert action.reason == "awaiting_required_checks"
+
+
+@pytest.mark.unit
+def test_absent_pending_has_hooks_grace_expired_routes_to_notify_human() -> None:
+    # HAS_HOOKS variant — pins that the carve-out covers both members of the
+    # merge-state tuple gate 8b matches (mirrors A.3 for the SUCCESS/NEUTRAL
+    # shape).
+    action = decide(
+        status=_status(
+            check_state=CheckState.PENDING,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.HAS_HOOKS,
+            awaiting_required_checks_grace_active=False,
+        ),
+        state=MonitorState(),
+        config=MonitorConfig(),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
+@pytest.mark.unit
+def test_absent_pending_clean_state_still_waits_at_gate_6() -> None:
+    # Narrowness pin: absent-PENDING on a CLEAN state does NOT escape gate 6 —
+    # no grace gate would catch it, and we must not merge a PENDING head blind.
+    # The carve-out is scoped to BLOCKED/HAS_HOOKS only.
+    action = decide(
+        status=_status(
+            check_state=CheckState.PENDING,
+            no_checks_observed=True,
+            merge_state_status=MergeStateStatus.CLEAN,
             awaiting_required_checks_grace_active=True,
         ),
         state=MonitorState(),

--- a/tests/unit/runtime/test_pr_monitor_require_ci.py
+++ b/tests/unit/runtime/test_pr_monitor_require_ci.py
@@ -265,7 +265,7 @@ def test_absent_pending_grace_expired_routes_to_notify_human() -> None:
             awaiting_required_checks_grace_active=False,
         ),
         state=MonitorState(),
-        config=MonitorConfig(),
+        config=MonitorConfig(require_ci=True),
     )
     assert isinstance(action, NotifyHuman)
 
@@ -282,7 +282,7 @@ def test_absent_pending_within_grace_routes_to_awaiting_required_checks() -> Non
             awaiting_required_checks_grace_active=True,
         ),
         state=MonitorState(),
-        config=MonitorConfig(),
+        config=MonitorConfig(require_ci=True),
     )
     assert isinstance(action, WaitForCI)
     assert action.reason == "awaiting_required_checks"
@@ -301,7 +301,7 @@ def test_absent_pending_has_hooks_grace_expired_routes_to_notify_human() -> None
             awaiting_required_checks_grace_active=False,
         ),
         state=MonitorState(),
-        config=MonitorConfig(),
+        config=MonitorConfig(require_ci=True),
     )
     assert isinstance(action, NotifyHuman)
 
@@ -319,7 +319,7 @@ def test_absent_pending_clean_state_still_waits_at_gate_6() -> None:
             awaiting_required_checks_grace_active=True,
         ),
         state=MonitorState(),
-        config=MonitorConfig(),
+        config=MonitorConfig(require_ci=True),
     )
     assert isinstance(action, WaitForCI)
     assert action.reason == "pending_checks"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_3b76c07bb0bd43338afed581` (agent: `opencode`, model: `ollama/glm-5.2:cloud`, effort: `xhigh`).


### Task
Fix issue #660 in agent-workspace-fabric: route the "absent status rollup PENDING" shape through the bounded required-CI grace so a required check that never starts still surfaces HUMAN_WAIT.

ROOT CAUSE (confirmed): PR #656 added a bounded grace (gate 8b) so that when a required CI check is expected but absent on a fresh head, the monitor defers to a bounded WaitForCI and only escalates HUMAN_WAIT after the grace expires. But there are TWO "absent CI" shapes, and #656 only handled one. When GitHub returns `statusCheckRollup = null`, the forge client reports `check_state = PENDING` together with `no_checks_observed = True`. With `merge_state_status` BLOCKED/HAS_HOOKS and `require_ci = True`, decide()'s gate 6 (`pending_checks` → `WaitForCI`) intercepts this BEFORE the new grace gate, regardless of `awaiting_required_checks_grace_active`. So a required-but-never-started check under the null-rollup shape polls FOREVER instead of surfacing HUMAN_WAIT after the grace — defeating #656's "a head that genuinely never gets CI still surfaces" guarantee for that shape.

THE FIX (HOLD SCOPE; subtle — read the gates carefully in src/awf/runtime/pr_monitor.py decide()):
Discriminate on `no_checks_observed`. The ABSENT-PENDING shape (`check_state == PENDING AND no_checks_observed == True`) must be allowed to reach the required-CI grace gate (so once the grace expires it escalates HUMAN_WAIT), while the GENUINE-PENDING shape (real checks present and running, `no_checks_observed == False`) must STAY at gate 6 / `WaitForCI`. Concretely: gate 6's `pending_checks` `WaitForCI` must NOT intercept the `no_checks_observed` PENDING shape once the grace has expired — let it fall through to the grace→HUMAN_WAIT path; the genuine-pending shape keeps waiting at gate 6 unchanged.

LOAD-BEARING CONSTRAINTS (do not violate):
- PRESERVE the #469 contract "require_ci=True waits forever [for genuinely pending checks]". The fix must ONLY change behavior for the ABSENT (no_checks_observed) PENDING shape, NEVER for the genuine-present-pending shape.
- DO NOT break the deliberate regression `test_pending_checks_still_routes_to_gate_6` (A.6) — that test pins the genuine-pending shape staying at gate 6. If it needs an update, update it ONLY to reflect the absent-vs-present discrimination, never to weaken the genuine-pending contract; and add a NEW test for the absent-PENDING shape reaching the grace→HUMAN_WAIT path.
- Do NOT change the grace mechanism itself, gates 1-5/7-10 unrelated logic, or any other monitor work.

TESTS:
- absent-PENDING shape (check_state=PENDING + no_checks_observed=True) + BLOCKED + require_ci, grace EXPIRED → NotifyHuman (not WaitForCI forever).
- same, grace ACTIVE → still WaitForCI (within grace).
- genuine-pending shape (no_checks_observed=False) → gate 6 WaitForCI unchanged (the A.6 contract).
- Keep the full suite green at the 99% coverage gate.

PR: title "fix: route absent-rollup PENDING through the required-CI grace so never-started checks surface HUMAN_WAIT (#660)"; body explains the two absent shapes + the no_checks_observed discriminator + that the #469/A.6 genuine-pending contract is preserved. State that it Fixes #660. Commit before exiting; the AWF monitor handles the PR. Do not address review comments or merge yourself.

Optimize for: the smallest correct change that re-routes ONLY the absent (no_checks_observed) PENDING shape to the grace→HUMAN_WAIT path, leaving the genuine-pending #469 contract fully intact.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor decision ordering for a specific CI/merge-state combination; behavior is tightly scoped but affects when humans are notified vs. bounded waits.
> 
> **Overview**
> Fixes a gap where **null status rollup** heads (`check_state == PENDING` and `no_checks_observed == True`) on **BLOCKED/HAS_HOOKS** with `require_ci=True` were stuck on gate 6’s `WaitForCI("pending_checks")` forever, so they never reached the bounded required-CI grace (gate 8b) or **HUMAN_WAIT** after grace (gate 9).
> 
> **`decide()` gate 6** now **skips** that **ABSENT-PENDING** shape only when merge state is BLOCKED or HAS_HOOKS, so behavior matches the SUCCESS/NEUTRAL absent-check path from #655/#656. **Genuine pending** checks (`no_checks_observed == False`) still wait at gate 6 per #469. **Absent-PENDING on CLEAN** still waits at gate 6 so a PENDING head is not merged blindly.
> 
> Unit tests clarify A.6 for genuine pending and add #660 cases for grace active/expired, HAS_HOOKS, and the CLEAN narrowness pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24ec36556853055877e790fb7a00e956e39603e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->