### PR TITLE
feat: expose awaiting_required_checks_grace_seconds as a profile monitor knob (#662)

### DIFF
--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -369,6 +369,29 @@ That message should not trigger `NotifyHuman` and should not block merge. AWF
 still respects the initial review grace window and still handles meaningful
 review threads from Gemini, CodeRabbit, humans, or other reviewers.
 
+### Awaiting-Required-Checks Grace
+
+When a required CI context is expected but absent on the current head — the
+common case right after the monitor pushes fix commits, when the forge has not
+started CI on the new head yet — AWF applies a bounded `awaiting_required_checks`
+grace window before escalating `NotifyHuman`:
+
+```yaml
+monitor:
+  awaiting_required_checks_grace_seconds: 600
+```
+
+Rules:
+
+- Default is 600 seconds (covers the observed ≈5.5-min CI-start lag with margin).
+- `0` (or any value `<= 0`) disables the grace: a required context that is
+  absent escalates `NotifyHuman` immediately (pre-#655 behavior).
+- The grace is head-scoped: a new `head_sha` starts a fresh window.
+- During the window the monitor stays in `WaitForCI` instead of escalating; if
+  CI genuinely never arrives, the window expires and the head escalates as
+  before.
+- The upper bound is 86400 seconds (parity with the other monitor knobs).
+
 ## Local Service Stack
 
 Docker Compose is the default local runtime for the always-on AWF control

--- a/openapi.json
+++ b/openapi.json
@@ -2968,6 +2968,12 @@
         "additionalProperties": false,
         "description": "PR monitor policy supplied by the workspace profile.",
         "properties": {
+          "awaiting_required_checks_grace_seconds": {
+            "default": 600.0,
+            "maximum": 86400.0,
+            "title": "Awaiting Required Checks Grace Seconds",
+            "type": "number"
+          },
           "initial_review_grace_period_seconds": {
             "default": 900.0,
             "maximum": 86400.0,

--- a/plans/AWAITING_REQUIRED_CHECKS_GRACE_VALIDATION.md
+++ b/plans/AWAITING_REQUIRED_CHECKS_GRACE_VALIDATION.md
@@ -1,0 +1,79 @@
+# Validation: Expose `awaiting_required_checks_grace_seconds` as a ProfileMonitor knob (#662)
+
+Validates the implementation in `plans/AWAITING_REQUIRED_CHECKS_GRACE_PLAN.md`
+(kept at `docs/awf-plans/ws_4509b5fc34874909b66d9bb1.md` in the workspace) against
+the saved plan. Scope is strictly additive wiring mirroring the existing monitor
+knobs end-to-end — no `decide()` gate logic, no grace behavior, no other monitor
+work changes.
+
+## Plan → implementation trace
+
+| Plan step | File(s) | Status |
+| --- | --- | --- |
+| 1. Add `awaiting_required_checks_grace_seconds: float = Field(default=600.0, le=86400)` to `ProfileMonitor`, no lower bound (permits the documented `<= 0` disable), docstring referencing #655/#662. | `src/awf/profiles/models.py` | ✅ done — default `600.0` preserves today's behavior, `le=86400` only (no `ge`), docstring added. |
+| 2. Thread it through `worker.py` `monitor_kwargs` like `require_ci` / `non_check_reviewer_settle_seconds`. | `src/awf/service/worker.py` | ✅ done — `awaiting_required_checks_grace_seconds` added to `monitor_kwargs`. |
+| 3. Add `awaiting_required_checks_grace_seconds: float = 600.0` to both `build_release_pr_monitor` and `build_feature_pr_monitor`; pass into each `MonitorConfig(...)`. | `src/awf/runtime/release_pr_monitor.py` | ✅ done — both builders, default `600.0` safety net, threaded into both `MonitorConfig` constructors. |
+| 4. Regenerate `openapi.json`; keep `--check` green. | `openapi.json` | ✅ done — `ProfileMonitor` schema gained the `awaiting_required_checks_grace_seconds` property; `python scripts/generate_openapi.py --check` passes. |
+| 4 (docs). Add a `docs/CONCEPTS.md` subsection under the monitor area documenting the knob (default 600s, `<= 0` disables). | `docs/CONCEPTS.md` | ✅ done — "Awaiting-Required-Checks Grace" subsection added after "Non-Actionable Bot Comments", consistent with the "Initial Review Grace" style. |
+| 5. Wiring tests: profile that sets → flows to `MonitorConfig`; profile that omits → keeps `600.0`; `<= 0` disables (reaches `MonitorConfig` as `<= 0`). | `tests/unit/profiles/test_profile_monitor.py`, `tests/unit/runtime/test_release_pr_monitor.py`, `tests/unit/service/test_worker.py` | ✅ done — see test inventory below. |
+
+## Test inventory (new/extended)
+
+`tests/unit/profiles/test_profile_monitor.py`:
+- `test_profile_monitor_awaiting_required_checks_grace_defaults_600` — default 600.0.
+- `test_profile_schema_accepts_awaiting_required_checks_grace_seconds` — set 120 parses.
+- `test_profile_schema_accepts_awaiting_required_checks_grace_seconds_zero_or_negative` — `0` and `-1` parse (documented disable).
+- `test_profile_schema_rejects_awaiting_required_checks_grace_seconds_above_86400` — `86401` raises `ValidationError` (bounds parity).
+
+`tests/unit/runtime/test_release_pr_monitor.py`:
+- `test_factories_plumb_configured_knobs` — extended to pass `awaiting_required_checks_grace_seconds=250` and assert `runner._config.awaiting_required_checks_grace_seconds == 250`.
+- `test_factories_awaiting_required_checks_grace_defaults_600` (parametrized over both builders) — omitting the kwarg yields `600.0`.
+- `test_factories_awaiting_required_checks_grace_zero_disables` (parametrized) — `0` reaches `MonitorConfig`.
+
+`tests/unit/service/test_worker.py`:
+- Default profile case — asserts `feature_monitor_kwargs["awaiting_required_checks_grace_seconds"] == 600`.
+- Custom `ProfileMonitor(...)` — adds `awaiting_required_checks_grace_seconds=250`; asserts it flows to both feature and release monitor kwargs.
+- Focused disable case — `ProfileMonitor(awaiting_required_checks_grace_seconds=0)` flows `0` to feature monitor kwargs.
+
+## Focused validation commands (run inside the agent phase)
+
+Per the AWF workspace contract (rule 4), the full AWF/GitHub validation suite
+(full `pytest --cov` gate, broad lint/type over `src/awf` and `tests`, full
+frontend build, CI-equivalent commands) is managed by AWF and GitHub CI after
+agent completion — **not** run here. Focused checks below cover the touched
+behavior.
+
+| Command | Result |
+| --- | --- |
+| `uv run --python 3.12 --extra dev pytest tests/unit/profiles/test_profile_monitor.py tests/unit/runtime/test_release_pr_monitor.py tests/unit/service/test_worker.py -q` | `38 passed` ✅ |
+| `uv run --python 3.12 --extra dev ruff check src/awf/profiles/models.py src/awf/service/worker.py src/awf/runtime/release_pr_monitor.py tests/unit/profiles/test_profile_monitor.py tests/unit/runtime/test_release_pr_monitor.py tests/unit/service/test_worker.py` | `All checks passed!` ✅ |
+| `uv run --python 3.12 --extra dev mypy src/awf/profiles/models.py src/awf/service/worker.py src/awf/runtime/release_pr_monitor.py` | `Success: no issues found in 3 source files` ✅ |
+| `uv run --python 3.12 --extra dev python scripts/generate_openapi.py --check` | `OK: openapi.json matches the current app spec.` ✅ |
+
+## Non-goals honored
+
+- `decide()` gate logic, the grace behavior in
+  `pr_monitor_runner/helpers.py`, `notify_human_loop.py`, `merge_loop.py`: untouched.
+- No per-workspace DB override column added (profile-only configurability, as scoped).
+- `pr_monitor_adoption.py`, MCP/CLI/REST adoption schemas, `workspaces_create.py`,
+  `workspaces_retry.py`, `provider_recovery.py`, `workspace_repo.py` untouched —
+  the per-workspace `initial_review_grace_period_seconds` override surface is out
+  of scope.
+- No unrelated refactor/rename/restructure.
+
+## Diff summary
+
+```
+ docs/CONCEPTS.md                              | 23 ++++++++++++
+ openapi.json                                  |  6 ++++
+ src/awf/profiles/models.py                    | 15 ++++++++
+ src/awf/runtime/release_pr_monitor.py         |  4 +++
+ src/awf/service/worker.py                     |  3 ++
+ tests/unit/profiles/test_profile_monitor.py   | 52 +++++++++++++++++++++++++--
+ tests/unit/runtime/test_release_pr_monitor.py | 35 ++++++++++++++++++
+ tests/unit/service/test_worker.py             | 27 ++++++++++++++
+ 8 files changed, 163 insertions(+), 2 deletions(-)
+```
+
+Additive, scoped, mirrors the existing monitor knobs end-to-end. No gaps found
+against the saved plan.

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -481,6 +481,21 @@ class ProfileMonitor(BaseModel):
         default_factory=lambda: ["greptile-apps", "chatgpt-codex-connector"],
         max_length=64,
     )
+    awaiting_required_checks_grace_seconds: float = Field(default=600.0, le=86400)
+    """Grace window for required CI that is expected but absent on the current
+    head before the monitor escalates ``NotifyHuman`` (#655 / #662).
+
+    Right after a monitor push the forge has not started CI on the new head yet,
+    so the head shows an empty check set while branch protection reports
+    ``BLOCKED`` (the required context is absent). Within this window the monitor
+    defers to a bounded ``WaitForCI`` instead of a premature ``NotifyHuman``; once
+    it expires a head that genuinely never gets CI escalates as before. The
+    default (``600.0``) preserves today's hard-coded behavior and covers the
+    observed ≈5.5-min CI-start lag with margin. Set ``<= 0`` to disable the grace
+    (escalate immediately, pre-#655 behavior). The upper bound (``86400``) mirrors
+    the other monitor knobs; there is deliberately no lower bound so the
+    documented ``<= 0`` disable escape hatch is reachable from operator
+    configuration."""
 
     @field_validator("non_check_reviewer_logins")
     @classmethod

--- a/src/awf/profiles/models.py
+++ b/src/awf/profiles/models.py
@@ -950,6 +950,9 @@ class WorkspaceProfile(BaseModel):
         )
 
 
+_MONITOR_AWAITING_REQUIRED_CHECKS_GRACE_SECONDS_DEFAULT = 600.0
+
+
 def normalize_inline_profile_snapshot(
     profile: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
@@ -963,13 +966,29 @@ def normalize_inline_profile_snapshot(
     an otherwise-identical replay now dumps ``"forge": "auto"`` (the unresolved
     input default). Default a missing ``forge`` to ``"auto"`` so replays of
     pre-forge inline profiles stay idempotent instead of raising a spurious
-    conflict. Returns a shallow copy; the input is never mutated.
+    conflict.
+
+    Likewise ``monitor.awaiting_required_checks_grace_seconds`` (#655 / #662) was
+    added after some inline-profile workspaces were persisted, so their stored
+    ``monitor`` sub-dict lacks the key while an otherwise-identical replay now
+    dumps the ``600.0`` default. Backfill a missing value there too so legacy
+    inline-profile replays stay idempotent. Returns a shallow copy; the input is
+    never mutated (the ``monitor`` sub-dict is copied only when backfilled).
     """
     if profile is None:
         return None
-    if "forge" in profile:
-        return dict(profile)
-    return {**profile, "forge": "auto"}
+    result = dict(profile)
+    if "forge" not in result:
+        result["forge"] = "auto"
+    monitor = result.get("monitor")
+    if isinstance(monitor, dict) and "awaiting_required_checks_grace_seconds" not in monitor:
+        result["monitor"] = {
+            **monitor,
+            "awaiting_required_checks_grace_seconds": (
+                _MONITOR_AWAITING_REQUIRED_CHECKS_GRACE_SECONDS_DEFAULT
+            ),
+        }
+    return result
 
 
 def _normalized_endpoint_env_name(name: str) -> str:

--- a/src/awf/runtime/release_pr_monitor.py
+++ b/src/awf/runtime/release_pr_monitor.py
@@ -56,6 +56,7 @@ def build_release_pr_monitor(
     non_check_reviewer_settle_seconds: float = 180.0,
     non_check_reviewer_logins: list[str] | tuple[str, ...] = ("greptile-apps",),
     require_ci: bool = True,
+    awaiting_required_checks_grace_seconds: float = 600.0,
     max_outer_iterations: int = 10_000,
     max_fix_cycle_passes: int = 5,
     merge_coordinator: MergeCoordinator | None = None,
@@ -80,6 +81,7 @@ def build_release_pr_monitor(
             pre_merge_settle_seconds=pre_merge_settle_seconds,
             non_check_reviewer_settle_seconds=non_check_reviewer_settle_seconds,
             non_check_reviewer_logins=tuple(non_check_reviewer_logins),
+            awaiting_required_checks_grace_seconds=awaiting_required_checks_grace_seconds,
         ),
         runner_config=MonitorRunnerConfig(
             max_outer_iterations=max_outer_iterations,
@@ -113,6 +115,7 @@ def build_feature_pr_monitor(
     non_check_reviewer_settle_seconds: float = 180.0,
     non_check_reviewer_logins: list[str] | tuple[str, ...] = ("greptile-apps",),
     require_ci: bool = True,
+    awaiting_required_checks_grace_seconds: float = 600.0,
     max_outer_iterations: int = 10_000,
     max_fix_cycle_passes: int = 5,
     merge_coordinator: MergeCoordinator | None = None,
@@ -137,6 +140,7 @@ def build_feature_pr_monitor(
             pre_merge_settle_seconds=pre_merge_settle_seconds,
             non_check_reviewer_settle_seconds=non_check_reviewer_settle_seconds,
             non_check_reviewer_logins=tuple(non_check_reviewer_logins),
+            awaiting_required_checks_grace_seconds=awaiting_required_checks_grace_seconds,
         ),
         runner_config=MonitorRunnerConfig(
             max_outer_iterations=max_outer_iterations,

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -259,6 +259,9 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             ),
             "non_check_reviewer_logins": profile.monitor.non_check_reviewer_logins,
             "require_ci": profile.monitor.require_ci,
+            "awaiting_required_checks_grace_seconds": (
+                profile.monitor.awaiting_required_checks_grace_seconds
+            ),
             "log_store": log_store,
             "merge_coordinator": merge_coordinator,
             "post_merge_target_reconciler": _post_merge_reconciler,

--- a/tests/unit/profiles/test_profile_models_helpers.py
+++ b/tests/unit/profiles/test_profile_models_helpers.py
@@ -192,3 +192,71 @@ def test_normalize_inline_profile_snapshot_preserves_present_forge() -> None:
 
     assert normalized == {"name": "inline", "forge": "github"}
     assert normalized is not explicit
+
+
+@pytest.mark.unit
+def test_normalize_inline_profile_snapshot_backfills_missing_monitor_grace() -> None:
+    """A pre-#655 legacy snapshot's ``monitor`` lacks the grace key; normalization
+    adds the input default so it compares equal to a fresh replay that dumps
+    ``awaiting_required_checks_grace_seconds=600.0``."""
+    legacy = {"name": "inline", "forge": "auto", "monitor": {"require_ci": True}}
+
+    normalized = normalize_inline_profile_snapshot(legacy)
+
+    assert normalized == {
+        "name": "inline",
+        "forge": "auto",
+        "monitor": {
+            "require_ci": True,
+            "awaiting_required_checks_grace_seconds": 600.0,
+        },
+    }
+    # The input snapshot (a live ORM attribute at the call sites) must not mutate.
+    assert legacy == {"name": "inline", "forge": "auto", "monitor": {"require_ci": True}}
+
+
+@pytest.mark.unit
+def test_normalize_inline_profile_snapshot_preserves_present_monitor_grace() -> None:
+    """A snapshot whose ``monitor`` already carries the grace value is unchanged
+    by normalization (other than a shallow copy)."""
+    explicit = {
+        "name": "inline",
+        "forge": "auto",
+        "monitor": {"awaiting_required_checks_grace_seconds": 120.0, "require_ci": True},
+    }
+
+    normalized = normalize_inline_profile_snapshot(explicit)
+
+    assert normalized == explicit
+    assert normalized is not explicit
+    assert normalized["monitor"] == explicit["monitor"]
+
+
+@pytest.mark.unit
+def test_normalize_inline_profile_snapshot_backfills_both_forge_and_monitor_grace() -> None:
+    """A truly legacy snapshot (pre-forge AND pre-#655) gets both backfills so it
+    compares equal to a fresh replay."""
+    legacy = {"name": "inline", "monitor": {"require_ci": True}}
+
+    normalized = normalize_inline_profile_snapshot(legacy)
+
+    assert normalized == {
+        "name": "inline",
+        "forge": "auto",
+        "monitor": {
+            "require_ci": True,
+            "awaiting_required_checks_grace_seconds": 600.0,
+        },
+    }
+    assert legacy == {"name": "inline", "monitor": {"require_ci": True}}
+
+
+@pytest.mark.unit
+def test_normalize_inline_profile_snapshot_skips_monitor_when_not_a_dict() -> None:
+    """A malformed ``monitor`` that is not a dict must not crash normalization; it
+    is passed through untouched so downstream validation surfaces the problem."""
+    malformed = {"name": "inline", "forge": "auto", "monitor": "not-a-dict"}
+
+    normalized = normalize_inline_profile_snapshot(malformed)
+
+    assert normalized == malformed

--- a/tests/unit/profiles/test_profile_monitor.py
+++ b/tests/unit/profiles/test_profile_monitor.py
@@ -2,13 +2,16 @@
 
 Split out of ``test_profiles`` to keep each first-party file under the
 line-count guardrail. Covers the ``monitor`` schema fields: the initial
-review grace period, the ``require_ci`` opt-out (#469), and the
-non-check-reviewer settle policy.
+review grace period, the ``require_ci`` opt-out (#469), the
+non-check-reviewer settle policy, and the ``awaiting_required_checks_grace_seconds``
+operator knob (#662) that exposes the #656 grace (including its documented
+``<= 0`` disable escape hatch).
 """
 
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from awf.profiles.models import WorkspaceProfile
 
@@ -82,3 +85,48 @@ def test_profile_schema_accepts_disabled_or_empty_non_check_reviewer_policy() ->
 
     assert profile.monitor.non_check_reviewer_settle_seconds == 0
     assert profile.monitor.non_check_reviewer_logins == []
+
+
+@pytest.mark.unit
+def test_profile_monitor_awaiting_required_checks_grace_defaults_600() -> None:
+    # Mirrors the MonitorConfig dataclass default, so profiles that omit it
+    # get byte-identical behavior to the pre-#662 hard-coded 600s (#662).
+    profile = WorkspaceProfile.model_validate({"name": "python-explicit"})
+    assert profile.monitor.awaiting_required_checks_grace_seconds == 600.0
+
+
+@pytest.mark.unit
+def test_profile_schema_accepts_awaiting_required_checks_grace_seconds() -> None:
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "python-explicit",
+            "monitor": {"awaiting_required_checks_grace_seconds": 120},
+        }
+    )
+    assert profile.monitor.awaiting_required_checks_grace_seconds == 120
+
+
+@pytest.mark.unit
+def test_profile_schema_accepts_awaiting_required_checks_grace_seconds_zero_or_negative() -> None:
+    # The field docstring documents ``<= 0`` as the disable escape hatch, so
+    # 0 and negative values must parse (#662).
+    for value in (0, -1):
+        profile = WorkspaceProfile.model_validate(
+            {
+                "name": "python-explicit",
+                "monitor": {"awaiting_required_checks_grace_seconds": value},
+            }
+        )
+        assert profile.monitor.awaiting_required_checks_grace_seconds == float(value)
+
+
+@pytest.mark.unit
+def test_profile_schema_rejects_awaiting_required_checks_grace_seconds_above_86400() -> None:
+    # Bounds parity with the existing monitor knobs (upper bound 86400s).
+    with pytest.raises(ValidationError):
+        WorkspaceProfile.model_validate(
+            {
+                "name": "python-explicit",
+                "monitor": {"awaiting_required_checks_grace_seconds": 86401},
+            }
+        )

--- a/tests/unit/runtime/test_release_pr_monitor.py
+++ b/tests/unit/runtime/test_release_pr_monitor.py
@@ -137,6 +137,7 @@ def test_factories_plumb_configured_knobs(tmp_path: Path) -> None:
         non_check_reviewer_settle_seconds=45,
         non_check_reviewer_logins=["custom-reviewer"],
         require_ci=False,
+        awaiting_required_checks_grace_seconds=250,
     )
     assert runner._config.poll_interval_seconds == 15
     assert runner._config.settle_interval_seconds == 7
@@ -145,6 +146,40 @@ def test_factories_plumb_configured_knobs(tmp_path: Path) -> None:
     assert runner._config.non_check_reviewer_settle_seconds == 45
     assert runner._config.non_check_reviewer_logins == ("custom-reviewer",)
     assert runner._config.require_ci is False
+    assert runner._config.awaiting_required_checks_grace_seconds == 250
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("builder", [build_release_pr_monitor, build_feature_pr_monitor])
+def test_factories_awaiting_required_checks_grace_defaults_600(builder, tmp_path: Path) -> None:
+    # Omitting the kwarg preserves the MonitorConfig dataclass default (#662).
+    cmd = FakeCommandRunner()
+    runner = builder(
+        session_factory=None,  # type: ignore[arg-type]
+        runner=cmd,
+        adapter=_StubAdapter(),
+        gh=GitHubClient(cmd),
+        validation=_validation(cmd, tmp_path),
+        worktrees_root=tmp_path,
+    )
+    assert runner._config.awaiting_required_checks_grace_seconds == 600.0
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("builder", [build_release_pr_monitor, build_feature_pr_monitor])
+def test_factories_awaiting_required_checks_grace_zero_disables(builder, tmp_path: Path) -> None:
+    # The documented ``<= 0`` disable escape hatch must reach MonitorConfig (#662).
+    cmd = FakeCommandRunner()
+    runner = builder(
+        session_factory=None,  # type: ignore[arg-type]
+        runner=cmd,
+        adapter=_StubAdapter(),
+        gh=GitHubClient(cmd),
+        validation=_validation(cmd, tmp_path),
+        worktrees_root=tmp_path,
+        awaiting_required_checks_grace_seconds=0,
+    )
+    assert runner._config.awaiting_required_checks_grace_seconds == 0
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -359,6 +359,8 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
         "greptile-apps",
         "chatgpt-codex-connector",
     ]
+    # Default profile omits the #662 knob -> MonitorConfig 600s default.
+    assert created["feature_monitor_kwargs"]["awaiting_required_checks_grace_seconds"] == 600
 
     raw_database_password = "runtime-db-password"
     raw_database_url = f"postgresql+asyncpg://awf:{raw_database_password}@postgres:5432/awf"
@@ -372,6 +374,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
             non_check_reviewer_settle_seconds=45,
             non_check_reviewer_logins=["custom-reviewer"],
             require_ci=False,
+            awaiting_required_checks_grace_seconds=250,
         ),
     )
     monitor = created["executor_monitor_factory"](
@@ -390,6 +393,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["feature_monitor_kwargs"]["non_check_reviewer_settle_seconds"] == 45
     assert created["feature_monitor_kwargs"]["non_check_reviewer_logins"] == ["custom-reviewer"]
     assert created["feature_monitor_kwargs"]["require_ci"] is False
+    assert created["feature_monitor_kwargs"]["awaiting_required_checks_grace_seconds"] == 250
     assert created["feature_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["feature_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
     expected_runtime_context = created["feature_monitor_kwargs"]["workspace_runtime_context"]
@@ -428,6 +432,7 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     assert created["release_monitor_kwargs"]["non_check_reviewer_settle_seconds"] == 45
     assert created["release_monitor_kwargs"]["non_check_reviewer_logins"] == ["custom-reviewer"]
     assert created["release_monitor_kwargs"]["require_ci"] is False
+    assert created["release_monitor_kwargs"]["awaiting_required_checks_grace_seconds"] == 250
     assert created["release_monitor_kwargs"]["log_store"] is created["executor_log_store"]
     assert created["release_monitor_kwargs"]["worktrees_root"] == work_dir / "git" / "worktrees"
     assert "post_merge_target_reconciler" in created["release_monitor_kwargs"]
@@ -484,6 +489,26 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
     )
     assert bitbucket_monitor is not None
     assert created["forge_client_forge"] == "bitbucket"
+
+    # The documented ``<= 0`` disable escape hatch must flow from the profile
+    # monitor policy to the monitor kwargs (#662).
+    created.pop("feature_monitor_kwargs", None)
+    created.pop("release_monitor_kwargs", None)
+    disable_profile = WorkspaceProfile(
+        name="disable-grace",
+        monitor=ProfileMonitor(awaiting_required_checks_grace_seconds=0),
+    )
+    created["executor_monitor_factory"](
+        object(),
+        disable_profile,
+        SimpleNamespace(
+            auto_merge=True,
+            initial_review_grace_period_seconds=None,
+            task_kind="feature_branch_pr",
+            repo_url="https://github.com/o/r.git",
+        ),
+    )
+    assert created["feature_monitor_kwargs"]["awaiting_required_checks_grace_seconds"] == 0
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_4509b5fc34874909b66d9bb1` (agent: `opencode`, model: `ollama/glm-5.2:cloud`, effort: `xhigh`).


### Task
Fix issue #662 in agent-workspace-fabric: expose the PR-monitor CI-absence grace as an operator-facing profile knob.

CONTEXT: PR #656 added `MonitorConfig.awaiting_required_checks_grace_seconds` (default 600.0) — the bounded grace before the monitor escalates HUMAN_WAIT when a required CI check is expected but absent. The field documents `<= 0` as a disable escape hatch, but that value is UNREACHABLE from operator configuration: `ProfileMonitor` forbids extra fields and has no such field, and `service/worker.py` only threads the existing initial-review/reviewer-settle/require-ci knobs into the monitor builders. So every profile is hard-coded to 600s.

THE FIX (HOLD SCOPE, additive wiring — no logic/contract changes):
1. Add `awaiting_required_checks_grace_seconds: float` (Optional, with a sensible default that preserves today's 600s behavior when unset) to the `ProfileMonitor` model (the workspace-profile monitor config). Allow `<= 0` (the documented disable escape hatch). Follow how the EXISTING monitor knobs (initial_review_grace_period_seconds, non_check_reviewer_settle_seconds, require_ci) are declared/validated on ProfileMonitor.
2. Thread it through `src/awf/service/worker.py` monitor_kwargs exactly like the existing knobs.
3. Add it as a parameter to `build_feature_pr_monitor` and `build_release_pr_monitor` so it reaches `MonitorConfig.awaiting_required_checks_grace_seconds` (default to the current 600.0 when not provided, so unchanged behavior for profiles that don't set it).
4. Regenerate `openapi.json` (the schema must reflect the new ProfileMonitor field). Update any doc-sync / profile-reference docs that enumerate monitor knobs.
5. Add wiring tests: a profile that sets the field flows it to MonitorConfig; a profile that omits it keeps 600.0; `<= 0` disables (reaches MonitorConfig as <= 0).

DO NOT change decide() gate logic, the grace behavior itself, or any other monitor work. This is pure configurability wiring. Keep the full suite green at the 99% coverage gate.

PR: title "feat: expose awaiting_required_checks_grace_seconds as a profile monitor knob (#662)"; body notes it makes the #656 grace operator-configurable (incl. the documented <=0 disable). State that it Fixes #662. Commit before exiting; the AWF monitor handles the PR. Do not address review comments or merge yourself.

Optimize for: a clean additive wiring diff mirroring the existing monitor knobs end-to-end (ProfileMonitor → worker.py → builders → MonitorConfig), with openapi + docs + tests.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive profile/API wiring with default 600s preserving current behavior; monitor decision logic is untouched.
> 
> **Overview**
> Makes the PR monitor’s **awaiting-required-checks** grace (previously only on `MonitorConfig` at a fixed 600s) **operator-configurable** via `monitor.awaiting_required_checks_grace_seconds` on workspace profiles, including the documented **`<= 0`** disable path.
> 
> The value is threaded **profile → worker `monitor_kwargs` → feature/release monitor builders → `MonitorConfig`**, with **OpenAPI** and **`docs/CONCEPTS.md`** updated. **`normalize_inline_profile_snapshot`** backfills missing `600.0` on legacy inline profiles so create/adoption idempotency replays still match.
> 
> **No** changes to `decide()` or grace runtime logic—only configurability wiring and tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e53fbd88df94f13e41c60d2a74010e83d4062fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->