### PR TITLE
fix: forge branch-protection re-check for merge-block attention, superseding the TTL heuristic (#671)

### DIFF
--- a/plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_PLAN.md
+++ b/plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_PLAN.md
@@ -1,0 +1,42 @@
+# Bitbucket CLEAN Queue Attention Plan
+
+## Problem Statement And Scope
+
+The PR monitor queue/reviewer/grace wait helper treats `MergeStateStatus.CLEAN` as
+a resolved branch-protection block. That is valid for GitHub, where `CLEAN`
+reflects the forge merge-state signal, but Bitbucket open PRs map to `CLEAN`
+because Bitbucket Cloud has no equivalent pre-merge signal. For Bitbucket, a
+`CLEAN` status must not clear an existing merge-block attention marker while the
+monitor is parked in queue/reviewer/grace waits.
+
+Scope is limited to the merge-block attention queue verdict and its direct
+callers/tests.
+
+## Requirements Checklist
+
+- Add a focused regression proving Bitbucket `CLEAN` preserves the marker and
+  `awaiting_human_since` during a merge queue wait.
+- Preserve existing GitHub behavior: GitHub `CLEAN` still clears resolved merge
+  block attention.
+- Keep the change scoped to `src/awf/runtime/pr_monitor_runner/**`, `tests/**`,
+  and this plan/validation artifact.
+- Run only focused tests for the changed behavior; AWF/GitHub own broad
+  validation after agent completion.
+
+## Implementation Steps
+
+1. Update the queue-verdict helper to accept forge context from the existing
+   `RepoRef` passed through merge/gate callers.
+2. Classify Bitbucket `CLEAN` as `indeterminate` so wait paths preserve existing
+   attention unless a stronger signal is available.
+3. Thread `repo` into direct queue-attention helper calls and status recheck
+   decisions.
+4. Add a Bitbucket queue-wait regression next to the existing merge queue
+   attention tests.
+
+## Verification Commands And Pass Criteria
+
+- Run the targeted test(s) in `tests/unit/runtime/test_merge_queue_ordering.py`
+  covering GitHub resolved and Bitbucket clean-preserve behavior.
+- Pass criteria: the focused tests pass locally; full AWF/GitHub validation is
+  left to the post-agent validation pipeline.

--- a/plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_VALIDATION.md
+++ b/plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_VALIDATION.md
@@ -1,0 +1,65 @@
+# Bitbucket CLEAN Queue Attention Validation
+
+Plan reference: `plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_PLAN.md`
+
+## Requirement Status
+
+- Complete: Added a focused regression proving Bitbucket `CLEAN` preserves the
+  merge-block marker and `awaiting_human_since` during queue-attention handling.
+- Complete: Preserved GitHub behavior; the existing GitHub `CLEAN` queue-wait
+  test still clears resolved merge-block attention.
+- Complete: Kept changes scoped to merge-block attention queue verdict callers,
+  focused runtime tests, and plan/validation artifacts.
+- Complete: Ran only focused local checks. Full AWF/GitHub validation is managed
+  after agent completion.
+
+## Evidence
+
+Changed files:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `src/awf/runtime/pr_monitor_runner/gates.py`
+- `src/awf/runtime/pr_monitor_runner/merge_loop.py`
+- `tests/unit/runtime/test_merge_queue_ordering.py`
+- `plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_PLAN.md`
+- `plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_VALIDATION.md`
+
+Focused checks run:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_bitbucket_clean_preserves_branch_protection_marker_on_merge_queue_wait -q
+```
+
+Initial red result before implementation: failed with
+`TypeError: _clear_or_preserve_merge_attention_for_queue_wait() got an unexpected keyword argument 'forge'`.
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved tests/unit/runtime/test_merge_queue_ordering.py::test_bitbucket_clean_preserves_branch_protection_marker_on_merge_queue_wait -q
+```
+
+Result: passed, `2 passed`.
+
+```bash
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_preserved_on_merge_queue_wait_when_forge_blocked \
+  tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved \
+  tests/unit/runtime/test_merge_queue_ordering.py::test_bitbucket_clean_preserves_branch_protection_marker_on_merge_queue_wait \
+  tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved \
+  tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_preserved_on_initial_grace_wait_when_recheck_errors \
+  -q
+```
+
+Result: passed, `5 passed`.
+
+```bash
+uv run --python 3.12 --extra dev ruff format src/awf/runtime/pr_monitor_runner/gates.py
+```
+
+Result: reformatted one file after the commit hook reported the focused format
+check failure.
+
+```bash
+uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/merge_loop.py tests/unit/runtime/test_merge_queue_ordering.py
+```
+
+Result: passed.

--- a/plans/MERGE_ATTENTION_CLEAN_QUEUE_PLAN.md
+++ b/plans/MERGE_ATTENTION_CLEAN_QUEUE_PLAN.md
@@ -1,0 +1,31 @@
+# Merge Attention CLEAN Queue Plan
+
+## Problem Statement and Scope
+
+An unresolved PR review thread reports that queue, reviewer-settle, or initial-grace waits can clear an active `merge_block_attention` marker when GitHub still reports `CLEAN` from the status that preceded a deterministic merge rejection. That `CLEAN` signal is not proof that the branch-protection block has been retried and resolved.
+
+Scope is limited to merge-block attention preservation in `src/awf/runtime/pr_monitor_runner/merge_attention.py` and focused regression coverage in `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+
+## Requirements Checklist
+
+- Preserve an existing merge-block attention marker and `awaiting_human_since` across queue-style waits when the observed GitHub merge-state signal is `CLEAN`.
+- Continue treating `BLOCKED` and `HAS_HOOKS` as active branch-protection signals.
+- Keep Bitbucket `CLEAN` conservative.
+- Do not broaden validation beyond focused tests for the changed behavior; AWF/GitHub own broad validation after agent completion.
+
+## Implementation Steps
+
+1. Add a focused regression test proving queue-wait handling preserves a prior merge-block marker and attention flag when status is GitHub `CLEAN`.
+2. Run that single test and confirm it fails against the current implementation.
+3. Update merge-attention queue verdict classification so `CLEAN` is indeterminate for queue-style waits and therefore preserves markers until a merge retry path confirms resolution.
+4. Update nearby documentation/comments to match the new preservation contract.
+5. Re-run the focused regression and a narrow related merge-attention test selection.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "clean_status_preserves_merge_block_attention_during_queue_wait"`
+  - Passes after the implementation change.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "queue_wait or clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked"`
+  - Passes for related queue/attention coverage.
+
+Full AWF/GitHub validation is intentionally not run during this agent phase.

--- a/plans/MERGE_ATTENTION_CLEAN_QUEUE_VALIDATION.md
+++ b/plans/MERGE_ATTENTION_CLEAN_QUEUE_VALIDATION.md
@@ -1,0 +1,35 @@
+# Merge Attention CLEAN Queue Validation
+
+Plan reference: `plans/MERGE_ATTENTION_CLEAN_QUEUE_PLAN.md`
+
+## Requirement Status
+
+- Preserve an existing merge-block attention marker and `awaiting_human_since` across queue-style waits when the observed GitHub merge-state signal is `CLEAN`: Complete.
+- Continue treating `BLOCKED` and `HAS_HOOKS` as active branch-protection signals: Complete.
+- Keep Bitbucket `CLEAN` conservative: Complete.
+- Do not broaden validation beyond focused tests for the changed behavior: Complete.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `plans/MERGE_ATTENTION_CLEAN_QUEUE_PLAN.md`
+- `plans/MERGE_ATTENTION_CLEAN_QUEUE_VALIDATION.md`
+
+Focused checks run:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "clean_status_preserves_merge_block_attention_during_queue_wait"`
+  - Failed before the implementation change with the marker cleared from in-memory state.
+  - Passed after the implementation change.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "queue_wait or clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked"`
+  - Passed: 3 passed, 19 deselected.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passed.
+
+Full AWF/GitHub validation was not run in this agent phase, per the workspace contract; AWF owns broad validation and merge-gate provenance after completion.
+
+## Gaps
+
+None.

--- a/plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_PLAN.md
+++ b/plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_PLAN.md
@@ -1,0 +1,47 @@
+# Merge Attention Queue Wait TTL Plan
+
+## Problem Statement And Scope
+
+PR review thread `PRRT_kwDOSJAM6s6LqhqC` reports that queue waits preserve an
+old `merge_block_attention` marker when forge status still reports branch
+protection active, but merge critical-section entry still applies the marker TTL
+alone. After a long queue wait, the aged marker can be treated as resolved and
+clear `awaiting_human_since` even though branch protection is still active.
+
+Scope is limited to `src/awf/runtime/pr_monitor_runner/**`, focused unit tests,
+and required plan/validation documents for this thread.
+
+## Requirements Checklist
+
+- [ ] Verify the review claim against current code.
+- [ ] Add a focused regression proving an active forge mergeability signal
+      preserves merge-block attention even when the marker is TTL-stale at
+      critical-section entry.
+- [ ] Keep existing stale-marker cleanup behavior for resolved or unproven
+      branch-protection blocks.
+- [ ] Keep the fix minimal and scoped to merge attention / merge loop.
+- [ ] Run focused tests only; full AWF/GitHub validation remains managed by AWF
+      after agent completion.
+- [ ] Commit the fix locally with a conventional commit message referencing the
+      review thread.
+
+## Implementation Steps
+
+1. Inspect `merge_attention.py` and `merge_loop.py` around queue-wait preserve
+   and critical-section entry.
+2. Write the failing regression in `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+3. Pass the current `status` and forge into `_clear_stale_merge_attention` from
+   merge critical-section entry.
+4. In `_clear_stale_merge_attention`, preserve and re-stamp the marker when the
+   forge verdict is still `active`, even if the TTL says stale.
+5. Run the focused merge-attention unit test file or selected tests that cover
+   the changed behavior.
+6. Write validation evidence in `plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_VALIDATION.md`.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Pass criterion: all merge-attention focused tests pass.
+
+Full repository validation, coverage gates, and CI-equivalent checks are not run
+inside this agent phase per the AWF workspace contract.

--- a/plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_VALIDATION.md
+++ b/plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_VALIDATION.md
@@ -1,0 +1,39 @@
+# Merge Attention Queue Wait TTL Validation
+
+Plan reference: `plans/MERGE_ATTENTION_QUEUE_WAIT_TTL_PLAN.md`
+
+## Requirement Status
+
+- Verify the review claim against current code: Complete.
+  - Evidence: `merge_loop.py` passed only the entry timestamp into
+    `_clear_stale_merge_attention`, while `merge_attention.py` applied TTL
+    freshness without considering the current active forge status.
+- Add a focused regression for active forge status plus TTL-stale marker:
+  Complete.
+  - Evidence:
+    `tests/unit/runtime/test_pr_monitor_merge_attention.py::test_clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked`.
+  - The regression failed before implementation with
+    `TypeError: _clear_stale_merge_attention() got an unexpected keyword argument 'status'`.
+- Keep existing stale-marker cleanup behavior for resolved or unproven blocks:
+  Complete.
+  - Evidence: existing merge-attention tests still pass.
+- Keep the fix minimal and scoped to merge attention / merge loop: Complete.
+  - Evidence: changed only merge attention helper, merge-loop call site, focused
+    regression test, and required plan/validation docs.
+- Run focused tests only: Complete.
+  - Evidence: commands below.
+- Commit locally with a conventional commit referencing the review thread:
+  Complete.
+
+## Verification Evidence
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py::test_clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked -q`
+  - Result before implementation: failed as expected.
+  - Result after implementation: passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Result: `21 passed in 34.17s`.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Result: `All checks passed!`
+
+Full AWF/GitHub validation, full coverage gates, and CI-equivalent commands were
+not run inside this agent phase per the AWF workspace contract.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md
@@ -115,9 +115,9 @@ Do not run full coverage gates, whole-repo pytest, full `.awf/workspace.yml` val
 
 ## Explicit Non-goals
 
-- Do not change branch management, push behavior, PR creation, or merge behavior.
-- Do not change #660/#662 required-check grace logic or broader `decide()` gate ordering.
-- Do not change #661 ordinary resolved-human attention clears before merge/pre-merge settle.
+- Avoid changing branch management, push behavior, PR creation, or merge behavior.
+- Leave #660/#662 required-check grace logic and broader `decide()` gate ordering unchanged.
+- Preserve #661 ordinary resolved-human attention clears before merge/pre-merge settle.
 - Do not introduce new branch-protection policy abstractions beyond what is required for this queue-wait marker decision.
-- Do not run broad AWF/GitHub-owned validation inside the agent phase.
-- Do not manually address review comments or merge the PR.
+- Keep broad AWF/GitHub-owned validation in the post-agent phase unless the operator explicitly requests it.
+- Manual review-comment resolution and PR merging remain out of scope for the agent phase.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md
@@ -1,0 +1,123 @@
+# Implementation Plan: Forge Re-check for Merge-block Attention (#671)
+
+## Problem Statement
+
+`merge_block_attention` currently uses marker age and the #666 preserve-while-queued re-stamp to decide whether `awaiting_human_since` should remain surfaced while the PR monitor is parked behind non-human waits such as merge queue, non-check reviewer settle, or initial review grace. That creates both issue #671 error modes:
+
+- false negative: an active branch-protection block can age past the TTL and be cleared while still blocked;
+- false positive: a resolved block can be re-stamped indefinitely while queued, keeping `awaiting_human_since` visible after the human gate resolved.
+
+The implementation will replace queue-wait age/re-stamp decisions with an observable forge branch-protection / mergeability re-check. The marker will be preserved only when the forge still says branch protection is active, cleared when the forge confirms resolution, and preserved conservatively when the re-check fails or is indeterminate.
+
+## Intended Files and Modules to Touch
+
+- `src/awf/runtime/pr_monitor_runner/merge_loop.py`
+  - Replace the queue-wait calls that currently use `_clear_stale_merge_attention(..., allow_age_out=False)` for merge-queue, reviewer-settle, and initial-grace waits with a forge-signal-driven clear/preserve path.
+  - Include both pre-lock wait arms and post-lock recheck arms.
+  - Reuse the already-fetched `PRStatus` for the current poll where it is sufficient; for post-lock paths that already re-fetch `merge_status`, use that refreshed status.
+  - Add a targeted status refresh only if the existing status is not sufficient to classify the marker state.
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+  - Add or adapt a helper that applies a queue-wait branch-protection verdict to `merge_block_attention` atomically/durably:
+    - `still_active` -> preserve the existing marker and `awaiting_human_since` without re-stamping;
+    - `resolved` -> clear the marker and `awaiting_human_since` in the existing atomic clear style;
+    - `indeterminate/error` -> preserve marker and `awaiting_human_since` without re-stamping.
+  - Remove the queue-wait TTL age-out/re-stamp behavior from the preserve path. Keep non-queue #661 merge-critical-section clears intact unless implementation proves they can share a helper without changing behavior.
+
+- `src/awf/runtime/pr_monitor.py`
+  - Update comments/docstrings around `MonitorState.merge_block_attention_active()` and `mark_merge_block_attention()` if they still describe queue-wait TTL as the contract.
+  - Avoid changing the state key shape unless strictly necessary; the marker can remain a timestamp from actual merge rejection stamps, but queue-wait decisions must no longer depend on age.
+
+- `tests/unit/runtime/test_merge_queue_ordering.py`
+  - Re-target `test_clear_stale_merge_attention_restamps_preserved_marker` and related merge-queue wait coverage away from re-stamp assertions and toward forge-signal behavior.
+  - Add explicit queue cases for forge-still-blocked, forge-resolved, and forge-indeterminate/error.
+
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Retain #661 fast-path and merge-critical-section intent tests.
+  - Update/remove queue-specific re-stamp expectations that conflict with the new no-re-stamp queue contract.
+  - Keep durable clear/preserve regression intent around marker plus `awaiting_human_since` atomicity.
+
+- Possibly `tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py` and `tests/unit/runtime/test_pr_monitor_initial_review_grace.py`
+  - Only if existing reviewer-settle or initial-grace tests need direct retargeting beyond the shared `_execute` tests in `test_merge_queue_ordering.py`.
+
+## Tests to Write First
+
+1. Forge says still blocked behind merge queue -> preserve stable attention
+   - Seed a workspace with `awaiting_human_since` and a `merge_block_attention` marker from a prior merge rejection.
+   - Execute `Merge()` into a merge-queue wait using a `PRStatus` whose forge signal indicates branch protection remains active, likely `merge_state_status in {BLOCKED, HAS_HOOKS}` with no higher-priority blocker.
+   - Assert `awaiting_human_since` remains exactly the original timestamp, `awaiting_human_reason` remains present, and the marker is not re-stamped by the queue wait.
+   - Assert no merge command/merge attempt occurred while queued.
+
+2. Forge says resolved behind merge queue -> clear promptly
+   - Seed the same attention and marker.
+   - Execute into a merge-queue wait using a clean/mergeable `PRStatus` indicating branch protection is no longer active.
+   - Assert the monitor still waits on the queue, but `awaiting_human_since`, `awaiting_human_reason`, and `merge_block_attention` are cleared promptly.
+   - Assert the marker is not preserved or re-stamped.
+
+3. Forge re-check is indeterminate or errors -> preserve conservatively
+   - Use a status with insufficient/unknown mergeability signal or monkeypatch the targeted re-check/fetch to raise a forge error, depending on the final helper shape.
+   - Assert the marker and original `awaiting_human_since` are preserved and stable.
+   - Assert no re-stamp occurs on preserve.
+
+4. Reviewer-settle and initial-grace parity
+   - Retarget existing resolved-marker-preserved tests so they assert:
+     - `merge_state_status=BLOCKED/HAS_HOOKS` preserves with a stable timer;
+     - `merge_state_status=CLEAN` clears promptly.
+   - Use the existing `_execute`-level reviewer-settle and initial-grace scenarios where possible to avoid duplicating setup.
+
+5. #661/#663 intent preservation
+   - Keep tests proving a resolved ordinary `NotifyHuman` attention clears before pre-merge settle / fast merge path.
+   - Keep tests proving an active branch-protection escalation stays surfaced with a stable timer, now because the forge confirms blocked rather than because a TTL is fresh.
+   - Keep durable atomic clear tests for marker + attention so a restart cannot observe one side without the other.
+
+## Implementation Steps
+
+1. Add failing tests first for merge-queue forge-blocked, forge-resolved, and forge-error/indeterminate behavior.
+2. Retarget the old re-stamp tests to assert the same protective intent with the new forge signal and stable marker semantics.
+3. Implement a small classification helper for queue-wait attention decisions, using `PRStatus.merge_state_status` as the primary observable signal:
+   - `BLOCKED` / `HAS_HOOKS` -> still active;
+   - clean mergeable states with no branch-protection signal -> resolved;
+   - `UNKNOWN` or failed targeted status fetch -> indeterminate.
+   If existing `PRStatus` fields prove insufficient while implementing, add one targeted forge status refresh through the existing `_fetch_status_for_decision` path and preserve on any `ForgeClientError`, `BaseFetchError`, or `BaseBehindCountError` from that refresh.
+4. Wire the queue-wait paths in `merge_loop.py` to call the new forge-signal helper before sleeping/waiting:
+   - pre-lock merge queue;
+   - pre-lock reviewer-settle;
+   - post-lock initial grace;
+   - post-lock reviewer-settle;
+   - post-lock merge queue.
+5. Remove the #666 queue preserve re-stamp behavior. Queue-wait preserve must keep the existing marker and timer stable rather than writing a fresh timestamp.
+6. Preserve the existing non-queue #661 behavior for merge-critical-section entry unless a test explicitly requires a compatible adjustment.
+7. Update comments/docstrings so they describe the forge-signal contract, not TTL/re-stamp queue heuristics.
+8. Create the implementation validation artifact required by `plans/PLAN_EXECUTION_PROTOCOL.md` during the implementation phase, recording files changed and focused command evidence.
+9. Commit locally with a scoped message after implementation, per the workspace contract. Do not push, rebase, switch branches, or merge.
+
+## Focused Validation Commands
+
+Run only targeted checks during implementation; AWF/GitHub own broad validation after the agent exits.
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py -q`
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+- If touched: `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_non_check_reviewer_settle.py tests/unit/runtime/test_pr_monitor_initial_review_grace.py -q`
+- Focused lint/type checks for touched runtime files only, if practical:
+  - `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py tests/unit/runtime/test_merge_queue_ordering.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - `uv run --python 3.12 --extra dev mypy src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py`
+
+Do not run full coverage gates, whole-repo pytest, full `.awf/workspace.yml` validation, or frontend builds during the agent phase unless the operator explicitly requests that diagnostic.
+
+## Risks and Assumptions
+
+- Assumption: `PRStatus.merge_state_status` is an adequate observable branch-protection signal for the queue decision when it is `BLOCKED` or `HAS_HOOKS`, and clean mergeability states are adequate to confirm resolution. If status is `UNKNOWN` or otherwise ambiguous, preserve.
+- Assumption: existing status fetches in the monitor poll and post-lock recheck paths are acceptable forge observations; a targeted additional fetch is only needed for ambiguous current status.
+- Risk: `merge_state_status=BLOCKED/HAS_HOOKS` can also represent transient required-check absence. Existing #660/#662 required-check grace behavior must remain unchanged; tests should avoid classifying absent-check grace as a resolved human block.
+- Risk: clearing marker and attention must remain atomic/durable to avoid restart windows. Reuse existing `get_for_update` transaction patterns.
+- Risk: removing re-stamp assertions may reduce coverage on timestamp branches. Replace them with behavioral tests over blocked/resolved/error branches, not coverage padding.
+- Risk: Bitbucket may not expose GitHub-style branch-protection semantics. Treat unsupported or indeterminate forge signals as preserve to avoid false-clearing escalation.
+
+## Explicit Non-goals
+
+- Do not change branch management, push behavior, PR creation, or merge behavior.
+- Do not change #660/#662 required-check grace logic or broader `decide()` gate ordering.
+- Do not change #661 ordinary resolved-human attention clears before merge/pre-merge settle.
+- Do not introduce new branch-protection policy abstractions beyond what is required for this queue-wait marker decision.
+- Do not run broad AWF/GitHub-owned validation inside the agent phase.
+- Do not manually address review comments or merge the PR.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -1,0 +1,33 @@
+# Validation: Forge Re-check for Merge-block Attention (#671)
+
+Plan reference: `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md`
+
+## Requirement Status
+
+- Complete: Queue/reviewer/initial-grace waits decide `merge_block_attention` from forge mergeability status instead of marker age.
+- Complete: Forge `BLOCKED` / `HAS_HOOKS` preserves the marker and stable `awaiting_human_since` without queue-wait re-stamping.
+- Complete: Forge `CLEAN` clears the marker and `awaiting_human_since` promptly while still waiting on the non-human gate.
+- Complete: Indeterminate or failed targeted re-check preserves conservatively.
+- Complete: The #666 `allow_age_out=False` queue preserve/re-stamp branch was removed; `_clear_stale_merge_attention` remains scoped to the #661 merge critical-section TTL path.
+- Complete: #661 critical-section behavior remains covered by focused merge-attention tests.
+
+## Files Changed
+
+- `src/awf/runtime/pr_monitor.py`
+- `src/awf/runtime/pr_monitor_runner/gates.py`
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `src/awf/runtime/pr_monitor_runner/merge_loop.py`
+- `src/awf/runtime/pr_monitor_runner/mixins.py`
+- `tests/unit/runtime/test_merge_queue_ordering.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+
+## Evidence
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Passed: `40 passed in 63.34s`
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/mixins.py tests/unit/runtime/test_merge_queue_ordering.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passed: `All checks passed!`
+- `uv run --python 3.12 --extra dev mypy src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/mixins.py`
+  - Passed: `Success: no issues found in 5 source files`
+
+Full AWF/GitHub validation, full coverage, and CI-equivalent gates were not run inside the agent phase per the workspace contract; AWF owns those after completion.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -89,7 +89,30 @@ Focused evidence:
 - `uv run --python 3.12 --extra dev ruff format --check tests/unit/runtime/test_merge_queue_ordering.py`
   - Passed: `1 file already formatted`
 
-Validation complete: Attempt 3 is the final validated state for this plan, and
+## Attempt 4 Validation-Failure Repair
+
+- Fixed the queue-wait verdict classifier so GitHub `CLEAN` is treated as a
+  resolved merge-block signal and clears `merge_block_attention` plus
+  `awaiting_human_since`.
+- Preserved the documented Bitbucket exception: Bitbucket open PRs map to
+  `CLEAN`, so Bitbucket `CLEAN` remains indeterminate and preserves
+  conservatively.
+- Retargeted the stale
+  `test_clean_status_preserves_merge_block_attention_during_queue_wait`
+  expectation to the Bitbucket-specific conservative path.
+
+Focused evidence:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved -q`
+  - Passed: `2 passed in 4.49s`
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime -k 'merge_attention or merge_block or stale or queue' -q`
+  - Passed: `205 passed, 2574 deselected in 195.85s`
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passed: `All checks passed!`
+- `uv run --python 3.12 --extra dev ruff format --check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passed: `2 files already formatted`
+
+Validation complete: Attempt 4 is the final validated state for this plan, and
 its focused evidence confirms the plan-conformance requirements are satisfied.
 The earlier attempts remain as repair history only; full AWF/GitHub validation
 continues to run after the agent phase.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -29,5 +29,39 @@ Plan reference: `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md`
   - Passed: `All checks passed!`
 - `uv run --python 3.12 --extra dev mypy src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/mixins.py`
   - Passed: `Success: no issues found in 5 source files`
+- Attempt 1 documentation repair checks:
+  - `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py`
+    - Passed: `All checks passed!`
+  - `uv run --python 3.12 --extra dev ruff format --check src/awf/runtime/pr_monitor_runner/merge_attention.py`
+    - Passed: `1 file already formatted`
+  - `uv run --python 3.12 --extra dev pytest tests/unit/runtime -k 'merge_attention or merge_block or stale or queue' -q`
+    - Passed: `202 passed, 2574 deselected in 192.12s`
+  - `git diff --check`
+    - Passed with no output.
 
-Full AWF/GitHub validation, full coverage, and CI-equivalent gates were not run inside the agent phase per the workspace contract; AWF owns those after completion.
+## Attempt 1 Conformance Repair
+
+- Documentation repair: updated
+  `src/awf/runtime/pr_monitor_runner/merge_attention.py` so
+  `_clear_stale_merge_attention` and its durable re-stamp helper no longer claim
+  queue/reviewer/initial-grace waits use the TTL re-stamp-on-preserve path. The
+  text now states that re-stamping is limited to the merge critical-section TTL
+  path, and queue/reviewer/initial-grace waits are forge-signal-driven via
+  `_clear_or_preserve_merge_attention_for_queue_wait`.
+- Configured full coverage gate: `.awf/workspace.yml` declares
+  `minimum_percent: 99` with command
+  `uv run --python 3.12 --extra dev pytest --timeout=300 --cov=awf --cov-report=term-missing --cov-fail-under=99`.
+- AWF-owned coverage evidence for this unpushed local head is not available
+  inside the agent workspace:
+  - no checked-in or temporary coverage artifact was present under `/workspace`
+    or `/tmp`;
+  - a read-only local control-plane DB lookup could not attach coverage
+    provenance because this workspace DB has no `validation_runs` table;
+  - `gh run list --repo dimileeh/agent-workspace-fabric --commit "$(git rev-parse HEAD)" --limit 20 --json ...`
+    returned `[]`.
+
+Full AWF/GitHub validation, the configured 99% coverage gate, and
+CI-equivalent gates were not run inside the agent phase per the workspace
+contract. No local document should be read as claiming that the 99% gate is
+satisfied for this head; AWF/GitHub must produce that authoritative evidence
+after the agent exits and the head is pushed.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -88,3 +88,8 @@ Focused evidence:
   - Passed: `All checks passed!`
 - `uv run --python 3.12 --extra dev ruff format --check tests/unit/runtime/test_merge_queue_ordering.py`
   - Passed: `1 file already formatted`
+
+Validation complete: Attempt 3 is the final validated state for this plan, and
+its focused evidence confirms the plan-conformance requirements are satisfied.
+The earlier attempts remain as repair history only; full AWF/GitHub validation
+continues to run after the agent phase.

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -63,3 +63,28 @@ Plan reference: `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md`
   documentation requirement for this agent pass.
 - No broad coverage command was run during this repair, consistent with the
   workspace contract and the saved plan non-goals.
+
+## Attempt 3 Conformance Repair
+
+- Retargeted the stale queue-wait TTL re-stamp regressions in
+  `tests/unit/runtime/test_merge_queue_ordering.py`:
+  - `test_clear_stale_merge_attention_restamps_preserved_marker` is now
+    `test_merge_critical_section_restamps_preserved_marker`.
+  - `test_clear_stale_merge_attention_restamps_preserved_marker_durably` is now
+    `test_merge_critical_section_restamps_preserved_marker_durably`.
+- Both tests now document the #661 merge critical-section-only TTL/re-stamp
+  behavior. Queue/reviewer/grace waits remain covered by #671 forge-signal
+  tests and preserve without re-stamping.
+- Updated
+  `test_merge_queue_wait_preserves_active_branch_protection_attention` to assert
+  the queue-wait marker is stable when forge status is `BLOCKED`, rather than
+  asserting or describing a queue-wait re-stamp.
+
+Focused evidence:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_merge_queue_wait_preserves_active_branch_protection_attention tests/unit/runtime/test_merge_queue_ordering.py::test_merge_critical_section_restamps_preserved_marker tests/unit/runtime/test_merge_queue_ordering.py::test_merge_critical_section_restamps_preserved_marker_durably -q`
+  - Passed: `3 passed in 4.82s`
+- `uv run --python 3.12 --extra dev ruff check tests/unit/runtime/test_merge_queue_ordering.py`
+  - Passed: `All checks passed!`
+- `uv run --python 3.12 --extra dev ruff format --check tests/unit/runtime/test_merge_queue_ordering.py`
+  - Passed: `1 file already formatted`

--- a/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
+++ b/plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md
@@ -48,20 +48,18 @@ Plan reference: `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md`
   text now states that re-stamping is limited to the merge critical-section TTL
   path, and queue/reviewer/initial-grace waits are forge-signal-driven via
   `_clear_or_preserve_merge_attention_for_queue_wait`.
-- Configured full coverage gate: `.awf/workspace.yml` declares
-  `minimum_percent: 99` with command
-  `uv run --python 3.12 --extra dev pytest --timeout=300 --cov=awf --cov-report=term-missing --cov-fail-under=99`.
-- AWF-owned coverage evidence for this unpushed local head is not available
-  inside the agent workspace:
-  - no checked-in or temporary coverage artifact was present under `/workspace`
-    or `/tmp`;
-  - a read-only local control-plane DB lookup could not attach coverage
-    provenance because this workspace DB has no `validation_runs` table;
-  - `gh run list --repo dimileeh/agent-workspace-fabric --commit "$(git rev-parse HEAD)" --limit 20 --json ...`
-    returned `[]`.
 
-Full AWF/GitHub validation, the configured 99% coverage gate, and
-CI-equivalent gates were not run inside the agent phase per the workspace
-contract. No local document should be read as claiming that the 99% gate is
-satisfied for this head; AWF/GitHub must produce that authoritative evidence
-after the agent exits and the head is pushed.
+## Attempt 2 Conformance Clarification
+
+- The previous validation note incorrectly framed unavailable full-coverage
+  evidence as a remaining plan-conformance gap. The saved plan's focused
+  validation section explicitly excludes full coverage gates, whole-repository
+  pytest, full `.awf/workspace.yml` validation, and frontend builds from the
+  agent phase.
+- The plan's validation requirement is the focused runtime evidence listed
+  above plus the AWF-managed post-agent validation pass. The configured
+  repository coverage gate remains a downstream AWF/GitHub merge gate outside
+  this plan-conformance artifact; it is not a missing implementation or
+  documentation requirement for this agent pass.
+- No broad coverage command was run during this repair, consistent with the
+  workspace contract and the saved plan non-goals.

--- a/plans/PR673_CI_COVERAGE_FIX_PLAN.md
+++ b/plans/PR673_CI_COVERAGE_FIX_PLAN.md
@@ -1,0 +1,38 @@
+# PR #673 CI Coverage Fix Plan
+
+## Problem Statement and Scope
+
+PR #673 fails CI only in `python-full-coverage`. The coverage combine step reports
+combined line+branch coverage of `98.996%`, below the required `99.00%`.
+
+Scope is limited to owned runtime monitor paths and tests. Do not edit workflow,
+coverage threshold, or unowned protected files. Do not run broad AWF/GitHub-owned
+validation locally.
+
+## Requirements Checklist
+
+- Identify the coverage miss from CI logs before changing code.
+- Add a meaningful focused test for reachable behavior in an owned changed area.
+- Keep changes minimal and avoid weakening or skipping checks.
+- Run targeted validation only for the changed tests/module.
+- Record validation evidence and note that broad validation is handled by AWF/CI.
+
+## Implementation Steps
+
+1. Inspect CI coverage logs and choose a reachable uncovered branch in
+   `src/awf/runtime/pr_monitor_runner`.
+2. Add a focused regression test that asserts the selected branch's behavior.
+3. Run the targeted test file or test case.
+4. Run focused lint for changed files if practical.
+5. Create `plans/PR673_CI_COVERAGE_FIX_VALIDATION.md`.
+6. Commit the scoped fix locally.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest <targeted test> -q`
+  - Passes.
+- `uv run --python 3.12 --extra dev ruff check <changed files>`
+  - Passes.
+
+Full coverage and full CI validation are intentionally not run locally; AWF and
+GitHub CI own broad validation after this agent phase.

--- a/plans/PR673_CI_COVERAGE_FIX_VALIDATION.md
+++ b/plans/PR673_CI_COVERAGE_FIX_VALIDATION.md
@@ -1,0 +1,53 @@
+# PR #673 CI Coverage Fix Validation
+
+Plan reference: `plans/PR673_CI_COVERAGE_FIX_PLAN.md`
+
+## Requirement Status
+
+- Identify the coverage miss from CI logs before changing code: Complete.
+  - CI `python-full-coverage` failed at combined line+branch coverage `98.996%`
+    below the `99.00%` requirement.
+  - The CI missing-lines report showed an owned reachable gap in
+    `src/awf/runtime/pr_monitor_runner/gates.py`, including lines `487-496`.
+- Add a meaningful focused test for reachable behavior in an owned changed area:
+  Complete.
+  - Added
+    `test_stale_gate_handler_records_ignored_callback_for_terminal_workspace`
+    in
+    `tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py`.
+  - The test asserts terminal workspaces do not dispatch stale recovery
+    operations and instead record `workspace.stale_callback_ignored`.
+- Keep changes minimal and avoid weakening or skipping checks: Complete.
+  - No workflow, threshold, or production behavior changes were made.
+- Run targeted validation only for the changed tests/module: Complete.
+  - Focused commands and results are listed below.
+- Record validation evidence and note broad validation ownership: Complete.
+  - Full AWF/GitHub validation and the full coverage gate were not run locally;
+    AWF and GitHub CI own broad validation after agent completion.
+
+## Evidence
+
+Files changed:
+
+- `plans/PR673_CI_COVERAGE_FIX_PLAN.md`
+- `plans/PR673_CI_COVERAGE_FIX_VALIDATION.md`
+- `tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py`
+
+Commands run:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py::test_stale_gate_handler_records_ignored_callback_for_terminal_workspace -q`
+  - Passed: `1 passed`.
+- `uv run --python 3.12 --extra dev ruff check tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py`
+  - Passed: `All checks passed!`
+- `uv run --python 3.12 --extra dev coverage run --branch -m pytest tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py::test_stale_gate_handler_records_ignored_callback_for_terminal_workspace -q && uv run --python 3.12 coverage report --include=src/awf/runtime/pr_monitor_runner/gates.py --show-missing`
+  - Test passed, then the report command exited with the repository-level
+    `fail-under=99.00` because this was intentionally a one-test targeted
+    coverage run.
+- `uv run --python 3.12 --extra dev coverage report --include=src/awf/runtime/pr_monitor_runner/gates.py --show-missing --fail-under=0`
+  - Passed and showed `gates.py` missing ranges no longer include lines
+    `487-496`; the remaining missing range resumes at `497`.
+
+## Gaps
+
+None for the saved plan. The full coverage gate is deferred to AWF/GitHub CI by
+workspace contract.

--- a/plans/PRRT_kwDOSJAM6s6LqOp2_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6LqOp2_PLAN.md
@@ -1,0 +1,37 @@
+# PRRT_kwDOSJAM6s6LqOp2 Plan
+
+## Problem Statement and Scope
+
+The review thread reports duplicated atomic clear logic in
+`src/awf/runtime/pr_monitor_runner/merge_attention.py`: the stale merge-attention
+branch and the queue-wait clear helper both perform the same locked workspace row
+transaction to remove the merge-block marker and clear workspace attention.
+
+Scope is limited to extracting the shared database transaction into a private
+coroutine and calling it from the existing two clear paths. No behavior change,
+branch management, push, or broad validation is in scope.
+
+## Requirements Checklist
+
+- Preserve the existing in-memory marker clear behavior in both callers.
+- Preserve the existing single `get_for_update` transaction that removes the
+  persisted merge-block marker and clears workspace attention.
+- Keep the missing-workspace no-op behavior.
+- Avoid unrelated refactors or test rewrites.
+- Run focused validation only; full AWF/GitHub validation remains owned by AWF
+  after agent completion.
+
+## Implementation Steps
+
+1. Replace the stale branch's inline database clear body with a call to a shared
+   private coroutine.
+2. Update `_clear_merge_block_attention_and_workspace_attention_durably` to clear
+   in-memory state and delegate the row transaction to the shared coroutine.
+3. Add the private coroutine containing the common locked row transaction.
+4. Run focused tests covering merge attention atomic-clear behavior.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Passes, confirming the existing atomic-clear, rollback, missing-workspace,
+    and helper behavior is preserved.

--- a/plans/PRRT_kwDOSJAM6s6LqOp2_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6LqOp2_VALIDATION.md
@@ -1,0 +1,38 @@
+# PRRT_kwDOSJAM6s6LqOp2 Validation
+
+Plan reference: `plans/PRRT_kwDOSJAM6s6LqOp2_PLAN.md`
+
+## Requirement Status
+
+- Preserve the existing in-memory marker clear behavior in both callers:
+  Complete. Both callers still call `state.clear_merge_block_attention()` before
+  delegating to the shared row transaction.
+- Preserve the existing single `get_for_update` transaction that removes the
+  persisted merge-block marker and clears workspace attention:
+  Complete. The common transaction now lives in
+  `_clear_merge_block_attention_and_workspace_attention_row_durably`.
+- Keep the missing-workspace no-op behavior:
+  Complete. The shared transaction still returns immediately when
+  `get_for_update` finds no workspace row.
+- Avoid unrelated refactors or test rewrites:
+  Complete. Only the targeted helper extraction and plan/validation docs changed.
+- Run focused validation only:
+  Complete. Full AWF/GitHub validation remains managed by AWF after agent
+  completion.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `plans/PRRT_kwDOSJAM6s6LqOp2_PLAN.md`
+- `plans/PRRT_kwDOSJAM6s6LqOp2_VALIDATION.md`
+
+Commands run:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Result: `20 passed in 32.76s`
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py`
+  - Result: `All checks passed!`
+
+No gaps remain.

--- a/plans/PRRT_kwDOSJAM6s6LqQs8_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6LqQs8_PLAN.md
@@ -1,0 +1,36 @@
+# PRRT_kwDOSJAM6s6LqQs8 Plan
+
+## Problem Statement and Scope
+
+The review thread reports that two merge-attention tests assert the durable
+post-lock marker is preserved, but do not assert that the in-memory
+`MonitorState.threads_addressed_ids` marker remains consistent with the
+persisted workspace marker. Scope is limited to verifying and, if valid, adding
+the missing parity assertions in `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+
+## Requirements Checklist
+
+- Verify the cited tests still lack in-memory/durable marker parity assertions.
+- Add only the minimal assertions needed to prove the in-memory marker survives
+  post-lock preservation beside the durable marker.
+- Preserve existing regression assertions and comments.
+- Run focused validation for the affected tests only; leave broad AWF/GitHub
+  validation to AWF after agent completion.
+- Commit the fix locally with a conventional commit for the review thread.
+
+## Implementation Steps
+
+1. Inspect the cited line and the related second location.
+2. Add `state.threads_addressed_ids` parity assertions after `persisted_raw` is
+   confirmed present in both affected tests.
+3. Run targeted pytest for the affected test file or specific affected tests.
+4. Record validation evidence in the companion validation document.
+5. Stage only changed files and commit.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k 'post_lock_gate_preserves_blocked_marker_without_restamping or long_coordinator_wait_preserves_fresh_at_entry_attention_across_post_lock_queue_wait'`
+
+Pass criteria: both targeted tests pass with the new parity assertions. Full
+suite, coverage, and CI-equivalent validation are intentionally not run in the
+agent phase because AWF owns broad validation after completion.

--- a/plans/PRRT_kwDOSJAM6s6LqQs8_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6LqQs8_VALIDATION.md
@@ -1,0 +1,41 @@
+# PRRT_kwDOSJAM6s6LqQs8 Validation
+
+Plan reference: `plans/PRRT_kwDOSJAM6s6LqQs8_PLAN.md`
+
+## Requirement Status
+
+- Verify the cited tests still lack in-memory/durable marker parity assertions:
+  Complete. The cited marker checks only asserted durable persistence and
+  timestamp ordering before this change.
+- Add only the minimal assertions needed to prove the in-memory marker survives
+  post-lock preservation beside the durable marker: Complete. Added one parity
+  assertion in each affected test.
+- Preserve existing regression assertions and comments: Complete. Existing
+  assertions and comments were left intact.
+- Run focused validation for the affected tests only; leave broad AWF/GitHub
+  validation to AWF after agent completion: Complete.
+- Commit the fix locally with a conventional commit for the review thread:
+  Complete.
+
+## Evidence
+
+Files changed:
+
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `plans/PRRT_kwDOSJAM6s6LqQs8_PLAN.md`
+- `plans/PRRT_kwDOSJAM6s6LqQs8_VALIDATION.md`
+
+Focused validation run:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k 'post_lock_gate_preserves_blocked_marker_without_restamping or long_coordinator_wait_preserves_fresh_at_entry_attention_across_post_lock_queue_wait'
+```
+
+Result: passed, `2 passed, 18 deselected`.
+
+Broad AWF/GitHub validation, full coverage gates, and CI-equivalent commands
+were not run in this agent phase; AWF owns those after completion.
+
+## Gaps
+
+No implementation or focused validation gaps remain.

--- a/plans/REVIEW_4555447384_PLAN.md
+++ b/plans/REVIEW_4555447384_PLAN.md
@@ -1,0 +1,32 @@
+# Review 4555447384 Repair Plan
+
+## Problem Statement and Scope
+
+CodeRabbit review-level comment `4555447384` summarized two inline test requests
+and two documentation clarity requests for PR #673. The current code must be
+verified first; only still-valid issues should be changed.
+
+## Requirements Checklist
+
+- Verify the referenced test assertions are present before editing tests.
+- Refactor the `MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md` non-goals section
+  to avoid repetitive sentence openers while preserving meaning.
+- Add a concluding validation summary after Attempt 3 in
+  `MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md` so the final validated
+  state is explicit.
+- Keep changes minimal and avoid broad AWF/GitHub-owned validation in the agent
+  phase.
+
+## Implementation Steps
+
+1. Inspect the referenced test and plan-document line ranges.
+2. Leave tests unchanged if they already contain the requested assertions.
+3. Edit only the two documentation sections needed for the valid nitpicks.
+4. Record focused validation evidence in a matching validation document.
+
+## Verification Commands and Pass Criteria
+
+- `git diff --check`
+  - Passes with no whitespace errors.
+
+Full AWF/GitHub validation remains managed by AWF after agent completion.

--- a/plans/REVIEW_4555447384_VALIDATION.md
+++ b/plans/REVIEW_4555447384_VALIDATION.md
@@ -1,0 +1,27 @@
+# Review 4555447384 Repair Validation
+
+Plan reference: `plans/REVIEW_4555447384_PLAN.md`
+
+## Requirement Status
+
+- Verify referenced test assertions are present before editing tests: Complete.
+  `tests/unit/runtime/test_merge_queue_ordering.py` already asserts
+  `fetch_calls == 1`, and `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  already compares the in-memory marker with the persisted marker.
+- Refactor the non-goals section for readability while preserving meaning:
+  Complete. `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_PLAN.md` now varies the
+  sentence openers without changing the listed non-goals.
+- Add a final validation summary after Attempt 3: Complete.
+  `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md` now states that
+  Attempt 3 is the final validated state and that its evidence satisfies the
+  plan-conformance requirements.
+- Keep changes minimal and avoid broad AWF/GitHub-owned validation: Complete.
+  Only review-targeted markdown files and this protocol pair changed.
+
+## Evidence
+
+- Inspected the referenced test ranges and confirmed no test edit was needed.
+- `git diff --check`
+  - Passed with no output.
+
+Full AWF/GitHub validation remains managed by AWF after agent completion.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -376,9 +376,10 @@ class MonitorState:
 
         Set when ``handle_merge_action``'s branch-protection fallback escalates to
         a human directly without recording a sticky blocker, so ``decide()`` keeps
-        returning ``Merge``. The non-human gate waits honor it to preserve the
-        still-active awaiting-human signal across polls instead of clearing it as a
-        resolved ``NotifyHuman`` episode.
+        returning ``Merge``. The merge critical-section entry uses this TTL check
+        to avoid clearing a still-active awaiting-human signal as a resolved
+        ``NotifyHuman`` episode. Queue/reviewer/grace waits use a fresh forge
+        mergeability signal instead.
 
         Distinguishes a STILL-blocked fallback (re-stamped every poll, fresh
         within the TTL) from a RESOLVED block (no fallback has fired recently,
@@ -522,7 +523,7 @@ class MonitorConfig:
     """Bounded TTL on the ``merge_block_attention`` marker that distinguishes a
     STILL-blocked branch-protection fallback (re-stamped every poll, fresh
     within the TTL) from a RESOLVED block (no fallback has fired recently, marker
-    age exceeds the TTL) (#661/#663).
+    age exceeds the TTL) at merge critical-section entry (#661/#663).
 
     The branch-protection fallback calls ``mark_merge_block_attention`` every
     poll while blocked, so the TTL only expires a block that has resolved

--- a/src/awf/runtime/pr_monitor_runner/gates.py
+++ b/src/awf/runtime/pr_monitor_runner/gates.py
@@ -390,9 +390,8 @@ async def _handle_merge_gate_blocker(
     )
     if grace_wait_seconds > 0:
         attention_status: PRStatus | None = status
-        if (
-            state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
-            and _merge_block_attention_queue_verdict(status) == "indeterminate"
+        if state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) and (
+            _merge_block_attention_queue_verdict(status, forge=repo.forge) == "indeterminate"
         ):
             try:
                 attention_status = await runner._fetch_status_for_decision(
@@ -407,6 +406,7 @@ async def _handle_merge_gate_blocker(
             workspace_id,
             state,
             status=attention_status,
+            forge=repo.forge,
         )
         if stale_reason is not None:
             grace_defer_payload: dict[str, object] = {

--- a/src/awf/runtime/pr_monitor_runner/gates.py
+++ b/src/awf/runtime/pr_monitor_runner/gates.py
@@ -10,15 +10,20 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import inspect
 
+from awf.common.forge_errors import ForgeClientError
 from awf.common.logging import get_logger
 from awf.db.enums import OperationStatus, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventCreate
-from awf.runtime.pr_monitor import MonitorState
+from awf.runtime.pr_monitor import _MERGE_BLOCK_ATTENTION_STATE_KEY, MonitorState
+from awf.runtime.pr_monitor_runner.merge_attention import (
+    _merge_block_attention_queue_verdict,
+)
 from awf.runtime.pr_monitor_runner.recovery_payloads import (
     _is_active_pr_monitor_recovery_operation,
     _monitor_recovery_conformance_payload,
 )
+from awf.runtime.pr_monitor_runner.types import BaseBehindCountError, BaseFetchError
 
 if TYPE_CHECKING:
     from awf.common.github_client import RepoRef
@@ -384,18 +389,25 @@ async def _handle_merge_gate_blocker(
         )
     )
     if grace_wait_seconds > 0:
-        # Resolve any stale awaiting-human flag before this non-human grace wait so
-        # a resolved ``NotifyHuman`` episode does not keep surfacing "awaiting human"
-        # while the monitor merely waits out the initial-review grace (whether the
-        # grace is deferring stale recovery or just gating an otherwise-clean merge).
-        # ``loop._execute`` excludes ``Merge`` and the manual-ready ``NotifyHuman``
-        # handoff from its general clear, so — like the other non-human gate waits in
-        # ``handle_merge_action`` — clear it here before parking (#659). An active
-        # branch-protection escalation is preserved by the helper
-        # (PRRT_kwDOSJAM6s6LXscz). PRESERVE-WHILE-QUEUED: the marker is never aged
-        # out by TTL while parked on the initial-grace wait (operator decision on
-        # #663).
-        await runner._clear_stale_merge_attention(workspace_id, state, allow_age_out=False)
+        attention_status: PRStatus | None = status
+        if (
+            state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
+            and _merge_block_attention_queue_verdict(status) == "indeterminate"
+        ):
+            try:
+                attention_status = await runner._fetch_status_for_decision(
+                    repo=repo,
+                    pr_number=pr_number,
+                    workspace_id=workspace_id,
+                    base_branch=base_branch,
+                )
+            except (ForgeClientError, BaseFetchError, BaseBehindCountError):
+                attention_status = None
+        await runner._clear_or_preserve_merge_attention_for_queue_wait(
+            workspace_id,
+            state,
+            status=attention_status,
+        )
         if stale_reason is not None:
             grace_defer_payload: dict[str, object] = {
                 "stale_reason": stale_reason,

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -28,14 +28,13 @@ def _merge_block_attention_queue_verdict(
     forge: str = "github",
 ) -> _MergeBlockAttentionQueueVerdict:
     """Classify branch-protection attention from an observable forge status."""
+    _ = forge
     if status is None:
         return "indeterminate"
     if status.merge_state_status in (MergeStateStatus.BLOCKED, MergeStateStatus.HAS_HOOKS):
         return "active"
-    if forge == "bitbucket" and status.merge_state_status is MergeStateStatus.CLEAN:
-        return "indeterminate"
     if status.merge_state_status is MergeStateStatus.CLEAN:
-        return "resolved"
+        return "indeterminate"
     return "indeterminate"
 
 
@@ -262,7 +261,8 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
 
     - branch protection still blocked -> preserve the existing marker and stable
       ``awaiting_human_since`` without re-stamping;
-    - clean/mergeable -> clear the marker and surfaced attention promptly;
+    - clean/mergeable -> preserve conservatively until a merge retry path
+      confirms resolution;
     - unknown/error -> preserve conservatively.
 
     Bitbucket open PRs map to ``CLEAN`` because Bitbucket Cloud does not expose a

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -232,16 +232,10 @@ async def _clear_stale_merge_attention(
     # touch ONLY the ``_MERGE_BLOCK_ATTENTION_STATE_KEY``, never flushing the
     # whole in-memory ``MonitorState``.
     state.clear_merge_block_attention()
-    async with self._deps.session_factory() as s:
-        repo = WorkspaceRepository(s)
-        ws = await repo.get_for_update(workspace_id)
-        if ws is None:
-            return
-        threads_addressed = dict(ws.monitor_threads_addressed or {})
-        if threads_addressed.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None) is not None:
-            ws.monitor_threads_addressed = threads_addressed
-        await repo.clear_workspace_attention(workspace_id)
-        await s.commit()
+    await _clear_merge_block_attention_and_workspace_attention_row_durably(
+        self,
+        workspace_id,
+    )
 
 
 async def _clear_or_preserve_merge_attention_for_queue_wait(
@@ -290,6 +284,17 @@ async def _clear_merge_block_attention_and_workspace_attention_durably(
 ) -> None:
     """Clear the marker and awaiting-human attention in one row transaction."""
     state.clear_merge_block_attention()
+    await _clear_merge_block_attention_and_workspace_attention_row_durably(
+        self,
+        workspace_id,
+    )
+
+
+async def _clear_merge_block_attention_and_workspace_attention_row_durably(
+    self: Any,
+    workspace_id: str,
+) -> None:
+    """Clear the persisted marker and awaiting-human attention in one transaction."""
     async with self._deps.session_factory() as s:
         repo = WorkspaceRepository(s)
         ws = await repo.get_for_update(workspace_id)

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -116,6 +116,8 @@ async def _clear_stale_merge_attention(
     state: MonitorState,
     *,
     now: datetime | None = None,
+    status: PRStatus | None = None,
+    forge: str = "github",
 ) -> None:
     """Clear a resolved attention flag at merge critical-section entry.
 
@@ -154,10 +156,13 @@ async def _clear_stale_merge_attention(
     mergeability signals without re-stamping the marker. When this helper does
     preserve a marker that is fresh at critical-section entry, it re-stamps with
     a current wall-clock and persists that single marker key durably. The
-    caller-supplied ``now`` still governs the preserve/clear decision, while the
-    fresh durable stamp keeps the critical-section TTL marker current for later
-    critical-section polls or restarts. A genuinely resolved marker (stale at
-    entry) is still cleared below.
+    caller-supplied ``now`` still governs the TTL preserve/clear decision, while
+    the fresh durable stamp keeps the critical-section TTL marker current for
+    later critical-section polls or restarts. When the current forge status
+    explicitly reports branch protection still active, preserve and re-stamp
+    even if a long queue wait aged the marker past the TTL without a fallback
+    re-stamp. A genuinely resolved marker (stale at entry with no active forge
+    signal) is still cleared below.
     """
     ttl_seconds = self._config.merge_block_attention_ttl_seconds
     reference = now if now is not None else datetime.now(UTC)
@@ -179,7 +184,8 @@ async def _clear_stale_merge_attention(
     # preserved across a serialized merge wait longer than the TTL. A marker
     # already stale at entry (the block resolved BEFORE the wait) is still
     # cleared.
-    if state.merge_block_attention_active(
+    forge_still_blocked = _merge_block_attention_queue_verdict(status, forge=forge) == "active"
+    if forge_still_blocked or state.merge_block_attention_active(
         now=reference,
         ttl_seconds=ttl_seconds if ttl_seconds is not None and ttl_seconds > 0 else None,
     ):

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -312,8 +312,8 @@ async def _clear_merge_block_attention_durably(self: Any, workspace_id: str) -> 
     ``run()`` loop only flushes ``state`` after ``_execute`` returns
     (``runner.py:455``). A cancel/restart before that full ``_persist_state``
     would otherwise reload the STALE marker from the persisted row while
-    ``awaiting_human_since`` is already null — so the next poll's
-    a later poll could then reload one side without the other, losing the
+    ``awaiting_human_since`` is already null — a later poll could then reload
+    one side without the other, losing the
     invariant that marker and surfaced attention move together
     (PRRT_kwDOSJAM6s6Lf_37).
 

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -28,13 +28,14 @@ def _merge_block_attention_queue_verdict(
     forge: str = "github",
 ) -> _MergeBlockAttentionQueueVerdict:
     """Classify branch-protection attention from an observable forge status."""
-    _ = forge
     if status is None:
         return "indeterminate"
     if status.merge_state_status in (MergeStateStatus.BLOCKED, MergeStateStatus.HAS_HOOKS):
         return "active"
     if status.merge_state_status is MergeStateStatus.CLEAN:
-        return "indeterminate"
+        if forge == "bitbucket":
+            return "indeterminate"
+        return "resolved"
     return "indeterminate"
 
 
@@ -261,8 +262,7 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
 
     - branch protection still blocked -> preserve the existing marker and stable
       ``awaiting_human_since`` without re-stamping;
-    - clean/mergeable -> preserve conservatively until a merge retry path
-      confirms resolution;
+    - clean/mergeable -> clear on GitHub because it confirms resolution;
     - unknown/error -> preserve conservatively.
 
     Bitbucket open PRs map to ``CLEAN`` because Bitbucket Cloud does not expose a

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -24,12 +24,16 @@ _MergeBlockAttentionQueueVerdict = Literal["active", "resolved", "indeterminate"
 
 def _merge_block_attention_queue_verdict(
     status: PRStatus | None,
+    *,
+    forge: str = "github",
 ) -> _MergeBlockAttentionQueueVerdict:
     """Classify branch-protection attention from an observable forge status."""
     if status is None:
         return "indeterminate"
     if status.merge_state_status in (MergeStateStatus.BLOCKED, MergeStateStatus.HAS_HOOKS):
         return "active"
+    if forge == "bitbucket" and status.merge_state_status is MergeStateStatus.CLEAN:
+        return "indeterminate"
     if status.merge_state_status is MergeStateStatus.CLEAN:
         return "resolved"
     return "indeterminate"
@@ -246,6 +250,7 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
     state: MonitorState,
     *,
     status: PRStatus | None,
+    forge: str = "github",
 ) -> None:
     """Apply the queue-wait forge verdict to ``merge_block_attention``.
 
@@ -259,12 +264,16 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
       ``awaiting_human_since`` without re-stamping;
     - clean/mergeable -> clear the marker and surfaced attention promptly;
     - unknown/error -> preserve conservatively.
+
+    Bitbucket open PRs map to ``CLEAN`` because Bitbucket Cloud does not expose a
+    GitHub-style merge-state signal, so Bitbucket ``CLEAN`` is treated like an
+    unknown signal and preserves conservatively.
     """
     if not state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY):
         state.clear_merge_block_attention()
         await self._clear_workspace_attention(workspace_id)
         return
-    verdict = _merge_block_attention_queue_verdict(status)
+    verdict = _merge_block_attention_queue_verdict(status, forge=forge)
     if verdict in ("active", "indeterminate"):
         return
     await _clear_merge_block_attention_and_workspace_attention_durably(

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -9,13 +9,30 @@ Behavior is unchanged: the functions are wired back onto the runner via
 from __future__ import annotations
 
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, Literal
 
 from awf.db.repositories import WorkspaceRepository
 from awf.runtime.pr_monitor import (
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
+    MergeStateStatus,
     MonitorState,
+    PRStatus,
 )
+
+_MergeBlockAttentionQueueVerdict = Literal["active", "resolved", "indeterminate"]
+
+
+def _merge_block_attention_queue_verdict(
+    status: PRStatus | None,
+) -> _MergeBlockAttentionQueueVerdict:
+    """Classify branch-protection attention from an observable forge status."""
+    if status is None:
+        return "indeterminate"
+    if status.merge_state_status in (MergeStateStatus.BLOCKED, MergeStateStatus.HAS_HOOKS):
+        return "active"
+    if status.merge_state_status is MergeStateStatus.CLEAN:
+        return "resolved"
+    return "indeterminate"
 
 
 async def _set_workspace_attention(self: Any, workspace_id: str, *, reason: str) -> None:
@@ -94,46 +111,18 @@ async def _clear_stale_merge_attention(
     state: MonitorState,
     *,
     now: datetime | None = None,
-    allow_age_out: bool = True,
 ) -> None:
-    """Clear a resolved ``NotifyHuman`` attention flag before a non-human gate wait,
-    unless the merge loop itself set attention for an *still-active* branch-protection
-    block.
+    """Clear a resolved attention flag at merge critical-section entry.
 
-    The merge loop's non-human gate waits (merge queue, reviewer settle, initial
-    review grace) and the merge critical-section entry clear ``awaiting_human_since``
-    so a *resolved* ``NotifyHuman`` episode does not keep surfacing "awaiting human"
-    while the monitor only waits on a non-human gate or is actively merging (#659,
-    #661). But the branch-protection fallback escalates to a human *without* a
-    sticky blocker, so ``decide()`` keeps returning ``Merge``; that attention is
-    still active while the block persists. Skipping the clear when the marker is
-    fresh keeps that signal up across a queue/settle/grace wait instead of wrongly
-    nulling it (PRRT_kwDOSJAM6s6LXscz, #663 regression).
+    This is the #661 merge-window path: once ``decide()`` resumes to ``Merge``,
+    clear stale ``NotifyHuman`` attention before the monitor parks in the
+    serialized merge lane. A merge-loop branch-protection fallback has no sticky
+    blocker, so a fresh ``merge_block_attention`` marker still means the merge
+    loop owns the surfaced human wait and must preserve it.
 
-    A bounded marker TTL distinguishes a STILL-blocked fallback (re-stamped every
-    poll, fresh within the TTL) from a RESOLVED block (no fallback has fired
-    recently, marker age exceeds the TTL) (#663). When the marker is stale the
-    helper clears it (via ``state.clear_merge_block_attention()``) and proceeds
-    with ``_clear_workspace_attention`` so the surfaced flag stops reporting
-    "awaiting human" once only non-human gates remain. When fresh (still-blocked)
-    behavior is unchanged (preserve — #663 regression intact).
-
-    PRESERVE-WHILE-QUEUED (operator decision on the #663 queue-wait tension): the
-    pre-merge non-human gate waits (merge queue, reviewer settle, initial review
-    grace) pass ``allow_age_out=False`` so the marker is NEVER aged out by TTL
-    while the monitor is parked behind a non-human gate — a still-active
-    branch-protection escalation that has resolved externally between polls is
-    indistinguishable from one that is still blocked while queued (both yield
-    ``decide()=Merge`` + queue blocker + a marker no fallback has re-stamped this
-    poll), so ageing the marker out by TTL would falsely clear a still-active
-    escalation. The marker persists until a REAL signal confirms resolution: a
-    merge re-stamp (the branch-protection fallback firing again), a successful
-    merge, or a new commit landing. The bounded false-positive (a resolved block
-    still shows "awaiting human" until the queue clears) is an ACCEPTED
-    limitation; no forge re-check is added (deferred to a follow-up). The
-    critical-section-entry clear (the #661 path) keeps ``allow_age_out=True`` so a
-    marker that was already stale at coordinator entry (the block resolved BEFORE
-    the wait) is still cleared once the monitor is actively merging.
+    Queue/reviewer/grace waits no longer use this TTL heuristic. They call
+    ``_clear_or_preserve_merge_attention_for_queue_wait`` and decide from an
+    observable forge mergeability signal instead (#671).
 
     The merge-method preflight arm needs no such guard: it records a sticky
     ``_merge_method_blocked_key`` so ``decide()`` returns ``NotifyHuman`` and these
@@ -192,38 +181,14 @@ async def _clear_stale_merge_attention(
         state.clear_merge_block_attention()
         await self._clear_workspace_attention(workspace_id)
         return
-    if not allow_age_out:
-        # PRESERVE-WHILE-QUEUED (operator decision on the #663 queue-wait
-        # tension): the monitor is parking behind a pre-merge non-human gate
-        # wait (merge queue / reviewer settle / initial review grace). While
-        # queued there is no observable signal distinguishing "block still
-        # active" from "block resolved externally between polls" — both yield
-        # ``decide()=Merge`` + queue blocker + a marker no fallback has
-        # re-stamped this poll — so ageing the marker out by TTL would
-        # falsely clear a still-active branch-protection escalation. Never
-        # age out by TTL here: the marker persists until a REAL signal
-        # confirms resolution (a merge re-stamp from the branch-protection
-        # fallback firing again, a successful merge, or a new commit
-        # landing). Re-stamp to a CURRENT wall-clock so the TTL clock resets
-        # for the next wait (PRRT_kwDOSJAM6s6LbXWQ), and persist the re-stamp
-        # durably so a cancel/restart during the wait does not strand the old
-        # marker timestamp on the DB row (PRRT_kwDOSJAM6s6LcL-G). The bounded
-        # false-positive (a resolved block still shows "awaiting human" until
-        # the queue clears) is an ACCEPTED limitation; no forge re-check is
-        # added (deferred to a follow-up).
-        stamp_now = datetime.now(UTC)
-        state.mark_merge_block_attention(now=stamp_now)
-        await self._persist_merge_block_attention_durably(workspace_id, state)
-        return
-    # ``allow_age_out=True`` (critical-section entry, the #661 path): use the
-    # bounded TTL to distinguish a STILL-blocked fallback (re-stamped every
-    # poll, fresh within the TTL) from a RESOLVED block (no fallback has fired
-    # recently, marker age exceeds the TTL). The freshness check uses
+    # Use the bounded TTL to distinguish a STILL-blocked fallback (re-stamped
+    # every poll, fresh within the TTL) from a RESOLVED block (no fallback has
+    # fired recently, marker age exceeds the TTL). The freshness check uses
     # ``reference`` (the caller-supplied ``now``): the critical-section entry
     # passes the coordinator-ENTRY timestamp so a marker FRESH at entry is
-    # preserved across a serialized merge wait longer than the TTL
-    # (PRRT_kwDOSJAM6s6La_SZ, PRRT_kwDOSJAM6s6LcfXk). A marker already stale
-    # at entry (the block resolved BEFORE the wait) is still cleared.
+    # preserved across a serialized merge wait longer than the TTL. A marker
+    # already stale at entry (the block resolved BEFORE the wait) is still
+    # cleared.
     if state.merge_block_attention_active(
         now=reference,
         ttl_seconds=ttl_seconds if ttl_seconds is not None and ttl_seconds > 0 else None,
@@ -276,13 +241,9 @@ async def _clear_stale_merge_attention(
     # (``runner.py:455``), and the prior two-commit sequence
     # (``_clear_workspace_attention`` then ``_clear_merge_block_attention_durably``)
     # left a cancel/restart window where ``awaiting_human_since`` was already
-    # nulled but the STALE marker still sat on the DB row. The next poll's
-    # ``_clear_stale_merge_attention`` — or the ``allow_age_out=False`` queue-wait
-    # preserve path — would then re-stamp the stale marker fresh and PRESERVE the
-    # human-wait signal without any fallback having fired to restore
-    # ``awaiting_human_since`` (the ``merge_loop.py`` branch-protection re-stamp
-    # only fires on an active rejection), wedging the monitor in a faux
-    # "awaiting human" state until another merge fallback runs
+    # nulled but the STALE marker still sat on the DB row. A later poll could then
+    # reload one side without the other, losing the invariant that marker and
+    # surfaced attention move together
     # (PRRT_kwDOSJAM6s6Lf_37, PRRT_kwDOSJAM6s6Lh0zt). Performing both writes under
     # one ``get_for_update`` transaction makes the marker/attention pair
     # unobservable independently — a restart can never see the cleared flag
@@ -292,6 +253,59 @@ async def _clear_stale_merge_attention(
     # single-key durable-clear pattern (``_clear_preserved_head_marker_durably``):
     # touch ONLY the ``_MERGE_BLOCK_ATTENTION_STATE_KEY``, never flushing the
     # whole in-memory ``MonitorState``.
+    state.clear_merge_block_attention()
+    async with self._deps.session_factory() as s:
+        repo = WorkspaceRepository(s)
+        ws = await repo.get_for_update(workspace_id)
+        if ws is None:
+            return
+        threads_addressed = dict(ws.monitor_threads_addressed or {})
+        if threads_addressed.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None) is not None:
+            ws.monitor_threads_addressed = threads_addressed
+        await repo.clear_workspace_attention(workspace_id)
+        await s.commit()
+
+
+async def _clear_or_preserve_merge_attention_for_queue_wait(
+    self: Any,
+    workspace_id: str,
+    state: MonitorState,
+    *,
+    status: PRStatus | None,
+) -> None:
+    """Apply the queue-wait forge verdict to ``merge_block_attention``.
+
+    Queue, reviewer-settle, and initial-grace waits do not attempt a merge, so
+    they cannot infer branch-protection state from a fresh merge rejection.
+    Instead, use the forge mergeability signal already observed for this poll
+    (or a targeted re-check performed by the caller when the signal was
+    indeterminate):
+
+    - branch protection still blocked -> preserve the existing marker and stable
+      ``awaiting_human_since`` without re-stamping;
+    - clean/mergeable -> clear the marker and surfaced attention promptly;
+    - unknown/error -> preserve conservatively.
+    """
+    if not state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY):
+        state.clear_merge_block_attention()
+        await self._clear_workspace_attention(workspace_id)
+        return
+    verdict = _merge_block_attention_queue_verdict(status)
+    if verdict in ("active", "indeterminate"):
+        return
+    await _clear_merge_block_attention_and_workspace_attention_durably(
+        self,
+        workspace_id,
+        state,
+    )
+
+
+async def _clear_merge_block_attention_and_workspace_attention_durably(
+    self: Any,
+    workspace_id: str,
+    state: MonitorState,
+) -> None:
+    """Clear the marker and awaiting-human attention in one row transaction."""
     state.clear_merge_block_attention()
     async with self._deps.session_factory() as s:
         repo = WorkspaceRepository(s)
@@ -316,12 +330,8 @@ async def _clear_merge_block_attention_durably(self: Any, workspace_id: str) -> 
     (``runner.py:455``). A cancel/restart before that full ``_persist_state``
     would otherwise reload the STALE marker from the persisted row while
     ``awaiting_human_since`` is already null — so the next poll's
-    ``_clear_stale_merge_attention`` (or the ``allow_age_out=False`` queue-wait
-    preserve path) would re-stamp the stale marker fresh and PRESERVE the
-    human-wait signal without any fallback having fired to restore
-    ``awaiting_human_since`` (the ``merge_loop.py`` branch-protection re-stamp
-    only fires on an active rejection), wedging the monitor in a faux
-    "awaiting human" state until another merge fallback runs
+    a later poll could then reload one side without the other, losing the
+    invariant that marker and surfaced attention move together
     (PRRT_kwDOSJAM6s6Lf_37).
 
     Mirrors the established single-key durable-clear pattern

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -66,13 +66,14 @@ async def _set_workspace_attention_with_merge_block_marker(
     (PRRT_kwDOSJAM6s6LbY_X), but created the RECIPROCAL window: a cancel/restart
     after the marker commit but before the attention commit leaves the DB with a
     FRESH ``__awf_merge_block_attention__`` marker but NULL
-    ``awaiting_human_since``. On the next poll, if the PR parks on a non-human gate
-    wait (merge queue / reviewer settle / initial review grace / merge lock)
-    BEFORE another merge attempt reaches the fallback, the preserve path in
-    ``_clear_stale_merge_attention`` sees the fresh marker, re-stamps it, and
-    returns WITHOUT setting ``awaiting_human_since`` — so the active
-    branch-protection escalation is never surfaced to the operator until a later
-    merge retry re-enters the fallback (PRRT_kwDOSJAM6s6Lcgk0).
+    ``awaiting_human_since``. On the next poll, if the PR reaches a preserving
+    gate before another merge attempt reaches the fallback, the merge
+    critical-section TTL path can preserve/re-stamp the marker, while queue,
+    reviewer-settle, and initial-grace waits can preserve from forge
+    mergeability signals. Neither path creates a missing ``awaiting_human_since``
+    episode, so the active branch-protection escalation would not be surfaced to
+    the operator until a later merge retry re-enters the fallback
+    (PRRT_kwDOSJAM6s6Lcgk0).
 
     Writing both the marker (merged onto ``monitor_threads_addressed``) and the
     attention columns (``awaiting_human_since`` / ``awaiting_human_reason``) on the
@@ -84,8 +85,8 @@ async def _set_workspace_attention_with_merge_block_marker(
 
     The merge-method preflight arm needs no such atomic pairing: it records a
     sticky ``_merge_method_blocked_key`` blocker that flips ``decide()`` to
-    ``NotifyHuman``, so the ``Merge``-arm non-human gate waits (and their preserve
-    path) are never reached for that head — the reciprocal window cannot form.
+    ``NotifyHuman``, so the ``Merge``-arm gate waits (and their preserve paths)
+    are never reached for that head — the reciprocal window cannot form.
     """
     stamped = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     async with self._deps.session_factory() as s:
@@ -142,32 +143,17 @@ async def _clear_stale_merge_attention(
     that was fresh when the wait started; a marker already stale at entry is
     still cleared (the block resolved before the wait).
 
-    Refresh on preserve: the branch-protection fallback only re-stamps the marker
-    when it actually runs (``handle_merge_action``'s merge-blocker arm, after the
-    serialized merge coordinator). Polls that park on a non-human gate wait
-    (merge queue, reviewer settle, initial review grace) BEFORE reaching the
-    merge attempt never re-stamp the marker, so a still-active block can age past
-    the TTL across consecutive waits and the next wait's clear would drop
-    ``awaiting_human_since`` even though the human gate is unchanged
-    (PRRT_kwDOSJAM6s6LbXWQ). Re-stamping the marker whenever this helper
-    preserves it resets the TTL clock for the next wait, so a marker that was
-    fresh when observed stays fresh across consecutive non-human gate waits.
-    The branch-protection fallback still re-stamps when it fires, and a genuinely
-    resolved marker (stale) is still cleared below.
-
-    The freshness check measures the marker's age against the caller-supplied
-    ``now`` (defaulting to the current wall-clock), but the durable re-stamp on
-    preserve ALWAYS uses a fresh ``datetime.now(UTC)``. The merge critical-section
-    entry and post-lock gate clears pass the coordinator-ENTRY timestamp as ``now``
-    so a marker FRESH at entry is preserved across a serialized merge wait longer
-    than the TTL (PRRT_kwDOSJAM6s6La_SZ, PRRT_kwDOSJAM6s6LcfXk); but that entry
-    timestamp is stale relative to real time after the wait, so re-stamping the
-    marker with it would let the marker age past the TTL during the subsequent
-    post-lock gate wait. The next poll — or a restart during that wait — would
-    then clear ``awaiting_human_since`` though the operator block never resolved
-    (PRRT_kwDOSJAM6s6LdM4X). Using a current wall-clock for the re-stamp keeps
-    the TTL clock fresh against real time going into the gate wait, while the
-    entry-time reference still governs the preserve/clear decision.
+    Refresh on preserve is now limited to this merge critical-section TTL path.
+    Queue, reviewer-settle, and initial-grace waits do not call this helper for
+    preserve decisions; they use
+    ``_clear_or_preserve_merge_attention_for_queue_wait`` and decide from forge
+    mergeability signals without re-stamping the marker. When this helper does
+    preserve a marker that is fresh at critical-section entry, it re-stamps with
+    a current wall-clock and persists that single marker key durably. The
+    caller-supplied ``now`` still governs the preserve/clear decision, while the
+    fresh durable stamp keeps the critical-section TTL marker current for later
+    critical-section polls or restarts. A genuinely resolved marker (stale at
+    entry) is still cleared below.
     """
     ttl_seconds = self._config.merge_block_attention_ttl_seconds
     reference = now if now is not None else datetime.now(UTC)
@@ -193,36 +179,24 @@ async def _clear_stale_merge_attention(
         now=reference,
         ttl_seconds=ttl_seconds if ttl_seconds is not None and ttl_seconds > 0 else None,
     ):
-        # Still-active block: refresh the marker's timestamp so the TTL clock
-        # resets for the next non-human gate wait. Without this, consecutive
-        # waits that never reach the merge-blocker fallback let the marker age
-        # past the TTL and the next wait clears the still-active signal
-        # (PRRT_kwDOSJAM6s6LbXWQ).
+        # Still-active block at merge critical-section entry: refresh the
+        # marker's timestamp so the TTL clock for this critical-section path
+        # stays current. Queue/reviewer/grace waits use forge-signal preserve
+        # decisions and do not re-stamp.
         #
-        # The durable re-stamp MUST use a CURRENT wall-clock: the entry
-        # timestamp is stale relative to real time after the wait, so stamping
-        # the marker with it would let the marker age past the TTL during the
-        # subsequent post-lock gate wait (merge queue / reviewer settle /
-        # initial review grace). The next poll — or a restart during that
-        # wait — would then measure the stale marker, exceed the TTL, clear
-        # ``awaiting_human_since``, and let the still-active branch-protection
-        # rejection re-stamp it, restarting the human-wait timer though the
-        # operator block never resolved (PRRT_kwDOSJAM6s6LdM4X). Use a fresh
-        # wall-clock for the re-stamp so the TTL clock resets against real time
-        # going into the gate wait; the freshness check is unaffected because
-        # a marker fresh at ``reference`` is still fresh at any later clock.
+        # The durable re-stamp MUST use a CURRENT wall-clock rather than the
+        # entry timestamp: ``reference`` may intentionally be older than real
+        # time after a serialized coordinator wait. Use a fresh wall-clock for
+        # the re-stamp while keeping the original entry reference for the
+        # preserve/clear decision.
         stamp_now = datetime.now(UTC)
         state.mark_merge_block_attention(now=stamp_now)
         # Persist the re-stamped marker DURABLY before returning. The outer
         # ``run()`` loop only flushes ``state`` after ``_execute`` returns
-        # (``runner.py:455``); a cancel/restart during the subsequent non-human
-        # gate wait (merge queue / reviewer settle / initial review grace)
-        # would otherwise strand the OLD marker timestamp on the DB row. On
-        # the next poll ``_clear_stale_merge_attention`` would measure the
-        # stale marker against ``now``, exceed the TTL, clear
-        # ``awaiting_human_since``, and let the still-active branch-protection
-        # rejection re-stamp it — restarting the human-wait timer even though
-        # the operator block never resolved (PRRT_kwDOSJAM6s6LcL-G). Mirrors the
+        # (``runner.py:455``); a cancel/restart before that flush would otherwise
+        # strand the OLD marker timestamp on the DB row. A later
+        # critical-section TTL check could then clear and re-surface the same
+        # still-active operator block as a new episode. Mirrors the
         # branch-protection fallback's own
         # ``mark_merge_block_attention`` + ``_persist_state`` pairing at
         # ``merge_loop.py:1424``. Persist ONLY the marker key (merged onto the
@@ -379,16 +353,15 @@ async def _persist_merge_block_attention_durably(
 ) -> None:
     """Persist ONLY the re-stamped merge-block attention marker to the DB row.
 
-    Companion to the "refresh on preserve" re-stamp in
+    Companion to the merge critical-section "refresh on preserve" re-stamp in
     :func:`_clear_stale_merge_attention`: that re-stamp lives in the in-memory
     ``state`` the outer ``run()`` loop only flushes AFTER ``_execute`` returns
-    (``runner.py:455``). A cancel/restart during the subsequent non-human gate
-    wait (merge queue / reviewer settle / initial review grace) would strand
-    the OLD marker timestamp on the persisted row; the next poll's
-    ``_clear_stale_merge_attention`` would measure the stale marker, exceed the
-    TTL, clear ``awaiting_human_since``, and let the still-active
-    branch-protection rejection re-stamp it — restarting the human-wait timer
-    even though the operator block never resolved (PRRT_kwDOSJAM6s6LcL-G).
+    (``runner.py:455``). Persisting the single marker key here avoids stranding
+    the OLD marker timestamp on the DB row after a cancel/restart before the
+    outer flush. Queue, reviewer-settle, and initial-grace waits use forge
+    mergeability signals via
+    :func:`_clear_or_preserve_merge_attention_for_queue_wait` and never use this
+    durable helper to re-stamp on preserve.
 
     Mirrors the established single-key durable persist pattern
     (``_persist_forge_transient_retry_count`` /

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -14,6 +14,7 @@ from awf.common.github_client import GitHubClientError, RepoRef
 from awf.runtime.logs import WorkspaceLogSink
 from awf.runtime.monitor_state_keys import _merge_method_blocked_key
 from awf.runtime.pr_monitor import (
+    _MERGE_BLOCK_ATTENTION_STATE_KEY,
     Merge,
     MonitorAction,
     MonitorState,
@@ -49,6 +50,9 @@ from awf.runtime.pr_monitor_runner.merge_attempts import (
     _attempt_merge_method,
     _MergeAttemptOutcome,
     _record_empty_effective_merge_methods_blocker,
+)
+from awf.runtime.pr_monitor_runner.merge_attention import (
+    _merge_block_attention_queue_verdict,
 )
 from awf.runtime.pr_monitor_runner.merge_methods import (
     _merge_method_mismatch_message,
@@ -164,19 +168,31 @@ async def handle_merge_action(
                 return cast(bool | None, handled)
 
         queue_blockers = await self._merge_queue_blockers_for_workspace(workspace_id)
+
+        async def _queue_wait_merge_attention_status(current_status: PRStatus) -> PRStatus | None:
+            if not state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY):
+                return current_status
+            if _merge_block_attention_queue_verdict(current_status) != "indeterminate":
+                return current_status
+            try:
+                return cast(
+                    PRStatus,
+                    await self._fetch_status_for_decision(
+                        repo=repo,
+                        pr_number=pr_number,
+                        workspace_id=workspace_id,
+                        base_branch=base_branch,
+                    ),
+                )
+            except (ForgeClientError, BaseFetchError, BaseBehindCountError):
+                return None
+
         if queue_blockers:
-            # Resolve any stale awaiting-human flag before this non-human gate wait:
-            # ``decide()`` returned ``Merge``, so a prior ``NotifyHuman`` block is
-            # gone and the operator signal must not stay "awaiting human" while the
-            # monitor only waits on the merge queue (#659). The branch-protection
-            # fallback also keeps ``decide()`` on ``Merge`` while genuinely awaiting a
-            # human, so the helper preserves *that* still-active signal across the
-            # queue wait (PRRT_kwDOSJAM6s6LXscz). PRESERVE-WHILE-QUEUED: while queued
-            # there is no observable signal distinguishing a still-active block from
-            # one resolved externally between polls, so the marker is NEVER aged out
-            # by TTL here — it persists until a real signal (merge re-stamp / success
-            # / new commit) confirms resolution (operator decision on #663).
-            await self._clear_stale_merge_attention(workspace_id, state, allow_age_out=False)
+            await self._clear_or_preserve_merge_attention_for_queue_wait(
+                workspace_id,
+                state,
+                status=await _queue_wait_merge_attention_status(status),
+            )
             await self._wait_for_merge_queue(
                 blockers=queue_blockers,
                 workspace_id=workspace_id,
@@ -204,14 +220,11 @@ async def handle_merge_action(
             monitor_log=monitor_log,
         )
         if settle_decision.wait_seconds > 0:
-            # Resolve any stale awaiting-human flag before this non-human settle
-            # wait so a resolved ``NotifyHuman`` episode does not keep surfacing
-            # "awaiting human" while the monitor only waits on reviewer settle (#659).
-            # An active branch-protection escalation is preserved by the helper
-            # (PRRT_kwDOSJAM6s6LXscz). PRESERVE-WHILE-QUEUED: the marker is never
-            # aged out by TTL while parked on the reviewer-settle wait (operator
-            # decision on #663).
-            await self._clear_stale_merge_attention(workspace_id, state, allow_age_out=False)
+            await self._clear_or_preserve_merge_attention_for_queue_wait(
+                workspace_id,
+                state,
+                status=await _queue_wait_merge_attention_status(status),
+            )
             requested_action = "validate" if pending_validation_gate is not None else "merge"
             settle_operation_context = _non_check_reviewer_settle_wait_operation_context(
                 self._config,
@@ -672,19 +685,10 @@ async def handle_merge_action(
                                     break
 
         if initial_grace_recheck_wait_seconds > 0:
-            # Clear any stale awaiting-human flag before this non-human grace wait
-            # so a resolved ``NotifyHuman`` episode does not keep surfacing
-            # "awaiting human" (#659); an active branch-protection escalation is
-            # preserved (PRRT_kwDOSJAM6s6LXscz). PRESERVE-WHILE-QUEUED: the
-            # marker is never aged out by TTL while parked on the initial-grace
-            # wait (operator decision on #663) — the ``allow_age_out=False``
-            # path re-stamps to a current wall-clock and persists durably
-            # regardless of the entry timestamp, so the explicit
-            # coordinator-ENTRY ``now`` is no longer needed here.
-            await self._clear_stale_merge_attention(
+            await self._clear_or_preserve_merge_attention_for_queue_wait(
                 workspace_id,
                 state,
-                allow_age_out=False,
+                status=await _queue_wait_merge_attention_status(merge_status),
             )
             _log.info(
                 "monitor.initial_review_grace_waiting",
@@ -716,13 +720,10 @@ async def handle_merge_action(
             return False
 
         if settle_recheck_decision is not None:
-            # Same stale-flag clear as the grace arm above. PRESERVE-WHILE-QUEUED:
-            # the marker is never aged out by TTL while parked on the
-            # reviewer-settle wait (operator decision on #663).
-            await self._clear_stale_merge_attention(
+            await self._clear_or_preserve_merge_attention_for_queue_wait(
                 workspace_id,
                 state,
-                allow_age_out=False,
+                status=await _queue_wait_merge_attention_status(merge_status),
             )
             settle_operation_context = _non_check_reviewer_settle_wait_operation_context(
                 self._config,
@@ -746,13 +747,10 @@ async def handle_merge_action(
             return False
 
         if queue_blockers_after_lock:
-            # Same stale-flag clear as the grace arm above. PRESERVE-WHILE-QUEUED:
-            # the marker is never aged out by TTL while parked on the post-lock
-            # merge-queue wait (operator decision on #663).
-            await self._clear_stale_merge_attention(
+            await self._clear_or_preserve_merge_attention_for_queue_wait(
                 workspace_id,
                 state,
-                allow_age_out=False,
+                status=await _queue_wait_merge_attention_status(merge_status),
             )
             await self._wait_for_merge_queue(
                 blockers=queue_blockers_after_lock,

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -172,7 +172,10 @@ async def handle_merge_action(
         async def _queue_wait_merge_attention_status(current_status: PRStatus) -> PRStatus | None:
             if not state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY):
                 return current_status
-            if _merge_block_attention_queue_verdict(current_status) != "indeterminate":
+            if (
+                _merge_block_attention_queue_verdict(current_status, forge=repo.forge)
+                != "indeterminate"
+            ):
                 return current_status
             try:
                 return cast(
@@ -192,6 +195,7 @@ async def handle_merge_action(
                 workspace_id,
                 state,
                 status=await _queue_wait_merge_attention_status(status),
+                forge=repo.forge,
             )
             await self._wait_for_merge_queue(
                 blockers=queue_blockers,
@@ -224,6 +228,7 @@ async def handle_merge_action(
                 workspace_id,
                 state,
                 status=await _queue_wait_merge_attention_status(status),
+                forge=repo.forge,
             )
             requested_action = "validate" if pending_validation_gate is not None else "merge"
             settle_operation_context = _non_check_reviewer_settle_wait_operation_context(
@@ -689,6 +694,7 @@ async def handle_merge_action(
                 workspace_id,
                 state,
                 status=await _queue_wait_merge_attention_status(merge_status),
+                forge=repo.forge,
             )
             _log.info(
                 "monitor.initial_review_grace_waiting",
@@ -724,6 +730,7 @@ async def handle_merge_action(
                 workspace_id,
                 state,
                 status=await _queue_wait_merge_attention_status(merge_status),
+                forge=repo.forge,
             )
             settle_operation_context = _non_check_reviewer_settle_wait_operation_context(
                 self._config,
@@ -751,6 +758,7 @@ async def handle_merge_action(
                 workspace_id,
                 state,
                 status=await _queue_wait_merge_attention_status(merge_status),
+                forge=repo.forge,
             )
             await self._wait_for_merge_queue(
                 blockers=queue_blockers_after_lock,

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -315,6 +315,8 @@ async def handle_merge_action(
             workspace_id,
             state,
             now=merge_critical_section_entered_at,
+            status=status,
+            forge=repo.forge,
         )
         fresh_action: MonitorAction | None = None
         fresh_status: PRStatus | None = None

--- a/src/awf/runtime/pr_monitor_runner/mixins.py
+++ b/src/awf/runtime/pr_monitor_runner/mixins.py
@@ -71,6 +71,9 @@ class RunnerDelegatesMixin:
     )
     _clear_workspace_attention = _merge_attention._clear_workspace_attention
     _clear_stale_merge_attention = _merge_attention._clear_stale_merge_attention
+    _clear_or_preserve_merge_attention_for_queue_wait = (
+        _merge_attention._clear_or_preserve_merge_attention_for_queue_wait
+    )
     _persist_merge_block_attention_durably = _merge_attention._persist_merge_block_attention_durably
     _clear_merge_block_attention_durably = _merge_attention._clear_merge_block_attention_durably
     _persist_forge_transient_retry_count = _lifecycle._persist_forge_transient_retry_count

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -738,6 +738,7 @@ async def test_merge_queue_wait_preserves_active_branch_protection_attention(
     # it because the forge still reports branch protection as blocked, not
     # because the timestamp is fresh.
     active_block_state.mark_merge_block_attention(now=datetime.now(UTC))
+    original_marker = active_block_state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     terminal = await runner._execute(
         action=Merge(),
@@ -766,46 +767,29 @@ async def test_merge_queue_wait_preserves_active_branch_protection_attention(
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
     assert workspace.awaiting_human_since == episode_start
     assert workspace.awaiting_human_reason == "GitHub rejected the merge attempt"
-    # The still-active marker was refreshed to this poll's wall-clock so the TTL
-    # clock resets for the next non-human gate wait (PRRT_kwDOSJAM6s6LbXWQ).
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY in active_block_state.threads_addressed_ids
-    refreshed_marker = active_block_state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    assert refreshed_marker != "1"
+    # Queue waits preserve from forge status and do not re-stamp the marker.
+    assert (
+        active_block_state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+        == original_marker
+    )
 
 
 @pytest.mark.unit
-async def test_clear_stale_merge_attention_restamps_preserved_marker(
+async def test_merge_critical_section_restamps_preserved_marker(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
-    """PRRT_kwDOSJAM6s6LbXWQ + PRRT_kwDOSJAM6s6LdM4X: ``_clear_stale_merge_attention``
-    must re-stamp a still-active marker so the TTL clock resets and consecutive
-    non-human gate waits do not age the marker past the TTL.
+    """#661 critical-section preserve re-stamps with a current wall-clock.
 
-    Without the re-stamp, a marker stamped once by the branch-protection fallback
-    is never refreshed during merge-queue/reviewer-settle/initial-grace waits
-    (the fallback only re-stamps when it actually runs, after the serialized
-    merge coordinator). After enough consecutive waits the marker ages past the
-    TTL and the next wait clears ``awaiting_human_since`` even though the human
-    gate is unchanged (PRRT_kwDOSJAM6s6LbXWQ).
-
-    PRRT_kwDOSJAM6s6LdM4X: the re-stamp must use a CURRENT wall-clock, not the
-    caller-supplied ``now``. The merge critical-section entry and post-lock gate
-    clears pass the coordinator-ENTRY timestamp as ``now`` so a marker FRESH at
-    entry is preserved across a serialized merge wait longer than the TTL
-    (PRRT_kwDOSJAM6s6La_SZ, PRRT_kwDOSJAM6s6LcfXk); but that entry timestamp is
-    stale relative to REAL time after the wait. Re-stamping the marker with the
-    stale entry timestamp would let the marker age past the TTL during the
-    subsequent post-lock gate wait, so the next poll — or a restart during that
-    wait — would clear ``awaiting_human_since`` though the operator block never
-    resolved. This test models that scenario directly: the caller ``now`` is a
-    stale entry timestamp (in the past, but still within the TTL of the marker
-    so the freshness check preserves it), and asserts the re-stamp is a CURRENT
-    wall-clock (within the real-now window around the call), NOT the stale
-    caller ``now``.
+    Queue/reviewer/grace waits are forge-signal driven (#671) and preserve
+    without re-stamping; this helper now covers the merge critical-section TTL
+    path only. When a marker is fresh at critical-section entry, the helper must
+    preserve it and write a current timestamp rather than the caller's older
+    entry timestamp, so a later critical-section check or restart does not age
+    the same active branch-protection block out as resolved.
     """
     workspace_id = await seed_monitoring_workspace(factory, pr_number=333)
     runner = make_runner(
@@ -824,12 +808,10 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker(
     state = MonitorState()
     state.mark_merge_block_attention(now=t_fallback)
 
-    # The coordinator-ENTRY timestamp was captured 10s ago (before a serialized
-    # merge wait). The marker age at entry is 20s (< 120s TTL) → FRESH at entry
-    # → preserved. But that entry timestamp is STALE relative to real time after
-    # the wait. The re-stamp MUST use a current wall-clock so the marker is fresh
-    # against real time going into the post-lock gate wait, NOT the stale entry
-    # timestamp.
+    # The coordinator-ENTRY timestamp was captured 10s ago. The marker age at
+    # entry is 20s (< 120s TTL), so it is fresh for the critical-section
+    # preserve decision. The re-stamp must use a current wall-clock, not the
+    # stale entry timestamp.
     stale_entry_now = real_start - timedelta(seconds=10)
     before_call = datetime.now(UTC)
     await runner._clear_stale_merge_attention(workspace_id, state, now=stale_entry_now)
@@ -839,19 +821,14 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker(
         state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
     )
     # The re-stamp is a CURRENT wall-clock (within the real-now window around
-    # the call), NOT the stale caller ``now``: the marker is fresh relative to
-    # real time going into the gate wait.
+    # the call), NOT the stale caller ``now``.
     assert first_stamp != stale_entry_now
     assert before_call <= first_stamp <= after_call
-    # And the marker age against the stale entry timestamp is now tiny (re-stamp
-    # is current, entry is in the past) rather than the 10s it was before — the
-    # TTL clock reset against real time, not the entry clock.
+    # And the stamp moved forward relative to the stale entry timestamp: the TTL
+    # clock for the critical-section path resets against real time.
     assert (first_stamp - stale_entry_now).total_seconds() >= 0
 
-    # A second preserve (modeling a later poll's post-lock clear) still preserves
-    # the marker and re-stamps it to a current wall-clock: consecutive non-human
-    # gate waits do not age the marker past the TTL because each preserve resets
-    # the clock against real time.
+    # A second critical-section preserve still keeps the marker current.
     second_before = datetime.now(UTC)
     await runner._clear_stale_merge_attention(workspace_id, state, now=stale_entry_now)
     second_after = datetime.now(UTC)
@@ -862,7 +839,7 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker(
     assert second_stamp != stale_entry_now
     assert second_before <= second_stamp <= second_after
 
-    # Parity: a genuinely RESOLVED marker (stale relative to its OWN last stamp,
+    # Parity: a genuinely RESOLVED marker (stale relative to its own last stamp,
     # well past the TTL with no re-stamp in between) is still cleared. Stamp a
     # fresh marker, then jump ``now`` past the TTL with no intervening preserve.
     resolved_state = MonitorState()
@@ -873,7 +850,7 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker(
 
 
 @pytest.mark.unit
-async def test_clear_stale_merge_attention_restamps_preserved_marker_durably(
+async def test_merge_critical_section_restamps_preserved_marker_durably(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
@@ -881,27 +858,13 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker_durably(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """PRRT_kwDOSJAM6s6LcL-G + PRRT_kwDOSJAM6s6LdM4X: the preserve re-stamp must
-    be DURABLE on the workspace row, not only in the in-memory ``state`` the loop
-    flushes later, AND must use a CURRENT wall-clock (not the caller's stale
-    ``now``).
+    """#661 critical-section preserve re-stamp is durable and current.
 
-    The outer ``run()`` loop only flushes ``state`` after ``_execute`` returns
-    (``runner.py:455``); a cancel/restart during the subsequent non-human gate
-    wait (merge queue / reviewer settle / initial review grace) would strand
-    the OLD marker timestamp on the persisted row. The next poll's
-    ``_clear_stale_merge_attention`` would then measure the stale marker
-    against ``now``, exceed the TTL, clear ``awaiting_human_since``, and let the
-    still-active branch-protection rejection re-stamp it — restarting the
-    human-wait timer even though the operator block never resolved.
-
-    The durable re-stamp uses a CURRENT wall-clock (PRRT_kwDOSJAM6s6LdM4X) so the
-    persisted marker is fresh relative to real time going into the gate wait,
-    not the stale coordinator-ENTRY timestamp the caller passes as ``now``.
-    Assert the re-stamped marker is on the persisted ``monitor_threads_addressed``
-    row WITHOUT any ``_persist_state`` flush (mirroring
-    ``test_terminal_directive_drop_clears_stale_preserved_marker_durably``),
-    and that it is a current wall-clock rather than the caller's ``now``.
+    The outer ``run()`` loop only flushes ``state`` after ``_execute`` returns.
+    This helper therefore persists the critical-section re-stamp directly, so a
+    cancel/restart cannot reload the old marker and age out the same active
+    branch-protection block. Queue/reviewer/grace waits use the #671 forge
+    signal path and do not re-stamp.
     """
     workspace_id = await seed_monitoring_workspace(factory, pr_number=334)
     runner = make_runner(
@@ -926,9 +889,8 @@ async def test_clear_stale_merge_attention_restamps_preserved_marker_durably(
     monkeypatch.setattr(runner, "_persist_state", _fail_persist_state)
 
     # Preserve + re-stamp: the caller passes a STALE coordinator-ENTRY timestamp
-    # (10s ago, marker age 20s < TTL → fresh at entry → preserved). The re-stamp
-    # must use a CURRENT wall-clock so the persisted marker is fresh against real
-    # time going into the gate wait.
+    # (10s ago, marker age 20s < TTL, so fresh at entry). The re-stamp must use
+    # a current wall-clock and be persisted directly.
     stale_entry_now = real_start - timedelta(seconds=10)
     before_call = datetime.now(UTC)
     await runner._clear_stale_merge_attention(workspace_id, state, now=stale_entry_now)

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -1078,6 +1078,55 @@ async def test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_r
 
 
 @pytest.mark.unit
+async def test_bitbucket_clean_preserves_branch_protection_marker_on_merge_queue_wait(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    """Bitbucket OPEN PRs map to CLEAN, so CLEAN is not a resolution signal."""
+    workspace_id = await seed_monitoring_workspace(
+        factory,
+        pr_number=522,
+        head_sha="b" * 40,
+    )
+    episode_start = datetime(2026, 4, 26, 11, 0, tzinfo=UTC)
+    async with factory() as session:
+        await WorkspaceRepository(session).set_workspace_attention(
+            workspace_id, reason="Bitbucket rejected the merge attempt", now=episode_start
+        )
+        await session.commit()
+    state = _stale_merge_block_state(episode_start=episode_start)
+    original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=0,
+    )
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_status(merge_state_status=MergeStateStatus.CLEAN),
+        forge="bitbucket",
+    )
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+
+    assert workspace.awaiting_human_since == episode_start
+    assert workspace.awaiting_human_reason == "Bitbucket rejected the merge attempt"
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == original_marker
+    assert (workspace.monitor_threads_addressed or {}) == {}
+
+
+@pytest.mark.unit
 async def test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -11,7 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import awf.db.repositories as repositories
 from awf.common.commands import FakeCommandRunner
-from awf.common.github_client import RepoRef
+from awf.common.github_client import GitHubClientError, RepoRef
 from awf.db.enums import AgentRuntime, OperationStatus, OperationType, TaskClass, WorkspaceStatus
 from awf.db.repositories import (
     MergeCandidateRepository,
@@ -27,6 +27,7 @@ from awf.db.session import make_session_factory
 from awf.runtime.pr_monitor import (
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
     Merge,
+    MergeStateStatus,
     MonitorState,
 )
 from awf.service.merge_queue import list_merge_queue_blockers_for_candidate
@@ -412,7 +413,7 @@ async def test_monitor_waits_for_older_candidate_without_notify_human(
         repo_url=REPO_URL,
         repo=RepoRef.from_url(REPO_URL),
         pr_number=102,
-        status=_status(),
+        status=_status(merge_state_status=MergeStateStatus.BLOCKED),
         state=MonitorState(),
         base_branch="development",
         remote_branch=f"awf/{later_workspace_id}",
@@ -733,8 +734,9 @@ async def test_merge_queue_wait_preserves_active_branch_protection_attention(
     )
 
     active_block_state = MonitorState()
-    # Stamp the marker FRESH (this poll's wall-clock) so the TTL gate treats it
-    # as still-blocked and the merge-queue wait preserves the signal (#663).
+    # The marker came from a prior merge rejection. The queue wait now preserves
+    # it because the forge still reports branch protection as blocked, not
+    # because the timestamp is fresh.
     active_block_state.mark_merge_block_attention(now=datetime.now(UTC))
 
     terminal = await runner._execute(
@@ -743,7 +745,7 @@ async def test_merge_queue_wait_preserves_active_branch_protection_attention(
         repo_url=REPO_URL,
         repo=RepoRef.from_url(REPO_URL),
         pr_number=312,
-        status=_status(),
+        status=_status(merge_state_status=MergeStateStatus.BLOCKED),
         state=active_block_state,
         base_branch="development",
         remote_branch=f"awf/{later_workspace_id}",
@@ -972,28 +974,14 @@ def _stale_merge_block_state(*, episode_start: datetime) -> MonitorState:
 
 
 @pytest.mark.unit
-async def test_resolved_branch_protection_marker_preserved_on_merge_queue_wait(
+async def test_branch_protection_marker_preserved_on_merge_queue_wait_when_forge_blocked(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
-    """#663 PRESERVE-WHILE-QUEUED (operator decision): a branch-protection block
-    that RESOLVED externally between polls is PRESERVED behind a merge-queue
-    wait, NOT cleared by TTL age-out.
-
-    While queued there is no observable signal distinguishing "block still
-    active" from "block resolved externally between polls" — both yield
-    ``decide()=Merge`` + queue blocker + a marker no fallback has re-stamped
-    this poll — so ageing the marker out by TTL would falsely clear a
-    still-active branch-protection escalation. The marker persists until a
-    REAL signal confirms resolution (a merge re-stamp / success / new commit).
-    The bounded false-positive (a resolved block still shows "awaiting human"
-    until the queue clears) is an ACCEPTED limitation; no forge re-check is
-    added (deferred to a follow-up). This reverses the prior #663 test which
-    asserted the stale marker was cleared behind a queue.
-    """
+    """#671: forge-confirmed branch protection preserves queue-wait attention."""
     now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
     _older_workspace_id, _older_attempt_id, _older_candidate_id = await _seed_monitoring_candidate(
         factory,
@@ -1016,6 +1004,7 @@ async def test_resolved_branch_protection_marker_preserved_on_merge_queue_wait(
         )
         await session.commit()
     state = _stale_merge_block_state(episode_start=episode_start)
+    original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     runner = make_runner(
         factory=factory,
@@ -1026,14 +1015,13 @@ async def test_resolved_branch_protection_marker_preserved_on_merge_queue_wait(
         initial_review_grace_period_seconds=0,
     )
 
-    before_execute = datetime.now(UTC)
     terminal = await runner._execute(
         action=Merge(),
         workspace_id=later_workspace_id,
         repo_url=REPO_URL,
         repo=RepoRef.from_url(REPO_URL),
         pr_number=322,
-        status=_status(),
+        status=_status(merge_state_status=MergeStateStatus.BLOCKED),
         state=state,
         base_branch="development",
         remote_branch=f"awf/{later_workspace_id}",
@@ -1041,7 +1029,6 @@ async def test_resolved_branch_protection_marker_preserved_on_merge_queue_wait(
         compose_file=tmp_path / "compose.yml",
         monitor_log=None,
     )
-    after_execute = datetime.now(UTC)
 
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(later_workspace_id)
@@ -1051,36 +1038,92 @@ async def test_resolved_branch_protection_marker_preserved_on_merge_queue_wait(
     assert terminal is False
     assert sleep_fn.calls == [60]
     assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
-    # PRESERVE-WHILE-QUEUED: the (stale) marker is PRESERVED behind the queue —
-    # the surfaced "awaiting human" signal stays up because resolution cannot be
-    # confirmed while queued. The bounded false-positive is accepted.
+    # Forge says branch protection is still active, so the surfaced signal stays
+    # up even though the timestamp is old. Queue waits do not re-stamp the marker.
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
     assert workspace.awaiting_human_since == episode_start
     assert workspace.awaiting_human_reason == "GitHub rejected the merge attempt"
-    # The marker was re-stamped (current wall-clock) and preserved in state, NOT
-    # aged out by TTL.
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY in state.threads_addressed_ids
-    preserved = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    assert preserved != "1"
-    # The re-stamp is a current wall-clock bracketed by the _execute call, so the
-    # TTL clock resets against real time for the next wait. Bracketing (rather
-    # than a fixed 30s threshold) is immune to CI stalls and rejects negative
-    # (future) timestamps.
-    assert before_execute <= datetime.fromisoformat(preserved) <= after_execute
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == original_marker
 
 
 @pytest.mark.unit
-async def test_resolved_branch_protection_marker_preserved_on_reviewer_settle_wait(
+async def test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
-    """#663 PRESERVE-WHILE-QUEUED parity: a RESOLVED branch-protection marker is
-    PRESERVED when the poll parks on the non-check reviewer-settle wait, NOT
-    cleared by TTL age-out (operator decision on #663).
-    """
+    """#671: forge-confirmed resolution clears queue-wait attention promptly."""
+    now = datetime(2026, 4, 26, 12, 0, tzinfo=UTC)
+    _older_workspace_id, _older_attempt_id, _older_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Older candidate resolved",
+        pr_number=421,
+        created_at=now,
+    )
+    later_workspace_id, _later_attempt_id, _later_candidate_id = await _seed_monitoring_candidate(
+        factory,
+        title="Later candidate resolved",
+        pr_number=422,
+        created_at=now + timedelta(minutes=5),
+    )
+
+    episode_start = datetime(2026, 4, 26, 11, 0, tzinfo=UTC)
+    async with factory() as session:
+        await WorkspaceRepository(session).set_workspace_attention(
+            later_workspace_id, reason="GitHub rejected the merge attempt", now=episode_start
+        )
+        await session.commit()
+    state = _stale_merge_block_state(episode_start=episode_start)
+
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=sleep_fn,
+        worktrees_root=tmp_path / "worktrees",
+        initial_review_grace_period_seconds=0,
+    )
+
+    terminal = await runner._execute(
+        action=Merge(),
+        workspace_id=later_workspace_id,
+        repo_url=REPO_URL,
+        repo=RepoRef.from_url(REPO_URL),
+        pr_number=422,
+        status=_status(merge_state_status=MergeStateStatus.CLEAN),
+        state=state,
+        base_branch="development",
+        remote_branch=f"awf/{later_workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+    )
+
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(later_workspace_id)
+        assert workspace is not None
+
+    assert terminal is False
+    assert sleep_fn.calls == [60]
+    assert not any(call.args[:3] == ["gh", "pr", "merge"] for call in cmd.calls)
+    assert workspace.status == WorkspaceStatus.monitoring_pr.value
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (workspace.monitor_threads_addressed or {})
+
+
+@pytest.mark.unit
+async def test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    cmd: FakeCommandRunner,
+    adapter: FakeAdapter,
+    sleep_fn: RecordedSleep,
+    tmp_path: Path,
+) -> None:
+    """#671 parity: forge-confirmed resolution clears reviewer-settle attention."""
     pr_number = 323
     head_sha = "c" * 40
     workspace_id = await seed_monitoring_workspace(
@@ -1116,14 +1159,13 @@ async def test_resolved_branch_protection_marker_preserved_on_reviewer_settle_wa
         non_check_reviewer_logins=("greptile-apps",),
     )
 
-    before_execute = datetime.now(UTC)
     terminal = await runner._execute(
         action=Merge(),
         workspace_id=workspace_id,
         repo_url=REPO_URL,
         repo=RepoRef.from_url(REPO_URL),
         pr_number=pr_number,
-        status=_status(head_sha=head_sha),
+        status=_status(head_sha=head_sha, merge_state_status=MergeStateStatus.CLEAN),
         state=state,
         base_branch="development",
         remote_branch=f"awf/{workspace_id}",
@@ -1131,7 +1173,6 @@ async def test_resolved_branch_protection_marker_preserved_on_reviewer_settle_wa
         compose_file=tmp_path / "compose.yml",
         monitor_log=None,
     )
-    after_execute = datetime.now(UTC)
 
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
@@ -1150,30 +1191,21 @@ async def test_resolved_branch_protection_marker_preserved_on_reviewer_settle_wa
     assert len(settle_ops) == 1
     assert workspace is not None
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
-    # PRESERVE-WHILE-QUEUED: the (stale) marker is PRESERVED behind the
-    # reviewer-settle wait — the surfaced signal stays up.
-    assert workspace.awaiting_human_since == episode_start
-    assert workspace.awaiting_human_reason == "GitHub rejected the merge attempt"
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY in state.threads_addressed_ids
-    preserved = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    assert preserved != "1"
-    # The re-stamp is a current wall-clock bracketed by the _execute call, immune
-    # to CI stalls and negative (future) timestamps (reviewer hardening).
-    assert before_execute <= datetime.fromisoformat(preserved) <= after_execute
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (workspace.monitor_threads_addressed or {})
 
 
 @pytest.mark.unit
-async def test_resolved_branch_protection_marker_preserved_on_initial_grace_wait(
+async def test_branch_protection_marker_preserved_on_initial_grace_wait_when_recheck_errors(
     factory: async_sessionmaker[AsyncSession],
     cmd: FakeCommandRunner,
     adapter: FakeAdapter,
     sleep_fn: RecordedSleep,
     tmp_path: Path,
 ) -> None:
-    """#663 PRESERVE-WHILE-QUEUED parity: a RESOLVED branch-protection marker is
-    PRESERVED when the poll parks on the initial-review-grace wait, NOT cleared
-    by TTL age-out (operator decision on #663).
-    """
+    """#671 conservative default: failed forge re-check preserves attention."""
     pr_number = 324
     workspace_id = await seed_monitoring_workspace(factory, pr_number=pr_number)
 
@@ -1185,6 +1217,7 @@ async def test_resolved_branch_protection_marker_preserved_on_initial_grace_wait
         )
         await session.commit()
     state = _stale_merge_block_state(episode_start=episode_start)
+    original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     runner = make_runner(
         factory=factory,
@@ -1195,14 +1228,22 @@ async def test_resolved_branch_protection_marker_preserved_on_initial_grace_wait
         initial_review_grace_period_seconds=900,
     )
 
-    before_execute = datetime.now(UTC)
+    async def _fail_fetch_status(*_args: object, **_kwargs: object) -> None:
+        raise GitHubClientError(
+            operation="fetch_pr_status",
+            returncode=1,
+            stderr="HTTP 502 Bad Gateway",
+        )
+
+    runner._fetch_status_for_decision = _fail_fetch_status  # type: ignore[method-assign]
+
     terminal = await runner._execute(
         action=Merge(),
         workspace_id=workspace_id,
         repo_url=REPO_URL,
         repo=RepoRef.from_url(REPO_URL),
         pr_number=pr_number,
-        status=_status(),
+        status=_status(merge_state_status=MergeStateStatus.UNKNOWN),
         state=state,
         base_branch="development",
         remote_branch=f"awf/{workspace_id}",
@@ -1210,7 +1251,6 @@ async def test_resolved_branch_protection_marker_preserved_on_initial_grace_wait
         compose_file=tmp_path / "compose.yml",
         monitor_log=None,
     )
-    after_execute = datetime.now(UTC)
 
     async with factory() as session:
         workspace = await WorkspaceRepository(session).get(workspace_id)
@@ -1229,13 +1269,8 @@ async def test_resolved_branch_protection_marker_preserved_on_initial_grace_wait
     assert len(grace_ops) == 1
     assert workspace is not None
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
-    # PRESERVE-WHILE-QUEUED: the (stale) marker is PRESERVED behind the
-    # initial-grace wait — the surfaced signal stays up.
+    # The current status was indeterminate and the targeted re-check errored, so
+    # preserve conservatively without re-stamping.
     assert workspace.awaiting_human_since == episode_start
     assert workspace.awaiting_human_reason == "GitHub rejected the merge attempt"
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY in state.threads_addressed_ids
-    preserved = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    assert preserved != "1"
-    # The re-stamp is a current wall-clock bracketed by the _execute call, immune
-    # to CI stalls and negative (future) timestamps (reviewer hardening).
-    assert before_execute <= datetime.fromisoformat(preserved) <= after_execute
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == original_marker

--- a/tests/unit/runtime/test_merge_queue_ordering.py
+++ b/tests/unit/runtime/test_merge_queue_ordering.py
@@ -1239,7 +1239,11 @@ async def test_branch_protection_marker_preserved_on_initial_grace_wait_when_rec
         initial_review_grace_period_seconds=900,
     )
 
+    fetch_calls = 0
+
     async def _fail_fetch_status(*_args: object, **_kwargs: object) -> None:
+        nonlocal fetch_calls
+        fetch_calls += 1
         raise GitHubClientError(
             operation="fetch_pr_status",
             returncode=1,
@@ -1282,6 +1286,7 @@ async def test_branch_protection_marker_preserved_on_initial_grace_wait_when_rec
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
     # The current status was indeterminate and the targeted re-check errored, so
     # preserve conservatively without re-stamping.
+    assert fetch_calls == 1
     assert workspace.awaiting_human_since == episode_start
     assert workspace.awaiting_human_reason == "GitHub rejected the merge attempt"
     assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == original_marker

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -379,6 +379,56 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
 
 
 @pytest.mark.unit
+async def test_clean_status_preserves_merge_block_attention_during_queue_wait(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6LqkOW: GitHub ``CLEAN`` during a queue-style wait is not
+    proof that a prior deterministic merge rejection has resolved.
+
+    The status that led into the prior merge attempt can already have been
+    ``CLEAN`` because the branch-protection fallback records no sticky blocker
+    and ``decide()`` keeps returning ``Merge``. If the next poll parks behind a
+    queue/reviewer/grace wait before retrying the merge, preserve the active
+    operator attention until the retry path confirms resolution.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    episode_start = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    state = MonitorState()
+    state.mark_merge_block_attention()
+    marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: marker}
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub rejected the merge attempt"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == "GitHub rejected the merge attempt"
+
+
+@pytest.mark.unit
 async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -379,18 +379,16 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
 
 
 @pytest.mark.unit
-async def test_clean_status_preserves_merge_block_attention_during_queue_wait(
+async def test_bitbucket_clean_status_preserves_merge_block_attention_during_queue_wait(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """PRRT_kwDOSJAM6s6LqkOW: GitHub ``CLEAN`` during a queue-style wait is not
-    proof that a prior deterministic merge rejection has resolved.
+    """Bitbucket ``CLEAN`` during a queue-style wait is not proof that a prior
+    deterministic merge rejection has resolved.
 
-    The status that led into the prior merge attempt can already have been
-    ``CLEAN`` because the branch-protection fallback records no sticky blocker
-    and ``decide()`` keeps returning ``Merge``. If the next poll parks behind a
-    queue/reviewer/grace wait before retrying the merge, preserve the active
-    operator attention until the retry path confirms resolution.
+    Bitbucket maps open PRs to ``CLEAN`` because it does not expose GitHub's
+    branch-protection merge-state signal. Preserve active operator attention for
+    that forge while GitHub ``CLEAN`` clears as a confirmed resolution.
     """
     workspace_id = await seed_monitoring_workspace(factory)
     runner = make_runner(
@@ -409,14 +407,14 @@ async def test_clean_status_preserves_merge_block_attention_during_queue_wait(
         assert ws is not None
         ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: marker}
         ws.awaiting_human_since = episode_start
-        ws.awaiting_human_reason = "GitHub rejected the merge attempt"
+        ws.awaiting_human_reason = "Bitbucket rejected the merge attempt"
         await session.commit()
 
     await runner._clear_or_preserve_merge_attention_for_queue_wait(
         workspace_id,
         state,
         status=_mergeable_status(),
-        forge="github",
+        forge="bitbucket",
     )
 
     assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
@@ -425,7 +423,7 @@ async def test_clean_status_preserves_merge_block_attention_during_queue_wait(
         assert ws_after is not None
     assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
     assert ws_after.awaiting_human_since == episode_start
-    assert ws_after.awaiting_human_reason == "GitHub rejected the merge attempt"
+    assert ws_after.awaiting_human_reason == "Bitbucket rejected the merge attempt"
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -498,6 +498,7 @@ async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
     assert ws.awaiting_human_reason is not None
     persisted_raw = (ws.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     assert persisted_raw is not None
+    assert state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) == persisted_raw
     assert persisted_raw != original_marker
     assert coordinator.yielded_at is not None
     assert datetime.fromisoformat(persisted_raw) < coordinator.yielded_at
@@ -746,6 +747,7 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
     assert ws.awaiting_human_reason is not None
     persisted_raw = (ws.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     assert persisted_raw is not None
+    assert state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) == persisted_raw
     assert persisted_raw != original_marker
     assert coordinator.yielded_at is not None
     assert datetime.fromisoformat(persisted_raw) < coordinator.yielded_at

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -918,6 +918,60 @@ async def test_clear_stale_merge_attention_drops_marker_durably_on_resolve(
 
 
 @pytest.mark.unit
+async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6LqhqC: a long queue wait can preserve an old
+    ``merge_block_attention`` marker without re-stamping it. When merge
+    critical-section entry sees the forge still reporting branch protection as
+    active, it must not treat the TTL-aged marker as resolved and clear
+    ``awaiting_human_since``.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    old_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp})
+    episode_start = datetime(2024, 1, 1, 12, tzinfo=UTC)
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp}
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub rejected the merge attempt"
+        await session.commit()
+
+    before_call = datetime.now(UTC)
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=datetime(2024, 1, 2, tzinfo=UTC),
+        status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
+        forge="github",
+    )
+    after_call = datetime.now(UTC)
+
+    refreshed_stamp = datetime.fromisoformat(
+        state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    )
+    assert before_call <= refreshed_stamp <= after_call
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == "GitHub rejected the merge attempt"
+    assert (ws_after.monitor_threads_addressed or {})[
+        _MERGE_BLOCK_ATTENTION_STATE_KEY
+    ] == refreshed_stamp.isoformat()
+
+
+@pytest.mark.unit
 async def test_clear_stale_merge_attention_atomic_clear_marker_absent_on_row_still_clears_attention(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -28,6 +28,7 @@ from awf.db.session import make_session_factory
 from awf.runtime.pr_monitor import (
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
     Merge,
+    MergeStateStatus,
     MonitorConfig,
     MonitorState,
 )
@@ -234,6 +235,7 @@ class _LongWaitMergeCoordinator:
     def __init__(self, wait_seconds: float) -> None:
         self._wait_seconds = wait_seconds
         self.entries: list[tuple[str, str]] = []
+        self.yielded_at: datetime | None = None
 
     @asynccontextmanager
     async def serialized_merge(
@@ -245,6 +247,7 @@ class _LongWaitMergeCoordinator:
         self.entries.append((repo_url, base_branch))
         # Real sleep so datetime.now(UTC) advances past the TTL inside the wait.
         await asyncio.sleep(self._wait_seconds)
+        self.yielded_at = datetime.now(UTC)
         yield
 
 
@@ -376,50 +379,15 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
 
 
 @pytest.mark.unit
-async def test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestamp(
+async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """PRRT_kwDOSJAM6s6LdM4X: after a serialized merge wait, the post-lock
-    non-human gate clear must re-stamp a FRESH-at-entry
-    ``merge_block_attention`` marker to a CURRENT wall-clock, not the
-    coordinator-ENTRY timestamp.
+    """#671: post-lock queue waits preserve only on forge-confirmed blockage.
 
-    The freshness check at the critical-section ENTRY still uses the entry
-    timestamp so a marker fresh at entry is preserved across the long wait
-    (PRRT_kwDOSJAM6s6La_SZ, PRRT_kwDOSJAM6s6LcfXk). But the durable re-stamp
-    that follows the preserve MUST be fresh relative to REAL time: the entry
-    timestamp is stale after the wait, so stamping the marker with it would let
-    the marker age past the TTL during the subsequent post-lock gate wait (merge
-    queue / reviewer settle / initial review grace). The next poll — or a
-    restart during that wait — would then measure the stale marker, exceed the
-    TTL, clear ``awaiting_human_since``, and let the still-active
-    branch-protection rejection re-stamp it, restarting the human-wait timer
-    though the operator block never resolved.
-
-    This test reproduces the review-thread scenario: a serialized merge wait,
-    then a post-lock queue blocker parks the monitor on a non-human gate wait.
-    It asserts the persisted marker on the row is a current wall-clock (within
-    the real-now window around the post-lock clear), NOT the coordinator-ENTRY
-    timestamp, so the signal survives the post-lock wait and a restart during
-    it.
-
-    The post-lock ``allow_age_out=False`` preserve is TTL-independent: it always
-    re-stamps with a current ``datetime.now(UTC)`` regardless of marker age, so
-    the regression under test (re-stamp with the stale entry timestamp) is
-    exercised purely by asserting that persisted re-stamp is a current
-    wall-clock strictly later than the entry window. The TTL only governs the
-    critical-section-entry clear's preserve/clear decision, so it just has to
-    keep the marker FRESH at that entry clear: the marker is stamped by the
-    test before ``_execute``, and the setup gap inside ``_execute`` (scope
-    policy refresh, merge-gate fetch, queue-blockers lookup, settle decision,
-    status fetch) is variable and can exceed a tiny TTL under CI load — which
-    would make the entry clear misclassify a fresh-at-setup marker as stale and
-    clear ``awaiting_human_since`` (a flaky false failure, not the regression
-    under test). A 30s TTL absorbs any plausible setup gap (matching the
-    sibling ``test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention``
-    rationale) while the 1.5s coordinator wait still advances real time past the
-    entry window so the post-lock re-stamp is strictly later than it.
+    The old queue preserve path re-stamped markers after the coordinator wait.
+    The signal is now forge-driven: ``BLOCKED`` preserves the existing marker and
+    stable timer without refreshing the timestamp.
     """
     workspace_id = await seed_monitoring_workspace(factory)
     sleep_fn = RecordedSleep()
@@ -452,11 +420,9 @@ async def test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestam
     # TTL is too tight under CI load (the setup gap can exceed it, making the
     # marker stale at entry and clearing ``awaiting_human_since`` — a flaky false
     # failure, not the regression under test). 30s absorbs any plausible setup
-    # gap. The post-lock ``allow_age_out=False`` preserve is TTL-independent
-    # (always re-stamps with a current wall-clock), so the regression under test
-    # (re-stamp with the stale entry timestamp) is exercised without the wait
-    # having to exceed the TTL; the 1.5s wait still advances real time past the
-    # entry window so the post-lock re-stamp is strictly later than it.
+    # gap. The post-lock queue wait is now forge-signal-driven; this setup only
+    # needs the critical-section-entry clear to preserve the marker before the
+    # serialized wait.
     monitor_config = MonitorConfig(
         auto_merge=True,
         poll_interval_seconds=60,
@@ -494,14 +460,10 @@ async def test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestam
         )
         await session.commit()
     state = MonitorState()
-    # Stamp the marker FRESH at this poll's entry — still-blocked. The 30s TTL
-    # absorbs the variable setup gap inside ``_execute`` so the marker is still
-    # fresh at the critical-section-entry clear. Capture the entry-window upper
-    # bound so the persisted re-stamp (taken AFTER the 1.5s wait) can be asserted
-    # strictly later than the entry timestamp — the post-lock preserve re-stamps
-    # with a CURRENT wall-clock, not the stale entry timestamp.
+    # Stamp the marker FRESH at this poll's entry so the #661 critical-section
+    # entry clear preserves it. The later post-lock queue wait must not re-stamp.
     state.mark_merge_block_attention()
-    entry_wall_clock_after = datetime.now(UTC)
+    original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     terminal = await runner._execute(
         action=Merge(),
@@ -509,7 +471,7 @@ async def test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestam
         repo_url=f"git@github.com:{_TEST_REPO.slug()}.git",
         repo=_TEST_REPO,
         pr_number=_TEST_PR_NUMBER,
-        status=_mergeable_status(),
+        status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
         state=state,
         base_branch=_TEST_DEFAULT_BASE_BRANCH,
         remote_branch=f"awf/{workspace_id}",
@@ -534,24 +496,11 @@ async def test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestam
     # reset (no flicker/restart of the human-wait timer).
     assert ws.awaiting_human_since == episode_start
     assert ws.awaiting_human_reason is not None
-    # The persisted marker is NOT the coordinator-ENTRY timestamp (which would
-    # be ~entry_wall_clock_before/after). It is a CURRENT wall-clock taken at the
-    # post-lock clear, so the marker is fresh relative to real time going into
-    # the post-lock gate wait. The post-lock ``allow_age_out=False`` preserve
-    # always re-stamps with ``datetime.now(UTC)`` (TTL-independent), so this
-    # assertion is what guards the PRRT_kwDOSJAM6s6LdM4X regression: a
-    # re-introduction of the stale entry-timestamp re-stamp would fail it.
     persisted_raw = (ws.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     assert persisted_raw is not None
-    persisted_stamp = datetime.fromisoformat(persisted_raw)
-    # The entry timestamp was captured before the 1.5s wait; the persisted
-    # re-stamp is taken AFTER the wait, so it must be strictly later than the
-    # entry-window upper bound (the wait alone advanced the clock past it).
-    assert persisted_stamp > entry_wall_clock_after
-    # And the persisted re-stamp is within the post-lock clear window (it is a
-    # current wall-clock at that clear, not the entry timestamp). Allow a loose
-    # upper bound to absorb DB round-trip latency under CI load.
-    assert (datetime.now(UTC) - persisted_stamp).total_seconds() < 30.0
+    assert persisted_raw != original_marker
+    assert coordinator.yielded_at is not None
+    assert datetime.fromisoformat(persisted_raw) < coordinator.yielded_at
 
 
 @pytest.mark.unit
@@ -677,26 +626,7 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """PRRT_kwDOSJAM6s6LcfXk: a serialized-merge wait longer than the merge-block
-    TTL must NOT clear a ``merge_block_attention`` marker that was FRESH at
-    coordinator entry when a post-lock queue blocker parks the monitor on a
-    non-human gate wait.
-
-    The critical-section-entry clear re-stamps a fresh marker to the entry
-    timestamp. The serialized merge coordinator can block behind another merge
-    for longer than the TTL with no branch-protection fallback firing (no poll
-    runs during the wait). Before the fix, the post-lock queue-blocker clear
-    measured the marker's age against the post-wait wall-clock (``now=None``),
-    so a marker fresh at entry aged past the TTL during the wait and was
-    misclassified as RESOLVED — clearing ``awaiting_human_since`` even though
-    the branch-protection block was still active. On the next poll the
-    fallback re-stamps via COALESCE, restarting the human-wait timer though
-    the operator block never resolved.
-
-    The fix passes the coordinator-ENTRY timestamp to the post-lock clears too,
-    so a marker fresh when the wait started stays fresh across the post-lock
-    queue wait; the attention signal is preserved.
-    """
+    """#671: a long coordinator wait still preserves when the forge says blocked."""
     workspace_id = await seed_monitoring_workspace(factory)
     sleep_fn = RecordedSleep()
     gh = _MergeMethodClient(
@@ -775,11 +705,11 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
         )
         await session.commit()
     state = MonitorState()
-    # Stamp the marker FRESH at this poll's entry — still-blocked. The
-    # coordinator wait (1.5s) exceeds the TTL (1.0s), so without the entry-time
-    # reference the post-lock queue clear would measure the marker against the
-    # post-wait wall-clock, age it past the TTL, and clear the signal.
+    # Stamp the marker FRESH at this poll's entry so the #661 critical-section
+    # entry clear preserves it. The later post-lock queue wait is decided by the
+    # forge ``BLOCKED`` signal, not marker age.
     state.mark_merge_block_attention()
+    original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     terminal = await runner._execute(
         action=Merge(),
@@ -787,7 +717,7 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
         repo_url=f"git@github.com:{_TEST_REPO.slug()}.git",
         repo=_TEST_REPO,
         pr_number=_TEST_PR_NUMBER,
-        status=_mergeable_status(),
+        status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
         state=state,
         base_branch=_TEST_DEFAULT_BASE_BRANCH,
         remote_branch=f"awf/{workspace_id}",
@@ -814,6 +744,11 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
     # reset (no flicker/restart of the human-wait timer).
     assert ws.awaiting_human_since == episode_start
     assert ws.awaiting_human_reason is not None
+    persisted_raw = (ws.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
+    assert persisted_raw is not None
+    assert persisted_raw != original_marker
+    assert coordinator.yielded_at is not None
+    assert datetime.fromisoformat(persisted_raw) < coordinator.yielded_at
 
 
 # ── Defensive no-op branches for the new atomic-persist helpers ──────────────
@@ -940,10 +875,8 @@ async def test_clear_stale_merge_attention_drops_marker_durably_on_resolve(
     in-memory ``state`` after ``_execute`` returns (``runner.py:455``); a
     cancel/restart before that full ``_persist_state`` would otherwise reload the
     STALE marker from the DB while ``awaiting_human_since`` is already null, so
-    the next poll's preserve path (or an ``allow_age_out=False`` queue-wait) would
-    re-stamp the stale marker fresh and PRESERVE the human-wait signal without
-    any fallback having fired to restore ``awaiting_human_since`` — wedging the
-    monitor in a faux "awaiting human" state until another merge fallback runs.
+    a later poll could otherwise observe the stale marker without the cleared
+    attention flag, losing the invariant that both pieces move together.
     """
     workspace_id = await seed_monitoring_workspace(factory)
     runner = make_runner(
@@ -970,7 +903,6 @@ async def test_clear_stale_merge_attention_drops_marker_durably_on_resolve(
         workspace_id,
         state,
         now=resolved_now,
-        allow_age_out=True,
     )
     # In-memory marker dropped and attention cleared.
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
@@ -1025,7 +957,6 @@ async def test_clear_stale_merge_attention_atomic_clear_marker_absent_on_row_sti
         workspace_id,
         state,
         now=resolved_now,
-        allow_age_out=True,
     )
     # In-memory marker dropped.
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
@@ -1319,7 +1250,6 @@ async def test_clear_stale_merge_attention_atomic_clear_rolls_back_together(
             workspace_id,
             state,
             now=resolved_now,
-            allow_age_out=True,
         )
     # A session was opened (the failing-commit one) — the runner attempted the
     # atomic clear, and the trap recorded exactly the single commit attempt the
@@ -1413,7 +1343,6 @@ async def test_clear_stale_merge_attention_atomic_clear_distinguishes_two_commit
         workspace_id,
         state,
         now=resolved_now,
-        allow_age_out=True,
     )
 
     # The atomic implementation performs EXACTLY one commit. A reintroduced
@@ -1456,7 +1385,6 @@ async def test_clear_stale_merge_attention_atomic_clear_missing_workspace_skips_
         "ws_does_not_exist",
         state,
         now=datetime(2024, 1, 2, tzinfo=UTC),
-        allow_age_out=True,
     )
     # In-memory marker is still dropped (the caller's signal), but no DB write
     # was attempted against a missing row.

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_013.py
@@ -39,6 +39,10 @@ from awf.runtime.pr_monitor_runner import (
     MonitorRunnerConfig,
     PullRequestMonitorRunner,
 )
+from awf.runtime.pr_monitor_runner.gates import (
+    _handle_merge_gate_blocker,
+    _MergeGateResult,
+)
 from awf.runtime.pr_monitor_runner.types import (
     BaseBehindCountError,
     BaseFetchError,
@@ -334,6 +338,68 @@ async def test_stale_recovery_dispatch_ignores_terminal_workspace_race(
         "callback_action": "recovery_dispatch",
         "expected_status": WorkspaceStatus.monitoring_pr.value,
         "actual_status": final_status.value,
+        "requested_status": WorkspaceStatus.ready.value,
+        "reason_code": "STALE_CALLBACK_IGNORED",
+    }
+
+
+@pytest.mark.unit
+async def test_stale_gate_handler_records_ignored_callback_for_terminal_workspace(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _force_workspace_status(factory, workspace_id, WorkspaceStatus.completed)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        assert ws is not None
+
+    handled = await _handle_merge_gate_blocker(
+        runner,
+        gate=_MergeGateResult(
+            workspace=ws,
+            stale_reason="validation_missing_for_current_head",
+            req_action="validate",
+        ),
+        workspace_id=workspace_id,
+        repo_url="git@github.com:dimileeh/aira-web.git",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        status=_status_for_helpers(),
+        state=MonitorState(),
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        monitor_log=None,
+        skip_initial_review_grace=True,
+    )
+
+    async with factory() as s:
+        refreshed = await WorkspaceRepository(s).get(workspace_id)
+        assert refreshed is not None
+        operations = await OperationRepository(s).list_all(workspace_id=workspace_id)
+        ignored_events = [
+            event
+            for event in refreshed.events
+            if event.event_type == "workspace.stale_callback_ignored"
+        ]
+
+    assert handled is True
+    assert refreshed.status == WorkspaceStatus.completed.value
+    assert operations == []
+    assert ignored_events[-1].payload == {
+        "callback_source": "pr_monitor",
+        "callback_action": "recovery_dispatch",
+        "expected_status": WorkspaceStatus.monitoring_pr.value,
+        "actual_status": WorkspaceStatus.completed.value,
         "requested_status": WorkspaceStatus.ready.value,
         "reason_code": "STALE_CALLBACK_IGNORED",
     }


### PR DESCRIPTION
## Summary

Fixes #671 by replacing the queue-wait `merge_block_attention` age/TTL heuristic with observable forge mergeability and branch-protection signals.

This consolidates the #667 false-clear and #668/#669 indefinite-re-stamp failure modes:

- forge still blocked (`BLOCKED` / `HAS_HOOKS`) preserves the existing marker and stable `awaiting_human_since`;
- forge resolved (`CLEAN` for GitHub) clears the marker and workspace attention promptly;
- forge errors or indeterminate status preserve conservatively;
- Bitbucket `CLEAN` is treated as indeterminate during queue/reviewer/grace waits.

The TTL re-stamp path remains scoped to merge critical-section entry, while merge-queue, reviewer-settle, and initial-grace waits now use forge-signal-driven clear/preserve behavior.

## Validation

Focused validation recorded in the checked-in validation artifacts:

- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py tests/unit/runtime/test_pr_monitor_merge_attention.py -q` -> `40 passed`
- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/mixins.py tests/unit/runtime/test_merge_queue_ordering.py tests/unit/runtime/test_pr_monitor_merge_attention.py` -> passed
- `uv run --python 3.12 --extra dev mypy src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/gates.py src/awf/runtime/pr_monitor_runner/mixins.py` -> passed
- Additional focused regressions for queue wait, critical-section restamp, GitHub `CLEAN`, Bitbucket `CLEAN`, and error-conservative preservation are documented in `plans/MERGE_BLOCK_ATTENTION_FORGE_RECHECK_VALIDATION.md` and `plans/BITBUCKET_CLEAN_QUEUE_ATTENTION_VALIDATION.md`.

AWF/GitHub own the broad post-agent validation, coverage gate, and merge gating after this workspace completes.

## Release Readiness

Affects the PR monitor surface: merge-block attention and `awaiting_human_since` during merge-queue, reviewer-settle, initial-grace, and merge critical-section handling.

Operator-visible behavior is conservative on uncertainty: AWF preserves attention when the forge state cannot confirm resolution, and clears only when the forge signal confirms the branch-protection block has resolved.

## Security / Secrets

No secrets, tokens, credentials, logs containing secrets, fixtures, screenshots, or new secret handling paths were added.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible PR monitor attention during merge queue and related waits; behavior is conservative on errors but alters when `awaiting_human_since` clears vs persists across GitHub/Bitbucket.
> 
> **Overview**
> Replaces **queue/reviewer/grace wait** decisions for `merge_block_attention` and `awaiting_human_since` with **forge merge-state signals** instead of marker age and queue-side re-stamping (#671).
> 
> **Queue-style waits** now call `_clear_or_preserve_merge_attention_for_queue_wait`, which classifies status via `_merge_block_attention_queue_verdict`: `BLOCKED` / `HAS_HOOKS` preserves the marker without re-stamping; GitHub `CLEAN` clears marker and attention; unknown or failed re-check preserves conservatively. **Bitbucket** treats `CLEAN` as indeterminate (open PRs map to `CLEAN`), so attention is not cleared on that signal alone. Indeterminate polls can trigger a targeted status refresh in `gates.py` / `merge_loop.py` before deciding.
> 
> **Merge critical-section entry** still uses the #661 TTL path in `_clear_stale_merge_attention`, but now accepts current `status`/`forge` so an **active forge block** can preserve and re-stamp even when the marker is TTL-stale after a long queue wait. Atomic marker+attention clears are deduplicated into a shared row transaction helper.
> 
> Tests and plan/validation docs are updated for forge-blocked/resolved/error and Bitbucket behavior; a small **coverage** test covers a terminal-workspace branch in `gates.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6522616841ae8bfcdbb8fb8cb82f5045623b2831. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced merge queue handling to more accurately preserve branch protection status during queue waits based on GitHub/Bitbucket forge signals.
  * Improved branch protection marker preservation when merge status is indeterminate or still blocked, preventing premature clearing of stale markers.
  * Fixed handling differences between GitHub `CLEAN` status and Bitbucket behavior during queue-wait scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->