### PR TITLE
Release: sync development → main (merge-attention clock seam + CLEAN hardening #675/#677)

### DIFF
--- a/plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_PLAN.md
+++ b/plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_PLAN.md
@@ -1,0 +1,47 @@
+# CI Full Coverage Origin Branch Plan
+
+## Problem Statement and Scope
+
+PR #678 now passes the prior Python coverage shard failures, but the current
+GitHub Actions run fails `python-full-coverage` at 98.996%, just under the 99%
+combined line+branch threshold. The downloaded coverage report identifies
+uncovered branches in the merge-block attention origin helper, specifically the
+persisted and explicit non-merge-rejection origin paths.
+
+Scope is limited to owned runtime PR monitor tests. Do not change coverage
+thresholds, workflow/configuration files, or production behavior unless the
+focused tests expose a real implementation defect.
+
+## Requirements Checklist
+
+- [ ] Add meaningful regression tests for merge-block attention origin behavior
+      that is currently untested.
+- [ ] Cover persisted merge-rejection origin so a restarted monitor preserves
+      operator attention through a GitHub `CLEAN` queue wait.
+- [ ] Cover persisted non-merge origin so ordinary branch-protection attention
+      clears when GitHub reports `CLEAN`.
+- [ ] Cover explicit in-memory non-merge origin precedence so stale persisted
+      merge-rejection origin cannot preserve an ordinary marker.
+- [ ] Run only focused local verification for the changed tests and lint surface.
+- [ ] Record validation evidence and leave broad AWF/GitHub validation to the
+      post-agent workflow.
+
+## Implementation Steps
+
+1. Add focused tests to the existing merge-attention persistence test module.
+2. Assert both in-memory marker state and persisted workspace attention fields
+   for preserve and clear outcomes.
+3. Run the targeted pytest tests that exercise the new cases.
+4. Run a focused lint check for the changed test file and plan/validation docs
+   if supported by the repo tooling.
+5. Create the validation document and commit the scoped repair locally.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest <new targeted tests> -q`
+  - Passes: the new regression tests succeed against Postgres.
+- `uv run --python 3.12 --extra dev ruff check tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+  - Passes: the changed test file has no lint issues.
+
+Full AWF/GitHub validation, including the exact full coverage gate, is managed
+after agent completion and must not be run broadly inside this repair cycle.

--- a/plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_VALIDATION.md
+++ b/plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_VALIDATION.md
@@ -1,0 +1,55 @@
+# CI Full Coverage Origin Branch Validation
+
+Plan reference: `plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_PLAN.md`
+
+## Requirement Status
+
+- Complete: Add meaningful regression tests for merge-block attention origin
+  behavior that was uncovered by the full coverage report.
+- Complete: Cover persisted merge-rejection origin. The new restart-style test
+  verifies GitHub `CLEAN` queue waits preserve attention when the row carries
+  merge-rejection origin.
+- Complete: Cover persisted non-merge origin. The new test verifies GitHub
+  `CLEAN` clears ordinary attention and removes both marker and origin keys.
+- Complete: Cover explicit in-memory non-merge origin precedence. The new test
+  verifies current state clears even when the row still contains older
+  merge-rejection origin.
+- Complete: Run focused local verification only. No broad coverage gate or full
+  AWF validation suite was run inside the agent phase.
+
+## Evidence
+
+Files changed:
+
+- `tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+- `plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_PLAN.md`
+- `plans/CI_FULL_COVERAGE_ORIGIN_BRANCH_VALIDATION.md`
+
+Focused commands run:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_preserves_persisted_merge_rejection_origin_after_restart tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_clears_persisted_non_rejection_origin_when_github_clean tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_uses_in_memory_non_rejection_origin_before_persisted_origin -q
+```
+
+Result: `3 passed in 4.21s`
+
+```bash
+uv run --python 3.12 --extra dev ruff check tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
+```
+
+Result: `All checks passed!`
+
+```bash
+uv run --python 3.12 --extra dev ruff format tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
+```
+
+Result: `1 file reformatted`
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q
+```
+
+Result after formatting: `15 passed in 16.88s`
+
+Full AWF/GitHub validation, including the exact `python-full-coverage` gate, is
+managed after agent completion per the workspace contract.

--- a/plans/CI_MERGE_ATTENTION_TEST_SPLIT_PLAN.md
+++ b/plans/CI_MERGE_ATTENTION_TEST_SPLIT_PLAN.md
@@ -1,0 +1,60 @@
+# CI Merge Attention Test Split Plan
+
+## Problem Statement And Scope
+
+PR #678 fails CI in two visible Python coverage shards:
+
+- `python-coverage-shards (8)` fails because
+  `tests/unit/runtime/test_pr_monitor_merge_attention.py` has grown to 1,618
+  lines, exceeding the repository maintainability guard's 1,500-line maximum
+  for first-party files.
+- `python-coverage-shards (5)` fails because stale branch-protection attention
+  remains set when GitHub reports a clean mergeability status before the monitor
+  parks on merge-queue or reviewer-settle waits.
+
+Scope is limited to merge-attention cleanup in
+`src/awf/runtime/pr_monitor_runner/merge_attention.py`, focused tests under
+`tests/**`, and the plan/validation documents.
+
+## Requirements Checklist
+
+- [ ] Keep all first-party files at or below the 1,500-line maintainability
+      guard.
+- [ ] Preserve the existing merge-attention regression coverage and assertions.
+- [ ] Clear stale, non-structured merge-block attention before clean GitHub
+      merge-queue and reviewer-settle waits.
+- [ ] Preserve structured merge-rejection-origin attention until an actual merge
+      retry confirms resolution.
+- [ ] Avoid broad AWF/GitHub-owned validation; run only focused local commands
+      that prove the split and the affected tests.
+- [ ] Commit the CI repair locally without pushing.
+
+## Implementation Steps
+
+1. Move the lower-level merge-attention persistence helper regressions from the
+   oversized module into a focused sibling test module.
+2. Keep shared fixtures/imports local to each module so tests remain readable
+   and independent.
+3. Reproduce the two shard-5 failures locally.
+4. Make structured merge-rejection origin authoritative for queue/reviewer wait
+   preservation, avoiding ambiguous reason-text preservation for stale generic
+   branch-protection attention.
+5. Run the maintainability guard and the affected merge-attention and
+   merge-queue tests.
+6. Record verification evidence in
+   `plans/CI_MERGE_ATTENTION_TEST_SPLIT_VALIDATION.md`.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_core_decomposition_maintainability.py::test_first_party_code_files_stay_under_line_limit -q`
+  - Passes with no oversized files.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q`
+  - Passes, preserving the split test coverage.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved -q`
+  - Passes, proving stale clean-status attention is cleared before non-human
+    waits.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_status_preserves_merge_rejection_attention_during_queue_wait tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_structured_merge_rejection_preserve_uses_state_not_db -q`
+  - Passes, proving structured merge-rejection-origin attention is still
+    preserved.
+
+Full AWF/GitHub validation remains managed by AWF after agent completion.

--- a/plans/CI_MERGE_ATTENTION_TEST_SPLIT_VALIDATION.md
+++ b/plans/CI_MERGE_ATTENTION_TEST_SPLIT_VALIDATION.md
@@ -1,0 +1,61 @@
+# CI Merge Attention Test Split Validation
+
+Plan reference: `plans/CI_MERGE_ATTENTION_TEST_SPLIT_PLAN.md`
+
+## Requirement Status
+
+- Complete: Keep all first-party files at or below the 1,500-line
+  maintainability guard.
+  - Evidence: `tests/unit/runtime/test_pr_monitor_merge_attention.py` is 998
+    lines and `tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+    is 655 lines.
+- Complete: Preserve the existing merge-attention regression coverage and
+  assertions.
+  - Evidence: the persistence-helper and atomic-clear regressions were moved
+    unchanged into
+    `tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`.
+- Complete: Clear stale, non-structured merge-block attention before clean
+  GitHub merge-queue and reviewer-settle waits.
+  - Evidence: the two shard-5 failing tests were reproduced locally before the
+    fix, then passed after making structured merge-rejection origin authoritative
+    for preservation.
+- Complete: Preserve structured merge-rejection-origin attention until an
+  actual merge retry confirms resolution.
+  - Evidence: focused structured-origin preservation tests passed after the
+    change.
+- Complete: Avoid broad AWF/GitHub-owned validation.
+  - Evidence: only targeted ruff and pytest commands listed below were run.
+    Full AWF/GitHub validation remains managed by AWF after agent completion.
+- Complete: Commit the CI repair locally without pushing.
+  - Evidence: local commit will be created after this validation document is
+    written; no push is performed by the agent.
+
+## Commands Run
+
+- `uv run --python 3.12 --extra dev ruff check tests/unit/runtime/test_pr_monitor_merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+  - Passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_core_decomposition_maintainability.py::test_first_party_code_files_stay_under_line_limit -q`
+  - Passed: `1 passed in 0.41s`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q`
+  - Passed before the behavior fix: `23 passed in 30.91s`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved -q`
+  - Failed before the fix, matching CI shard 5: both tests left
+    `workspace.awaiting_human_since` set.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py tests/unit/runtime/test_merge_queue_ordering.py`
+  - Passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_merge_queue_wait_when_forge_resolved tests/unit/runtime/test_merge_queue_ordering.py::test_branch_protection_marker_cleared_on_reviewer_settle_wait_when_forge_resolved -q`
+  - Passed after the fix: `2 passed in 4.76s`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_status_preserves_merge_rejection_attention_during_queue_wait tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_structured_merge_rejection_preserve_uses_state_not_db -q`
+  - Passed after the fix: `2 passed in 3.07s`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/test_core_decomposition_maintainability.py::test_first_party_code_files_stay_under_line_limit -q`
+  - Re-run after the behavior fix; passed: `1 passed in 0.41s`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q`
+  - Re-run after the behavior fix; passed: `23 passed in 30.78s`.
+
+## Files Changed
+
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `plans/CI_MERGE_ATTENTION_TEST_SPLIT_PLAN.md`
+- `plans/CI_MERGE_ATTENTION_TEST_SPLIT_VALIDATION.md`

--- a/plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_PLAN.md
+++ b/plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_PLAN.md
@@ -1,0 +1,46 @@
+# Merge Attention CLEAN DB Round-Trip Plan
+
+## Problem Statement and Scope
+
+Greptile reported that GitHub `CLEAN` handling for an active merge-block attention
+marker opens a fresh database session to decide whether the marker originated from
+a merge rejection. The current branch already stores structured merge-rejection
+origin in `MonitorState`, so queue-wait `CLEAN` preservation should use that
+in-memory state before falling back to persisted legacy reason text.
+
+Scope is limited to `src/awf/runtime/pr_monitor_runner/merge_attention.py` and
+focused unit coverage for this behavior.
+
+## Requirements Checklist
+
+- Avoid a database read on GitHub `CLEAN` queue-wait polls when the in-memory
+  merge-block marker has structured merge-rejection origin.
+- Preserve the existing legacy fallback for rows whose persisted state predates
+  structured origin metadata.
+- Keep existing CLEAN behavior: merge-rejection origin preserves, ordinary
+  non-rejection markers clear.
+- Add focused regression coverage for the no-session structured-origin path.
+- Run only targeted tests/checks; AWF/GitHub owns broad validation after agent
+  completion.
+
+## Implementation Steps
+
+1. Change the merge-rejection-origin helper to accept `MonitorState` and return
+   immediately when the structured origin is present in memory.
+2. Keep the existing DB-backed compatibility read only when state lacks structured
+   origin metadata.
+3. Update call sites in merge-attention helpers.
+4. Add a unit test that monkeypatches the runner session factory to fail and
+   proves a structured merge-rejection marker under GitHub `CLEAN` preserves
+   without opening a session.
+
+## Verification Commands and Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Passes.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_state.py -q`
+  - Passes.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passes.
+
+Full AWF/GitHub validation is intentionally not run inside this agent phase.

--- a/plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_VALIDATION.md
+++ b/plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_VALIDATION.md
@@ -1,0 +1,50 @@
+# Merge Attention CLEAN DB Round-Trip Validation
+
+Plan reference: `plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_PLAN.md`
+
+## Requirement Status
+
+- Avoid a database read on GitHub `CLEAN` queue-wait polls when structured
+  merge-rejection origin is in memory: Complete.
+  - `_merge_block_attention_originated_from_merge_rejection` now returns from
+    `MonitorState.merge_block_attention_originated_from_merge_rejection()` before
+    opening a session.
+  - Added `test_github_clean_structured_merge_rejection_preserve_uses_state_not_db`,
+    which fails if the structured-origin preserve path touches `session_factory`.
+
+- Preserve legacy fallback for rows predating structured origin metadata:
+  Complete.
+  - The existing DB-backed workspace read and human-reason compatibility check
+    remains in place when the structured origin key is absent from state.
+
+- Keep existing CLEAN behavior for rejection vs non-rejection markers: Complete.
+  - Existing queue-wait regression tests still cover GitHub `CLEAN` preserve for
+    rejection-origin attention and clear for ordinary non-rejection attention.
+
+- Add focused regression coverage: Complete.
+  - New regression coverage added in
+    `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+
+- Run only targeted validation: Complete.
+  - Full AWF/GitHub validation was not run in the agent phase; AWF owns broad
+    validation, provenance, and merge gating after completion.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_PLAN.md`
+- `plans/MERGE_ATTENTION_CLEAN_DB_ROUNDTRIP_VALIDATION.md`
+
+Focused commands run:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  - Passed: `23 passed in 30.94s`
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_state.py -q`
+  - Passed: `10 passed in 0.79s`
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  - Passed: `All checks passed!`
+
+No remaining planned gaps.

--- a/plans/MERGE_ATTENTION_CLOCK_SEAM_PLAN.md
+++ b/plans/MERGE_ATTENTION_CLOCK_SEAM_PLAN.md
@@ -1,0 +1,42 @@
+# Merge Attention Clock Seam Plan
+
+## Problem Statement
+
+Fix #675 and #677 in the merge-block attention path. The fresh-at-entry
+regressions must use a deterministic clock so they fail against post-wait
+wall-clock classification, and queue/reviewer/grace waits must not clear a
+merge-rejection-origin marker merely because GitHub reports `CLEAN`.
+
+## Requirements Checklist
+
+- Add one runner now-provider seam, defaulting to `datetime.now(UTC)`.
+- Use the seam for merge critical-section entry, merge-block marker stamps,
+  freshness checks, durable re-stamps, and workspace attention timestamps in the
+  touched merge-attention path.
+- Tighten both fresh-at-entry regressions with a small TTL and fake clock.
+- Add a regression for GitHub `CLEAN` preserving merge-rejection-origin
+  attention.
+- Preserve the GitHub-vs-Bitbucket `CLEAN` asymmetry for non-rejection
+  observable resolution.
+- Keep changes scoped to merge-attention timing/clock logic and focused tests.
+- Run only focused validation; broad AWF/GitHub validation remains post-agent.
+
+## Implementation Steps
+
+1. Add the now-provider dependency and route existing `datetime.now(UTC)` reads
+   in `merge_loop.py` and `merge_attention.py` through it.
+2. Update merge-rejection marker stamping to pass the injected time.
+3. Harden queue-wait clearing so GitHub `CLEAN` resolves ordinary markers but
+   preserves merge-rejection-origin attention.
+4. Replace real-sleep TTL regressions with fake-clock coordinator advances.
+5. Add the #677 regression and revise the #671 asymmetry test minimally.
+6. Run the targeted merge-attention test file and focused lint/type checks if
+   signatures changed.
+
+## Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py src/awf/runtime/pr_monitor_runner/runner.py src/awf/runtime/pr_monitor_runner/types.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+
+Full suite, coverage gates, and CI-equivalent validation are intentionally left
+to AWF after completion.

--- a/plans/MERGE_ATTENTION_CLOCK_SEAM_VALIDATION.md
+++ b/plans/MERGE_ATTENTION_CLOCK_SEAM_VALIDATION.md
@@ -1,0 +1,83 @@
+# Merge Attention Clock Seam Validation
+
+Plan reference: `plans/MERGE_ATTENTION_CLOCK_SEAM_PLAN.md`
+
+## Requirement Status
+
+- Add one runner now-provider seam: Complete.
+  - Added `now` to `_RunnerDeps` and `PullRequestMonitorRunner`, defaulting to
+    `datetime.now(UTC)` via `_utcnow`.
+
+- Use the seam for merge critical-section entry, marker stamps, freshness
+  checks, durable re-stamps, and workspace attention timestamps: Complete.
+  - Updated `merge_loop.py` critical-section entry, merge-rejection marker
+    stamping, and merge critical-section grace decoration.
+  - Updated `merge_attention.py` attention writes, TTL reference fallback, and
+    durable re-stamp time.
+
+- Tighten both fresh-at-entry regressions with a small TTL and fake clock:
+  Complete.
+  - Added `_FakeClock` and deterministic `_LongWaitMergeCoordinator`.
+  - Retightened the long coordinator wait and post-lock queue wait regressions to
+    `merge_block_attention_ttl_seconds=1.0`.
+
+- Add #677 regression for GitHub `CLEAN` preserving merge-rejection-origin
+  attention: Complete.
+  - Added
+    `test_github_clean_status_preserves_merge_rejection_attention_during_queue_wait`.
+
+- Preserve GitHub-vs-Bitbucket `CLEAN` asymmetry for non-rejection observable
+  resolution: Complete.
+  - Kept Bitbucket `CLEAN` preservation.
+  - Added
+    `test_github_clean_status_clears_non_rejection_attention_during_queue_wait`.
+
+- Keep scope minimal: Complete.
+  - Touched only merge-attention/merge-loop clock logic, runner dependency
+    plumbing, focused tests, and required plan/validation docs.
+
+## Evidence
+
+Initial red check:
+
+```bash
+uv run --python 3.12 --extra dev pytest \
+  tests/unit/runtime/test_pr_monitor_merge_attention.py::test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention \
+  tests/unit/runtime/test_pr_monitor_merge_attention.py::test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_post_lock_queue_wait \
+  tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_status_preserves_merge_rejection_attention_during_queue_wait -q
+```
+
+Result before implementation: failed as expected because `now=` was unsupported
+and GitHub `CLEAN` cleared the merge-rejection marker.
+
+Focused passing checks:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q
+```
+
+Result: `21 passed in 28.27s`.
+
+```bash
+uv run --python 3.12 --extra dev ruff check \
+  src/awf/runtime/pr_monitor_runner/merge_attention.py \
+  src/awf/runtime/pr_monitor_runner/merge_loop.py \
+  src/awf/runtime/pr_monitor_runner/runner.py \
+  src/awf/runtime/pr_monitor_runner/types.py \
+  tests/unit/runtime/test_pr_monitor_merge_attention.py
+```
+
+Result: passed.
+
+```bash
+uv run --python 3.12 --extra dev mypy \
+  src/awf/runtime/pr_monitor_runner/merge_attention.py \
+  src/awf/runtime/pr_monitor_runner/merge_loop.py \
+  src/awf/runtime/pr_monitor_runner/runner.py \
+  src/awf/runtime/pr_monitor_runner/types.py
+```
+
+Result: passed.
+
+Full AWF/GitHub validation, full coverage, and CI-equivalent suites were not run
+inside the agent phase per the workspace contract.

--- a/plans/MERGE_ATTENTION_DB_ORIGIN_PLAN.md
+++ b/plans/MERGE_ATTENTION_DB_ORIGIN_PLAN.md
@@ -1,0 +1,29 @@
+# Merge Attention DB Origin Plan
+
+## Problem Statement And Scope
+
+An unresolved PR review thread reports that a GitHub `CLEAN` queue/reviewer/grace wait can preserve merge-block attention because the merge-rejection origin exists only in the workspace row, while the in-memory `MonitorState` still lacks `__awf_merge_block_attention_origin__`. The outer monitor loop later persists the full in-memory state, which can overwrite `monitor_threads_addressed` and erase the DB-derived origin.
+
+Scope is limited to `src/awf/runtime/pr_monitor_runner/merge_attention.py` and focused regression coverage under `tests/`.
+
+## Requirements Checklist
+
+- Reproduce the reported state-loss path with a focused regression test.
+- Preserve existing behavior for explicit in-memory non-rejection origins.
+- Copy DB-derived merge-rejection origin into in-memory state before returning from the queue-wait preserve branch.
+- Avoid broad refactors or unrelated validation.
+- Commit the local fix with a conventional commit message tied to the thread id.
+
+## Implementation Steps
+
+1. Add a regression test that seeds a persisted merge-rejection origin, calls `_clear_or_preserve_merge_attention_for_queue_wait()`, then calls `_persist_state()` and verifies the origin remains durable.
+2. Update merge-attention origin detection/preserve logic so DB-derived merge-rejection origin is materialized into `MonitorState`.
+3. Run the focused regression test file or specific tests only.
+4. Create `plans/MERGE_ATTENTION_DB_ORIGIN_VALIDATION.md` with requirement-by-requirement evidence.
+5. Stage only changed files and commit locally.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q`
+
+Pass criteria: the new regression and existing merge-attention persistence tests pass. Full AWF/GitHub validation is managed after agent completion and is intentionally not run here.

--- a/plans/MERGE_ATTENTION_DB_ORIGIN_VALIDATION.md
+++ b/plans/MERGE_ATTENTION_DB_ORIGIN_VALIDATION.md
@@ -1,0 +1,33 @@
+# Merge Attention DB Origin Validation
+
+Plan reference: `plans/MERGE_ATTENTION_DB_ORIGIN_PLAN.md`
+
+## Requirement Status
+
+- Reproduce the reported state-loss path with a focused regression test: Complete.
+  - Updated `tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_preserves_persisted_merge_rejection_origin_after_restart` to call `_persist_state()` after the queue-wait preserve helper.
+  - Confirmed the regression failed before the implementation change with `KeyError: '__awf_merge_block_attention_origin__'`.
+- Preserve existing behavior for explicit in-memory non-rejection origins: Complete.
+  - Existing focused persistence tests still cover explicit non-rejection origin precedence.
+- Copy DB-derived merge-rejection origin into in-memory state before returning from the queue-wait preserve branch: Complete.
+  - `src/awf/runtime/pr_monitor_runner/merge_attention.py` now copies the structured DB origin into `MonitorState` when `_merge_block_attention_originated_from_merge_rejection()` recovers it from the workspace row.
+- Avoid broad refactors or unrelated validation: Complete.
+  - Changes are limited to the merge-attention helper, the focused regression test, and plan/validation documents.
+- Commit the local fix with a conventional commit message tied to the thread id: Complete.
+
+## Evidence
+
+- Focused failing regression before implementation:
+  - `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_preserves_persisted_merge_rejection_origin_after_restart -q`
+  - Result before fix: failed with missing in-memory `__awf_merge_block_attention_origin__`.
+- Focused passing regression after implementation:
+  - `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py::test_queue_wait_preserves_persisted_merge_rejection_origin_after_restart -q`
+  - Result: passed.
+- Focused persistence suite:
+  - `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py -q`
+  - Result: `15 passed`.
+- Focused lint:
+  - `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py`
+  - Result: passed.
+
+Full AWF/GitHub validation is managed by AWF after agent completion and was intentionally not run in this workspace repair phase.

--- a/plans/MERGE_REJECTION_ORIGIN_PLAN.md
+++ b/plans/MERGE_REJECTION_ORIGIN_PLAN.md
@@ -1,0 +1,41 @@
+# Merge Rejection Origin Plan
+
+## Problem Statement and Scope
+
+PR review thread `PRRT_kwDOSJAM6s6L1IlT` reports that merge-rejection
+preservation is inferred from the user-facing `awaiting_human_reason` text.
+That makes machine behavior depend on a human-readable message.
+
+Scope is limited to merge-block attention markers in
+`src/awf/runtime/pr_monitor.py`,
+`src/awf/runtime/pr_monitor_runner/merge_attention.py`, and focused tests.
+
+## Requirements Checklist
+
+- Store merge-rejection origin as structured monitor state instead of relying on
+  `awaiting_human_reason` text for new markers.
+- Persist the origin marker atomically with the existing merge-block marker and
+  attention row update.
+- Clear the origin marker whenever the merge-block marker is cleared.
+- Preserve compatibility for already-persisted legacy merge-rejection markers
+  that only have the prior reason text.
+- Add focused regression coverage proving a changed human-readable reason still
+  preserves merge-rejection attention when the structured origin flag is set.
+
+## Implementation Steps
+
+1. Add a reserved merge-block origin key/value and helper methods to
+   `MonitorState`.
+2. Mark deterministic merge API rejections with the structured origin when the
+   merge loop stamps the merge-block attention marker.
+3. Update durable marker persist/clear paths to include/remove the origin key.
+4. Replace the primary string-based origin check with structured marker lookup,
+   retaining a legacy fallback only for older rows without the origin marker.
+5. Update focused merge-attention tests and run the narrow affected test subset.
+
+## Verification Commands
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_state.py tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+
+Full AWF/GitHub validation is managed after agent completion and will not be run
+inside this repair cycle.

--- a/plans/MERGE_REJECTION_ORIGIN_RESTAMP_PLAN.md
+++ b/plans/MERGE_REJECTION_ORIGIN_RESTAMP_PLAN.md
@@ -1,0 +1,29 @@
+# Merge Rejection Origin Restamp Plan
+
+## Problem Statement And Scope
+
+PR review thread `PRRT_kwDOSJAM6s6L1ZHt` reports that
+`_clear_stale_merge_attention` can preserve a TTL-stale merge-rejection marker
+but re-stamp it without the structured merge-rejection origin. The scope is
+limited to preserving that origin during the critical-section re-stamp path and
+covering the behavior with a focused regression test.
+
+## Requirements Checklist
+
+- Verify the review claim against the local `merge_attention.py` and
+  `MonitorState` behavior.
+- Add or update a focused regression test that fails when the structured
+  merge-rejection origin is lost during stale critical-section preservation.
+- Change only the re-stamp behavior needed for this review thread.
+- Run focused tests for the changed behavior only. Full AWF/GitHub validation is
+  managed after the agent phase.
+
+## Implementation Steps
+
+1. Update the existing critical-section merge-rejection preservation regression
+   to assert the structured origin remains in memory and in the persisted row.
+2. Pass `originated_from_merge_rejection=True` when the preserve branch is
+   specifically preserving a merge-rejection-origin marker.
+3. Run the targeted unit test for the regression.
+4. Record validation evidence in
+   `plans/MERGE_REJECTION_ORIGIN_RESTAMP_VALIDATION.md`.

--- a/plans/MERGE_REJECTION_ORIGIN_RESTAMP_VALIDATION.md
+++ b/plans/MERGE_REJECTION_ORIGIN_RESTAMP_VALIDATION.md
@@ -1,0 +1,35 @@
+# Merge Rejection Origin Restamp Validation
+
+Plan reference: `plans/MERGE_REJECTION_ORIGIN_RESTAMP_PLAN.md`
+
+## Requirement Status
+
+- Verify the review claim against local code: Complete. `MonitorState.merge_block_attention_active(...)`
+  clears stale markers via `clear_merge_block_attention()`, which also removes
+  the structured origin before the preserve re-stamp branch.
+- Add focused regression coverage: Complete. The existing critical-section
+  merge-rejection preservation test now asserts the origin survives in memory and
+  in `monitor_threads_addressed`.
+- Change only the required re-stamp behavior: Complete. The preserve branch now
+  passes `originated_from_merge_rejection=True` when the marker was already known
+  or proven to come from a merge rejection.
+- Run focused checks only: Complete. Full AWF/GitHub validation is managed after
+  agent completion.
+
+## Evidence
+
+- Changed `src/awf/runtime/pr_monitor_runner/merge_attention.py`.
+- Changed `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+- Added this validation note and the corresponding plan.
+
+Focused commands:
+
+```bash
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py::test_github_clean_status_preserves_stale_merge_rejection_attention_at_critical_section -q
+uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q
+uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py
+```
+
+Results: all focused checks passed after implementation. The single regression
+failed before the production change with a missing
+`__awf_merge_block_attention_origin__` key, confirming the reviewer-reported bug.

--- a/plans/MERGE_REJECTION_ORIGIN_VALIDATION.md
+++ b/plans/MERGE_REJECTION_ORIGIN_VALIDATION.md
@@ -1,0 +1,45 @@
+# Merge Rejection Origin Validation
+
+Plan reference: `MERGE_REJECTION_ORIGIN_PLAN.md`
+
+## Requirement Status
+
+- Store merge-rejection origin as structured monitor state instead of relying on
+  `awaiting_human_reason` text for new markers: Complete.
+- Persist the origin marker atomically with the existing merge-block marker and
+  attention row update: Complete.
+- Clear the origin marker whenever the merge-block marker is cleared: Complete.
+- Preserve compatibility for already-persisted legacy merge-rejection markers
+  that only have the prior reason text: Complete, via a prefix-only fallback when
+  no structured origin key exists.
+- Add focused regression coverage proving a changed human-readable reason still
+  preserves merge-rejection attention when the structured origin flag is set:
+  Complete.
+
+## Evidence
+
+Changed files:
+
+- `src/awf/runtime/pr_monitor.py`
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `src/awf/runtime/pr_monitor_runner/merge_loop.py`
+- `tests/unit/runtime/test_pr_monitor_state.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+
+Test-first failure:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_state.py tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  failed before implementation with `TypeError` for the new
+  `originated_from_merge_rejection` marker API.
+
+Passing focused checks:
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_state.py tests/unit/runtime/test_pr_monitor_merge_attention.py -q`
+  passed: 32 tests.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py tests/unit/runtime/test_pr_monitor_state.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  passed.
+- `uv run --python 3.12 --extra dev mypy src/awf/runtime/pr_monitor.py src/awf/runtime/pr_monitor_runner/merge_attention.py src/awf/runtime/pr_monitor_runner/merge_loop.py`
+  passed.
+
+Full AWF/GitHub validation is managed after agent completion and was not run in
+this repair cycle.

--- a/plans/MERGE_REJECTION_STALE_ATTENTION_PLAN.md
+++ b/plans/MERGE_REJECTION_STALE_ATTENTION_PLAN.md
@@ -1,0 +1,41 @@
+# Merge Rejection Stale Attention Plan
+
+## Problem Statement And Scope
+
+PR review thread `PRRT_kwDOSJAM6s6L1FjH` reports that
+`_clear_stale_merge_attention` can clear a TTL-stale merge-block marker that
+originated from a deterministic merge rejection even when GitHub reports
+`CLEAN`. Actor/push restrictions can be invisible to `mergeStateStatus`, so the
+critical-section entry path should preserve that attention until the merge retry
+confirms success or re-stamps the rejection.
+
+Scope is limited to `src/awf/runtime/pr_monitor_runner/merge_attention.py` and
+focused regression coverage in `tests/unit/runtime/test_pr_monitor_merge_attention.py`.
+
+## Requirements Checklist
+
+- Add a failing regression for a TTL-stale merge-block marker whose persisted
+  `awaiting_human_reason` says GitHub rejected the merge attempt while status is
+  `CLEAN`.
+- Preserve and durably re-stamp that marker at merge critical-section entry.
+- Keep existing stale non-rejection behavior: ordinary resolved markers still
+  clear attention and the marker.
+- Run only focused tests for the touched behavior.
+- Record validation evidence in a matching validation document.
+
+## Implementation Steps
+
+1. Add the focused regression test first and confirm it fails.
+2. Update `_clear_stale_merge_attention` to apply the merge-rejection-origin
+   preservation check before the stale clear.
+3. Re-run the focused regression and nearby merge-attention tests that cover the
+   stale clear/preserve contract.
+4. Create `plans/MERGE_REJECTION_STALE_ATTENTION_VALIDATION.md` with requirement
+   status and evidence.
+
+## Verification Commands And Pass Criteria
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "github_clean_status_preserves_stale_merge_rejection_attention_at_critical_section or clear_stale_merge_attention_drops_marker_durably_on_resolve or clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked or github_clean_status_clears_non_rejection_attention_during_queue_wait"`
+
+Pass criteria: the new regression and nearby stale clear/preserve tests pass.
+Full AWF/GitHub validation is managed by AWF after agent completion.

--- a/plans/MERGE_REJECTION_STALE_ATTENTION_VALIDATION.md
+++ b/plans/MERGE_REJECTION_STALE_ATTENTION_VALIDATION.md
@@ -1,0 +1,43 @@
+# Merge Rejection Stale Attention Validation
+
+Plan reference: `plans/MERGE_REJECTION_STALE_ATTENTION_PLAN.md`
+
+## Requirement Status
+
+- Add a failing regression for a TTL-stale merge-block marker whose persisted
+  `awaiting_human_reason` says GitHub rejected the merge attempt while status is
+  `CLEAN`: Complete.
+- Preserve and durably re-stamp that marker at merge critical-section entry:
+  Complete.
+- Keep existing stale non-rejection behavior: ordinary resolved markers still
+  clear attention and the marker: Complete.
+- Run only focused tests for the touched behavior: Complete.
+- Record validation evidence in this document: Complete.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `plans/MERGE_REJECTION_STALE_ATTENTION_PLAN.md`
+- `plans/MERGE_REJECTION_STALE_ATTENTION_VALIDATION.md`
+
+Focused checks run:
+
+- Failing-before regression:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k github_clean_status_preserves_stale_merge_rejection_attention_at_critical_section`
+  failed with `KeyError: '__awf_merge_block_attention__'`, confirming the marker
+  was cleared before the fix.
+- Passing focused regression set:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "github_clean_status_preserves_stale_merge_rejection_attention_at_critical_section or clear_stale_merge_attention_drops_marker_durably_on_resolve or clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked or github_clean_status_clears_non_rejection_attention_during_queue_wait"`
+  passed: `4 passed, 18 deselected`.
+- Focused lint:
+  `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`
+  passed.
+
+Full AWF/GitHub validation is managed by AWF after agent completion.
+
+## Gaps
+
+None.

--- a/plans/PRRT_kwDOSJAM6s6L2Znf_PLAN.md
+++ b/plans/PRRT_kwDOSJAM6s6L2Znf_PLAN.md
@@ -1,0 +1,37 @@
+# PRRT_kwDOSJAM6s6L2Znf Plan
+
+## Problem Statement and Scope
+
+The review thread reports that `_clear_stale_merge_attention` can drop a
+persisted merge-rejection origin when refreshing an existing
+`merge_block_attention` marker. The helper already consults persisted origin
+for stale/non-active markers, but not for fresh markers or markers preserved
+because the forge still reports branch protection active.
+
+Scope is limited to the merge-block attention refresh path and a focused
+regression test.
+
+## Requirements
+
+- Verify the refresh path preserves merge-rejection origin when the origin is
+  present only in the workspace row.
+- Keep the current in-memory explicit-origin precedence behavior.
+- Do not change queue-wait clearing semantics or unrelated monitor behavior.
+- Run only focused tests for the changed behavior; broad AWF/GitHub validation
+  remains owned by AWF after agent completion.
+
+## Implementation Steps
+
+1. Add a failing regression test for `_clear_stale_merge_attention` covering a
+   marker with no in-memory origin and persisted merge-rejection origin.
+2. Update the refresh path to reuse the DB-backed origin lookup when the marker
+   is going to be preserved and refreshed.
+3. Run the focused regression test, then the relevant focused merge-attention
+   test file if practical.
+4. Record results in `plans/PRRT_kwDOSJAM6s6L2Znf_VALIDATION.md`.
+
+## Verification
+
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "critical_section_refresh_preserves_persisted_merge_rejection_origin"`
+- Optional focused file check:
+  `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`

--- a/plans/PRRT_kwDOSJAM6s6L2Znf_VALIDATION.md
+++ b/plans/PRRT_kwDOSJAM6s6L2Znf_VALIDATION.md
@@ -1,0 +1,34 @@
+# PRRT_kwDOSJAM6s6L2Znf Validation
+
+Plan reference: `plans/PRRT_kwDOSJAM6s6L2Znf_PLAN.md`
+
+## Requirement Status
+
+- Complete: Verified the refresh path preserves merge-rejection origin when the
+  origin is present only in the workspace row.
+- Complete: Kept in-memory explicit-origin precedence by continuing to use the
+  existing `_merge_block_attention_originated_from_merge_rejection` helper.
+- Complete: Left queue-wait clearing semantics and unrelated monitor behavior
+  unchanged.
+- Complete: Ran focused checks only. Full AWF/GitHub validation is managed by
+  AWF after agent completion.
+
+## Evidence
+
+Files changed:
+
+- `src/awf/runtime/pr_monitor_runner/merge_attention.py`
+- `tests/unit/runtime/test_pr_monitor_merge_attention.py`
+- `plans/PRRT_kwDOSJAM6s6L2Znf_PLAN.md`
+- `plans/PRRT_kwDOSJAM6s6L2Znf_VALIDATION.md`
+
+Focused checks:
+
+- Initial regression check failed before the implementation with
+  `KeyError: '__awf_merge_block_attention_origin__'`.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q -k "critical_section_refresh_preserves_persisted_merge_rejection_origin"`:
+  passed, 2 passed.
+- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_pr_monitor_merge_attention.py -q`:
+  passed, 13 passed.
+- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/pr_monitor_runner/merge_attention.py tests/unit/runtime/test_pr_monitor_merge_attention.py`:
+  passed.

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -308,6 +308,16 @@ decision core; it exists only so ``handle_merge_action``'s non-human gate waits
 human signal across polls instead of clearing it as a resolved ``NotifyHuman``
 episode (PRRT_kwDOSJAM6s6LXscz)."""
 
+_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY = "__awf_merge_block_attention_origin__"
+"""Reserved ``MonitorState.threads_addressed_ids`` key carrying structured origin
+metadata for ``_MERGE_BLOCK_ATTENTION_STATE_KEY``.
+
+The merge-block marker itself stores the TTL timestamp. This companion key keeps
+machine decisions independent from the user-facing ``awaiting_human_reason``
+text while staying in the same persisted state map and row transaction."""
+
+_MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION = "merge_rejection"
+
 
 @dataclass
 class MonitorState:
@@ -436,10 +446,15 @@ class MonitorState:
             return True
         # Stale (resolved): drop the marker so the clear proceeds and the next
         # fresh poll re-stamps cleanly.
-        self.threads_addressed_ids.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None)
+        self.clear_merge_block_attention()
         return False
 
-    def mark_merge_block_attention(self, *, now: datetime | None = None) -> None:
+    def mark_merge_block_attention(
+        self,
+        *,
+        now: datetime | None = None,
+        originated_from_merge_rejection: bool = False,
+    ) -> None:
         """Flag that the merge loop set attention for an active branch-protection block.
 
         Stamps a wall-clock timestamp (default ``datetime.now(UTC)``) so a later
@@ -451,10 +466,22 @@ class MonitorState:
         """
         stamped = now if now is not None else datetime.now(UTC)
         self.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] = stamped.isoformat()
+        if originated_from_merge_rejection:
+            self.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] = (
+                _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+            )
+
+    def merge_block_attention_originated_from_merge_rejection(self) -> bool:
+        """Whether the current merge-block marker came from a merge API rejection."""
+        return (
+            self.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY)
+            == _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+        )
 
     def clear_merge_block_attention(self) -> None:
         """Drop the merge-block attention marker (idempotent)."""
         self.threads_addressed_ids.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None)
+        self.threads_addressed_ids.pop(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY, None)
 
     def changed_thread_ids(self) -> set[str]:
         return set(self._changed_thread_ids)

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -339,6 +339,11 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
     - clean/mergeable -> clear on GitHub because it confirms resolution;
     - unknown/error -> preserve conservatively.
 
+    Every preserve path first recovers a persisted merge-rejection origin into
+    ``state`` (the recovery's documented side effect) so the outer
+    ``_persist_state`` flush after the wait carries it forward instead of
+    overwriting ``monitor_threads_addressed`` without it (PRRT_kwDOSJAM6s6L3TpA).
+
     Bitbucket open PRs map to ``CLEAN`` because Bitbucket Cloud does not expose a
     GitHub-style merge-state signal, so Bitbucket ``CLEAN`` is treated like an
     unknown signal and preserves conservatively.
@@ -348,16 +353,29 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
         await self._clear_workspace_attention(workspace_id)
         return
     verdict = _merge_block_attention_queue_verdict(status, forge=forge)
+    # Recover any persisted merge-rejection origin into ``state`` BEFORE every
+    # preserve return, not just the CLEAN branch below. The recovery has a side
+    # effect — copying the DB origin into ``state.threads_addressed_ids`` (see
+    # ``_merge_block_attention_originated_from_merge_rejection``) — and the outer
+    # ``run()`` loop's full-state ``_persist_state`` flush after this wait rebuilds
+    # ``monitor_threads_addressed`` from ``state``. In the marker-without-companion-key
+    # case this helper is meant to recover, returning on a BLOCKED/unknown verdict
+    # without recovering would let that flush overwrite the row WITHOUT the origin;
+    # a later GitHub CLEAN wait would then find no origin and clear a still-active
+    # actor/push restriction (PRRT_kwDOSJAM6s6L3TpA). The recovery short-circuits
+    # without a DB read when the origin is already in memory, so preserve paths with
+    # no merge-rejection origin pay nothing extra.
+    originated_from_merge_rejection = await _merge_block_attention_originated_from_merge_rejection(
+        self,
+        workspace_id,
+        state,
+    )
     if verdict in ("active", "indeterminate"):
         return
     # GitHub CLEAN proves ordinary mergeability signals resolved, but actor/push
     # restrictions that rejected a merge attempt are invisible to mergeStateStatus.
     # A later merge retry is the positive confirmation for that case.
-    if await _merge_block_attention_originated_from_merge_rejection(
-        self,
-        workspace_id,
-        state,
-    ):
+    if originated_from_merge_rejection:
         return
     await _clear_merge_block_attention_and_workspace_attention_durably(
         self,

--- a/src/awf/runtime/pr_monitor_runner/merge_attention.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_attention.py
@@ -8,11 +8,13 @@ Behavior is unchanged: the functions are wired back onto the runner via
 
 from __future__ import annotations
 
-from datetime import UTC, datetime
-from typing import Any, Literal
+from datetime import datetime
+from typing import Any, Literal, cast
 
 from awf.db.repositories import WorkspaceRepository
 from awf.runtime.pr_monitor import (
+    _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION,
+    _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY,
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
     MergeStateStatus,
     MonitorState,
@@ -20,6 +22,46 @@ from awf.runtime.pr_monitor import (
 )
 
 _MergeBlockAttentionQueueVerdict = Literal["active", "resolved", "indeterminate"]
+
+
+def _now(self: Any) -> datetime:
+    return cast(datetime, self._deps.now())
+
+
+async def _merge_block_attention_originated_from_merge_rejection(
+    self: Any,
+    workspace_id: str,
+    state: MonitorState,
+) -> bool:
+    """Whether structured state says the attention came from a merge rejection.
+
+    Generic legacy reason text such as "GitHub rejected the merge attempt" also
+    covers ordinary branch-protection fallback. Treating that ambiguous text as
+    merge-rejection origin would keep stale branch-protection attention surfaced
+    even after GitHub reports the PR clean before a queue/reviewer wait.
+
+    When the origin is recovered from the workspace row, copy it into
+    ``MonitorState`` before returning. Queue/reviewer/grace preserve branches do
+    not re-stamp or durably persist the marker themselves; the outer monitor
+    loop's full-state flush must therefore carry the recovered origin forward
+    instead of overwriting ``monitor_threads_addressed`` without it.
+    """
+    if state.merge_block_attention_originated_from_merge_rejection():
+        return True
+    if _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY in state.threads_addressed_ids:
+        return False
+    async with self._deps.session_factory() as s:
+        ws = await WorkspaceRepository(s).get(workspace_id)
+        if ws is None:
+            return False
+        addressed = ws.monitor_threads_addressed or {}
+        origin = addressed.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY)
+        if origin == _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION:
+            state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] = origin
+            return True
+        if origin is not None:
+            return False
+    return False
 
 
 def _merge_block_attention_queue_verdict(
@@ -49,7 +91,7 @@ async def _set_workspace_attention(self: Any, workspace_id: str, *, reason: str)
         await WorkspaceRepository(s).set_workspace_attention(
             workspace_id,
             reason=reason,
-            now=datetime.now(UTC),
+            now=_now(self),
         )
         await s.commit()
 
@@ -93,6 +135,7 @@ async def _set_workspace_attention_with_merge_block_marker(
     are never reached for that head — the reciprocal window cannot form.
     """
     stamped = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
+    origin = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY)
     async with self._deps.session_factory() as s:
         ws = await WorkspaceRepository(s).get_for_update(workspace_id)
         if ws is None:
@@ -101,11 +144,15 @@ async def _set_workspace_attention_with_merge_block_marker(
             threads_addressed = dict(ws.monitor_threads_addressed or {})
             if threads_addressed.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) != stamped:
                 threads_addressed[_MERGE_BLOCK_ATTENTION_STATE_KEY] = stamped
-                ws.monitor_threads_addressed = threads_addressed
+            if origin is None:
+                threads_addressed.pop(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY, None)
+            elif threads_addressed.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY) != origin:
+                threads_addressed[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] = origin
+            ws.monitor_threads_addressed = threads_addressed
         await WorkspaceRepository(s).set_workspace_attention(
             workspace_id,
             reason=reason,
-            now=datetime.now(UTC),
+            now=_now(self),
         )
         await s.commit()
 
@@ -161,11 +208,14 @@ async def _clear_stale_merge_attention(
     later critical-section polls or restarts. When the current forge status
     explicitly reports branch protection still active, preserve and re-stamp
     even if a long queue wait aged the marker past the TTL without a fallback
-    re-stamp. A genuinely resolved marker (stale at entry with no active forge
-    signal) is still cleared below.
+    re-stamp. Also preserve stale markers whose surfaced attention came from a
+    prior merge rejection: actor/push restrictions may be invisible to GitHub
+    ``CLEAN`` and require an actual merge retry to confirm resolution. A
+    genuinely resolved marker (stale at entry with no active forge signal and no
+    merge-rejection origin) is still cleared below.
     """
     ttl_seconds = self._config.merge_block_attention_ttl_seconds
-    reference = now if now is not None else datetime.now(UTC)
+    reference = now if now is not None else _now(self)
     raw = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     if not raw:
         # No marker: a resolved ``NotifyHuman`` episode (not branch-protection),
@@ -185,22 +235,46 @@ async def _clear_stale_merge_attention(
     # already stale at entry (the block resolved BEFORE the wait) is still
     # cleared.
     forge_still_blocked = _merge_block_attention_queue_verdict(status, forge=forge) == "active"
-    if forge_still_blocked or state.merge_block_attention_active(
+    structured_rejection_origin = state.merge_block_attention_originated_from_merge_rejection()
+    explicit_origin_in_memory = _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY in (
+        state.threads_addressed_ids
+    )
+    marker_fresh_at_entry = state.merge_block_attention_active(
         now=reference,
         ttl_seconds=ttl_seconds if ttl_seconds is not None and ttl_seconds > 0 else None,
-    ):
+    )
+    if structured_rejection_origin or explicit_origin_in_memory:
+        merge_rejection_origin = structured_rejection_origin
+    else:
+        merge_rejection_origin = await _merge_block_attention_originated_from_merge_rejection(
+            self,
+            workspace_id,
+            state,
+        )
+    preserve_rejection_origin = (
+        not forge_still_blocked and not marker_fresh_at_entry and merge_rejection_origin
+    )
+    if forge_still_blocked or marker_fresh_at_entry or preserve_rejection_origin:
         # Still-active block at merge critical-section entry: refresh the
         # marker's timestamp so the TTL clock for this critical-section path
         # stays current. Queue/reviewer/grace waits use forge-signal preserve
         # decisions and do not re-stamp.
+        #
+        # GitHub ``CLEAN`` is also not proof that actor/push restrictions have
+        # resolved after a prior merge rejection: those restrictions are only
+        # confirmed by retrying the merge. Queue waits preserve that marker
+        # without re-stamping, so it can legitimately be TTL-stale here.
         #
         # The durable re-stamp MUST use a CURRENT wall-clock rather than the
         # entry timestamp: ``reference`` may intentionally be older than real
         # time after a serialized coordinator wait. Use a fresh wall-clock for
         # the re-stamp while keeping the original entry reference for the
         # preserve/clear decision.
-        stamp_now = datetime.now(UTC)
-        state.mark_merge_block_attention(now=stamp_now)
+        stamp_now = _now(self)
+        state.mark_merge_block_attention(
+            now=stamp_now,
+            originated_from_merge_rejection=merge_rejection_origin,
+        )
         # Persist the re-stamped marker DURABLY before returning. The outer
         # ``run()`` loop only flushes ``state`` after ``_execute`` returns
         # (``runner.py:455``); a cancel/restart before that flush would otherwise
@@ -276,6 +350,15 @@ async def _clear_or_preserve_merge_attention_for_queue_wait(
     verdict = _merge_block_attention_queue_verdict(status, forge=forge)
     if verdict in ("active", "indeterminate"):
         return
+    # GitHub CLEAN proves ordinary mergeability signals resolved, but actor/push
+    # restrictions that rejected a merge attempt are invisible to mergeStateStatus.
+    # A later merge retry is the positive confirmation for that case.
+    if await _merge_block_attention_originated_from_merge_rejection(
+        self,
+        workspace_id,
+        state,
+    ):
+        return
     await _clear_merge_block_attention_and_workspace_attention_durably(
         self,
         workspace_id,
@@ -307,7 +390,11 @@ async def _clear_merge_block_attention_and_workspace_attention_row_durably(
         if ws is None:
             return
         threads_addressed = dict(ws.monitor_threads_addressed or {})
-        if threads_addressed.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None) is not None:
+        removed_marker = threads_addressed.pop(_MERGE_BLOCK_ATTENTION_STATE_KEY, None) is not None
+        removed_origin = (
+            threads_addressed.pop(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY, None) is not None
+        )
+        if removed_marker or removed_origin:
             ws.monitor_threads_addressed = threads_addressed
         await repo.clear_workspace_attention(workspace_id)
         await s.commit()
@@ -368,13 +455,21 @@ async def _persist_merge_block_attention_durably(
     stamped = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_STATE_KEY)
     if stamped is None:
         return
+    origin = state.threads_addressed_ids.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY)
     async with self._deps.session_factory() as s:
         ws = await WorkspaceRepository(s).get_for_update(workspace_id)
         if ws is None:
             return
         threads_addressed = dict(ws.monitor_threads_addressed or {})
-        if threads_addressed.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) == stamped:
+        if (
+            threads_addressed.get(_MERGE_BLOCK_ATTENTION_STATE_KEY) == stamped
+            and threads_addressed.get(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY) == origin
+        ):
             return
         threads_addressed[_MERGE_BLOCK_ATTENTION_STATE_KEY] = stamped
+        if origin is None:
+            threads_addressed.pop(_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY, None)
+        else:
+            threads_addressed[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] = origin
         ws.monitor_threads_addressed = threads_addressed
         await s.commit()

--- a/src/awf/runtime/pr_monitor_runner/merge_loop.py
+++ b/src/awf/runtime/pr_monitor_runner/merge_loop.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import time
 from dataclasses import replace
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, cast
 
@@ -306,7 +305,7 @@ async def handle_merge_action(
         # human-wait timer though the block never resolved
         # (PRRT_kwDOSJAM6s6La_SZ). Use the entry timestamp so a fresh-at-entry
         # marker is preserved; a stale-at-entry marker is still cleared.
-        merge_critical_section_entered_at = datetime.now(UTC)
+        merge_critical_section_entered_at = self._deps.now()
         # #661: clear a resolved ``NotifyHuman`` flag BEFORE the non-human merge-
         # lock wait so it does not stay "awaiting human" once ``decide()`` resumes
         # to ``Merge``. The entry timestamp (above) preserves a FRESH marker and
@@ -474,7 +473,7 @@ async def handle_merge_action(
                     # so an unpersisted marker would re-read as absent forever and
                     # a genuine never-CI head would never escalate past the grace.
                     grace_active, grace_state_changed = _awaiting_required_checks_grace(
-                        checked_status, state, self._config, now=datetime.now(UTC)
+                        checked_status, state, self._config, now=self._deps.now()
                     )
                     if grace_state_changed:
                         pre_merge_state_changed = True
@@ -1079,7 +1078,10 @@ async def handle_merge_action(
             # surfacing the escalation (PRRT_kwDOSJAM6s6Lcgk0). One row, one
             # transaction; the outer ``run()`` loop flushes the rest of ``state``
             # after ``_execute`` returns.
-            state.mark_merge_block_attention()
+            state.mark_merge_block_attention(
+                now=self._deps.now(),
+                originated_from_merge_rejection=True,
+            )
             await self._set_workspace_attention_with_merge_block_marker(
                 workspace_id,
                 state,

--- a/src/awf/runtime/pr_monitor_runner/runner.py
+++ b/src/awf/runtime/pr_monitor_runner/runner.py
@@ -71,6 +71,10 @@ from awf.runtime.validation import ValidationRunner
 from awf.service.provider_recovery import PROVIDER_AUTH_FAILED
 
 
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
 class PullRequestMonitorRunner(RunnerDelegatesMixin):
     """Drives the ``monitoring_pr`` stage for a single workspace."""
 
@@ -92,6 +96,7 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
         post_merge_target_reconciler: PostMergeTargetReconciler | None = None,
         workspace_runtime_context: str = "",
         provider_recovery_default_model: str | None = None,
+        now: Callable[[], datetime] | None = None,
     ) -> None:
         self._deps = _RunnerDeps(
             session_factory=session_factory,
@@ -100,6 +105,7 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
             gh=gh,
             validation=validation,
             sleep=sleep,
+            now=now or _utcnow,
             provider_recovery_default_model=provider_recovery_default_model,
             log_store=log_store,
             post_merge_target_reconciler=post_merge_target_reconciler,
@@ -363,7 +369,7 @@ class PullRequestMonitorRunner(RunnerDelegatesMixin):
                 # unpersisted marker would re-read as absent forever and a genuine
                 # never-CI head would never escalate past the grace.
                 grace_active, grace_state_changed = _awaiting_required_checks_grace(
-                    status, state, self._config, now=datetime.now(UTC)
+                    status, state, self._config, now=self._deps.now()
                 )
                 if grace_state_changed:
                     await self._persist_state(workspace_id, state)

--- a/src/awf/runtime/pr_monitor_runner/types.py
+++ b/src/awf/runtime/pr_monitor_runner/types.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -55,6 +56,7 @@ class _RunnerDeps:
     adapter: AgentAdapter
     gh: ForgeClient
     sleep: Callable[[float], Awaitable[None]]
+    now: Callable[[], datetime]
     validation: ValidationRunner | None = None
     provider_recovery_default_model: str | None = None
     log_store: LogStore | None = None

--- a/tests/unit/runtime/_monitor_runner_fixtures.py
+++ b/tests/unit/runtime/_monitor_runner_fixtures.py
@@ -13,7 +13,9 @@ surface.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -356,6 +358,7 @@ def make_runner(
     post_merge_target_reconciler: Any | None = None,
     provider_recovery_default_model: str | None = None,
     gh: Any | None = None,
+    now: Callable[[], datetime] | None = None,
 ) -> PullRequestMonitorRunner:
     """Construct a PullRequestMonitorRunner wired for integration-style unit tests."""
     kwargs: dict = {
@@ -389,4 +392,6 @@ def make_runner(
         kwargs["merge_coordinator"] = merge_coordinator
     if post_merge_target_reconciler is not None:
         kwargs["post_merge_target_reconciler"] = post_merge_target_reconciler
+    if now is not None:
+        kwargs["now"] = now
     return PullRequestMonitorRunner(**kwargs)

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -10,13 +10,11 @@ poll, so the branch-protection fallback cannot re-stamp during it).
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -26,6 +24,8 @@ from awf.common.github_client import GitHubClientError
 from awf.db.repositories import WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.runtime.pr_monitor import (
+    _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION,
+    _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY,
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
     Merge,
     MergeStateStatus,
@@ -221,10 +221,28 @@ async def test_resolved_human_wait_clears_attention_on_fast_path_into_merge(
         assert ws.awaiting_human_reason is None
 
 
+class _FakeClock:
+    """Deterministic wall clock for merge-attention TTL regressions."""
+
+    def __init__(self, current: datetime, *, tick_seconds: float = 0.0) -> None:
+        self._current = current
+        self._tick = timedelta(seconds=tick_seconds)
+
+    def now(self) -> datetime:
+        current = self._current
+        self._current += self._tick
+        return current
+
+    def advance(self, seconds: float) -> datetime:
+        self._current += timedelta(seconds=seconds)
+        return self._current
+
+
 class _LongWaitMergeCoordinator:
-    """A merge coordinator that actually sleeps before yielding, advancing the
-    wall-clock past a tiny TTL so a marker stamped fresh at entry ages out
-    during the serialized wait.
+    """A merge coordinator that advances a fake clock before yielding.
+
+    The clock moves past a tiny TTL so a marker stamped fresh at entry ages out
+    during the serialized wait without depending on scheduler timing.
 
     Models the real Postgres/InProcess coordinators blocking behind another
     merge in the same repo/base lane: no branch-protection fallback fires
@@ -232,8 +250,9 @@ class _LongWaitMergeCoordinator:
     reproduce the flicker described in PRRT_kwDOSJAM6s6La_SZ.
     """
 
-    def __init__(self, wait_seconds: float) -> None:
+    def __init__(self, *, wait_seconds: float, clock: _FakeClock) -> None:
         self._wait_seconds = wait_seconds
+        self._clock = clock
         self.entries: list[tuple[str, str]] = []
         self.yielded_at: datetime | None = None
 
@@ -245,9 +264,7 @@ class _LongWaitMergeCoordinator:
         base_branch: str,
     ) -> AsyncIterator[None]:
         self.entries.append((repo_url, base_branch))
-        # Real sleep so datetime.now(UTC) advances past the TTL inside the wait.
-        await asyncio.sleep(self._wait_seconds)
-        self.yielded_at = datetime.now(UTC)
+        self.yielded_at = self._clock.advance(self._wait_seconds)
         yield
 
 
@@ -294,17 +311,10 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
         pr_number=_TEST_PR_NUMBER,
         base_branch=_TEST_DEFAULT_BASE_BRANCH,
     )
-    # TTL large enough that the marker stays FRESH at coordinator entry
-    # regardless of how long the pre-coordinator setup (DB loads, gate checks)
-    # takes inside ``_execute`` — the production entry-time fix measures the
-    # marker's age against the coordinator-ENTRY clock, so the marker only has
-    # to be fresh *then*, not survive the whole setup gap. A 1.0s TTL is too
-    # tight under CI load (the setup gap can exceed it, making the marker stale
-    # at entry and clearing ``awaiting_human_since`` — a flaky false failure,
-    # not the regression under test). 30s absorbs any plausible setup gap while
-    # still exercising the long-wait path; the during-wait aging only mattered
-    # for the pre-fix post-wait clock behavior, which is already fixed
-    # (PRRT_kwDOSJAM6s6La_SZ).
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC), tick_seconds=0.01)
+    # The fake clock makes the marker fresh at coordinator entry, then stale
+    # after the coordinator advances past the tight TTL. This fails if the
+    # preserve decision accidentally uses the post-wait wall clock.
     monitor_config = MonitorConfig(
         auto_merge=True,
         poll_interval_seconds=60,
@@ -312,9 +322,9 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
         initial_review_grace_period_seconds=0,
         non_check_reviewer_settle_seconds=0,
         non_check_reviewer_logins=(),
-        merge_block_attention_ttl_seconds=30.0,
+        merge_block_attention_ttl_seconds=1.0,
     )
-    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5)
+    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5, clock=clock)
     runner = PullRequestMonitorRunner(
         session_factory=factory,
         runner=FakeCommandRunner(),
@@ -329,6 +339,7 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
         sleep=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
         merge_coordinator=coordinator,
+        now=clock.now,
     )
 
     # Seed a stable episode start from an earlier poll (COALESCE'd start). The
@@ -346,7 +357,7 @@ async def test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention(
     # fix preserves the marker across the wait; without that fix the
     # critical-section-entry clear would measure age against the post-wait
     # clock and (with a tight TTL) wipe the signal.
-    state.mark_merge_block_attention()
+    state.mark_merge_block_attention(now=clock.now())
 
     terminal = await runner._execute(
         action=Merge(),
@@ -388,7 +399,8 @@ async def test_bitbucket_clean_status_preserves_merge_block_attention_during_que
 
     Bitbucket maps open PRs to ``CLEAN`` because it does not expose GitHub's
     branch-protection merge-state signal. Preserve active operator attention for
-    that forge while GitHub ``CLEAN`` clears as a confirmed resolution.
+    that forge while GitHub ``CLEAN`` remains allowed to clear ordinary
+    non-rejection markers as a confirmed resolution.
     """
     workspace_id = await seed_monitoring_workspace(factory)
     runner = make_runner(
@@ -427,6 +439,283 @@ async def test_bitbucket_clean_status_preserves_merge_block_attention_during_que
 
 
 @pytest.mark.unit
+async def test_github_clean_status_preserves_merge_rejection_attention_during_queue_wait(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """#677: GitHub ``CLEAN`` is not proof that an actor/push restriction which
+    rejected the previous merge attempt has resolved.
+
+    Actor and push restrictions are invisible to ``mergeStateStatus``. A queue,
+    reviewer-settle, or grace wait does not retry the merge, so it must preserve
+    rejection-origin attention until a later merge attempt confirms success or
+    re-stamps the rejection.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    episode_start = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    state = MonitorState()
+    state.mark_merge_block_attention(
+        now=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
+        originated_from_merge_rejection=True,
+    )
+    marker_state = dict(state.threads_addressed_ids)
+    marker = marker_state[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = marker_state
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {}) == marker_state
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == "GitHub merge was denied by branch actor restrictions"
+
+
+@pytest.mark.unit
+async def test_github_clean_structured_merge_rejection_preserve_uses_state_not_db(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured merge-rejection origin is already in ``MonitorState``.
+
+    A GitHub ``CLEAN`` queue wait must preserve from that in-memory marker
+    without opening a second workspace session. Rows without structured origin
+    are intentionally not preserved from ambiguous reason text.
+    """
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    state = MonitorState()
+    state.mark_merge_block_attention(
+        now=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
+        originated_from_merge_rejection=True,
+    )
+    marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+
+    def _forbidden_session_factory() -> None:
+        raise AssertionError("structured merge-rejection origin should not read the DB")
+
+    monkeypatch.setattr(runner._deps, "session_factory", _forbidden_session_factory)
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        "unused-workspace-id",
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
+
+
+@pytest.mark.unit
+async def test_github_clean_status_preserves_stale_merge_rejection_attention_at_critical_section(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6L1FjH: critical-section entry must not clear a TTL-stale
+    marker when the surfaced attention came from a prior merge rejection.
+
+    Actor/push restrictions can reject the merge attempt while remaining
+    invisible to GitHub's ``mergeStateStatus``. Queue waits preserve that marker
+    without re-stamping, so it can be TTL-stale by the next critical-section
+    entry even though the operator block has not been confirmed resolved.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState()
+    state.mark_merge_block_attention(
+        now=datetime(2024, 1, 1, tzinfo=UTC),
+        originated_from_merge_rejection=True,
+    )
+    state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] = stale_stamp
+    marker_state = dict(state.threads_addressed_ids)
+    episode_start = datetime(2024, 1, 1, 12, tzinfo=UTC)
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = marker_state
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
+        await session.commit()
+
+    before_call = datetime.now(UTC)
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=datetime(2024, 1, 2, tzinfo=UTC),
+        status=_mergeable_status(),
+        forge="github",
+    )
+    after_call = datetime.now(UTC)
+
+    refreshed_stamp = datetime.fromisoformat(
+        state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    )
+    assert before_call <= refreshed_stamp <= after_call
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == "GitHub merge was denied by branch actor restrictions"
+    assert (ws_after.monitor_threads_addressed or {})[
+        _MERGE_BLOCK_ATTENTION_STATE_KEY
+    ] == refreshed_stamp.isoformat()
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] == (
+        _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+    )
+    assert (ws_after.monitor_threads_addressed or {})[
+        _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY
+    ] == _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("forge_still_blocked", [False, True])
+async def test_critical_section_refresh_preserves_persisted_merge_rejection_origin(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    *,
+    forge_still_blocked: bool,
+) -> None:
+    """PRRT_kwDOSJAM6s6L2Znf: refresh must not erase DB-backed origin.
+
+    A restart can leave the marker in memory without the structured origin
+    while the workspace row still records merge-rejection origin. If the marker
+    is refreshed because it is fresh at entry, or because the forge still
+    reports branch protection active, the durable refresh must keep that
+    persisted origin so later GitHub ``CLEAN`` queue waits cannot clear the
+    active merge-rejection attention without a merge retry.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    if forge_still_blocked:
+        marker_time = datetime(2024, 1, 1, tzinfo=UTC)
+        reference = datetime(2024, 1, 2, tzinfo=UTC)
+        status = replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED)
+    else:
+        marker_time = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC)
+        reference = datetime(2026, 1, 1, 12, 0, 2, tzinfo=UTC)
+        status = _mergeable_status()
+    marker = marker_time.isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: marker})
+    persisted_state = {
+        _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+        _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION,
+    }
+    episode_start = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = persisted_state
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
+        await session.commit()
+
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=reference,
+        status=status,
+        forge="github",
+    )
+
+    assert (
+        state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY]
+        == _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+    )
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {})[
+        _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY
+    ] == _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == (
+        "GitHub merge was denied by branch actor restrictions"
+    )
+
+
+@pytest.mark.unit
+async def test_github_clean_status_clears_non_rejection_attention_during_queue_wait(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """#671: GitHub ``CLEAN`` still clears an ordinary merge-block marker when no
+    prior merge rejection is the source of the surfaced attention.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    state = MonitorState()
+    state.mark_merge_block_attention(now=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC))
+    marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: marker}
+        ws.awaiting_human_since = datetime(2026, 1, 1, 12, tzinfo=UTC)
+        ws.awaiting_human_reason = "prior non-rejection escalation"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert ws_after.awaiting_human_since is None
+    assert ws_after.awaiting_human_reason is None
+
+
+@pytest.mark.unit
 async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
@@ -460,17 +749,9 @@ async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
         status="open",
         blocker_state="ready",
     )
-    # TTL large enough that the marker stays FRESH at the critical-section-entry
-    # clear regardless of how long the pre-coordinator setup (DB loads, gate
-    # checks, status fetch) takes inside ``_execute`` — the production entry-time
-    # fix measures the marker's age against the coordinator-ENTRY clock, so the
-    # marker only has to be fresh *then*, not survive the whole setup gap. A 1.0s
-    # TTL is too tight under CI load (the setup gap can exceed it, making the
-    # marker stale at entry and clearing ``awaiting_human_since`` — a flaky false
-    # failure, not the regression under test). 30s absorbs any plausible setup
-    # gap. The post-lock queue wait is now forge-signal-driven; this setup only
-    # needs the critical-section-entry clear to preserve the marker before the
-    # serialized wait.
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC), tick_seconds=0.01)
+    # The fake clock keeps the setup gap out of the assertion while still making
+    # the marker stale by the time the post-lock queue wait runs.
     monitor_config = MonitorConfig(
         auto_merge=True,
         poll_interval_seconds=60,
@@ -478,9 +759,9 @@ async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
         initial_review_grace_period_seconds=0,
         non_check_reviewer_settle_seconds=0,
         non_check_reviewer_logins=(),
-        merge_block_attention_ttl_seconds=30.0,
+        merge_block_attention_ttl_seconds=1.0,
     )
-    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5)
+    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5, clock=clock)
     runner = _QueueAfterLockRunner(
         blocker=blocker,
         session_factory=factory,
@@ -496,6 +777,7 @@ async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
         sleep=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
         merge_coordinator=coordinator,
+        now=clock.now,
     )
 
     # Seed a stable episode start from an earlier poll's branch-protection
@@ -510,7 +792,7 @@ async def test_post_lock_gate_preserves_blocked_marker_without_restamping(
     state = MonitorState()
     # Stamp the marker FRESH at this poll's entry so the #661 critical-section
     # entry clear preserves it. The later post-lock queue wait must not re-stamp.
-    state.mark_merge_block_attention()
+    state.mark_merge_block_attention(now=clock.now())
     original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     terminal = await runner._execute(
@@ -588,7 +870,8 @@ async def test_stale_at_coordinator_entry_marker_still_cleared_after_long_wait(
         non_check_reviewer_logins=(),
         merge_block_attention_ttl_seconds=1.0,
     )
-    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5)
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC), tick_seconds=0.01)
+    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5, clock=clock)
     runner = PullRequestMonitorRunner(
         session_factory=factory,
         runner=FakeCommandRunner(),
@@ -603,6 +886,7 @@ async def test_stale_at_coordinator_entry_marker_still_cleared_after_long_wait(
         sleep=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
         merge_coordinator=coordinator,
+        now=clock.now,
     )
 
     # Seed the surfaced attention from a prior, now-resolved poll. The marker is
@@ -699,24 +983,9 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
         status="open",
         blocker_state="ready",
     )
-    # TTL large enough that the marker stays FRESH at the critical-section-entry
-    # clear regardless of how long the pre-coordinator setup (DB loads, gate
-    # checks, status fetch) takes inside ``_execute`` — the production entry-time
-    # fix measures the marker's age against the coordinator-ENTRY clock, so the
-    # marker only has to be fresh *then*, not survive the whole setup gap. A 1.0s
-    # TTL is too tight under CI load (the setup gap can exceed it, making the
-    # marker stale at entry and clearing ``awaiting_human_since`` — a flaky false
-    # failure, not the regression under test). 30s absorbs any plausible setup
-    # gap. The regression under test (post-wait wall-clock measurement
-    # reclassifying a fresh-at-entry marker as stale) is exercised by the 1.5s
-    # coordinator wait advancing real time past the entry window — the production
-    # fix already passes the entry timestamp to the post-lock clears, so the
-    # small-TTL "post-wait reclassification" rationale only described the
-    # PRE-FIX behavior and is TTL-independent here now; the 1.5s wait still
-    # drives the post-lock preserve path. Mirrors the sibling
-    # ``test_post_lock_gate_restamp_uses_current_wall_clock_not_entry_timestamp``
-    # (PRRT_kwDOSJAM6s6LdM4X) and ``test_long_merge_coordinator_wait_preserves_fresh_at_entry_attention``
-    # (PRRT_kwDOSJAM6s6La_SZ) TTL bumps.
+    clock = _FakeClock(datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC), tick_seconds=0.01)
+    # The fake clock makes the marker fresh at entry and stale after the
+    # serialized wait, without depending on real elapsed time in CI.
     monitor_config = MonitorConfig(
         auto_merge=True,
         poll_interval_seconds=60,
@@ -724,9 +993,9 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
         initial_review_grace_period_seconds=0,
         non_check_reviewer_settle_seconds=0,
         non_check_reviewer_logins=(),
-        merge_block_attention_ttl_seconds=30.0,
+        merge_block_attention_ttl_seconds=1.0,
     )
-    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5)
+    coordinator = _LongWaitMergeCoordinator(wait_seconds=1.5, clock=clock)
     runner = _QueueAfterLockRunner(
         blocker=blocker,
         session_factory=factory,
@@ -742,6 +1011,7 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
         sleep=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
         merge_coordinator=coordinator,
+        now=clock.now,
     )
 
     # Seed a stable episode start from an earlier poll's branch-protection
@@ -757,7 +1027,7 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
     # Stamp the marker FRESH at this poll's entry so the #661 critical-section
     # entry clear preserves it. The later post-lock queue wait is decided by the
     # forge ``BLOCKED`` signal, not marker age.
-    state.mark_merge_block_attention()
+    state.mark_merge_block_attention(now=clock.now())
     original_marker = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
 
     terminal = await runner._execute(
@@ -799,621 +1069,3 @@ async def test_long_coordinator_wait_preserves_fresh_at_entry_attention_across_p
     assert persisted_raw != original_marker
     assert coordinator.yielded_at is not None
     assert datetime.fromisoformat(persisted_raw) < coordinator.yielded_at
-
-
-# ── Defensive no-op branches for the new atomic-persist helpers ──────────────
-#
-# ``_set_workspace_attention_with_merge_block_marker`` and
-# ``_persist_merge_block_attention_durably`` each have defensive early-returns
-# for a missing workspace row (a GC/destroy race) and, for the durable persist,
-# an absent in-memory marker (the caller did not re-stamp) or an already-equal
-# persisted value (no-op write). These mirror the established single-key
-# durable-persist no-op pattern (``_clear_preserved_head_marker_durably`` /
-# ``_persist_forge_transient_retry_count``); each branch is exercised here so
-# the helpers never silently lose coverage.
-
-
-@pytest.mark.unit
-async def test_set_workspace_attention_with_merge_block_marker_missing_workspace_is_noop(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The atomic marker+attention write no-ops when the workspace row is gone (a
-    GC/destroy race between the fallback and the commit) rather than raising."""
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # No marker is stamped, but the helper must not raise on a missing workspace
-    # even when one IS present in state — the row lookup gates the whole write.
-    state = MonitorState()
-    state.mark_merge_block_attention()
-    await runner._set_workspace_attention_with_merge_block_marker(
-        "ws_does_not_exist",
-        state,
-        reason="merge_blocked",
-    )
-
-
-@pytest.mark.unit
-async def test_persist_merge_block_attention_durably_missing_workspace_is_noop(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The durable marker persist no-ops when the workspace row is gone (a
-    GC/destroy race between the preserve re-stamp and the durable write)."""
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    state = MonitorState()
-    state.mark_merge_block_attention()
-    await runner._persist_merge_block_attention_durably("ws_does_not_exist", state)
-
-
-@pytest.mark.unit
-async def test_persist_merge_block_attention_durably_absent_marker_is_noop(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The durable persist no-ops when the in-memory marker is absent — the
-    caller did not re-stamp, so there is nothing to durably persist."""
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # No marker stamped into state ⇒ the helper returns before touching the DB.
-    state = MonitorState()
-    await runner._persist_merge_block_attention_durably(workspace_id, state)
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get(workspace_id)
-        assert ws is not None
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws.monitor_threads_addressed or {})
-
-
-@pytest.mark.unit
-async def test_persist_merge_block_attention_durably_already_equal_is_noop(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The durable persist no-ops when the persisted marker already equals the
-    in-memory stamp (idempotent re-write guard) — the DB value is left untouched
-    and no redundant commit is issued."""
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # Stamp the marker durably first so the DB row already carries it.
-    state = MonitorState()
-    state.mark_merge_block_attention()
-    await runner._persist_merge_block_attention_durably(workspace_id, state)
-    stamped = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get(workspace_id)
-        assert ws is not None
-    assert (ws.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
-    # A second persist with the SAME stamp must short-circuit (no-op write).
-    await runner._persist_merge_block_attention_durably(workspace_id, state)
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_drops_marker_durably_on_resolve(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """PRRT_kwDOSJAM6s6Lf_37: ``_clear_stale_merge_attention``'s stale (resolved)
-    branch must durably remove the merge-block marker from the persisted row,
-    not just drop it in memory. The outer ``run()`` loop only flushes the whole
-    in-memory ``state`` after ``_execute`` returns (``runner.py:455``); a
-    cancel/restart before that full ``_persist_state`` would otherwise reload the
-    STALE marker from the DB while ``awaiting_human_since`` is already null, so
-    a later poll could otherwise observe the stale marker without the cleared
-    attention flag, losing the invariant that both pieces move together.
-    """
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # Seed a stale marker (resolved block) into BOTH the in-memory state and the
-    # persisted row — the state the monitor would reload after a cancel/restart
-    # before the outer loop's full ``_persist_state`` flush.
-    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
-        assert ws is not None
-        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
-        await session.commit()
-    # Drive the stale (resolved) branch with a TTL that the marker exceeds, and a
-    # ``reference`` (entry ``now``) far enough past the stamp to age it out.
-    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
-    await runner._clear_stale_merge_attention(
-        workspace_id,
-        state,
-        now=resolved_now,
-    )
-    # In-memory marker dropped and attention cleared.
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
-    # The persisted row must NOT carry the stale marker anymore — the durable
-    # clear closed the cancel/restart window.
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
-    assert ws_after.awaiting_human_since is None
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """PRRT_kwDOSJAM6s6LqhqC: a long queue wait can preserve an old
-    ``merge_block_attention`` marker without re-stamping it. When merge
-    critical-section entry sees the forge still reporting branch protection as
-    active, it must not treat the TTL-aged marker as resolved and clear
-    ``awaiting_human_since``.
-    """
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    old_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp})
-    episode_start = datetime(2024, 1, 1, 12, tzinfo=UTC)
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
-        assert ws is not None
-        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp}
-        ws.awaiting_human_since = episode_start
-        ws.awaiting_human_reason = "GitHub rejected the merge attempt"
-        await session.commit()
-
-    before_call = datetime.now(UTC)
-    await runner._clear_stale_merge_attention(
-        workspace_id,
-        state,
-        now=datetime(2024, 1, 2, tzinfo=UTC),
-        status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
-        forge="github",
-    )
-    after_call = datetime.now(UTC)
-
-    refreshed_stamp = datetime.fromisoformat(
-        state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    )
-    assert before_call <= refreshed_stamp <= after_call
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert ws_after.awaiting_human_since == episode_start
-    assert ws_after.awaiting_human_reason == "GitHub rejected the merge attempt"
-    assert (ws_after.monitor_threads_addressed or {})[
-        _MERGE_BLOCK_ATTENTION_STATE_KEY
-    ] == refreshed_stamp.isoformat()
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_atomic_clear_marker_absent_on_row_still_clears_attention(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The stale (resolved) atomic-clear branch still clears ``awaiting_human_since``
-    and commits when the persisted row carries NO merge-block marker — the in-memory
-    ``state`` had a marker (driving the stale branch) but the durable row never
-    received it (the outer loop had not flushed ``_persist_state`` yet, or a
-    restart reloaded a marker-less row that a same-poll preserve then re-stamped).
-
-    The ``threads_addressed.pop(...) is None`` guard must skip the redundant
-    ``monitor_threads_addressed`` reassignment (line 303) WITHOUT skipping the
-    attention clear + commit (lines 304-305): a row that already lacks the marker
-    still needs ``awaiting_human_since`` cleared so the resolved ``NotifyHuman``
-    episode stops surfacing. Covers the missing branch in the atomic clear path.
-    """
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # The in-memory state carries a stale marker (drives the stale branch), but
-    # the persisted row has NO marker — only an active attention flag to clear.
-    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
-        assert ws is not None
-        # No marker on the row; attention flag set from a prior escalation.
-        ws.monitor_threads_addressed = {}
-        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
-        ws.awaiting_human_reason = "merge_blocked"
-        await session.commit()
-    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
-    await runner._clear_stale_merge_attention(
-        workspace_id,
-        state,
-        now=resolved_now,
-    )
-    # In-memory marker dropped.
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
-    # The persisted row still carries no marker, and the attention flag is cleared
-    # despite the marker-absent branch skipping the threads_addressed reassignment.
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
-    assert ws_after.awaiting_human_since is None
-
-
-@pytest.mark.unit
-async def test_set_workspace_attention_with_merge_block_marker_absent_marker_skips_marker_write(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The atomic write sets ``awaiting_human_since`` even when no marker is
-    stamped into state (the caller did not re-stamp) — the marker merge is
-    skipped, but the attention flag is still persisted. This is the defensive
-    ``if stamped is not None`` False branch: production always stamps at the
-    merge_loop call site, but the helper must not drop the attention write when
-    the marker is absent."""
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # No marker stamped into state ⇒ the marker merge is skipped, but the
-    # attention flag must still be persisted.
-    state = MonitorState()
-    await runner._set_workspace_attention_with_merge_block_marker(
-        workspace_id,
-        state,
-        reason="merge_blocked",
-    )
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get(workspace_id)
-        assert ws is not None
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws.monitor_threads_addressed or {})
-    assert ws.awaiting_human_since is not None
-    assert ws.awaiting_human_reason == "merge_blocked"
-
-
-@pytest.mark.unit
-async def test_set_workspace_attention_with_merge_block_marker_already_equal_skips_marker_merge(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """The atomic write's marker merge is idempotent: when the DB row already
-    carries the in-memory stamp, the merge is skipped (no redundant assignment)
-    but the attention flag is still refreshed and committed. This is the
-    ``if threads_addressed.get(...) != stamped`` False branch — a second
-    fallback poll re-stamps the same marker the first poll already persisted."""
-    workspace_id = await seed_monitoring_workspace(factory)
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # First call persists the marker AND sets attention.
-    state = MonitorState()
-    state.mark_merge_block_attention()
-    await runner._set_workspace_attention_with_merge_block_marker(
-        workspace_id,
-        state,
-        reason="merge_blocked",
-    )
-    stamped = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get(workspace_id)
-        assert ws is not None
-    assert (ws.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
-    first_attention = ws.awaiting_human_since
-    assert first_attention is not None
-    # A second call with the SAME stamp must skip the marker merge (already
-    # equal) but still refresh and commit the attention flag.
-    await runner._set_workspace_attention_with_merge_block_marker(
-        workspace_id,
-        state,
-        reason="merge_blocked",
-    )
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
-    assert ws_after.awaiting_human_since is not None
-
-
-class _CommitTrapSession:
-    """Wraps an ``AsyncSession`` so ``commit`` can be trapped by attempt number.
-
-    Counts every ``commit`` call into the shared ``commit_attempts`` dict (key
-    ``"n"``) and raises ``RuntimeError`` on the attempt matching ``fail_on_attempt``
-    (1-indexed) BEFORE delegating to ``inner.commit()``, so the simulated DB
-    failure rolls that transaction back. ``fail_on_attempt=None`` never raises.
-
-    This lets a regression FAIL for the prior two-commit implementation while
-    PASSING for the current single-transaction atomic clear:
-
-    * ``fail_on_attempt=1`` simulates a failure on the (only) atomic commit —
-      the current implementation rolls both writes back (the
-      ``PRRT_kwDOSJAM6s6Lh0zt`` rollback contract). The prior two-commit
-      sequence would also roll its first commit back and never reach the
-      second, so this case does NOT by itself distinguish old from new (the
-      targeted ``fail_on_attempt=2`` case below does).
-    * ``fail_on_attempt=2`` lets the first commit land (the prior
-      implementation's ``_clear_workspace_attention`` clearing
-      ``awaiting_human_since``) and raises on the second (the prior
-      ``_clear_merge_block_attention_durably`` marker removal) — exposing the
-      half-cleared restart window the atomic fix closed. The current
-      single-commit implementation never reaches attempt 2, so it completes
-      with both fields cleared and exactly one recorded commit attempt.
-    """
-
-    def __init__(
-        self,
-        inner: AsyncSession,
-        commit_attempts: dict[str, int],
-        *,
-        fail_on_attempt: int | None = None,
-    ) -> None:
-        self._inner = inner
-        self._commit_attempts = commit_attempts
-        self._fail_on_attempt = fail_on_attempt
-
-    def __getattr__(self, name: str) -> Any:
-        return getattr(self._inner, name)
-
-    async def commit(self) -> None:
-        self._commit_attempts["n"] += 1
-        if self._fail_on_attempt is not None and (
-            self._commit_attempts["n"] == self._fail_on_attempt
-        ):
-            raise RuntimeError("simulated DB failure mid-transaction")
-        await self._inner.commit()
-
-    async def __aenter__(self) -> _CommitTrapSession:
-        await self._inner.__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
-        await self._inner.__aexit__(exc_type, exc, tb)
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_atomic_clear_rolls_back_together(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """PRRT_kwDOSJAM6s6Lh0zt: the stale (resolved) branch's marker removal and
-    ``awaiting_human_since`` clear MUST land in a SINGLE transaction. The prior
-    two-commit sequence (``_clear_workspace_attention`` then
-    ``_clear_merge_block_attention_durably``) left a cancel/restart window where
-    ``awaiting_human_since`` was already nulled but the STALE marker still sat on
-    the DB row — so the next poll's preserve path re-stamped the stale marker
-    fresh and wedged the monitor in a faux "awaiting human" state until another
-    merge fallback ran (the ``PRRT_kwDOSJAM6s6Lf_37`` window's reciprocal). With
-    both writes under one ``get_for_update`` transaction, a mid-transaction
-    failure rolls BOTH back: a restart can never observe the cleared flag
-    without the also-cleared marker, or vice versa.
-
-    This test simulates the restart window by making the stale-branch commit
-    raise. Under the atomic fix the transaction rolls back in full, so the row
-    still carries BOTH the stale marker AND the still-set attention flag —
-    exactly the pre-failure state, with neither half observable alone. The
-    in-memory marker is dropped before the DB write (mirroring production), so
-    the assertion focuses on the DB row's atomic consistency.
-    """
-    workspace_id = await seed_monitoring_workspace(factory)
-    # Seed a stale marker (resolved block) and an active attention flag into the
-    # persisted row — the state the monitor would reload after a cancel/restart
-    # before the outer loop's full ``_persist_state`` flush.
-    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
-        assert ws is not None
-        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
-        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
-        ws.awaiting_human_reason = "merge_blocked"
-        await session.commit()
-
-    # Wrap the session factory so the FIRST session's commit raises — the
-    # restart-window between the (old) two commits, now exercised against the
-    # single atomic transaction.
-    commit_attempts: dict[str, int] = {"n": 0}
-
-    @asynccontextmanager
-    async def _failing_factory() -> AsyncIterator[_CommitTrapSession]:
-        commit_attempts["n"]  # shared counter touched inside the trap
-        async with factory() as inner:
-            yield _CommitTrapSession(inner, commit_attempts, fail_on_attempt=1)
-
-    runner = make_runner(
-        factory=factory,  # type: ignore[arg-type]
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    # Override the runner's session factory with the failing-commit wrapper so
-    # the stale branch's single atomic commit raises mid-transaction.
-    runner._deps = replace(runner._deps, session_factory=_failing_factory)
-
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
-    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
-    # The stale branch raises mid-transaction; the atomic transaction rolls back.
-    with pytest.raises(RuntimeError, match="simulated DB failure"):
-        await runner._clear_stale_merge_attention(
-            workspace_id,
-            state,
-            now=resolved_now,
-        )
-    # A session was opened (the failing-commit one) — the runner attempted the
-    # atomic clear, and the trap recorded exactly the single commit attempt the
-    # atomic transaction performs.
-    assert commit_attempts["n"] >= 1
-
-    # Under the atomic fix, the transaction rolled back in full: the row still
-    # carries BOTH the stale marker AND the still-set attention flag — neither
-    # half of the marker/attention pair is observable independently. This is
-    # the contract the prior two-commit sequence violated.
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert (ws_after.monitor_threads_addressed or {}).get(
-        _MERGE_BLOCK_ATTENTION_STATE_KEY
-    ) == stale_stamp
-    assert ws_after.awaiting_human_since is not None
-    assert ws_after.awaiting_human_reason == "merge_blocked"
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_atomic_clear_distinguishes_two_commit_window(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """PRRT_kwDOSJAM6s6Lh0zt (PRRT_kwDOSJAM6s6LiZkN): the atomic clear MUST
-    complete with a SINGLE commit that lands BOTH the stale marker removal and
-    the ``awaiting_human_since`` clear. The sibling rollback regression above
-    traps a mid-transaction failure (``fail_on_attempt=1``), but it does NOT by
-    itself distinguish the current single-transaction implementation from the
-    prior two-commit sequence: the prior ``_clear_workspace_attention`` (commit
-    #1) then ``_clear_merge_block_attention_durably`` (commit #2) would ALSO
-    roll its first commit back and never reach the second when commit #1
-    raises, leaving both fields unchanged — the same observable end state as the
-    atomic rollback.
-
-    This targeted regression lets the FIRST commit land and traps the SECOND
-    (``fail_on_attempt=2``). Under the prior two-commit implementation the
-    first commit (``_clear_workspace_attention``) would clear
-    ``awaiting_human_since`` and succeed, then the second commit
-    (``_clear_merge_block_attention_durably``) would raise — leaving the DB in
-    the half-cleared restart window (attention already nulled but the STALE
-    marker still on the row) and surfacing the ``RuntimeError``. Under the
-    current single-transaction atomic clear there is only ONE commit, so the
-    trap is never reached (``fail_on_attempt=2``), the helper completes
-    cleanly, and BOTH the marker and the attention flag are cleared together.
-    Asserting exactly one recorded commit attempt AND both fields cleared
-    makes this regression FAIL for the reintroduced two-commit approach (which
-    would either raise on the second commit or leave the half-cleared state
-    visible) while passing only for the atomic implementation.
-    """
-    workspace_id = await seed_monitoring_workspace(factory)
-    # Seed a stale marker (resolved block) and an active attention flag — the
-    # pre-clear persisted state the atomic clear is meant to roll back from on
-    # the stale (resolved) branch.
-    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    async with factory() as session:
-        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
-        assert ws is not None
-        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
-        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
-        ws.awaiting_human_reason = "merge_blocked"
-        await session.commit()
-
-    # Trap the SECOND commit: the prior two-commit implementation would land
-    # the attention clear on commit #1 and raise on commit #2 (marker removal),
-    # surfacing the half-cleared restart window. The current single-transaction
-    # atomic clear performs exactly one commit and never reaches attempt 2.
-    commit_attempts: dict[str, int] = {"n": 0}
-
-    @asynccontextmanager
-    async def _trapping_factory() -> AsyncIterator[_CommitTrapSession]:
-        async with factory() as inner:
-            yield _CommitTrapSession(inner, commit_attempts, fail_on_attempt=2)
-
-    runner = make_runner(
-        factory=factory,  # type: ignore[arg-type]
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    runner._deps = replace(runner._deps, session_factory=_trapping_factory)
-
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
-    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
-    # The atomic clear completes with its single commit; the trap (set on
-    # attempt 2) is never reached. The prior two-commit implementation would
-    # raise here on its second commit.
-    await runner._clear_stale_merge_attention(
-        workspace_id,
-        state,
-        now=resolved_now,
-    )
-
-    # The atomic implementation performs EXACTLY one commit. A reintroduced
-    # two-commit sequence would record two attempts (and raise on the second).
-    assert commit_attempts["n"] == 1
-
-    # Both the stale marker AND the attention flag are cleared together in
-    # that single transaction — neither half of the pair is observable alone.
-    # A prior two-commit implementation that survived commit #1 but raised on
-    # commit #2 would leave the half-cleared state: marker still present,
-    # attention already nulled.
-    async with factory() as session:
-        ws_after = await WorkspaceRepository(session).get(workspace_id)
-        assert ws_after is not None
-    assert (ws_after.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY) is None
-    assert ws_after.awaiting_human_since is None
-    assert ws_after.awaiting_human_reason is None
-
-
-@pytest.mark.unit
-async def test_clear_stale_merge_attention_atomic_clear_missing_workspace_skips_writes(
-    factory: async_sessionmaker[AsyncSession],
-    tmp_path: Path,
-) -> None:
-    """PRRT_kwDOSJAM6s6Lh0zt: the atomic clear no-ops when the workspace row is
-    gone (a GC/destroy race between the stale-clear and the atomic write) — no
-    marker removal, no attention clear, no commit. Mirrors the established
-    ``get_for_update``-returns-None no-op guard in the sibling durable helpers."""
-    runner = make_runner(
-        factory=factory,
-        cmd=FakeCommandRunner(),
-        adapter=FakeAdapter(),
-        sleep_fn=RecordedSleep(),
-        worktrees_root=tmp_path,
-    )
-    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
-    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
-    # The workspace does not exist — the atomic clear returns before any write.
-    await runner._clear_stale_merge_attention(
-        "ws_does_not_exist",
-        state,
-        now=datetime(2024, 1, 2, tzinfo=UTC),
-    )
-    # In-memory marker is still dropped (the caller's signal), but no DB write
-    # was attempted against a missing row.
-    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids

--- a/tests/unit/runtime/test_pr_monitor_merge_attention.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention.py
@@ -546,12 +546,21 @@ async def test_github_clean_status_preserves_stale_merge_rejection_attention_at_
     entry even though the operator block has not been confirmed resolved.
     """
     workspace_id = await seed_monitoring_workspace(factory)
+    # Inject a deterministic re-stamp clock distinct from BOTH the TTL
+    # ``reference`` below (2024-01-02) and real wall-clock time. The durable
+    # re-stamp routes through the runner clock (``_now`` → ``self._deps.now``),
+    # never the ``reference`` used only for the preserve/clear decision, so the
+    # exact-value assertion pins the re-stamp source and catches a misrouted
+    # ``now()`` the way the coordinator-wait tests do — wall-clock bounds could
+    # not.
+    restamp_clock = datetime(2025, 7, 1, 8, 30, tzinfo=UTC)
     runner = make_runner(
         factory=factory,
         cmd=FakeCommandRunner(),
         adapter=FakeAdapter(),
         sleep_fn=RecordedSleep(),
         worktrees_root=tmp_path,
+        now=lambda: restamp_clock,
     )
     stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
     state = MonitorState()
@@ -570,7 +579,6 @@ async def test_github_clean_status_preserves_stale_merge_rejection_attention_at_
         ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
         await session.commit()
 
-    before_call = datetime.now(UTC)
     await runner._clear_stale_merge_attention(
         workspace_id,
         state,
@@ -578,12 +586,11 @@ async def test_github_clean_status_preserves_stale_merge_rejection_attention_at_
         status=_mergeable_status(),
         forge="github",
     )
-    after_call = datetime.now(UTC)
 
     refreshed_stamp = datetime.fromisoformat(
         state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
     )
-    assert before_call <= refreshed_stamp <= after_call
+    assert refreshed_stamp == restamp_clock
     async with factory() as session:
         ws_after = await WorkspaceRepository(session).get(workspace_id)
         assert ws_after is not None

--- a/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
@@ -21,6 +21,7 @@ from awf.runtime.pr_monitor import (
     _MERGE_BLOCK_ATTENTION_STATE_KEY,
     MergeStateStatus,
     MonitorState,
+    PRStatus,
 )
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._merge_methods_fixtures import _mergeable_status
@@ -306,6 +307,75 @@ async def test_queue_wait_preserves_persisted_merge_rejection_origin_after_resta
     assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] == (
         _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
     )
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {}) == persisted_state
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == (
+        "GitHub merge was denied by branch actor restrictions"
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "status",
+    [
+        pytest.param(
+            replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
+            id="blocked-active",
+        ),
+        pytest.param(None, id="indeterminate"),
+    ],
+)
+async def test_queue_wait_recovers_persisted_origin_on_preserve(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    status: PRStatus | None,
+) -> None:
+    """A BLOCKED/unknown queue-wait preserve must still recover the persisted
+    merge-rejection origin into ``state``. Otherwise the outer ``_persist_state``
+    flush after the wait drops the DB-only origin, and a later GitHub ``CLEAN``
+    wait would clear a still-active actor/push restriction (PRRT_kwDOSJAM6s6L3TpA)."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    marker = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC).isoformat()
+    # Marker-without-companion-key in memory (e.g. a restarted/re-stamped state):
+    # the structured origin lives only on the persisted row.
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: marker})
+    episode_start = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    persisted_state = {
+        _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+        _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: (_MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION),
+    }
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = persisted_state
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=status,
+        forge="github",
+    )
+    # The preserve branch must have copied the persisted origin into memory so the
+    # full-state flush below cannot drop it.
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] == (
+        _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+    )
+    await runner._persist_state(workspace_id, state)
+
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
     async with factory() as session:
         ws_after = await WorkspaceRepository(session).get(workspace_id)
         assert ws_after is not None

--- a/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
@@ -1,0 +1,808 @@
+"""Regression tests for PR monitor merge-attention persistence helpers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION,
+    _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY,
+    _MERGE_BLOCK_ATTENTION_STATE_KEY,
+    MergeStateStatus,
+    MonitorState,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._merge_methods_fixtures import _mergeable_status
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Provide an isolated async session factory for persistence tests."""
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+# ── Defensive no-op branches for the new atomic-persist helpers ──────────────
+#
+# ``_set_workspace_attention_with_merge_block_marker`` and
+# ``_persist_merge_block_attention_durably`` each have defensive early-returns
+# for a missing workspace row (a GC/destroy race) and, for the durable persist,
+# an absent in-memory marker (the caller did not re-stamp) or an already-equal
+# persisted value (no-op write). These mirror the established single-key
+# durable-persist no-op pattern (``_clear_preserved_head_marker_durably`` /
+# ``_persist_forge_transient_retry_count``); each branch is exercised here so
+# the helpers never silently lose coverage.
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_with_merge_block_marker_missing_workspace_is_noop(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The atomic marker+attention write no-ops when the workspace row is gone (a
+    GC/destroy race between the fallback and the commit) rather than raising."""
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # No marker is stamped, but the helper must not raise on a missing workspace
+    # even when one IS present in state — the row lookup gates the whole write.
+    state = MonitorState()
+    state.mark_merge_block_attention()
+    await runner._set_workspace_attention_with_merge_block_marker(
+        "ws_does_not_exist",
+        state,
+        reason="merge_blocked",
+    )
+
+
+@pytest.mark.unit
+async def test_persist_merge_block_attention_durably_missing_workspace_is_noop(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The durable marker persist no-ops when the workspace row is gone (a
+    GC/destroy race between the preserve re-stamp and the durable write)."""
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    state = MonitorState()
+    state.mark_merge_block_attention()
+    await runner._persist_merge_block_attention_durably("ws_does_not_exist", state)
+
+
+@pytest.mark.unit
+async def test_persist_merge_block_attention_durably_absent_marker_is_noop(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The durable persist no-ops when the in-memory marker is absent — the
+    caller did not re-stamp, so there is nothing to durably persist."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # No marker stamped into state ⇒ the helper returns before touching the DB.
+    state = MonitorState()
+    await runner._persist_merge_block_attention_durably(workspace_id, state)
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws.monitor_threads_addressed or {})
+
+
+@pytest.mark.unit
+async def test_persist_merge_block_attention_durably_already_equal_is_noop(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The durable persist no-ops when the persisted marker already equals the
+    in-memory stamp (idempotent re-write guard) — the DB value is left untouched
+    and no redundant commit is issued."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # Stamp the marker durably first so the DB row already carries it.
+    state = MonitorState()
+    state.mark_merge_block_attention()
+    await runner._persist_merge_block_attention_durably(workspace_id, state)
+    stamped = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+    assert (ws.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
+    # A second persist with the SAME stamp must short-circuit (no-op write).
+    await runner._persist_merge_block_attention_durably(workspace_id, state)
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_drops_marker_durably_on_resolve(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6Lf_37: ``_clear_stale_merge_attention``'s stale (resolved)
+    branch must durably remove the merge-block marker from the persisted row,
+    not just drop it in memory. The outer ``run()`` loop only flushes the whole
+    in-memory ``state`` after ``_execute`` returns (``runner.py:455``); a
+    cancel/restart before that full ``_persist_state`` would otherwise reload the
+    STALE marker from the DB while ``awaiting_human_since`` is already null, so
+    a later poll could otherwise observe the stale marker without the cleared
+    attention flag, losing the invariant that both pieces move together.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # Seed a stale marker (resolved block) into BOTH the in-memory state and the
+    # persisted row — the state the monitor would reload after a cancel/restart
+    # before the outer loop's full ``_persist_state`` flush.
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
+        await session.commit()
+    # Drive the stale (resolved) branch with a TTL that the marker exceeds, and a
+    # ``reference`` (entry ``now``) far enough past the stamp to age it out.
+    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=resolved_now,
+    )
+    # In-memory marker dropped and attention cleared.
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    # The persisted row must NOT carry the stale marker anymore — the durable
+    # clear closed the cancel/restart window.
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert ws_after.awaiting_human_since is None
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_still_blocked(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6LqhqC: a long queue wait can preserve an old
+    ``merge_block_attention`` marker without re-stamping it. When merge
+    critical-section entry sees the forge still reporting branch protection as
+    active, it must not treat the TTL-aged marker as resolved and clear
+    ``awaiting_human_since``.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    old_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp})
+    episode_start = datetime(2024, 1, 1, 12, tzinfo=UTC)
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp}
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub rejected the merge attempt"
+        await session.commit()
+
+    before_call = datetime.now(UTC)
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=datetime(2024, 1, 2, tzinfo=UTC),
+        status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
+        forge="github",
+    )
+    after_call = datetime.now(UTC)
+
+    refreshed_stamp = datetime.fromisoformat(
+        state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    )
+    assert before_call <= refreshed_stamp <= after_call
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == "GitHub rejected the merge attempt"
+    assert (ws_after.monitor_threads_addressed or {})[
+        _MERGE_BLOCK_ATTENTION_STATE_KEY
+    ] == refreshed_stamp.isoformat()
+
+
+@pytest.mark.unit
+async def test_queue_wait_preserves_persisted_merge_rejection_origin_after_restart(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A restarted monitor can reload the marker without structured origin in
+    memory, so the queue-wait preserve decision must consult persisted origin."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    marker = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: marker})
+    episode_start = datetime(2026, 1, 1, 12, tzinfo=UTC)
+    persisted_state = {
+        _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+        _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: (_MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION),
+    }
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = persisted_state
+        ws.awaiting_human_since = episode_start
+        ws.awaiting_human_reason = "GitHub merge was denied by branch actor restrictions"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+    await runner._persist_state(workspace_id, state)
+
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY] == marker
+    assert state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY] == (
+        _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+    )
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {}) == persisted_state
+    assert ws_after.awaiting_human_since == episode_start
+    assert ws_after.awaiting_human_reason == (
+        "GitHub merge was denied by branch actor restrictions"
+    )
+
+
+@pytest.mark.unit
+async def test_queue_wait_clears_persisted_non_rejection_origin_when_github_clean(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Persisted structured origin is authoritative after restart, and an
+    explicit non-rejection origin must not be preserved on GitHub ``CLEAN``."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    marker = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: marker})
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {
+            _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+            _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: "ordinary_branch_protection",
+        }
+        ws.awaiting_human_since = datetime(2026, 1, 1, 12, tzinfo=UTC)
+        ws.awaiting_human_reason = "ordinary branch protection still blocked"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY not in state.threads_addressed_ids
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert ws_after.awaiting_human_since is None
+    assert ws_after.awaiting_human_reason is None
+
+
+@pytest.mark.unit
+async def test_queue_wait_uses_in_memory_non_rejection_origin_before_persisted_origin(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Current in-memory origin wins over stale persisted origin so an ordinary
+    marker is not kept alive by an older merge-rejection row value."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    marker = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(
+        threads_addressed_ids={
+            _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+            _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: "ordinary_branch_protection",
+        }
+    )
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {
+            _MERGE_BLOCK_ATTENTION_STATE_KEY: marker,
+            _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY: (
+                _MERGE_BLOCK_ATTENTION_ORIGIN_MERGE_REJECTION
+            ),
+        }
+        ws.awaiting_human_since = datetime(2026, 1, 1, 12, tzinfo=UTC)
+        ws.awaiting_human_reason = "stale persisted merge rejection"
+        await session.commit()
+
+    await runner._clear_or_preserve_merge_attention_for_queue_wait(
+        workspace_id,
+        state,
+        status=_mergeable_status(),
+        forge="github",
+    )
+
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY not in state.threads_addressed_ids
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert _MERGE_BLOCK_ATTENTION_ORIGIN_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert ws_after.awaiting_human_since is None
+    assert ws_after.awaiting_human_reason is None
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_atomic_clear_marker_absent_on_row_still_clears_attention(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The stale (resolved) atomic-clear branch still clears ``awaiting_human_since``
+    and commits when the persisted row carries NO merge-block marker — the in-memory
+    ``state`` had a marker (driving the stale branch) but the durable row never
+    received it (the outer loop had not flushed ``_persist_state`` yet, or a
+    restart reloaded a marker-less row that a same-poll preserve then re-stamped).
+
+    The ``threads_addressed.pop(...) is None`` guard must skip the redundant
+    ``monitor_threads_addressed`` reassignment (line 303) WITHOUT skipping the
+    attention clear + commit (lines 304-305): a row that already lacks the marker
+    still needs ``awaiting_human_since`` cleared so the resolved ``NotifyHuman``
+    episode stops surfacing. Covers the missing branch in the atomic clear path.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # The in-memory state carries a stale marker (drives the stale branch), but
+    # the persisted row has NO marker — only an active attention flag to clear.
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        # No marker on the row; attention flag set from a prior escalation.
+        ws.monitor_threads_addressed = {}
+        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
+        ws.awaiting_human_reason = "merge_blocked"
+        await session.commit()
+    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=resolved_now,
+    )
+    # In-memory marker dropped.
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    # The persisted row still carries no marker, and the attention flag is cleared
+    # despite the marker-absent branch skipping the threads_addressed reassignment.
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws_after.monitor_threads_addressed or {})
+    assert ws_after.awaiting_human_since is None
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_with_merge_block_marker_absent_marker_skips_marker_write(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The atomic write sets ``awaiting_human_since`` even when no marker is
+    stamped into state (the caller did not re-stamp) — the marker merge is
+    skipped, but the attention flag is still persisted. This is the defensive
+    ``if stamped is not None`` False branch: production always stamps at the
+    merge_loop call site, but the helper must not drop the attention write when
+    the marker is absent."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # No marker stamped into state ⇒ the marker merge is skipped, but the
+    # attention flag must still be persisted.
+    state = MonitorState()
+    await runner._set_workspace_attention_with_merge_block_marker(
+        workspace_id,
+        state,
+        reason="merge_blocked",
+    )
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in (ws.monitor_threads_addressed or {})
+    assert ws.awaiting_human_since is not None
+    assert ws.awaiting_human_reason == "merge_blocked"
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_with_merge_block_marker_already_equal_skips_marker_merge(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The atomic write's marker merge is idempotent: when the DB row already
+    carries the in-memory stamp, the merge is skipped (no redundant assignment)
+    but the attention flag is still refreshed and committed. This is the
+    ``if threads_addressed.get(...) != stamped`` False branch — a second
+    fallback poll re-stamps the same marker the first poll already persisted."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # First call persists the marker AND sets attention.
+    state = MonitorState()
+    state.mark_merge_block_attention()
+    await runner._set_workspace_attention_with_merge_block_marker(
+        workspace_id,
+        state,
+        reason="merge_blocked",
+    )
+    stamped = state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+    assert (ws.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
+    first_attention = ws.awaiting_human_since
+    assert first_attention is not None
+    # A second call with the SAME stamp must skip the marker merge (already
+    # equal) but still refresh and commit the attention flag.
+    await runner._set_workspace_attention_with_merge_block_marker(
+        workspace_id,
+        state,
+        reason="merge_blocked",
+    )
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {})[_MERGE_BLOCK_ATTENTION_STATE_KEY] == stamped
+    assert ws_after.awaiting_human_since is not None
+
+
+class _CommitTrapSession:
+    """Wraps an ``AsyncSession`` so ``commit`` can be trapped by attempt number.
+
+    Counts every ``commit`` call into the shared ``commit_attempts`` dict (key
+    ``"n"``) and raises ``RuntimeError`` on the attempt matching ``fail_on_attempt``
+    (1-indexed) BEFORE delegating to ``inner.commit()``, so the simulated DB
+    failure rolls that transaction back. ``fail_on_attempt=None`` never raises.
+
+    This lets a regression FAIL for the prior two-commit implementation while
+    PASSING for the current single-transaction atomic clear:
+
+    * ``fail_on_attempt=1`` simulates a failure on the (only) atomic commit —
+      the current implementation rolls both writes back (the
+      ``PRRT_kwDOSJAM6s6Lh0zt`` rollback contract). The prior two-commit
+      sequence would also roll its first commit back and never reach the
+      second, so this case does NOT by itself distinguish old from new (the
+      targeted ``fail_on_attempt=2`` case below does).
+    * ``fail_on_attempt=2`` lets the first commit land (the prior
+      implementation's ``_clear_workspace_attention`` clearing
+      ``awaiting_human_since``) and raises on the second (the prior
+      ``_clear_merge_block_attention_durably`` marker removal) — exposing the
+      half-cleared restart window the atomic fix closed. The current
+      single-commit implementation never reaches attempt 2, so it completes
+      with both fields cleared and exactly one recorded commit attempt.
+    """
+
+    def __init__(
+        self,
+        inner: AsyncSession,
+        commit_attempts: dict[str, int],
+        *,
+        fail_on_attempt: int | None = None,
+    ) -> None:
+        self._inner = inner
+        self._commit_attempts = commit_attempts
+        self._fail_on_attempt = fail_on_attempt
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    async def commit(self) -> None:
+        self._commit_attempts["n"] += 1
+        if self._fail_on_attempt is not None and (
+            self._commit_attempts["n"] == self._fail_on_attempt
+        ):
+            raise RuntimeError("simulated DB failure mid-transaction")
+        await self._inner.commit()
+
+    async def __aenter__(self) -> _CommitTrapSession:
+        await self._inner.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        await self._inner.__aexit__(exc_type, exc, tb)
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_atomic_clear_rolls_back_together(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6Lh0zt: the stale (resolved) branch's marker removal and
+    ``awaiting_human_since`` clear MUST land in a SINGLE transaction. The prior
+    two-commit sequence (``_clear_workspace_attention`` then
+    ``_clear_merge_block_attention_durably``) left a cancel/restart window where
+    ``awaiting_human_since`` was already nulled but the STALE marker still sat on
+    the DB row — so the next poll's preserve path re-stamped the stale marker
+    fresh and wedged the monitor in a faux "awaiting human" state until another
+    merge fallback ran (the ``PRRT_kwDOSJAM6s6Lf_37`` window's reciprocal). With
+    both writes under one ``get_for_update`` transaction, a mid-transaction
+    failure rolls BOTH back: a restart can never observe the cleared flag
+    without the also-cleared marker, or vice versa.
+
+    This test simulates the restart window by making the stale-branch commit
+    raise. Under the atomic fix the transaction rolls back in full, so the row
+    still carries BOTH the stale marker AND the still-set attention flag —
+    exactly the pre-failure state, with neither half observable alone. The
+    in-memory marker is dropped before the DB write (mirroring production), so
+    the assertion focuses on the DB row's atomic consistency.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    # Seed a stale marker (resolved block) and an active attention flag into the
+    # persisted row — the state the monitor would reload after a cancel/restart
+    # before the outer loop's full ``_persist_state`` flush.
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
+        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
+        ws.awaiting_human_reason = "merge_blocked"
+        await session.commit()
+
+    # Wrap the session factory so the FIRST session's commit raises — the
+    # restart-window between the (old) two commits, now exercised against the
+    # single atomic transaction.
+    commit_attempts: dict[str, int] = {"n": 0}
+
+    @asynccontextmanager
+    async def _failing_factory() -> AsyncIterator[_CommitTrapSession]:
+        commit_attempts["n"]  # shared counter touched inside the trap
+        async with factory() as inner:
+            yield _CommitTrapSession(inner, commit_attempts, fail_on_attempt=1)
+
+    runner = make_runner(
+        factory=factory,  # type: ignore[arg-type]
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    # Override the runner's session factory with the failing-commit wrapper so
+    # the stale branch's single atomic commit raises mid-transaction.
+    runner._deps = replace(runner._deps, session_factory=_failing_factory)
+
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
+    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
+    # The stale branch raises mid-transaction; the atomic transaction rolls back.
+    with pytest.raises(RuntimeError, match="simulated DB failure"):
+        await runner._clear_stale_merge_attention(
+            workspace_id,
+            state,
+            now=resolved_now,
+        )
+    # A session was opened (the failing-commit one) — the runner attempted the
+    # atomic clear, and the trap recorded exactly the single commit attempt the
+    # atomic transaction performs.
+    assert commit_attempts["n"] >= 1
+
+    # Under the atomic fix, the transaction rolled back in full: the row still
+    # carries BOTH the stale marker AND the still-set attention flag — neither
+    # half of the marker/attention pair is observable independently. This is
+    # the contract the prior two-commit sequence violated.
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {}).get(
+        _MERGE_BLOCK_ATTENTION_STATE_KEY
+    ) == stale_stamp
+    assert ws_after.awaiting_human_since is not None
+    assert ws_after.awaiting_human_reason == "merge_blocked"
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_atomic_clear_distinguishes_two_commit_window(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6Lh0zt (PRRT_kwDOSJAM6s6LiZkN): the atomic clear MUST
+    complete with a SINGLE commit that lands BOTH the stale marker removal and
+    the ``awaiting_human_since`` clear. The sibling rollback regression above
+    traps a mid-transaction failure (``fail_on_attempt=1``), but it does NOT by
+    itself distinguish the current single-transaction implementation from the
+    prior two-commit sequence: the prior ``_clear_workspace_attention`` (commit
+    #1) then ``_clear_merge_block_attention_durably`` (commit #2) would ALSO
+    roll its first commit back and never reach the second when commit #1
+    raises, leaving both fields unchanged — the same observable end state as the
+    atomic rollback.
+
+    This targeted regression lets the FIRST commit land and traps the SECOND
+    (``fail_on_attempt=2``). Under the prior two-commit implementation the
+    first commit (``_clear_workspace_attention``) would clear
+    ``awaiting_human_since`` and succeed, then the second commit
+    (``_clear_merge_block_attention_durably``) would raise — leaving the DB in
+    the half-cleared restart window (attention already nulled but the STALE
+    marker still on the row) and surfacing the ``RuntimeError``. Under the
+    current single-transaction atomic clear there is only ONE commit, so the
+    trap is never reached (``fail_on_attempt=2``), the helper completes
+    cleanly, and BOTH the marker and the attention flag are cleared together.
+    Asserting exactly one recorded commit attempt AND both fields cleared
+    makes this regression FAIL for the reintroduced two-commit approach (which
+    would either raise on the second commit or leave the half-cleared state
+    visible) while passing only for the atomic implementation.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    # Seed a stale marker (resolved block) and an active attention flag — the
+    # pre-clear persisted state the atomic clear is meant to roll back from on
+    # the stale (resolved) branch.
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get_for_update(workspace_id)
+        assert ws is not None
+        ws.monitor_threads_addressed = {_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp}
+        ws.awaiting_human_since = datetime(2024, 1, 1, tzinfo=UTC)
+        ws.awaiting_human_reason = "merge_blocked"
+        await session.commit()
+
+    # Trap the SECOND commit: the prior two-commit implementation would land
+    # the attention clear on commit #1 and raise on commit #2 (marker removal),
+    # surfacing the half-cleared restart window. The current single-transaction
+    # atomic clear performs exactly one commit and never reaches attempt 2.
+    commit_attempts: dict[str, int] = {"n": 0}
+
+    @asynccontextmanager
+    async def _trapping_factory() -> AsyncIterator[_CommitTrapSession]:
+        async with factory() as inner:
+            yield _CommitTrapSession(inner, commit_attempts, fail_on_attempt=2)
+
+    runner = make_runner(
+        factory=factory,  # type: ignore[arg-type]
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    runner._deps = replace(runner._deps, session_factory=_trapping_factory)
+
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
+    resolved_now = datetime(2024, 1, 2, tzinfo=UTC)
+    # The atomic clear completes with its single commit; the trap (set on
+    # attempt 2) is never reached. The prior two-commit implementation would
+    # raise here on its second commit.
+    await runner._clear_stale_merge_attention(
+        workspace_id,
+        state,
+        now=resolved_now,
+    )
+
+    # The atomic implementation performs EXACTLY one commit. A reintroduced
+    # two-commit sequence would record two attempts (and raise on the second).
+    assert commit_attempts["n"] == 1
+
+    # Both the stale marker AND the attention flag are cleared together in
+    # that single transaction — neither half of the pair is observable alone.
+    # A prior two-commit implementation that survived commit #1 but raised on
+    # commit #2 would leave the half-cleared state: marker still present,
+    # attention already nulled.
+    async with factory() as session:
+        ws_after = await WorkspaceRepository(session).get(workspace_id)
+        assert ws_after is not None
+    assert (ws_after.monitor_threads_addressed or {}).get(_MERGE_BLOCK_ATTENTION_STATE_KEY) is None
+    assert ws_after.awaiting_human_since is None
+    assert ws_after.awaiting_human_reason is None
+
+
+@pytest.mark.unit
+async def test_clear_stale_merge_attention_atomic_clear_missing_workspace_skips_writes(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6Lh0zt: the atomic clear no-ops when the workspace row is
+    gone (a GC/destroy race between the stale-clear and the atomic write) — no
+    marker removal, no attention clear, no commit. Mirrors the established
+    ``get_for_update``-returns-None no-op guard in the sibling durable helpers."""
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    stale_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
+    state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: stale_stamp})
+    # The workspace does not exist — the atomic clear returns before any write.
+    await runner._clear_stale_merge_attention(
+        "ws_does_not_exist",
+        state,
+        now=datetime(2024, 1, 2, tzinfo=UTC),
+    )
+    # In-memory marker is still dropped (the caller's signal), but no DB write
+    # was attempted against a missing row.
+    assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids

--- a/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
+++ b/tests/unit/runtime/test_pr_monitor_merge_attention_persistence.py
@@ -215,12 +215,21 @@ async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_sti
     ``awaiting_human_since``.
     """
     workspace_id = await seed_monitoring_workspace(factory)
+    # Inject a deterministic re-stamp clock distinct from BOTH the TTL
+    # ``reference`` below (2024-01-02) and real wall-clock time. The durable
+    # re-stamp routes through the runner clock (``_now`` → ``self._deps.now``),
+    # never the ``reference`` used only for the preserve/clear decision, so the
+    # exact-value assertion pins the re-stamp source and catches a misrouted
+    # ``now()`` (e.g. accidentally re-stamping from ``reference``) the way the
+    # coordinator-wait tests do — wall-clock bounds could not.
+    restamp_clock = datetime(2025, 7, 1, 8, 30, tzinfo=UTC)
     runner = make_runner(
         factory=factory,
         cmd=FakeCommandRunner(),
         adapter=FakeAdapter(),
         sleep_fn=RecordedSleep(),
         worktrees_root=tmp_path,
+        now=lambda: restamp_clock,
     )
     old_stamp = datetime(2024, 1, 1, tzinfo=UTC).isoformat()
     state = MonitorState(threads_addressed_ids={_MERGE_BLOCK_ATTENTION_STATE_KEY: old_stamp})
@@ -233,7 +242,6 @@ async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_sti
         ws.awaiting_human_reason = "GitHub rejected the merge attempt"
         await session.commit()
 
-    before_call = datetime.now(UTC)
     await runner._clear_stale_merge_attention(
         workspace_id,
         state,
@@ -241,12 +249,11 @@ async def test_clear_stale_merge_attention_preserves_stale_marker_when_forge_sti
         status=replace(_mergeable_status(), merge_state_status=MergeStateStatus.BLOCKED),
         forge="github",
     )
-    after_call = datetime.now(UTC)
 
     refreshed_stamp = datetime.fromisoformat(
         state.threads_addressed_ids[_MERGE_BLOCK_ATTENTION_STATE_KEY]
     )
-    assert before_call <= refreshed_stamp <= after_call
+    assert refreshed_stamp == restamp_clock
     async with factory() as session:
         ws_after = await WorkspaceRepository(session).get(workspace_id)
         assert ws_after is not None

--- a/tests/unit/runtime/test_pr_monitor_state.py
+++ b/tests/unit/runtime/test_pr_monitor_state.py
@@ -41,6 +41,17 @@ def test_mark_merge_block_attention_stamps_wall_clock_timestamp() -> None:
 
 
 @pytest.mark.unit
+def test_mark_merge_block_attention_records_merge_rejection_origin() -> None:
+    """A structured marker, not the human-facing reason text, records origin."""
+    state = MonitorState()
+    now = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
+
+    state.mark_merge_block_attention(now=now, originated_from_merge_rejection=True)
+
+    assert state.merge_block_attention_originated_from_merge_rejection() is True
+
+
+@pytest.mark.unit
 def test_merge_block_attention_active_true_within_ttl() -> None:
     """A fresh marker (age <= TTL) reports active — still-blocked, preserved."""
     state = MonitorState()
@@ -58,13 +69,14 @@ def test_merge_block_attention_active_false_after_ttl_drops_marker() -> None:
     """A stale marker (age > TTL) reports inactive (RESOLVED) and is dropped."""
     state = MonitorState()
     stamped = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
-    state.mark_merge_block_attention(now=stamped)
+    state.mark_merge_block_attention(now=stamped, originated_from_merge_rejection=True)
 
     # 300s later with a 120s TTL: age 300 > TTL 120 → resolved.
     later = stamped + timedelta(seconds=300)
     assert state.merge_block_attention_active(now=later, ttl_seconds=120.0) is False
     # The stale marker is dropped so the next fresh poll re-stamps cleanly.
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert state.merge_block_attention_originated_from_merge_rejection() is False
 
 
 @pytest.mark.unit
@@ -141,15 +153,18 @@ def test_clear_merge_block_attention_drops_marker_idempotently() -> None:
     """``clear_merge_block_attention`` is an idempotent pop (unchanged behavior)."""
     state = MonitorState()
     now = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
-    state.mark_merge_block_attention(now=now)
+    state.mark_merge_block_attention(now=now, originated_from_merge_rejection=True)
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY in state.threads_addressed_ids
+    assert state.merge_block_attention_originated_from_merge_rejection() is True
 
     state.clear_merge_block_attention()
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert state.merge_block_attention_originated_from_merge_rejection() is False
 
     # Second clear is a no-op.
     state.clear_merge_block_attention()
     assert _MERGE_BLOCK_ATTENTION_STATE_KEY not in state.threads_addressed_ids
+    assert state.merge_block_attention_originated_from_merge_rejection() is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Promote the merged `development` backlog to `main`. Delta since the last release (#676): one merge-attention hardening fix.

- **#678** (fixes #675, #677) — add an injectable clock seam to the merge critical-section path so the `fresh_at_entry` regressions deterministically catch post-wait wall-clock misclassification (#675); and stop treating `mergeStateStatus=CLEAN` as proof a merge-rejection block resolved, so a still-active actor/push restriction (invisible to CLEAN) is preserved instead of false-clearing `awaiting_human_since` (#677).

Mechanical release sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches merge-loop human-attention and persistence invariants with many edge cases; behavior is heavily tested but wrong logic could hide real blocks or leave stale "awaiting human" signals.
> 
> **Overview**
> Hardens **PR monitor merge-block attention** so operator signals stay correct across long waits, GitHub `CLEAN`, and restarts—fixes **#675** (fresh-at-entry TTL) and **#677** (false-clear on merge rejection).
> 
> **Structured merge-rejection origin** replaces inferring preservation from `awaiting_human_reason`. `MonitorState` gains `__awf_merge_block_attention_origin__`; merge API rejections stamp `originated_from_merge_rejection=True`, and durable persist/clear paths keep marker and origin in sync. Queue waits and critical-section logic use structured origin (with DB recovery when memory lacks it) so GitHub `CLEAN` clears ordinary branch-protection attention but **preserves** actor/push-restriction cases until a merge retry; in-memory non-rejection origin wins over stale DB merge-rejection values.
> 
> **Injectable `now`** on `_RunnerDeps` / `PullRequestMonitorRunner` routes merge-attention and merge-loop timestamps through one clock; tests use `_FakeClock` and tight TTLs instead of real sleeps.
> 
> **Tests**: persistence-heavy cases move to `test_pr_monitor_merge_attention_persistence.py` (line-limit guard); new regressions cover origin branches, no-DB preserve when origin is in memory, and `_persist_state` not dropping recovered origin. Many `plans/*` plan/validation docs document the repair cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e82f35c9fba685a158899fa23dd19a0444b269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->