### PR TITLE
Release: merge development into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,23 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --python 3.12 --extra dev
+        run: |
+          set -euo pipefail
+          last_rc=1
+          for attempt in 1 2 3; do
+            echo "uv sync attempt ${attempt}/3"
+            if uv sync --python 3.12 --extra dev; then
+              exit 0
+            else
+              last_rc=$?
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "uv sync failed; retrying in 10s"
+              sleep 10
+            fi
+          done
+          echo "uv sync failed after 3 attempts"
+          exit "${last_rc}"
 
       - name: Verify Docker and Compose
         run: |
@@ -157,7 +173,23 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --python 3.12 --extra dev
+        run: |
+          set -euo pipefail
+          last_rc=1
+          for attempt in 1 2 3; do
+            echo "uv sync attempt ${attempt}/3"
+            if uv sync --python 3.12 --extra dev; then
+              exit 0
+            else
+              last_rc=$?
+            fi
+            if [ "${attempt}" -lt 3 ]; then
+              echo "uv sync failed; retrying in 10s"
+              sleep 10
+            fi
+          done
+          echo "uv sync failed after 3 attempts"
+          exit "${last_rc}"
 
       - name: Download coverage shards
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/src/awf/common/github_transient.py
+++ b/src/awf/common/github_transient.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 NON_TRANSIENT_GITHUB_ERROR_MARKERS = (
-    "bad credentials",
     "not logged in",
     "please run gh auth login",
     "not found",
@@ -49,6 +48,16 @@ TRANSIENT_GITHUB_ERROR_MARKERS = (
 )
 
 AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = (
+    # #515 symmetry with Bitbucket: 401 auth failures can be transient auth
+    # blips and are bounded-retried; deterministic not-logged-in/not-configured
+    # markers above still win first and remain terminal. Bare bad-credentials
+    # errors still need 401/requires-authentication evidence before retrying.
+    "bad credentials",
+    "http 401",
+    "requires authentication",
+)
+
+GITHUB_AUTH_TRANSIENT_EVIDENCE_MARKERS = (
     "http 401",
     "requires authentication",
 )
@@ -66,17 +75,51 @@ GITHUB_API_CONTEXT_MARKERS = (
     "gh pr create",
 )
 
+GITHUB_AUTH_TRANSIENT_CONTEXT_MARKERS = (
+    "api.github.com",
+    "github api",
+    "graphql",
+    "gh api",
+)
+
+GITHUB_AMBIGUOUS_AUTH_TRANSIENT_CONTEXT_MARKERS = (
+    *GITHUB_AUTH_TRANSIENT_CONTEXT_MARKERS,
+    "gh pr ",
+    "gh issue create",
+    "list_runs_for_sha",
+    "view_run_log",
+)
+
 
 def is_transient_github_error_text(*, operation: str, stderr: str) -> bool:
     """Return whether a GitHub CLI/API failure looks transient."""
 
-    text = f"{operation}\n{stderr}".lower()
+    operation_text = operation.lower()
+    stderr_text = stderr.lower()
+    text = f"{operation_text}\n{stderr_text}"
     if any(marker in text for marker in NON_TRANSIENT_GITHUB_ERROR_MARKERS):
         return False
-    if any(marker in text for marker in GITHUB_RESUBMIT_TRANSIENT_MARKERS) and any(
-        marker in text for marker in GITHUB_API_CONTEXT_MARKERS
-    ):
-        return True
+    has_bad_credentials = "bad credentials" in stderr_text
+    has_auth_transient_evidence = any(
+        marker in stderr_text for marker in GITHUB_AUTH_TRANSIENT_EVIDENCE_MARKERS
+    )
+    has_ambiguous_auth_transient_context = any(
+        marker in operation_text for marker in GITHUB_AMBIGUOUS_AUTH_TRANSIENT_CONTEXT_MARKERS
+    )
+    if has_bad_credentials and not has_auth_transient_evidence:
+        return False
+    if has_bad_credentials and not has_ambiguous_auth_transient_context:
+        return False
+    has_resubmit_guidance = any(marker in text for marker in GITHUB_RESUBMIT_TRANSIENT_MARKERS)
+    has_api_context = any(marker in text for marker in GITHUB_API_CONTEXT_MARKERS)
+    if has_resubmit_guidance and has_api_context:
+        if has_auth_transient_evidence and operation_text.startswith("gh pr create"):
+            return False
+        return not (has_auth_transient_evidence and not has_ambiguous_auth_transient_context)
+    if has_auth_transient_evidence and operation_text.startswith("gh pr create"):
+        return False
     if any(marker in text for marker in TRANSIENT_GITHUB_ERROR_MARKERS):
         return True
-    return any(marker in text for marker in AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS)
+    if not any(marker in stderr_text for marker in AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS):
+        return False
+    return has_ambiguous_auth_transient_context

--- a/src/awf/runtime/pr_monitor_runner/constants.py
+++ b/src/awf/runtime/pr_monitor_runner/constants.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 
 from awf.common.github_transient import (
+    AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
     NON_TRANSIENT_GITHUB_ERROR_MARKERS,
     TRANSIENT_GITHUB_ERROR_MARKERS,
 )
@@ -46,9 +47,10 @@ _TASK_TAG_UNSET = _TaskTagUnset()
 # ``Requires authentication (HTTP 401)`` is frequently a transient GraphQL blip
 # on a valid token (#515) and is handled as bounded-retryable below. These strong
 # markers are checked first in ``_is_transient_github_client_error`` and win, so a
-# 401 combined with e.g. ``Bad credentials`` still fails fast.
+# deterministic not-logged-in/not-found fault still fails fast.
 _NON_TRANSIENT_GITHUB_ERROR_MARKERS = NON_TRANSIENT_GITHUB_ERROR_MARKERS
 _TRANSIENT_GITHUB_ERROR_MARKERS = TRANSIENT_GITHUB_ERROR_MARKERS
+_AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS = AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS
 
 _GITHUB_TRANSIENT_RETRY_REASON = "GITHUB_TRANSIENT_RETRY"
 

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -26,7 +26,10 @@ from awf.common.bitbucket_client import (
     BitbucketClientError,
 )
 from awf.common.github_client import GitHubClientError
-from awf.common.github_transient import is_transient_github_error_text
+from awf.common.github_transient import (
+    GITHUB_AUTH_TRANSIENT_EVIDENCE_MARKERS,
+    is_transient_github_error_text,
+)
 from awf.control.quality_gates import QualityGateViolation
 from awf.control.state_machine import WorkspaceStateMachine
 from awf.db.enums import (
@@ -840,7 +843,10 @@ def _is_transient_base_fetch_error(exc: BaseFetchError) -> bool:
         return False
     if _REMOTE_TRACKING_REF_LOCK_RACE_RE.search(str(exc)):
         return True
-    if "bad credentials" in text and "http 401" not in text:
+    has_auth_transient_evidence = any(
+        marker in text for marker in GITHUB_AUTH_TRANSIENT_EVIDENCE_MARKERS
+    )
+    if "bad credentials" in text and not has_auth_transient_evidence:
         return False
     if any(marker in text for marker in _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS):
         return True

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -89,6 +89,7 @@ from awf.runtime.pr_monitor_runner.comments import (
     VerdictResult,
 )
 from awf.runtime.pr_monitor_runner.constants import (
+    _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS,
     _AUTHORIZATION_BEARER_RE,
     _AWF_VERDICT,
     _BASE_FETCH_RETRY_COUNT_KEY_PREFIX,
@@ -838,6 +839,10 @@ def _is_transient_base_fetch_error(exc: BaseFetchError) -> bool:
     if any(marker in text for marker in _NON_TRANSIENT_GITHUB_ERROR_MARKERS):
         return False
     if _REMOTE_TRACKING_REF_LOCK_RACE_RE.search(str(exc)):
+        return True
+    if "bad credentials" in text and "http 401" not in text:
+        return False
+    if any(marker in text for marker in _AMBIGUOUS_GITHUB_AUTH_TRANSIENT_MARKERS):
         return True
     return any(marker in text for marker in _TRANSIENT_GITHUB_ERROR_MARKERS)
 

--- a/tests/unit/common/test_github_transient.py
+++ b/tests/unit/common/test_github_transient.py
@@ -29,6 +29,22 @@ def test_generic_malformed_http_400_without_resubmit_guidance_is_not_transient()
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "HTTP 503 from GitHub",
+        "gateway timeout while contacting api.github.com",
+        "connection reset by peer",
+    ],
+)
+def test_github_server_and_network_markers_are_transient(stderr: str) -> None:
+    assert is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr=stderr,
+    )
+
+
+@pytest.mark.unit
 def test_resubmit_wording_without_github_api_context_is_not_transient() -> None:
     assert not is_transient_github_error_text(
         operation="local validator",
@@ -37,8 +53,205 @@ def test_resubmit_wording_without_github_api_context_is_not_transient() -> None:
 
 
 @pytest.mark.unit
-def test_deterministic_github_auth_error_wins_over_resubmit_wording() -> None:
+def test_github_bad_credentials_401_is_ambiguous_transient() -> None:
+    assert is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr="gh api graphql failed (exit=1): gh: Bad credentials (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+def test_bare_github_api_bad_credentials_is_not_transient_without_401_evidence() -> None:
     assert not is_transient_github_error_text(
         operation="gh api graphql",
+        stderr="Bad credentials",
+    )
+
+
+@pytest.mark.unit
+def test_bare_pr_create_bad_credentials_without_auth_context_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="Bad credentials",
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_bad_credentials_with_generic_try_again_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="Bad credentials. Please try again.",
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_bad_credentials_401_without_api_context_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="gh: Bad credentials (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+def test_bad_credentials_401_without_github_operation_context_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="git push",
+        stderr="gh: Bad credentials (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_bad_credentials_401_with_graphql_stderr_context_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="https://api.github.com/graphql: Bad credentials (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "operation",
+    ["gh api graphql", "gh pr create", "gh pr merge", "gh pr comment"],
+)
+def test_bad_credentials_with_resubmit_guidance_without_auth_form_is_not_transient(
+    operation: str,
+) -> None:
+    assert not is_transient_github_error_text(
+        operation=operation,
         stderr="Bad credentials. Please try resubmitting your request.",
+    )
+
+
+@pytest.mark.unit
+def test_api_bad_credentials_with_resubmit_guidance_and_401_is_transient() -> None:
+    assert is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr="Bad credentials (HTTP 401). Please try resubmitting your request.",
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_bad_credentials_with_resubmit_guidance_and_401_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr=(
+            "https://api.github.com/graphql: Bad credentials (HTTP 401). "
+            "Please try resubmitting your request."
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_requires_authentication_resubmit_guidance_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr=("gh: Requires authentication (HTTP 401). Please try resubmitting your request."),
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation", ["gh pr merge", "gh pr comment"])
+def test_pr_cli_requires_authentication_resubmit_guidance_is_transient(operation: str) -> None:
+    assert is_transient_github_error_text(
+        operation=operation,
+        stderr=(
+            "https://api.github.com/graphql: Requires authentication (HTTP 401). "
+            "Please try resubmitting your request."
+        ),
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_requires_authentication_without_resubmit_guidance_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+def test_pr_create_requires_authentication_with_generic_try_again_is_not_transient() -> None:
+    assert not is_transient_github_error_text(
+        operation="gh pr create",
+        stderr="gh: Requires authentication (HTTP 401). Please try again.",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "not logged in to any GitHub hosts",
+        "To get started with GitHub CLI, please run gh auth login",
+        "repository not found",
+        "could not resolve to a Repository with the name 'org/repo'",
+        "could not resolve to a node",
+    ],
+)
+def test_deterministic_github_auth_and_not_found_markers_stay_non_transient(
+    stderr: str,
+) -> None:
+    assert not is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr=stderr,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "HTTP 401",
+        "Requires authentication",
+        "gh: Requires authentication (HTTP 401)",
+    ],
+)
+def test_ambiguous_github_401_markers_stay_transient(stderr: str) -> None:
+    assert is_transient_github_error_text(
+        operation="gh api graphql",
+        stderr=stderr,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("operation", "stderr"),
+    [
+        ("gh pr merge", "gh: Requires authentication (HTTP 401)"),
+        ("gh pr comment", "HTTP 401"),
+        ("gh pr merge", "gh: Bad credentials (HTTP 401)"),
+        ("gh pr comment", "gh: Bad credentials (HTTP 401)"),
+    ],
+)
+def test_ambiguous_github_401_markers_are_transient_for_pr_cli_operations(
+    operation: str,
+    stderr: str,
+) -> None:
+    assert is_transient_github_error_text(
+        operation=operation,
+        stderr=stderr,
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("operation", ["list_runs_for_sha", "view_run_log"])
+def test_failed_ci_log_fetch_ambiguous_401_markers_are_transient(operation: str) -> None:
+    assert is_transient_github_error_text(
+        operation=operation,
+        stderr="gh: Requires authentication (HTTP 401)",
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "stderr",
+    [
+        "gh: Requires authentication (HTTP 401)",
+        "gh: Bad credentials (HTTP 401)",
+    ],
+)
+def test_deferred_issue_create_ambiguous_401_markers_are_transient(stderr: str) -> None:
+    assert is_transient_github_error_text(
+        operation="gh issue create",
+        stderr=stderr,
     )

--- a/tests/unit/runtime/test_pr_creator.py
+++ b/tests/unit/runtime/test_pr_creator.py
@@ -659,7 +659,13 @@ class TestPushAndOpen:
         runner = FakeCommandRunner()
         _queue_pre_push_diagnostics(runner)
         runner.queue_result(returncode=0)  # push succeeds
-        runner.queue_result(returncode=1, stderr="Bad credentials")
+        runner.queue_result(
+            returncode=1,
+            stderr=(
+                "https://api.github.com/graphql: Bad credentials (HTTP 401). "
+                "Please try resubmitting your request."
+            ),
+        )
 
         creator = PullRequestCreator(
             runner,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
@@ -627,15 +627,15 @@ def test_transient_github_error_classifier_keeps_auth_errors_terminal() -> None:
             stderr="gh api graphql failed (exit=1): gh: Requires authentication (HTTP 401)",
         )
     )
-    # Strong, unambiguous permanent markers still fail fast — including when
-    # combined with a 401 (the strong marker is checked first and wins).
-    assert not _is_transient_github_client_error(
+    # GitHub can also spell the ambiguous 401 blip as ``Bad credentials``.
+    assert _is_transient_github_client_error(
         GitHubClientError(
             operation="gh api graphql",
             returncode=1,
-            stderr="Bad credentials",
+            stderr="gh api graphql failed (exit=1): gh: Bad credentials (HTTP 401)",
         )
     )
+    # Strong, unambiguous permanent markers still fail fast.
     assert not _is_transient_github_client_error(
         GitHubClientError(
             operation="gh api graphql",
@@ -661,7 +661,7 @@ def test_transient_github_error_classifier_keeps_auth_errors_terminal() -> None:
         GitHubClientError(
             operation="gh api graphql",
             returncode=1,
-            stderr="Bad credentials; Requires authentication (HTTP 401)",
+            stderr="repository not found",
         )
     )
     assert not _is_transient_github_client_error(
@@ -689,6 +689,12 @@ def test_transient_base_fetch_classifier_and_corrupt_retry_count_recovery() -> N
             "origin/codex/awf-post-merge-fixes  (unable to update local ref)"
         )
     )
+    assert _is_transient_base_fetch_error(
+        BaseFetchError("git fetch origin main failed: gh: Bad credentials (HTTP 401)")
+    )
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError("git fetch origin main failed: gh: Bad credentials")
+    )
     assert not _is_transient_base_fetch_error(
         BaseFetchError("git fetch origin development failed: repository not found")
     )
@@ -705,13 +711,18 @@ def test_transient_base_fetch_classifier_and_corrupt_retry_count_recovery() -> N
             "The requested URL returned error: 401"
         )
     )
-    # #516 (PRRT_kwDOSJAM6s6InGJP) regression: git smart-HTTP surfaces genuine
-    # credential failures as ``error: RPC failed; HTTP 401`` — a contiguous
-    # ``HTTP 401`` substring. The ambiguous-auth markers are scoped to the GitHub
-    # API client path only, so this base-fetch auth failure must still fail fast
-    # rather than be bounded-retried as a transient blip.
-    assert not _is_transient_base_fetch_error(
+    # Full #515 symmetry: ambiguous GitHub 401 text is bounded-retryable on the
+    # base-fetch path too. This deliberately accepts the slower failure path for
+    # genuine expired-token smart-HTTP failures so intermittent GitHub auth blips
+    # get the same bounded retry budget as the API client path.
+    assert _is_transient_base_fetch_error(
         BaseFetchError("error: RPC failed; HTTP 401 curl 22 The requested URL returned error: 401")
+    )
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError("fatal: not logged in to any GitHub hosts")
+    )
+    assert not _is_transient_base_fetch_error(
+        BaseFetchError("To get started with GitHub CLI, please run gh auth login")
     )
     retry_key = "__awf_base_fetch_retry_count:sync_base"
     state = MonitorState(threads_addressed_ids={retry_key: "not-an-integer"})

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_001.py
@@ -692,6 +692,9 @@ def test_transient_base_fetch_classifier_and_corrupt_retry_count_recovery() -> N
     assert _is_transient_base_fetch_error(
         BaseFetchError("git fetch origin main failed: gh: Bad credentials (HTTP 401)")
     )
+    assert _is_transient_base_fetch_error(
+        BaseFetchError("git fetch origin main failed: gh: Bad credentials; requires authentication")
+    )
     assert not _is_transient_base_fetch_error(
         BaseFetchError("git fetch origin main failed: gh: Bad credentials")
     )

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_017.py
@@ -115,11 +115,11 @@ async def test_github_transient_401_retries_with_backoff_then_exhausts(
         sleep_fn=sleep_fn,
         worktrees_root=tmp_path / "worktrees",
     )
-    # The exact #515 failure string — a bare 401 with no strong permanent marker.
+    # GitHub can spell the ambiguous #515 401 blip as "Bad credentials".
     exc = GitHubClientError(
         operation="gh api graphql",
         returncode=1,
-        stderr="gh: Requires authentication (HTTP 401)",
+        stderr="gh api graphql failed (exit=1): gh: Bad credentials (HTTP 401)",
     )
     state = MonitorState()
 
@@ -162,6 +162,7 @@ async def test_github_transient_401_retries_with_backoff_then_exhausts(
         assert exhausted_events[0].reason_code == "GITHUB_TRANSIENT_RETRY_EXHAUSTED"
         assert exhausted_events[0].payload["retry_number"] == 6
         assert exhausted_events[0].payload["max_retries"] == 5
+        assert "Bad credentials (HTTP 401)" in exhausted_events[0].payload["stderr"]
 
 
 @pytest.mark.unit
@@ -649,12 +650,12 @@ async def test_deterministic_fault_clears_stale_prior_transient_counter(
         returncode=1,
         stderr="gh: Requires authentication (HTTP 401)",
     )
-    # A strong permanent marker ("bad credentials") => deterministic, never retried,
-    # even though the same string also carries the ambiguous ``HTTP 401`` token.
+    # A deterministic CLI-not-authed marker is never retried, even though a
+    # separate bad-credentials 401 can now be bounded-retryable.
     deterministic_exc = GitHubClientError(
         operation="gh api graphql",
         returncode=1,
-        stderr="gh: Bad credentials (HTTP 401)",
+        stderr="gh: not logged in to any GitHub hosts",
     )
     state = MonitorState()
 

--- a/tests/unit/runtime/test_release_pr_sync.py
+++ b/tests/unit/runtime/test_release_pr_sync.py
@@ -681,7 +681,13 @@ class TestFindOrCreateReleasePr:
     async def test_deterministic_create_failure_reraises_without_recheck(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0, stdout="[]")  # gh pr list -> none
-        fake.queue_result(returncode=1, stderr="Bad credentials")  # gh pr create -> fails
+        fake.queue_result(
+            returncode=1,
+            stderr=(
+                "https://api.github.com/graphql: Bad credentials (HTTP 401). "
+                "Please try resubmitting your request."
+            ),
+        )  # gh pr create -> fails
         gh = GitHubClient(fake)
 
         with pytest.raises(GitHubClientError) as exc:


### PR DESCRIPTION
Automated AWF release PR syncing `development` into `main`.

Opened by the `sync_release_pr` task kind and monitored with release/manual behavior (auto-merge disabled). Merging into the release target stays human-gated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor, base-fetch, and shared GitHub error classification around auth/401—wrong rules could retry real credential failures or fail fast on blips; CI retry is low risk.
> 
> **Overview**
> **Refines when GitHub/gh failures are treated as transient** so intermittent auth blips get the same bounded retry budget as other forge errors, aligned with Bitbucket (#515).
> 
> `bad credentials` is no longer always terminal: it can be retryable when stderr shows **HTTP 401** / **requires authentication** and the **operation** looks like API/PR/CI/issue work—not bare errors, not `git push`, and **`gh pr create`** stays **non-transient** even with GraphQL/resubmit wording (deterministic PR-open failures). Strong markers (not logged in, repo not found, etc.) still fail fast. **Base fetch** classification mirrors this (e.g. smart-HTTP `HTTP 401` can retry; bare bad credentials cannot).
> 
> **CI** wraps `uv sync` in **3 attempts** with **10s** backoff on the Python coverage shard and combine jobs.
> 
> Tests and monitor/PR-creator expectations are updated for the new matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f3ad827520ff4d49f699b9a496bdc5729634cab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->