### PR TITLE
fix(pr-monitor): retire guided review human waits

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -132,7 +132,11 @@ async def _run_operator_hint_cycle(
         if pushed_head_sha:
             state.last_push_sha = pushed_head_sha
         await _finalize_operator_hint_resume(
-            self, workspace_id=workspace_id, state=state, hint=hint
+            self,
+            workspace_id=workspace_id,
+            state=state,
+            hint=hint,
+            acted_feedback_text=hint.directive,
         )
         return _GitPushResult(pushed=False, failed=False, returncode=0)
     # Restart-after-consume recovery for a DIRECTIVE that DROPPED the preserved
@@ -174,10 +178,17 @@ async def _run_operator_hint_cycle(
         ):
             state.last_push_sha = local_head_sha
             await _finalize_operator_hint_resume(
-                self, workspace_id=workspace_id, state=state, hint=hint
+                self,
+                workspace_id=workspace_id,
+                state=state,
+                hint=hint,
+                acted_feedback_text=hint.directive,
             )
             return _GitPushResult(pushed=False, failed=False, returncode=0)
+    acted_feedback_text = hint.directive
     if hint.directive or not active_grant_specs:
+        if not hint.directive:
+            acted_feedback_text = hint.reason
         prompt = operator_hint_prompt(
             pr_number=pr_number,
             repo_slug=repo.slug(),
@@ -483,7 +494,11 @@ async def _run_operator_hint_cycle(
         if pushed_head_sha:
             state.last_push_sha = pushed_head_sha
         await _finalize_operator_hint_resume(
-            self, workspace_id=workspace_id, state=state, hint=hint
+            self,
+            workspace_id=workspace_id,
+            state=state,
+            hint=hint,
+            acted_feedback_text=acted_feedback_text,
         )
         return _GitPushResult(pushed=False, failed=False, returncode=0)
     push_result = (
@@ -649,7 +664,11 @@ async def _run_operator_hint_cycle(
             mark_operator_hint_needs_human(state, reason)
             return cast(_GitPushResult, push_result)
         await _finalize_operator_hint_resume(
-            self, workspace_id=workspace_id, state=state, hint=hint
+            self,
+            workspace_id=workspace_id,
+            state=state,
+            hint=hint,
+            acted_feedback_text=acted_feedback_text,
         )
         return cast(_GitPushResult, push_result)
 
@@ -658,7 +677,13 @@ async def _run_operator_hint_cycle(
         state.last_push_sha = pushed_head_sha
     # Single-use: consume the operator grants now that the resumed change pushed,
     # so a later DIFFERENT protected change re-blocks and must be granted again.
-    await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state, hint=hint)
+    await _finalize_operator_hint_resume(
+        self,
+        workspace_id=workspace_id,
+        state=state,
+        hint=hint,
+        acted_feedback_text=acted_feedback_text,
+    )
     return cast(_GitPushResult, push_result)
 
 
@@ -993,7 +1018,12 @@ async def _clear_dropped_preserved_marker_after_terminal_directive(
 
 
 async def _finalize_operator_hint_resume(
-    self: Any, *, workspace_id: str, state: MonitorState, hint: OperatorHint | None = None
+    self: Any,
+    *,
+    workspace_id: str,
+    state: MonitorState,
+    hint: OperatorHint | None = None,
+    acted_feedback_text: str | None = None,
 ) -> None:
     """Close out a settled protected-block resume so the next cycle starts clean.
 
@@ -1020,11 +1050,14 @@ async def _finalize_operator_hint_resume(
     hint processed for the remainder of this cycle."""
     await self._clear_preserved_marker_and_consume_grants_durably(workspace_id)
     await self._clear_block_resume_phase(workspace_id)
-    _finalize_processed_operator_hint(state, hint=hint)
+    _finalize_processed_operator_hint(state, hint=hint, acted_feedback_text=acted_feedback_text)
 
 
 def _finalize_processed_operator_hint(
-    state: MonitorState, *, hint: OperatorHint | None = None
+    state: MonitorState,
+    *,
+    hint: OperatorHint | None = None,
+    acted_feedback_text: str | None = None,
 ) -> None:
     """Mark the operator hint processed and drop the protected-block preserved-head
     marker.
@@ -1039,7 +1072,9 @@ def _finalize_processed_operator_hint(
     """
     pending_hint = getattr(state, "pending_operator_hint", None)
     active_hint = pending_hint or hint
-    _mark_referenced_needs_human_feedback_answered(state, hint=active_hint)
+    _mark_referenced_needs_human_feedback_answered(
+        state, hint=active_hint, acted_text=acted_feedback_text
+    )
     state.threads_addressed_ids.pop(_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY, None)
     if hasattr(state, "pending_operator_hint") and pending_hint is None and active_hint is not None:
         state.pending_operator_hint = active_hint
@@ -1047,7 +1082,10 @@ def _finalize_processed_operator_hint(
 
 
 def _mark_referenced_needs_human_feedback_answered(
-    state: MonitorState, *, hint: OperatorHint | None = None
+    state: MonitorState,
+    *,
+    hint: OperatorHint | None = None,
+    acted_text: str | None = None,
 ) -> None:
     """Retire review-level ``needs_human`` verdicts a guide explicitly answered.
 
@@ -1058,6 +1096,10 @@ def _mark_referenced_needs_human_feedback_answered(
     processed and the next ``decide()`` poll immediately re-enters the same stale
     HUMAN_WAIT.
 
+    ``hint.reason`` can be audit context for approve-and-keep grant-only resumes,
+    which skip the CLI entirely. Callers pass ``acted_text`` when a directiveless
+    reason was actually presented to the agent; otherwise only a directive counts.
+
     This helper intentionally leaves any stored ``__review_comment_body_hash__``
     marker unchanged because it does not receive the live ``ReviewComment`` needed
     to recompute the hash. To keep the retirement durable across the next
@@ -1067,7 +1109,7 @@ def _mark_referenced_needs_human_feedback_answered(
     """
     if hint is None:
         return
-    text = hint.directive or hint.reason
+    text = acted_text if acted_text is not None else hint.directive
     if not text:
         return
     for referenced_id in _operator_hint_feedback_id_candidates(text):

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -136,7 +136,11 @@ async def _run_operator_hint_cycle(
             workspace_id=workspace_id,
             state=state,
             hint=hint,
-            acted_feedback_text=hint.directive,
+            acted_feedback_text=(
+                hint.reason
+                if hint.directive is None and hint.reason_code == "OPERATOR_REMONITOR"
+                else hint.directive
+            ),
         )
         return _GitPushResult(pushed=False, failed=False, returncode=0)
     # Restart-after-consume recovery for a DIRECTIVE that DROPPED the preserved

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -1060,10 +1060,10 @@ def _mark_referenced_needs_human_feedback_answered(
 
     This helper intentionally leaves any stored ``__review_comment_body_hash__``
     marker unchanged because it does not receive the live ``ReviewComment`` needed
-    to recompute the hash. A caller that retires the verdict while holding that
-    object should refresh the marker at the same time; otherwise a concurrent
-    reviewer edit can make the next stale-state sweep clear this false-positive
-    retirement and requeue the comment for triage.
+    to recompute the hash. To keep the retirement durable across the next
+    stale-state sweep, it only retires rows that already have body-hash sidecar
+    state. Legacy rows without that marker remain ``needs_human`` until a path
+    holding the live comment can snapshot the body.
     """
     if hint is None:
         return
@@ -1074,9 +1074,15 @@ def _mark_referenced_needs_human_feedback_answered(
         for item_id in _operator_hint_feedback_storage_key_candidates(referenced_id):
             if state.threads_addressed_ids.get(item_id) != "needs_human":
                 continue
+            if not state.threads_addressed_ids.get(_operator_hint_feedback_body_hash_key(item_id)):
+                continue
             state.mark_addressed(item_id, "false_positive")
             state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
             break
+
+
+def _operator_hint_feedback_body_hash_key(item_id: str) -> str:
+    return f"__review_comment_body_hash__:{item_id}"
 
 
 def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -1057,6 +1057,13 @@ def _mark_referenced_needs_human_feedback_answered(
     guide that names the original issue/review feedback id must also update the
     persisted verdict. Otherwise the hint is marked processed and the next
     ``decide()`` poll immediately re-enters the same stale HUMAN_WAIT.
+
+    This helper intentionally leaves any stored ``__review_comment_body_hash__``
+    marker unchanged because it does not receive the live ``ReviewComment`` needed
+    to recompute the hash. A caller that retires the verdict while holding that
+    object should refresh the marker at the same time; otherwise a concurrent
+    reviewer edit can make the next stale-state sweep clear this false-positive
+    retirement and requeue the comment for triage.
     """
     if hint is None:
         return

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any, cast
 
@@ -40,6 +41,8 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorMirrorHooksPathRepairFailedError,
     _MonitorPolicyBlockedError,
 )
+
+_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\b(?:issue:)?\d{6,}\b")
 
 
 async def _run_operator_hint_cycle(
@@ -123,7 +126,9 @@ async def _run_operator_hint_cycle(
         pushed_head_sha = await self._rev_parse_head(worktree_path)
         if pushed_head_sha:
             state.last_push_sha = pushed_head_sha
-        await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state)
+        await _finalize_operator_hint_resume(
+            self, workspace_id=workspace_id, state=state, hint=hint
+        )
         return _GitPushResult(pushed=False, failed=False, returncode=0)
     # Restart-after-consume recovery for a DIRECTIVE that DROPPED the preserved
     # commit. A directive-only resume can resolve the block by dropping the preserved
@@ -163,7 +168,9 @@ async def _run_operator_hint_cycle(
             preserved_head_sha=local_head_sha,
         ):
             state.last_push_sha = local_head_sha
-            await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state)
+            await _finalize_operator_hint_resume(
+                self, workspace_id=workspace_id, state=state, hint=hint
+            )
             return _GitPushResult(pushed=False, failed=False, returncode=0)
     if hint.directive or not active_grant_specs:
         prompt = operator_hint_prompt(
@@ -470,7 +477,9 @@ async def _run_operator_hint_cycle(
         pushed_head_sha = await self._rev_parse_head(worktree_path)
         if pushed_head_sha:
             state.last_push_sha = pushed_head_sha
-        await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state)
+        await _finalize_operator_hint_resume(
+            self, workspace_id=workspace_id, state=state, hint=hint
+        )
         return _GitPushResult(pushed=False, failed=False, returncode=0)
     push_result = (
         await self._repair_protected_scope_commits_before_push(
@@ -634,7 +643,9 @@ async def _run_operator_hint_cycle(
             )
             mark_operator_hint_needs_human(state, reason)
             return cast(_GitPushResult, push_result)
-        await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state)
+        await _finalize_operator_hint_resume(
+            self, workspace_id=workspace_id, state=state, hint=hint
+        )
         return cast(_GitPushResult, push_result)
 
     pushed_head_sha = await self._rev_parse_head(worktree_path)
@@ -642,7 +653,7 @@ async def _run_operator_hint_cycle(
         state.last_push_sha = pushed_head_sha
     # Single-use: consume the operator grants now that the resumed change pushed,
     # so a later DIFFERENT protected change re-blocks and must be granted again.
-    await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state)
+    await _finalize_operator_hint_resume(self, workspace_id=workspace_id, state=state, hint=hint)
     return cast(_GitPushResult, push_result)
 
 
@@ -977,7 +988,7 @@ async def _clear_dropped_preserved_marker_after_terminal_directive(
 
 
 async def _finalize_operator_hint_resume(
-    self: Any, *, workspace_id: str, state: MonitorState
+    self: Any, *, workspace_id: str, state: MonitorState, hint: OperatorHint | None = None
 ) -> None:
     """Close out a settled protected-block resume so the next cycle starts clean.
 
@@ -1004,10 +1015,12 @@ async def _finalize_operator_hint_resume(
     hint processed for the remainder of this cycle."""
     await self._clear_preserved_marker_and_consume_grants_durably(workspace_id)
     await self._clear_block_resume_phase(workspace_id)
-    _finalize_processed_operator_hint(state)
+    _finalize_processed_operator_hint(state, hint=hint)
 
 
-def _finalize_processed_operator_hint(state: MonitorState) -> None:
+def _finalize_processed_operator_hint(
+    state: MonitorState, *, hint: OperatorHint | None = None
+) -> None:
     """Mark the operator hint processed and drop the protected-block preserved-head
     marker.
 
@@ -1019,8 +1032,52 @@ def _finalize_processed_operator_hint(state: MonitorState) -> None:
     restart-recovery shortcut and skip the CLI — silently ignoring the operator's
     new repair request (PRRT_kwDOSJAM6s6KE2BX). A fresh block re-records the marker.
     """
+    pending_hint = getattr(state, "pending_operator_hint", None)
+    active_hint = pending_hint or hint
+    _mark_referenced_needs_human_feedback_answered(state, hint=active_hint)
     state.threads_addressed_ids.pop(_PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY, None)
+    if hasattr(state, "pending_operator_hint") and pending_hint is None and active_hint is not None:
+        state.pending_operator_hint = active_hint
     mark_operator_hint_processed(state)
+
+
+def _mark_referenced_needs_human_feedback_answered(
+    state: MonitorState, *, hint: OperatorHint | None = None
+) -> None:
+    """Retire review-level ``needs_human`` verdicts a guide explicitly answered.
+
+    Operator guides are the sanctioned path for resolving a monitor HUMAN_WAIT.
+    For review-level comments there is no GitHub thread to resolve, so a consumed
+    guide that names the original issue/review feedback id must also update the
+    persisted verdict. Otherwise the hint is marked processed and the next
+    ``decide()`` poll immediately re-enters the same stale HUMAN_WAIT.
+    """
+    if hint is None:
+        return
+    text = "\n".join(part for part in (hint.directive, hint.reason) if part)
+    if not text:
+        return
+    for item_id in _operator_hint_feedback_id_candidates(text):
+        if state.threads_addressed_ids.get(item_id) != "needs_human":
+            continue
+        state.mark_addressed(item_id, "false_positive")
+        state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
+
+
+def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for match in _OPERATOR_HINT_FEEDBACK_ID_RE.finditer(text):
+        raw = match.group(0)
+        forms = (
+            (raw, raw.removeprefix("issue:")) if raw.startswith("issue:") else (raw, f"issue:{raw}")
+        )
+        for item_id in forms:
+            if item_id in seen:
+                continue
+            seen.add(item_id)
+            candidates.append(item_id)
+    return tuple(candidates)
 
 
 def _operator_hint_block_reason(verdict: VerdictResult) -> str:

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -44,9 +44,9 @@ from awf.runtime.pr_monitor_runner.types import (
 
 # Recognize the persisted review-comment key forms surfaced back to operators:
 # GitHub review bodies may be bare databaseIds, while issue/review comments use
-# ``issue:<databaseId>``. The caller still requires an exact stale
-# ``needs_human`` key match before retiring anything, which preserves the
-# over-clear guard for unrelated numbers in guide text.
+# ``issue:<databaseId>``. Retirement still requires a stale ``needs_human``
+# storage-key match before clearing anything, which preserves the over-clear
+# guard for unrelated numbers in guide text.
 _OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b|\b\d{6,}\b")
 
 
@@ -1069,11 +1069,13 @@ def _mark_referenced_needs_human_feedback_answered(
     text = "\n".join(part for part in (hint.directive, hint.reason) if part)
     if not text:
         return
-    for item_id in _operator_hint_feedback_id_candidates(text):
-        if state.threads_addressed_ids.get(item_id) != "needs_human":
-            continue
-        state.mark_addressed(item_id, "false_positive")
-        state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
+    for referenced_id in _operator_hint_feedback_id_candidates(text):
+        for item_id in _operator_hint_feedback_storage_key_candidates(referenced_id):
+            if state.threads_addressed_ids.get(item_id) != "needs_human":
+                continue
+            state.mark_addressed(item_id, "false_positive")
+            state.threads_addressed_ids.pop(f"__needs_human_reason__:{item_id}", None)
+            break
 
 
 def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
@@ -1086,6 +1088,12 @@ def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
         seen.add(item_id)
         candidates.append(item_id)
     return tuple(candidates)
+
+
+def _operator_hint_feedback_storage_key_candidates(referenced_id: str) -> tuple[str, ...]:
+    if referenced_id.startswith("issue:"):
+        return (referenced_id, referenced_id.removeprefix("issue:"))
+    return (referenced_id,)
 
 
 def _operator_hint_block_reason(verdict: VerdictResult) -> str:

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -42,13 +42,12 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorPolicyBlockedError,
 )
 
-# Require the ``issue:`` prefix: review-comment ids are stored as
-# ``issue:<numeric databaseId>`` (see ``github_client``), so the prefixed form is
-# the only key in ``threads_addressed_ids``. Matching a bare 6+ digit number would
-# let an unrelated number in free-text directive/reason (a PR number, a line
-# count, a pasted id) coincidentally clear the WRONG ``needs_human`` verdict on
-# this merge-gating path. Requiring the prefix removes that over-clear window.
-_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b")
+# Recognize the persisted review-comment key forms surfaced back to operators:
+# GitHub review bodies may be bare databaseIds, while issue/review comments use
+# ``issue:<databaseId>``. The caller still requires an exact stale
+# ``needs_human`` key match before retiring anything, which preserves the
+# over-clear guard for unrelated numbers in guide text.
+_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b|\b\d{6,}\b")
 
 
 async def _run_operator_hint_cycle(
@@ -1081,7 +1080,7 @@ def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
     candidates: list[str] = []
     seen: set[str] = set()
     for match in _OPERATOR_HINT_FEEDBACK_ID_RE.finditer(text):
-        item_id = match.group(0)  # always ``issue:<databaseId>`` — the stored key form
+        item_id = match.group(0)
         if item_id in seen:
             continue
         seen.add(item_id)

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -42,7 +42,13 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorPolicyBlockedError,
 )
 
-_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\b(?:issue:)?\d{6,}\b")
+# Require the ``issue:`` prefix: review-comment ids are stored as
+# ``issue:<numeric databaseId>`` (see ``github_client``), so the prefixed form is
+# the only key in ``threads_addressed_ids``. Matching a bare 6+ digit number would
+# let an unrelated number in free-text directive/reason (a PR number, a line
+# count, a pasted id) coincidentally clear the WRONG ``needs_human`` verdict on
+# this merge-gating path. Requiring the prefix removes that over-clear window.
+_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b")
 
 
 async def _run_operator_hint_cycle(
@@ -1068,15 +1074,11 @@ def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
     candidates: list[str] = []
     seen: set[str] = set()
     for match in _OPERATOR_HINT_FEEDBACK_ID_RE.finditer(text):
-        raw = match.group(0)
-        forms = (
-            (raw, raw.removeprefix("issue:")) if raw.startswith("issue:") else (raw, f"issue:{raw}")
-        )
-        for item_id in forms:
-            if item_id in seen:
-                continue
-            seen.add(item_id)
-            candidates.append(item_id)
+        item_id = match.group(0)  # always ``issue:<databaseId>`` — the stored key form
+        if item_id in seen:
+            continue
+        seen.add(item_id)
+        candidates.append(item_id)
     return tuple(candidates)
 
 

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -1053,9 +1053,10 @@ def _mark_referenced_needs_human_feedback_answered(
 
     Operator guides are the sanctioned path for resolving a monitor HUMAN_WAIT.
     For review-level comments there is no GitHub thread to resolve, so a consumed
-    guide that names the original issue/review feedback id must also update the
-    persisted verdict. Otherwise the hint is marked processed and the next
-    ``decide()`` poll immediately re-enters the same stale HUMAN_WAIT.
+    guide that names the original issue/review feedback id in the acted-on text
+    must also update the persisted verdict. Otherwise the hint is marked
+    processed and the next ``decide()`` poll immediately re-enters the same stale
+    HUMAN_WAIT.
 
     This helper intentionally leaves any stored ``__review_comment_body_hash__``
     marker unchanged because it does not receive the live ``ReviewComment`` needed
@@ -1066,7 +1067,7 @@ def _mark_referenced_needs_human_feedback_answered(
     """
     if hint is None:
         return
-    text = "\n".join(part for part in (hint.directive, hint.reason) if part)
+    text = hint.directive or hint.reason
     if not text:
         return
     for referenced_id in _operator_hint_feedback_id_candidates(text):

--- a/src/awf/runtime/pr_monitor_runner/operator_hints.py
+++ b/src/awf/runtime/pr_monitor_runner/operator_hints.py
@@ -42,12 +42,25 @@ from awf.runtime.pr_monitor_runner.types import (
     _MonitorPolicyBlockedError,
 )
 
-# Recognize the persisted review-comment key forms surfaced back to operators:
-# GitHub review bodies may be bare databaseIds, while issue/review comments use
-# ``issue:<databaseId>``. Retirement still requires a stale ``needs_human``
-# storage-key match before clearing anything, which preserves the over-clear
-# guard for unrelated numbers in guide text.
-_OPERATOR_HINT_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b|\b\d{6,}\b")
+# Recognize the persisted review-comment key forms surfaced back to operators.
+# ``issue:<databaseId>`` is already an explicit feedback key; bare databaseIds
+# must appear with feedback/comment id context so unrelated long numbers do not
+# retire stale review waits.
+_OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE = re.compile(r"\bissue:\d{6,}\b", re.IGNORECASE)
+_OPERATOR_HINT_BARE_FEEDBACK_ID_RE = re.compile(
+    r"""
+    \b
+    (?:
+        feedback
+        | review(?:[\s_-]+comment)?
+        | comment
+    )
+    [\s_-]*id[\s:#-]*
+    (?P<id>\d{6,})
+    \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 
 async def _run_operator_hint_cycle(
@@ -1134,8 +1147,16 @@ def _operator_hint_feedback_body_hash_key(item_id: str) -> str:
 def _operator_hint_feedback_id_candidates(text: str) -> tuple[str, ...]:
     candidates: list[str] = []
     seen: set[str] = set()
-    for match in _OPERATOR_HINT_FEEDBACK_ID_RE.finditer(text):
-        item_id = match.group(0)
+    matches: list[tuple[int, str]] = []
+    matches.extend(
+        (match.start(), match.group(0).lower())
+        for match in _OPERATOR_HINT_ISSUE_FEEDBACK_ID_RE.finditer(text)
+    )
+    matches.extend(
+        (match.start("id"), match.group("id"))
+        for match in _OPERATOR_HINT_BARE_FEEDBACK_ID_RE.finditer(text)
+    )
+    for _, item_id in sorted(matches, key=lambda candidate: candidate[0]):
         if item_id in seen:
             continue
         seen.add(item_id)

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -1050,7 +1050,10 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
         }
     )
     hint = OperatorHint(
-        reason=("Operator confirmed 1234567, issue:2345678, and issue:7654321 are non-blocking."),
+        reason=(
+            "Operator confirmed feedback id 1234567, issue:2345678, "
+            "and issue:7654321 are non-blocking."
+        ),
         operation_id="op_referenced_feedback",
         requested_at="2026-06-25T18:20:00+00:00",
     )
@@ -1065,6 +1068,30 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
     assert "__needs_human_reason__:issue:7654321" not in state.threads_addressed_ids
     assert state.threads_addressed_ids["9999999"] == "needs_human"
     assert state.threads_addressed_ids["__needs_human_reason__:9999999"] == "still blocking"
+
+
+def test_operator_hint_retire_referenced_needs_human_feedback_rejects_uncontextual_bare_id() -> (
+    None
+):
+    state = MonitorState(
+        threads_addressed_ids={
+            "1234567": "needs_human",
+            _review_comment_body_state_key("1234567"): pr_feedback_body_hash("bare review body"),
+            "__needs_human_reason__:1234567": "operator asked for help",
+        }
+    )
+    hint = OperatorHint(
+        reason="Operator closed ticket 1234567; proceed.",
+        operation_id="op_uncontextual_bare_feedback",
+        requested_at="2026-06-25T18:20:00+00:00",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint, acted_text=hint.reason)
+
+    assert state.threads_addressed_ids["1234567"] == "needs_human"
+    assert state.threads_addressed_ids["__needs_human_reason__:1234567"] == (
+        "operator asked for help"
+    )
 
 
 def test_operator_hint_retire_referenced_needs_human_feedback_requires_body_hash() -> None:
@@ -1142,5 +1169,5 @@ def test_operator_hint_retire_referenced_needs_human_feedback_noops_without_acte
 
 def test_operator_hint_feedback_id_candidates_preserve_first_unique_ids() -> None:
     assert _operator_hint_feedback_id_candidates(
-        "issue:111111 issue:111111 222222 222222 issue:333333"
+        "issue:111111 issue:111111 feedback id 222222 feedback id 222222 issue:333333"
     ) == ("issue:111111", "222222", "issue:333333")

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from awf.common.commands import FakeCommandRunner
 from awf.common.github_client import RepoRef
+from awf.db.repositories import pr_feedback_body_hash
 from awf.db.session import make_session_factory
 from awf.runtime.monitor_state_keys import (
     _non_check_reviewer_settle_done_key,
@@ -175,7 +176,7 @@ def test_processed_operator_guide_retires_referenced_review_needs_human() -> Non
         threads_addressed_ids={
             "issue:4788370423": "needs_human",
             "__needs_human_reason__:issue:4788370423": "maintainer must choose",
-            "__review_comment_body_hash__:issue:4788370423": "old-hash",
+            "__review_comment_body_hash__:issue:4788370423": pr_feedback_body_hash(comment.body),
         },
     )
 

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -61,6 +61,7 @@ from awf.runtime.pr_monitor_runner.lifecycle import (
 )
 from awf.runtime.pr_monitor_runner.operator_hints import (
     _finalize_processed_operator_hint,
+    _mark_referenced_needs_human_feedback_answered,
     _operator_hint_block_reason,
 )
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
@@ -1013,3 +1014,30 @@ async def test_operator_hint_cycle_marks_pushed_hint_processed_without_empty_hea
         state.threads_addressed_ids[operator_hint_processed_key("op_pushed_without_head")]
         == "processed"
     )
+
+
+def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_review_id() -> None:
+    state = MonitorState(
+        threads_addressed_ids={
+            "1234567": "needs_human",
+            "__needs_human_reason__:1234567": "operator asked for help",
+            "issue:7654321": "needs_human",
+            "__needs_human_reason__:issue:7654321": "operator asked for help",
+            "9999999": "needs_human",
+            "__needs_human_reason__:9999999": "still blocking",
+        }
+    )
+    hint = OperatorHint(
+        reason="Operator confirmed 1234567 and issue:7654321 are non-blocking.",
+        operation_id="op_referenced_feedback",
+        requested_at="2026-06-25T18:20:00+00:00",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+
+    assert state.threads_addressed_ids["1234567"] == "false_positive"
+    assert "__needs_human_reason__:1234567" not in state.threads_addressed_ids
+    assert state.threads_addressed_ids["issue:7654321"] == "false_positive"
+    assert "__needs_human_reason__:issue:7654321" not in state.threads_addressed_ids
+    assert state.threads_addressed_ids["9999999"] == "needs_human"
+    assert state.threads_addressed_ids["__needs_human_reason__:9999999"] == "still blocking"

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -1021,6 +1021,8 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
         threads_addressed_ids={
             "1234567": "needs_human",
             "__needs_human_reason__:1234567": "operator asked for help",
+            "2345678": "needs_human",
+            "__needs_human_reason__:2345678": "operator cited prefixed key",
             "issue:7654321": "needs_human",
             "__needs_human_reason__:issue:7654321": "operator asked for help",
             "9999999": "needs_human",
@@ -1028,7 +1030,7 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
         }
     )
     hint = OperatorHint(
-        reason="Operator confirmed 1234567 and issue:7654321 are non-blocking.",
+        reason=("Operator confirmed 1234567, issue:2345678, and issue:7654321 are non-blocking."),
         operation_id="op_referenced_feedback",
         requested_at="2026-06-25T18:20:00+00:00",
     )
@@ -1037,6 +1039,8 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
 
     assert state.threads_addressed_ids["1234567"] == "false_positive"
     assert "__needs_human_reason__:1234567" not in state.threads_addressed_ids
+    assert state.threads_addressed_ids["2345678"] == "false_positive"
+    assert "__needs_human_reason__:2345678" not in state.threads_addressed_ids
     assert state.threads_addressed_ids["issue:7654321"] == "false_positive"
     assert "__needs_human_reason__:issue:7654321" not in state.threads_addressed_ids
     assert state.threads_addressed_ids["9999999"] == "needs_human"

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -270,6 +270,44 @@ def test_processed_operator_guide_keeps_unreferenced_needs_human_blocking() -> N
     assert isinstance(action, NotifyHuman)
 
 
+def test_processed_operator_guide_ignores_bare_number_without_issue_prefix() -> None:
+    """A bare 6+ digit number (no ``issue:`` prefix) must NOT clear a needs_human
+    verdict: an unrelated number in the directive/reason (a PR number, a line
+    count, a pasted id) must not coincidentally retire the wrong review wait on
+    this merge-gating path."""
+    comment = ReviewComment(
+        comment_id="issue:4788370423",
+        body_excerpt="needs a human decision",
+        author="coderabbitai",
+        source_kind="issue",
+    )
+    state = MonitorState(
+        pending_operator_hint=OperatorHint(
+            reason="reverted the change touching 4788370423 lines in the log",
+            directive="Closed PR 4788370423; proceed with the merge.",
+            operation_id="op_bare_number",
+            reason_code="OPERATOR_GUIDE",
+        ),
+        threads_addressed_ids={
+            "issue:4788370423": "needs_human",
+            "__needs_human_reason__:issue:4788370423": "maintainer must choose",
+        },
+    )
+
+    _finalize_processed_operator_hint(state)
+
+    # The bare number is not the prefixed key form, so the verdict survives and
+    # the review wait keeps blocking the merge.
+    assert state.threads_addressed_ids["issue:4788370423"] == "needs_human"
+    assert "__needs_human_reason__:issue:4788370423" in state.threads_addressed_ids
+    action = decide(
+        _ready_status(review_comments=(comment,)),
+        state,
+        MonitorConfig(auto_merge=True),
+    )
+    assert isinstance(action, NotifyHuman)
+
+
 def test_remonitor_elapsed_settle_helpers_filter_current_head() -> None:
     done_current = _non_check_reviewer_settle_done_key(
         pr_number=42,

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -64,6 +64,7 @@ from awf.runtime.pr_monitor_runner.operator_hints import (
     _finalize_processed_operator_hint,
     _mark_referenced_needs_human_feedback_answered,
     _operator_hint_block_reason,
+    _operator_hint_feedback_id_candidates,
 )
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 from tests.postgres import postgres_test_engine
@@ -333,6 +334,15 @@ def test_remonitor_elapsed_settle_helpers_filter_current_head() -> None:
         threads_addressed,
         pr_number=None,
         head_sha="current",
+    )
+    assert (
+        remonitor_elapsed_settle_head_shas(
+            threads_addressed,
+            pr_number=None,
+            preferred_head_sha="other",
+            current_head_sha="current",
+        )
+        == ()
     )
     assert remonitor_elapsed_settle_head_shas(
         threads_addressed,
@@ -1107,3 +1117,28 @@ def test_operator_hint_retire_referenced_needs_human_feedback_uses_acted_text() 
     )
     assert state.threads_addressed_ids["issue:222222"] == "false_positive"
     assert "__needs_human_reason__:issue:222222" not in state.threads_addressed_ids
+
+
+def test_operator_hint_retire_referenced_needs_human_feedback_noops_without_acted_text() -> None:
+    state = MonitorState(
+        threads_addressed_ids={
+            "issue:111111": "needs_human",
+            _review_comment_body_state_key("issue:111111"): pr_feedback_body_hash("audit body"),
+            "__needs_human_reason__:issue:111111": "still blocking",
+        }
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=None)
+    _mark_referenced_needs_human_feedback_answered(
+        state,
+        hint=OperatorHint(reason=None, directive=None, operation_id="op_empty_hint"),
+    )
+
+    assert state.threads_addressed_ids["issue:111111"] == "needs_human"
+    assert state.threads_addressed_ids["__needs_human_reason__:issue:111111"] == ("still blocking")
+
+
+def test_operator_hint_feedback_id_candidates_preserve_first_unique_ids() -> None:
+    assert _operator_hint_feedback_id_candidates(
+        "issue:111111 issue:111111 222222 222222 issue:333333"
+    ) == ("issue:111111", "222222", "issue:333333")

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -35,6 +35,7 @@ from awf.runtime.operator_hints import (
 )
 from awf.runtime.pr_monitor import (
     CheckState,
+    Merge,
     MergeableState,
     MergeStateStatus,
     MonitorConfig,
@@ -43,6 +44,7 @@ from awf.runtime.pr_monitor import (
     OperatorHint,
     PRStatus,
     ReviewComment,
+    decide,
 )
 from awf.runtime.pr_monitor_runner.comments import VerdictResult
 from awf.runtime.pr_monitor_runner.helpers import (
@@ -56,7 +58,10 @@ from awf.runtime.pr_monitor_runner.lifecycle import (
     _operator_hint_matches,
     _refresh_operator_state_from_workspace,
 )
-from awf.runtime.pr_monitor_runner.operator_hints import _operator_hint_block_reason
+from awf.runtime.pr_monitor_runner.operator_hints import (
+    _finalize_processed_operator_hint,
+    _operator_hint_block_reason,
+)
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import (
@@ -93,6 +98,7 @@ def _ready_status(
     *,
     merge_state_status: MergeStateStatus = MergeStateStatus.CLEAN,
     blocking_reviews: tuple[ReviewComment, ...] = (),
+    review_comments: tuple[ReviewComment, ...] = (),
 ) -> PRStatus:
     return PRStatus(
         number=42,
@@ -100,7 +106,7 @@ def _ready_status(
         mergeable=MergeableState.MERGEABLE,
         check_state=CheckState.SUCCESS,
         unresolved_inline_threads=(),
-        unresolved_review_comments=(),
+        unresolved_review_comments=review_comments,
         blocking_reviews=blocking_reviews,
         base_behind_count=0,
         merge_state_status=merge_state_status,
@@ -148,6 +154,120 @@ def test_operator_hint_markers_noop_without_pending_hint_or_operation_id() -> No
     assert state.pending_operator_hint is not None
     assert state.pending_operator_hint.status == "agent_failed"
     assert state.pending_operator_hint.status_reason == "provider unavailable"
+
+
+def test_processed_operator_guide_retires_referenced_review_needs_human() -> None:
+    """A consumed guide that names a review feedback id must clear that stale wait."""
+    comment = ReviewComment(
+        comment_id="issue:4788370423",
+        body_excerpt="old review-level summary",
+        body="old review-level summary",
+        author="coderabbitai",
+        source_kind="issue",
+    )
+    state = MonitorState(
+        pending_operator_hint=OperatorHint(
+            reason="operator said issue:4788370423 is stale and non-blocking",
+            directive="Reply AWF-VERDICT: FALSE POSITIVE for issue:4788370423.",
+            operation_id="op_answered_review",
+            reason_code="OPERATOR_GUIDE",
+        ),
+        threads_addressed_ids={
+            "issue:4788370423": "needs_human",
+            "__needs_human_reason__:issue:4788370423": "maintainer must choose",
+            "__review_comment_body_hash__:issue:4788370423": "old-hash",
+        },
+    )
+
+    _finalize_processed_operator_hint(state)
+
+    assert state.pending_operator_hint is None
+    assert state.threads_addressed_ids["issue:4788370423"] == "false_positive"
+    assert "__needs_human_reason__:issue:4788370423" not in state.threads_addressed_ids
+    assert (
+        state.threads_addressed_ids[operator_hint_processed_key("op_answered_review")]
+        == "processed"
+    )
+    action = decide(
+        _ready_status(review_comments=(comment,)),
+        state,
+        MonitorConfig(auto_merge=True),
+    )
+    assert isinstance(action, Merge)
+
+
+def test_processed_operator_guide_uses_action_hint_when_pending_hint_was_cleared() -> None:
+    """Finalization can receive the action hint after pending storage was cleared."""
+    comment = ReviewComment(
+        comment_id="issue:4788406681",
+        body_excerpt="old review-level summary",
+        body="old review-level summary",
+        author="coderabbitai",
+        source_kind="issue",
+    )
+    state = MonitorState(
+        threads_addressed_ids={
+            "issue:4788406681": "needs_human",
+            "__needs_human_reason__:issue:4788406681": "maintainer must choose",
+        },
+    )
+    hint = OperatorHint(
+        reason=None,
+        directive="Treat issue:4788406681 as already answered by the operator.",
+        operation_id="op_action_hint",
+        reason_code="OPERATOR_GUIDE",
+    )
+
+    _finalize_processed_operator_hint(state, hint=hint)
+
+    assert state.pending_operator_hint is None
+    assert state.threads_addressed_ids["issue:4788406681"] == "false_positive"
+    assert "__needs_human_reason__:issue:4788406681" not in state.threads_addressed_ids
+    assert state.threads_addressed_ids[operator_hint_processed_key("op_action_hint")] == "processed"
+    action = decide(
+        _ready_status(review_comments=(comment,)),
+        state,
+        MonitorConfig(auto_merge=True),
+    )
+    assert isinstance(action, Merge)
+
+
+def test_processed_operator_guide_keeps_unreferenced_needs_human_blocking() -> None:
+    """A guide must not clear unrelated review comments that still need humans."""
+    mentioned = ReviewComment(
+        comment_id="issue:4788370423",
+        body_excerpt="operator answered this one",
+        author="coderabbitai",
+        source_kind="issue",
+    )
+    unmentioned = ReviewComment(
+        comment_id="issue:4788406681",
+        body_excerpt="different human decision",
+        author="coderabbitai",
+        source_kind="issue",
+    )
+    state = MonitorState(
+        pending_operator_hint=OperatorHint(
+            reason="operator answered issue:4788370423 only",
+            operation_id="op_partial_answer",
+            reason_code="OPERATOR_GUIDE",
+        ),
+        threads_addressed_ids={
+            "issue:4788370423": "needs_human",
+            "issue:4788406681": "needs_human",
+        },
+    )
+
+    _finalize_processed_operator_hint(state)
+
+    assert state.threads_addressed_ids["issue:4788370423"] == "false_positive"
+    assert state.threads_addressed_ids["issue:4788406681"] == "needs_human"
+    action = decide(
+        _ready_status(review_comments=(mentioned, unmentioned)),
+        state,
+        MonitorConfig(auto_merge=True),
+    )
+    assert isinstance(action, NotifyHuman)
 
 
 def test_remonitor_elapsed_settle_helpers_filter_current_head() -> None:

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -1045,3 +1045,29 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
     assert "__needs_human_reason__:issue:7654321" not in state.threads_addressed_ids
     assert state.threads_addressed_ids["9999999"] == "needs_human"
     assert state.threads_addressed_ids["__needs_human_reason__:9999999"] == "still blocking"
+
+
+def test_operator_hint_retire_referenced_needs_human_feedback_uses_acted_text() -> None:
+    state = MonitorState(
+        threads_addressed_ids={
+            "issue:111111": "needs_human",
+            "__needs_human_reason__:issue:111111": "audit-only blocker",
+            "issue:222222": "needs_human",
+            "__needs_human_reason__:issue:222222": "directive blocker",
+        }
+    )
+    hint = OperatorHint(
+        reason="Audit context mentions issue:111111 for operator traceability.",
+        directive="Resolve the feedback in issue:222222.",
+        operation_id="op_referenced_feedback_directive",
+        requested_at="2026-06-25T18:20:00+00:00",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+
+    assert state.threads_addressed_ids["issue:111111"] == "needs_human"
+    assert (
+        state.threads_addressed_ids["__needs_human_reason__:issue:111111"] == "audit-only blocker"
+    )
+    assert state.threads_addressed_ids["issue:222222"] == "false_positive"
+    assert "__needs_human_reason__:issue:222222" not in state.threads_addressed_ids

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -52,6 +52,7 @@ from awf.runtime.pr_monitor_runner.helpers import (
     _is_manual_ready_handoff,
     _is_protected_manual_ready_handoff,
     _non_check_reviewer_activity_freeze_elapsed_seconds,
+    _review_comment_body_state_key,
 )
 from awf.runtime.pr_monitor_runner.lifecycle import (
     _merge_concurrent_operator_freeze_state,
@@ -211,6 +212,7 @@ def test_processed_operator_guide_uses_action_hint_when_pending_hint_was_cleared
         threads_addressed_ids={
             "issue:4788406681": "needs_human",
             "__needs_human_reason__:issue:4788406681": "maintainer must choose",
+            _review_comment_body_state_key("issue:4788406681"): pr_feedback_body_hash(comment.body),
         },
     )
     hint = OperatorHint(
@@ -256,6 +258,9 @@ def test_processed_operator_guide_keeps_unreferenced_needs_human_blocking() -> N
         ),
         threads_addressed_ids={
             "issue:4788370423": "needs_human",
+            _review_comment_body_state_key("issue:4788370423"): pr_feedback_body_hash(
+                mentioned.body_excerpt
+            ),
             "issue:4788406681": "needs_human",
         },
     )
@@ -1020,10 +1025,13 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
     state = MonitorState(
         threads_addressed_ids={
             "1234567": "needs_human",
+            _review_comment_body_state_key("1234567"): pr_feedback_body_hash("bare review body"),
             "__needs_human_reason__:1234567": "operator asked for help",
             "2345678": "needs_human",
+            _review_comment_body_state_key("2345678"): pr_feedback_body_hash("prefixed key body"),
             "__needs_human_reason__:2345678": "operator cited prefixed key",
             "issue:7654321": "needs_human",
+            _review_comment_body_state_key("issue:7654321"): pr_feedback_body_hash("issue body"),
             "__needs_human_reason__:issue:7654321": "operator asked for help",
             "9999999": "needs_human",
             "__needs_human_reason__:9999999": "still blocking",
@@ -1047,12 +1055,40 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
     assert state.threads_addressed_ids["__needs_human_reason__:9999999"] == "still blocking"
 
 
+def test_operator_hint_retire_referenced_needs_human_feedback_requires_body_hash() -> None:
+    state = MonitorState(
+        threads_addressed_ids={
+            "1234567": "needs_human",
+            "__needs_human_reason__:1234567": "legacy row without hash",
+            "issue:7654321": "needs_human",
+            _review_comment_body_state_key("issue:7654321"): pr_feedback_body_hash("known body"),
+            "__needs_human_reason__:issue:7654321": "operator asked for help",
+        }
+    )
+    hint = OperatorHint(
+        reason="Operator confirmed 1234567 and issue:7654321 are non-blocking.",
+        operation_id="op_referenced_feedback_missing_hash",
+        requested_at="2026-06-25T18:20:00+00:00",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+
+    assert state.threads_addressed_ids["1234567"] == "needs_human"
+    assert state.threads_addressed_ids["__needs_human_reason__:1234567"] == (
+        "legacy row without hash"
+    )
+    assert state.threads_addressed_ids["issue:7654321"] == "false_positive"
+    assert "__needs_human_reason__:issue:7654321" not in state.threads_addressed_ids
+
+
 def test_operator_hint_retire_referenced_needs_human_feedback_uses_acted_text() -> None:
     state = MonitorState(
         threads_addressed_ids={
             "issue:111111": "needs_human",
+            _review_comment_body_state_key("issue:111111"): pr_feedback_body_hash("audit body"),
             "__needs_human_reason__:issue:111111": "audit-only blocker",
             "issue:222222": "needs_human",
+            _review_comment_body_state_key("issue:222222"): pr_feedback_body_hash("directive body"),
             "__needs_human_reason__:issue:222222": "directive blocker",
         }
     )

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -1053,7 +1053,7 @@ def test_operator_hint_retire_referenced_needs_human_feedback_accepts_bare_revie
         requested_at="2026-06-25T18:20:00+00:00",
     )
 
-    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint, acted_text=hint.reason)
 
     assert state.threads_addressed_ids["1234567"] == "false_positive"
     assert "__needs_human_reason__:1234567" not in state.threads_addressed_ids
@@ -1081,7 +1081,7 @@ def test_operator_hint_retire_referenced_needs_human_feedback_requires_body_hash
         requested_at="2026-06-25T18:20:00+00:00",
     )
 
-    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint, acted_text=hint.reason)
 
     assert state.threads_addressed_ids["1234567"] == "needs_human"
     assert state.threads_addressed_ids["__needs_human_reason__:1234567"] == (

--- a/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py
@@ -266,7 +266,9 @@ def test_processed_operator_guide_keeps_unreferenced_needs_human_blocking() -> N
         },
     )
 
-    _finalize_processed_operator_hint(state)
+    _finalize_processed_operator_hint(
+        state, acted_feedback_text="operator answered issue:4788370423 only"
+    )
 
     assert state.threads_addressed_ids["issue:4788370423"] == "false_positive"
     assert state.threads_addressed_ids["issue:4788406681"] == "needs_human"

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_002.py
@@ -28,6 +28,9 @@ from awf.runtime.pr_monitor import (
     PRStatus,
 )
 from awf.runtime.pr_monitor_runner.comments import VerdictResult
+from awf.runtime.pr_monitor_runner.operator_hints import (
+    _mark_referenced_needs_human_feedback_answered,
+)
 from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult, _ProtectedScopePushBlock
 from tests.postgres import postgres_test_engine
 from tests.unit.runtime._monitor_runner_fixtures import (
@@ -38,6 +41,9 @@ from tests.unit.runtime._monitor_runner_fixtures import (
 )
 
 REPO_URL = "git@github.com:dimileeh/aira-web.git"
+REVIEW_COMMENT_ID = "issue:3476977020"
+REVIEW_COMMENT_BODY_HASH_KEY = f"__review_comment_body_hash__:{REVIEW_COMMENT_ID}"
+REVIEW_COMMENT_NEEDS_HUMAN_REASON_KEY = f"__needs_human_reason__:{REVIEW_COMMENT_ID}"
 
 
 @pytest.fixture
@@ -89,6 +95,63 @@ async def _seed_active_grant(
         )
         await session.commit()
     return grant_id
+
+
+@pytest.mark.unit
+def test_directiveless_operator_hint_reason_does_not_retire_referenced_needs_human() -> None:
+    """Grant-only audit reasons are not acted-on review-feedback text.
+
+    Approve-and-keep resumes skip the CLI, so mentioning a review id in the audit
+    reason must not convert a stored ``needs_human`` review verdict to
+    ``false_positive``.
+    """
+    state = MonitorState(
+        threads_addressed_ids={
+            REVIEW_COMMENT_ID: "needs_human",
+            REVIEW_COMMENT_BODY_HASH_KEY: "body-hash",
+            REVIEW_COMMENT_NEEDS_HUMAN_REASON_KEY: "review still needs a human",
+        }
+    )
+    hint = OperatorHint(
+        reason=f"approved protected path; related review feedback {REVIEW_COMMENT_ID}",
+        operation_id="op_grant_only_mentions_review",
+        requested_at="2026-06-25T19:30:00+00:00",
+        reason_code="OPERATOR_GUIDE",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+
+    assert state.threads_addressed_ids[REVIEW_COMMENT_ID] == "needs_human"
+    assert state.threads_addressed_ids[REVIEW_COMMENT_BODY_HASH_KEY] == "body-hash"
+    assert (
+        state.threads_addressed_ids[REVIEW_COMMENT_NEEDS_HUMAN_REASON_KEY]
+        == "review still needs a human"
+    )
+
+
+@pytest.mark.unit
+def test_operator_hint_directive_retires_referenced_needs_human() -> None:
+    """A directive is acted-on text and may retire the referenced review verdict."""
+    state = MonitorState(
+        threads_addressed_ids={
+            REVIEW_COMMENT_ID: "needs_human",
+            REVIEW_COMMENT_BODY_HASH_KEY: "body-hash",
+            REVIEW_COMMENT_NEEDS_HUMAN_REASON_KEY: "review still needs a human",
+        }
+    )
+    hint = OperatorHint(
+        reason="operator guide audit note",
+        directive=f"Resolve {REVIEW_COMMENT_ID} as false positive after checking the code.",
+        operation_id="op_directive_mentions_review",
+        requested_at="2026-06-25T19:35:00+00:00",
+        reason_code="OPERATOR_GUIDE",
+    )
+
+    _mark_referenced_needs_human_feedback_answered(state, hint=hint)
+
+    assert state.threads_addressed_ids[REVIEW_COMMENT_ID] == "false_positive"
+    assert state.threads_addressed_ids[REVIEW_COMMENT_BODY_HASH_KEY] == "body-hash"
+    assert REVIEW_COMMENT_NEEDS_HUMAN_REASON_KEY not in state.threads_addressed_ids
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_operator_hints_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_operator_hints_part_005.py
@@ -350,6 +350,83 @@ async def test_operator_hint_directive_drop_restart_finalizes_without_rerunning_
 
 
 @pytest.mark.unit
+async def test_operator_hint_remonitor_restart_shortcut_uses_reason_as_acted_text(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A plain remonitor has no directive; its reason is the prompt text the agent
+    acted on. If the restart-after-consume shortcut finalizes with only
+    ``hint.directive`` it leaves referenced review-level ``needs_human`` rows stale
+    even though the remonitor was processed."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path,
+    )
+    hint = OperatorHint(
+        reason="remonitor after addressing issue:4788370423 in the PR discussion",
+        operation_id="op_remonitor_restart",
+        requested_at="2026-06-25T00:00:00+00:00",
+    )
+    state = MonitorState(
+        pending_operator_hint=hint,
+        threads_addressed_ids={
+            _PROTECTED_BLOCK_PRESERVED_HEAD_STATE_KEY: "preserved-sha",
+            "issue:4788370423": "needs_human",
+            "__review_comment_body_hash__:issue:4788370423": "body-hash",
+            "__needs_human_reason__:issue:4788370423": "operator needs to answer",
+        },
+    )
+
+    async def _no_preexisting_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _start_head_ok(**_kwargs: object) -> tuple[str, None]:
+        return ("preserved-sha", None)
+
+    async def _already_on_remote(**_kwargs: object) -> bool:
+        return True
+
+    async def _cli_must_not_run(**_kwargs: object) -> object:
+        pytest.fail("restart finalization must not re-invoke the CLI")
+
+    async def _push_must_not_run(**_kwargs: object) -> _GitPushResult:
+        pytest.fail("an already-pushed preserved commit must NOT be re-pushed")
+
+    async def _head(*_args: object, **_kwargs: object) -> str:
+        return "preserved-sha"
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_preexisting_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head_ok)
+    monkeypatch.setattr(runner, "_preserved_commit_already_on_remote", _already_on_remote)
+    monkeypatch.setattr(runner, "_invoke_cli_for_verdict_result", _cli_must_not_run)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _push_must_not_run)
+    monkeypatch.setattr(runner, "_rev_parse_head", _head)
+
+    result = await runner._run_operator_hint_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        hint=hint,
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.pushed is False
+    assert result.failed is False
+    assert state.threads_addressed_ids["issue:4788370423"] == "false_positive"
+    assert "__needs_human_reason__:issue:4788370423" not in state.threads_addressed_ids
+    assert state.pending_operator_hint is None
+
+
+@pytest.mark.unit
 async def test_operator_hint_directive_drop_restart_skips_shortcut_for_revert_on_top_marker(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- retire review-level `needs_human` verdicts when a consumed operator guide explicitly references the review/issue id it answered
- pass the active operator hint through resume finalization so guides can still be marked processed after pending state is cleared
- add regression coverage proving stale review-level HUMAN_WAIT does not re-block merge while unrelated waits stay blocking

## Verification
- `uv run pytest -q tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py`
- `uv run ruff check src/awf/runtime/pr_monitor_runner/operator_hints.py tests/unit/runtime/test_pr_monitor_operator_hint_coverage_edges.py`
- `uv run mypy src/awf/runtime/pr_monitor_runner/operator_hints.py`

## Context
This fixes the AWF monitor bookkeeping loop observed on awf-cloud PR180, where GitHub review state was clean but a stale review-level `needs_human` entry kept re-entering HUMAN_WAIT after operator guidance had already answered it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor merge-gating state and id parsing for operator hints; incorrect retirement could unblock merge or leave stale waits, though guards (body hash, contextual ids, acted-text scoping) limit blast radius.
> 
> **Overview**
> Fixes a monitor loop where a consumed operator guide still left review-level **`needs_human`** entries in persisted state, so **`decide()`** kept re-entering HUMAN_WAIT even after GitHub was clean.
> 
> On operator-hint resume finalization, the runner now parses **`issue:<id>`** and contextual bare feedback ids from the **acted-on** text (directive, remonitor reason, or explicit `acted_feedback_text`), and marks matching stored review verdicts as **`false_positive`** when they already have a body-hash sidecar—without touching unrelated waits or legacy rows missing the hash. Grant-only audit reasons that never ran the CLI do not retire review feedback.
> 
> **`_finalize_operator_hint_resume`** and **`_finalize_processed_operator_hint`** take the active hint and acted text through all finalize paths (including remonitor restart shortcuts), so retirement still runs when pending hint storage was cleared earlier.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffd579baf8a00b6b2f9e6fdbf65496ce63332ebe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->