### PR TITLE
ci: retry transient PyPI flakes in release-artifacts install steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,14 +290,17 @@ jobs:
         run: |
           set -euo pipefail
           uv venv --python 3.12
+          last_rc=1
           for attempt in 1 2 3; do
             echo "uv pip install build attempt ${attempt}/3"
             if uv pip install build; then
               break
+            else
+              last_rc=$?
             fi
             if [ "${attempt}" -eq 3 ]; then
               echo "uv pip install build failed after 3 attempts"
-              exit 1
+              exit "${last_rc}"
             fi
             echo "uv pip install build failed; retrying in 10s"
             sleep 10
@@ -309,14 +312,17 @@ jobs:
           set -euo pipefail
           uv venv --python 3.12 /tmp/awf-wheel-smoke
           cd /tmp
+          last_rc=1
           for attempt in 1 2 3; do
             echo "uv pip install wheel attempt ${attempt}/3"
             if uv pip install --python /tmp/awf-wheel-smoke/bin/python "$GITHUB_WORKSPACE"/dist/*.whl; then
               break
+            else
+              last_rc=$?
             fi
             if [ "${attempt}" -eq 3 ]; then
               echo "uv pip install wheel failed after 3 attempts"
-              exit 1
+              exit "${last_rc}"
             fi
             echo "uv pip install wheel failed; retrying in 10s"
             sleep 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,15 +288,39 @@ jobs:
 
       - name: Build wheel and sdist
         run: |
+          set -euo pipefail
           uv venv --python 3.12
-          uv pip install build
+          for attempt in 1 2 3; do
+            echo "uv pip install build attempt ${attempt}/3"
+            if uv pip install build; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "uv pip install build failed after 3 attempts"
+              exit 1
+            fi
+            echo "uv pip install build failed; retrying in 10s"
+            sleep 10
+          done
           .venv/bin/python -m build
 
       - name: Install wheel and verify entrypoints
         run: |
+          set -euo pipefail
           uv venv --python 3.12 /tmp/awf-wheel-smoke
           cd /tmp
-          uv pip install --python /tmp/awf-wheel-smoke/bin/python "$GITHUB_WORKSPACE"/dist/*.whl
+          for attempt in 1 2 3; do
+            echo "uv pip install wheel attempt ${attempt}/3"
+            if uv pip install --python /tmp/awf-wheel-smoke/bin/python "$GITHUB_WORKSPACE"/dist/*.whl; then
+              break
+            fi
+            if [ "${attempt}" -eq 3 ]; then
+              echo "uv pip install wheel failed after 3 attempts"
+              exit 1
+            fi
+            echo "uv pip install wheel failed; retrying in 10s"
+            sleep 10
+          done
           /tmp/awf-wheel-smoke/bin/awf --help
           /tmp/awf-wheel-smoke/bin/awf init --help
           /tmp/awf-wheel-smoke/bin/awf service bootstrap --help


### PR DESCRIPTION
## What
Wrap `release-artifacts`' two `uv pip install` steps (build tool + wheel smoke-test) in the same 3x transient-retry loop the other jobs already use.

## Why
`lint-and-type`, `python-coverage-shards`, and `python-full-coverage` already retry their dependency install (3x `uv sync`). `release-artifacts` did not, so a transient PyPI download failure on `uv pip install build` (or the wheel install) fails the whole release job. After this, **every** CI dependency-install step self-heals transient flakes.

## Why not `uv sync` here
`release-artifacts` installs the `build` tool and the built wheel into a smoke-test venv — not the dev environment — so it deliberately keeps `uv pip install` and only gains the retry wrapper.

## Effect
Closes the recurring loop where the PR monitor kept needing per-workspace `.github/workflows/ci.yml` grants to harden flaky install steps (#683, #686). No production code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI workflow-only changes; no application or packaging logic is modified.
> 
> **Overview**
> Hardens the **`release-artifacts`** job so transient PyPI failures are less likely to fail the whole release gate.
> 
> Both **`uv pip install`** steps now match the other Python jobs: **`set -euo pipefail`**, then up to **3 attempts** with a **10s** pause—first for **`build`** before **`python -m build`**, then for installing the built **`.whl`** into the smoke-test venv. Entrypoint and bootstrap asset checks are unchanged; only install resilience is added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 123f77c90c3b5cd9ecd27c0316fb7ee5b23d2982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->