### PR TITLE
F16-Core/T16.0 Core capability discovery and runtime driver seam

### DIFF
--- a/docs/REST_API_REFERENCE.md
+++ b/docs/REST_API_REFERENCE.md
@@ -14,10 +14,11 @@ A checked-in stable copy is available as `openapi.json` in the repository root.
 All endpoints return JSON. Endpoints requiring authentication use the
 `Authorization: Bearer $AWF_API_TOKEN` header.
 
-Public operators' health/readiness probes intentionally remain usable without
-`AWF_API_TOKEN` so monitoring can run during bootstrapping. Workspace metadata
-and control surfaces require the header and return a `503 API_TOKEN_NOT_CONFIGURED`
-envelope when authentication is enabled but `AWF_API_TOKEN` is missing.
+Public health/readiness probes and Core discovery intentionally remain usable
+without `AWF_API_TOKEN` so monitoring and in-cluster discovery can run during
+bootstrapping. Workspace metadata, control surfaces, and release readiness
+require the header and return a `503 API_TOKEN_NOT_CONFIGURED` envelope when
+authentication is enabled but `AWF_API_TOKEN` is missing.
 
 Common response patterns:
 
@@ -29,6 +30,27 @@ Common response patterns:
 ---
 
 ## Health and Readiness
+
+### Core discovery
+
+No auth required. Dependency-free discovery document for Core package identity
+and public capabilities. The payload is stable and does not include configured
+tokens or runtime secrets.
+
+```bash
+curl http://localhost:8000/.well-known/awf-core.json
+```
+
+Response shape:
+
+```json
+{
+  "package_name": "agent-workspace-fabric",
+  "package_version": "0.1.0",
+  "git_commit": "unknown",
+  "capabilities": ["workspace.execution.v1"]
+}
+```
 
 ### Liveness check
 
@@ -58,17 +80,20 @@ Each sub-check includes a stable `reason` code for alert routing.
 
 ### Release readiness
 
-No auth required. Returns the AWF Core local release scorecard.
+Auth required (`Authorization: Bearer $AWF_API_TOKEN`). Returns the AWF Core
+local release scorecard.
 
 ```bash
-curl http://localhost:8000/release-readiness
+curl -H "Authorization: Bearer $AWF_API_TOKEN" \
+  http://localhost:8000/release-readiness
 ```
 
 Returns `200` when the release is ready, `503` otherwise. Supports query params
 `provider`, `failure_window_hours`, `slo_window_hours`.
 
 ```bash
-curl "http://localhost:8000/release-readiness?provider=claude_code&provider=cursor"
+curl -H "Authorization: Bearer $AWF_API_TOKEN" \
+  "http://localhost:8000/release-readiness?provider=claude_code&provider=cursor"
 ```
 
 The filtered example intentionally includes Cursor. Repeat `provider` to compare
@@ -305,10 +330,11 @@ curl -X POST "http://localhost:8000/v1/workspaces/ws_123/retry?provider_readines
 ## Release Readiness
 
 See Health and Readiness above. Evaluates SLO metrics, validation, and
-dependency health to produce a local release scorecard.
+dependency health to produce a local release scorecard. Auth required.
 
 ```bash
-curl http://localhost:8000/release-readiness
+curl -H "Authorization: Bearer $AWF_API_TOKEN" \
+  http://localhost:8000/release-readiness
 ```
 
 ---

--- a/openapi.json
+++ b/openapi.json
@@ -731,6 +731,38 @@
         "title": "CoordinationOverlapResponse",
         "type": "object"
       },
+      "CoreDiscoveryResponse": {
+        "description": "Public, secret-free Core discovery response.",
+        "properties": {
+          "capabilities": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Capabilities",
+            "type": "array"
+          },
+          "git_commit": {
+            "title": "Git Commit",
+            "type": "string"
+          },
+          "package_name": {
+            "title": "Package Name",
+            "type": "string"
+          },
+          "package_version": {
+            "title": "Package Version",
+            "type": "string"
+          }
+        },
+        "required": [
+          "package_name",
+          "package_version",
+          "git_commit",
+          "capabilities"
+        ],
+        "title": "CoreDiscoveryResponse",
+        "type": "object"
+      },
       "DiskCheckResponse": {
         "properties": {
           "checked_path": {
@@ -11679,6 +11711,27 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/.well-known/awf-core.json": {
+      "get": {
+        "operationId": "core_discovery__well_known_awf_core_json_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoreDiscoveryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Core Discovery",
+        "tags": [
+          "system"
+        ]
+      }
+    },
     "/healthz": {
       "get": {
         "operationId": "healthz_healthz_get",

--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -46,6 +46,7 @@ from awf.api.routes import (
 from awf.common.config import Settings, get_settings, validate_production_settings
 from awf.db.session import make_engine, make_session_factory
 from awf.service.callbacks import shutdown_callback_target_validation_executor
+from awf.service.core_discovery import CORE_DISCOVERY_STATE_ATTR, build_core_discovery_payload
 
 
 def configure_database(
@@ -109,6 +110,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
         lifespan=_lifespan if use_lifespan else None,
     )
     health.reset_egress_audit_summary_counts_task(app.state)
+    setattr(app.state, CORE_DISCOVERY_STATE_ATTR, build_core_discovery_payload())
     app.add_exception_handler(
         WebSocketAuthorizationDenialError,
         websocket_authorization_denial_handler,

--- a/src/awf/api/app.py
+++ b/src/awf/api/app.py
@@ -28,6 +28,7 @@ from awf.api.routes import (
     artifacts,
     callbacks,
     controls,
+    discovery,
     events,
     health,
     locks,
@@ -114,6 +115,7 @@ def create_app(*, use_lifespan: bool = True) -> FastAPI:
     )
 
     app.include_router(health.router)
+    app.include_router(discovery.router)
     app.include_router(callbacks.router)
     app.include_router(workspaces.router)
     app.include_router(events.router)

--- a/src/awf/api/routes/discovery.py
+++ b/src/awf/api/routes/discovery.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from awf.service.core_discovery import (
     CoreDiscoveryResponse,
-    build_core_discovery_payload,
+    core_discovery_payload_from_state,
 )
 
 router = APIRouter(tags=["system"])
 
 
 @router.get("/.well-known/awf-core.json", response_model=CoreDiscoveryResponse)
-async def core_discovery() -> CoreDiscoveryResponse:
-    return build_core_discovery_payload().to_response()
+async def core_discovery(request: Request) -> CoreDiscoveryResponse:
+    return core_discovery_payload_from_state(request.app.state).to_response()

--- a/src/awf/api/routes/discovery.py
+++ b/src/awf/api/routes/discovery.py
@@ -1,0 +1,17 @@
+"""Public AWF Core discovery endpoint."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from awf.service.core_discovery import (
+    CoreDiscoveryResponse,
+    build_core_discovery_payload,
+)
+
+router = APIRouter(tags=["system"])
+
+
+@router.get("/.well-known/awf-core.json", response_model=CoreDiscoveryResponse)
+async def core_discovery() -> CoreDiscoveryResponse:
+    return build_core_discovery_payload().to_response()

--- a/src/awf/runtime/driver.py
+++ b/src/awf/runtime/driver.py
@@ -1,0 +1,175 @@
+"""Cloud-neutral workspace runtime driver contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+from awf.runtime.inspection import RuntimeInspector, RuntimeSnapshot
+
+if TYPE_CHECKING:
+    from awf.node.cleanup import WorkspaceCleanupResult
+    from awf.runtime.validation_types import ValidationResult
+
+WORKSPACE_EXECUTION_V1 = "workspace.execution.v1"
+LOCAL_RUNTIME_DRIVER = "local"
+
+
+@dataclass(frozen=True)
+class RuntimeDriverConfig:
+    """Core runtime-driver selection.
+
+    AWF Core currently ships only the local Docker/Compose driver. Unsupported
+    names fail explicitly so cloud substrates can plug in at the seam instead of
+    silently changing Core behavior.
+    """
+
+    name: str = LOCAL_RUNTIME_DRIVER
+
+    def __post_init__(self) -> None:
+        if self.name != LOCAL_RUNTIME_DRIVER:
+            raise ValueError(f"Unsupported AWF Core runtime driver: {self.name}")
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return (WORKSPACE_EXECUTION_V1,)
+
+
+@dataclass(frozen=True)
+class WorkspaceProvisionRequest:
+    workspace_id: str
+    execution_claim_epoch: int | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceStartRequest:
+    workspace_id: str
+    execution_owner_id: str | None = None
+    execution_lease_expires_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceStopRequest:
+    workspace_id: str
+    repo_url: str
+    compose_project_name: str | None = None
+    compose_file_path: Path | None = None
+    worktree_host_path: Path | None = None
+    remove_volumes: bool = True
+    remove_worktree: bool = True
+
+
+@dataclass(frozen=True)
+class WorkspaceValidateRequest:
+    workspace_id: str
+    compose_project: str
+    compose_file: Path
+    test_commands: tuple[str, ...] = ()
+    requires_database: bool = False
+    workspace_worktree: Path | None = None
+
+
+@dataclass(frozen=True)
+class WorkspaceStatusRequest:
+    compose_project_name: str | None
+
+
+@runtime_checkable
+class WorkspaceRuntimeDriver(Protocol):
+    @property
+    def capabilities(self) -> tuple[str, ...]:  # pragma: no cover - Protocol declaration.
+        ...
+
+    async def provision(
+        self,
+        request: WorkspaceProvisionRequest,
+    ) -> Any:  # pragma: no cover - Protocol declaration.
+        ...
+
+    async def start(
+        self,
+        request: WorkspaceStartRequest,
+    ) -> Any:  # pragma: no cover - Protocol declaration.
+        ...
+
+    async def stop(
+        self,
+        request: WorkspaceStopRequest,
+    ) -> WorkspaceCleanupResult:  # pragma: no cover - Protocol declaration.
+        ...
+
+    async def validate(
+        self,
+        request: WorkspaceValidateRequest,
+    ) -> ValidationResult:  # pragma: no cover - Protocol declaration.
+        ...
+
+    async def status(
+        self,
+        request: WorkspaceStatusRequest,
+    ) -> RuntimeSnapshot:  # pragma: no cover - Protocol declaration.
+        ...
+
+
+class LocalRuntimeDriver:
+    """Thin adapter over the existing local Docker/Compose collaborators."""
+
+    def __init__(
+        self,
+        *,
+        provisioner: Any,
+        executor: Any,
+        cleaner: Any,
+        validation_runner: Any,
+        runtime_inspector: Any | None = None,
+    ) -> None:
+        self.provisioner = provisioner
+        self.executor = executor
+        self.cleaner = cleaner
+        self.validation_runner = validation_runner
+        self.runtime_inspector = runtime_inspector or RuntimeInspector()
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        return (WORKSPACE_EXECUTION_V1,)
+
+    async def provision(self, request: WorkspaceProvisionRequest) -> Any:
+        if request.execution_claim_epoch is None:
+            return await self.provisioner.provision(request.workspace_id)
+        return await self.provisioner.provision_claimed(
+            request.workspace_id,
+            execution_claim_epoch=request.execution_claim_epoch,
+        )
+
+    async def start(self, request: WorkspaceStartRequest) -> Any:
+        return await self.executor.execute(
+            request.workspace_id,
+            execution_owner_id=request.execution_owner_id,
+            execution_lease_expires_at=request.execution_lease_expires_at,
+        )
+
+    async def stop(self, request: WorkspaceStopRequest) -> Any:
+        return await self.cleaner.cleanup(
+            workspace_id=request.workspace_id,
+            repo_url=request.repo_url,
+            compose_project_name=request.compose_project_name,
+            compose_file_path=request.compose_file_path,
+            worktree_host_path=request.worktree_host_path,
+            remove_volumes=request.remove_volumes,
+            remove_worktree=request.remove_worktree,
+        )
+
+    async def validate(self, request: WorkspaceValidateRequest) -> Any:
+        return await self.validation_runner.run(
+            workspace_id=request.workspace_id,
+            compose_project=request.compose_project,
+            compose_file=request.compose_file,
+            test_commands=list(request.test_commands),
+            requires_database=request.requires_database,
+            workspace_worktree=request.workspace_worktree,
+        )
+
+    async def status(self, request: WorkspaceStatusRequest) -> Any:
+        return await self.runtime_inspector.inspect(request.compose_project_name)

--- a/src/awf/runtime/driver.py
+++ b/src/awf/runtime/driver.py
@@ -54,6 +54,7 @@ class WorkspaceStartRequest:
 class WorkspaceStopRequest:
     workspace_id: str
     repo_url: str
+    companion_worktrees: tuple[tuple[str, str], ...] = ()
     compose_project_name: str | None = None
     compose_file_path: Path | None = None
     worktree_host_path: Path | None = None
@@ -154,6 +155,7 @@ class LocalRuntimeDriver:
         return await self.cleaner.cleanup(
             workspace_id=request.workspace_id,
             repo_url=request.repo_url,
+            companion_worktrees=request.companion_worktrees,
             compose_project_name=request.compose_project_name,
             compose_file_path=request.compose_file_path,
             worktree_host_path=request.worktree_host_path,

--- a/src/awf/service/core_discovery.py
+++ b/src/awf/service/core_discovery.py
@@ -1,0 +1,72 @@
+"""Secret-free AWF Core capability discovery payload."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from dataclasses import dataclass
+
+from pydantic import BaseModel
+
+from awf import __version__
+from awf.runtime.driver import WORKSPACE_EXECUTION_V1
+
+PACKAGE_NAME = "agent-workspace-fabric"
+UNKNOWN_GIT_COMMIT = "unknown"
+
+
+class CoreDiscoveryResponse(BaseModel):
+    """Public, secret-free Core discovery response."""
+
+    package_name: str
+    package_version: str
+    git_commit: str
+    capabilities: list[str]
+
+
+@dataclass(frozen=True)
+class CoreDiscoveryPayload:
+    """Internal immutable discovery payload before API serialization."""
+
+    package_name: str = PACKAGE_NAME
+    package_version: str = __version__
+    git_commit: str = UNKNOWN_GIT_COMMIT
+    capabilities: tuple[str, ...] = (WORKSPACE_EXECUTION_V1,)
+
+    def to_response(self) -> CoreDiscoveryResponse:
+        return CoreDiscoveryResponse(
+            package_name=self.package_name,
+            package_version=self.package_version,
+            git_commit=self.git_commit,
+            capabilities=list(self.capabilities),
+        )
+
+
+def build_core_discovery_payload() -> CoreDiscoveryPayload:
+    """Build the stable public Core discovery payload without reading secrets."""
+
+    return CoreDiscoveryPayload(git_commit=_resolve_git_commit())
+
+
+def _resolve_git_commit() -> str:
+    env_commit = os.environ.get("AWF_GIT_COMMIT")
+    if env_commit is not None and env_commit.strip():
+        return env_commit.strip()
+    return _git_rev_parse_head() or UNKNOWN_GIT_COMMIT
+
+
+def _git_rev_parse_head() -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=1,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    commit = result.stdout.strip()
+    return commit or None

--- a/src/awf/service/core_discovery.py
+++ b/src/awf/service/core_discovery.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 from dataclasses import dataclass
+from pathlib import Path
 
 from pydantic import BaseModel
 
@@ -65,10 +66,27 @@ def _resolve_git_commit() -> str:
     return _git_rev_parse_head() or UNKNOWN_GIT_COMMIT
 
 
+def _core_source_checkout_root() -> Path | None:
+    module_file = Path(__file__).resolve()
+    try:
+        package_dir = module_file.parents[1]
+        checkout_root = module_file.parents[3]
+    except IndexError:  # pragma: no cover - supported module paths are nested under awf/service.
+        return None
+    if package_dir != (checkout_root / "src" / "awf").resolve():
+        return None
+    if not (checkout_root / ".git").exists():
+        return None
+    return checkout_root
+
+
 def _git_rev_parse_head() -> str | None:
+    checkout_root = _core_source_checkout_root()
+    if checkout_root is None:
+        return None
     try:
         result = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+            ["git", "-C", str(checkout_root), "rev-parse", "HEAD"],
             check=False,
             capture_output=True,
             text=True,

--- a/src/awf/service/core_discovery.py
+++ b/src/awf/service/core_discovery.py
@@ -13,6 +13,7 @@ from awf.runtime.driver import WORKSPACE_EXECUTION_V1
 
 PACKAGE_NAME = "agent-workspace-fabric"
 UNKNOWN_GIT_COMMIT = "unknown"
+CORE_DISCOVERY_STATE_ATTR = "core_discovery_payload"
 
 
 class CoreDiscoveryResponse(BaseModel):
@@ -46,6 +47,15 @@ def build_core_discovery_payload() -> CoreDiscoveryPayload:
     """Build the stable public Core discovery payload without reading secrets."""
 
     return CoreDiscoveryPayload(git_commit=_resolve_git_commit())
+
+
+def core_discovery_payload_from_state(app_state: object) -> CoreDiscoveryPayload:
+    """Return the cached discovery payload without resolving git during requests."""
+
+    payload = getattr(app_state, CORE_DISCOVERY_STATE_ATTR, None)
+    if isinstance(payload, CoreDiscoveryPayload):
+        return payload
+    return CoreDiscoveryPayload()
 
 
 def _resolve_git_commit() -> str:

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -37,6 +37,8 @@ from awf.node.provisioner import Provisioner, ProvisionerConfig
 from awf.node.secret_mounts import LocalSecretLeaseMountResolver
 from awf.node.stack_launcher import ComposeStackLauncher
 from awf.profiles.models import WorkspaceProfile
+from awf.runtime.driver import LocalRuntimeDriver, WorkspaceRuntimeDriver
+from awf.runtime.inspection import RuntimeInspector
 from awf.runtime.logs import LogStore
 from awf.runtime.merge_coordinator import (
     InProcessMergeCoordinator,
@@ -82,6 +84,7 @@ _log = get_logger(__name__)
 class WorkerRuntime:
     engine: AsyncEngine
     worker: ControlWorker
+    runtime_driver: WorkspaceRuntimeDriver
 
 
 # Tasks scheduled by _release_forge_client_after_build_error are kept referenced
@@ -298,6 +301,13 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         pr_monitor_factory=_pr_monitor_factory,
         log_store=log_store,
         usage_sampler=usage_collector,
+    )
+    runtime_driver = LocalRuntimeDriver(
+        provisioner=provisioner,
+        executor=executor,
+        cleaner=runtime_cleaner,
+        validation_runner=validation,
+        runtime_inspector=RuntimeInspector(),
     )
     orphan_dir_teardown = build_default_compose_teardown(compose)
     classified_orphan_teardown = build_orphan_compose_teardown(compose)
@@ -568,7 +578,7 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             workspace_peak_memory_gb=settings.workspace_peak_memory_gb,
         ),
     )
-    return WorkerRuntime(engine=engine, worker=worker)
+    return WorkerRuntime(engine=engine, worker=worker, runtime_driver=runtime_driver)
 
 
 def _companion_image_builder_for(

--- a/tests/unit/api/test_core_discovery.py
+++ b/tests/unit/api/test_core_discovery.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 
@@ -66,6 +69,41 @@ async def test_core_discovery_uses_safe_unknown_git_commit_fallback(
 
     assert response.status_code == 200
     assert response.json()["git_commit"] == "unknown"
+
+
+def test_git_rev_parse_head_anchors_lookup_to_core_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    foreign_repo = tmp_path / "foreign-project"
+    foreign_repo.mkdir()
+    monkeypatch.chdir(foreign_repo)
+    expected_root = Path(core_discovery_service.__file__).resolve().parents[3]
+
+    def _run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        git_dir_index = args.index("-C") if "-C" in args else None
+        command_root = Path(args[git_dir_index + 1]) if git_dir_index is not None else None
+        stdout = "core-head\n" if command_root == expected_root else "foreign-head\n"
+        return SimpleNamespace(returncode=0, stdout=stdout)
+
+    monkeypatch.setattr(core_discovery_service.subprocess, "run", _run)
+
+    assert core_discovery_service._git_rev_parse_head() == "core-head"
+
+
+def test_git_rev_parse_head_returns_none_outside_core_source_checkout(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    installed_module = tmp_path / ".venv/lib/python3.12/site-packages/awf/service/core_discovery.py"
+    monkeypatch.setattr(core_discovery_service, "__file__", str(installed_module))
+
+    def _run(args: list[str], **kwargs: object) -> SimpleNamespace:
+        raise AssertionError("installed-layout discovery must not run git from a surrounding repo")
+
+    monkeypatch.setattr(core_discovery_service.subprocess, "run", _run)
+
+    assert core_discovery_service._git_rev_parse_head() is None
 
 
 async def test_core_discovery_caches_git_commit_before_requests(

--- a/tests/unit/api/test_core_discovery.py
+++ b/tests/unit/api/test_core_discovery.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 from awf import __version__
 from awf.api.app import create_app
 from awf.common.config import get_settings
+from awf.service import core_discovery as core_discovery_service
 
 DISCOVERY_PATH = "/.well-known/awf-core.json"
 
@@ -65,6 +66,35 @@ async def test_core_discovery_uses_safe_unknown_git_commit_fallback(
 
     assert response.status_code == 200
     assert response.json()["git_commit"] == "unknown"
+
+
+async def test_core_discovery_caches_git_commit_before_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AWF_GIT_COMMIT", raising=False)
+    calls = 0
+
+    def _initial_git_commit() -> str:
+        nonlocal calls
+        calls += 1
+        return "cached-head"
+
+    def _request_path_git_commit() -> str:
+        raise AssertionError("discovery request path must not resolve git commit")
+
+    monkeypatch.setattr(core_discovery_service, "_git_rev_parse_head", _initial_git_commit)
+    app = create_app(use_lifespan=False)
+    monkeypatch.setattr(core_discovery_service, "_git_rev_parse_head", _request_path_git_commit)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.get(DISCOVERY_PATH)
+        second = await client.get(DISCOVERY_PATH)
+
+    assert first.status_code == 200
+    assert first.json()["git_commit"] == "cached-head"
+    assert second.status_code == 200
+    assert second.json()["git_commit"] == "cached-head"
+    assert calls == 1
 
 
 async def test_core_discovery_does_not_weaken_protected_routes(

--- a/tests/unit/api/test_core_discovery.py
+++ b/tests/unit/api/test_core_discovery.py
@@ -1,0 +1,86 @@
+"""Core discovery endpoint contract tests."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from awf import __version__
+from awf.api.app import create_app
+from awf.common.config import get_settings
+
+DISCOVERY_PATH = "/.well-known/awf-core.json"
+
+
+def _client_without_database() -> AsyncClient:
+    app = create_app(use_lifespan=False)
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+async def test_core_discovery_is_public_with_token_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    token = "secret-token-that-must-not-leak"
+    monkeypatch.setenv("AWF_API_TOKEN", token)
+    monkeypatch.setenv("AWF_GIT_COMMIT", "abc1234")
+    get_settings.cache_clear()
+
+    try:
+        async with _client_without_database() as client:
+            response = await client.get(DISCOVERY_PATH)
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload == {
+        "package_name": "agent-workspace-fabric",
+        "package_version": __version__,
+        "git_commit": "abc1234",
+        "capabilities": ["workspace.execution.v1"],
+    }
+    assert token not in response.text
+
+
+async def test_core_discovery_and_health_do_not_require_database() -> None:
+    async with _client_without_database() as client:
+        discovery = await client.get(DISCOVERY_PATH)
+        health = await client.get("/healthz")
+
+    assert discovery.status_code == 200
+    assert health.status_code == 200
+
+
+async def test_core_discovery_uses_safe_unknown_git_commit_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AWF_GIT_COMMIT", raising=False)
+    monkeypatch.setattr(
+        "awf.service.core_discovery._git_rev_parse_head",
+        lambda: None,
+    )
+
+    async with _client_without_database() as client:
+        response = await client.get(DISCOVERY_PATH)
+
+    assert response.status_code == 200
+    assert response.json()["git_commit"] == "unknown"
+
+
+async def test_core_discovery_does_not_weaken_protected_routes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWF_API_TOKEN", "protected-token")
+    get_settings.cache_clear()
+
+    try:
+        async with _client_without_database() as client:
+            discovery = await client.get(DISCOVERY_PATH)
+            missing_auth = await client.get("/v1/operations")
+    finally:
+        get_settings.cache_clear()
+
+    assert discovery.status_code == 200
+    assert missing_auth.status_code == 401
+    assert missing_auth.headers["WWW-Authenticate"] == "Bearer"
+    assert missing_auth.json()["detail"]["error_code"] == "UNAUTHORIZED"

--- a/tests/unit/api/test_openapi_artifact.py
+++ b/tests/unit/api/test_openapi_artifact.py
@@ -36,6 +36,13 @@ _HTTP_EXCEPTION_ERROR_RESPONSE_REF = "#/components/schemas/HttpExceptionErrorRes
 _CALLBACK_HTTP_EXCEPTION_ERROR_RESPONSE_REF = "#/components/schemas/HTTPExceptionErrorResponse"
 _ERROR_RESPONSE_REF = "#/components/schemas/ErrorResponse"
 _RELEASE_READINESS_RESPONSE_REF = "#/components/schemas/ReleaseReadinessResponse"
+_PUBLIC_PROBE_AND_DISCOVERY_OPERATIONS = frozenset(
+    {
+        ("get", "/.well-known/awf-core.json"),
+        ("get", "/healthz"),
+        ("get", "/readyz"),
+    }
+)
 
 _API_TOKEN_PROTECTED_REST_OPERATIONS = frozenset(
     {
@@ -108,6 +115,7 @@ def test_spec_is_valid_openapi_3x(openapi_spec: dict) -> None:
 @pytest.mark.unit
 def test_all_route_prefixes_present(openapi_spec: dict) -> None:
     expected_prefixes = [
+        "/.well-known/awf-core.json",
         "/healthz",
         "/readyz",
         "/release-readiness",
@@ -220,6 +228,7 @@ def test_key_endpoint_methods_exist(openapi_spec: dict) -> None:
         ("GET", "/release-readiness"),
         ("POST", "/v1/workspaces/{workspace_id}/cancel"),
         ("DELETE", "/v1/workspaces/{workspace_id}"),
+        ("GET", "/.well-known/awf-core.json"),
     ]
     for method, path in expected_methods:
         assert path in paths, (
@@ -429,6 +438,21 @@ def test_api_token_routes_are_documented_as_bearer_authenticated(
     assert (
         auth_error_schema.get("properties", {}).get("detail", {}).get("$ref") == _ERROR_RESPONSE_REF
     )
+
+
+@pytest.mark.unit
+def test_public_probe_and_discovery_routes_do_not_advertise_bearer_auth(
+    openapi_spec: dict,
+) -> None:
+    paths = openapi_spec.get("paths", {})
+
+    for method, path in sorted(_PUBLIC_PROBE_AND_DISCOVERY_OPERATIONS):
+        operation = paths[path][method]
+        assert operation.get("security") in (None, []), (
+            f"{method.upper()} {path} must remain public for service probes/discovery"
+        )
+        assert "401" not in operation.get("responses", {})
+        assert "503" not in operation.get("responses", {})
 
 
 @pytest.mark.unit

--- a/tests/unit/contracts/test_surface_metadata_alignment.py
+++ b/tests/unit/contracts/test_surface_metadata_alignment.py
@@ -142,6 +142,13 @@ def test_readiness_route_is_public_for_service_probing() -> None:
 
 
 @pytest.mark.unit
+def test_core_discovery_route_is_public_for_service_discovery() -> None:
+    route = rest_routes().get(("GET", "/.well-known/awf-core.json"))
+    assert route is not None
+    assert "require_api_token" not in route.dependencies
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("method, path", WORKSPACE_METADATA_ROUTES_REQUIRING_AUTH)
 def test_workspace_metadata_routes_remain_auth_protected(method: str, path: str) -> None:
     route = rest_routes().get((method, path))

--- a/tests/unit/runtime/test_runtime_driver.py
+++ b/tests/unit/runtime/test_runtime_driver.py
@@ -43,6 +43,10 @@ async def test_local_runtime_driver_delegates_to_local_collaborators(tmp_path: P
     status_result = object()
     compose_file = tmp_path / "compose.yml"
     worktree = tmp_path / "repo"
+    companion_worktrees = (
+        ("ws_1-adopted-api", "https://github.com/o/api.git"),
+        ("ws_1-fork-web", "https://github.com/o/web.git"),
+    )
 
     class _Provisioner:
         async def provision(self, workspace_id: str) -> object:
@@ -133,6 +137,7 @@ async def test_local_runtime_driver_delegates_to_local_collaborators(tmp_path: P
                 compose_project_name="awf_ws_1",
                 compose_file_path=compose_file,
                 worktree_host_path=worktree,
+                companion_worktrees=companion_worktrees,
                 remove_volumes=False,
                 remove_worktree=False,
             )
@@ -178,6 +183,7 @@ async def test_local_runtime_driver_delegates_to_local_collaborators(tmp_path: P
                 "compose_project_name": "awf_ws_1",
                 "compose_file_path": compose_file,
                 "worktree_host_path": worktree,
+                "companion_worktrees": companion_worktrees,
                 "remove_volumes": False,
                 "remove_worktree": False,
             },

--- a/tests/unit/runtime/test_runtime_driver.py
+++ b/tests/unit/runtime/test_runtime_driver.py
@@ -1,0 +1,197 @@
+"""Runtime-driver seam contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from awf.runtime.driver import (
+    WORKSPACE_EXECUTION_V1,
+    LocalRuntimeDriver,
+    RuntimeDriverConfig,
+    WorkspaceProvisionRequest,
+    WorkspaceStartRequest,
+    WorkspaceStatusRequest,
+    WorkspaceStopRequest,
+    WorkspaceValidateRequest,
+)
+
+
+@pytest.mark.unit
+def test_runtime_driver_config_defaults_to_local_execution_capability() -> None:
+    config = RuntimeDriverConfig()
+
+    assert config.name == "local"
+    assert config.capabilities == (WORKSPACE_EXECUTION_V1,)
+
+
+@pytest.mark.unit
+def test_runtime_driver_config_rejects_unsupported_core_driver() -> None:
+    with pytest.raises(ValueError, match="Unsupported AWF Core runtime driver"):
+        RuntimeDriverConfig(name="gke")
+
+
+@pytest.mark.unit
+async def test_local_runtime_driver_delegates_to_local_collaborators(tmp_path: Path) -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    provision_result = object()
+    start_result = object()
+    stop_result = object()
+    validate_result = object()
+    status_result = object()
+    compose_file = tmp_path / "compose.yml"
+    worktree = tmp_path / "repo"
+
+    class _Provisioner:
+        async def provision(self, workspace_id: str) -> object:
+            calls.append(("provision", {"workspace_id": workspace_id}))
+            return provision_result
+
+        async def provision_claimed(
+            self,
+            workspace_id: str,
+            execution_claim_epoch: int | None = None,
+        ) -> object:
+            calls.append(
+                (
+                    "provision_claimed",
+                    {
+                        "workspace_id": workspace_id,
+                        "execution_claim_epoch": execution_claim_epoch,
+                    },
+                )
+            )
+            return provision_result
+
+    class _Executor:
+        async def execute(
+            self,
+            workspace_id: str,
+            *,
+            execution_owner_id: str | None = None,
+            execution_lease_expires_at: object = None,
+        ) -> object:
+            calls.append(
+                (
+                    "execute",
+                    {
+                        "workspace_id": workspace_id,
+                        "execution_owner_id": execution_owner_id,
+                        "execution_lease_expires_at": execution_lease_expires_at,
+                    },
+                )
+            )
+            return start_result
+
+    class _Cleaner:
+        async def cleanup(self, **kwargs: object) -> object:
+            calls.append(("cleanup", dict(kwargs)))
+            return stop_result
+
+    class _Validation:
+        async def run(self, **kwargs: object) -> object:
+            calls.append(("validate", dict(kwargs)))
+            return validate_result
+
+    class _Inspector:
+        async def inspect(self, compose_project_name: str | None) -> object:
+            calls.append(("inspect", {"compose_project_name": compose_project_name}))
+            return status_result
+
+    driver = LocalRuntimeDriver(
+        provisioner=_Provisioner(),
+        executor=_Executor(),
+        cleaner=_Cleaner(),
+        validation_runner=_Validation(),
+        runtime_inspector=_Inspector(),
+    )
+
+    assert driver.capabilities == (WORKSPACE_EXECUTION_V1,)
+    assert (
+        await driver.provision(
+            WorkspaceProvisionRequest(workspace_id="ws_1", execution_claim_epoch=7)
+        )
+        is provision_result
+    )
+    assert (
+        await driver.start(
+            WorkspaceStartRequest(
+                workspace_id="ws_1",
+                execution_owner_id="node-1",
+                execution_lease_expires_at=None,
+            )
+        )
+        is start_result
+    )
+    assert (
+        await driver.stop(
+            WorkspaceStopRequest(
+                workspace_id="ws_1",
+                repo_url="https://github.com/o/r.git",
+                compose_project_name="awf_ws_1",
+                compose_file_path=compose_file,
+                worktree_host_path=worktree,
+                remove_volumes=False,
+                remove_worktree=False,
+            )
+        )
+        is stop_result
+    )
+    assert (
+        await driver.validate(
+            WorkspaceValidateRequest(
+                workspace_id="ws_1",
+                compose_project="awf_ws_1",
+                compose_file=compose_file,
+                test_commands=("pytest tests/unit/test_example.py -q",),
+                requires_database=True,
+                workspace_worktree=worktree,
+            )
+        )
+        is validate_result
+    )
+    assert (
+        await driver.status(WorkspaceStatusRequest(compose_project_name="awf_ws_1"))
+        is status_result
+    )
+
+    assert calls == [
+        (
+            "provision_claimed",
+            {"workspace_id": "ws_1", "execution_claim_epoch": 7},
+        ),
+        (
+            "execute",
+            {
+                "workspace_id": "ws_1",
+                "execution_owner_id": "node-1",
+                "execution_lease_expires_at": None,
+            },
+        ),
+        (
+            "cleanup",
+            {
+                "workspace_id": "ws_1",
+                "repo_url": "https://github.com/o/r.git",
+                "compose_project_name": "awf_ws_1",
+                "compose_file_path": compose_file,
+                "worktree_host_path": worktree,
+                "remove_volumes": False,
+                "remove_worktree": False,
+            },
+        ),
+        (
+            "validate",
+            {
+                "workspace_id": "ws_1",
+                "compose_project": "awf_ws_1",
+                "compose_file": compose_file,
+                "test_commands": ["pytest tests/unit/test_example.py -q"],
+                "requires_database": True,
+                "workspace_worktree": worktree,
+            },
+        ),
+        ("inspect", {"compose_project_name": "awf_ws_1"}),
+    ]

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -17,6 +17,7 @@ from awf.common.audit import REDACTION_MARKER
 from awf.common.config import Settings
 from awf.node.companion_images import CompanionImageBuilder
 from awf.profiles.models import ProfileMonitor, ProfileRuntime, ProfileService, WorkspaceProfile
+from awf.runtime.driver import LocalRuntimeDriver
 from awf.runtime.merge_coordinator import InProcessMergeCoordinator
 from awf.service import worker as worker_mod
 from awf.service.config import ServiceSettings, resolve_service_settings
@@ -509,6 +510,140 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
         ),
     )
     assert created["feature_monitor_kwargs"]["awaiting_required_checks_grace_seconds"] == 0
+
+
+@pytest.mark.unit
+def test_build_worker_runtime_defaults_to_local_runtime_driver_without_changing_worker_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    created: dict[str, Any] = {}
+
+    class _Engine:
+        pass
+
+    class _Runner:
+        pass
+
+    class _LogStore:
+        def __init__(self, *, root: Path, session_factory: object) -> None:
+            created["log_store"] = self
+            created["log_root"] = root
+            created["log_session_factory"] = session_factory
+
+    class _ValidationRunner:
+        def __init__(self, *, runner: object, artifacts_dir: Path, log_store: object) -> None:
+            created["validation"] = self
+            created["validation_runner"] = runner
+            created["validation_artifacts_dir"] = artifacts_dir
+            created["validation_log_store"] = log_store
+
+    class _PullRequestCreator:
+        def __init__(self, runner: object) -> None:
+            created["pr_creator"] = self
+            created["pr_creator_runner"] = runner
+
+    class _BranchOpenPullRequestResolver:
+        def __init__(self, runner: object) -> None:
+            created["open_pr_resolver"] = self
+            created["open_pr_resolver_runner"] = runner
+
+    class _GitManager:
+        def __init__(self, work_dir: Path, **kwargs: object) -> None:
+            created["git"] = self
+            created["git_work_dir"] = work_dir
+            created["git_kwargs"] = kwargs
+
+    class _ComposeManager:
+        def __init__(self, *, work_dir: Path, template_path: Path) -> None:
+            created["compose"] = self
+            created["compose_work_dir"] = work_dir
+            created["compose_template_path"] = template_path
+
+    class _WorkspaceCleaner:
+        def __init__(self, *, git: object, compose: object) -> None:
+            created["runtime_cleaner"] = self
+            created["cleaner_git"] = git
+            created["cleaner_compose"] = compose
+
+    class _LocalSecretLeaseMountResolver:
+        def __init__(self, **kwargs: object) -> None:
+            created["secret_lease_resolver"] = self
+            created["secret_lease_kwargs"] = kwargs
+
+    class _ComposeStackLauncher:
+        def __init__(self, **kwargs: object) -> None:
+            created["stack_launcher"] = self
+            created["stack_launcher_kwargs"] = kwargs
+
+    class _Provisioner:
+        def __init__(self, **kwargs: object) -> None:
+            created["provisioner"] = self
+            created["provisioner_kwargs"] = kwargs
+
+    class _WorkspaceExecutor:
+        def __init__(self, **kwargs: object) -> None:
+            created["executor"] = self
+            created["executor_kwargs"] = kwargs
+
+    class _ControlWorker:
+        def __init__(self, **kwargs: object) -> None:
+            created["worker"] = self
+            created["worker_kwargs"] = kwargs
+
+    engine = _Engine()
+    session_factory = object()
+
+    monkeypatch.setattr(worker_mod, "make_engine", lambda _url: engine)
+    monkeypatch.setattr(worker_mod, "make_session_factory", lambda _engine: session_factory)
+    monkeypatch.setattr(worker_mod, "AsyncioSubprocessRunner", _Runner)
+    monkeypatch.setattr(worker_mod, "LogStore", _LogStore)
+    monkeypatch.setattr(worker_mod, "ValidationRunner", _ValidationRunner)
+    monkeypatch.setattr(worker_mod, "PullRequestCreator", _PullRequestCreator)
+    monkeypatch.setattr(worker_mod, "BranchOpenPullRequestResolver", _BranchOpenPullRequestResolver)
+    monkeypatch.setattr(worker_mod, "GitManager", _GitManager)
+    monkeypatch.setattr(worker_mod, "ComposeManager", _ComposeManager)
+    monkeypatch.setattr(worker_mod, "WorkspaceCleaner", _WorkspaceCleaner)
+    monkeypatch.setattr(worker_mod, "LocalSecretLeaseMountResolver", _LocalSecretLeaseMountResolver)
+    monkeypatch.setattr(worker_mod, "ComposeStackLauncher", _ComposeStackLauncher)
+    monkeypatch.setattr(worker_mod, "Provisioner", _Provisioner)
+    monkeypatch.setattr(worker_mod, "WorkspaceExecutor", _WorkspaceExecutor)
+    monkeypatch.setattr(worker_mod, "ControlWorker", _ControlWorker)
+    monkeypatch.setattr(
+        worker_mod, "_companion_image_builder_for", lambda _settings, _compose: None
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_apply_service_git_environment",
+        lambda env: created.setdefault("applied_git_env", env),
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "_merge_coordinator_for_database_url",
+        _in_process_merge_coordinator,
+    )
+    monkeypatch.delenv("SSH_AUTH_SOCK", raising=False)
+
+    runtime = worker_mod.build_worker_runtime(_settings(tmp_path))
+
+    assert runtime.engine is engine
+    assert runtime.worker is created["worker"]
+    assert isinstance(runtime.runtime_driver, LocalRuntimeDriver)
+    assert runtime.runtime_driver.provisioner is created["provisioner"]
+    assert runtime.runtime_driver.executor is created["executor"]
+    assert runtime.runtime_driver.cleaner is created["runtime_cleaner"]
+    assert runtime.runtime_driver.validation_runner is created["validation"]
+    assert runtime.runtime_driver.runtime_inspector.__class__ is worker_mod.RuntimeInspector
+    assert runtime.runtime_driver.capabilities == ("workspace.execution.v1",)
+    assert created["worker_kwargs"]["provisioner"] is created["provisioner"]
+    assert created["worker_kwargs"]["executor"] is created["executor"]
+    assert created["worker_kwargs"]["runtime_cleaner"] is created["runtime_cleaner"]
+    assert created["worker_kwargs"]["open_pr_resolver"] is created["open_pr_resolver"]
+    assert created["executor_kwargs"]["compose"] is created["compose"]
+    assert created["executor_kwargs"]["validation"] is created["validation"]
+    assert created["provisioner_kwargs"]["service_diagnostics"] is created["compose"]
+    assert created["cleaner_git"] is created["git"]
+    assert created["cleaner_compose"] is created["compose"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_3c293c931c274baa8b5dbd53` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).


### Task
Environment notes:
- You are working in /workspace on public AWF Core (agent-workspace-fabric), not awf-cloud.
- This task is the first Core PR for the AWF Cloud GKE-native execution MVP. awf-cloud needs a stable Core contract so it can keep Core authoritative for generic workspace lifecycle, validation provenance, controls, and PR monitor behavior while awf-cloud supplies the GKE substrate.
- Read /workspace/AGENTS.md, /workspace/README.md, docs/awf_prd_v2.2.md as needed, and inspect the existing FastAPI route/service patterns before editing.
- git is functional in /workspace. Commit before exiting. Do not push; AWF handles push, PR creation, monitoring, and merge.

Task: F16-Core/T16.0 Core capability discovery and runtime driver seam.

Goal:
Make the smallest Core change that unblocks awf-cloud from depending on a public Core execution contract, without changing local Docker/Compose behavior.

What to do:
1. Add a safe Core discovery endpoint at /.well-known/awf-core.json, following existing FastAPI route/test patterns. The response must be stable, secret-free, and compatible with awf-cloud's Core adapter expectations: package_name, package_version, git_commit, and capabilities including workspace.execution.v1.
2. Document and test token expectations clearly: healthz and discovery must be safe for in-cluster readiness/discovery; protected workspace/control routes remain protected by AWF_API_TOKEN and existing auth behavior must not weaken.
3. Add a cloud-neutral runtime-driver contract seam for workspace execution substrate selection. Local Docker/Compose remains the default implementation and existing behavior must be unchanged. This PR should introduce the Protocol/model/config boundary and a local-driver default/fake tests, not a GKE implementation.
4. Wire the seam only far enough that future code can delegate provision/start/stop/validate/status through a runtime driver without forking Core lifecycle semantics. Do not implement Kubernetes, cloud secrets, GCS, Terraform, awf-cloud, SaaS auth, billing, or cloud tenant records here.
5. Add regression tests for discovery shape/capabilities/auth non-regression and for the runtime-driver seam defaulting to the local driver without changing worker construction behavior.

Out of scope:
- awf-cloud changes, GKE controller code, Kubernetes manifests, Docker-in-Docker, docker.sock mounts, privileged GKE workers, PR monitor rewrites, validation provenance rewrites, SaaS/BYOK/OAuth/API key behavior, .github workflows, .awf profile changes, committed plans/ artifacts.

Validation evidence requirement:
- Run and record exact exit codes for focused tests covering the new discovery endpoint and runtime-driver seam.
- Also run targeted ruff/mypy for changed Python modules and git diff --check.

---
Validation: 8 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive (new public discovery route, driver abstraction) with explicit regression tests; local execution paths remain the default and worker dependencies are unchanged.
> 
> **Overview**
> Introduces a **public, secret-free Core discovery** endpoint at `/.well-known/awf-core.json` (package identity, `git_commit`, and `capabilities` including `workspace.execution.v1`), cached at app startup so request handling does not shell out to git. **OpenAPI and REST docs** are updated accordingly.
> 
> **Auth expectations** are clarified and tightened in documentation: `healthz`, `readyz`, and discovery stay unauthenticated for probes and in-cluster discovery; **`/release-readiness` is documented as bearer-protected** alongside workspace/control routes, with contract tests ensuring discovery does not weaken protected routes.
> 
> Adds a **cloud-neutral `WorkspaceRuntimeDriver` protocol** and **`LocalRuntimeDriver`** that delegates provision/start/stop/validate/status to existing Docker/Compose collaborators. **`build_worker_runtime`** constructs and returns this driver on `WorkerRuntime` without changing how **`ControlWorker`** is wired (same provisioner/executor/cleaner instances).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9110e95770b5190d4b32f9b4073edeef163c5982. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->