### PR TITLE
fix(#709): route coverage/format/typecheck CI failures to fix-pass (share CI_CODE_FAILURE_MARKERS)

### DIFF
--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -32,6 +32,22 @@ _MAX_SUMMARIES = 8
 _MAX_LINE_CHARS = 500
 _DEFAULT_PYTEST_REPRO_COMMAND = "uv run --python 3.12 --extra dev pytest"
 
+CI_CODE_FAILURE_MARKERS = (
+    "failed test",
+    "pytest failed",
+    "assertionerror",
+    "assert failed",
+    "coverage failure",
+    "fail-under",
+    "typecheck",
+    "type check",
+    "would reformat:",
+    "found lint errors",
+    "found type errors",
+    "syntaxerror",
+    "traceback (most recent call last)",
+)
+
 
 @dataclass(frozen=True)
 class CiFailureEvidence:
@@ -237,9 +253,12 @@ def _extract_assertion_snippets(lines: Iterable[str]) -> list[str]:
 
 def _extract_error_summaries(lines: Iterable[str]) -> list[str]:
     """Collect concise error summary lines from displayed CI log output."""
-    summaries: list[str] = []
+    marker_summaries: list[str] = []
+    generic_summaries: list[str] = []
     for line in lines:
-        if (
+        if _line_has_code_failure_marker(line):
+            marker_summaries.append(line)
+        elif (
             line.startswith("FAILED ")
             or "AssertionError" in line
             or line.startswith("Error:")
@@ -248,8 +267,13 @@ def _extract_error_summaries(lines: Iterable[str]) -> list[str]:
             or _RUFF_DIAGNOSTIC_RE.search(line)
             or line.lower().startswith(("error ", "error:", "fatal:"))
         ):
-            summaries.append(line)
-    return summaries
+            generic_summaries.append(line)
+    return [*marker_summaries, *generic_summaries]
+
+
+def _line_has_code_failure_marker(line: str) -> bool:
+    lowered = line.lower()
+    return any(marker in lowered for marker in CI_CODE_FAILURE_MARKERS)
 
 
 def _suggest_repro_commands(

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -13,6 +13,7 @@ _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
 _PYTHON_DIAGNOSTIC_RE = re.compile(
     r"\b(?:src|tests)/[^\s:]+\.py:\d+(?::\d+)?:\s*(?:error|warning):"
 )
+_RUFF_DIAGNOSTIC_RE = re.compile(r"\b(?:src|tests)/[^\s:]+\.py:\d+:\d+:\s*[A-Z][A-Z0-9]+\b")
 _COMMAND_MARKERS = (
     "uv run ",
     "python -m pytest",
@@ -268,6 +269,7 @@ def _extract_error_summaries(lines: Iterable[str]) -> list[str]:
             or "::error" in message
             or "Process completed with exit code" in message
             or _PYTHON_DIAGNOSTIC_RE.search(message)
+            or _RUFF_DIAGNOSTIC_RE.search(message)
             or message.lower().startswith(("error ", "error:", "fatal:"))
         ):
             generic_summaries.append(line)

--- a/src/awf/runtime/ci_failure_evidence.py
+++ b/src/awf/runtime/ci_failure_evidence.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 from awf.common.redaction import redact_secrets
 
 _ANSI_RE = re.compile(r"\x1b\[[0-9;?]*[A-Za-z]")
-_RUFF_DIAGNOSTIC_RE = re.compile(r"\b(?:src|tests)/[^\s:]+\.py:\d+:\d+:")
+_PYTHON_DIAGNOSTIC_RE = re.compile(
+    r"\b(?:src|tests)/[^\s:]+\.py:\d+(?::\d+)?:\s*(?:error|warning):"
+)
 _COMMAND_MARKERS = (
     "uv run ",
     "python -m pytest",
@@ -256,19 +258,28 @@ def _extract_error_summaries(lines: Iterable[str]) -> list[str]:
     marker_summaries: list[str] = []
     generic_summaries: list[str] = []
     for line in lines:
-        if _line_has_code_failure_marker(line):
+        message = _github_log_message_segment(line)
+        if _line_has_code_failure_marker(message):
             marker_summaries.append(line)
         elif (
-            line.startswith("FAILED ")
-            or "AssertionError" in line
-            or line.startswith("Error:")
-            or "::error" in line
-            or "Process completed with exit code" in line
-            or _RUFF_DIAGNOSTIC_RE.search(line)
-            or line.lower().startswith(("error ", "error:", "fatal:"))
+            message.startswith("FAILED ")
+            or "AssertionError" in message
+            or message.startswith("Error:")
+            or "::error" in message
+            or "Process completed with exit code" in message
+            or _PYTHON_DIAGNOSTIC_RE.search(message)
+            or message.lower().startswith(("error ", "error:", "fatal:"))
         ):
             generic_summaries.append(line)
     return [*marker_summaries, *generic_summaries]
+
+
+def _github_log_message_segment(line: str) -> str:
+    """Return the message after GitHub's job and step log prefixes."""
+    parts = line.split("\t", 2)
+    if len(parts) == 3 and parts[0].strip() and parts[1].strip():
+        return parts[2].strip()
+    return line
 
 
 def _line_has_code_failure_marker(line: str) -> bool:

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -39,6 +39,7 @@ from datetime import UTC, datetime
 from typing import Literal
 
 from awf.runtime._docker_pull_detection import _log_shows_docker_registry_timeout
+from awf.runtime.ci_failure_evidence import CI_CODE_FAILURE_MARKERS
 from awf.runtime.monitor_state_keys import (
     _merge_method_blocked_key,
     _outdated_resolve_requeued_key,
@@ -620,22 +621,6 @@ _CI_TRANSIENT_INFRA_WAIT_KEY_PREFIX = "__awf_ci_infra_wait:"
 
 _CI_FAILED_JOB_RERUN_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT"})
 
-_CI_CODE_FAILURE_MARKERS = (
-    "failed test",
-    "pytest failed",
-    "assertionerror",
-    "assert failed",
-    "coverage failure",
-    "fail-under",
-    "typecheck",
-    "type check",
-    "would reformat:",
-    "found lint errors",
-    "found type errors",
-    "syntaxerror",
-    "traceback (most recent call last)",
-)
-
 _CI_CODE_FAILURE_PATTERNS = (
     re.compile(r"(?m)^[^\n:]+:\d+:\d+:\s+[A-Z]\d{3}\b"),
     re.compile(r"(?m)^[^\n:]+:\d+:\s+error:\s+.+\[[a-z0-9-]+\]"),
@@ -907,7 +892,7 @@ def _has_structured_code_failure_evidence(failure: CheckFailure) -> bool:
 
 
 def _looks_like_code_failure_text(text: str) -> bool:
-    if any(marker in text for marker in _CI_CODE_FAILURE_MARKERS):
+    if any(marker in text for marker in CI_CODE_FAILURE_MARKERS):
         return True
     return any(pattern.search(text) for pattern in _CI_CODE_FAILURE_PATTERNS)
 

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -180,6 +180,24 @@ def test_ci_failure_evidence_ignores_github_step_prefix_for_marker_matching() ->
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_preserves_ruff_diagnostics_without_tail_marker() -> None:
+    diagnostic = (
+        "python\tLint (ruff)\t"
+        "src/awf/runtime/ci_failure_evidence.py:15:5: F401 `re` imported but unused"
+    )
+    boilerplate = [
+        f"python\tLint (ruff)\t2026-06-28T20:35:{second:02d}Z setup line" for second in range(10)
+    ]
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join([*boilerplate, diagnostic]),
+        check_name="Lint (ruff)",
+    )
+
+    assert evidence.error_summaries == (diagnostic.replace("\t", " "),)
+
+
+@pytest.mark.unit
 def test_ci_failure_evidence_preserves_prefixed_github_error_annotations() -> None:
     """Timestamped check-name prefixes do not hide coverage annotations."""
     prefixed_annotation = (

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -8,6 +8,8 @@ import pytest
 
 from awf.runtime import ci_failure_evidence
 
+_COVERAGE_FAIL_UNDER_LINE = "Coverage failure: total of 98.94 is less than fail-under=99.00"
+
 
 @pytest.mark.unit
 def test_ci_failure_evidence_handles_empty_logs_with_warning() -> None:
@@ -96,6 +98,66 @@ def test_ci_failure_evidence_preserves_github_error_annotations() -> None:
     ) in evidence.error_summaries
     assert timestamped_annotation in evidence.error_summaries
     assert "Error: Process completed with exit code 1." in evidence.error_summaries
+
+
+@pytest.mark.unit
+def test_ci_failure_evidence_preserves_coverage_fail_under_summary() -> None:
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join(
+            [
+                "Name                     Stmts   Miss  Cover",
+                "src/awf/runtime/foo.py      100      2    98%",
+                _COVERAGE_FAIL_UNDER_LINE,
+                "Error: Process completed with exit code 1.",
+            ]
+        ),
+        check_name="python-full-coverage",
+    )
+
+    assert _COVERAGE_FAIL_UNDER_LINE in evidence.error_summaries
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("marker", ci_failure_evidence.CI_CODE_FAILURE_MARKERS)
+def test_ci_failure_evidence_preserves_every_code_failure_marker(marker: str) -> None:
+    marker_line = f"CI marker evidence: {marker}"
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        marker_line,
+        check_name="marker-consistency",
+    )
+
+    assert marker_line in evidence.error_summaries
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "summary_line",
+    (
+        "would reformat: src/awf/runtime/pr_monitor.py",
+        "Found type errors",
+    ),
+)
+def test_ci_failure_evidence_preserves_black_and_mypy_summaries(summary_line: str) -> None:
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        summary_line,
+        check_name="lint-and-type",
+    )
+
+    assert summary_line in evidence.error_summaries
+
+
+@pytest.mark.unit
+def test_ci_failure_evidence_prioritizes_marker_summaries_within_cap() -> None:
+    generic_errors = [f"Error: generic failure {index}" for index in range(10)]
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join([*generic_errors, _COVERAGE_FAIL_UNDER_LINE]),
+        check_name="python-full-coverage",
+    )
+
+    assert len(evidence.error_summaries) == ci_failure_evidence._MAX_SUMMARIES  # noqa: SLF001
+    assert _COVERAGE_FAIL_UNDER_LINE in evidence.error_summaries
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_ci_failure_evidence.py
+++ b/tests/unit/runtime/test_ci_failure_evidence.py
@@ -161,6 +161,25 @@ def test_ci_failure_evidence_prioritizes_marker_summaries_within_cap() -> None:
 
 
 @pytest.mark.unit
+def test_ci_failure_evidence_ignores_github_step_prefix_for_marker_matching() -> None:
+    diagnostic = (
+        "python\tType check (mypy)\t"
+        "src/awf/runtime/ci_failure_evidence.py:260: error: Incompatible types"
+    )
+    boilerplate = [
+        f"python\tType check (mypy)\t2026-06-28T20:28:{second:02d}Z setup line"
+        for second in range(10)
+    ]
+
+    evidence = ci_failure_evidence.extract_ci_failure_evidence(
+        "\n".join([*boilerplate, diagnostic]),
+        check_name="Type check (mypy)",
+    )
+
+    assert evidence.error_summaries == (diagnostic.replace("\t", " "),)
+
+
+@pytest.mark.unit
 def test_ci_failure_evidence_preserves_prefixed_github_error_annotations() -> None:
     """Timestamped check-name prefixes do not hide coverage annotations."""
     prefixed_annotation = (

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_003.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from awf.runtime import ci_failure_evidence
 from awf.runtime.pr_monitor import (
     CheckFailure,
     CheckState,
@@ -21,6 +22,7 @@ from awf.runtime.pr_monitor import (
     RerunTransientCI,
     ReviewComment,
     ReviewThread,
+    _has_actionable_ci_failure_evidence,
     _log_shows_docker_registry_timeout,
     decide,
 )
@@ -214,6 +216,73 @@ class TestCiFailure:
         assert isinstance(action, NotifyHuman)
         assert action.message is not None
         assert "without actionable code-failure evidence" in action.message
+
+    @pytest.mark.unit
+    def test_coverage_fail_under_summary_reports_ci_failure_when_tail_is_truncated(
+        self,
+    ) -> None:
+        coverage_line = "Coverage failure: total of 98.94 is less than fail-under=99.00"
+        evidence = ci_failure_evidence.extract_ci_failure_evidence(
+            "\n".join(
+                [
+                    "python-full-coverage\tRun coverage report\tcoverage report --fail-under=99",
+                    coverage_line,
+                    "Error: Process completed with exit code 1.",
+                ]
+            ),
+            check_name="python-full-coverage",
+        )
+        failure = CheckFailure(
+            name="python-full-coverage",
+            conclusion="FAILURE",
+            log_excerpt="Error: Process completed with exit code 1.",
+            run_id="25897584271",
+            failing_commands=evidence.failing_commands,
+            error_summaries=evidence.error_summaries,
+            suggested_repro_commands=evidence.suggested_repro_commands,
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert coverage_line in evidence.error_summaries
+        assert _has_actionable_ci_failure_evidence(failure)
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "summary_line",
+        (
+            "Coverage failure: total of 98.94 is less than fail-under=99.00",
+            "would reformat: src/awf/runtime/pr_monitor.py",
+            "Found type errors",
+        ),
+    )
+    def test_structured_code_failure_summary_reports_ci_failure_without_tail_marker(
+        self,
+        summary_line: str,
+    ) -> None:
+        failure = CheckFailure(
+            name="lint-and-type",
+            conclusion="FAILURE",
+            log_excerpt="Error: Process completed with exit code 1.",
+            run_id="25897584271",
+            error_summaries=(summary_line,),
+        )
+
+        action = decide(
+            _status(check_state=CheckState.FAILURE, ci_failures=(failure,)),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert _has_actionable_ci_failure_evidence(failure)
+        assert isinstance(action, ReportCiFailure)
+        assert action.failures == (failure,)
 
     @pytest.mark.unit
     def test_mixed_run_with_rollup_marker_and_code_evidence_reports_failure(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e2a3c6b3e6e24348b22ee23b` (agent: `codex`, model: `gpt-5.5`, effort: `high`).


### Task
Fix Core issue #709: the PR monitor escalates actionable CI failures (coverage fail-under, and likely black/mypy) to a human instead of routing them to a fix-pass. Repo: agent-workspace-fabric (public AWF Core), branch feature -> development. A /plan-eng-review locked the design below; implement it exactly. Strict TDD.

## Root cause (verified)
The classifier `_has_actionable_ci_failure_evidence` (src/awf/runtime/pr_monitor.py:915) checks `failure.error_summaries` and `failure.log_excerpt` against `_CI_CODE_FAILURE_MARKERS` (pr_monitor.py:623), which ALREADY includes "coverage failure" and "fail-under". But:
1. `error_summaries` is built by `_extract_error_summaries` (src/awf/runtime/ci_failure_evidence.py:238) using a SEPARATE hardcoded allowlist (FAILED , AssertionError, Error:, ::error, Process completed with exit code, a ruff regex, error/fatal:). The coverage line `Coverage failure: total of 98.94 is less than fail-under=99.00` starts with "Coverage failure:" and matches NONE -> dropped before the classifier sees it.
2. `failure.log_excerpt` is only `_tail(log_text, log_tail_chars)` (src/awf/common/github_client.py:967). In a multi-job run the coverage line is earlier than the tail window and is pushed out.
So both classifier inputs miss the line -> `_ci_failure_action` returns NotifyHuman(_CI_UNACTIONABLE_HUMAN_MESSAGE) (pr_monitor.py:983) instead of ReportCiFailure. Verified live on PR #708.

## Fix (locked) — share the marker set (DRY), cycle-safe
1. Move the canonical code-failure marker set into `src/awf/runtime/ci_failure_evidence.py` as a module-level constant `CI_CODE_FAILURE_MARKERS` (lift the current `_CI_CODE_FAILURE_MARKERS` tuple from pr_monitor.py). In `pr_monitor.py`, import it from ci_failure_evidence and use it everywhere `_CI_CODE_FAILURE_MARKERS` is referenced (delete the local copy). VERIFIED cycle-safe: ci_failure_evidence.py does NOT import pr_monitor, so pr_monitor importing ci_failure_evidence introduces no import cycle. (The `_CI_CODE_FAILURE_PATTERNS` regex tuple can stay in pr_monitor.py; only the string-marker tuple needs sharing — but if the extractor benefits from the patterns too, share those as well, your call, keep it DRY.)
2. In `_extract_error_summaries`, keep a line if it matches the EXISTING allowlist OR contains any `CI_CODE_FAILURE_MARKERS` marker (case-insensitive). Now any line the classifier would deem actionable survives into `error_summaries`, independent of `log_excerpt` tail truncation.
3. CAP REFINEMENT: `error_summaries` is truncated to `_MAX_SUMMARIES=8` (ci_failure_evidence.py:75). Ensure marker-matching (actionable) lines are PRIORITIZED within the cap so a coverage/fail-under line is never crowded out by generic error-ish lines (e.g., order marker-matching lines first before applying the cap, or guarantee their inclusion). Preserve dedupe + the existing `_MAX_LINE_CHARS` truncation.

## Tests (cover all; full suite green at the exact 99% coverage gate)
- a `python-full-coverage` `--log-failed` excerpt containing `Coverage failure: total of 98.94 is less than fail-under=99.00` -> `extract_ci_failure_evidence` puts it in `error_summaries` -> `_has_actionable_ci_failure_evidence` True -> `_ci_failure_action` returns ReportCiFailure (NOT NotifyHuman).
- a coverage line earlier than the log_excerpt tail window -> still routes to a fix-pass (the structured path catches it).
- parametrized marker-consistency: EVERY `CI_CODE_FAILURE_MARKERS` entry, present as a log line, is preserved by the extractor (guards future drift).
- completeness: black `would reformat:` and mypy `found type errors` lines -> actionable.
- cap crowd-out: a log with >8 generic error-ish lines PLUS one coverage line -> the coverage line still survives in `error_summaries`.
- REGRESSION: a genuinely non-actionable rollup-only failure ("a required ci job did not pass") still escalates (NotifyHuman); a transient failure still reruns/waits as before (no false-actionable).

## Constraints
Strict TDD. Right-sized diff (~2-3 files: ci_failure_evidence.py, pr_monitor.py, tests). Do NOT change log_excerpt tail sizing, the 99% gate, or the coverage shard layout. Do NOT touch protected quality-gate files. Commit in /workspace; do NOT push or open a PR (AWF owns push, PR, validation, review, merge). Full suite must pass the exact ~99% coverage gate.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how failed CI logs are parsed and when the monitor chooses ReportCiFailure vs NotifyHuman; behavior is narrow and heavily unit-tested but affects automated repair routing.
> 
> **Overview**
> Fixes PR monitor routing that sent **coverage fail-under**, **black**, and **mypy** failures to humans instead of the CI fix-pass when those lines never reached `error_summaries` or fell outside truncated log tails.
> 
> **`CI_CODE_FAILURE_MARKERS`** is now defined once in `ci_failure_evidence.py` and imported by `pr_monitor.py`, so the log extractor and actionable-CI classifier use the same strings.
> 
> **`_extract_error_summaries`** keeps lines that match those markers (case-insensitive), ranks marker hits **before** generic error lines so they survive the 8-line cap, and matches on the message after GitHub job/step tab prefixes. Python/ruff diagnostic regexes were broadened for mypy and ruff lines without trailing rule codes.
> 
> Tests cover marker preservation, cap crowd-out, prefixed logs, and `decide` returning **`ReportCiFailure`** when only structured summaries exist (e.g. truncated tail).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7ec5fa679c6a9256d6e101757a3cfa29a5b8dc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->