### PR TITLE
fix(#711): WaitForCI on a failed shard of an in-progress run instead of premature human escalation

### DIFF
--- a/src/awf/common/bitbucket_client.py
+++ b/src/awf/common/bitbucket_client.py
@@ -380,7 +380,7 @@ class BitbucketClient:
         log_tail_chars: int = 3000,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: Sequence[CheckTiming] = (),  # noqa: ARG002 - GitHub-only fallback input
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         """Fetch logs for failing checks via the Bitbucket pipeline-lookup chain.
 
         Commit statuses do not carry pipeline/step UUIDs, so for FAILED statuses we
@@ -397,12 +397,16 @@ class BitbucketClient:
         )
         failed = [s for s in statuses if str(s.get("state") or "").upper() in {"FAILED", "STOPPED"}]
         if not failed:
-            return ()
+            return (), False
 
         pipeline = await self._find_pipeline_for_commit(repo, head_sha, pr_number, source_branch)
         if pipeline is None:
-            return tuple(
-                self._external_status_failure(status, pytest_fallback_commands) for status in failed
+            return (
+                tuple(
+                    self._external_status_failure(status, pytest_fallback_commands)
+                    for status in failed
+                ),
+                False,
             )
 
         pipeline_uuid = _clean_optional_str(pipeline.get("uuid"))
@@ -412,8 +416,12 @@ class BitbucketClient:
             else []
         )
         if not failing_steps:
-            return tuple(
-                self._external_status_failure(status, pytest_fallback_commands) for status in failed
+            return (
+                tuple(
+                    self._external_status_failure(status, pytest_fallback_commands)
+                    for status in failed
+                ),
+                False,
             )
 
         failures: list[CheckFailure] = []
@@ -454,7 +462,7 @@ class BitbucketClient:
             for status in failed
             if not is_pipeline_owned_status(status)
         )
-        return tuple(failures)
+        return tuple(failures), False
 
     async def rerun_failed_workflow_jobs(
         self,

--- a/src/awf/common/forge.py
+++ b/src/awf/common/forge.py
@@ -55,6 +55,7 @@ from awf.db.enums import ForgeKind
 from awf.runtime.pr_monitor import CheckFailure, CheckTiming, PRStatus
 
 FORGE_NOT_SUPPORTED_REASON_CODE = "FORGE_NOT_SUPPORTED"
+CheckFailureLogResult = tuple[tuple[CheckFailure, ...], bool]
 
 # Distinct from ``FORGE_NOT_SUPPORTED``: the forge itself *is* supported (GitHub or
 # Bitbucket Cloud), but the GitHub-only ``BranchOpenPullRequestResolver`` cannot
@@ -127,8 +128,8 @@ class ForgeClient(Protocol):
         log_tail_chars: int = 3000,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: Sequence[CheckTiming] = (),
-    ) -> tuple[CheckFailure, ...] | tuple[tuple[CheckFailure, ...], bool]:
-        """Return failing-check logs and, when available, an in-progress-run signal."""
+    ) -> CheckFailureLogResult:
+        """Return failing-check logs and whether relevant runs are still in progress."""
         ...
 
     async def rerun_failed_workflow_jobs(self, *, repo: RepoRef, run_id: str) -> None:

--- a/src/awf/common/forge.py
+++ b/src/awf/common/forge.py
@@ -127,8 +127,8 @@ class ForgeClient(Protocol):
         log_tail_chars: int = 3000,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: Sequence[CheckTiming] = (),
-    ) -> tuple[CheckFailure, ...]:
-        """Return logs for failing/timed-out checks at ``head_sha``."""
+    ) -> tuple[CheckFailure, ...] | tuple[tuple[CheckFailure, ...], bool]:
+        """Return failing-check logs and, when available, an in-progress-run signal."""
         ...
 
     async def rerun_failed_workflow_jobs(self, *, repo: RepoRef, run_id: str) -> None:

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -935,60 +935,59 @@ class GitHubClient:
             for run in runs_raw or []
             if run.get("databaseId") is not None
         }
-        check_run_id_by_run = {
-            run_id: check_run_id
-            for check in _rollup_action_run_failures(rollup_checks)
-            for run_id, check_run_id in (
-                (
-                    _actions_run_id_from_details_url(check.details_url),
-                    _actions_check_run_id_from_details_url(check.details_url),
-                ),
-            )
-            if run_id is not None and check_run_id is not None
-        }
+        check_run_ids_by_run: dict[str, list[str]] = {}
+        for check in _rollup_action_run_failures(rollup_checks):
+            run_id = _actions_run_id_from_details_url(check.details_url)
+            check_run_id = _actions_check_run_id_from_details_url(check.details_url)
+            if run_id is None or check_run_id is None:
+                continue
+            check_run_ids = check_run_ids_by_run.setdefault(run_id, [])
+            if check_run_id not in check_run_ids:
+                check_run_ids.append(check_run_id)
 
-        async def _annotation_log_text(check_run_id: str | None) -> str:
-            if check_run_id is None:
+        async def _annotation_log_text(check_run_ids: Sequence[str]) -> str:
+            if not check_run_ids:
                 return ""
-            result = await self._run_gh(
-                [
-                    "gh",
-                    "api",
-                    f"repos/{repo.slug()}/check-runs/{check_run_id}/annotations",
-                    "--paginate",
-                    "--slurp",
-                ],
-                operation="check_run_annotations",
-                strict=False,
-            )
-            if not result.ok or not result.stdout.strip():
-                return ""
-            try:
-                payload = json.loads(result.stdout)
-            except json.JSONDecodeError:
-                return ""
-            if not isinstance(payload, list):
-                return ""
-            annotations: list[dict[str, Any]] = []
-            for page_or_item in payload:
-                if isinstance(page_or_item, dict):
-                    annotations.append(page_or_item)
-                elif isinstance(page_or_item, list):
-                    annotations.extend(item for item in page_or_item if isinstance(item, dict))
             lines: list[str] = []
-            for item in annotations:
-                message = _clean_optional_str(item.get("message"))
-                raw_details = _clean_optional_str(item.get("raw_details"))
-                path = _clean_optional_str(item.get("path"))
-                start_line = item.get("start_line")
-                start_column = item.get("start_column")
-                if path and isinstance(start_line, int) and message:
-                    column = start_column if isinstance(start_column, int) else 1
-                    lines.append(f"{path}:{start_line}:{column}: {message}")
-                elif message:
-                    lines.append(message)
-                if raw_details:
-                    lines.extend(raw_details.splitlines())
+            for check_run_id in check_run_ids:
+                result = await self._run_gh(
+                    [
+                        "gh",
+                        "api",
+                        f"repos/{repo.slug()}/check-runs/{check_run_id}/annotations",
+                        "--paginate",
+                        "--slurp",
+                    ],
+                    operation="check_run_annotations",
+                    strict=False,
+                )
+                if not result.ok or not result.stdout.strip():
+                    continue
+                try:
+                    payload = json.loads(result.stdout)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(payload, list):
+                    continue
+                annotations: list[dict[str, Any]] = []
+                for page_or_item in payload:
+                    if isinstance(page_or_item, dict):
+                        annotations.append(page_or_item)
+                    elif isinstance(page_or_item, list):
+                        annotations.extend(item for item in page_or_item if isinstance(item, dict))
+                for item in annotations:
+                    message = _clean_optional_str(item.get("message"))
+                    raw_details = _clean_optional_str(item.get("raw_details"))
+                    path = _clean_optional_str(item.get("path"))
+                    start_line = item.get("start_line")
+                    start_column = item.get("start_column")
+                    if path and isinstance(start_line, int) and message:
+                        column = start_column if isinstance(start_column, int) else 1
+                        lines.append(f"{path}:{start_line}:{column}: {message}")
+                    elif message:
+                        lines.append(message)
+                    if raw_details:
+                        lines.extend(raw_details.splitlines())
             return "\n".join(lines)
 
         async def _append_failure(
@@ -996,7 +995,7 @@ class GitHubClient:
             run_id: str | None,
             run_name: str,
             conclusion: str,
-            check_run_id: str | None = None,
+            check_run_ids: Sequence[str] = (),
         ) -> None:
             log = (
                 await self._run_gh(
@@ -1017,7 +1016,7 @@ class GitHubClient:
             )
             raw_log_text = log.stdout if log is not None else ""
             if not raw_log_text.strip():
-                raw_log_text = await _annotation_log_text(check_run_id)
+                raw_log_text = await _annotation_log_text(check_run_ids)
             log_text = redact_ci_log(raw_log_text)
             evidence = extract_ci_failure_evidence(
                 raw_log_text,
@@ -1056,7 +1055,7 @@ class GitHubClient:
                 run_id=run_id,
                 run_name=run_name,
                 conclusion=conclusion_upper,
-                check_run_id=check_run_id_by_run.get(run_id or ""),
+                check_run_ids=check_run_ids_by_run.get(run_id or "", ()),
             )
         for check in _rollup_action_run_failures(rollup_checks):
             run_id = _actions_run_id_from_details_url(check.details_url)
@@ -1070,7 +1069,7 @@ class GitHubClient:
                 run_id=run_id,
                 run_name=check.name,
                 conclusion=(check.conclusion or "FAILURE").upper(),
-                check_run_id=_actions_check_run_id_from_details_url(check.details_url),
+                check_run_ids=check_run_ids_by_run.get(run_id, ()),
             )
         return (tuple(failures), runs_in_progress)
 

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -64,6 +64,7 @@ _log = get_logger(__name__)
 # monitor handoff.
 _PR_URL_PATTERN = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
 _ACTIONS_RUN_JOB_PATH_RE = re.compile(r"/actions/runs/(?P<run_id>\d+)/job/(?P<job_id>\d+)")
+_CHECK_RUN_API_PATH_RE = re.compile(r"/repos/[^/]+/[^/]+/check-runs/(?P<check_run_id>\d+)$")
 _FAILED_CHECK_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"})
 
 
@@ -935,21 +936,46 @@ class GitHubClient:
             for run in runs_raw or []
             if run.get("databaseId") is not None
         }
-        check_run_ids_by_run: dict[str, list[str]] = {}
+        job_ids_by_run: dict[str, list[str]] = {}
         for check in _rollup_action_run_failures(rollup_checks):
             run_id = _actions_run_id_from_details_url(check.details_url)
-            check_run_id = _actions_check_run_id_from_details_url(check.details_url)
-            if run_id is None or check_run_id is None:
+            job_id = _actions_job_id_from_details_url(check.details_url)
+            if run_id is None or job_id is None:
                 continue
-            check_run_ids = check_run_ids_by_run.setdefault(run_id, [])
-            if check_run_id not in check_run_ids:
-                check_run_ids.append(check_run_id)
+            job_ids = job_ids_by_run.setdefault(run_id, [])
+            if job_id not in job_ids:
+                job_ids.append(job_id)
 
-        async def _annotation_log_text(check_run_ids: Sequence[str]) -> str:
-            if not check_run_ids:
+        async def _check_run_id_for_job(job_id: str) -> str | None:
+            result = await self._run_gh(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo.slug()}/actions/jobs/{job_id}",
+                ],
+                operation="workflow_job",
+                strict=False,
+            )
+            if not result.ok or not result.stdout.strip():
+                return None
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                return None
+            if not isinstance(payload, dict):
+                return None
+            return _actions_check_run_id_from_api_url(
+                _clean_optional_str(payload.get("check_run_url"))
+            )
+
+        async def _annotation_log_text(job_ids: Sequence[str]) -> str:
+            if not job_ids:
                 return ""
             lines: list[str] = []
-            for check_run_id in check_run_ids:
+            for job_id in job_ids:
+                check_run_id = await _check_run_id_for_job(job_id)
+                if check_run_id is None:
+                    continue
                 result = await self._run_gh(
                     [
                         "gh",
@@ -995,7 +1021,7 @@ class GitHubClient:
             run_id: str | None,
             run_name: str,
             conclusion: str,
-            check_run_ids: Sequence[str] = (),
+            job_ids: Sequence[str] = (),
         ) -> None:
             log = (
                 await self._run_gh(
@@ -1016,7 +1042,7 @@ class GitHubClient:
             )
             raw_log_text = log.stdout if log is not None else ""
             if not raw_log_text.strip():
-                raw_log_text = await _annotation_log_text(check_run_ids)
+                raw_log_text = await _annotation_log_text(job_ids)
             log_text = redact_ci_log(raw_log_text)
             evidence = extract_ci_failure_evidence(
                 raw_log_text,
@@ -1055,7 +1081,7 @@ class GitHubClient:
                 run_id=run_id,
                 run_name=run_name,
                 conclusion=conclusion_upper,
-                check_run_ids=check_run_ids_by_run.get(run_id or "", ()),
+                job_ids=job_ids_by_run.get(run_id or "", ()),
             )
         for check in _rollup_action_run_failures(rollup_checks):
             run_id = _actions_run_id_from_details_url(check.details_url)
@@ -1069,7 +1095,7 @@ class GitHubClient:
                 run_id=run_id,
                 run_name=check.name,
                 conclusion=(check.conclusion or "FAILURE").upper(),
-                check_run_ids=check_run_ids_by_run.get(run_id, ()),
+                job_ids=job_ids_by_run.get(run_id, ()),
             )
         return (tuple(failures), runs_in_progress)
 
@@ -1462,7 +1488,7 @@ def _actions_run_id_from_details_url(details_url: str | None) -> str | None:
     return match.group("run_id")
 
 
-def _actions_check_run_id_from_details_url(details_url: str | None) -> str | None:
+def _actions_job_id_from_details_url(details_url: str | None) -> str | None:
     if not details_url:
         return None
     parsed = urlsplit(details_url)
@@ -1472,6 +1498,18 @@ def _actions_check_run_id_from_details_url(details_url: str | None) -> str | Non
     if match is None:
         return None
     return match.group("job_id")
+
+
+def _actions_check_run_id_from_api_url(check_run_url: str | None) -> str | None:
+    if not check_run_url:
+        return None
+    parsed = urlsplit(check_run_url)
+    if parsed.netloc.lower() != "api.github.com":
+        return None
+    match = _CHECK_RUN_API_PATH_RE.search(parsed.path)
+    if match is None:
+        return None
+    return match.group("check_run_id")
 
 
 # ── Tiny helpers kept private to avoid accidental imports ──────────────────

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -63,7 +63,7 @@ _log = get_logger(__name__)
 # PR-number extraction would otherwise silently yield ``None`` and break the
 # monitor handoff.
 _PR_URL_PATTERN = re.compile(r"https://github\.com/[^/\s]+/[^/\s]+/pull/\d+")
-_ACTIONS_RUN_JOB_PATH_RE = re.compile(r"/actions/runs/(?P<run_id>\d+)/job/\d+")
+_ACTIONS_RUN_JOB_PATH_RE = re.compile(r"/actions/runs/(?P<run_id>\d+)/job/(?P<job_id>\d+)")
 _FAILED_CHECK_CONCLUSIONS = frozenset({"FAILURE", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED"})
 
 
@@ -900,7 +900,7 @@ class GitHubClient:
         log_tail_chars: int = 3000,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: Sequence[CheckTiming] = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         """Fetch logs for failing/timed-out checks via ``gh run view``.
 
         The GraphQL PR query only surfaces an aggregate ``statusCheckRollup``
@@ -929,12 +929,69 @@ class GitHubClient:
         )
         failures: list[CheckFailure] = []
         seen_run_ids: set[str] = set()
+        runs_in_progress = False
+        status_by_run = {
+            str(run["databaseId"]): str(run.get("status") or "").lower()
+            for run in runs_raw or []
+            if run.get("databaseId") is not None
+        }
+        check_run_id_by_run = {
+            run_id: check_run_id
+            for check in _rollup_action_run_failures(rollup_checks)
+            for run_id, check_run_id in (
+                (
+                    _actions_run_id_from_details_url(check.details_url),
+                    _actions_check_run_id_from_details_url(check.details_url),
+                ),
+            )
+            if run_id is not None and check_run_id is not None
+        }
+
+        async def _annotation_log_text(check_run_id: str | None) -> str:
+            if check_run_id is None:
+                return ""
+            result = await self._run_gh(
+                [
+                    "gh",
+                    "api",
+                    f"repos/{repo.slug()}/check-runs/{check_run_id}/annotations",
+                    "--paginate",
+                ],
+                operation="check_run_annotations",
+                strict=False,
+            )
+            if not result.ok or not result.stdout.strip():
+                return ""
+            try:
+                payload = json.loads(result.stdout)
+            except json.JSONDecodeError:
+                return ""
+            if not isinstance(payload, list):
+                return ""
+            lines: list[str] = []
+            for item in payload:
+                if not isinstance(item, dict):
+                    continue
+                message = _clean_optional_str(item.get("message"))
+                raw_details = _clean_optional_str(item.get("raw_details"))
+                path = _clean_optional_str(item.get("path"))
+                start_line = item.get("start_line")
+                start_column = item.get("start_column")
+                if path and isinstance(start_line, int) and message:
+                    column = start_column if isinstance(start_column, int) else 1
+                    lines.append(f"{path}:{start_line}:{column}: {message}")
+                elif message:
+                    lines.append(message)
+                if raw_details:
+                    lines.extend(raw_details.splitlines())
+            return "\n".join(lines)
 
         async def _append_failure(
             *,
             run_id: str | None,
             run_name: str,
             conclusion: str,
+            check_run_id: str | None = None,
         ) -> None:
             log = (
                 await self._run_gh(
@@ -954,6 +1011,8 @@ class GitHubClient:
                 else None
             )
             raw_log_text = log.stdout if log is not None else ""
+            if not raw_log_text.strip():
+                raw_log_text = await _annotation_log_text(check_run_id)
             log_text = redact_ci_log(raw_log_text)
             evidence = extract_ci_failure_evidence(
                 raw_log_text,
@@ -984,23 +1043,31 @@ class GitHubClient:
             run_id = str(database_id) if database_id is not None else None
             if run_id is not None:
                 seen_run_ids.add(run_id)
+            if str(run.get("status") or "").lower() != "completed":
+                runs_in_progress = True
+                continue
             run_name = run.get("name") or (f"run/{run_id}" if run_id is not None else "run/unknown")
             await _append_failure(
                 run_id=run_id,
                 run_name=run_name,
                 conclusion=conclusion_upper,
+                check_run_id=check_run_id_by_run.get(run_id or ""),
             )
         for check in _rollup_action_run_failures(rollup_checks):
             run_id = _actions_run_id_from_details_url(check.details_url)
             if run_id is None or run_id in seen_run_ids:
                 continue
             seen_run_ids.add(run_id)
+            if status_by_run.get(run_id) not in {None, "completed"}:
+                runs_in_progress = True
+                continue
             await _append_failure(
                 run_id=run_id,
                 run_name=check.name,
                 conclusion=(check.conclusion or "FAILURE").upper(),
+                check_run_id=_actions_check_run_id_from_details_url(check.details_url),
             )
-        return tuple(failures)
+        return (tuple(failures), runs_in_progress)
 
     async def rerun_failed_workflow_jobs(self, *, repo: RepoRef, run_id: str) -> None:
         """Rerun only failed jobs for a workflow run.
@@ -1389,6 +1456,18 @@ def _actions_run_id_from_details_url(details_url: str | None) -> str | None:
     if match is None:
         return None
     return match.group("run_id")
+
+
+def _actions_check_run_id_from_details_url(details_url: str | None) -> str | None:
+    if not details_url:
+        return None
+    parsed = urlsplit(details_url)
+    if parsed.netloc.lower() != "github.com":
+        return None
+    match = _ACTIONS_RUN_JOB_PATH_RE.search(parsed.path)
+    if match is None:
+        return None
+    return match.group("job_id")
 
 
 # ── Tiny helpers kept private to avoid accidental imports ──────────────────

--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -956,6 +956,7 @@ class GitHubClient:
                     "api",
                     f"repos/{repo.slug()}/check-runs/{check_run_id}/annotations",
                     "--paginate",
+                    "--slurp",
                 ],
                 operation="check_run_annotations",
                 strict=False,
@@ -968,10 +969,14 @@ class GitHubClient:
                 return ""
             if not isinstance(payload, list):
                 return ""
+            annotations: list[dict[str, Any]] = []
+            for page_or_item in payload:
+                if isinstance(page_or_item, dict):
+                    annotations.append(page_or_item)
+                elif isinstance(page_or_item, list):
+                    annotations.extend(item for item in page_or_item if isinstance(item, dict))
             lines: list[str] = []
-            for item in payload:
-                if not isinstance(item, dict):
-                    continue
+            for item in annotations:
                 message = _clean_optional_str(item.get("message"))
                 raw_details = _clean_optional_str(item.get("raw_details"))
                 path = _clean_optional_str(item.get("path"))

--- a/src/awf/runtime/pr_monitor.py
+++ b/src/awf/runtime/pr_monitor.py
@@ -1221,7 +1221,13 @@ def decide(status: PRStatus, state: MonitorState, config: MonitorConfig) -> Moni
     if status.blocking_reviews:
         return NotifyHuman()
 
-    # 5. CI failures.
+    # 5. A failed shard can surface while the workflow run is still in progress.
+    # GitHub does not publish the downloadable failed-log archive until the run
+    # completes, so wait instead of classifying an empty evidence snapshot.
+    if status.ci_runs_in_progress:
+        return WaitForCI(reason="ci_run_in_progress")
+
+    # 5b. CI failures.
     if status.check_state == CheckState.FAILURE:
         return _ci_failure_action(status, state, config)
 

--- a/src/awf/runtime/pr_monitor_actions.py
+++ b/src/awf/runtime/pr_monitor_actions.py
@@ -97,6 +97,7 @@ class WaitForCI:
         "pending_checks",
         "unknown_mergeable_state",
         "awaiting_required_checks",
+        "ci_run_in_progress",
     ] = "pending_checks"
 
 

--- a/src/awf/runtime/pr_monitor_models.py
+++ b/src/awf/runtime/pr_monitor_models.py
@@ -193,6 +193,7 @@ class PRStatus:
     shipped PR #335 / #336 as "ready to merge" when they were BEHIND)."""
 
     ci_failures: tuple[CheckFailure, ...] = ()
+    ci_runs_in_progress: bool = False
     checks: tuple[CheckTiming, ...] = ()
     no_checks_observed: bool = False
     """Forge authoritatively reported an EMPTY check/status set for this head.

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -483,16 +483,10 @@ def _monitor_state_verdict(verdict: str) -> Verdict:
 
 def _with_ci_failures(
     status: PRStatus,
-    failures: tuple[CheckFailure, ...] | tuple[tuple[CheckFailure, ...], bool],
+    failures: tuple[tuple[CheckFailure, ...], bool],
 ) -> PRStatus:
     """Immutable-replace CI failure evidence on a ``PRStatus``."""
-    ci_runs_in_progress = False
-    ci_failures: tuple[CheckFailure, ...]
-    if len(failures) == 2 and isinstance(failures[0], tuple) and isinstance(failures[1], bool):
-        ci_failures = failures[0]
-        ci_runs_in_progress = failures[1]
-    else:
-        ci_failures = failures
+    ci_failures, ci_runs_in_progress = failures
     return replace(
         status,
         ci_failures=ci_failures,

--- a/src/awf/runtime/pr_monitor_runner/helpers.py
+++ b/src/awf/runtime/pr_monitor_runner/helpers.py
@@ -481,12 +481,23 @@ def _monitor_state_verdict(verdict: str) -> Verdict:
     return "fix_committed"
 
 
-def _with_ci_failures(status: PRStatus, failures: tuple[CheckFailure, ...]) -> PRStatus:
-    """Immutable-replace ci_failures on a ``PRStatus`` (frozen dataclass)."""
-    # Import dataclasses.replace locally to keep the top-level imports tight.
-    from dataclasses import replace
-
-    return replace(status, ci_failures=failures)
+def _with_ci_failures(
+    status: PRStatus,
+    failures: tuple[CheckFailure, ...] | tuple[tuple[CheckFailure, ...], bool],
+) -> PRStatus:
+    """Immutable-replace CI failure evidence on a ``PRStatus``."""
+    ci_runs_in_progress = False
+    ci_failures: tuple[CheckFailure, ...]
+    if len(failures) == 2 and isinstance(failures[0], tuple) and isinstance(failures[1], bool):
+        ci_failures = failures[0]
+        ci_runs_in_progress = failures[1]
+    else:
+        ci_failures = failures
+    return replace(
+        status,
+        ci_failures=ci_failures,
+        ci_runs_in_progress=ci_runs_in_progress,
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_004.py
+++ b/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_004.py
@@ -63,9 +63,10 @@ async def test_failing_check_logs_pipeline_chain() -> None:
         text="E   assert 1 == 2\nFAILED tests/test_x.py::test_y\n",
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(), pr_number=42, head_sha=_HEAD, log_tail_chars=3000
     )
+    assert _runs_in_progress is False
     assert len(failures) == 1
     failure = failures[0]
     assert failure.name == "Test"
@@ -81,7 +82,9 @@ async def test_failing_check_logs_no_failed_statuses_returns_empty() -> None:
         values=[{"state": "SUCCESSFUL", "name": "ok"}],
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert failures == ()
 
 
@@ -94,7 +97,7 @@ async def test_failing_check_logs_external_status_falls_back_to_pytest() -> None
     )
     fake.page("GET", _PIPELINES, values=[])  # no pipeline → external status
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(),
         pr_number=42,
         head_sha=_HEAD,
@@ -121,7 +124,9 @@ async def test_failing_check_logs_pipeline_without_failing_step_falls_back() -> 
         values=[{"uuid": "s1", "name": "Build", "state": {"result": {"name": "SUCCESSFUL"}}}],
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert len(failures) == 1
     assert failures[0].run_id is None  # external fallback path
 
@@ -163,7 +168,7 @@ async def test_failing_check_logs_stopped_pipeline_step_keeps_log_evidence() -> 
         text="E   infrastructure error\n",
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(), pr_number=42, head_sha=_HEAD, log_tail_chars=3000
     )
     by_name = {f.name: f for f in failures}
@@ -202,7 +207,7 @@ async def test_failing_check_logs_surfaces_external_status_alongside_failing_ste
         text="FAILED tests/test_x.py::test_y\n",
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(), pr_number=42, head_sha=_HEAD, pytest_fallback_commands=["uv run pytest -q"]
     )
     by_name = {f.name: f for f in failures}
@@ -239,7 +244,9 @@ async def test_failing_check_logs_skips_pipeline_status_identified_by_url() -> N
         text="FAILED tests/test_x.py::test_y\n",
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert [f.name for f in failures] == ["Test"]  # no duplicate external row for the pipeline
 
 
@@ -277,7 +284,9 @@ async def test_failing_check_logs_omits_refname_without_pr_context() -> None:
         values=[{"state": "SUCCESSFUL", "name": "ok"}],
     )
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert failures == ()
     statuses_call = next(
         r for r in fake.calls("GET") if r.url.path == f"{_REPO}/commit/{_HEAD}/statuses"
@@ -347,7 +356,9 @@ async def test_failing_check_logs_pipeline_scoped_to_pr_ref() -> None:
     )
     client = make_client(fake)
     await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert [f.name for f in failures] == ["Test"]
     assert failures[0].run_id == "pipe-1"  # matched the PR ref, not the newer other-ref pipeline
 
@@ -369,7 +380,7 @@ async def test_failing_check_logs_pipeline_wrong_ref_falls_back_to_external() ->
     fake.page("GET", _PIPELINES, values=[{"uuid": "other-ref", "target": {"ref_name": "main"}}])
     client = make_client(fake)
     await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(), pr_number=42, head_sha=_HEAD, pytest_fallback_commands=["uv run pytest -q"]
     )
     assert len(failures) == 1
@@ -400,7 +411,7 @@ async def test_failing_check_logs_other_pr_pipeline_falls_back_to_external() -> 
     )
     client = make_client(fake)
     await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
-    failures = await client.fetch_failing_check_logs(
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
         repo=repo(), pr_number=42, head_sha=_HEAD, pytest_fallback_commands=["uv run pytest -q"]
     )
     assert len(failures) == 1
@@ -433,7 +444,9 @@ async def test_failing_check_logs_pipeline_without_ref_metadata_keeps_newest() -
     )
     client = make_client(fake)
     await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert [f.name for f in failures] == ["Test"]
     assert failures[0].run_id == "pipe-1"
 
@@ -479,7 +492,9 @@ async def test_failing_check_logs_prefers_pr_pipeline_over_branch_pipeline() -> 
     )
     client = make_client(fake)
     await client.fetch_pr_status(repo=repo(), pr_number=42, base_behind_count=0)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert [f.name for f in failures] == ["Test"]
     assert failures[0].run_id == "pr-pipe"  # PR pipeline, not the newer branch pipeline
 

--- a/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_005.py
+++ b/tests/unit/common/test_bitbucket_client_parts/test_bitbucket_client_part_005.py
@@ -346,7 +346,9 @@ async def test_step_log_404_is_tolerated_as_empty() -> None:
     )
     fake.enqueue("GET", f"{_REPO}/pipelines/p1/steps/s1/log", status=404, json={"e": 1})
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert failures[0].log_excerpt == ""
 
 
@@ -379,7 +381,9 @@ async def test_step_log_follows_offorigin_307_redirect_without_forge_auth() -> N
     )
     fake.enqueue("GET", "/log-storage/s1", text="E   assert 1 == 2\nFAILED tests/test_x.py")
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert "assert 1 == 2" in failures[0].log_excerpt
     # The off-origin storage hop must not carry the forge credential.
     storage_call = next(r for r in fake.calls("GET") if r.url.path == "/log-storage/s1")
@@ -425,7 +429,9 @@ async def test_step_log_second_offorigin_redirect_is_refused_not_followed() -> N
     )
     fake.enqueue("GET", "/secret", text="leaked-internal-data")
     client = make_client(fake)
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     assert failures[0].log_excerpt == ""
     # The second off-origin target must never be contacted.
     assert all(r.url.host != "evil.internal.example" for r in fake.calls("GET"))
@@ -466,7 +472,9 @@ async def test_step_log_transport_failure_yields_empty_log_not_raise() -> None:
         ),
         auth=BitbucketAuth(mode="bearer", api_token="bb-token-aaaaaaaaaaaa"),
     )
-    failures = await client.fetch_failing_check_logs(repo=repo(), pr_number=42, head_sha=_HEAD)
+    failures, _runs_in_progress = await client.fetch_failing_check_logs(
+        repo=repo(), pr_number=42, head_sha=_HEAD
+    )
     # The CI failure is still surfaced, just with no log evidence — not raised.
     assert failures[0].conclusion == "FAILURE"
     assert failures[0].log_excerpt == ""

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_004.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_004.py
@@ -188,7 +188,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -232,7 +232,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -275,7 +275,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -320,7 +320,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -366,7 +366,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -402,7 +402,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -441,7 +441,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -478,7 +478,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -515,7 +515,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -552,7 +552,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -590,7 +590,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -627,7 +627,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -667,7 +667,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -697,7 +697,7 @@ class TestFetchFailingCheckLogs:
         fake.queue_result(returncode=1, stderr="log not found")
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
 
@@ -740,7 +740,7 @@ class TestFetchFailingCheckLogs:
         # 3) gh run view 3 --log-failed (for unit-tests)
         fake.queue_result(returncode=0, stdout="timeout log")
         client = GitHubClient(fake)
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -778,7 +778,7 @@ class TestFetchFailingCheckLogs:
         )
         fake.queue_result(returncode=1, stderr="log not found")
         client = GitHubClient(fake)
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
         assert len(failures) == 1
@@ -802,7 +802,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
 
@@ -829,7 +829,7 @@ class TestFetchFailingCheckLogs:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
 
@@ -853,7 +853,7 @@ class TestFetchFailingCheckLogs:
             ),
         )
         client = GitHubClient(fake)
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
         assert failures == ()
@@ -864,7 +864,7 @@ class TestFetchFailingCheckLogs:
         fake.queue_result(returncode=0, stdout="")
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, _runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"), pr_number=1, head_sha="abc"
         )
 

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
@@ -220,7 +220,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         )
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -238,6 +238,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         assert failures[0].name == "python-coverage-shards (7)"
         assert failures[0].run_id == "123"
         assert "Docker pull failed" in failures[0].log_excerpt
+        assert runs_in_progress is False
         assert _run_view_calls(fake) == [
             ["gh", "run", "view", "123", "--repo", "o/r", "--log-failed"]
         ]
@@ -253,6 +254,7 @@ class TestFetchFailingCheckLogsRollupFallback:
                         "databaseId": 123,
                         "name": "python-coverage-shards (7)",
                         "conclusion": "FAILURE",
+                        "status": "completed",
                     }
                 ]
             ),
@@ -260,7 +262,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         fake.queue_result(returncode=0, stdout="HTTP status server error (502 Bad Gateway)")
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -275,7 +277,137 @@ class TestFetchFailingCheckLogsRollupFallback:
         )
 
         assert len(failures) == 1
+        assert runs_in_progress is False
         assert len(_run_view_calls(fake)) == 1
+
+    @pytest.mark.unit
+    async def test_rollup_fallback_skips_in_progress_actions_run_without_fetching_log(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": 123,
+                        "name": "python-coverage-shards (7)",
+                        "conclusion": "",
+                        "status": "in_progress",
+                    }
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"),
+            pr_number=1,
+            head_sha="abc",
+            rollup_checks=(
+                CheckTiming(
+                    name="python-coverage-shards (7)",
+                    conclusion="FAILURE",
+                    details_url="https://github.com/o/r/actions/runs/123/job/456",
+                    app_slug="github-actions",
+                ),
+            ),
+        )
+
+        assert failures == ()
+        assert runs_in_progress is True
+        assert _run_view_calls(fake) == []
+
+    @pytest.mark.unit
+    async def test_run_list_skips_failed_in_progress_run_without_fetching_log(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": 124,
+                        "name": "python-coverage-shards (8)",
+                        "conclusion": "FAILURE",
+                        "status": "in_progress",
+                    }
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"),
+            pr_number=1,
+            head_sha="abc",
+        )
+
+        assert failures == ()
+        assert runs_in_progress is True
+        assert _run_view_calls(fake) == []
+
+    @pytest.mark.unit
+    async def test_completed_empty_log_uses_check_run_annotations_fallback(self) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": 125,
+                        "name": "lint-and-type",
+                        "conclusion": "FAILURE",
+                        "status": "completed",
+                    }
+                ]
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="")
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "path": "src/awf/runtime/foo.py",
+                        "start_line": 10,
+                        "annotation_level": "failure",
+                        "message": "F401 imported but unused",
+                        "raw_details": "Error: Process completed with exit code 1.",
+                    }
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"),
+            pr_number=1,
+            head_sha="abc",
+            rollup_checks=(
+                CheckTiming(
+                    name="lint-and-type",
+                    conclusion="FAILURE",
+                    details_url="https://github.com/o/r/actions/runs/125/job/789",
+                    app_slug="github-actions",
+                ),
+            ),
+        )
+
+        assert runs_in_progress is False
+        assert len(failures) == 1
+        assert "src/awf/runtime/foo.py:10:1: F401 imported but unused" in failures[0].log_excerpt
+        assert "Process completed with exit code 1" in failures[0].log_excerpt
+        assert any("F401 imported" in item for item in failures[0].error_summaries)
+        assert any(
+            call.args
+            == [
+                "gh",
+                "api",
+                "repos/o/r/check-runs/789/annotations",
+                "--paginate",
+            ]
+            for call in fake.calls
+        )
 
     @pytest.mark.unit
     async def test_rollup_fallback_ignores_non_actions_evidence(self) -> None:
@@ -283,7 +415,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         fake.queue_result(returncode=0, stdout="[]")
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -327,6 +459,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         )
 
         assert failures == ()
+        assert runs_in_progress is False
         assert _run_view_calls(fake) == []
 
     @pytest.mark.unit
@@ -336,7 +469,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         fake.queue_result(returncode=1, stderr="gh network timeout with ghp_secret")
         client = GitHubClient(fake)
 
-        failures = await client.fetch_failing_check_logs(
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
             repo=RepoRef(owner="o", name="r"),
             pr_number=1,
             head_sha="abc",
@@ -351,6 +484,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         )
 
         assert len(failures) == 1
+        assert runs_in_progress is False
         assert failures[0].log_excerpt == ""
         assert failures[0].evidence_warnings == (
             "GitHub Actions log unavailable for failed check python-coverage-shards (7).",

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
@@ -367,6 +367,10 @@ class TestFetchFailingCheckLogsRollupFallback:
         fake.queue_result(returncode=0, stdout="")
         fake.queue_result(
             returncode=0,
+            stdout=json.dumps({"check_run_url": "https://api.github.com/repos/o/r/check-runs/456"}),
+        )
+        fake.queue_result(
+            returncode=0,
             stdout=json.dumps(
                 [
                     [
@@ -417,7 +421,16 @@ class TestFetchFailingCheckLogsRollupFallback:
             == [
                 "gh",
                 "api",
-                "repos/o/r/check-runs/789/annotations",
+                "repos/o/r/actions/jobs/789",
+            ]
+            for call in fake.calls
+        )
+        assert any(
+            call.args
+            == [
+                "gh",
+                "api",
+                "repos/o/r/check-runs/456/annotations",
                 "--paginate",
                 "--slurp",
             ]
@@ -445,6 +458,10 @@ class TestFetchFailingCheckLogsRollupFallback:
         fake.queue_result(returncode=0, stdout="")
         fake.queue_result(
             returncode=0,
+            stdout=json.dumps({"check_run_url": "https://api.github.com/repos/o/r/check-runs/456"}),
+        )
+        fake.queue_result(
+            returncode=0,
             stdout=json.dumps(
                 [
                     [
@@ -457,6 +474,10 @@ class TestFetchFailingCheckLogsRollupFallback:
                     ]
                 ]
             ),
+        )
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps({"check_run_url": "https://api.github.com/repos/o/r/check-runs/457"}),
         )
         fake.queue_result(
             returncode=0,
@@ -504,8 +525,8 @@ class TestFetchFailingCheckLogsRollupFallback:
             for call in fake.calls
             if call.args[:2] == ["gh", "api"] and call.args[2].endswith("/annotations")
         ] == [
-            "repos/o/r/check-runs/789/annotations",
-            "repos/o/r/check-runs/790/annotations",
+            "repos/o/r/check-runs/456/annotations",
+            "repos/o/r/check-runs/457/annotations",
         ]
 
     @pytest.mark.unit

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
@@ -347,7 +347,9 @@ class TestFetchFailingCheckLogsRollupFallback:
         assert _run_view_calls(fake) == []
 
     @pytest.mark.unit
-    async def test_completed_empty_log_uses_check_run_annotations_fallback(self) -> None:
+    async def test_completed_empty_log_uses_paginated_check_run_annotations_fallback(
+        self,
+    ) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(
             returncode=0,
@@ -367,13 +369,24 @@ class TestFetchFailingCheckLogsRollupFallback:
             returncode=0,
             stdout=json.dumps(
                 [
-                    {
-                        "path": "src/awf/runtime/foo.py",
-                        "start_line": 10,
-                        "annotation_level": "failure",
-                        "message": "F401 imported but unused",
-                        "raw_details": "Error: Process completed with exit code 1.",
-                    }
+                    [
+                        {
+                            "path": "src/awf/runtime/foo.py",
+                            "start_line": 10,
+                            "annotation_level": "failure",
+                            "message": "F401 imported but unused",
+                            "raw_details": "Error: Process completed with exit code 1.",
+                        }
+                    ],
+                    [
+                        {
+                            "path": "src/awf/runtime/bar.py",
+                            "start_line": 22,
+                            "start_column": 7,
+                            "annotation_level": "failure",
+                            "message": "E501 line too long",
+                        }
+                    ],
                 ]
             ),
         )
@@ -396,6 +409,7 @@ class TestFetchFailingCheckLogsRollupFallback:
         assert runs_in_progress is False
         assert len(failures) == 1
         assert "src/awf/runtime/foo.py:10:1: F401 imported but unused" in failures[0].log_excerpt
+        assert "src/awf/runtime/bar.py:22:7: E501 line too long" in failures[0].log_excerpt
         assert "Process completed with exit code 1" in failures[0].log_excerpt
         assert any("F401 imported" in item for item in failures[0].error_summaries)
         assert any(
@@ -405,6 +419,7 @@ class TestFetchFailingCheckLogsRollupFallback:
                 "api",
                 "repos/o/r/check-runs/789/annotations",
                 "--paginate",
+                "--slurp",
             ]
             for call in fake.calls
         )

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_005.py
@@ -425,6 +425,90 @@ class TestFetchFailingCheckLogsRollupFallback:
         )
 
     @pytest.mark.unit
+    async def test_completed_empty_log_fetches_annotations_for_each_failed_shard(
+        self,
+    ) -> None:
+        fake = FakeCommandRunner()
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    {
+                        "databaseId": 125,
+                        "name": "python-coverage-shards",
+                        "conclusion": "FAILURE",
+                        "status": "completed",
+                    }
+                ]
+            ),
+        )
+        fake.queue_result(returncode=0, stdout="")
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    [
+                        {
+                            "path": "tests/unit/test_alpha.py",
+                            "start_line": 11,
+                            "annotation_level": "failure",
+                            "message": "alpha shard failed",
+                        }
+                    ]
+                ]
+            ),
+        )
+        fake.queue_result(
+            returncode=0,
+            stdout=json.dumps(
+                [
+                    [
+                        {
+                            "path": "tests/unit/test_beta.py",
+                            "start_line": 22,
+                            "annotation_level": "failure",
+                            "message": "beta shard failed",
+                        }
+                    ]
+                ]
+            ),
+        )
+        client = GitHubClient(fake)
+
+        failures, runs_in_progress = await client.fetch_failing_check_logs(
+            repo=RepoRef(owner="o", name="r"),
+            pr_number=1,
+            head_sha="abc",
+            rollup_checks=(
+                CheckTiming(
+                    name="python-coverage-shards (1)",
+                    conclusion="FAILURE",
+                    details_url="https://github.com/o/r/actions/runs/125/job/789",
+                    app_slug="github-actions",
+                ),
+                CheckTiming(
+                    name="python-coverage-shards (2)",
+                    conclusion="FAILURE",
+                    details_url="https://github.com/o/r/actions/runs/125/job/790",
+                    app_slug="github-actions",
+                ),
+            ),
+        )
+
+        assert runs_in_progress is False
+        assert len(failures) == 1
+        assert "tests/unit/test_alpha.py:11:1: alpha shard failed" in failures[0].log_excerpt
+        assert "tests/unit/test_beta.py:22:1: beta shard failed" in failures[0].log_excerpt
+        assert [
+            call.args[2]
+            for call in fake.calls
+            if call.args[:2] == ["gh", "api"] and call.args[2].endswith("/annotations")
+        ] == [
+            "repos/o/r/check-runs/789/annotations",
+            "repos/o/r/check-runs/790/annotations",
+        ]
+
+    @pytest.mark.unit
     async def test_rollup_fallback_ignores_non_actions_evidence(self) -> None:
         fake = FakeCommandRunner()
         fake.queue_result(returncode=0, stdout="[]")

--- a/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_parts/test_pr_monitor_part_003.py
@@ -21,6 +21,7 @@ from awf.runtime.pr_monitor import (
     RerunTransientCI,
     ReviewComment,
     ReviewThread,
+    WaitForCI,
     _log_shows_docker_registry_timeout,
     decide,
 )
@@ -73,6 +74,7 @@ def _status(
     base_behind: int = 0,
     merge_state_status: MergeStateStatus = MergeStateStatus.CLEAN,
     ci_failures: tuple[CheckFailure, ...] = (),
+    ci_runs_in_progress: bool = False,
     closed: bool = False,
     merged: bool = False,
 ) -> PRStatus:
@@ -91,12 +93,40 @@ def _status(
         base_behind_count=base_behind,
         merge_state_status=merge_state_status,
         ci_failures=ci_failures,
+        ci_runs_in_progress=ci_runs_in_progress,
         closed=closed,
         merged=merged,
     )
 
 
 class TestCiFailure:
+    @pytest.mark.unit
+    def test_failed_check_with_ci_run_in_progress_waits_before_missing_log_escalation(
+        self,
+    ) -> None:
+        action = decide(
+            _status(
+                check_state=CheckState.FAILURE,
+                ci_failures=(),
+                ci_runs_in_progress=True,
+            ),
+            MonitorState(),
+            MonitorConfig(),
+        )
+
+        assert isinstance(action, WaitForCI)
+        assert action.reason == "ci_run_in_progress"
+
+    @pytest.mark.unit
+    def test_no_failure_without_ci_run_in_progress_keeps_existing_terminal_path(self) -> None:
+        action = decide(
+            _status(check_state=CheckState.SUCCESS, ci_runs_in_progress=False),
+            MonitorState(),
+            MonitorConfig(auto_merge=False),
+        )
+
+        assert isinstance(action, NotifyHuman)
+
     @pytest.mark.unit
     def test_transient_failure_dispatches_rerun_before_agent_repair(self) -> None:
         failure = CheckFailure(

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_007.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_007.py
@@ -1027,7 +1027,7 @@ def test_pending_check_and_defer_helpers_cover_unknown_and_review_paths() -> Non
     )
     with_failures = _with_ci_failures(
         _status_for_helpers(),
-        (CheckFailure(name="pytest", conclusion="FAILURE", log_excerpt="failed"),),
+        ((CheckFailure(name="pytest", conclusion="FAILURE", log_excerpt="failed"),), False),
     )
     assert with_failures.ci_failures[0].name == "pytest"
 

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_001.py
@@ -215,12 +215,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
@@ -206,12 +206,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_003.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_003.py
@@ -115,12 +115,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_004.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_004.py
@@ -197,12 +197,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:
@@ -954,7 +954,7 @@ async def test_agent_service_recovery_sentinel_finishes_monitor_operation(
     elif case == "ci_repair":
         failures = (CheckFailure(name="tests", conclusion="FAILURE", log_excerpt="boom"),)
         action = ReportCiFailure(failures=failures)
-        status = _with_ci_failures(status, failures)
+        status = _with_ci_failures(status, (failures, False))
         target_method = "_run_ci_fix"
         expected_type = "ci_repair"
         expected_result["failure_count"] = 1
@@ -1062,7 +1062,7 @@ async def test_superseded_agent_service_recovery_cancels_monitor_operation(
     elif case == "ci_repair":
         failures = (CheckFailure(name="tests", conclusion="FAILURE", log_excerpt="boom"),)
         action = ReportCiFailure(failures=failures)
-        status = _with_ci_failures(status, failures)
+        status = _with_ci_failures(status, (failures, False))
         target_method = "_run_ci_fix"
         expected_type = "ci_repair"
         expected_result["failure_count"] = 1
@@ -1227,7 +1227,7 @@ async def test_ci_repair_provider_recovery_exceptions_finish_operation(
             repo_url="git@github.com:dimileeh/aira-web.git",
             repo=RepoRef(owner="dimileeh", name="aira-web"),
             pr_number=42,
-            status=_with_ci_failures(_green_status(), failures),
+            status=_with_ci_failures(_green_status(), (failures, False)),
             state=MonitorState(started_at=0.0),
             base_branch="development",
             remote_branch=f"awf/{workspace_id}",

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_005.py
@@ -470,9 +470,10 @@ class TestMiscMonitorHelpers:
     @pytest.mark.unit
     def test_ci_failure_replacement_preserves_status_shape(self) -> None:
         failure = CheckFailure(name="tests", conclusion="FAILURE", log_excerpt="boom")
-        updated = _with_ci_failures(_status(), (failure,))
+        updated = _with_ci_failures(_status(), ((failure,), True))
 
         assert updated.ci_failures == (failure,)
+        assert updated.ci_runs_in_progress is True
         assert updated.head_sha == "abc123"
 
     @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_005.py
@@ -294,12 +294,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_008.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_008.py
@@ -95,12 +95,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_009.py
@@ -209,12 +209,12 @@ class _CapturingGH:
         head_sha: str,
         pytest_fallback_commands: Sequence[str] = (),
         rollup_checks: object = (),
-    ) -> tuple[CheckFailure, ...]:
+    ) -> tuple[tuple[CheckFailure, ...], bool]:
         del rollup_checks
         self.failing_log_requests.append(
             (repo, pr_number, head_sha, tuple(pytest_fallback_commands))
         )
-        return ()
+        return (), False
 
     async def post_comment(self, *, repo: RepoRef, pr_number: int, body: str) -> None:
         if self.post_errors:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_16f285140f144038beb4b3f6` (agent: `codex`, model: `gpt-5.5`, effort: `high`).


### Task
Fix Core issue #711: the PR monitor escalates a failed shard of a STILL-RUNNING workflow to a human because it classifies the failure before the run's log archive exists. Repo: agent-workspace-fabric (public AWF Core), branch feature -> development. A /plan-eng-review locked the design below; implement it exactly. Strict TDD.

## Root cause (verified live + in code)
AWF reads failure logs via `gh run view <run> --log-failed` (`src/awf/common/github_client.py:948`). GitHub's downloadable log archive does NOT exist until the whole run completes -> for an `in_progress` run it returns 0 bytes (verified: aira-agent PR #723, shard failed 20:47:21, AWF escalated 20:48:02 while the run was still in_progress). Empty log -> empty evidence + empty `log_excerpt` -> `_has_actionable_ci_failure_evidence` (`pr_monitor.py:915`) False -> `_ci_failure_action` returns `NotifyHuman(_CI_UNACTIONABLE_HUMAN_MESSAGE)` (`pr_monitor.py:983`). Premature escalation.

Why it isn't skipped: `_fetch_failed_check_logs` (`github_client.py:893`) has two failure-gathering loops. Loop 1 (`:978-992`, the `gh run list` loop) filters on `conclusion in _FAILED_CHECK_CONCLUSIONS` (an in_progress run has empty conclusion -> skipped). Loop 2 (`:993-1002`, the rollup fallback) takes each FAILED check from the PR statusCheckRollup, extracts the run id from `detailsUrl`, and calls `_append_failure` with NO run-completion gate. `runs_raw` already fetches each run's `status` at `:924` but it is UNUSED. So loop 2 fetches an empty `--log-failed` for an in_progress run and builds an unactionable CheckFailure -> escalation.

## Verified call order (the signal can reach decide())
`fetch_pr_status` (`github_client.py:584`) builds `PRStatus` with `ci_failures=()` (`:789`); the rollup-failure path calls the failing-check-log gather; `src/awf/runtime/pr_monitor_runner/helpers.py:489` `_with_ci_failures(status, failures)` populates `ci_failures` via `replace(...)`; then `decide()` (`pr_monitor.py:1040`) runs. decide() already has WaitForCI paths (`pending_checks` `:1256`, `awaiting_required_checks` `:1373`) but only when the rollup is PENDING; a failed shard skips them.

## Fix (locked) — gather-layer run-completion gate + propagated signal
1. In `_fetch_failed_check_logs`, build `status_by_run = {run_id: status}` from the already-fetched `runs_raw` (`:924`). In BOTH loop 1 and loop 2, if a failing check's run status is not `completed`, SKIP it (do NOT fetch `--log-failed` for it) and set a local `runs_in_progress = True`. Return `(tuple(failures), runs_in_progress)` (adjust the return type + the public wrapper accordingly).
2. Add a field `ci_runs_in_progress: bool = False` to `PRStatus` (`pr_monitor.py`). In `_with_ci_failures` (`helpers.py:489`), set it from the gather's flag alongside `ci_failures` (use `replace(status, ci_failures=..., ci_runs_in_progress=...)`).
3. In `decide()`, when `status.ci_runs_in_progress` is True, return `WaitForCI(reason="ci_run_in_progress")` BEFORE the CI-failure classification/escalation path. This avoids the `_CI_MISSING_LOGS` trap (`pr_monitor.py:945` — empty `ci_failures` would otherwise return `NotifyHuman(_CI_MISSING_LOGS_HUMAN_MESSAGE)`): the wait must be an explicit signal, not inferred from an empty failure set.
4. SECONDARY SAFETY: if `--log-failed` returns empty BUT the run IS `completed`, fall back to the check-run annotations (e.g. via `gh api repos/<repo>/check-runs/<id>/annotations`, carrying messages like "Process completed with exit code 1") before declaring the failure unactionable, so a completed run with a purged/empty archive is not silently unactionable. Keep this minimal and only on the completed-run path.

## Tests (cover all; full suite green at the exact 99% coverage gate)
- a failed rollup check whose run status is `in_progress` -> NOT gathered as a terminal failure; gather returns `runs_in_progress=True`; `PRStatus.ci_runs_in_progress` True; `decide()` returns `WaitForCI(reason="ci_run_in_progress")` (NOT NotifyHuman).
- the same check once its run is `completed` -> gathered, classified normally (actionable -> ReportCiFailure; empty-but-completed -> annotations fallback).
- REGRESSION: a `completed` failed run classifies/routes/escalates EXACTLY as today (no behavior change for completed runs) — assert ReportCiFailure for an actionable completed failure, and the existing NotifyHuman paths for completed-but-unactionable.
- REGRESSION: a no-failure pending run still waits/merges as today (no false WaitForCI).
- gate applies to BOTH loops (run-list loop and rollup fallback).
- annotations fallback: completed run + empty `--log-failed` + annotation "Process completed with exit code 1" -> still classified (not silently unactionable).

## Constraints
Strict TDD. Right-sized diff (~2-3 files: github_client.py, pr_monitor.py [PRStatus + decide + the gather return-type plumbing], helpers.py, tests). Do NOT change `--log-failed` to per-job fetch or change log_tail sizing. Do NOT touch the #709 extractor/classifier marker work (separate PR). Do NOT touch protected quality-gate files. Commit in /workspace; do NOT push or open a PR (AWF owns push/PR/validation/review/merge). Full suite must pass the exact ~99% coverage gate.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the PR monitor decision order and GitHub CI log gathering contract; behavior for completed runs is intended to stay the same aside from the new annotation fallback.
> 
> **Overview**
> Fixes premature **NotifyHuman** when a failed check appears on a GitHub Actions run that is still **in_progress** and `--log-failed` is empty.
> 
> **`fetch_failing_check_logs`** now returns **`(failures, runs_in_progress)`** on the forge seam. On GitHub, both the run-list and rollup-fallback paths skip non-**completed** runs (no log fetch) and set **`runs_in_progress`**. For **completed** runs with empty logs, it falls back to paginated **check-run annotations** (via job → check-run id from rollup **`detailsUrl`**). Bitbucket keeps the same tuple shape and always reports **`runs_in_progress=False`**.
> 
> **`PRStatus`** gains **`ci_runs_in_progress`**, populated by **`_with_ci_failures`**. **`decide()`** returns **`WaitForCI(reason="ci_run_in_progress")`** before the CI-failure / missing-evidence escalation path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b1412ace542a526c98cdf4822ac9b6264df31c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->