### PR TITLE
[codex] Pass agent auth env through compose exec

### DIFF
--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -31,6 +31,7 @@ from awf.common.compose_exec import (
 )
 from awf.common.logging import get_logger
 from awf.db.enums import AgentRuntime
+from awf.profiles.compose import AGENT_AUTH_ENV_VARS
 from awf.runtime.logs import LogStore
 
 _log = get_logger(__name__)
@@ -256,6 +257,7 @@ class AgentAdapter(ABC):
             source=log_source,
             label=self.name.value,
             preserve_stdin=True,
+            env_passthrough=AGENT_AUTH_ENV_VARS,
         )
         args = invocation.args
         _log.info(

--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -31,7 +31,7 @@ from awf.common.compose_exec import (
 )
 from awf.common.logging import get_logger
 from awf.db.enums import AgentRuntime
-from awf.profiles.compose import AGENT_AUTH_ENV_VARS
+from awf.profiles.compose import agent_exec_env_passthrough
 from awf.runtime.logs import LogStore
 
 _log = get_logger(__name__)
@@ -257,7 +257,7 @@ class AgentAdapter(ABC):
             source=log_source,
             label=self.name.value,
             preserve_stdin=True,
-            env_passthrough=AGENT_AUTH_ENV_VARS,
+            env_passthrough=agent_exec_env_passthrough(compose_file=compose_file),
         )
         args = invocation.args
         _log.info(

--- a/src/awf/common/compose_exec.py
+++ b/src/awf/common/compose_exec.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import asyncio
 import re
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Final
@@ -30,6 +31,7 @@ future workdir change from silently regressing the #620 root cause."""
 
 EXEC_PROCESS_CLEANUP_FAILED = "EXEC_PROCESS_CLEANUP_FAILED"
 _INVOCATION_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+_ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _log = get_logger(__name__)
 
 
@@ -83,6 +85,7 @@ def build_tracked_compose_exec(
     workdir: str = DEFAULT_AGENT_WORKDIR,
     invocation_id: str | None = None,
     preserve_stdin: bool = False,
+    env_passthrough: Sequence[str] = (),
 ) -> TrackedComposeExec:
     """Build a compose-exec argv that tags the in-container command."""
 
@@ -98,6 +101,7 @@ def build_tracked_compose_exec(
             compose_file=compose_file,
             service=service,
             workdir=workdir,
+            env_passthrough=env_passthrough,
         ),
         "sh",
         "-lc",
@@ -230,7 +234,9 @@ def _compose_exec_prefix(
     compose_file: Path,
     service: str,
     workdir: str,
+    env_passthrough: Sequence[str] = (),
 ) -> list[str]:
+    env_args = [arg for name in _unique_env_passthrough(env_passthrough) for arg in ("-e", name)]
     return [
         "docker",
         "compose",
@@ -242,6 +248,7 @@ def _compose_exec_prefix(
         "-T",
         "-w",
         workdir,
+        *env_args,
         service,
     ]
 
@@ -253,6 +260,18 @@ def _new_invocation_id() -> str:
 def _validate_invocation_id(invocation_id: str) -> None:
     if not _INVOCATION_ID_RE.fullmatch(invocation_id):
         raise ValueError("invocation_id contains unsupported shell characters")
+
+
+def _unique_env_passthrough(env_passthrough: Sequence[str]) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for name in env_passthrough:
+        if not _ENV_NAME_RE.fullmatch(name):
+            raise ValueError("env_passthrough contains unsupported environment variable names")
+        if name not in seen:
+            names.append(name)
+            seen.add(name)
+    return tuple(names)
 
 
 def _tracked_exec_wrapper_script(*, preserve_stdin: bool = False) -> str:

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -460,7 +460,11 @@ def agent_environment_keys_from_compose_file(compose_file: Path) -> frozenset[st
     return _try_agent_environment_keys_from_compose_file(compose_file) or frozenset()
 
 
-def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
+def agent_exec_env_passthrough(
+    *,
+    compose_file: Path,
+    host_env: Mapping[str, str] | None = None,
+) -> tuple[str, ...]:
     """Return auth env var names safe to pass through on ``compose exec -e``.
 
     Mirrors ``agent_environment_with_legacy_host_auth`` shadowing: when compose
@@ -472,9 +476,11 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
     shell and overrides the running container's env, clobbering profile-owned or
     lease-resolved credentials/endpoints — including declared env leases that
     render as same-name ``${NAME}`` placeholders. Only auth keys absent from the
-    compose environment remain eligible for exec-time passthrough.
+    compose environment **and** configured in the worker env remain eligible for
+    exec-time passthrough.
     """
 
+    source_env = os.environ if host_env is None else host_env
     compose_env = _try_agent_environment_from_compose_file(compose_file)
     if compose_env is None:
         # Unreadable compose: assume profile-owned OLLAMA_HOST would shadow the worker
@@ -485,7 +491,9 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
         shadowing = _shadowing_worker_ollama_keys(set(compose_env))
         profile_owned = _profile_owned_auth_keys(compose_env)
     excluded = shadowing | profile_owned
-    return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in excluded)
+    return tuple(
+        name for name in AGENT_AUTH_ENV_VARS if name not in excluded and source_env.get(name)
+    )
 
 
 def _profile_owned_auth_keys(compose_env: Mapping[str, str]) -> frozenset[str]:

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -423,10 +423,10 @@ def _shadowing_worker_ollama_keys(profile_keys: set[str]) -> frozenset[str]:
     return frozenset(_OLLAMA_BASE_URL_ENV_KEYS[:top])
 
 
-def _try_agent_environment_keys_from_compose_file(
+def _try_agent_environment_from_compose_file(
     compose_file: Path,
-) -> frozenset[str] | None:
-    """Return agent env keys from compose, or ``None`` when the file is unreadable."""
+) -> dict[str, str] | None:
+    """Return agent env pairs from compose, or ``None`` when the file is unreadable."""
 
     try:
         payload = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
@@ -440,7 +440,18 @@ def _try_agent_environment_keys_from_compose_file(
     agent = services.get("agent")
     if not isinstance(agent, Mapping):
         return None
-    return _compose_environment_keys(agent.get("environment"))
+    return _compose_environment_mapping(agent.get("environment"))
+
+
+def _try_agent_environment_keys_from_compose_file(
+    compose_file: Path,
+) -> frozenset[str] | None:
+    """Return agent env keys from compose, or ``None`` when the file is unreadable."""
+
+    compose_env = _try_agent_environment_from_compose_file(compose_file)
+    if compose_env is None:
+        return None
+    return frozenset(compose_env)
 
 
 def agent_environment_keys_from_compose_file(compose_file: Path) -> frozenset[str]:
@@ -455,29 +466,54 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
     Mirrors ``agent_environment_with_legacy_host_auth`` shadowing: when compose
     generation omitted a higher-precedence worker Ollama key so a profile-owned
     daemon wins, do not re-inject that key via exec-time ``-e`` passthrough.
+
+    Also skip keys already rendered into the agent service with a concrete value.
+    ``docker compose exec -e NAME`` (no value) re-reads ``NAME`` from the worker
+    shell and overrides the running container's env, clobbering profile-owned or
+    lease-resolved credentials/endpoints. Only legacy ``${NAME}`` placeholders —
+    intentionally host-owned — remain eligible for exec-time passthrough.
     """
 
-    keys = _try_agent_environment_keys_from_compose_file(compose_file)
-    if keys is None:
+    compose_env = _try_agent_environment_from_compose_file(compose_file)
+    if compose_env is None:
         # Unreadable compose: assume profile-owned OLLAMA_HOST would shadow the worker
         # base URL rather than treat a parse failure as "no profile Ollama keys".
         shadowing = _shadowing_worker_ollama_keys({"OLLAMA_HOST"})
+        profile_owned = frozenset[str]()
     else:
-        shadowing = _shadowing_worker_ollama_keys(set(keys))
-    return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in shadowing)
+        shadowing = _shadowing_worker_ollama_keys(set(compose_env))
+        profile_owned = _profile_owned_auth_keys(compose_env)
+    excluded = shadowing | profile_owned
+    return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in excluded)
+
+
+def _is_legacy_host_env_placeholder(key: str, value: str) -> bool:
+    return value == f"${{{key}}}"
+
+
+def _profile_owned_auth_keys(compose_env: Mapping[str, str]) -> frozenset[str]:
+    return frozenset(
+        name
+        for name in AGENT_AUTH_ENV_VARS
+        if name in compose_env and not _is_legacy_host_env_placeholder(name, compose_env[name])
+    )
+
+
+def _compose_environment_mapping(environment: object) -> dict[str, str]:
+    if isinstance(environment, Mapping):
+        return {str(key): str(value) for key, value in environment.items()}
+    if isinstance(environment, list):
+        mapping: dict[str, str] = {}
+        for item in environment:
+            if isinstance(item, str):
+                key, sep, value = item.partition("=")
+                if key:
+                    mapping[key] = value if sep else ""
+            elif isinstance(item, Mapping):
+                mapping.update({str(key): str(value) for key, value in item.items()})
+        return mapping
+    return {}
 
 
 def _compose_environment_keys(environment: object) -> frozenset[str]:
-    if isinstance(environment, Mapping):
-        return frozenset(str(key) for key in environment)
-    if isinstance(environment, list):
-        keys: set[str] = set()
-        for item in environment:
-            if isinstance(item, str):
-                key, _, _ = item.partition("=")
-                if key:
-                    keys.add(key)
-            elif isinstance(item, Mapping):
-                keys.update(str(key) for key in item)
-        return frozenset(keys)
-    return frozenset()
+    return frozenset(_compose_environment_mapping(environment))

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -514,7 +514,3 @@ def _compose_environment_mapping(environment: object) -> dict[str, str]:
                 mapping.update({str(key): str(value) for key, value in item.items()})
         return mapping
     return {}
-
-
-def _compose_environment_keys(environment: object) -> frozenset[str]:
-    return frozenset(_compose_environment_mapping(environment))

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -423,22 +423,30 @@ def _shadowing_worker_ollama_keys(profile_keys: set[str]) -> frozenset[str]:
     return frozenset(_OLLAMA_BASE_URL_ENV_KEYS[:top])
 
 
-def agent_environment_keys_from_compose_file(compose_file: Path) -> frozenset[str]:
-    """Return env var names declared on the agent service in a rendered compose file."""
+def _try_agent_environment_keys_from_compose_file(
+    compose_file: Path,
+) -> frozenset[str] | None:
+    """Return agent env keys from compose, or ``None`` when the file is unreadable."""
 
     try:
         payload = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
     except (OSError, yaml.YAMLError):
-        return frozenset()
+        return None
     if not isinstance(payload, Mapping):
-        return frozenset()
+        return None
     services = payload.get("services")
     if not isinstance(services, Mapping):
-        return frozenset()
+        return None
     agent = services.get("agent")
     if not isinstance(agent, Mapping):
-        return frozenset()
+        return None
     return _compose_environment_keys(agent.get("environment"))
+
+
+def agent_environment_keys_from_compose_file(compose_file: Path) -> frozenset[str]:
+    """Return env var names declared on the agent service in a rendered compose file."""
+
+    return _try_agent_environment_keys_from_compose_file(compose_file) or frozenset()
 
 
 def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
@@ -449,9 +457,13 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
     daemon wins, do not re-inject that key via exec-time ``-e`` passthrough.
     """
 
-    shadowing = _shadowing_worker_ollama_keys(
-        set(agent_environment_keys_from_compose_file(compose_file))
-    )
+    keys = _try_agent_environment_keys_from_compose_file(compose_file)
+    if keys is None:
+        # Unreadable compose: assume profile-owned OLLAMA_HOST would shadow the worker
+        # base URL rather than treat a parse failure as "no profile Ollama keys".
+        shadowing = _shadowing_worker_ollama_keys({"OLLAMA_HOST"})
+    else:
+        shadowing = _shadowing_worker_ollama_keys(set(keys))
     return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in shadowing)
 
 

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -430,7 +430,7 @@ def _try_agent_environment_from_compose_file(
 
     try:
         payload = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
-    except (OSError, yaml.YAMLError):
+    except (OSError, yaml.YAMLError, UnicodeDecodeError):
         return None
     if not isinstance(payload, Mapping):
         return None

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import urlunsplit
 
+import yaml
+
 from awf.node.compose_manager import ComposeService
 from awf.profiles.lint import profile_service_volume_lint_errors
 from awf.profiles.models import (
@@ -419,3 +421,51 @@ def _shadowing_worker_ollama_keys(profile_keys: set[str]) -> frozenset[str]:
         return frozenset()
     top = min(declared)
     return frozenset(_OLLAMA_BASE_URL_ENV_KEYS[:top])
+
+
+def agent_environment_keys_from_compose_file(compose_file: Path) -> frozenset[str]:
+    """Return env var names declared on the agent service in a rendered compose file."""
+
+    try:
+        payload = yaml.safe_load(compose_file.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return frozenset()
+    if not isinstance(payload, Mapping):
+        return frozenset()
+    services = payload.get("services")
+    if not isinstance(services, Mapping):
+        return frozenset()
+    agent = services.get("agent")
+    if not isinstance(agent, Mapping):
+        return frozenset()
+    return _compose_environment_keys(agent.get("environment"))
+
+
+def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
+    """Return auth env var names safe to pass through on ``compose exec -e``.
+
+    Mirrors ``agent_environment_with_legacy_host_auth`` shadowing: when compose
+    generation omitted a higher-precedence worker Ollama key so a profile-owned
+    daemon wins, do not re-inject that key via exec-time ``-e`` passthrough.
+    """
+
+    shadowing = _shadowing_worker_ollama_keys(
+        set(agent_environment_keys_from_compose_file(compose_file))
+    )
+    return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in shadowing)
+
+
+def _compose_environment_keys(environment: object) -> frozenset[str]:
+    if isinstance(environment, Mapping):
+        return frozenset(str(key) for key in environment)
+    if isinstance(environment, list):
+        keys: set[str] = set()
+        for item in environment:
+            if isinstance(item, str):
+                key, _, _ = item.partition("=")
+                if key:
+                    keys.add(key)
+            elif isinstance(item, Mapping):
+                keys.update(str(key) for key in item)
+        return frozenset(keys)
+    return frozenset()

--- a/src/awf/profiles/compose.py
+++ b/src/awf/profiles/compose.py
@@ -467,11 +467,12 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
     generation omitted a higher-precedence worker Ollama key so a profile-owned
     daemon wins, do not re-inject that key via exec-time ``-e`` passthrough.
 
-    Also skip keys already rendered into the agent service with a concrete value.
+    Also skip keys already rendered into the agent service environment block.
     ``docker compose exec -e NAME`` (no value) re-reads ``NAME`` from the worker
     shell and overrides the running container's env, clobbering profile-owned or
-    lease-resolved credentials/endpoints. Only legacy ``${NAME}`` placeholders —
-    intentionally host-owned — remain eligible for exec-time passthrough.
+    lease-resolved credentials/endpoints — including declared env leases that
+    render as same-name ``${NAME}`` placeholders. Only auth keys absent from the
+    compose environment remain eligible for exec-time passthrough.
     """
 
     compose_env = _try_agent_environment_from_compose_file(compose_file)
@@ -487,16 +488,8 @@ def agent_exec_env_passthrough(*, compose_file: Path) -> tuple[str, ...]:
     return tuple(name for name in AGENT_AUTH_ENV_VARS if name not in excluded)
 
 
-def _is_legacy_host_env_placeholder(key: str, value: str) -> bool:
-    return value == f"${{{key}}}"
-
-
 def _profile_owned_auth_keys(compose_env: Mapping[str, str]) -> frozenset[str]:
-    return frozenset(
-        name
-        for name in AGENT_AUTH_ENV_VARS
-        if name in compose_env and not _is_legacy_host_env_placeholder(name, compose_env[name])
-    )
+    return frozenset(name for name in AGENT_AUTH_ENV_VARS if name in compose_env)
 
 
 def _compose_environment_mapping(environment: object) -> dict[str, str]:

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -355,6 +355,13 @@ class TestCodexAdapter:
 
     @pytest.mark.unit
     async def test_passthroughs_provider_auth_env_names_to_exec_without_values(self) -> None:
+        """Adapter exec argv mirrors ``agent_exec_env_passthrough`` and never passes values.
+
+        ``_COMPOSE_FILE`` is intentionally missing so adapter and expected helper share the
+        same unreadable-compose fallback. Compose-aware Ollama shadowing is covered in
+        ``test_workspace_services_compose`` and
+        ``test_profile_ollama_host_exec_passthrough_skips_worker_base_url``.
+        """
         runner = FakeCommandRunner()
         adapter = CodexAdapter(runner=runner)
 

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -354,7 +354,10 @@ class TestCodexAdapter:
         _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
-    async def test_passthroughs_provider_auth_env_names_to_exec_without_values(self) -> None:
+    async def test_passthroughs_provider_auth_env_names_to_exec_without_values(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
         """Adapter exec argv mirrors ``agent_exec_env_passthrough`` and never passes values.
 
         ``_COMPOSE_FILE`` is intentionally missing so adapter and expected helper share the
@@ -362,6 +365,8 @@ class TestCodexAdapter:
         ``test_workspace_services_compose`` and
         ``test_profile_ollama_host_exec_passthrough_skips_worker_base_url``.
         """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-worker")
+        monkeypatch.setenv("OLLAMA_HOST", "http://ollama.worker:11434")
         runner = FakeCommandRunner()
         adapter = CodexAdapter(runner=runner)
 
@@ -385,7 +390,9 @@ class TestCodexAdapter:
     async def test_profile_ollama_host_exec_passthrough_skips_worker_base_url(
         self,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-worker")
         compose_file = tmp_path / "compose.yml"
         compose_file.write_text(
             """

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -36,7 +36,7 @@ from awf.adapters.opencode import OpenCodeAdapter
 from awf.common.commands import CommandResult, FakeCommandRunner
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.db.enums import AgentRuntime
-from awf.profiles.compose import AGENT_AUTH_ENV_VARS
+from awf.profiles.compose import agent_exec_env_passthrough
 
 _PROMPT = "Add a one-line docstring to src/module/__init__.py."
 _LONG_PROMPT = "Review this oversized PR comment.\n" + ("x" * 140_000)
@@ -369,9 +369,45 @@ class TestCodexAdapter:
         env_slice = args[args.index("exec") + 4 : service_idx]
 
         assert env_slice
-        for name in AGENT_AUTH_ENV_VARS:
+        expected = agent_exec_env_passthrough(compose_file=_COMPOSE_FILE)
+        for name in expected:
             assert ["-e", name] == env_slice[env_slice.index(name) - 1 : env_slice.index(name) + 1]
         assert not any("sk-live-secret-value" in arg for arg in args)
+
+    @pytest.mark.unit
+    async def test_profile_ollama_host_exec_passthrough_skips_worker_base_url(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        compose_file = tmp_path / "compose.yml"
+        compose_file.write_text(
+            """
+services:
+  agent:
+    environment:
+      OLLAMA_HOST: http://ollama.profile:11434
+""".strip(),
+            encoding="utf-8",
+        )
+        runner = FakeCommandRunner()
+        adapter = CodexAdapter(runner=runner)
+
+        await adapter.run(
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=compose_file,
+            prompt=_PROMPT,
+        )
+
+        args = runner.calls[0].args
+        service_idx = args.index("agent")
+        env_slice = args[args.index("exec") + 4 : service_idx]
+        passthrough_names = {
+            env_slice[index + 1] for index, flag in enumerate(env_slice) if flag == "-e"
+        }
+
+        assert "OLLAMA_HOST" in passthrough_names
+        assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough_names
+        assert "OPENAI_API_KEY" in passthrough_names
 
     @pytest.mark.unit
     async def test_wall_timeout_raises_structured_error_and_closes_log_streams(self) -> None:

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -405,7 +405,7 @@ services:
             env_slice[index + 1] for index, flag in enumerate(env_slice) if flag == "-e"
         }
 
-        assert "OLLAMA_HOST" in passthrough_names
+        assert "OLLAMA_HOST" not in passthrough_names
         assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough_names
         assert "OPENAI_API_KEY" in passthrough_names
 

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -36,6 +36,7 @@ from awf.adapters.opencode import OpenCodeAdapter
 from awf.common.commands import CommandResult, FakeCommandRunner
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.db.enums import AgentRuntime
+from awf.profiles.compose import AGENT_AUTH_ENV_VARS
 
 _PROMPT = "Add a one-line docstring to src/module/__init__.py."
 _LONG_PROMPT = "Review this oversized PR comment.\n" + ("x" * 140_000)
@@ -351,6 +352,26 @@ class TestCodexAdapter:
         )
 
         _assert_prompt_sent_on_stdin(runner)
+
+    @pytest.mark.unit
+    async def test_passthroughs_provider_auth_env_names_to_exec_without_values(self) -> None:
+        runner = FakeCommandRunner()
+        adapter = CodexAdapter(runner=runner)
+
+        await adapter.run(
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            prompt=_PROMPT,
+        )
+
+        args = runner.calls[0].args
+        service_idx = args.index("agent")
+        env_slice = args[args.index("exec") + 4 : service_idx]
+
+        assert env_slice
+        for name in AGENT_AUTH_ENV_VARS:
+            assert ["-e", name] == env_slice[env_slice.index(name) - 1 : env_slice.index(name) + 1]
+        assert not any("sk-live-secret-value" in arg for arg in args)
 
     @pytest.mark.unit
     async def test_wall_timeout_raises_structured_error_and_closes_log_streams(self) -> None:

--- a/tests/unit/common/test_compose_exec_cleanup.py
+++ b/tests/unit/common/test_compose_exec_cleanup.py
@@ -116,6 +116,49 @@ def test_cleanup_command_bounds_integer_sleep_fallback_wait() -> None:
     assert "awf_cleanup_wait_limit=2" in script
 
 
+def test_agent_exec_can_passthrough_provider_auth_env_names_without_values() -> None:
+    invocation = build_tracked_compose_exec(
+        compose_project="awf_ws_123",
+        compose_file=Path("/tmp/ws/compose.yml"),
+        cli_args=["codex", "exec", "-"],
+        source="agent",
+        label="codex",
+        invocation_id="awf_provider_env",
+        env_passthrough=[
+            "OPENAI_API_KEY",
+            "CODEX_API_KEY",
+            "OPENAI_API_KEY",
+        ],
+    )
+
+    args = invocation.args
+    exec_idx = args.index("exec")
+    service_idx = args.index("agent")
+
+    assert args[exec_idx : exec_idx + 4] == ["exec", "-T", "-w", "/workspace"]
+    assert args[service_idx - 4 : service_idx] == [
+        "-e",
+        "OPENAI_API_KEY",
+        "-e",
+        "CODEX_API_KEY",
+    ]
+    assert "sk-live-secret-value" not in " ".join(args)
+    assert args.count("OPENAI_API_KEY") == 1
+    assert args[service_idx + 1 : service_idx + 4] == ["sh", "-lc", invocation.wrapper_script]
+
+
+def test_rejects_unsafe_passthrough_env_names() -> None:
+    with pytest.raises(ValueError, match="env_passthrough"):
+        build_tracked_compose_exec(
+            compose_project="awf_ws_123",
+            compose_file=Path("/tmp/ws/compose.yml"),
+            cli_args=["codex"],
+            source="agent",
+            label="codex",
+            env_passthrough=["OPENAI_API_KEY=sk-live-secret-value"],
+        )
+
+
 def test_preserved_stdin_setsid_path_uses_open_fd_not_path_redirection() -> None:
     script = compose_exec._tracked_exec_wrapper_script(preserve_stdin=True)  # noqa: SLF001
     setsid_block = script[script.index("if command -v setsid") : script.index('wait "$child_pid"')]

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -255,7 +255,10 @@ def test_worker_ollama_base_url_injected_when_profile_declares_none() -> None:
 @pytest.mark.unit
 def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_host_auth(monkeypatch)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-worker")
     compose_file = tmp_path / "compose.yml"
     compose_file.write_text(
         yaml.safe_dump(
@@ -283,7 +286,11 @@ def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
 @pytest.mark.unit
 def test_agent_exec_env_passthrough_fails_closed_when_compose_unreadable(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_host_auth(monkeypatch)
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama.worker:11434")
+
     missing = tmp_path / "missing.yml"
     assert not missing.exists()
     passthrough = agent_exec_env_passthrough(compose_file=missing)
@@ -299,7 +306,11 @@ def test_agent_exec_env_passthrough_fails_closed_when_compose_unreadable(
 @pytest.mark.unit
 def test_agent_exec_env_passthrough_includes_worker_ollama_when_compose_has_no_env_keys(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_host_auth(monkeypatch)
+    monkeypatch.setenv("AWF_OPENCODE_OLLAMA_BASE_URL", "http://ollama.worker:11434/v1")
+
     compose_file = tmp_path / "compose.yml"
     compose_file.write_text(
         yaml.safe_dump({"services": {"agent": {"image": "agent:latest"}}}),
@@ -462,9 +473,33 @@ def test_declared_env_lease_same_name_placeholder_suppressed_from_exec_passthrou
 
 
 @pytest.mark.unit
+def test_agent_exec_env_passthrough_omits_unconfigured_worker_auth_keys(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Absent compose keys must not passthrough unless the worker env defines them."""
+
+    _clear_host_auth(monkeypatch)
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump({"services": {"agent": {"image": "agent:latest"}}}),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "OPENAI_BASE_URL" not in passthrough
+    assert "GOOGLE_APPLICATION_CREDENTIALS" not in passthrough
+    assert passthrough == ()
+
+
+@pytest.mark.unit
 def test_profile_base_url_still_allows_worker_ollama_host_exec_passthrough(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _clear_host_auth(monkeypatch)
+    monkeypatch.setenv("OLLAMA_HOST", "http://ollama.worker:11434")
     compose_file = tmp_path / "compose.yml"
     compose_file.write_text(
         yaml.safe_dump(

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -281,6 +281,37 @@ def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
 
 
 @pytest.mark.unit
+def test_agent_exec_env_passthrough_fails_closed_when_compose_unreadable(
+    tmp_path: Path,
+) -> None:
+    missing = tmp_path / "missing.yml"
+    assert not missing.exists()
+    passthrough = agent_exec_env_passthrough(compose_file=missing)
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
+    assert "OLLAMA_HOST" in passthrough
+
+    bad_yaml = tmp_path / "bad-yaml.yml"
+    bad_yaml.write_text("services:\n  agent:\n    - [\n", encoding="utf-8")
+    passthrough = agent_exec_env_passthrough(compose_file=bad_yaml)
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
+
+
+@pytest.mark.unit
+def test_agent_exec_env_passthrough_includes_worker_ollama_when_compose_has_no_env_keys(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump({"services": {"agent": {"image": "agent:latest"}}}),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" in passthrough
+
+
+@pytest.mark.unit
 def test_agent_environment_keys_from_compose_file_rejects_invalid_shapes(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -14,6 +14,7 @@ from awf.node.git_manager import WorktreeLayout
 from awf.node.stack_launcher import ComposeStackLauncher, WorkspaceStackLaunchRequest
 from awf.profiles.compose import (
     AGENT_AUTH_ENV_VARS,
+    agent_environment_keys_from_compose_file,
     agent_environment_with_github_token,
     agent_environment_with_legacy_host_auth,
     agent_exec_env_passthrough,
@@ -277,6 +278,94 @@ def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
     assert "OLLAMA_HOST" in passthrough
     assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
     assert "OPENAI_API_KEY" in passthrough
+
+
+@pytest.mark.unit
+def test_agent_environment_keys_from_compose_file_rejects_invalid_shapes(
+    tmp_path: Path,
+) -> None:
+    assert agent_environment_keys_from_compose_file(tmp_path / "missing.yml") == frozenset()
+
+    scalar = tmp_path / "scalar.yml"
+    scalar.write_text("not-a-mapping\n", encoding="utf-8")
+    assert agent_environment_keys_from_compose_file(scalar) == frozenset()
+
+    no_services = tmp_path / "no-services.yml"
+    no_services.write_text("version: '3'\n", encoding="utf-8")
+    assert agent_environment_keys_from_compose_file(no_services) == frozenset()
+
+    no_agent = tmp_path / "no-agent.yml"
+    no_agent.write_text(
+        yaml.safe_dump({"services": {"postgres": {"image": "postgres:16"}}}),
+        encoding="utf-8",
+    )
+    assert agent_environment_keys_from_compose_file(no_agent) == frozenset()
+
+    bad_yaml = tmp_path / "bad-yaml.yml"
+    bad_yaml.write_text("services:\n  agent:\n    - [\n", encoding="utf-8")
+    assert agent_environment_keys_from_compose_file(bad_yaml) == frozenset()
+
+    unsupported_env = tmp_path / "unsupported-env.yml"
+    unsupported_env.write_text(
+        yaml.safe_dump({"services": {"agent": {"environment": 123}}}),
+        encoding="utf-8",
+    )
+    assert agent_environment_keys_from_compose_file(unsupported_env) == frozenset()
+
+
+@pytest.mark.unit
+def test_agent_environment_keys_from_compose_file_parses_list_environment(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": [
+                            "OLLAMA_HOST=http://ollama.profile:11434",
+                            "WORKSPACE_ID=ws_123",
+                            {"OPENAI_API_KEY": "${OPENAI_API_KEY}"},
+                            "=skip-empty-key",
+                            42,
+                        ]
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    keys = agent_environment_keys_from_compose_file(compose_file)
+
+    assert keys == frozenset({"OLLAMA_HOST", "WORKSPACE_ID", "OPENAI_API_KEY"})
+
+
+@pytest.mark.unit
+def test_agent_exec_env_passthrough_honors_list_format_compose_environment(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": [
+                            "OLLAMA_HOST=http://ollama.profile:11434",
+                        ]
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "OLLAMA_HOST" in passthrough
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -16,6 +16,7 @@ from awf.profiles.compose import (
     AGENT_AUTH_ENV_VARS,
     agent_environment_with_github_token,
     agent_environment_with_legacy_host_auth,
+    agent_exec_env_passthrough,
     profile_agent_environment,
     profile_services,
     resolve_app_endpoints,
@@ -248,6 +249,60 @@ def test_worker_ollama_base_url_injected_when_profile_declares_none() -> None:
     )
 
     assert env == (("AWF_OPENCODE_OLLAMA_BASE_URL", "${AWF_OPENCODE_OLLAMA_BASE_URL}"),)
+
+
+@pytest.mark.unit
+def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": {
+                            "WORKSPACE_ID": "ws_123",
+                            "OLLAMA_HOST": "http://ollama.profile:11434",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "OLLAMA_HOST" in passthrough
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
+    assert "OPENAI_API_KEY" in passthrough
+
+
+@pytest.mark.unit
+def test_profile_base_url_still_allows_worker_ollama_host_exec_passthrough(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": {
+                            "AWF_OPENCODE_OLLAMA_BASE_URL": "http://ollama.profile:11434/v1",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" in passthrough
+    assert "OLLAMA_HOST" in passthrough
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -275,7 +275,7 @@ def test_profile_ollama_host_suppresses_worker_base_url_exec_passthrough(
 
     passthrough = agent_exec_env_passthrough(compose_file=compose_file)
 
-    assert "OLLAMA_HOST" in passthrough
+    assert "OLLAMA_HOST" not in passthrough
     assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
     assert "OPENAI_API_KEY" in passthrough
 
@@ -395,8 +395,39 @@ def test_agent_exec_env_passthrough_honors_list_format_compose_environment(
 
     passthrough = agent_exec_env_passthrough(compose_file=compose_file)
 
-    assert "OLLAMA_HOST" in passthrough
+    assert "OLLAMA_HOST" not in passthrough
     assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
+
+
+@pytest.mark.unit
+def test_profile_owned_auth_env_literals_suppressed_from_exec_passthrough(
+    tmp_path: Path,
+) -> None:
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": {
+                            "OPENAI_API_KEY": "sk-profile-owned",
+                            "OPENAI_BASE_URL": "https://profile.proxy/v1",
+                            "ANTHROPIC_BASE_URL": "https://anthropic.profile/v1",
+                            "CODEX_API_KEY": "${CODEX_API_KEY}",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "OPENAI_API_KEY" not in passthrough
+    assert "OPENAI_BASE_URL" not in passthrough
+    assert "ANTHROPIC_BASE_URL" not in passthrough
+    assert "CODEX_API_KEY" in passthrough
 
 
 @pytest.mark.unit
@@ -421,7 +452,7 @@ def test_profile_base_url_still_allows_worker_ollama_host_exec_passthrough(
 
     passthrough = agent_exec_env_passthrough(compose_file=compose_file)
 
-    assert "AWF_OPENCODE_OLLAMA_BASE_URL" in passthrough
+    assert "AWF_OPENCODE_OLLAMA_BASE_URL" not in passthrough
     assert "OLLAMA_HOST" in passthrough
 
 

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -347,6 +347,10 @@ def test_agent_environment_keys_from_compose_file_rejects_invalid_shapes(
     bad_yaml.write_text("services:\n  agent:\n    - [\n", encoding="utf-8")
     assert agent_environment_keys_from_compose_file(bad_yaml) == frozenset()
 
+    invalid_utf8 = tmp_path / "invalid-utf8.yml"
+    invalid_utf8.write_bytes(b"services:\n  agent:\n    \xff\xfe\n")
+    assert agent_environment_keys_from_compose_file(invalid_utf8) == frozenset()
+
     unsupported_env = tmp_path / "unsupported-env.yml"
     unsupported_env.write_text(
         yaml.safe_dump({"services": {"agent": {"environment": 123}}}),

--- a/tests/unit/runtime/test_workspace_services_compose.py
+++ b/tests/unit/runtime/test_workspace_services_compose.py
@@ -427,7 +427,38 @@ def test_profile_owned_auth_env_literals_suppressed_from_exec_passthrough(
     assert "OPENAI_API_KEY" not in passthrough
     assert "OPENAI_BASE_URL" not in passthrough
     assert "ANTHROPIC_BASE_URL" not in passthrough
-    assert "CODEX_API_KEY" in passthrough
+    assert "CODEX_API_KEY" not in passthrough
+
+
+@pytest.mark.unit
+def test_declared_env_lease_same_name_placeholder_suppressed_from_exec_passthrough(
+    tmp_path: Path,
+) -> None:
+    """Env provider leases with target == source render ``${NAME}`` like legacy host auth.
+
+    Exec-time ``-e NAME`` must not re-inject worker env for keys already declared in
+    compose — Docker resolved them at stack launch and ``exec -e`` would override
+    with a potentially stale worker value.
+    """
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        yaml.safe_dump(
+            {
+                "services": {
+                    "agent": {
+                        "environment": {
+                            "OPENAI_API_KEY": "${OPENAI_API_KEY}",
+                        }
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    passthrough = agent_exec_env_passthrough(compose_file=compose_file)
+
+    assert "OPENAI_API_KEY" not in passthrough
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- pass configured agent auth environment names through `docker compose exec` without exposing values in argv
- validate and deduplicate env passthrough names
- cover adapter and compose-exec behavior

## Why
Agent commands launched through local Docker Compose need provider auth variables inside the container, but AWF should only pass variable names and never serialize secret values.

## Validation
- `uv run --extra dev pytest -q tests/unit/adapters/test_adapters.py tests/unit/common/test_compose_exec_cleanup.py`
- commit hooks: ruff, ruff format, mypy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider auth and exec-time env injection; mistakes could leak wrong endpoints or override compose-resolved secrets, though only names are passed and exclusion rules are heavily tested.
> 
> **Overview**
> Agent runs now forward **configured provider auth environment variable names** into `docker compose exec` via `-e NAME` (no values in argv), so coding CLIs inside the agent container can see worker credentials without secrets appearing in process listings.
> 
> **Compose exec** gains an optional `env_passthrough` list: names are validated, deduplicated, and emitted as `-e` flags before the service name. **Profile compose** adds `agent_exec_env_passthrough`, which reads the rendered compose file’s agent `environment` block and only forwards auth keys that are set on the worker **and** not already declared in compose—avoiding exec-time overrides that would clobber profile-owned literals, `${NAME}` placeholders, or Ollama URL shadowing consistent with stack launch. Unreadable compose fails closed on higher-precedence Ollama passthrough.
> 
> The shared **agent adapter** wires this helper into every tracked exec invocation; unit tests cover argv shape, Ollama/profile suppression, and unsafe name rejection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a883d8233aa987a0edbb3e3842004a20ee388634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `docker compose exec` now passes through selected environment variables to agent containers, improving access to auth-related settings at runtime.
  * Compose-based agent configuration is now read more intelligently so only appropriate environment variables are forwarded.

* **Bug Fixes**
  * Prevents re-sending environment variables that are already defined in the container’s compose configuration.
  * Avoids passing through unsafe or duplicate environment variable names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->