### PR TITLE
[codex] Normalize asyncpg advisory lock DSNs

### DIFF
--- a/src/awf/runtime/merge_coordinator.py
+++ b/src/awf/runtime/merge_coordinator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import weakref
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from typing import Protocol, cast
@@ -48,6 +48,17 @@ class _AdvisoryConnection(Protocol):
 
 
 _AdvisoryConnect = Callable[[str], Awaitable[_AdvisoryConnection]]
+_URLQueryValue = tuple[str, ...] | str
+
+_AWF_ENGINE_ONLY_QUERY_KEYS: frozenset[str] = frozenset(
+    {
+        "awf_search_path",
+        "awf_null_pool",
+        "awf_connect_timeout",
+        "awf_connect_attempts",
+        "awf_connect_retries",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -188,7 +199,46 @@ def _asyncpg_dsn_from_engine(engine: AsyncEngine) -> str:
     url = engine.url
     if "+" in url.drivername:
         url = url.set(drivername=url.drivername.split("+", 1)[0])
+    query = _advisory_asyncpg_query(url.query)
+    if query != dict(url.query):
+        url = url.set(query=query)
     return url.render_as_string(hide_password=False)
+
+
+def _advisory_asyncpg_query(query: Mapping[str, _URLQueryValue]) -> dict[str, _URLQueryValue]:
+    normalized: dict[str, _URLQueryValue] = {}
+    query_dict = dict(query or {})
+    has_sslmode = "sslmode" in query_dict
+    for key, value in query_dict.items():
+        if key in _AWF_ENGINE_ONLY_QUERY_KEYS:
+            continue
+        if key == "ssl":
+            if not has_sslmode:
+                sslmode = _ssl_query_value_to_sslmode(_single_query_value(value))
+                if sslmode is not None:
+                    normalized["sslmode"] = sslmode
+            continue
+        normalized[key] = value
+    return normalized
+
+
+def _single_query_value(value: _URLQueryValue) -> str | None:
+    if isinstance(value, tuple):
+        return value[0] if value else None
+    return value
+
+
+def _ssl_query_value_to_sslmode(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip().lower()
+    if normalized in {"0", "false", "no", "off", "disable", "disabled"}:
+        return "disable"
+    if normalized in {"1", "true", "yes", "on", "require", "required"}:
+        return "require"
+    if normalized in {"allow", "prefer", "verify-ca", "verify-full"}:
+        return normalized
+    return None
 
 
 DEFAULT_MERGE_COORDINATOR = InProcessMergeCoordinator()

--- a/tests/unit/runtime/test_merge_coordinator.py
+++ b/tests/unit/runtime/test_merge_coordinator.py
@@ -343,6 +343,28 @@ class TestPostgresAdvisoryMergeCoordinator:
             == "postgresql://awf:secret@db:5432/awf"
         )
 
+    @pytest.mark.unit
+    def test_asyncpg_dsn_from_engine_normalizes_cloud_sql_ssl_query(self) -> None:
+        engine = cast(
+            AsyncEngine,
+            SimpleNamespace(
+                url=make_url(
+                    "postgresql+asyncpg://awf:secret@db:5432/awf"
+                    "?ssl=require"
+                    "&awf_search_path=awf_core"
+                    "&awf_null_pool=1"
+                    "&awf_connect_timeout=5"
+                    "&awf_connect_attempts=3"
+                    "&awf_connect_retries=3"
+                )
+            ),
+        )
+
+        assert (
+            merge_coordinator_mod._asyncpg_dsn_from_engine(engine)
+            == "postgresql://awf:secret@db:5432/awf?sslmode=require"
+        )
+
 
 def _fake_engine() -> AsyncEngine:
     return cast(

--- a/tests/unit/runtime/test_merge_coordinator.py
+++ b/tests/unit/runtime/test_merge_coordinator.py
@@ -365,6 +365,93 @@ class TestPostgresAdvisoryMergeCoordinator:
             == "postgresql://awf:secret@db:5432/awf?sslmode=require"
         )
 
+    @pytest.mark.unit
+    def test_asyncpg_dsn_from_engine_preserves_non_awf_query_params(self) -> None:
+        engine = cast(
+            AsyncEngine,
+            SimpleNamespace(
+                url=make_url(
+                    "postgresql+asyncpg://awf:secret@db:5432/awf?application_name=awf&ssl=true"
+                )
+            ),
+        )
+
+        assert (
+            merge_coordinator_mod._asyncpg_dsn_from_engine(engine)
+            == "postgresql://awf:secret@db:5432/awf?application_name=awf&sslmode=require"
+        )
+
+    @pytest.mark.unit
+    def test_asyncpg_dsn_from_engine_keeps_existing_sslmode_over_ssl(self) -> None:
+        engine = cast(
+            AsyncEngine,
+            SimpleNamespace(
+                url=make_url(
+                    "postgresql+asyncpg://awf:secret@db:5432/awf?sslmode=verify-full&ssl=require"
+                )
+            ),
+        )
+
+        assert (
+            merge_coordinator_mod._asyncpg_dsn_from_engine(engine)
+            == "postgresql://awf:secret@db:5432/awf?sslmode=verify-full"
+        )
+
+    @pytest.mark.unit
+    def test_asyncpg_dsn_from_engine_drops_unrecognized_ssl_value(self) -> None:
+        engine = cast(
+            AsyncEngine,
+            SimpleNamespace(url=make_url("postgresql+asyncpg://awf:secret@db:5432/awf?ssl=maybe")),
+        )
+
+        assert (
+            merge_coordinator_mod._asyncpg_dsn_from_engine(engine)
+            == "postgresql://awf:secret@db:5432/awf"
+        )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        ("ssl_value", "expected_sslmode"),
+        [
+            ("false", "disable"),
+            ("0", "disable"),
+            ("no", "disable"),
+            ("true", "require"),
+            ("1", "require"),
+            ("require", "require"),
+            ("prefer", "prefer"),
+            ("allow", "allow"),
+            ("verify-ca", "verify-ca"),
+            ("verify-full", "verify-full"),
+        ],
+    )
+    def test_asyncpg_dsn_from_engine_maps_ssl_values_to_sslmode(
+        self,
+        ssl_value: str,
+        expected_sslmode: str,
+    ) -> None:
+        engine = cast(
+            AsyncEngine,
+            SimpleNamespace(
+                url=make_url(f"postgresql+asyncpg://awf:secret@db:5432/awf?ssl={ssl_value}")
+            ),
+        )
+
+        assert (
+            merge_coordinator_mod._asyncpg_dsn_from_engine(engine)
+            == f"postgresql://awf:secret@db:5432/awf?sslmode={expected_sslmode}"
+        )
+
+    @pytest.mark.unit
+    def test_advisory_asyncpg_query_reads_ssl_from_tuple_value(self) -> None:
+        assert merge_coordinator_mod._advisory_asyncpg_query({"ssl": ("require",)}) == {
+            "sslmode": "require"
+        }
+
+    @pytest.mark.unit
+    def test_advisory_asyncpg_query_drops_ssl_when_tuple_is_empty(self) -> None:
+        assert merge_coordinator_mod._advisory_asyncpg_query({"ssl": ()}) == {}
+
 
 def _fake_engine() -> AsyncEngine:
     return cast(


### PR DESCRIPTION
## Summary
- strip AWF engine-only query parameters before opening asyncpg advisory-lock connections
- translate `ssl=require` into asyncpg-compatible `sslmode=require`
- cover Cloud SQL-style engine URL normalization

## Why
The merge coordinator builds a direct asyncpg DSN from SQLAlchemy engine URLs. Engine-only AWF query params and `ssl=` can break advisory-lock connections even though the app engine itself is valid.

## F21A overlap
PR721 touches profile capability discovery only; this PR touches merge coordinator advisory-lock DSN handling and does not overlap file-level scope.

## Validation
- `uv run --extra dev pytest -q tests/unit/runtime/test_merge_coordinator.py`
- commit hooks: ruff, ruff format, mypy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TLS and connection parameters for Postgres advisory locks used during auto-merge; mis-mapping could break locks in production DB setups, though behavior is narrowly scoped and well-tested.
> 
> **Overview**
> **Postgres advisory-lock connections** now get a DSN derived from the SQLAlchemy engine URL with query parameters adjusted for raw `asyncpg.connect`, so Cloud SQL–style URLs work for merge coordination even when the app engine URL is valid.
> 
> `_asyncpg_dsn_from_engine` runs URL query through new normalization: **AWF-only keys** (`awf_search_path`, `awf_null_pool`, connect timeout/retry knobs) are **dropped** because they are consumed by `session.py` for the pooled engine, not by asyncpg. **`ssl=` is removed** and mapped to **`sslmode=`** when `sslmode` is absent (booleans, `require`, `verify-*`, etc.); existing `sslmode` wins, unrecognized `ssl` values are omitted, and other params like `application_name` are kept.
> 
> Unit tests cover Cloud SQL–style URLs, ssl/sslmode precedence, param stripping, and tuple-valued query values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38ea07d661bed75ae63ab45b90dba9120fb92145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->