### PR TITLE
[codex] Repair agent worktree git ownership

### DIFF
--- a/src/awf/control/executor/git_ops.py
+++ b/src/awf/control/executor/git_ops.py
@@ -67,12 +67,15 @@ def _agent_git_writability_preflight_script(workspace_id: str) -> str:
     return f"""
 set -eu
 workspace_id={quoted_workspace_id}
-git status --porcelain >/dev/null
-blob=$(printf 'awf git preflight %s\\n' "$workspace_id" | git hash-object -w --stdin)
-git cat-file -e "$blob^{{blob}}"
+git_awf() {{
+  git -c "safe.directory=$(pwd -P)" "$@"
+}}
+git_awf status --porcelain >/dev/null
+blob=$(printf 'awf git preflight %s\\n' "$workspace_id" | git_awf hash-object -w --stdin)
+git_awf cat-file -e "$blob^{{blob}}"
 ref="refs/awf/preflight/$workspace_id"
-git update-ref "$ref" HEAD
-git update-ref -d "$ref"
+git_awf update-ref "$ref" HEAD
+git_awf update-ref -d "$ref"
 """.strip()
 
 
@@ -206,7 +209,8 @@ async def _repair_agent_git_ownership(
 ) -> bool:
     _ = executor
     try:
-        await asyncio.to_thread(repair_agent_writable_worktree, None, worktree_path)
+        mirror_path = mirror_path_for_worktree(worktree_path)
+        await asyncio.to_thread(repair_agent_writable_worktree, mirror_path, worktree_path)
     except Exception:
         _log.exception(
             "executor.agent_git_ownership_repair_failed",

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -23,6 +23,7 @@ import hashlib
 import os
 import re
 import shutil
+import stat
 import subprocess
 import weakref
 from collections.abc import Mapping
@@ -62,6 +63,7 @@ _POISONED_MIRROR_HOOKS_PATH_PATTERNS = {
 }
 AGENT_RUNTIME_UID = 1000
 AGENT_RUNTIME_GID = 1000
+_OWNER_WRITABLE_DIR_MODE = stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR
 
 
 @dataclass(frozen=True)
@@ -1206,6 +1208,8 @@ def _chown_targets(targets: tuple[_ChownTarget, ...], uid: int, gid: int) -> Non
             os.lchown(target.path, uid, gid)
         else:
             os.chown(target.path, uid, gid)
+            if target.path.is_dir():
+                _ensure_owner_writable_dir(target.path)
 
 
 async def _repair_mirror_hooks_path_once(mirror_path: Path) -> tuple[bool, bool]:
@@ -1403,6 +1407,7 @@ def _chown_tree(path: Path, uid: int, gid: int, *, directories_only: bool = Fals
     os.chown(path, uid, gid)
     if not path.is_dir():
         return
+    _ensure_owner_writable_dir(path)
 
     for root, dirs, files in os.walk(path, followlinks=False):
         for name in dirs:
@@ -1411,6 +1416,7 @@ def _chown_tree(path: Path, uid: int, gid: int, *, directories_only: bool = Fals
                 os.lchown(child, uid, gid)
             else:
                 os.chown(child, uid, gid)
+                _ensure_owner_writable_dir(child)
         if directories_only:
             continue
         for name in files:
@@ -1419,3 +1425,10 @@ def _chown_tree(path: Path, uid: int, gid: int, *, directories_only: bool = Fals
                 os.lchown(child, uid, gid)
             else:
                 os.chown(child, uid, gid)
+
+
+def _ensure_owner_writable_dir(path: Path) -> None:
+    mode = path.stat(follow_symlinks=False).st_mode
+    desired_mode = stat.S_IMODE(mode | _OWNER_WRITABLE_DIR_MODE)
+    if desired_mode != stat.S_IMODE(mode):
+        path.chmod(desired_mode)

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_004.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_004.py
@@ -45,11 +45,12 @@ def test_git_error_indicates_missing_head_object() -> None:
 def test_agent_git_writability_preflight_script_exercises_object_and_ref_writes() -> None:
     script = _agent_git_writability_preflight_script("ws_preflight")
 
-    assert "git status --porcelain" in script
-    assert "git hash-object -w --stdin" in script
-    assert 'git cat-file -e "$blob^{blob}"' in script
-    assert 'git update-ref "$ref" HEAD' in script
-    assert 'git update-ref -d "$ref"' in script
+    assert 'git -c "safe.directory=$(pwd -P)" "$@"' in script
+    assert "git_awf status --porcelain" in script
+    assert "git_awf hash-object -w --stdin" in script
+    assert 'git_awf cat-file -e "$blob^{blob}"' in script
+    assert 'git_awf update-ref "$ref" HEAD' in script
+    assert 'git_awf update-ref -d "$ref"' in script
 
 
 @pytest.mark.unit
@@ -79,7 +80,7 @@ async def test_agent_git_writability_preflight_runs_inside_agent_container(
     assert call.args[call.args.index("-p") + 1] == "awf_ws_preflight"
     assert call.args[call.args.index("-f") + 1] == str(compose_file)
     assert "agent_git_writability_preflight" not in " ".join(call.args[:10])
-    assert "git hash-object -w --stdin" in " ".join(call.args)
+    assert "git_awf hash-object -w --stdin" in " ".join(call.args)
 
 
 @pytest.mark.unit
@@ -181,6 +182,28 @@ async def test_repair_agent_git_ownership_reports_repair_exceptions(
         worktree_path=tmp_path / "worktree",
         reason="test",
     )
+
+
+@pytest.mark.unit
+async def test_repair_agent_git_ownership_repairs_linked_mirror(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    mirror, worktree = _fake_linked_worktree(tmp_path)
+    executor = _executor_with_runner(FakeCommandRunner(), tmp_path)
+    captured: list[tuple[Path | None, Path]] = []
+
+    def _repair(layout_mirror: Path | None, worktree_path: Path) -> None:
+        captured.append((layout_mirror, worktree_path))
+
+    monkeypatch.setattr(executor_git_ops, "repair_agent_writable_worktree", _repair)
+
+    assert await executor._repair_agent_git_ownership(
+        workspace_id="ws_linked_mirror",
+        worktree_path=worktree,
+        reason="agent_git_writability_preflight",
+    )
+    assert captured == [(mirror.resolve(), worktree)]
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import stat
 import subprocess
 from collections.abc import Callable
 from pathlib import Path
@@ -451,6 +452,39 @@ class TestAddWorktree:
         assert layout.worktree_path in chowned
         assert mirror / "objects" in chowned
         assert protected_object not in chowned
+
+    @pytest.mark.unit
+    def test_repair_agent_writable_worktree_makes_object_dirs_owner_writable(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        mirror = tmp_path / "mirror.git"
+        objects = mirror / "objects"
+        fanout = objects / "ab"
+        fanout.mkdir(parents=True)
+        loose_object = fanout / "cdef"
+        loose_object.write_text("object\n", encoding="utf-8")
+        pack = objects / "pack"
+        pack.mkdir()
+        worktree = tmp_path / "worktree"
+        linked_git_dir = mirror / "worktrees" / "ws"
+        linked_git_dir.mkdir(parents=True)
+        worktree.mkdir()
+        (worktree / ".git").write_text(f"gitdir: {linked_git_dir}\n", encoding="utf-8")
+        for directory in (objects, fanout, pack):
+            directory.chmod(0o500)
+        loose_object.chmod(0o400)
+
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+        monkeypatch.setattr(os, "chown", lambda *_args: None)
+        monkeypatch.setattr(os, "lchown", lambda *_args: None)
+
+        git_manager.repair_agent_writable_worktree(mirror, worktree)
+
+        for directory in (objects, fanout, pack):
+            assert directory.stat().st_mode & stat.S_IWUSR
+        assert not loose_object.stat().st_mode & stat.S_IWUSR
 
     @pytest.mark.unit
     async def test_agent_owner_preparation_skips_when_owner_or_root_is_absent(


### PR DESCRIPTION
## Summary
- run git writability preflight with a workspace-local safe.directory wrapper
- repair the linked mirror associated with the worktree before retrying agent git operations
- ensure repaired directories are owner-writable while keeping loose object files untouched

## Why
Agent-owned worktrees can still fail git writes when linked mirror paths or directory modes are not repaired alongside the worktree.

## F21A overlap
PR721 touches profile capability discovery only; this PR touches executor/git-manager ownership paths and does not overlap file-level scope.

## Validation
- `uv run --extra dev pytest -q tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_004.py tests/unit/node/test_git_manager.py`
- commit hooks: ruff, ruff format, mypy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes filesystem permissions and git repair paths for agent worktrees; mistakes could block commits or weaken object immutability, but scope is narrow and covered by unit tests.
> 
> **Overview**
> Improves **agent git write reliability** when linked worktrees share a bare mirror: writability preflight in the agent container now runs git through a `git_awf` helper that sets **`safe.directory` to the worktree path**, and ownership repair passes the **resolved linked mirror** into `repair_agent_writable_worktree` instead of repairing only the worktree.
> 
> During agent ownership repair, **`_ensure_owner_writable_dir`** sets owner read/write/execute on repaired **directories** (including mirror `objects` fanout dirs) while **loose object files stay read-only**, matching the existing directories-only chown policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 371814366f4d1d50f5c72d1749d04055e381e87c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->