### PR TITLE
task_tag: accept Aira task keys (AIRA-T299) and emit bracketed [AIRA-T299] in PR titles

### DIFF
--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -172,7 +172,15 @@ class WorkspaceTask(BaseModel):
     @field_validator("task_tag")
     @classmethod
     def _validate_task_tag(cls, value: str | None) -> str | None:
-        """Normalize + validate the optional task tag; ``None`` when absent."""
+        """Normalize and validate an optional task tag; ``None`` when absent.
+
+        Accepts a Jira issue key (``PROJ-123``) or an Aira task entity key
+        (``PROJ-T123``). Pass bare keys (``AIRA-T299``); bracketed
+        ``[AIRA-T299]`` is accepted and normalized, but bare is recommended
+        because ``[`` is a shell glob character. Entity keys appear bracketed on
+        the PR title and AWF commits but bare on the branch; Jira keys are bare
+        everywhere.
+        """
         return validate_task_tag(value)
 
     @field_validator("kind")
@@ -391,7 +399,14 @@ class PullRequestMonitorAdoptionRequest(BaseModel):
     @field_validator("task_tag")
     @classmethod
     def _validate_task_tag(cls, value: str | None) -> str | None:
-        """Normalize + validate the optional task tag; ``None`` when absent."""
+        """Normalize and validate an optional task tag; ``None`` when absent.
+
+        Accepts a Jira issue key (``PROJ-123``) or an Aira task entity key
+        (``PROJ-T123``). Pass bare keys (``AIRA-T299``); bracketed
+        ``[AIRA-T299]`` is accepted and normalized, but bare is recommended
+        because ``[`` is a shell glob character. Entity keys appear bracketed
+        on AWF monitor commits; Jira keys are bare.
+        """
         return validate_task_tag(value)
 
 

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -172,7 +172,7 @@ class WorkspaceTask(BaseModel):
     @field_validator("task_tag")
     @classmethod
     def _validate_task_tag(cls, value: str | None) -> str | None:
-        """Normalize + validate the optional Jira issue key; ``None`` when absent."""
+        """Normalize + validate the optional task tag; ``None`` when absent."""
         return validate_task_tag(value)
 
     @field_validator("kind")
@@ -391,7 +391,7 @@ class PullRequestMonitorAdoptionRequest(BaseModel):
     @field_validator("task_tag")
     @classmethod
     def _validate_task_tag(cls, value: str | None) -> str | None:
-        """Normalize + validate the optional Jira issue key; ``None`` when absent."""
+        """Normalize + validate the optional task tag; ``None`` when absent."""
         return validate_task_tag(value)
 
 

--- a/src/awf/cli/workspace_commands.py
+++ b/src/awf/cli/workspace_commands.py
@@ -55,7 +55,7 @@ def _option_value(value: Any) -> str:
 
 
 def _task_tag_callback(value: str | None) -> str | None:
-    """Validate ``--task-tag`` locally; reject malformed Jira keys with a clear error."""
+    """Validate ``--task-tag`` locally; reject malformed keys with a clear error."""
     try:
         return validate_task_tag(value)
     except ValueError as exc:
@@ -72,8 +72,10 @@ def workspace_create(
         "--task-tag",
         callback=_task_tag_callback,
         help=(
-            "Optional Jira issue key (e.g. PROJ-123) prepended to the branch, PR "
-            "title, and every AWF-authored commit message so work links to the issue."
+            "Optional task tag: Jira issue key (e.g. PROJ-123) or Aira task entity "
+            "key (e.g. PROJ-T123). Pass bare keys (AIRA-T299); bracketed [AIRA-T299] "
+            "is accepted. Entity keys appear bracketed on the PR title and AWF commits "
+            "but bare on the branch; Jira keys are bare everywhere."
         ),
     ),
     branch_base: str | None = typer.Option(
@@ -891,8 +893,10 @@ def workspace_adopt_pr(
         "--task-tag",
         callback=_task_tag_callback,
         help=(
-            "Optional Jira issue key (e.g. PROJ-123) prepended to every "
-            "AWF-authored monitor commit message so fixes link to the issue."
+            "Optional task tag: Jira issue key (e.g. PROJ-123) or Aira task entity "
+            "key (e.g. PROJ-T123). Pass bare keys (AIRA-T299); bracketed [AIRA-T299] "
+            "is accepted. Entity keys appear bracketed on AWF monitor commits; Jira "
+            "keys are bare."
         ),
     ),
     reason: str | None = typer.Option(None, "--reason", help="Operator audit reason."),

--- a/src/awf/common/task_tag.py
+++ b/src/awf/common/task_tag.py
@@ -1,10 +1,18 @@
-"""Task-tag (Jira issue key) helpers.
+"""Task-tag helpers for Jira issue keys and Aira task entity keys.
 
-A *task tag* is an optional Jira-style issue key (e.g. ``PROJ-123``) that an
-operator attaches to a workspace via ``--task-tag``. When present, AWF prepends
-it to the branch name, the PR title, and **every commit message AWF authors** so
-the resulting branch/PR/commits auto-link to the Jira issue in BitBucket+Jira
-orgs (see https://support.atlassian.com/jira-software-cloud/docs/reference-issues-in-your-development-work/).
+A *task tag* is an optional key an operator attaches to a workspace via
+``--task-tag``. AWF accepts two shapes:
+
+- **Jira issue key** (e.g. ``PROJ-123``) — prepended **bare** to branch, PR
+  title, and every AWF-authored commit message for BitBucket+Jira auto-linking.
+- **Aira task entity key** (e.g. ``PROJ-T123``) — prepended in **brackets**
+  on title/commits (``[PROJ-T123] …``) so Aira's PR linker resolves the task;
+  the branch always uses the bare key (``PROJ-T123-awf/<id>``) because git
+  forbids ``[`` in ref names.
+
+Pass **bare** keys at the CLI (``AIRA-T299``); bracketed ``[AIRA-T299]`` is
+accepted and normalized, but bare is recommended because ``[`` is a shell glob
+character.
 
 Every helper here is a strict no-op when the tag is falsy, so the feature is
 fully backward-compatible when ``--task-tag`` is omitted. Format defaults live as
@@ -18,6 +26,9 @@ from typing import Final
 
 TASK_TAG_PATTERN: Final = re.compile(r"^[A-Z][A-Z0-9]+-[0-9]+$")
 """Jira issue key shape: an uppercase project key, a hyphen, then a number."""
+
+ENTITY_KEY_PATTERN: Final = re.compile(r"^[A-Z][A-Z0-9]{1,9}-T[0-9]+$")
+"""Aira task entity key shape: alpha-leading project prefix, ``-T``, then digits."""
 
 BRANCH_SEP: Final = "-"
 """Separator between the tag and a branch name → ``PROJ-123-awf/<id>``."""
@@ -37,22 +48,43 @@ def normalize_task_tag(value: str | None) -> str | None:
     return stripped or None
 
 
+def _strip_balanced_brackets(value: str) -> str:
+    """Strip one balanced surrounding ``[...]`` wrapper when present."""
+    if value.startswith("[") and value.endswith("]"):
+        return value[1:-1].strip()
+    return value
+
+
+def _is_entity_key(tag: str) -> bool:
+    """True when ``tag`` matches the Aira task entity key shape."""
+    return bool(ENTITY_KEY_PATTERN.match(tag))
+
+
 def validate_task_tag(value: str | None) -> str | None:
     """Normalize then validate a task tag.
 
-    Returns the normalized tag, ``None`` when absent/blank, and raises
+    Returns the canonical bare tag, ``None`` when absent/blank, and raises
     ``ValueError`` with a clear message when the value is non-empty but does not
-    match the Jira issue-key shape.
+    match a Jira issue key (``PROJ-123``) or an Aira task entity key
+    (``PROJ-T123``).
     """
     normalized = normalize_task_tag(value)
     if normalized is None:
         return None
-    if not TASK_TAG_PATTERN.match(normalized):
+    candidate = _strip_balanced_brackets(normalized)
+    if not candidate:
         raise ValueError(
-            f"invalid task tag {normalized!r}: expected a Jira issue key like "
-            "'PROJ-123' (uppercase project key, hyphen, number)"
+            "invalid task tag: expected a Jira issue key like 'PROJ-123' "
+            "or an Aira task entity key like 'PROJ-T123' "
+            "(uppercase project key, hyphen, number; entity keys use -T<number>)"
         )
-    return normalized
+    if TASK_TAG_PATTERN.match(candidate) or ENTITY_KEY_PATTERN.match(candidate):
+        return candidate
+    raise ValueError(
+        f"invalid task tag {normalized!r}: expected a Jira issue key like "
+        "'PROJ-123' or an Aira task entity key like 'PROJ-T123' "
+        "(uppercase project key, hyphen, number; entity keys use -T<number>)"
+    )
 
 
 def branch_with_task_tag(branch: str, tag: str | None) -> str:
@@ -61,7 +93,8 @@ def branch_with_task_tag(branch: str, tag: str | None) -> str:
     Idempotent: if ``branch`` already starts with ``"{tag}-"`` it is returned
     unchanged, consistent with :func:`title_with_task_tag` and
     :func:`commit_message_with_task_tag`, so a caller that passes an
-    already-tagged branch never accumulates a double prefix.
+    already-tagged branch never accumulates a double prefix. Branches always
+    use the bare key — never bracketed — because git forbids ``[`` in ref names.
     """
     if not tag:
         return branch
@@ -74,12 +107,17 @@ def branch_with_task_tag(branch: str, tag: str | None) -> str:
 def _leads_with_task_key(text: str, tag: str) -> bool:
     """True when ``text`` already begins with ``tag`` as a delimited leading token.
 
-    "Delimited" means the tag is followed by end-of-string or a non-alphanumeric
-    boundary — a space (``"PROJ-123 …"``) or a punctuation form such as a colon
-    (``"PROJ-123: …"``, a common Jira title shape). The boundary check is what
-    stops a *longer* key (``PROJ-1234`` when ``tag`` is ``PROJ-123``) from being
+    For entity keys the emitted form is bracketed (``"[{tag}] …"``); for Jira
+    keys it is bare (``"{tag} …"`` or ``"{tag}: …"``). The boundary check stops
+    a *longer* key (``PROJ-1234`` when ``tag`` is ``PROJ-123``) from being
     mistaken for an already-tagged leading key.
     """
+    if _is_entity_key(tag):
+        bracketed = f"[{tag}]"
+        if not text.startswith(bracketed):
+            return False
+        rest = text[len(bracketed) :]
+        return not rest or not rest[0].isalnum()
     if not text.startswith(tag):
         return False
     rest = text[len(tag) :]
@@ -87,56 +125,54 @@ def _leads_with_task_key(text: str, tag: str) -> bool:
 
 
 def title_with_task_tag(title: str, tag: str | None) -> str:
-    """Prepend ``tag`` to a PR ``title`` with the message separator; no-op if falsy.
+    """Prepend ``tag`` to a PR ``title``; no-op if falsy.
 
-    Idempotent on any already-tagged title: if ``title`` already begins with the
-    key as a delimited leading token — the ``"{tag} "`` form *or* a punctuation
-    form such as ``"{tag}: …"`` (a common Jira title shape) — it is returned
-    unchanged, so a caller never accumulates a duplicated ``"{tag} {tag}: …"``
-    prefix that weakens Jira auto-linking. Consistent with
+    Entity keys are bracketed (``"[{tag}] …"``); Jira keys stay bare
+    (``"{tag} …"``). Idempotent on the emitted form so a caller never
+    accumulates a duplicated prefix. Consistent with
     :func:`commit_message_with_task_tag`.
     """
     if not tag:
         return title
     if _leads_with_task_key(title, tag):
         return title
+    if _is_entity_key(tag):
+        return f"[{tag}]{MESSAGE_SEP}{title}"
     return f"{tag}{MESSAGE_SEP}{title}"
 
 
 def strip_leading_task_tag(text: str, tag: str | None) -> str:
     """Remove a single leading task key from ``text``; no-op if falsy/absent.
 
-    Strips the key when it leads as a delimited token — the ``"{tag} "`` space
-    form *or* a punctuation form such as ``"{tag}: …"`` (a common Jira title
-    shape) — together with the trailing delimiter run, so the first real word
-    begins the result. The delimited-token check is shared with
-    :func:`title_with_task_tag` / :func:`commit_message_with_task_tag`, so a
-    *longer* key (``PROJ-1234`` when ``tag`` is ``PROJ-123``) is left untouched.
+    Strips the emitted leading form — bracketed for entity keys, bare (space or
+    colon delimiter) for Jira keys — together with the trailing delimiter run.
+    The delimited-token check is shared with :func:`title_with_task_tag` /
+    :func:`commit_message_with_task_tag`, so a *longer* key is left untouched.
 
     Use this before embedding a (possibly already-tagged) ``task_title`` inside a
     composed commit subject such as ``f"awf: {title}"``: stripping the leading key
     first means the subsequent :func:`commit_message_with_task_tag` re-application
-    yields a single leading key (``"{tag} awf: …"``) instead of a duplicated
-    ``"{tag} awf: {tag}: …"`` that weakens Jira auto-linking.
+    yields a single leading key instead of a duplicated prefix.
     """
     if not tag:
         return text
     if not _leads_with_task_key(text, tag):
         return text
-    return re.sub(r"^[^0-9A-Za-z]+", "", text[len(tag) :])
+    prefix_len = len(f"[{tag}]") if _is_entity_key(tag) else len(tag)
+    return re.sub(r"^[^0-9A-Za-z]+", "", text[prefix_len:])
 
 
 def commit_message_with_task_tag(message: str, tag: str | None) -> str:
     """Prepend ``tag`` to a commit ``message``; no-op if falsy.
 
-    Idempotent on any already-tagged message: if ``message`` already begins with
-    the key as a delimited leading token — the ``"{tag} "`` form or a punctuation
-    form such as ``"{tag}: …"`` — it is returned unchanged, so monitor re-runs and
-    ``%B``-reusing reparents never accumulate a double prefix. Consistent with
-    :func:`title_with_task_tag`.
+    Entity keys are bracketed (``"[{tag}] …"``); Jira keys stay bare. Idempotent
+    on the emitted form so monitor re-runs and ``%B``-reusing reparents never
+    accumulate a double prefix. Consistent with :func:`title_with_task_tag`.
     """
     if not tag:
         return message
     if _leads_with_task_key(message, tag):
         return message
+    if _is_entity_key(tag):
+        return f"[{tag}]{MESSAGE_SEP}{message}"
     return f"{tag}{MESSAGE_SEP}{message}"

--- a/src/awf/common/task_tag.py
+++ b/src/awf/common/task_tag.py
@@ -74,7 +74,7 @@ def validate_task_tag(value: str | None) -> str | None:
     candidate = _strip_balanced_brackets(normalized)
     if not candidate:
         raise ValueError(
-            "invalid task tag: expected a Jira issue key like 'PROJ-123' "
+            f"invalid task tag {normalized!r}: expected a Jira issue key like 'PROJ-123' "
             "or an Aira task entity key like 'PROJ-T123' "
             "(uppercase project key, hyphen, number; entity keys use -T<number>)"
         )

--- a/src/awf/mcp/control_tools.py
+++ b/src/awf/mcp/control_tools.py
@@ -197,8 +197,9 @@ def register_control_tools(
             default=None,
             max_length=64,
             description=(
-                "Optional Jira issue key (e.g. PROJ-123) prepended to every "
-                "AWF-authored monitor commit message so fixes link to the issue."
+                "Optional task tag: Jira issue key (e.g. PROJ-123) or Aira task "
+                "entity key (e.g. PROJ-T123). Pass bare keys; bracketed input is "
+                "accepted. Entity keys appear bracketed on AWF monitor commits."
             ),
         ),
         reason: str | None = Field(

--- a/src/awf/mcp/workspace_tools.py
+++ b/src/awf/mcp/workspace_tools.py
@@ -246,8 +246,10 @@ def register_workspace_tools(
             default=None,
             max_length=64,
             description=(
-                "Optional Jira issue key (e.g. PROJ-123) prepended to the branch, PR "
-                "title, and every AWF-authored commit message so work links to the issue."
+                "Optional task tag: Jira issue key (e.g. PROJ-123) or Aira task "
+                "entity key (e.g. PROJ-T123). Pass bare keys; bracketed input is "
+                "accepted. Entity keys appear bracketed on the PR title and AWF "
+                "commits but bare on the branch."
             ),
         ),
         task_class: TaskClass | None = Field(

--- a/tests/unit/api/test_task_tag_schema.py
+++ b/tests/unit/api/test_task_tag_schema.py
@@ -31,6 +31,24 @@ def _create_request(task_tag: str | None | object = "__unset__") -> WorkspaceCre
 
 
 @pytest.mark.unit
+def test_workspace_task_accepts_entity_task_key() -> None:
+    task = WorkspaceTask(title="t", prompt="p", task_tag="AIRA-T299")
+    assert task.task_tag == "AIRA-T299"
+
+
+@pytest.mark.unit
+def test_workspace_task_rejects_feature_entity_key() -> None:
+    with pytest.raises(ValidationError, match="task tag"):
+        WorkspaceTask(title="t", prompt="p", task_tag="AIRA-F42")
+
+
+@pytest.mark.unit
+def test_adoption_request_accepts_entity_task_key() -> None:
+    request = PullRequestMonitorAdoptionRequest(pr_url="https://x/pr/1", task_tag="AIRA-T299")
+    assert request.task_tag == "AIRA-T299"
+
+
+@pytest.mark.unit
 def test_workspace_task_accepts_valid_tag() -> None:
     task = WorkspaceTask(title="t", prompt="p", task_tag="PROJ-123")
     assert task.task_tag == "PROJ-123"

--- a/tests/unit/common/test_task_tag.py
+++ b/tests/unit/common/test_task_tag.py
@@ -264,8 +264,9 @@ def test_validate_jira_regression_aira_299() -> None:
     ],
 )
 def test_validate_rejects_empty_bracket_wrapper(value: str) -> None:
-    with pytest.raises(ValueError, match="task tag"):
+    with pytest.raises(ValueError, match="task tag") as exc_info:
         validate_task_tag(value)
+    assert repr(value) in str(exc_info.value)
 
 
 # --- Entity key title / commit (T2) ---

--- a/tests/unit/common/test_task_tag.py
+++ b/tests/unit/common/test_task_tag.py
@@ -1,6 +1,8 @@
-"""Tests for the task-tag (Jira issue key) helpers."""
+"""Tests for the task-tag (Jira issue key + Aira entity key) helpers."""
 
 from __future__ import annotations
+
+import subprocess
 
 import pytest
 
@@ -202,3 +204,169 @@ def test_commit_message_idempotent_on_colon_form_leading_key() -> None:
     # Same colon-form leading-key guard as title_with_task_tag — the helpers are
     # documented as mutually consistent.
     assert commit_message_with_task_tag("PROJ-123: do work", "PROJ-123") == "PROJ-123: do work"
+
+
+# --- Entity key validation (T1) ---
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["AIRA-T299", "PROJ-T1", "AB-T99999"],
+)
+def test_validate_accepts_entity_task_keys(value: str) -> None:
+    assert validate_task_tag(value) == value
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("[AIRA-T299]", "AIRA-T299"),
+        ("  [AIRA-T299]  ", "AIRA-T299"),
+        ("[ AIRA-T299 ]", "AIRA-T299"),
+    ],
+)
+def test_validate_normalizes_bracketed_entity_keys(value: str, expected: str) -> None:
+    assert validate_task_tag(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "AIRA-F42",  # feature key — task-only
+        "12-T3",  # digit-leading prefix
+        "AIRA-299X",  # trailing junk
+        "aira-t299",  # lowercase
+        "[AIRA-T299",  # unbalanced open bracket
+        "AIRA-T299]",  # unbalanced close bracket
+    ],
+)
+def test_validate_rejects_invalid_entity_shapes(value: str) -> None:
+    with pytest.raises(ValueError, match="task tag"):
+        validate_task_tag(value)
+
+
+def test_validate_error_message_names_both_shapes() -> None:
+    with pytest.raises(ValueError, match="PROJ-123") as exc_info:
+        validate_task_tag("bad-key")
+    message = str(exc_info.value)
+    assert "-T" in message or "entity" in message.lower()
+
+
+def test_validate_jira_regression_aira_299() -> None:
+    assert validate_task_tag("AIRA-299") == "AIRA-299"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "[]",
+        "[   ]",
+    ],
+)
+def test_validate_rejects_empty_bracket_wrapper(value: str) -> None:
+    with pytest.raises(ValueError, match="task tag"):
+        validate_task_tag(value)
+
+
+# --- Entity key title / commit (T2) ---
+
+
+def test_title_with_entity_task_tag_brackets_key() -> None:
+    assert title_with_task_tag("Fix the bug", "AIRA-T299") == "[AIRA-T299] Fix the bug"
+
+
+def test_commit_message_with_entity_task_tag_brackets_key() -> None:
+    assert commit_message_with_task_tag("awf: do work", "AIRA-T299") == "[AIRA-T299] awf: do work"
+
+
+def test_title_jira_regression_stays_bare() -> None:
+    assert title_with_task_tag("Fix the bug", "AIRA-299") == "AIRA-299 Fix the bug"
+
+
+def test_commit_message_jira_regression_stays_bare() -> None:
+    assert commit_message_with_task_tag("awf: do work", "AIRA-299") == "AIRA-299 awf: do work"
+
+
+def test_title_entity_idempotent_on_bracketed_form() -> None:
+    once = title_with_task_tag("Fix the bug", "AIRA-T299")
+    twice = title_with_task_tag(once, "AIRA-T299")
+    assert once == twice == "[AIRA-T299] Fix the bug"
+
+
+def test_commit_message_entity_idempotent_on_bracketed_form() -> None:
+    once = commit_message_with_task_tag("awf: do work", "AIRA-T299")
+    twice = commit_message_with_task_tag(once, "AIRA-T299")
+    assert once == twice == "[AIRA-T299] awf: do work"
+
+
+def test_title_entity_longer_key_boundary_not_treated_as_tagged() -> None:
+    assert title_with_task_tag("[AIRA-T2999] Fix", "AIRA-T299") == ("[AIRA-T299] [AIRA-T2999] Fix")
+    assert title_with_task_tag("AIRA-T2999 Fix", "AIRA-T299") == ("[AIRA-T299] AIRA-T2999 Fix")
+
+
+def test_commit_message_entity_longer_key_boundary_not_treated_as_tagged() -> None:
+    assert commit_message_with_task_tag("[AIRA-T2999] msg", "AIRA-T299") == (
+        "[AIRA-T299] [AIRA-T2999] msg"
+    )
+
+
+# --- Entity key branch (T2) ---
+
+
+def test_branch_with_entity_task_tag_stays_bare() -> None:
+    assert branch_with_task_tag("awf/ws_123", "AIRA-T299") == "AIRA-T299-awf/ws_123"
+
+
+def test_branch_jira_regression_aira_299() -> None:
+    assert branch_with_task_tag("awf/ws_123", "AIRA-299") == "AIRA-299-awf/ws_123"
+
+
+def _assert_git_ref_valid(branch: str) -> None:
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", branch],
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr.decode()
+
+
+@pytest.mark.parametrize("tag", ["AIRA-T299", "AIRA-299", "PROJ-123"])
+def test_branch_with_task_tag_passes_git_check_ref_format(tag: str) -> None:
+    branch = branch_with_task_tag("awf/ws_627d325e3d6144899eef4624", tag)
+    assert "[" not in branch
+    _assert_git_ref_valid(branch)
+
+
+# --- Entity key strip / leads-with (T2) ---
+
+
+def test_strip_leading_task_tag_entity_bracketed_form() -> None:
+    assert strip_leading_task_tag("[AIRA-T299] Fix the bug", "AIRA-T299") == "Fix the bug"
+
+
+def test_strip_leading_task_tag_entity_longer_key_untouched() -> None:
+    assert strip_leading_task_tag("[AIRA-T2999] Fix", "AIRA-T299") == "[AIRA-T2999] Fix"
+
+
+def test_strip_then_commit_tag_entity_yields_single_bracketed_key() -> None:
+    title = "[AIRA-T299] Fix the bug"
+    subject = commit_message_with_task_tag(
+        f"awf: {strip_leading_task_tag(title, 'AIRA-T299')}", "AIRA-T299"
+    )
+    assert subject == "[AIRA-T299] awf: Fix the bug"
+
+
+# --- Integration: all three formatters for entity key (T2) ---
+
+
+def test_entity_key_integration_all_formatters() -> None:
+    tag = "AIRA-T299"
+    title = title_with_task_tag("Async workspace support", tag)
+    commit = commit_message_with_task_tag("awf: initial commit", tag)
+    branch = branch_with_task_tag("awf/ws_627d325e3d6144899eef4624", tag)
+
+    assert title == "[AIRA-T299] Async workspace support"
+    assert commit == "[AIRA-T299] awf: initial commit"
+    assert branch == "AIRA-T299-awf/ws_627d325e3d6144899eef4624"
+    assert "[" not in branch
+    _assert_git_ref_valid(branch)


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_627d325e3d6144899eef4624` (agent: `cursor`, model: `auto`, effort: `high`).


### Task
Implement the AWF change specified in the PLAN below. It has already been engineering-reviewed and Codex-reviewed; the design decisions are LOCKED. Implement exactly as specified.

SCOPE GUARD (important): this task_tag-adjacent code previously spiraled into ~15k lines of over-engineering on PR #708. Do NOT repeat that. Implement ONLY what the plan lists. Do NOT add edge cases, package-manager/scope handling, shell-parsing, or 'robustness' beyond the plan's explicit 'Edge cases' + 'Tests' sections. The Jira shape (-<integer>) and the entity shape (-T<integer>) are provably DISJOINT — do NOT add collision handling. Task keys only; REJECT -F feature keys. Confine the change to src/awf/common/task_tag.py + its tests + the exact 5 doc-string sites named in T3. Keep the module at 100% coverage, mypy + ruff clean, and run the coverage suite before finishing. If a reviewer bot asks for edge cases beyond this plan, reply that they are deliberately out of scope (advisory) rather than implementing them.

=== PLAN ===
# AWF task_tag: accept Aira entity (task) keys + emit bracketed `[AIRA-T299]`

## Problem

AWF's `--task-tag` today accepts only Jira-shaped keys (`^[A-Z][A-Z0-9]+-[0-9]+$`, e.g.
`AIRA-299`) and emits them **bare** on the PR title, branch, and every AWF commit. That is
correct for BitBucket+Jira auto-linking.

But Aira (aira-agent) links a PR to a task differently (verified in
`aira-agent/src/aira_agent/services/github_pr_linker.py`):
- Its task key is an **entity key** `AIRA-T299` — `entity_keys.py:151`:
  `task.key = f"{project.key_prefix}-T{number}"`.
- `extract_task_id_from_pr_title` links **only** when the PR title carries the key in
  **brackets**: `[AIRA-T299] …` (prefix) or `… (AIRA-T299)` / `… [AIRA-T299]` (suffix), and
  resolves the extracted key against `Task.key` / `Task.id` via `select(Task.id, Task.key)`
  (**tasks only**; never `jira_issue_key`, never feature keys).
- Git forbids `[` in ref names (`git check-ref-format` rejects `[AIRA-T299]-…`; proven), so
  the bracket can go on the title/commit but **never** the branch.

So a workspace tagged for an Aira task links to nothing: `AIRA-299` is the wrong key shape
(`AIRA-T299` needed) AND it is bare (Aira needs brackets). PR #764 (`AIRA-299 Async…`) is
the live example — unlinked.

## Decisions (locked in eng-review + Codex outside voice)

1. **Fix AWF only.** AWF is the only layer that can carry the real entity key `AIRA-T299`
   end-to-end; aira-agent already links `[AIRA-T299]` so it needs zero change. The aira-agent
   route is strictly weaker (AWF's validation blocks the entity key from reaching it).
2. **Operator passes the bare key `AIRA-T299`; AWF owns the brackets.** AWF emits
   `[AIRA-T299]` in title/commits and `AIRA-T299-awf/<id>` on the branch. AWF also *accepts*
   `[AIRA-T299]` and normalizes it (strips brackets) so bracketed input is not rejected — but
   bare is the recommended, shell-glob-safe form (`[` is a glob char).
3. **Shape-driven, not a flag.** The tag's shape selects behavior. Jira shape → bare
   everywhere (unchanged). Entity shape (`-T`) → bracketed title/commit, bare-key branch.
4. **Task keys only (reject `-F` feature keys).** Aira's PR linker resolves only against
   `Task.key`; a feature key `AIRA-F42` would emit `[AIRA-F42]` and link to nothing, so we
   reject it with a clear error rather than create a false expectation (fail-loud). Expand to
   `-F` only if/when Aira adds feature-PR linking (one-line pattern change).

**Shape disjointness (why 3 is safe):** a valid Jira key is `PROJECT-<integer>` — the part
after the hyphen is digits only. The entity shape requires `-T<integer>` (a `T` before the
digits). The two are provably disjoint: no valid Jira key can match the entity pattern, so
shape-driven selection never mis-brackets a real Jira key. (Codex flagged a `PROJ-T123`
collision; overridden — `PROJ-T123` is not a valid Jira issue key.)

## Design (all in `src/awf/common/task_tag.py`)

```
                       --task-tag  AIRA-T299   (or [AIRA-T299] — normalized)
                              │
                              ▼
        validate_task_tag():  strip whitespace + strip one balanced surrounding [ ]
                              accept if JIRA-shape OR ENTITY(task)-shape, else ValueError
                              → canonical BARE key, e.g. "AIRA-T299"
                              │
          ┌───────────────────┼─────────────────────────────┐
          ▼                    ▼                             ▼
 title_with_task_tag    commit_message_with_task_tag   branch_with_task_tag
 entity → "[K] title"   entity → "[K] msg"             ALWAYS "K-branch"  (no '[' — git rule)
 jira   → "K title"     jira   → "K msg"               entity → AIRA-T299-awf/<id>
 (idempotent on [K])    (idempotent on [K])            jira   → AIRA-299-awf/<id>
```

Concrete changes:

1. **New pattern + predicate**
   - `ENTITY_KEY_PATTERN = re.compile(r"^[A-Z][A-Z0-9]{1,9}-T[0-9]+$")` — **task-only**,
     **alpha-leading** prefix (2-10 chars total), matching the existing Jira validator's
     `^[A-Z]` posture. (Codex: not `[A-Z0-9]{2,10}` — that admitted digit-leading `12-T3`.)
   - `_is_entity_key(tag: str) -> bool` → `bool(ENTITY_KEY_PATTERN.match(tag))`.

2. **`validate_task_tag`** — after `normalize_task_tag`, strip a single balanced surrounding
   `[...]` (only when it opens `[` and ends `]`), re-normalize whitespace, then accept if
   `TASK_TAG_PATTERN` (Jira) OR `ENTITY_KEY_PATTERN` (task) matches; else the existing
   `ValueError`, message naming BOTH accepted shapes. Returns the canonical **bare** key.

3. **`title_with_task_tag` / `commit_message_with_task_tag`** — bracket only for entity keys:
   - entity: `f"[{tag}]{MESSAGE_SEP}"` → `[AIRA-T299] title`
   - jira: `f"{tag}{MESSAGE_SEP}"` → `AIRA-299 title` (unchanged)
   - **Idempotency guards the EMITTED form** (`[K]` for entity, `{K} `/`{K}:` for Jira). Call
     sites pass a **tag-free** title (`ws.task_title` never carries a key), so the primary
     flow always composes fresh; the guard only stops double-application on already-emitted
     output (reparent/`%B` reuse). Upgrading a legacy bare `K title` → `[K] title` is a
     backfill concern and is **out of scope** (see below).

4. **`branch_with_task_tag`** — unchanged logic, ALWAYS bare `f"{tag}{BRANCH_SEP}{branch}"`.
   Entity `AIRA-T299` → valid ref `AIRA-T299-awf/<id>`. Never brackets.

5. **Idempotency helpers `_leads_with_task_key` / `strip_leading_task_tag`** — **shape-driven**:
   for an entity key recognize/strip the bracketed leading form `[{tag}]` (delimiter `]`);
   for a Jira key keep the bare `{tag} `/`{tag}:` forms. AWF never emits bracketed Jira, so a
   `[AIRA-299]`-bracketed Jira title is not a form AWF produces — the strip stays mode-scoped.

## Edge cases

- `[AIRA-T299]` / `  [AIRA-T299]  ` / `[ AIRA-T299 ]` input → normalized to `AIRA-T299`
  (strip brackets + whitespace, then the strict pattern is the real gate).
- Unbalanced `[AIRA-T299` or `AIRA-T299]` → rejected (only a fully balanced wrapper is stripped).
- Longer-key boundary: tag `AIRA-T299` must not treat `AIRA-T2999 …` or `[AIRA-T2999] …` as
  already-tagged — bracketed check keys on the closing `]`, bare check on the delimiter.
- Case: keys are uppercase (Aira generates them uppercase); lowercase rejected (matches the
  existing Jira posture — no silent uppercasing).
- `AIRA-F42` (feature) → **rejected** (task-only decision).
- `AIRA-299` (Jira) → bare everywhere, byte-identical to today (regression-guarded).

## Tests (`tests/unit/common/test_task_tag*.py` — keep module at 100%)

- `validate`: Jira accept→canonical; entity `AIRA-T299` accept→canonical; `[AIRA-T299]`→
  `AIRA-T299`; **reject** `AIRA-F42`, `12-T3`, `AIRA-299X`, lowercase, `[AIRA-T299`,
  `AIRA-T299]`, empty→None.
- `title`/`commit`: entity→`[K] x`; **Jira→`K x` (regression guard, must stay bare)**;
  idempotent on `[K] x`; falsy tag no-op; longer-key boundary.
- `branch`: entity→`AIRA-T299-x`; **assert the result passes `git check-ref-format --branch`
  via subprocess** (not a hand-rolled regex — Codex: avoids false confidence); Jira→`AIRA-299-x`
  (regression guard); idempotent; falsy no-op.
- `strip_leading_task_tag`/`_leads_with_task_key`: entity strips `[K] `; Jira strips bare
  `K `/`K:`; leaves a longer key untouched.
- **Integration test (Codex): compose all three for one entity key** — assert
  `title_with_task_tag`→`[AIRA-T299] …`, `branch_with_task_tag`→`AIRA-T299-…` (git-valid, no
  `[`), `commit_message_with_task_tag`→`[AIRA-T299] …` together, so a call site can't silently
  bypass a formatter.

## What already exists (reuse, don't rebuild)

- All 6 functions in `task_tag.py` — extended, not rebuilt.
- The 4 formatter call sites (`pr_open_step.py:48`, `provisioner_helpers.py:118`,
  `monitor_handoff_sync.py:275`, executor commit path) — **unchanged** (pass-through).
- **Single validation source (verified):** `api/schemas.py:176` `_validate_task_tag` delegates
  to `validate_task_tag`; the CLI callback (`workspace_commands.py:60`) and MCP tools also
  funnel through it. openapi.json carries only `maxLength: 64` (no `pattern`). So extending the
  one function covers every entry point — **no second gate, no schema/openapi change.**
- Aira's `ENTITY_KEY_PREFIX_PATTERN` shape — mirrored (not imported; different repo).

## NOT in scope

- aira-agent changes — its linker already matches `[AIRA-T299]`; nothing to do.
- `-F` feature keys — rejected (Aira links only `Task.key`); revisit when Aira links features.
- `jira_issue_key`-based linking in aira-agent — needs per-task setup; rejected.
- **Backfill of already-open bare-tagged PRs (e.g. #764)** — they stay bare; only new
  workspaces get the bracketed title. Re-tagging an existing PR is a separate manual action.
  (Corollary: monitors do NOT "upgrade" a legacy bare `AIRA-T299 title` to bracketed.)
- Configurable separator / bracket style — an existing stated non-goal in `task_tag.py`.

## Failure modes (new codepaths)

- Operator types `[AIRA-T299]` unquoted → the **shell** globs it before AWF runs. Mitigation:
  bare is the documented form; AWF still accepts bracketed when quoted. (Shell layer, not
  AWF-testable; documented in `--task-tag` help.)
- Idempotency miss → double prefix `[K] [K] …` weakening Aira linking → covered by the
  bracketed idempotency test (no-op + test) → not silent.
- A branch-formatter change reintroduces `[` → invalid ref, push fails at commit → covered by
  the `git check-ref-format --branch` test → loud, not silent.

## Implementation Tasks

- [ ] **T1 (P1, human ~1.5h / CC ~15min)** — `task_tag.py`: add `ENTITY_KEY_PATTERN`
  (task-only, alpha-lead) + `_is_entity_key`; extend `validate_task_tag` (bracket-strip +
  dual-shape accept, reject `-F`). Verify: `pytest tests/unit/common/test_task_tag*.py`.
- [ ] **T2 (P1, same module)** — shape-driven bracketing in `title_with_task_tag` /
  `commit_message_with_task_tag`; `branch_with_task_tag` stays bare; shape-driven idempotency
  helpers. Verify: new + Jira-regression tests green; branch passes `git check-ref-format`.
- [ ] **T3 (P2, ~10min)** — kill the "Jira issue key" doc drift at ALL 5 sites Codex flagged:
  `cli/workspace_commands.py:75` + `:894`, `mcp/control_tools.py:200`,
  `mcp/workspace_tools.py:249`, and the `api/schemas.py:175` docstring + `task_tag.py` module
  docstring — describe BOTH accepted shapes and the bare-input guidance. Verify:
  `awf workspace create --help` shows both forms; no "PROJ-123"-only description remains.

## GSTACK REVIEW REPORT

| Review | Trigger | Why | Runs | Status | Findings |
|--------|---------|-----|------|--------|----------|
| CEO Review | `/plan-ceo-review` | Scope & strategy | 0 | — | — |
| Codex Review | `/codex review` | Independent 2nd opinion | 1 | issues_found | 12 raised; 1 overridden, ~8 folded, 1 fork resolved (task-only) |
| Eng Review | `/plan-eng-review` | Architecture & tests (required) | 1 | clean | 3 forks resolved (direction, input form, feature keys); 0 critical gaps |
| Design Review | `/plan-design-review` | UI/UX gaps | 0 | — | — |
| DX Review | `/plan-devex-review` | Developer experience gaps | 0 | — | — |

- **CODEX:** surfaced doc-drift (5 sites → T3), the task-vs-feature scope (resolved task-only),
  and idempotency/test refinements (git check-ref-format, integration test) — all folded. The
  second-validation-gate blocker was checked and ruled out (single source via `api/schemas.py:176`).
- **CROSS-MODEL:** one tension — Codex flagged a `PROJ-T123` shape collision; overridden with
  the Jira-key-format reason (Jira keys are `PROJECT-<integer>` only, provably disjoint from `-T<n>`).
- **VERDICT:** ENG CLEARED — ready to implement (AWF-only, `task_tag.py` + tests; T3 doc sweep).

NO UNRESOLVED DECISIONS

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to task-tag validation/formatting with strong unit coverage; Jira paths are regression-tested and existing call sites are unchanged pass-throughs.
> 
> **Overview**
> Extends `--task-tag` so workspaces can link to **Aira task entity keys** (`AIRA-T299`) in addition to Jira issue keys, without changing formatter call sites.
> 
> **`validate_task_tag`** now accepts entity-shaped keys (`-T` + digits), rejects feature keys (`AIRA-F42`), strips optional balanced `[…]` wrappers to a canonical bare key, and keeps Jira keys (`AIRA-299`) behaving as today. **Shape drives output:** entity keys get **`[KEY]`** on PR titles and AWF commit messages; Jira keys stay bare; **branches always use the bare key** (git-safe). Idempotent strip/prefix helpers were updated for bracketed entity forms.
> 
> Docs/help on REST schemas, CLI `--task-tag`, and MCP fields now describe both key shapes and bare-input guidance. Unit tests cover validation, formatting, Jira regressions, and `git check-ref-format` on tagged branch names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c237cf2e6ace83dd4749e503169e3ce7f460701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->