### PR TITLE
chore(deps): ignore eslint 10+ and hypothesis 6.156+ in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,20 @@ updates:
     schedule:
       interval: "weekly"
     target-branch: "development"
+    ignore:
+      # 6.156.x dropped sdist; breaks uv sync on platforms without a wheel.
+      - dependency-name: "hypothesis"
+        versions: [">=6.156.0"]
 
   - package-ecosystem: "npm"
     directory: "/apps/console"
     schedule:
       interval: "weekly"
     target-branch: "development"
+    ignore:
+      # eslint-config-next@16.x plugins still peer-cap at ESLint 9.
+      - dependency-name: "eslint"
+        versions: [">=10.0.0"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Dependabot ignore rules for two bumps that should not land yet:

- **ESLint 10+** — `eslint-config-next@16.2.9` and its plugins (`eslint-plugin-import`, `eslint-plugin-jsx-a11y`, `eslint-plugin-react`) still peer-cap at ESLint 9. The bump in #734 breaks `npm --prefix apps/console run lint` and strict peer installs.
- **Hypothesis 6.156+** — 6.156.1 ships only platform wheels (no sdist), which breaks `uv sync --extra dev` on supported Python versions without a matching wheel (e.g. CPython 3.15). See #741.

After merge, please close #734 and #741 manually (this token cannot close PRs).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8972d792-fe52-4d91-916e-b31e88fad50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8972d792-fe52-4d91-916e-b31e88fad50e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to skip certain newer package versions that are not yet compatible with the project’s current setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->