### PR TITLE
fix(#743): recover blocked workspaces; stop conformance demanding CI-delegated evidence

### DIFF
--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -379,13 +379,43 @@ async def execute(
             return
         if not await _repair_mirror_hooks_path_or_mark_failed(failure_stage="before profile setup"):
             return
+        # On a *directive* blocked-resume (the agent re-runs to act on the operator
+        # directive) the warm venv/stack usually survives the block, so re-running
+        # the often-flaky profile ``setup`` phase is redundant and is the direct
+        # cause of #743 (``uv venv --python 3.14`` re-run dies terminally). Skip
+        # ``setup`` only when a health probe confirms the validate toolchain still
+        # resolves in the container; on ANY doubt (a missing tool, a probe-infra
+        # error, a torn-down stack) fall through to a normal setup run. A
+        # grant-resume (``resume_skip_agent``) always re-runs setup because an
+        # approved config/dep edit may have staled the env.
+        setup_phase_names: tuple[str, ...] = ("setup", "pre_agent")
+        if resume_from_blocked and not resume_skip_agent:
+            env_probe = await self._validation.probe_validate_command_tools(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                profile=profile,
+            )
+            if not env_probe.probe_errored and not env_probe.missing:
+                setup_phase_names = ("pre_agent",)
+                _log.info(
+                    "executor.blocked_resume_setup_skipped_env_healthy",
+                    workspace_id=workspace_id,
+                )
+            else:
+                _log.info(
+                    "executor.blocked_resume_setup_rerun_env_unhealthy",
+                    workspace_id=workspace_id,
+                    probe_errored=env_probe.probe_errored,
+                    missing_tools=[target.tool for target in env_probe.missing],
+                )
         try:
             setup_result = await self._validation.run_profile_phases(
                 workspace_id=workspace_id,
                 compose_project=compose_project,
                 compose_file=compose_file,
                 profile=profile,
-                phase_names=("setup", "pre_agent"),
+                phase_names=setup_phase_names,
                 worktree_path=worktree_path,
             )
         except ComposeExecCleanupError as exc:
@@ -419,6 +449,28 @@ async def execute(
             setup_failure_reason_code = (
                 SETUP_DEPENDENCY_NETWORK_FAILURE if setup_dependency_details is not None else None
             )
+            if resume_from_blocked:
+                # A setup failure on a blocked-resume must not discard the operator
+                # directive and spent work by terminally failing. Re-pause into
+                # ``blocked`` (operator-recoverable) so the operator can resolve the
+                # provisioning issue and re-issue ``guide`` (#743). The wrapper
+                # finalizes any active recovery operations itself and clears the
+                # directive hint, so the worker will not auto-resume straight back
+                # into the same failure (no loop).
+                reblocked = await self.enter_blocked_for_resume_setup_failure(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.running,
+                    resume_phase="setup",
+                    execution_owner_id=execution_owner_id,
+                )
+                _log.info(
+                    "executor.blocked_resume_setup_failed_repaused",
+                    workspace_id=workspace_id,
+                    repaused=reblocked,
+                    reason_code=setup_failure_reason_code,
+                    command=first_fail.command if first_fail is not None else None,
+                )
+                return
             if recovery is not None:
                 recovery_setup_failure_reason_code = (
                     setup_failure_reason_code or "MONITOR_RECOVERY_SETUP_FAILED"

--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -379,36 +379,16 @@ async def execute(
             return
         if not await _repair_mirror_hooks_path_or_mark_failed(failure_stage="before profile setup"):
             return
-        # On a *directive* blocked-resume (the agent re-runs to act on the operator
-        # directive) the warm venv/stack usually survives the block, so re-running
-        # the often-flaky profile ``setup`` phase is redundant and is the direct
-        # cause of #743 (``uv venv --python 3.14`` re-run dies terminally). Skip
-        # ``setup`` only when a health probe confirms the validate toolchain still
-        # resolves in the container; on ANY doubt (a missing tool, a probe-infra
-        # error, a torn-down stack) fall through to a normal setup run. A
-        # grant-resume (``resume_skip_agent``) always re-runs setup because an
-        # approved config/dep edit may have staled the env.
-        setup_phase_names: tuple[str, ...] = ("setup", "pre_agent")
-        if resume_from_blocked and not resume_skip_agent:
-            env_probe = await self._validation.probe_validate_command_tools(
-                workspace_id=workspace_id,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                profile=profile,
-            )
-            if not env_probe.probe_errored and not env_probe.missing:
-                setup_phase_names = ("pre_agent",)
-                _log.info(
-                    "executor.blocked_resume_setup_skipped_env_healthy",
-                    workspace_id=workspace_id,
-                )
-            else:
-                _log.info(
-                    "executor.blocked_resume_setup_rerun_env_unhealthy",
-                    workspace_id=workspace_id,
-                    probe_errored=env_probe.probe_errored,
-                    missing_tools=[target.tool for target in env_probe.missing],
-                )
+        # Directive resume reuses the warm env + skips flaky ``setup`` when healthy;
+        # grant/normal re-run it (#743). See ``_blocked_resume_setup_phase_names``.
+        setup_phase_names = await self._blocked_resume_setup_phase_names(
+            workspace_id=workspace_id,
+            compose_project=compose_project,
+            compose_file=compose_file,
+            profile=profile,
+            resume_from_blocked=resume_from_blocked,
+            resume_skip_agent=resume_skip_agent,
+        )
         try:
             setup_result = await self._validation.run_profile_phases(
                 workspace_id=workspace_id,
@@ -450,25 +430,13 @@ async def execute(
                 SETUP_DEPENDENCY_NETWORK_FAILURE if setup_dependency_details is not None else None
             )
             if resume_from_blocked:
-                # A setup failure on a blocked-resume must not discard the operator
-                # directive and spent work by terminally failing. Re-pause into
-                # ``blocked`` (operator-recoverable) so the operator can resolve the
-                # provisioning issue and re-issue ``guide`` (#743). The wrapper
-                # finalizes any active recovery operations itself and clears the
-                # directive hint, so the worker will not auto-resume straight back
-                # into the same failure (no loop).
-                reblocked = await self.enter_blocked_for_resume_setup_failure(
+                # Setup failure on a blocked-resume re-pauses into ``blocked``
+                # instead of terminally failing (#743). See helper below.
+                await self._reblock_on_resume_setup_failure(
                     workspace_id=workspace_id,
-                    from_status=WorkspaceStatus.running,
-                    resume_phase="setup",
                     execution_owner_id=execution_owner_id,
-                )
-                _log.info(
-                    "executor.blocked_resume_setup_failed_repaused",
-                    workspace_id=workspace_id,
-                    repaused=reblocked,
-                    reason_code=setup_failure_reason_code,
-                    command=first_fail.command if first_fail is not None else None,
+                    setup_failure_reason_code=setup_failure_reason_code,
+                    first_fail=first_fail,
                 )
                 return
             if recovery is not None:

--- a/src/awf/control/executor/execution_flow.py
+++ b/src/awf/control/executor/execution_flow.py
@@ -379,16 +379,16 @@ async def execute(
             return
         if not await _repair_mirror_hooks_path_or_mark_failed(failure_stage="before profile setup"):
             return
-        # Directive resume reuses the warm env + skips flaky ``setup`` when healthy;
-        # grant/normal re-run it (#743). See ``_blocked_resume_setup_phase_names``.
-        setup_phase_names = await self._blocked_resume_setup_phase_names(
-            workspace_id=workspace_id,
-            compose_project=compose_project,
-            compose_file=compose_file,
-            profile=profile,
-            resume_from_blocked=resume_from_blocked,
-            resume_skip_agent=resume_skip_agent,
-        )
+        # A directive resume reuses the warm env + skips flaky ``setup`` when a
+        # probe passes; grant/normal runs re-run it (#743).
+        setup_phase_names: tuple[str, ...] = ("setup", "pre_agent")
+        if resume_from_blocked and not resume_skip_agent:
+            setup_phase_names = await self._blocked_resume_setup_phase_names(
+                workspace_id=workspace_id,
+                compose_project=compose_project,
+                compose_file=compose_file,
+                profile=profile,
+            )
         try:
             setup_result = await self._validation.run_profile_phases(
                 workspace_id=workspace_id,

--- a/src/awf/control/executor/mixins.py
+++ b/src/awf/control/executor/mixins.py
@@ -151,6 +151,7 @@ class ExecutorDelegatesMixin:
     _record_health_check_failed_event = _state_ops._record_health_check_failed_event
     _mark_failed = _state_ops._mark_failed
     enter_blocked_for_protected_violation = _state_ops.enter_blocked_for_protected_violation
+    enter_blocked_for_resume_setup_failure = _state_ops.enter_blocked_for_resume_setup_failure
     enter_recovering_for_provider_failure = _state_ops.enter_recovering_for_provider_failure
     _persist_block_baseline_coverage = _state_ops._persist_block_baseline_coverage
     _persist_block_planning_conformance_handoff = (

--- a/src/awf/control/executor/mixins.py
+++ b/src/awf/control/executor/mixins.py
@@ -153,6 +153,8 @@ class ExecutorDelegatesMixin:
     enter_blocked_for_protected_violation = _state_ops.enter_blocked_for_protected_violation
     enter_blocked_for_resume_setup_failure = _state_ops.enter_blocked_for_resume_setup_failure
     enter_recovering_for_provider_failure = _state_ops.enter_recovering_for_provider_failure
+    _blocked_resume_setup_phase_names = _state_ops._blocked_resume_setup_phase_names
+    _reblock_on_resume_setup_failure = _state_ops._reblock_on_resume_setup_failure
     _persist_block_baseline_coverage = _state_ops._persist_block_baseline_coverage
     _persist_block_planning_conformance_handoff = (
         _state_ops._persist_block_planning_conformance_handoff

--- a/src/awf/control/executor/planning_conformance.py
+++ b/src/awf/control/executor/planning_conformance.py
@@ -61,6 +61,10 @@ from awf.runtime.planning import (
     build_conformance_failure_evidence,
     build_conformance_prompt,
     parse_conformance_report,
+    satisfied_report_for_ci_delegated_validation,
+)
+from awf.runtime.validation_setup import (
+    validate_phase_command_strings,
 )
 from awf.service.artifacts import (
     DEPOSITED_CONFORMANCE_NAME,
@@ -251,8 +255,9 @@ async def _run_post_validation_conformance_check(
     conformance_scope_baseline: _PostValidationConformanceScopeBaseline | None = None,
 ) -> _PlanningRunFailure | None:
     # Post-validation conformance is strictly report-only, regardless of
-    # ordinary planning unexplained-deviation policy.
-    del profile
+    # ordinary planning unexplained-deviation policy. ``profile`` is still needed
+    # to pin the AWF validation command set in the prompt (#743).
+    awf_validation_commands = validate_phase_command_strings(profile)
     evidence = await self._validation_run_evidence_for_conformance(validation_run_id)
     if conformance_scope_baseline is None:
         conformance_scope_baseline = await self._capture_post_validation_conformance_scope_baseline(
@@ -286,6 +291,7 @@ async def _run_post_validation_conformance_check(
             report_path=agent_report_path,
             iteration=handoff.iteration + 1,
             validation_evidence=evidence,
+            awf_validation_commands=awf_validation_commands,
         ),
         model=model,
         workspace_id=workspace.id,
@@ -324,7 +330,27 @@ async def _run_post_validation_conformance_check(
         report_text = compare_result.stdout
     report = parse_conformance_report(report_text or "")
     if not report.satisfied:
-        return _build_unsatisfied_failure(report, handoff, validation_run_id)
+        # This recheck runs only inside the ``val_result.all_passed`` branch, so
+        # AWF has produced every piece of evidence it is configured to produce.
+        # If the agent's only remaining gaps are awf_validation_evidence demands,
+        # they are for commands AWF does not run (delegated to CI) — resolve as
+        # satisfied instead of failing and pushing the agent into editing the
+        # protected ``.awf/workspace.yml`` to force AWF to run them (#743).
+        ci_delegated_report = satisfied_report_for_ci_delegated_validation(report)
+        if ci_delegated_report is None:
+            return _build_unsatisfied_failure(report, handoff, validation_run_id)
+        _log.info(
+            "executor.post_validation_conformance_ci_delegated_satisfied",
+            workspace_id=workspace.id,
+            validation_run_id=validation_run_id,
+            gaps=list(report.gaps),
+            reason_code=report.reason_code,
+        )
+        report = ci_delegated_report
+        # The agent's on-disk report is the not-satisfied one we just coerced, so
+        # it no longer matches the satisfied report we serve. Force the rewrite
+        # below so the served artifact and the recorded event agree.
+        report_from_fresh_file = False
     # Track whether the on-worktree report actually carries the satisfied
     # report we want to serve. A fresh file is already correct; an AWF-
     # synthesized rewrite from stdout/stale disk is correct only when the

--- a/src/awf/control/executor/planning_ops.py
+++ b/src/awf/control/executor/planning_ops.py
@@ -72,6 +72,9 @@ from awf.runtime.planning import (
     parse_conformance_report,
     render_workspace_path,
 )
+from awf.runtime.validation_setup import (
+    validate_phase_command_strings,
+)
 from awf.runtime.workspace_prompt_context import (
     render_workspace_runtime_context,
 )
@@ -1025,6 +1028,7 @@ async def _run_agent_task_with_optional_planning(
                     plan_path=agent_plan_path,
                     report_path=agent_report_path,
                     iteration=iteration,
+                    awf_validation_commands=validate_phase_command_strings(profile),
                 ),
                 model=model,
                 workspace_id=workspace.id,

--- a/src/awf/control/executor/state_ops.py
+++ b/src/awf/control/executor/state_ops.py
@@ -12,7 +12,7 @@ from datetime import (
     UTC,
     datetime,
 )
-from typing import Any
+from typing import Any, Final
 
 from sqlalchemy import (
     String,
@@ -50,6 +50,7 @@ from awf.control.operator_grants import (
     consume_active_operator_grants_in_session,
 )
 from awf.control.quality_gates import (
+    PROTECTED_QUALITY_GATE_BLOCK_TYPE,
     QUALITY_GATE_POLICY_CHANGED_REASON_CODE,
     GrantSpec,
     QualityGateViolation,
@@ -472,9 +473,24 @@ async def enter_blocked_for_protected_violation(
     violations: Sequence[QualityGateViolation],
     resume_phase: str,
     execution_owner_id: str | None = None,
+    block_type: str = PROTECTED_QUALITY_GATE_BLOCK_TYPE,
+    block_reason_code: str = QUALITY_GATE_POLICY_CHANGED_REASON_CODE,
+    stale_action: str = "enter_blocked_for_protected_violation",
+    recovery_finalize_reason_code: str = QUALITY_GATE_POLICY_CHANGED_REASON_CODE,
+    recovery_finalize_message: str = (
+        "Protected quality-gate violation paused the workspace mid-recovery."
+    ),
 ) -> bool:
     """Pause a workspace into ``blocked`` for an operator decision instead of
-    terminally failing on a protected quality-gate violation.
+    terminally failing.
+
+    Defaults describe the protected quality-gate pause (its original and primary
+    caller). The ``block_type`` / ``block_reason_code`` / ``stale_action`` /
+    ``recovery_finalize_*`` parameters let other non-terminal pause causes reuse
+    the exact same epoch-fenced CAS, warm-stack preservation, stale-skip, and
+    mid-recovery finalization — e.g. a resume-time profile-setup failure (#743),
+    which re-blocks (operator-recoverable) instead of terminally failing and
+    discarding the operator directive.
 
     This is the single entry point used at every pre-PR protected-gate fail site:
     it replaces ``_mark_failed(... QUALITY_GATE_POLICY_CHANGED ...)`` so the spent
@@ -502,6 +518,8 @@ async def enter_blocked_for_protected_violation(
             from_status=from_status,
             violations=violations,
             resume_phase=resume_phase,
+            block_type=block_type,
+            block_reason_code=block_reason_code,
             execution_owner_id=execution_owner_id,
         )
         if ws is None:
@@ -510,7 +528,7 @@ async def enter_blocked_for_protected_violation(
                 await self._record_stale_action_skip(
                     repo,
                     current,
-                    action="enter_blocked_for_protected_violation",
+                    action=stale_action,
                     expected=from_status,
                     reason_code="EXECUTOR_ENTER_BLOCKED_SKIPPED",
                 )
@@ -522,7 +540,7 @@ async def enter_blocked_for_protected_violation(
                         session,
                         workspace_id=workspace_id,
                         callback_source="executor",
-                        callback_action="enter_blocked_for_protected_violation",
+                        callback_action=stale_action,
                         expected_status=from_status,
                         actual_status=current.status,
                     )
@@ -550,11 +568,52 @@ async def enter_blocked_for_protected_violation(
             session,
             workspace_id=workspace_id,
             status=OperationStatus.failed,
-            reason_code=QUALITY_GATE_POLICY_CHANGED_REASON_CODE,
-            error_message=("Protected quality-gate violation paused the workspace mid-recovery."),
+            reason_code=recovery_finalize_reason_code,
+            error_message=recovery_finalize_message,
         )
         await session.commit()
         return True
+
+
+RESUME_SETUP_FAILURE_BLOCK_TYPE: Final[str] = "resume_setup_failure"
+"""``block_type`` recorded when profile setup fails on a blocked-resume (#743)."""
+RESUME_SETUP_FAILED_REASON_CODE: Final[str] = "RESUME_SETUP_FAILED"
+"""Block reason code for a resume-time profile-setup failure."""
+
+
+async def enter_blocked_for_resume_setup_failure(
+    self: Any,
+    *,
+    workspace_id: str,
+    from_status: WorkspaceStatus,
+    resume_phase: str,
+    execution_owner_id: str | None = None,
+) -> bool:
+    """Re-pause a resumed workspace into ``blocked`` when profile setup fails on a
+    blocked-resume, instead of terminally failing (#743).
+
+    On a blocked-resume the warm venv/stack usually survives, so setup is skipped
+    when a health probe passes (see ``execute``). When setup DOES run on a resume
+    and fails — a genuinely torn-down env whose ``uv venv`` cannot rebuild —
+    terminally failing would discard the operator directive and the spent work.
+    Re-blocking keeps the workspace operator-recoverable: reusing the protected
+    pause's epoch-fenced CAS clears the directive hint (so the worker does not
+    auto-resume straight back into the same failure — no loop) and the operator
+    can re-issue ``guide`` once the underlying provisioning issue is resolved.
+    """
+    return await enter_blocked_for_protected_violation(
+        self,
+        workspace_id=workspace_id,
+        from_status=from_status,
+        violations=(),
+        resume_phase=resume_phase,
+        execution_owner_id=execution_owner_id,
+        block_type=RESUME_SETUP_FAILURE_BLOCK_TYPE,
+        block_reason_code=RESUME_SETUP_FAILED_REASON_CODE,
+        stale_action="enter_blocked_for_resume_setup_failure",
+        recovery_finalize_reason_code=RESUME_SETUP_FAILED_REASON_CODE,
+        recovery_finalize_message=("Profile setup failed on blocked-resume; paused for operator."),
+    )
 
 
 class ProviderFailureDivert(enum.Enum):

--- a/src/awf/control/executor/state_ops.py
+++ b/src/awf/control/executor/state_ops.py
@@ -624,19 +624,15 @@ async def _blocked_resume_setup_phase_names(
     compose_project: str,
     compose_file: Path,
     profile: WorkspaceProfile,
-    resume_from_blocked: bool,
-    resume_skip_agent: bool,
 ) -> tuple[str, ...]:
-    """Return the profile-setup phase set to run on this ``execute`` entry (#743).
+    """Return the profile-setup phase set for a *directive* blocked-resume (#743).
 
-    A *directive* blocked-resume (the agent re-runs) reuses the warm venv/stack and
-    SKIPS the flaky ``setup`` phase when an env-health probe confirms the validate
-    toolchain still resolves in the container; on ANY doubt (a missing tool, a
-    probe-infra error, a torn-down stack) it re-runs setup. Grant-resume and normal
-    runs always run setup, since an approved config/dep edit may have staled the env.
+    The caller invokes this only on a directive resume (the agent re-runs). It
+    reuses the warm venv/stack and SKIPS the flaky ``setup`` phase when an
+    env-health probe confirms the validate toolchain still resolves in the
+    container; on ANY doubt (a missing tool, a probe-infra error, a torn-down
+    stack) it re-runs setup.
     """
-    if not (resume_from_blocked and not resume_skip_agent):
-        return ("setup", "pre_agent")
     env_probe = await self._validation.probe_validate_command_tools(
         workspace_id=workspace_id,
         compose_project=compose_project,

--- a/src/awf/control/executor/state_ops.py
+++ b/src/awf/control/executor/state_ops.py
@@ -12,6 +12,7 @@ from datetime import (
     UTC,
     datetime,
 )
+from pathlib import Path
 from typing import Any, Final
 
 from sqlalchemy import (
@@ -613,6 +614,73 @@ async def enter_blocked_for_resume_setup_failure(
         stale_action="enter_blocked_for_resume_setup_failure",
         recovery_finalize_reason_code=RESUME_SETUP_FAILED_REASON_CODE,
         recovery_finalize_message=("Profile setup failed on blocked-resume; paused for operator."),
+    )
+
+
+async def _blocked_resume_setup_phase_names(
+    self: Any,
+    *,
+    workspace_id: str,
+    compose_project: str,
+    compose_file: Path,
+    profile: WorkspaceProfile,
+    resume_from_blocked: bool,
+    resume_skip_agent: bool,
+) -> tuple[str, ...]:
+    """Return the profile-setup phase set to run on this ``execute`` entry (#743).
+
+    A *directive* blocked-resume (the agent re-runs) reuses the warm venv/stack and
+    SKIPS the flaky ``setup`` phase when an env-health probe confirms the validate
+    toolchain still resolves in the container; on ANY doubt (a missing tool, a
+    probe-infra error, a torn-down stack) it re-runs setup. Grant-resume and normal
+    runs always run setup, since an approved config/dep edit may have staled the env.
+    """
+    if not (resume_from_blocked and not resume_skip_agent):
+        return ("setup", "pre_agent")
+    env_probe = await self._validation.probe_validate_command_tools(
+        workspace_id=workspace_id,
+        compose_project=compose_project,
+        compose_file=compose_file,
+        profile=profile,
+    )
+    if not env_probe.probe_errored and not env_probe.missing:
+        _log.info("executor.blocked_resume_setup_skipped_env_healthy", workspace_id=workspace_id)
+        return ("pre_agent",)
+    _log.info(
+        "executor.blocked_resume_setup_rerun_env_unhealthy",
+        workspace_id=workspace_id,
+        probe_errored=env_probe.probe_errored,
+        missing_tools=[target.tool for target in env_probe.missing],
+    )
+    return ("setup", "pre_agent")
+
+
+async def _reblock_on_resume_setup_failure(
+    self: Any,
+    *,
+    workspace_id: str,
+    execution_owner_id: str | None,
+    setup_failure_reason_code: str | None,
+    first_fail: Any,
+) -> None:
+    """Re-pause a blocked-resume into ``blocked`` on a setup failure (#743).
+
+    Terminally failing would discard the operator directive and the spent work; the
+    workspace stays operator-recoverable instead. The wrapper clears the directive
+    hint so the worker does not auto-resume straight back into the same failure.
+    """
+    reblocked = await self.enter_blocked_for_resume_setup_failure(
+        workspace_id=workspace_id,
+        from_status=WorkspaceStatus.running,
+        resume_phase="setup",
+        execution_owner_id=execution_owner_id,
+    )
+    _log.info(
+        "executor.blocked_resume_setup_failed_repaused",
+        workspace_id=workspace_id,
+        repaused=reblocked,
+        reason_code=setup_failure_reason_code,
+        command=first_fail.command if first_fail is not None else None,
     )
 
 

--- a/src/awf/control/quality_gates.py
+++ b/src/awf/control/quality_gates.py
@@ -32,8 +32,10 @@ class GrantSpec:
     approve_policy_downgrade: bool = False
 
 
+AWF_WORKSPACE_CONFIG_PATH: Final[str] = ".awf/workspace.yml"
+"""Repo-relative path of the AWF workspace config (a protected quality-gate file)."""
 PROTECTED_QUALITY_GATE_PATHS: Final[tuple[str, ...]] = (
-    ".awf/workspace.yml",
+    AWF_WORKSPACE_CONFIG_PATH,
     ".coveragerc",
     ".github/workflows/",
     "pyproject.toml",
@@ -418,13 +420,22 @@ def quality_gate_violation_message(violations: list[QualityGateViolation]) -> st
     """Build an operator-facing failure message for protected gate edits."""
     details = "\n".join(f"- {_format_violation_detail(v)}" for v in violations[:8])
     suffix = "" if len(violations) <= 8 else f"\n- ... and {len(violations) - 8} more"
-    return (
+    message = (
         "agent changed protected quality-gate file(s) outside declared owned_paths:\n"
         f"{details}{suffix}\n"
         "AWF only allows narrowly classified safe protected-file edits without "
         "explicit ownership. Add meaningful tests or declare explicit ownership "
         "of the policy file when an operator-approved policy change is required."
     )
+    if any(_normalize_path(v.path) == AWF_WORKSPACE_CONFIG_PATH for v in violations):
+        message += (
+            f"\nNote: editing AWF validation config in {AWF_WORKSPACE_CONFIG_PATH} "
+            "has no effect mid-run — `requested_tier` is set at dispatch "
+            "(validation.requested_tier) and `final_gate` is fixed at provision "
+            "time. Do not edit the file to raise the AWF validation level; a "
+            "validation command the repo delegates to CI is gated by CI, not AWF."
+        )
+    return message
 
 
 def quality_gate_violation_details(
@@ -462,6 +473,33 @@ def diff_classified_protected_paths(
     for raw_path in changed_paths:
         path = _normalize_path(raw_path)
         if path and requires_protected_file_diff(path) and not _is_owned(path, owned_paths):
+            paths.append(path)
+    return tuple(dict.fromkeys(paths))
+
+
+def unowned_protected_paths(
+    changed_paths: Sequence[str],
+    *,
+    owned_paths: Sequence[str] = (),
+) -> tuple[str, ...]:
+    """Return changed paths matching a protected quality-gate pattern that are not
+    covered by ``owned_paths`` (normalized, dedup-ordered).
+
+    Unlike :func:`diff_classified_protected_paths` (pyproject/workflow only, for
+    diff classification), this covers *every* protected pattern. Conformance
+    salvage uses it to drop a protected edit the agent never owned so a retry
+    cannot re-apply the exact change that caused the block (#743). Uses the same
+    normalization and ownership check as the gate itself, so the exclusion can
+    never drift from what the gate protects.
+    """
+    paths: list[str] = []
+    for raw_path in changed_paths:
+        path = _normalize_path(raw_path)
+        if (
+            path
+            and _matched_protected_pattern(path) is not None
+            and not _is_owned(path, owned_paths)
+        ):
             paths.append(path)
     return tuple(dict.fromkeys(paths))
 
@@ -534,6 +572,8 @@ __all__ = [
     "protected_quality_gate_pattern",
     "requires_protected_file_diff",
     "diff_classified_protected_paths",
+    "unowned_protected_paths",
+    "AWF_WORKSPACE_CONFIG_PATH",
     "changed_paths_are_only_internal_plan_artifacts",
     "plan_only_output_message",
 ]

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -381,6 +381,39 @@ def build_execution_prompt(
     )
 
 
+def _awf_validation_scope_section(awf_validation_commands: Sequence[str] | None) -> str:
+    """Render the conformance-prompt section that pins AWF's validation scope.
+
+    Passing the resolved ``validate:`` command set (empty tuple included) lets the
+    agent tell an AWF-owned gate from a CI-delegated one, so it stops raising
+    ``awf_validation_evidence`` for commands AWF never runs — and stops editing
+    the protected ``.awf/workspace.yml`` to force AWF to run them (#743). ``None``
+    means "caller did not supply the set" and renders nothing (back-compat).
+    """
+    if awf_validation_commands is None:
+        return ""
+    if awf_validation_commands:
+        command_lines = "\n".join(f"- `{command}`" for command in awf_validation_commands)
+        return (
+            "### AWF validation scope\n"
+            "AWF's validation phase for this workspace runs exactly these commands:\n"
+            f"{command_lines}\n"
+            "A validation command that is NOT in this set (for example a test "
+            "command the repo delegates to GitHub CI) is gated by CI, not AWF. Do "
+            "not report an `awf_validation_evidence` gap for a command outside this "
+            "set, and never edit `.awf/workspace.yml` to make AWF run it — that file "
+            "is a protected quality gate and its validation config is fixed at "
+            "dispatch time.\n\n"
+        )
+    return (
+        "### AWF validation scope\n"
+        "AWF's validation phase for this workspace runs no agent-visible validation "
+        "commands; all such gates are delegated to GitHub CI. Do not report an "
+        "`awf_validation_evidence` gap, and never edit `.awf/workspace.yml` to add "
+        "one.\n\n"
+    )
+
+
 def build_conformance_prompt(
     *,
     task_prompt: str,
@@ -388,12 +421,14 @@ def build_conformance_prompt(
     report_path: Path,
     iteration: int,
     validation_evidence: str | None = None,
+    awf_validation_commands: Sequence[str] | None = None,
 ) -> str:
     validation_evidence_section = (
         f"### Validation evidence\n{validation_evidence.strip()}\n\n"
         if validation_evidence and validation_evidence.strip()
         else ""
     )
+    awf_validation_scope_section = _awf_validation_scope_section(awf_validation_commands)
     gap_kind_lines = "\n".join(
         f"- `{kind.value}`: {_gap_kind_definition(kind)}" for kind in GapKind
     )
@@ -415,6 +450,7 @@ def build_conformance_prompt(
         "`CONFORMANCE_REQUIRES_AWF_VALIDATION` only when "
         "every remaining gap is missing, stale, or insufficient AWF-owned validation "
         "evidence. Do not use it for implementation, API, plan, or documentation gaps.\n\n"
+        f"{awf_validation_scope_section}"
         f"{validation_evidence_section}"
         f"Write a JSON object to `{report_path.as_posix()}` and also print the same JSON object "
         "as your final response. The object must have this shape:\n\n"
@@ -472,6 +508,40 @@ def conformance_requires_awf_validation(
     if not all(gap.kind is GapKind.awf_validation_evidence for gap in report.gaps):
         return False
     return bool(before_compare)
+
+
+def satisfied_report_for_ci_delegated_validation(
+    report: PlanConformanceReport,
+) -> PlanConformanceReport | None:
+    """Return a *satisfied* equivalent of ``report`` when every remaining gap is
+    an AWF-validation-evidence demand, else ``None``.
+
+    Callers invoke this only after AWF's validation phase has already passed all
+    of its resolved commands (the post-validation conformance recheck runs inside
+    the ``val_result.all_passed`` branch). At that point AWF has produced every
+    piece of evidence it is configured to produce, so a still-standing
+    ``awf_validation_evidence`` gap is necessarily a demand for a command AWF
+    does not run — a check the repo delegates to CI. Resolving conformance as
+    satisfied here stops the loop that otherwise fails with
+    ``PLAN_CONFORMANCE_UNSATISFIED`` and pushes the agent into editing the
+    protected ``.awf/workspace.yml`` to force AWF to run the CI-delegated command
+    (#743). Any non-validation gap (implementation, test, docs, …) still fails,
+    so genuine plan gaps are unaffected.
+    """
+    if report.satisfied:
+        return None
+    if not report.gaps:
+        return None
+    if not all(gap.kind is GapKind.awf_validation_evidence for gap in report.gaps):
+        return None
+    return PlanConformanceReport(
+        status=PlanConformanceStatus.satisfied,
+        summary=(
+            "AWF validation passed; remaining checks are delegated to CI and are "
+            f"not part of the AWF validate set. {report.summary}".strip()
+        ),
+        reason_code=report.reason_code,
+    )
 
 
 def classify_conformance_stall(

--- a/src/awf/runtime/planning.py
+++ b/src/awf/runtime/planning.py
@@ -29,6 +29,9 @@ if TYPE_CHECKING:
 PLAN_CONFORMANCE_UNSATISFIED = "PLAN_CONFORMANCE_UNSATISFIED"
 PLAN_CONFORMANCE_REPORTED = "PLAN_CONFORMANCE_REPORTED"
 CONFORMANCE_REQUIRES_AWF_VALIDATION = "CONFORMANCE_REQUIRES_AWF_VALIDATION"
+CONFORMANCE_CI_DELEGATED_SATISFIED = "CONFORMANCE_CI_DELEGATED_SATISFIED"
+"""Satisfied-flavour reason code for a conformance outcome resolved as CI-delegated
+(AWF validation passed; the only remaining gaps are for commands AWF does not run)."""
 AGENT_PLAN_PHASE_SCOPE_VIOLATION = "AGENT_PLAN_PHASE_SCOPE_VIOLATION"
 AGENT_STALLED_IN_CONFORMANCE = "AGENT_STALLED_IN_CONFORMANCE"
 AGENT_IDLE_TIMEOUT_REASON_CODE = "AGENT_IDLE_TIMEOUT"
@@ -540,7 +543,9 @@ def satisfied_report_for_ci_delegated_validation(
             "AWF validation passed; remaining checks are delegated to CI and are "
             f"not part of the AWF validate set. {report.summary}".strip()
         ),
-        reason_code=report.reason_code,
+        # A satisfied outcome must not carry the unsatisfied-flavour reason code it
+        # was coerced from — downstream event/observability code reads this field.
+        reason_code=CONFORMANCE_CI_DELEGATED_SATISFIED,
     )
 
 

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -174,18 +174,25 @@ _HTTP_HEALTHCHECK_SCRIPT = (
 
 
 def validate_phase_command_strings(profile: WorkspaceProfile) -> list[str]:
-    """Return the resolved AWF ``validate:`` command strings for a profile.
+    """Return the resolved AWF-owned validation command strings for a profile.
 
-    This is the exact AWF-owned validation command set (``post_agent`` +
-    ``validate`` phases, in execution order) that AWF runs after the agent
-    completes. Callers use it to distinguish an AWF-owned validation gate from a
-    command the repo delegates to CI, so plan-conformance does not demand
-    AWF-internal evidence for a CI-delegated command (#743).
+    This is the exact command set AWF runs after the agent completes: the
+    ``post_agent`` + ``validate`` phase commands (in execution order) PLUS the
+    profile's coverage ``final_gate`` command when ``final_gate == "coverage"``.
+    Callers use it to distinguish an AWF-owned validation gate from a command the
+    repo delegates to CI, so plan-conformance does not demand AWF-internal
+    evidence for a CI-delegated command (#743). The coverage final-gate command
+    must be included, or a profile with an empty ``validate:`` set + a local
+    coverage gate would be misreported as running no AWF validation at all.
     """
-    return [
+    commands = [
         step.command.command
         for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
     ]
+    coverage_command = profile.validation.coverage.command
+    if profile.validation.strategy.final_gate == "coverage" and coverage_command is not None:
+        commands.append(coverage_command.command)
+    return commands
 
 
 def profile_phase_command_plan(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -173,6 +173,21 @@ _HTTP_HEALTHCHECK_SCRIPT = (
 )
 
 
+def validate_phase_command_strings(profile: WorkspaceProfile) -> list[str]:
+    """Return the resolved AWF ``validate:`` command strings for a profile.
+
+    This is the exact AWF-owned validation command set (``post_agent`` +
+    ``validate`` phases, in execution order) that AWF runs after the agent
+    completes. Callers use it to distinguish an AWF-owned validation gate from a
+    command the repo delegates to CI, so plan-conformance does not demand
+    AWF-internal evidence for a CI-delegated command (#743).
+    """
+    return [
+        step.command.command
+        for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
+    ]
+
+
 def profile_phase_command_plan(
     profile: WorkspaceProfile,
     phase_names: list[str] | tuple[str, ...],

--- a/src/awf/service/conformance_salvage.py
+++ b/src/awf/service/conformance_salvage.py
@@ -7,12 +7,13 @@ import json
 import os
 import subprocess
 import tempfile
-from collections.abc import Mapping
-from dataclasses import dataclass
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from awf.control.quality_gates import unowned_protected_paths
 from awf.runtime.planning import build_conformance_retry_prompt
 from awf.service._git_salvage_utils import (
     CompletedProcessLike,
@@ -59,6 +60,7 @@ class ConformanceSalvageCapture:
     created_at: str
     plan_path: str | None = None
     report_path: str | None = None
+    quarantined_protected_paths: list[str] = field(default_factory=list)
 
     def as_policy(self) -> dict[str, Any]:
         """Convert capture metadata into a plan-policy payload."""
@@ -83,6 +85,8 @@ class ConformanceSalvageCapture:
             payload["plan_path"] = self.plan_path
         if self.report_path:
             payload["report_path"] = self.report_path
+        if self.quarantined_protected_paths:
+            payload["quarantined_protected_paths"] = self.quarantined_protected_paths
         return payload
 
 
@@ -111,9 +115,17 @@ def capture_conformance_salvage(
     conformance_evidence_ref: dict[str, str] | None,
     source_branch_name: str | None,
     source_remote_push_branch: str | None,
+    owned_paths: Sequence[str] = (),
     run_subprocess: SubprocessRun | None = None,
 ) -> ConformanceSalvageCapture:
-    """Capture a salvage patch and metadata from a failed workspace run."""
+    """Capture a salvage patch and metadata from a failed workspace run.
+
+    ``owned_paths`` is the source attempt's declared ownership. Any changed
+    protected quality-gate file NOT covered by it (e.g. an ``.awf/workspace.yml``
+    edit that caused a block) is quarantined: excluded from both the recorded
+    implementation paths and the re-applied binary patch, so a retry cannot
+    replay the exact protected change that caused the block (#743).
+    """
     if not source_base_commit:
         raise ConformanceSalvageError(
             reason_code=SALVAGE_BASE_UNAVAILABLE,
@@ -148,7 +160,7 @@ def capture_conformance_salvage(
         git_env = {**env_base, "GIT_INDEX_FILE": index_path}
         _run_git(source_worktree, ["read-tree", "HEAD"], run=run, env=git_env)
         _run_git(source_worktree, ["add", "-A", "--", "."], run=run, env=git_env)
-        implementation_paths = _git_lines(
+        all_implementation_paths = _git_lines(
             _run_git(
                 source_worktree,
                 [
@@ -179,15 +191,35 @@ def capture_conformance_salvage(
                 env=git_env,
             ).stdout
         )
+        # Quarantine any changed protected quality-gate file the source attempt did
+        # not own. Dropping it from BOTH the recorded implementation paths and the
+        # binary patch below is what stops a retry from replaying the exact
+        # protected change (e.g. the `.awf/workspace.yml` edit) that caused the
+        # block (#743). The name list alone is cosmetic; the patch exclusion is
+        # load-bearing, and both use the same quarantine set so they can't drift.
+        quarantined_protected_paths = list(
+            unowned_protected_paths(all_implementation_paths, owned_paths=owned_paths)
+        )
+        quarantined_set = set(quarantined_protected_paths)
+        implementation_paths = [
+            path for path in all_implementation_paths if path not in quarantined_set
+        ]
         if not implementation_paths:
             raise ConformanceSalvageError(
                 reason_code=SALVAGE_NO_IMPLEMENTATION_DIFF,
                 message=(
-                    "Conformance retry found no implementation diff to salvage; "
-                    "only AWF plan/conformance artifacts changed."
+                    "Conformance retry found no salvageable implementation diff; only "
+                    "AWF plan/conformance artifacts or quarantined protected "
+                    "quality-gate files changed."
                 ),
-                detail={"plan_artifact_paths": plan_artifact_paths},
+                detail={
+                    "plan_artifact_paths": plan_artifact_paths,
+                    "quarantined_protected_paths": quarantined_protected_paths,
+                },
             )
+        exclude_pathspecs = [f":(exclude){INTERNAL_PLAN_ARTIFACT_PREFIX}**"] + [
+            f":(exclude){path}" for path in quarantined_protected_paths
+        ]
         patch = _run_git(
             source_worktree,
             [
@@ -197,7 +229,7 @@ def capture_conformance_salvage(
                 source_base_commit,
                 "--",
                 ".",
-                f":(exclude){INTERNAL_PLAN_ARTIFACT_PREFIX}**",
+                *exclude_pathspecs,
             ],
             run=run,
             env=git_env,
@@ -223,6 +255,7 @@ def capture_conformance_salvage(
         created_at=datetime.now(UTC).isoformat(),
         plan_path=_optional_str(evidence.get("plan_path")),
         report_path=_optional_str(evidence.get("report_path")),
+        quarantined_protected_paths=quarantined_protected_paths,
     )
     metadata_path = patch_path.with_suffix(".json")
     metadata_path.write_text(
@@ -240,6 +273,19 @@ def build_conformance_salvage_retry_prompt(
 ) -> str:
     """Build a retry prompt that replays recovered conformance implementation diffs."""
     paths = _implementation_path_lines(salvage)
+    quarantined = salvage.get("quarantined_protected_paths") or []
+    quarantine_section = ""
+    if quarantined:
+        quarantine_lines = "\n".join(f"- `{path}`" for path in quarantined)
+        quarantine_section = (
+            "### Quarantined protected quality-gate edits\n"
+            "AWF intentionally DROPPED the following protected quality-gate file "
+            "edit(s) from the salvage because the prior attempt did not own them — "
+            "they caused a protected-file block. Do NOT re-create these edits. If a "
+            "policy change is genuinely required, ask the operator to grant explicit "
+            "ownership of the file instead of editing it yourself:\n"
+            f"{quarantine_lines}\n\n"
+        )
     return (
         "## Automatic AWF salvage\n\n"
         "AWF automatically captured the prior implementation diff from the failed "
@@ -247,6 +293,7 @@ def build_conformance_salvage_retry_prompt(
         "the agent runs. Continue from the recovered implementation; do not "
         "restart from scratch unless the recovered code is unusable.\n\n"
         f"### Salvaged implementation paths\n{paths}\n\n"
+        + quarantine_section
         + build_conformance_retry_prompt(task_prompt=task_prompt, evidence=evidence)
     )
 

--- a/src/awf/service/workspaces_create.py
+++ b/src/awf/service/workspaces_create.py
@@ -1308,11 +1308,22 @@ def profile_with_requested_tier(
     profile: WorkspaceProfile,
     requested_tier: int,
 ) -> WorkspaceProfile:
-    """Return a profile copy with the validation requested_tier overridden."""
-    if profile.validation.requested_tier == requested_tier:
+    """Return a profile whose validation ``requested_tier`` is raised to the
+    dispatch value when the dispatch value is higher.
+
+    Dispatch ``requested_tier`` may only *raise* the profile's declared tier,
+    never lower it. The repo's ``.awf/workspace.yml`` declares a validation
+    floor, and the dispatch payload defaults ``requested_tier`` to ``1`` with no
+    "unset" sentinel (``api/schemas.py``); a hard replace therefore silently
+    downgraded a repo that asked for a higher tier (#743). Honoring the ``max``
+    matches the downstream ``max()`` tier resolution in
+    ``_validation_tier_for_workspace`` so the two agree.
+    """
+    effective_tier = max(profile.validation.requested_tier, requested_tier)
+    if profile.validation.requested_tier == effective_tier:
         return profile
     return profile.model_copy(
         update={
-            "validation": profile.validation.model_copy(update={"requested_tier": requested_tier})
+            "validation": profile.validation.model_copy(update={"requested_tier": effective_tier})
         }
     )

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -291,6 +291,7 @@ async def retry_workspace_row(
                 ),
                 source_branch_name=source.branch_name,
                 source_remote_push_branch=source.remote_push_branch,
+                owned_paths=list(source.owned_paths),
                 run_subprocess=run_subprocess,
             )
         except ConformanceSalvageError as exc:
@@ -323,6 +324,7 @@ async def retry_workspace_row(
                 conformance_evidence_ref=agent_timeout_context.evidence_ref,
                 source_branch_name=source.branch_name,
                 source_remote_push_branch=source.remote_push_branch,
+                owned_paths=list(source.owned_paths),
                 run_subprocess=run_subprocess,
             )
         except ConformanceSalvageError as exc:

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_002.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_002.py
@@ -609,6 +609,79 @@ async def test_satisfied_post_validation_conformance_report_is_written_not_commi
 
 
 @pytest.mark.unit
+async def test_post_validation_conformance_ci_delegated_gaps_resolve_satisfied(
+    tmp_path: Path,
+) -> None:
+    """After AWF validation passed, awf_validation_evidence-only gaps are CI-delegated
+    and resolve satisfied instead of PLAN_CONFORMANCE_UNSATISFIED (#743).
+
+    The agent, unable to produce AWF-internal evidence for a CI-delegated command,
+    returns a still-not-satisfied report whose only gaps are awf_validation_evidence.
+    Because this recheck runs only after ``val_result.all_passed``, AWF has produced
+    all the evidence it can, so the check coerces the outcome to satisfied rather than
+    failing the workspace (which pushed the agent to edit the protected config).
+    """
+    worktree_path = tmp_path / "worktree"
+    runner = _GitRestoreFakeRunner(worktree_path)
+    report_path = Path("docs/awf-plans/ws_post.conformance.json")
+    report_file = worktree_path / report_path
+    report_file.parent.mkdir(parents=True)
+    ci_delegated_report = (
+        '{"status":"needs_iteration","summary":"pytest evidence was not produced by AWF",'
+        '"gaps":[{"kind":"awf_validation_evidence","detail":"pytest evidence is missing"}],'
+        '"reason_code":"CONFORMANCE_REQUIRES_AWF_VALIDATION"}'
+    )
+    report_file.write_text(ci_delegated_report, encoding="utf-8")
+    runner.queue_result(returncode=0, stdout="")  # changed paths before conformance
+    runner.queue_result(returncode=0, stdout="validated-head\n")
+    runner.queue_result(returncode=0, stdout=f"?? {report_path.as_posix()}\n")
+    runner.queue_result(returncode=0, stdout="")  # committed paths since validated HEAD
+    runner.queue_result(
+        returncode=128, stderr="fatal: pathspec '...' did not match any files\n"
+    )  # git restore report path (untracked -> fails, then plain unlink)
+    executor = _executor_with_runner(runner, tmp_path)
+    executor._validation_run_evidence_for_conformance = AsyncMock(  # type: ignore[method-assign]
+        return_value="VALIDATION_OK"
+    )
+    event_markers: list[str] = []
+
+    async def record_event(**_kwargs: object) -> None:
+        event_markers.append("record")
+
+    executor._record_post_validation_conformance_event = record_event  # type: ignore[method-assign]
+    profile = WorkspaceProfile.model_validate({"name": "planned", "planning": {"required": True}})
+    handoff = _PlanningValidationHandoff(
+        report=PlanConformanceReport(
+            status=PlanConformanceStatus.needs_iteration,
+            summary="AWF validation evidence is missing.",
+            gaps=("Run AWF validation.",),
+            reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        ),
+        plan_path=Path("docs/awf-plans/ws_post.md"),
+        report_path=report_path,
+        iteration=0,
+        max_iterations=2,
+    )
+
+    failure = await executor._run_post_validation_conformance_check(
+        adapter=_PlanningAdapter(ci_delegated_report),  # type: ignore[arg-type]
+        workspace=SimpleNamespace(id="ws_post", task_prompt="do it", task_tag=None),  # type: ignore[arg-type]
+        profile=profile,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        worktree_path=worktree_path,
+        model=None,
+        handoff=handoff,
+        validation_run_id="validation-run-1",
+        base_commit="base-commit-sha",
+    )
+
+    # Coerced to satisfied: no PLAN_CONFORMANCE_UNSATISFIED failure, event recorded.
+    assert failure is None
+    assert event_markers == ["record"]
+
+
+@pytest.mark.unit
 async def test_satisfied_post_validation_conformance_report_fails_when_unlink_leaves_dirty_index(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/control/test_executor_parts/test_executor_part_008.py
+++ b/tests/unit/control/test_executor_parts/test_executor_part_008.py
@@ -25,6 +25,10 @@ from awf.control.executor import (
 from awf.control.executor.constants import (
     POST_AGENT_COMMIT_PRECOMMIT_FAILED_REASON_CODE,
 )
+from awf.control.executor.state_ops import (
+    RESUME_SETUP_FAILED_REASON_CODE,
+    RESUME_SETUP_FAILURE_BLOCK_TYPE,
+)
 from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import OperatorGrantAuditRecord
 from awf.db.repositories import WorkspaceRepository
@@ -32,6 +36,7 @@ from awf.db.session import make_session_factory
 from awf.node.compose_manager import ComposeManager
 from awf.runtime.pr_creator import PullRequestCreator
 from awf.runtime.validation import (
+    ValidateToolProbeResult,
     ValidationCommandResult,
     ValidationCoverageResult,
     ValidationResult,
@@ -442,6 +447,152 @@ async def test_blocked_resume_grant_does_not_invoke_fix_agent_on_validation_fail
     assert validate_phase_calls == 1
     # The coding adapter was never invoked — no fix-pass agent run (which would
     # carry a fix prompt as ``input_bytes``) spent tokens or touched the change.
+    agent_calls = [call for call in fake.calls if call.input_bytes is not None]
+    assert agent_calls == []
+
+
+def _fake_env_probe(result: ValidateToolProbeResult) -> Any:
+    async def _probe(**_kwargs: Any) -> ValidateToolProbeResult:
+        return result
+
+    return _probe
+
+
+def _capture_profile_phase_names(
+    executor: WorkspaceExecutor,
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[tuple[str, ...]]:
+    phase_calls: list[tuple[str, ...]] = []
+    real_run_profile_phases = executor._validation.run_profile_phases
+
+    async def _capture(
+        *, phase_names: tuple[str, ...] | list[str], **kwargs: Any
+    ) -> ValidationResult:
+        phase_calls.append(tuple(phase_names))
+        return await real_run_profile_phases(phase_names=phase_names, **kwargs)
+
+    monkeypatch.setattr(executor._validation, "run_profile_phases", _capture)
+    return phase_calls
+
+
+@pytest.mark.unit
+async def test_blocked_directive_resume_skips_setup_when_env_healthy(
+    executor: WorkspaceExecutor,
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directive resume with a healthy env skips the flaky ``setup`` phase (#743)."""
+    ws_id = await _seed_resumable_blocked_workspace(
+        factory, grant_path=None, directive="revert the protected change"
+    )
+    fake.queue_result(returncode=0, stdout="codex finished")
+    _queue_blocked_resume_to_push(fake, ws_id=ws_id)
+
+    monkeypatch.setattr(
+        executor._validation,
+        "probe_validate_command_tools",
+        _fake_env_probe(ValidateToolProbeResult()),  # healthy: no missing, no error
+    )
+    phase_calls = _capture_profile_phase_names(executor, monkeypatch)
+
+    await executor.resume_blocked_execution(ws_id)
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        assert ws is not None
+        assert ws.status == WorkspaceStatus.completed.value
+    # ``setup`` was skipped: the profile-phase call carried only ``pre_agent``.
+    assert ("setup", "pre_agent") not in phase_calls
+    assert ("pre_agent",) in phase_calls
+
+
+@pytest.mark.unit
+async def test_blocked_directive_resume_reruns_setup_when_env_unhealthy(
+    executor: WorkspaceExecutor,
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directive resume whose env probe reports trouble re-runs setup (safe fallback)."""
+    ws_id = await _seed_resumable_blocked_workspace(
+        factory, grant_path=None, directive="revert the protected change"
+    )
+    fake.queue_result(returncode=0, stdout="codex finished")
+    _queue_blocked_resume_to_push(fake, ws_id=ws_id)
+
+    monkeypatch.setattr(
+        executor._validation,
+        "probe_validate_command_tools",
+        _fake_env_probe(ValidateToolProbeResult(probe_errored=True)),  # unhealthy
+    )
+    phase_calls = _capture_profile_phase_names(executor, monkeypatch)
+
+    await executor.resume_blocked_execution(ws_id)
+
+    # On any probe doubt, setup re-runs (the full setup+pre_agent phase set).
+    assert ("setup", "pre_agent") in phase_calls
+
+
+@pytest.mark.unit
+async def test_blocked_resume_setup_failure_reblocks_instead_of_failing(
+    executor: WorkspaceExecutor,
+    fake: FakeCommandRunner,
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A setup failure on a blocked-resume re-pauses into ``blocked``, not ``failed`` (#743).
+
+    Terminally failing would discard the operator directive and spent work; the
+    workspace stays operator-recoverable instead.
+    """
+    ws_id = await _seed_resumable_blocked_workspace(
+        factory, grant_path=None, directive="revert the protected change"
+    )
+    # Unhealthy env → setup runs; then setup fails (e.g. uv venv --python 3.14).
+    monkeypatch.setattr(
+        executor._validation,
+        "probe_validate_command_tools",
+        _fake_env_probe(ValidateToolProbeResult(probe_errored=True)),
+    )
+    stdout_path = tmp_path / "setup.stdout"
+    stderr_path = tmp_path / "setup.stderr"
+    stdout_path.write_text("error: failed to fetch python 3.14\n", encoding="utf-8")
+    stderr_path.write_text("uv venv failed\n", encoding="utf-8")
+    failing_setup = ValidationResult(
+        commands=[
+            ValidationCommandResult(
+                command="uv venv --python 3.14 .venv",
+                returncode=1,
+                duration_seconds=0.1,
+                stdout_path=stdout_path,
+                stderr_path=stderr_path,
+                reason_code="COMMAND_FAILED",
+            )
+        ]
+    )
+    real_run_profile_phases = executor._validation.run_profile_phases
+
+    async def _fail_setup(
+        *, phase_names: tuple[str, ...] | list[str], **kwargs: Any
+    ) -> ValidationResult:
+        if tuple(phase_names) == ("setup", "pre_agent"):
+            return failing_setup
+        return await real_run_profile_phases(phase_names=phase_names, **kwargs)
+
+    monkeypatch.setattr(executor._validation, "run_profile_phases", _fail_setup)
+
+    await executor.resume_blocked_execution(ws_id)
+
+    async with factory() as s:
+        ws = await WorkspaceRepository(s).get(ws_id)
+        assert ws is not None
+        # Re-blocked (operator-recoverable), NOT terminally failed.
+        assert ws.status == WorkspaceStatus.blocked.value
+        assert ws.block_reason_code == RESUME_SETUP_FAILED_REASON_CODE
+        assert ws.block_type == RESUME_SETUP_FAILURE_BLOCK_TYPE
+    # No agent fix-pass ran (setup died before the agent).
     agent_calls = [call for call in fake.calls if call.input_bytes is not None]
     assert agent_calls == []
 

--- a/tests/unit/control/test_quality_gates_743.py
+++ b/tests/unit/control/test_quality_gates_743.py
@@ -1,0 +1,84 @@
+"""Quality-gate tests for issue #743: unowned-protected path detection and the
+`.awf/workspace.yml` tier/final_gate no-op note in the block message."""
+
+from __future__ import annotations
+
+import pytest
+
+from awf.control.quality_gates import (
+    find_protected_quality_gate_changes,
+    quality_gate_violation_message,
+    unowned_protected_paths,
+)
+
+
+@pytest.mark.unit
+def test_unowned_protected_paths_covers_all_patterns_and_normalizes() -> None:
+    """unowned_protected_paths spans every protected pattern (not just pyproject/workflow).
+
+    It underpins the conformance-salvage quarantine (#743): a changed protected
+    file the source did not own is what a retry must not replay.
+    """
+    paths = unowned_protected_paths(
+        [
+            " ./.awf/workspace.yml ",
+            ".coveragerc",
+            ".\\.github\\workflows\\ci.yml",
+            "src/awf/runtime/validation.py",
+            "pytest.ini",
+            " ",
+        ]
+    )
+
+    assert paths == (
+        ".awf/workspace.yml",
+        ".coveragerc",
+        ".github/workflows/ci.yml",
+        "pytest.ini",
+    )
+
+
+@pytest.mark.unit
+def test_unowned_protected_paths_excludes_owned() -> None:
+    """A protected path covered by owned_paths is not returned."""
+    paths = unowned_protected_paths(
+        [".awf/workspace.yml", "pyproject.toml"],
+        owned_paths=[".awf/workspace.yml"],
+    )
+
+    assert paths == ("pyproject.toml",)
+
+
+@pytest.mark.unit
+def test_violation_message_flags_workspace_yml_tier_and_final_gate_noop() -> None:
+    """A .awf/workspace.yml edit must warn the tier/final_gate edit is a no-op (#743).
+
+    ``requested_tier`` is set at dispatch and ``final_gate`` is fixed at provision
+    time, so editing them in the protected file has no effect. The message must
+    say so, so agents stop editing the file to try to escalate AWF validation.
+    """
+    violations = find_protected_quality_gate_changes(
+        changed_paths=[".awf/workspace.yml"],
+        owned_paths=[],
+    )
+
+    message = quality_gate_violation_message(violations)
+
+    assert ".awf/workspace.yml" in message
+    assert "requested_tier" in message
+    assert "final_gate" in message
+    assert "dispatch" in message
+
+
+@pytest.mark.unit
+def test_violation_message_omits_workspace_yml_note_for_other_files() -> None:
+    """The tier/final_gate note only appears for .awf/workspace.yml edits."""
+    violations = find_protected_quality_gate_changes(
+        changed_paths=["pytest.ini"],
+        owned_paths=[],
+    )
+
+    message = quality_gate_violation_message(violations)
+
+    assert "pytest.ini" in message
+    assert "requested_tier" not in message

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_001.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_001.py
@@ -8,7 +8,6 @@ from awf.control.quality_gates import (
     ProtectedFileDiff,
     diff_classified_protected_paths,
     find_protected_quality_gate_changes,
-    unowned_protected_paths,
 )
 
 
@@ -84,43 +83,6 @@ def test_diff_classified_protected_paths_excludes_owned_protected_paths() -> Non
     )
 
     assert paths == (".github/workflows/ci.yml", "pyproject.toml")
-
-
-@pytest.mark.unit
-def test_unowned_protected_paths_covers_all_patterns_and_normalizes() -> None:
-    """unowned_protected_paths spans every protected pattern (not just pyproject/workflow).
-
-    It underpins the conformance-salvage quarantine (#743): a changed protected
-    file the source did not own is what a retry must not replay.
-    """
-    paths = unowned_protected_paths(
-        [
-            " ./.awf/workspace.yml ",
-            ".coveragerc",
-            ".\\.github\\workflows\\ci.yml",
-            "src/awf/runtime/validation.py",
-            "pytest.ini",
-            " ",
-        ]
-    )
-
-    assert paths == (
-        ".awf/workspace.yml",
-        ".coveragerc",
-        ".github/workflows/ci.yml",
-        "pytest.ini",
-    )
-
-
-@pytest.mark.unit
-def test_unowned_protected_paths_excludes_owned() -> None:
-    """A protected path covered by owned_paths is not returned."""
-    paths = unowned_protected_paths(
-        [".awf/workspace.yml", "pyproject.toml"],
-        owned_paths=[".awf/workspace.yml"],
-    )
-
-    assert paths == ("pyproject.toml",)
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_001.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_001.py
@@ -8,6 +8,7 @@ from awf.control.quality_gates import (
     ProtectedFileDiff,
     diff_classified_protected_paths,
     find_protected_quality_gate_changes,
+    unowned_protected_paths,
 )
 
 
@@ -83,6 +84,43 @@ def test_diff_classified_protected_paths_excludes_owned_protected_paths() -> Non
     )
 
     assert paths == (".github/workflows/ci.yml", "pyproject.toml")
+
+
+@pytest.mark.unit
+def test_unowned_protected_paths_covers_all_patterns_and_normalizes() -> None:
+    """unowned_protected_paths spans every protected pattern (not just pyproject/workflow).
+
+    It underpins the conformance-salvage quarantine (#743): a changed protected
+    file the source did not own is what a retry must not replay.
+    """
+    paths = unowned_protected_paths(
+        [
+            " ./.awf/workspace.yml ",
+            ".coveragerc",
+            ".\\.github\\workflows\\ci.yml",
+            "src/awf/runtime/validation.py",
+            "pytest.ini",
+            " ",
+        ]
+    )
+
+    assert paths == (
+        ".awf/workspace.yml",
+        ".coveragerc",
+        ".github/workflows/ci.yml",
+        "pytest.ini",
+    )
+
+
+@pytest.mark.unit
+def test_unowned_protected_paths_excludes_owned() -> None:
+    """A protected path covered by owned_paths is not returned."""
+    paths = unowned_protected_paths(
+        [".awf/workspace.yml", "pyproject.toml"],
+        owned_paths=[".awf/workspace.yml"],
+    )
+
+    assert paths == ("pyproject.toml",)
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_004.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_004.py
@@ -732,41 +732,6 @@ fail_under = 80
 
 
 @pytest.mark.unit
-def test_violation_message_flags_workspace_yml_tier_and_final_gate_noop() -> None:
-    """A .awf/workspace.yml edit must warn the tier/final_gate edit is a no-op (#743).
-
-    ``requested_tier`` is set at dispatch and ``final_gate`` is fixed at provision
-    time, so editing them in the protected file has no effect. The message must
-    say so, so agents stop editing the file to try to escalate AWF validation.
-    """
-    violations = find_protected_quality_gate_changes(
-        changed_paths=[".awf/workspace.yml"],
-        owned_paths=[],
-    )
-
-    message = quality_gate_violation_message(violations)
-
-    assert ".awf/workspace.yml" in message
-    assert "requested_tier" in message
-    assert "final_gate" in message
-    assert "dispatch" in message
-
-
-@pytest.mark.unit
-def test_violation_message_omits_workspace_yml_note_for_other_files() -> None:
-    """The tier/final_gate note only appears for .awf/workspace.yml edits."""
-    violations = find_protected_quality_gate_changes(
-        changed_paths=["pytest.ini"],
-        owned_paths=[],
-    )
-
-    message = quality_gate_violation_message(violations)
-
-    assert "pytest.ini" in message
-    assert "requested_tier" not in message
-
-
-@pytest.mark.unit
 def test_missing_protected_file_diff_blocks_conservatively() -> None:
     violations = find_protected_quality_gate_changes(
         changed_paths=["pyproject.toml"],

--- a/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_004.py
+++ b/tests/unit/control/test_quality_gates_parts/test_quality_gates_part_004.py
@@ -732,6 +732,41 @@ fail_under = 80
 
 
 @pytest.mark.unit
+def test_violation_message_flags_workspace_yml_tier_and_final_gate_noop() -> None:
+    """A .awf/workspace.yml edit must warn the tier/final_gate edit is a no-op (#743).
+
+    ``requested_tier`` is set at dispatch and ``final_gate`` is fixed at provision
+    time, so editing them in the protected file has no effect. The message must
+    say so, so agents stop editing the file to try to escalate AWF validation.
+    """
+    violations = find_protected_quality_gate_changes(
+        changed_paths=[".awf/workspace.yml"],
+        owned_paths=[],
+    )
+
+    message = quality_gate_violation_message(violations)
+
+    assert ".awf/workspace.yml" in message
+    assert "requested_tier" in message
+    assert "final_gate" in message
+    assert "dispatch" in message
+
+
+@pytest.mark.unit
+def test_violation_message_omits_workspace_yml_note_for_other_files() -> None:
+    """The tier/final_gate note only appears for .awf/workspace.yml edits."""
+    violations = find_protected_quality_gate_changes(
+        changed_paths=["pytest.ini"],
+        owned_paths=[],
+    )
+
+    message = quality_gate_violation_message(violations)
+
+    assert "pytest.ini" in message
+    assert "requested_tier" not in message
+
+
+@pytest.mark.unit
 def test_missing_protected_file_diff_blocks_conservatively() -> None:
     violations = find_protected_quality_gate_changes(
         changed_paths=["pyproject.toml"],

--- a/tests/unit/runtime/test_planning_parts/test_planning_part_001.py
+++ b/tests/unit/runtime/test_planning_parts/test_planning_part_001.py
@@ -33,6 +33,7 @@ from awf.runtime.planning import (
     parse_conformance_report,
     render_coordination_warning_section,
     render_workspace_path,
+    satisfied_report_for_ci_delegated_validation,
 )
 from awf.service.coordination import MAX_COORDINATION_WARNING_OVERLAPS
 
@@ -399,6 +400,47 @@ def test_conformance_prompt_is_evidence_only_and_does_not_rerun_validation() -> 
         "git commit",
     ):
         assert command in prompt
+    # No validate-set was supplied here, so no AWF-validation-scope section.
+    assert "AWF validation scope" not in prompt
+
+
+@pytest.mark.unit
+def test_conformance_prompt_pins_validate_set_and_flags_ci_delegation() -> None:
+    """The prompt enumerates AWF's validate set so the agent stops flagging (#743).
+
+    A command absent from the set is CI-delegated; the agent must not raise an
+    awf_validation_evidence gap for it nor edit the protected workspace.yml.
+    """
+    prompt = build_conformance_prompt(
+        task_prompt="Add /link",
+        plan_path=Path("docs/awf-plans/ws_1.md"),
+        report_path=Path("docs/awf-plans/ws_1.conformance.json"),
+        iteration=0,
+        awf_validation_commands=["ruff check .", "python -m aira_agent.typecheck.mypy_budget"],
+    )
+
+    assert "AWF validation scope" in prompt
+    assert "ruff check ." in prompt
+    assert "python -m aira_agent.typecheck.mypy_budget" in prompt
+    assert "gated by CI, not AWF" in prompt
+    assert "delegates to GitHub CI" in prompt
+    assert ".awf/workspace.yml" in prompt
+
+
+@pytest.mark.unit
+def test_conformance_prompt_flags_empty_validate_set_as_fully_ci_delegated() -> None:
+    """An empty validate set means every gate is CI-owned — do not demand evidence."""
+    prompt = build_conformance_prompt(
+        task_prompt="Add /link",
+        plan_path=Path("docs/awf-plans/ws_1.md"),
+        report_path=Path("docs/awf-plans/ws_1.conformance.json"),
+        iteration=0,
+        awf_validation_commands=[],
+    )
+
+    assert "AWF validation scope" in prompt
+    assert "no agent-visible validation commands" in prompt
+    assert "delegated to GitHub CI" in prompt
 
 
 @pytest.mark.unit
@@ -507,6 +549,70 @@ def test_conformance_requires_awf_validation_accepts_hyphenated_reason_code() ->
     )
 
     assert conformance_requires_awf_validation(report, {Path("src/awf/runtime/planning.py")})
+
+
+@pytest.mark.unit
+def test_ci_delegated_validation_report_is_satisfied_when_only_validation_gaps() -> None:
+    """After AWF validation passed, awf_validation_evidence-only gaps are CI-delegated (#743).
+
+    They resolve to a satisfied report rather than PLAN_CONFORMANCE_UNSATISFIED.
+    """
+    report = PlanConformanceReport(
+        status=PlanConformanceStatus.needs_iteration,
+        summary="pytest evidence was not produced by AWF validation.",
+        reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        gaps=(
+            ConformanceGap(
+                kind=GapKind.awf_validation_evidence,
+                detail="AWF-owned validation evidence is missing for pytest.",
+            ),
+        ),
+    )
+
+    coerced = satisfied_report_for_ci_delegated_validation(report)
+
+    assert coerced is not None
+    assert coerced.satisfied
+    assert coerced.status is PlanConformanceStatus.satisfied
+    assert "delegated to CI" in coerced.summary
+    # Original report is untouched (frozen dataclass).
+    assert not report.satisfied
+
+
+@pytest.mark.unit
+def test_ci_delegated_validation_report_none_when_a_real_gap_remains() -> None:
+    """A non-validation gap (implementation/test/docs) must still fail conformance."""
+    report = PlanConformanceReport(
+        status=PlanConformanceStatus.needs_iteration,
+        summary="Endpoint not wired.",
+        reason_code=CONFORMANCE_REQUIRES_AWF_VALIDATION,
+        gaps=(
+            ConformanceGap(
+                kind=GapKind.awf_validation_evidence,
+                detail="pytest evidence missing.",
+            ),
+            ConformanceGap(kind=GapKind.implementation, detail="POST /link not implemented."),
+        ),
+    )
+
+    assert satisfied_report_for_ci_delegated_validation(report) is None
+
+
+@pytest.mark.unit
+def test_ci_delegated_validation_report_none_for_satisfied_or_empty() -> None:
+    """No coercion for an already-satisfied report or a report with no gaps."""
+    already = PlanConformanceReport(
+        status=PlanConformanceStatus.satisfied,
+        summary="done",
+    )
+    empty = PlanConformanceReport(
+        status=PlanConformanceStatus.needs_iteration,
+        summary="no actionable gap",
+        gaps=(),
+    )
+
+    assert satisfied_report_for_ci_delegated_validation(already) is None
+    assert satisfied_report_for_ci_delegated_validation(empty) is None
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_planning_parts/test_planning_part_001.py
+++ b/tests/unit/runtime/test_planning_parts/test_planning_part_001.py
@@ -11,6 +11,7 @@ import pytest
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     AGENT_WORKTREE_ROOT,
+    CONFORMANCE_CI_DELEGATED_SATISFIED,
     CONFORMANCE_REQUIRES_AWF_VALIDATION,
     MAX_CONFORMANCE_TEXT_CHARS,
     PLAN_CONFORMANCE_REPORTED,
@@ -575,6 +576,10 @@ def test_ci_delegated_validation_report_is_satisfied_when_only_validation_gaps()
     assert coerced.satisfied
     assert coerced.status is PlanConformanceStatus.satisfied
     assert "delegated to CI" in coerced.summary
+    # A satisfied outcome must carry a satisfied-flavour reason code, NOT the
+    # unsatisfied CONFORMANCE_REQUIRES_AWF_VALIDATION it was coerced from.
+    assert coerced.reason_code == CONFORMANCE_CI_DELEGATED_SATISFIED
+    assert coerced.reason_code != CONFORMANCE_REQUIRES_AWF_VALIDATION
     # Original report is untouched (frozen dataclass).
     assert not report.satisfied
 

--- a/tests/unit/runtime/test_validation_setup_validate_probe_targets.py
+++ b/tests/unit/runtime/test_validation_setup_validate_probe_targets.py
@@ -17,6 +17,7 @@ from awf.runtime.validation import (
     _leading_executables,
     validate_command_probe_targets,
 )
+from awf.runtime.validation_setup import validate_phase_command_strings
 
 
 def _profile_with_validate(commands: list[str]) -> WorkspaceProfile:
@@ -917,3 +918,47 @@ class TestValidateCommandProbeTargets:
             ("ruff", "ruff check ."),
             ("coverage", "coverage run -m pytest"),
         ]
+
+
+class TestValidatePhaseCommandStrings:
+    """The AWF-owned validation command set the conformance prompt enumerates (#745)."""
+
+    @pytest.mark.unit
+    def test_includes_coverage_final_gate_command(self) -> None:
+        """A coverage ``final_gate`` command is part of what AWF runs, so it is listed."""
+        profile = _profile_with_coverage_gate(
+            validate=["ruff check ."],
+            final_gate="coverage",
+            coverage_command="coverage run -m pytest",
+        )
+
+        assert validate_phase_command_strings(profile) == [
+            "ruff check .",
+            "coverage run -m pytest",
+        ]
+
+    @pytest.mark.unit
+    def test_empty_validate_with_coverage_gate_is_not_reported_empty(self) -> None:
+        """The regression: empty ``validate`` + a coverage gate still runs coverage in AWF.
+
+        Reporting an empty set here would tell the agent AWF runs no validation and
+        wrongly treat the coverage gate as CI-delegated.
+        """
+        profile = _profile_with_coverage_gate(
+            validate=[],
+            final_gate="coverage",
+            coverage_command="coverage run -m pytest",
+        )
+
+        assert validate_phase_command_strings(profile) == ["coverage run -m pytest"]
+
+    @pytest.mark.unit
+    def test_excludes_coverage_command_when_final_gate_is_not_coverage(self) -> None:
+        """With ``final_gate`` other than coverage, AWF does not run the coverage command."""
+        profile = _profile_with_coverage_gate(
+            validate=["ruff check ."],
+            final_gate="none",
+            coverage_command="coverage run -m pytest",
+        )
+
+        assert validate_phase_command_strings(profile) == ["ruff check ."]

--- a/tests/unit/service/_workspace_retry_helpers.py
+++ b/tests/unit/service/_workspace_retry_helpers.py
@@ -144,6 +144,7 @@ def _create_conformance_source_worktree(
     workspace_id: str,
     *,
     implementation_diff: bool = True,
+    protected_edit: bool = False,
 ) -> str:
     worktree = Path(settings.work_dir) / "git" / "worktrees" / workspace_id
     worktree.mkdir(parents=True)
@@ -152,6 +153,9 @@ def _create_conformance_source_worktree(
     _git(["config", "user.email", "awf@test.local"], worktree)
     (worktree / "src/awf").mkdir(parents=True)
     (worktree / "src/awf/retry.py").write_text("def retry():\n    return 'old'\n")
+    if protected_edit:
+        (worktree / ".awf").mkdir(parents=True)
+        (worktree / ".awf/workspace.yml").write_text("awf:\n  validation:\n    requested_tier: 1\n")
     _git(["add", "."], worktree)
     _git(["commit", "-q", "-m", "base"], worktree)
     base_commit = _git(["rev-parse", "HEAD"], worktree)
@@ -165,6 +169,10 @@ def _create_conformance_source_worktree(
         (worktree / "src/awf/retry.py").write_text("def retry():\n    return 'new'\n")
         (worktree / "tests/unit").mkdir(parents=True)
         (worktree / "tests/unit/test_retry.py").write_text("def test_retry():\n    assert True\n")
+    if protected_edit:
+        # The agent edited the protected quality-gate config outside owned_paths —
+        # the change that caused the block. A retry must NOT replay it (#743).
+        (worktree / ".awf/workspace.yml").write_text("awf:\n  validation:\n    requested_tier: 2\n")
     return base_commit
 
 

--- a/tests/unit/service/test_conformance_salvage.py
+++ b/tests/unit/service/test_conformance_salvage.py
@@ -12,6 +12,7 @@ from awf.service import conformance_salvage as salvage_mod
 from awf.service.conformance_salvage import (
     CONFORMANCE_SALVAGE_POLICY_KEY,
     SALVAGE_BASE_UNAVAILABLE,
+    SALVAGE_NO_IMPLEMENTATION_DIFF,
     SALVAGE_SOURCE_UNAVAILABLE,
     ConformanceSalvageCapture,
     ConformanceSalvageError,
@@ -148,6 +149,130 @@ def test_capture_policy_includes_optional_source_and_string_gap(tmp_path: Path) 
     assert policy["remaining_gaps"] == ["add tests"]
     assert policy["plan_path"] == "docs/awf-plans/ws_capture.md"
     assert policy["report_path"] == "docs/awf-plans/ws_capture.conformance.json"
+
+
+def _seed_source_worktree_with_protected_edit(
+    work_dir: Path, workspace_id: str
+) -> tuple[Path, str]:
+    """Seed a worktree whose agent edited BOTH an impl file and .awf/workspace.yml."""
+    worktree = work_dir / "git" / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    _git(["init", "-q"], worktree)
+    _git(["config", "user.name", "AWF Test"], worktree)
+    _git(["config", "user.email", "awf@test.local"], worktree)
+    (worktree / "src").mkdir()
+    (worktree / "src/app.py").write_text("VALUE = 'old'\n", encoding="utf-8")
+    (worktree / ".awf").mkdir()
+    (worktree / ".awf/workspace.yml").write_text(
+        "awf:\n  validation:\n    requested_tier: 1\n", encoding="utf-8"
+    )
+    _git(["add", "."], worktree)
+    _git(["commit", "-q", "-m", "base"], worktree)
+    base_commit = _git(["rev-parse", "HEAD"], worktree)
+    (worktree / "src/app.py").write_text("VALUE = 'new'\n", encoding="utf-8")
+    (worktree / ".awf/workspace.yml").write_text(
+        "awf:\n  validation:\n    requested_tier: 2\n", encoding="utf-8"
+    )
+    return worktree, base_commit
+
+
+@pytest.mark.unit
+def test_capture_quarantines_unowned_protected_workspace_yml(tmp_path: Path) -> None:
+    """An unowned .awf/workspace.yml edit is dropped from the salvage names AND patch (#743)."""
+    _, base_commit = _seed_source_worktree_with_protected_edit(tmp_path, "ws_quarantine")
+
+    capture = capture_conformance_salvage(
+        work_dir=tmp_path,
+        source_workspace_id="ws_quarantine",
+        source_base_commit=base_commit,
+        conformance_evidence={"gaps": "add tests"},
+        conformance_evidence_ref=None,
+        source_branch_name=None,
+        source_remote_push_branch=None,
+        owned_paths=[],
+    )
+
+    assert capture.quarantined_protected_paths == [".awf/workspace.yml"]
+    assert ".awf/workspace.yml" not in capture.implementation_paths
+    assert "src/app.py" in capture.implementation_paths
+    # The load-bearing part: the re-applied binary patch must not carry the edit.
+    patch_text = capture.patch_path.read_text(encoding="utf-8")
+    assert ".awf/workspace.yml" not in patch_text
+    assert "src/app.py" in patch_text
+    assert capture.as_policy()["quarantined_protected_paths"] == [".awf/workspace.yml"]
+
+
+@pytest.mark.unit
+def test_capture_keeps_owned_protected_edit(tmp_path: Path) -> None:
+    """A protected file the source explicitly owns is NOT quarantined."""
+    _, base_commit = _seed_source_worktree_with_protected_edit(tmp_path, "ws_owned")
+
+    capture = capture_conformance_salvage(
+        work_dir=tmp_path,
+        source_workspace_id="ws_owned",
+        source_base_commit=base_commit,
+        conformance_evidence=None,
+        conformance_evidence_ref=None,
+        source_branch_name=None,
+        source_remote_push_branch=None,
+        owned_paths=[".awf/workspace.yml"],
+    )
+
+    assert capture.quarantined_protected_paths == []
+    assert ".awf/workspace.yml" in capture.implementation_paths
+    patch_text = capture.patch_path.read_text(encoding="utf-8")
+    assert ".awf/workspace.yml" in patch_text
+    assert "quarantined_protected_paths" not in capture.as_policy()
+
+
+@pytest.mark.unit
+def test_capture_raises_when_only_unowned_protected_changed(tmp_path: Path) -> None:
+    """If the only change is an unowned protected file, there is nothing to salvage."""
+    worktree = tmp_path / "git" / "worktrees" / "ws_only_protected"
+    worktree.mkdir(parents=True)
+    _git(["init", "-q"], worktree)
+    _git(["config", "user.name", "AWF Test"], worktree)
+    _git(["config", "user.email", "awf@test.local"], worktree)
+    (worktree / "src").mkdir()
+    (worktree / "src/app.py").write_text("VALUE = 'x'\n", encoding="utf-8")
+    (worktree / ".awf").mkdir()
+    (worktree / ".awf/workspace.yml").write_text("awf: {}\n", encoding="utf-8")
+    _git(["add", "."], worktree)
+    _git(["commit", "-q", "-m", "base"], worktree)
+    base_commit = _git(["rev-parse", "HEAD"], worktree)
+    (worktree / ".awf/workspace.yml").write_text("awf:\n  changed: true\n", encoding="utf-8")
+
+    with pytest.raises(ConformanceSalvageError) as exc_info:
+        capture_conformance_salvage(
+            work_dir=tmp_path,
+            source_workspace_id="ws_only_protected",
+            source_base_commit=base_commit,
+            conformance_evidence=None,
+            conformance_evidence_ref=None,
+            source_branch_name=None,
+            source_remote_push_branch=None,
+            owned_paths=[],
+        )
+
+    assert exc_info.value.reason_code == SALVAGE_NO_IMPLEMENTATION_DIFF
+    assert exc_info.value.detail["quarantined_protected_paths"] == [".awf/workspace.yml"]
+
+
+@pytest.mark.unit
+def test_salvage_retry_prompt_flags_quarantined_protected_paths() -> None:
+    """The retry prompt tells the agent the protected edit was dropped (do not redo)."""
+    prompt = build_conformance_salvage_retry_prompt(
+        task_prompt="Add /link",
+        evidence={"gaps": "add tests"},
+        salvage={
+            "implementation_paths": ["src/app.py"],
+            "quarantined_protected_paths": [".awf/workspace.yml"],
+        },
+    )
+
+    assert "Quarantined protected quality-gate edits" in prompt
+    assert ".awf/workspace.yml" in prompt
+    assert "Do NOT re-create" in prompt
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_workspace_retry_salvage.py
+++ b/tests/unit/service/test_workspace_retry_salvage.py
@@ -358,6 +358,53 @@ async def test_retry_conformance_unsatisfied_auto_salvages_implementation_diff(
     )
 
 
+@pytest.mark.unit
+async def test_retry_quarantines_unowned_protected_edit_from_salvage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A retry must not replay an unowned ``.awf/workspace.yml`` edit from salvage (#743).
+
+    End-to-end regression for the cascade: the source attempt edited the protected
+    config (unowned), so the retry salvage quarantines it — it appears in neither
+    the recorded implementation paths nor the re-applied patch, so applying the
+    salvage can never re-create the exact change that caused the block.
+    """
+    settings = _settings_with_work_dir(tmp_path)
+    service = WorkspaceService(factory)
+    first = await service.create(_request())
+    base_commit = _create_conformance_source_worktree(settings, first.id, protected_edit=True)
+    await _mark_conformance_failed(factory, first.id, base_commit=base_commit)
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first.id,
+            provider_readiness_override=True,
+            provider_readiness_override_reason="retry service test fixture",
+            settings=settings,
+        )
+        await session.commit()
+
+    async with factory() as session:
+        retried = await WorkspaceRepository(session).get(retry.new_workspace.id)
+        assert retried is not None
+
+    salvage = retried.task_policy["conformance_salvage"]
+    assert salvage["quarantined_protected_paths"] == [".awf/workspace.yml"]
+    assert ".awf/workspace.yml" not in salvage["implementation_paths"]
+    assert salvage["implementation_paths"] == [
+        "src/awf/retry.py",
+        "tests/unit/test_retry.py",
+    ]
+    # The load-bearing guarantee: the re-applied patch carries no protected edit.
+    patch_text = Path(salvage["patch_path"]).read_text()
+    assert ".awf/workspace.yml" not in patch_text
+    # The retry prompt tells the agent the policy edit was intentionally dropped.
+    assert "Quarantined protected quality-gate edits" in retried.task_prompt
+    assert ".awf/workspace.yml" in retried.task_prompt
+
+
 async def test_retry_conformance_unsatisfied_without_evidence_still_salvages_diff(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
@@ -267,6 +267,29 @@ def test_v2_task_policy_and_profile_tier_helpers_cover_noop_and_updates() -> Non
 
 
 @pytest.mark.unit
+def test_profile_with_requested_tier_honors_repo_floor_over_lower_dispatch() -> None:
+    """A repo-declared tier must survive a lower dispatch default (RC3-B, #743).
+
+    The dispatch payload defaults ``requested_tier`` to 1 with no "unset"
+    sentinel, so a hard replace silently downgraded a repo whose
+    ``.awf/workspace.yml`` declared a higher tier. Honor the max: dispatch can
+    only raise the repo's validation floor, never lower it (consistent with the
+    downstream ``max()`` tier resolution).
+    """
+    repo_tier_two = WorkspaceProfile(name="unit-profile", validation={"requested_tier": 2})
+
+    # A lower dispatch tier must not clobber the repo's declared floor.
+    kept = profile_with_requested_tier(repo_tier_two, 1)
+    assert kept is repo_tier_two
+    assert kept.validation.requested_tier == 2
+
+    # A higher dispatch tier still raises the floor.
+    raised = profile_with_requested_tier(repo_tier_two, 3)
+    assert raised.validation.requested_tier == 3
+    assert repo_tier_two.validation.requested_tier == 2
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("source_branch", "expected_source"),
     [("release/cut", "release/cut"), (None, "development")],


### PR DESCRIPTION
Fixes #743.

## The cascade

An aira-agent task got stuck in an **unrecoverable loop**. One root trigger produced a protected-file block; both recovery levers (`retry`, `guide`) then deterministically failed:

- **RC3 (root trigger):** plan-conformance demanded AWF-internal `pytest` evidence for a command the repo delegates to CI (absent from its `validate:` set, `final_gate: none`), pushing the agent to edit the protected `.awf/workspace.yml` to force AWF to run it — the edit that blocked. The tier edit was also a silent no-op.
- **RC2 (`retry` broken):** conformance salvage re-applied that protected `.awf/workspace.yml` edit on retry → re-blocked on the identical deviation.
- **RC1 (`guide` broken):** `guide --directive` → `ORDERED_BLOCKED_RESUME` re-ran `uv venv --python 3.14` → `service_startup_failure` → `blocked → failed` before the agent ran, discarding the directive.

## The fix (3 slices, commits per slice)

**RC1 — blocked-resume reuses the warm env; setup failure is non-terminal.** A directive resume skips the `setup` phase when an env-health probe (`probe_validate_command_tools`) confirms the warm container's validate toolchain still resolves; on any doubt it re-runs setup. A grant resume always re-runs setup (an approved config/dep edit may have staled the env). A setup failure on *any* blocked-resume now re-pauses into `blocked` (operator-recoverable) instead of terminally failing — the directive/work is preserved; the hint is cleared so the worker can't auto-loop.

**RC2 — salvage quarantines the unowned protected file.** `capture_conformance_salvage` takes `owned_paths` and excludes the unowned-protected subset from **both** the recorded paths and the load-bearing binary patch (one exclusion set, so they can't drift), records `quarantined_protected_paths`, and tells the retry agent the edit was dropped. Owned protected files are untouched; no auto-owning.

**RC3 — conformance stops demanding CI-delegated evidence; honor-max tier.** After AWF validation has passed all its resolved commands, a still-standing `awf_validation_evidence`-only report is coerced to *satisfied* (keyed on `ValidationRun` status — no free-text gap parsing) instead of looping to `PLAN_CONFORMANCE_UNSATISFIED`. The conformance prompt enumerates the repo's `validate:` set and marks commands outside it CI-delegated. `profile_with_requested_tier` now uses `max(repo, dispatch)` so a repo's declared validation floor isn't silently downgraded.

## Review + testing

Locked via `/plan-eng-review` (architecture + 2 cross-model hardenings from a Codex pass: the env-health probe over bare `venv-exists`, and the ValidationRun-status signal after finding conformance gaps are free-text).

- Unit tests for every new branch (RC1 skip/rerun/re-block; RC2 quarantine names+patch+prompt, owned-kept, only-protected-raises; RC3 CI-delegated-satisfied vs real-gap-still-fails, tier max, prompt enumeration, block-message note).
- Integration-style regressions: blocked→resume completes at the executor level; conformance-failed source touching `.awf/workspace.yml` → retry → no re-block.
- Local gate green: ruff, ruff-format, mypy (427 files). Full aggregate 99% coverage runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YYHkW221F9QLc3QY5aQouz

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core executor blocked-resume transitions, post-validation conformance outcomes, and salvage patch contents—behavior changes that affect operator recovery loops and what diffs retries replay, though heavily unit-tested.
> 
> **Overview**
> Fixes the **#743** loop where conformance pushed agents to edit protected `.awf/workspace.yml`, retries replayed that edit, and blocked `guide` resumes died on setup and terminal `failed`.
> 
> **Blocked resume (executor):** Directive resumes (`not resume_skip_agent`) may run only `pre_agent` when `probe_validate_command_tools` says the warm validate toolchain is healthy; otherwise they still run `setup` + `pre_agent`. Profile setup failure on a blocked resume **re-enters `blocked`** via a generalized `enter_blocked_for_protected_violation` (`resume_setup_failure` / `RESUME_SETUP_FAILED`) instead of marking `failed`.
> 
> **Conformance & validation:** `validate_phase_command_strings` drives a new **AWF validation scope** section in conformance prompts. After AWF validation has passed, post-validation conformance can coerce reports whose **only** gaps are `awf_validation_evidence` to satisfied (`satisfied_report_for_ci_delegated_validation`). Quality-gate block text for `.awf/workspace.yml` warns that mid-run tier edits are no-ops.
> 
> **Salvage & tier:** `capture_conformance_salvage` takes `owned_paths`, **quarantines** unowned protected paths from paths and the binary patch, and surfaces that in retry prompts. `profile_with_requested_tier` uses **`max(repo, dispatch)`** so dispatch default `1` cannot lower the repo floor.
> 
> **Tests:** Unit/integration coverage for skip/rerun/re-block, quarantine, CI-delegated satisfied, tier max, and prompt enumeration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014fe6993de625a22b71ab874f95aa029764006e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->