### PR TITLE
fix(hosted): omit Core-local worktree paths from delegation

### DIFF
--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -444,12 +444,15 @@ class HostedValidationDelegate:
             run_healthchecks=run_healthchecks,
         )
         expected_command_count = len(expected_commands)
+        # Hosted Jobs use their own /workspace/repo checkout; never send a
+        # Core-local filesystem path (Cloud rejects non-null worktree_path).
+        del worktree_path
         payload: dict[str, Any] = {
             "workspace_id": workspace_id,
             "profile": _hosted_validation_profile_payload(profile),
             "phase_names": list(phase_names),
             "run_healthchecks": run_healthchecks,
-            "worktree_path": str(worktree_path) if worktree_path is not None else None,
+            "worktree_path": None,
             "include_coverage": include_coverage,
             "pr_identity": _hosted_pr_identity_payload(pr_identity or {}),
         }

--- a/tests/unit/runtime/test_hosted_validation_worktree_boundary.py
+++ b/tests/unit/runtime/test_hosted_validation_worktree_boundary.py
@@ -1,0 +1,80 @@
+"""Hosted validation must not leak Core-local worktree_path to Cloud."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from awf.profiles.models import WorkspaceProfile
+from awf.runtime.hosted_delegation import HostedValidationDelegate
+from tests.unit.runtime.test_hosted_validation_delegate import _config
+
+
+@pytest.mark.unit
+async def test_run_profile_phases_omits_core_local_worktree_path(
+    tmp_path: Path,
+) -> None:
+    """Core-local worktree paths must never appear in hosted POST bodies."""
+    seen: dict[str, Any] = {}
+    core_worktree = tmp_path / "core-worktree"
+    core_worktree_str = str(core_worktree)
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_boundary_1",
+                    "workspace_id": "ws_boundary",
+                    "operation_url": "/v1/operations/val_boundary_1",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_boundary_1":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_boundary_1",
+                    "workspace_id": "ws_boundary",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "uv run pytest tests/unit/foo -q",
+                            "returncode": 0,
+                            "duration_seconds": 0.5,
+                            "stdout": "passed\n",
+                            "stderr": "",
+                            "phase": "validate",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_boundary",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=WorkspaceProfile(name="hosted-boundary-test"),
+            phase_names=("validate",),
+            worktree_path=core_worktree,
+            include_coverage=False,
+        )
+
+    assert "body" in seen
+    body = seen["body"]
+    assert core_worktree_str not in json.dumps(body, sort_keys=True)
+    assert body.get("worktree_path") is None
+    assert result.all_passed
+    assert len(result.commands) == 1
+    assert result.commands[0].command == "uv run pytest tests/unit/foo -q"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_54fb0e7dbd544ac2a7dae55a` (agent: `cursor`, model: `auto`, effort: `xhigh`).


### Task
Live Phase 1 GKE evidence on 2026-07-15 exposed a precise hosted delegation contract bug. An adopted PR monitor (Core workspace ws_57099a2eaa204e149cdf356b for awf-cloud PR 372) failed setup because HostedValidationDelegate.run_profile_phases serialized the Core worker's local worktree_path into POST /v1/validation-runs. AWF Cloud deliberately rejects every non-null worktree_path with HTTP 400 because hosted validation Jobs always operate on their own /workspace/repo checkout and cannot use a path from the Core worker pod. Implement a narrowly scoped strict-TDD fix at the Core hosted HTTP boundary: callers may continue passing a local Path for API compatibility/local bookkeeping, but the hosted validation request must omit worktree_path or serialize it as null, never expose the Core-local filesystem path. Add a dedicated focused regression file tests/unit/runtime/test_hosted_validation_worktree_boundary.py that constructs HostedValidationDelegate with an httpx MockTransport, passes a non-null Core-local worktree path to run_profile_phases, and proves the POST body does not carry that path while the operation still maps successfully. Do not touch the existing test_hosted_validation_delegate_part_001.py because another active workspace owns it. Review probe/coverage payloads to preserve their current behavior; do not change unrelated validation semantics. Run uv run --python 3.12 --extra dev pytest -q tests/unit/runtime/test_hosted_validation_worktree_boundary.py, relevant ruff, and git diff --check. Git works in /workspace; commit before exiting. Do not push; AWF owns PR creation, monitoring, repair, and merge.

---
Validation: 5 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow HTTP payload fix at the hosted validation boundary with a focused regression test; probe/coverage delegation paths are unchanged.
> 
> **Overview**
> Fixes hosted PR monitor setup failures where **AWF Cloud** returned HTTP 400 because `POST /v1/validation-runs` carried a Core worker **local** `worktree_path`. Hosted jobs always use their own `/workspace/repo` checkout and reject any non-null path.
> 
> **`HostedValidationDelegate.run_profile_phases`** still accepts `worktree_path` for API compatibility, but the hosted request body now always sets **`worktree_path` to `null`** and never serializes the Core filesystem path.
> 
> Adds **`tests/unit/runtime/test_hosted_validation_worktree_boundary.py`**: MockTransport asserts the POST body omits the local path and delegation still maps terminal command results successfully.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96da8519dcbac80eb2017301b03e24b358ad868. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->