### PR TITLE
fix(hosted): normalize Compose volume names for delegated validation

### DIFF
--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -57,6 +57,9 @@ _HOSTED_PHASE_COMMAND_FIELDS = ("setup", "pre_agent", "post_agent", "validate", 
 _HOSTED_DATABASE_COMMAND_FIELDS = ("generated_setup", "pre_validation_refresh")
 _HOSTED_COMMAND_SECRET_ASSIGNMENT_KEYS = frozenset({"MYSQL_PWD", "PGPASSWORD"})
 _HOSTED_DNS1123_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_HOSTED_COMPOSE_INTERPOLATED_TARGET_PATTERN = re.compile(
+    r"^\$(?:\{[A-Za-z_][A-Za-z0-9_]*|[A-Za-z_][A-Za-z0-9_]*)"
+)
 _HOSTED_VOLUME_INVALID_RUN_PATTERN = re.compile(r"[^a-z0-9-]+")
 _HOSTED_VOLUME_HYPHEN_RUN_PATTERN = re.compile(r"-+")
 _HOSTED_VOLUME_HASH_LENGTHS = (10, 12, 16, 20, 24, 32)
@@ -554,7 +557,11 @@ def _hosted_validation_compose_short_named_volume_source(volume: str) -> str | N
     if _hosted_validation_compose_short_volume_is_windows_path(volume):
         return None
     source, separator, remainder = volume.partition(":")
-    if not separator or not source or not remainder.startswith("/"):
+    if (
+        not separator
+        or not source
+        or not _hosted_validation_compose_short_volume_has_container_target(remainder)
+    ):
         return None
     if _hosted_validation_compose_volume_source_is_host_path(source):
         return None
@@ -563,6 +570,10 @@ def _hosted_validation_compose_short_named_volume_source(volume: str) -> str | N
 
 def _hosted_validation_compose_short_volume_is_windows_path(volume: str) -> bool:
     return bool(re.match(r"^[A-Za-z]:[\\/]", volume))
+
+
+def _hosted_validation_compose_short_volume_has_container_target(target: str) -> bool:
+    return target.startswith("/") or bool(_HOSTED_COMPOSE_INTERPOLATED_TARGET_PATTERN.match(target))
 
 
 def _hosted_validation_compose_mapping_named_volume_source(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -353,8 +353,11 @@ def _hosted_validation_compose_volume_names(
 ) -> Iterator[str]:
     volumes = compose.get("volumes")
     if isinstance(volumes, Mapping):
-        for name in volumes:
+        for name, volume in volumes.items():
             yield str(name)
+            explicit_name = _hosted_validation_compose_volume_declaration_explicit_name(volume)
+            if explicit_name is not None:
+                yield explicit_name
 
     services = compose.get("services")
     if not isinstance(services, Mapping):
@@ -380,6 +383,17 @@ def _hosted_validation_compose_service_volume_names(
             source = None
         if source is not None:
             yield source
+
+
+def _hosted_validation_compose_volume_declaration_explicit_name(
+    volume: object,
+) -> str | None:
+    if not isinstance(volume, Mapping):
+        return None
+    name = volume.get("name")
+    if not isinstance(name, str) or not name:
+        return None
+    return name
 
 
 def _hosted_validation_dns1123_label_is_valid(value: str) -> bool:
@@ -426,7 +440,29 @@ def _hosted_validation_sanitize_rendered_stack_volumes(
         translated_name = volume_translations.get(volume_name, volume_name)
         if translated_name in payload:
             raise ValueError("hosted rendered stack volume declaration collision")
-        payload[translated_name] = _hosted_validation_sanitize_compose_value(value)
+        payload[translated_name] = _hosted_validation_sanitize_rendered_stack_volume(
+            value,
+            volume_translations=volume_translations,
+        )
+    return payload
+
+
+def _hosted_validation_sanitize_rendered_stack_volume(
+    volume: object,
+    *,
+    volume_translations: Mapping[str, str],
+) -> Any:
+    if not isinstance(volume, Mapping):
+        return _hosted_validation_sanitize_compose_value(volume)
+    payload: dict[str, Any] = {}
+    for key, value in volume.items():
+        field = str(key)
+        if field == "name" and isinstance(value, str):
+            payload[field] = _hosted_validation_sanitize_compose_value(
+                volume_translations.get(value, value)
+            )
+            continue
+        payload[field] = _hosted_validation_sanitize_compose_value(value)
     return payload
 
 

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -352,32 +352,24 @@ def _hosted_validation_compose_volume_name_translations(
         translations[name] = translated_name
         used_names[translated_name] = name
 
-    return _hosted_validation_redacted_top_level_volume_translations(
-        compose,
-        translations=translations,
-    )
+    return _hosted_validation_redacted_volume_translations(translations)
 
 
-def _hosted_validation_redacted_top_level_volume_translations(
-    compose: Mapping[object, object],
-    *,
+def _hosted_validation_redacted_volume_translations(
     translations: Mapping[str, str],
 ) -> dict[str, str]:
-    volumes = compose.get("volumes")
-    if not isinstance(volumes, Mapping):
-        return dict(translations)
-
-    top_level_names = [str(name) for name in volumes]
     redacted_names = {
         name
-        for name in top_level_names
+        for name, translated_name in translations.items()
         if _hosted_validation_compose_volume_name_needs_redaction(
             name,
-            translated_name=translations.get(name, name),
+            translated_name=translated_name,
         )
     }
     used_names = {
-        translations.get(name, name) for name in top_level_names if name not in redacted_names
+        translated_name
+        for name, translated_name in translations.items()
+        if name not in redacted_names
     }
     if (
         not redacted_names

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import base64
+import hashlib
 import re
+from collections import Counter
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import Any
@@ -54,6 +56,11 @@ _HOSTED_COVERAGE_OMITTED_RUNTIME_ENV = frozenset({"PIP_EXTRA_INDEX_URL", "PIP_IN
 _HOSTED_PHASE_COMMAND_FIELDS = ("setup", "pre_agent", "post_agent", "validate", "cleanup")
 _HOSTED_DATABASE_COMMAND_FIELDS = ("generated_setup", "pre_validation_refresh")
 _HOSTED_COMMAND_SECRET_ASSIGNMENT_KEYS = frozenset({"MYSQL_PWD", "PGPASSWORD"})
+_HOSTED_DNS1123_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$")
+_HOSTED_VOLUME_INVALID_RUN_PATTERN = re.compile(r"[^a-z0-9-]+")
+_HOSTED_VOLUME_HYPHEN_RUN_PATTERN = re.compile(r"-+")
+_HOSTED_VOLUME_HASH_LENGTHS = (10, 12, 16, 20, 24, 32)
+_HOSTED_KUBERNETES_LABEL_MAX_LENGTH = 63
 _log = get_logger(__name__)
 
 
@@ -153,16 +160,25 @@ def _hosted_validation_rendered_stack_payload(
     if not isinstance(parsed, Mapping):
         return None
 
+    volume_translations = _hosted_validation_compose_volume_name_translations(parsed)
     rendered_stack: dict[str, Any] = {
         "schema": _HOSTED_RENDERED_STACK_SCHEMA,
         "compose_project": compose_project,
         "compose_file_path": str(compose_file),
-        "services": _hosted_validation_rendered_stack_services(parsed.get("services")),
+        "services": _hosted_validation_rendered_stack_services(
+            parsed.get("services"),
+            volume_translations=volume_translations,
+        ),
     }
-    for key in ("volumes", "networks"):
-        value = parsed.get(key)
-        if isinstance(value, Mapping):
-            rendered_stack[key] = _hosted_validation_sanitize_compose_value(value)
+    volumes = parsed.get("volumes")
+    if isinstance(volumes, Mapping):
+        rendered_stack["volumes"] = _hosted_validation_sanitize_rendered_stack_volumes(
+            volumes,
+            volume_translations=volume_translations,
+        )
+    networks = parsed.get("networks")
+    if isinstance(networks, Mapping):
+        rendered_stack["networks"] = _hosted_validation_sanitize_compose_value(networks)
     return rendered_stack
 
 
@@ -247,7 +263,11 @@ def _hosted_validation_agent_auth_env_passthrough_names(
     )
 
 
-def _hosted_validation_rendered_stack_services(services: object) -> dict[str, Any]:
+def _hosted_validation_rendered_stack_services(
+    services: object,
+    *,
+    volume_translations: Mapping[str, str],
+) -> dict[str, Any]:
     """Return sanitized non-agent services from a rendered compose document."""
     if not isinstance(services, Mapping):
         return {}
@@ -256,19 +276,260 @@ def _hosted_validation_rendered_stack_services(services: object) -> dict[str, An
         service_name = str(name)
         if service_name == "agent" or not isinstance(service, Mapping):
             continue
-        payload[service_name] = _hosted_validation_sanitize_compose_service(service)
+        payload[service_name] = _hosted_validation_sanitize_compose_service(
+            service,
+            volume_translations=volume_translations,
+        )
     return payload
 
 
-def _hosted_validation_sanitize_compose_service(service: Mapping[str, object]) -> dict[str, Any]:
+def _hosted_validation_sanitize_compose_service(
+    service: Mapping[str, object],
+    *,
+    volume_translations: Mapping[str, str],
+) -> dict[str, Any]:
     payload: dict[str, Any] = {}
     for key, value in service.items():
         field = str(key)
         if field == "environment":
             payload[field] = _hosted_validation_sanitize_compose_environment(value)
             continue
+        if field == "volumes":
+            payload[field] = _hosted_validation_sanitize_compose_service_volumes(
+                value,
+                volume_translations=volume_translations,
+            )
+            continue
         payload[field] = _hosted_validation_sanitize_compose_value(value)
     return payload
+
+
+def _hosted_validation_compose_volume_name_translations(
+    compose: Mapping[object, object],
+) -> dict[str, str]:
+    volume_names = set(_hosted_validation_compose_volume_names(compose))
+    if not volume_names:
+        return {}
+
+    normalized_names = {
+        name: _hosted_validation_normalized_compose_volume_name(name) for name in volume_names
+    }
+    candidates = {
+        name: _hosted_validation_bounded_compose_volume_name(normalized_name)
+        for name, normalized_name in normalized_names.items()
+    }
+    candidate_counts = Counter(candidates.values())
+    translations: dict[str, str] = {}
+    used_names: dict[str, str] = {}
+
+    for name in sorted(volume_names):
+        if _hosted_validation_dns1123_label_is_valid(name):
+            translations[name] = name
+            used_names[name] = name
+
+    for name in sorted(volume_names):
+        if name in translations:
+            continue
+        candidate = candidates[name]
+        if candidate_counts[candidate] == 1 and candidate not in used_names:
+            translated_name = candidate
+        else:
+            translated_name = _hosted_validation_disambiguated_compose_volume_name(
+                normalized_base=normalized_names[name],
+                original_name=name,
+                used_names=used_names,
+            )
+        previous_original = used_names.get(translated_name)
+        if previous_original is not None and previous_original != name:
+            raise ValueError("hosted rendered stack volume name collision")
+        translations[name] = translated_name
+        used_names[translated_name] = name
+
+    return translations
+
+
+def _hosted_validation_compose_volume_names(
+    compose: Mapping[object, object],
+) -> Iterator[str]:
+    volumes = compose.get("volumes")
+    if isinstance(volumes, Mapping):
+        for name in volumes:
+            yield str(name)
+
+    services = compose.get("services")
+    if not isinstance(services, Mapping):
+        return
+    for name, service in services.items():
+        if str(name) == "agent" or not isinstance(service, Mapping):
+            continue
+        yield from _hosted_validation_compose_service_volume_names(service)
+
+
+def _hosted_validation_compose_service_volume_names(
+    service: Mapping[object, object],
+) -> Iterator[str]:
+    volumes = service.get("volumes")
+    if not isinstance(volumes, list):
+        return
+    for volume in volumes:
+        if isinstance(volume, str):
+            source = _hosted_validation_compose_short_named_volume_source(volume)
+        elif isinstance(volume, Mapping):
+            source = _hosted_validation_compose_mapping_named_volume_source(volume)
+        else:
+            source = None
+        if source is not None:
+            yield source
+
+
+def _hosted_validation_dns1123_label_is_valid(value: str) -> bool:
+    return _HOSTED_DNS1123_LABEL_PATTERN.fullmatch(value) is not None
+
+
+def _hosted_validation_normalized_compose_volume_name(value: str) -> str:
+    normalized = _HOSTED_VOLUME_INVALID_RUN_PATTERN.sub("-", value.lower())
+    normalized = _HOSTED_VOLUME_HYPHEN_RUN_PATTERN.sub("-", normalized).strip("-")
+    return normalized or "volume"
+
+
+def _hosted_validation_bounded_compose_volume_name(value: str) -> str:
+    return value[:_HOSTED_KUBERNETES_LABEL_MAX_LENGTH].rstrip("-") or "volume"
+
+
+def _hosted_validation_disambiguated_compose_volume_name(
+    *,
+    normalized_base: str,
+    original_name: str,
+    used_names: Mapping[str, str],
+) -> str:
+    digest = hashlib.sha256(original_name.encode("utf-8")).hexdigest()
+    for hash_length in _HOSTED_VOLUME_HASH_LENGTHS:
+        suffix = f"-{digest[:hash_length]}"
+        max_prefix_length = _HOSTED_KUBERNETES_LABEL_MAX_LENGTH - len(suffix)
+        if max_prefix_length <= 0:
+            continue
+        prefix = normalized_base[:max_prefix_length].rstrip("-") or "volume"
+        candidate = f"{prefix}{suffix}"
+        if _hosted_validation_dns1123_label_is_valid(candidate) and candidate not in used_names:
+            return candidate
+    raise ValueError("hosted rendered stack volume name collision")
+
+
+def _hosted_validation_sanitize_rendered_stack_volumes(
+    volumes: Mapping[object, object],
+    *,
+    volume_translations: Mapping[str, str],
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for name, value in volumes.items():
+        volume_name = str(name)
+        translated_name = volume_translations.get(volume_name, volume_name)
+        if translated_name in payload:
+            raise ValueError("hosted rendered stack volume declaration collision")
+        payload[translated_name] = _hosted_validation_sanitize_compose_value(value)
+    return payload
+
+
+def _hosted_validation_sanitize_compose_service_volumes(
+    volumes: object,
+    *,
+    volume_translations: Mapping[str, str],
+) -> Any:
+    if not isinstance(volumes, list):
+        return _hosted_validation_sanitize_compose_value(volumes)
+    return [
+        _hosted_validation_sanitize_compose_service_volume(
+            volume,
+            volume_translations=volume_translations,
+        )
+        for volume in volumes
+    ]
+
+
+def _hosted_validation_sanitize_compose_service_volume(
+    volume: object,
+    *,
+    volume_translations: Mapping[str, str],
+) -> Any:
+    if isinstance(volume, str):
+        return _hosted_validation_sanitize_compose_short_volume(
+            volume,
+            volume_translations=volume_translations,
+        )
+    if isinstance(volume, Mapping):
+        return _hosted_validation_sanitize_compose_volume_mapping(
+            volume,
+            volume_translations=volume_translations,
+        )
+    return _hosted_validation_sanitize_compose_value(volume)
+
+
+def _hosted_validation_sanitize_compose_short_volume(
+    volume: str,
+    *,
+    volume_translations: Mapping[str, str],
+) -> str:
+    source = _hosted_validation_compose_short_named_volume_source(volume)
+    if source is None:
+        return redact_secrets(volume)
+    translated_source = volume_translations.get(source, source)
+    _source, _separator, remainder = volume.partition(":")
+    return redact_secrets(f"{translated_source}:{remainder}")
+
+
+def _hosted_validation_sanitize_compose_volume_mapping(
+    volume: Mapping[object, object],
+    *,
+    volume_translations: Mapping[str, str],
+) -> dict[str, Any]:
+    source = _hosted_validation_compose_mapping_named_volume_source(volume)
+    payload: dict[str, Any] = {}
+    for key, value in volume.items():
+        field = str(key)
+        if field == "source" and source is not None:
+            payload[field] = _hosted_validation_sanitize_compose_value(
+                volume_translations.get(source, source)
+            )
+            continue
+        payload[field] = _hosted_validation_sanitize_compose_value(value)
+    return payload
+
+
+def _hosted_validation_compose_short_named_volume_source(volume: str) -> str | None:
+    if _hosted_validation_compose_short_volume_is_windows_path(volume):
+        return None
+    source, separator, remainder = volume.partition(":")
+    if not separator or not source or not remainder.startswith("/"):
+        return None
+    if _hosted_validation_compose_volume_source_is_host_path(source):
+        return None
+    return source
+
+
+def _hosted_validation_compose_short_volume_is_windows_path(volume: str) -> bool:
+    return bool(re.match(r"^[A-Za-z]:[\\/]", volume))
+
+
+def _hosted_validation_compose_mapping_named_volume_source(
+    volume: Mapping[object, object],
+) -> str | None:
+    type_value = volume.get("type")
+    if type_value is not None and (
+        not isinstance(type_value, str) or type_value.lower() != "volume"
+    ):
+        return None
+    source = volume.get("source")
+    if not isinstance(source, str) or not source:
+        return None
+    if _hosted_validation_compose_volume_source_is_host_path(source):
+        return None
+    return source
+
+
+def _hosted_validation_compose_volume_source_is_host_path(source: str) -> bool:
+    return (
+        source.startswith(("/", ".", "~", "$")) or "/" in source or "\\" in source or ":" in source
+    )
 
 
 def _hosted_validation_sanitize_compose_environment(environment: object) -> Any:

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -520,9 +520,12 @@ def _hosted_validation_sanitize_compose_short_volume(
     source = _hosted_validation_compose_short_named_volume_source(volume)
     if source is None:
         return redact_secrets(volume)
-    translated_source = volume_translations.get(source, source)
+    sanitized_source = _hosted_validation_sanitize_compose_volume_name(
+        source,
+        volume_translations=volume_translations,
+    )
     _source, _separator, remainder = volume.partition(":")
-    return redact_secrets(f"{translated_source}:{remainder}")
+    return redact_secrets(f"{sanitized_source}:{remainder}")
 
 
 def _hosted_validation_sanitize_compose_volume_mapping(
@@ -535,8 +538,9 @@ def _hosted_validation_sanitize_compose_volume_mapping(
     for key, value in volume.items():
         field = str(key)
         if field in {"source", "src"} and source is not None and value == source:
-            payload[field] = _hosted_validation_sanitize_compose_value(
-                volume_translations.get(source, source)
+            payload[field] = _hosted_validation_sanitize_compose_volume_name(
+                source,
+                volume_translations=volume_translations,
             )
             continue
         payload[field] = _hosted_validation_sanitize_compose_value(value)

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -458,12 +458,24 @@ def _hosted_validation_sanitize_rendered_stack_volume(
     for key, value in volume.items():
         field = str(key)
         if field == "name" and isinstance(value, str):
-            payload[field] = _hosted_validation_sanitize_compose_value(
-                volume_translations.get(value, value)
+            payload[field] = _hosted_validation_sanitize_compose_volume_name(
+                value,
+                volume_translations=volume_translations,
             )
             continue
         payload[field] = _hosted_validation_sanitize_compose_value(value)
     return payload
+
+
+def _hosted_validation_sanitize_compose_volume_name(
+    name: str,
+    *,
+    volume_translations: Mapping[str, str],
+) -> str:
+    sanitized_original = redact_secrets(name)
+    if sanitized_original != name:
+        return sanitized_original
+    return redact_secrets(volume_translations.get(name, name))
 
 
 def _hosted_validation_sanitize_compose_service_volumes(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -437,10 +437,13 @@ def _hosted_validation_sanitize_rendered_stack_volumes(
     payload: dict[str, Any] = {}
     for name, value in volumes.items():
         volume_name = str(name)
-        translated_name = volume_translations.get(volume_name, volume_name)
-        if translated_name in payload:
+        sanitized_name = _hosted_validation_sanitize_compose_volume_name(
+            volume_name,
+            volume_translations=volume_translations,
+        )
+        if sanitized_name in payload:
             raise ValueError("hosted rendered stack volume declaration collision")
-        payload[translated_name] = _hosted_validation_sanitize_rendered_stack_volume(
+        payload[sanitized_name] = _hosted_validation_sanitize_rendered_stack_volume(
             value,
             volume_translations=volume_translations,
         )

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -64,6 +64,7 @@ _HOSTED_VOLUME_INVALID_RUN_PATTERN = re.compile(r"[^a-z0-9-]+")
 _HOSTED_VOLUME_HYPHEN_RUN_PATTERN = re.compile(r"-+")
 _HOSTED_VOLUME_HASH_LENGTHS = (10, 12, 16, 20, 24, 32)
 _HOSTED_KUBERNETES_LABEL_MAX_LENGTH = 63
+_HOSTED_REDACTED_VOLUME_NAME = "redacted"
 _log = get_logger(__name__)
 
 
@@ -480,8 +481,12 @@ def _hosted_validation_sanitize_compose_volume_name(
 ) -> str:
     sanitized_original = redact_secrets(name)
     if sanitized_original != name:
-        return sanitized_original
-    return redact_secrets(volume_translations.get(name, name))
+        return _HOSTED_REDACTED_VOLUME_NAME
+    translated_name = volume_translations.get(name, name)
+    sanitized_translated = redact_secrets(translated_name)
+    if sanitized_translated != translated_name:
+        return _HOSTED_REDACTED_VOLUME_NAME
+    return sanitized_translated
 
 
 def _hosted_validation_sanitize_compose_service_volumes(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -65,6 +65,9 @@ _HOSTED_VOLUME_HYPHEN_RUN_PATTERN = re.compile(r"-+")
 _HOSTED_VOLUME_HASH_LENGTHS = (10, 12, 16, 20, 24, 32)
 _HOSTED_KUBERNETES_LABEL_MAX_LENGTH = 63
 _HOSTED_REDACTED_VOLUME_NAME = "redacted"
+_HOSTED_REDACTED_VOLUME_NAME_PATTERN = re.compile(
+    rf"^{_HOSTED_REDACTED_VOLUME_NAME}(?:-(?:[2-9]|[1-9][0-9]+))?$"
+)
 _log = get_logger(__name__)
 
 
@@ -349,7 +352,59 @@ def _hosted_validation_compose_volume_name_translations(
         translations[name] = translated_name
         used_names[translated_name] = name
 
-    return translations
+    return _hosted_validation_redacted_top_level_volume_translations(
+        compose,
+        translations=translations,
+    )
+
+
+def _hosted_validation_redacted_top_level_volume_translations(
+    compose: Mapping[object, object],
+    *,
+    translations: Mapping[str, str],
+) -> dict[str, str]:
+    volumes = compose.get("volumes")
+    if not isinstance(volumes, Mapping):
+        return dict(translations)
+
+    top_level_names = [str(name) for name in volumes]
+    redacted_names = {
+        name
+        for name in top_level_names
+        if _hosted_validation_compose_volume_name_needs_redaction(
+            name,
+            translated_name=translations.get(name, name),
+        )
+    }
+    used_names = {
+        translations.get(name, name) for name in top_level_names if name not in redacted_names
+    }
+    if (
+        not redacted_names
+        or len(redacted_names) == 1
+        and _HOSTED_REDACTED_VOLUME_NAME not in used_names
+    ):
+        return dict(translations)
+
+    payload = dict(translations)
+    for name in sorted(redacted_names):
+        placeholder = _hosted_validation_next_redacted_volume_name(used_names)
+        payload[name] = placeholder
+        used_names.add(placeholder)
+    return payload
+
+
+def _hosted_validation_next_redacted_volume_name(used_names: set[str]) -> str:
+    index = 1
+    while True:
+        candidate = (
+            _HOSTED_REDACTED_VOLUME_NAME
+            if index == 1
+            else f"{_HOSTED_REDACTED_VOLUME_NAME}-{index}"
+        )
+        if candidate not in used_names:
+            return candidate
+        index += 1
 
 
 def _hosted_validation_compose_volume_names(
@@ -479,14 +534,23 @@ def _hosted_validation_sanitize_compose_volume_name(
     *,
     volume_translations: Mapping[str, str],
 ) -> str:
-    sanitized_original = redact_secrets(name)
-    if sanitized_original != name:
-        return _HOSTED_REDACTED_VOLUME_NAME
     translated_name = volume_translations.get(name, name)
-    sanitized_translated = redact_secrets(translated_name)
-    if sanitized_translated != translated_name:
+    if _hosted_validation_compose_volume_name_needs_redaction(
+        name,
+        translated_name=translated_name,
+    ):
+        if _HOSTED_REDACTED_VOLUME_NAME_PATTERN.fullmatch(translated_name):
+            return translated_name
         return _HOSTED_REDACTED_VOLUME_NAME
-    return sanitized_translated
+    return translated_name
+
+
+def _hosted_validation_compose_volume_name_needs_redaction(
+    name: str,
+    *,
+    translated_name: str,
+) -> bool:
+    return redact_secrets(name) != name or redact_secrets(translated_name) != translated_name
 
 
 def _hosted_validation_sanitize_compose_service_volumes(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -522,7 +522,7 @@ def _hosted_validation_sanitize_compose_volume_mapping(
     payload: dict[str, Any] = {}
     for key, value in volume.items():
         field = str(key)
-        if field == "source" and source is not None:
+        if field in {"source", "src"} and source is not None and value == source:
             payload[field] = _hosted_validation_sanitize_compose_value(
                 volume_translations.get(source, source)
             )
@@ -555,6 +555,8 @@ def _hosted_validation_compose_mapping_named_volume_source(
     ):
         return None
     source = volume.get("source")
+    if not isinstance(source, str) or not source:
+        source = volume.get("src")
     if not isinstance(source, str) or not source:
         return None
     if _hosted_validation_compose_volume_source_is_host_path(source):

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -164,13 +164,21 @@ services:
       - type: volume
         source: cache_data
         target: /cache-long
+      - type: volume
+        src: cache_data
+        target: /cache-src-long
       - source: other_data
         target: /other-long
+      - src: other_data
+        target: /other-src-long
       - source: ./host-cache-long
         target: /host-long
       - type: bind
         source: bind_data
         target: /bind
+      - type: bind
+        src: bind_data
+        target: /bind-src
 volumes:
   cache_data:
     labels:
@@ -195,9 +203,12 @@ volumes:
         "./host-cache:/cache-host",
         "${HOST_CACHE}:/cache-env",
         {"type": "volume", "source": "cache-data", "target": "/cache-long"},
+        {"type": "volume", "src": "cache-data", "target": "/cache-src-long"},
         {"source": "other-data", "target": "/other-long"},
+        {"src": "other-data", "target": "/other-src-long"},
         {"source": "./host-cache-long", "target": "/host-long"},
         {"type": "bind", "source": "bind_data", "target": "/bind"},
+        {"type": "bind", "src": "bind_data", "target": "/bind-src"},
     ]
 
 

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -120,7 +120,8 @@ services:
     volumes:
       - postgres_data:/ignored-agent-mount
 volumes:
-  postgres_data: {}
+  postgres_data:
+    name: awf-ws_hosted-postgres_data
 """.lstrip(),
         encoding="utf-8",
     )
@@ -134,7 +135,7 @@ volumes:
     assert payload["schema"] == "hosted_validation_rendered_stack.v1"
     assert payload["compose_project"] == "awf_ws_hosted"
     assert payload["compose_file_path"] == str(compose_file)
-    assert payload["volumes"] == {"postgres-data": {}}
+    assert payload["volumes"] == {"postgres-data": {"name": "awf-ws-hosted-postgres-data"}}
     assert payload["services"] == {
         "postgres": {
             "image": "postgres:16",

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -433,6 +433,63 @@ volumes:
 
 
 @pytest.mark.unit
+def test_rendered_stack_payload_disambiguates_redacted_top_level_volume_keys(
+    tmp_path: Path,
+) -> None:
+    """Multiple secret-shaped top-level volume keys must not collide."""
+    first_token_name = "ghp_volumeSecretToken123456"
+    first_translated_name = "ghp-volumesecrettoken123456"
+    second_token_name = "gho_volumeSecretToken123456"
+    second_translated_name = "gho-volumesecrettoken123456"
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - {first_token_name}:/cache-first
+      - type: volume
+        source: {second_token_name}
+        target: /cache-second
+volumes:
+  {first_token_name}: {{}}
+  {second_token_name}: {{}}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    redacted_volume_names = set(payload["volumes"])
+    assert len(redacted_volume_names) == 2
+    assert all(
+        name == "redacted" or re.fullmatch(r"redacted-[0-9]+", name)
+        for name in redacted_volume_names
+    )
+    for name in redacted_volume_names:
+        _assert_dns1123_label(name)
+    backend_volumes = payload["services"]["backend"]["volumes"]
+    assert {
+        backend_volumes[0].partition(":")[0],
+        backend_volumes[1]["source"],
+    } == redacted_volume_names
+    body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
+    for secret in (
+        first_token_name,
+        first_translated_name,
+        second_token_name,
+        second_translated_name,
+    ):
+        assert secret not in body
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("token_name", "translated_token_name"),
     [

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -405,7 +405,7 @@ def test_rendered_stack_payload_redacts_token_volume_key_before_translation(
     token_name: str,
     translated_token_name: str,
 ) -> None:
-    """Token-shaped top-level volume keys must be redacted before normalization."""
+    """Token-shaped volume keys must redact to a DNS-safe hosted placeholder."""
     compose_file = tmp_path / "compose.yml"
     compose_file.write_text(
         f"""
@@ -424,8 +424,10 @@ volumes:
     )
 
     assert payload is not None
-    assert payload["volumes"] == {"<redacted>": {}}
+    assert payload["volumes"] == {"redacted": {}}
+    _assert_dns1123_label(next(iter(payload["volumes"])))
     body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
     assert token_name not in body
     assert translated_token_name not in body
 
@@ -443,7 +445,7 @@ def test_rendered_stack_payload_redacts_token_explicit_volume_name_before_transl
     token_name: str,
     translated_token_name: str,
 ) -> None:
-    """Token-shaped explicit volume names must be redacted before normalization."""
+    """Token-shaped explicit names must redact to a DNS-safe hosted placeholder."""
     compose_file = tmp_path / "compose.yml"
     compose_file.write_text(
         f"""
@@ -465,8 +467,10 @@ volumes:
     )
 
     assert payload is not None
-    assert payload["volumes"] == {"cache": {"name": "<redacted>"}}
+    assert payload["volumes"] == {"cache": {"name": "redacted"}}
+    _assert_dns1123_label(payload["volumes"]["cache"]["name"])
     body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
     assert token_name not in body
     assert translated_token_name not in body
 
@@ -475,7 +479,7 @@ volumes:
 def test_rendered_stack_payload_redacts_token_service_volume_sources_before_translation(
     tmp_path: Path,
 ) -> None:
-    """Token-shaped service volume sources must be redacted before normalization."""
+    """Token-shaped service volume sources redact to DNS-safe hosted placeholders."""
     short_token_name = "ghp_volumeSecretToken123456"
     short_translated_name = "ghp-volumesecrettoken123456"
     source_token_name = "AIzaVolumeSecretToken123456"
@@ -507,11 +511,19 @@ services:
 
     assert payload is not None
     assert payload["services"]["backend"]["volumes"] == [
-        "<redacted>:/cache-short",
-        {"type": "volume", "source": "<redacted>", "target": "/cache-source"},
-        {"type": "volume", "src": "<redacted>", "target": "/cache-src"},
+        "redacted:/cache-short",
+        {"type": "volume", "source": "redacted", "target": "/cache-source"},
+        {"type": "volume", "src": "redacted", "target": "/cache-src"},
     ]
+    for volume in payload["services"]["backend"]["volumes"]:
+        source = (
+            volume.partition(":")[0]
+            if isinstance(volume, str)
+            else volume["source" if "source" in volume else "src"]
+        )
+        _assert_dns1123_label(source)
     body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
     for secret in (
         short_token_name,
         short_translated_name,

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -14,6 +15,13 @@ from awf.runtime.hosted_delegation_payloads import (
     _hosted_validation_profile_payload,
     _hosted_validation_rendered_stack_payload,
 )
+
+_DNS1123_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
+
+
+def _assert_dns1123_label(value: str) -> None:
+    assert len(value) <= 63
+    assert _DNS1123_LABEL_PATTERN.fullmatch(value) is not None
 
 
 @pytest.mark.unit
@@ -92,6 +100,280 @@ volumes:
     assert payload is not None
     assert payload["services"] == {}
     assert payload["volumes"] == {"pgdata": {}}
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_normalizes_postgres_data_named_volume(
+    tmp_path: Path,
+) -> None:
+    """Hosted rendered stacks use DNS-1123 volume names for the GKE failure case."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: postgres:16
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+  agent:
+    image: awf-agent-runtime:latest
+    volumes:
+      - postgres_data:/ignored-agent-mount
+volumes:
+  postgres_data: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["schema"] == "hosted_validation_rendered_stack.v1"
+    assert payload["compose_project"] == "awf_ws_hosted"
+    assert payload["compose_file_path"] == str(compose_file)
+    assert payload["volumes"] == {"postgres-data": {}}
+    assert payload["services"] == {
+        "postgres": {
+            "image": "postgres:16",
+            "volumes": ["postgres-data:/var/lib/postgresql/data"],
+        }
+    }
+    body = json.dumps(payload, sort_keys=True)
+    assert "postgres_data" not in body
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_uses_one_volume_translation_for_supported_shapes(
+    tmp_path: Path,
+) -> None:
+    """Top-level declarations and supported service refs cannot diverge."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - cache_data:/cache
+      - ./host-cache:/cache-host
+      - ${HOST_CACHE}:/cache-env
+      - type: volume
+        source: cache_data
+        target: /cache-long
+      - source: other_data
+        target: /other-long
+      - source: ./host-cache-long
+        target: /host-long
+      - type: bind
+        source: bind_data
+        target: /bind
+volumes:
+  cache_data:
+    labels:
+      purpose: cache
+  other_data: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["volumes"] == {
+        "cache-data": {"labels": {"purpose": "cache"}},
+        "other-data": {},
+    }
+    assert payload["services"]["backend"]["volumes"] == [
+        "cache-data:/cache",
+        "./host-cache:/cache-host",
+        "${HOST_CACHE}:/cache-env",
+        {"type": "volume", "source": "cache-data", "target": "/cache-long"},
+        {"source": "other-data", "target": "/other-long"},
+        {"source": "./host-cache-long", "target": "/host-long"},
+        {"type": "bind", "source": "bind_data", "target": "/bind"},
+    ]
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_preserves_valid_dns1123_named_volume(
+    tmp_path: Path,
+) -> None:
+    """Already valid hosted volume labels stay stable."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: postgres:16
+    volumes:
+      - pg-data:/var/lib/postgresql/data
+      - type: volume
+        source: pg-data
+        target: /backup
+volumes:
+  pg-data: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["volumes"] == {"pg-data": {}}
+    assert payload["services"]["postgres"]["volumes"] == [
+        "pg-data:/var/lib/postgresql/data",
+        {"type": "volume", "source": "pg-data", "target": "/backup"},
+    ]
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_disambiguates_volume_normalization_collisions(
+    tmp_path: Path,
+) -> None:
+    """Distinct Compose volume names must not alias after hosted normalization."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  underscore:
+    image: postgres:16
+    volumes:
+      - pg_data:/data-underscore
+  dot:
+    image: postgres:16
+    volumes:
+      - pg.data:/data-dot
+  valid:
+    image: postgres:16
+    volumes:
+      - pg-data:/data-valid
+volumes:
+  pg_data: {}
+  pg.data: {}
+  pg-data: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    first = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+    second = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert first is not None
+    assert second is not None
+    assert first == second
+    translated_names = set(first["volumes"])
+    assert len(translated_names) == 3
+    assert "pg-data" in translated_names
+    for name in translated_names:
+        _assert_dns1123_label(name)
+
+    underscore_source = first["services"]["underscore"]["volumes"][0].partition(":")[0]
+    dot_source = first["services"]["dot"]["volumes"][0].partition(":")[0]
+    valid_source = first["services"]["valid"]["volumes"][0].partition(":")[0]
+    assert valid_source == "pg-data"
+    assert {underscore_source, dot_source, valid_source} == translated_names
+    assert len({underscore_source, dot_source, valid_source}) == 3
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_disambiguates_long_volume_names(tmp_path: Path) -> None:
+    """Long names are bounded without silently aliasing shared prefixes."""
+    first_volume = f"shared_{'x' * 80}_alpha"
+    second_volume = f"shared_{'x' * 80}_bravo"
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  first:
+    image: postgres:16
+    volumes:
+      - {first_volume}:/data-first
+  second:
+    image: postgres:16
+    volumes:
+      - {second_volume}:/data-second
+volumes:
+  {first_volume}: {{}}
+  {second_volume}: {{}}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    translated_names = set(payload["volumes"])
+    assert len(translated_names) == 2
+    for name in translated_names:
+        _assert_dns1123_label(name)
+    first_source = payload["services"]["first"]["volumes"][0].partition(":")[0]
+    second_source = payload["services"]["second"]["volumes"][0].partition(":")[0]
+    assert first_source in translated_names
+    assert second_source in translated_names
+    assert first_source != second_source
+    body = json.dumps(payload, sort_keys=True)
+    assert first_volume not in body
+    assert second_volume not in body
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_volume_normalization_keeps_payload_secret_free(
+    tmp_path: Path,
+) -> None:
+    """Volume-specific rewriting must still route service values through redaction."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: postgres:16
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_PASSWORD: literal-postgres-secret
+      DATABASE_URL: postgresql://user:literal-url-secret@postgres/awf
+      PUBLIC_URL: http://postgres:5432
+volumes:
+  postgres_data: {}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["volumes"] == {"postgres-data": {}}
+    assert payload["services"]["postgres"]["environment"] == {
+        "POSTGRES_PASSWORD": "${POSTGRES_PASSWORD}",
+        "DATABASE_URL": "${DATABASE_URL}",
+        "PUBLIC_URL": "http://postgres:5432",
+    }
+    body = json.dumps(payload, sort_keys=True)
+    assert "literal-postgres-secret" not in body
+    assert "literal-url-secret" not in body
+    assert "user:literal-url-secret" not in body
+    assert "postgres_data" not in body
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -398,6 +398,44 @@ volumes:
         ("AIzaVolumeSecretToken123456", "aizavolumesecrettoken123456"),
     ],
 )
+def test_rendered_stack_payload_redacts_token_volume_key_before_translation(
+    tmp_path: Path,
+    token_name: str,
+    translated_token_name: str,
+) -> None:
+    """Token-shaped top-level volume keys must be redacted before normalization."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+volumes:
+  {token_name}: {{}}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["volumes"] == {"<redacted>": {}}
+    body = json.dumps(payload, sort_keys=True)
+    assert token_name not in body
+    assert translated_token_name not in body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("token_name", "translated_token_name"),
+    [
+        ("ghp_volumeSecretToken123456", "ghp-volumesecrettoken123456"),
+        ("AIzaVolumeSecretToken123456", "aizavolumesecrettoken123456"),
+    ],
+)
 def test_rendered_stack_payload_redacts_token_explicit_volume_name_before_translation(
     tmp_path: Path,
     token_name: str,

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -161,6 +161,7 @@ services:
     image: backend:latest
     volumes:
       - cache_data:/cache
+      - cache_data:${CACHE_DIR}
       - ./host-cache:/cache-host
       - ${HOST_CACHE}:/cache-env
       - type: volume
@@ -202,6 +203,7 @@ volumes:
     }
     assert payload["services"]["backend"]["volumes"] == [
         "cache-data:/cache",
+        "cache-data:${CACHE_DIR}",
         "./host-cache:/cache-host",
         "${HOST_CACHE}:/cache-env",
         {"type": "volume", "source": "cache-data", "target": "/cache-long"},

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -430,6 +430,58 @@ volumes:
 
 
 @pytest.mark.unit
+def test_rendered_stack_payload_redacts_token_service_volume_sources_before_translation(
+    tmp_path: Path,
+) -> None:
+    """Token-shaped service volume sources must be redacted before normalization."""
+    short_token_name = "ghp_volumeSecretToken123456"
+    short_translated_name = "ghp-volumesecrettoken123456"
+    source_token_name = "AIzaVolumeSecretToken123456"
+    source_translated_name = "aizavolumesecrettoken123456"
+    src_token_name = "gho_volumeSecretToken123456"
+    src_translated_name = "gho-volumesecrettoken123456"
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - {short_token_name}:/cache-short
+      - type: volume
+        source: {source_token_name}
+        target: /cache-source
+      - type: volume
+        src: {src_token_name}
+        target: /cache-src
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["services"]["backend"]["volumes"] == [
+        "<redacted>:/cache-short",
+        {"type": "volume", "source": "<redacted>", "target": "/cache-source"},
+        {"type": "volume", "src": "<redacted>", "target": "/cache-src"},
+    ]
+    body = json.dumps(payload, sort_keys=True)
+    for secret in (
+        short_token_name,
+        short_translated_name,
+        source_token_name,
+        source_translated_name,
+        src_token_name,
+        src_translated_name,
+    ):
+        assert secret not in body
+
+
+@pytest.mark.unit
 def test_rendered_stack_payload_sanitizes_list_environment(tmp_path: Path) -> None:
     """List-form Compose environments preserve shape while removing secrets."""
     compose_file = tmp_path / "compose.yml"

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -533,6 +533,60 @@ volumes:
 
 
 @pytest.mark.unit
+def test_rendered_stack_payload_disambiguates_redacted_explicit_volume_names(
+    tmp_path: Path,
+) -> None:
+    """Multiple secret-shaped explicit volume names must not alias."""
+    first_token_name = "ghp_volumeSecretToken123456"
+    first_translated_name = "ghp-volumesecrettoken123456"
+    second_token_name = "gho_volumeSecretToken123456"
+    second_translated_name = "gho-volumesecrettoken123456"
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - cache-a:/cache-a
+      - cache-b:/cache-b
+volumes:
+  cache-a:
+    name: {first_token_name}
+  cache-b:
+    name: {second_token_name}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    explicit_names = {
+        payload["volumes"]["cache-a"]["name"],
+        payload["volumes"]["cache-b"]["name"],
+    }
+    assert len(explicit_names) == 2
+    assert all(
+        name == "redacted" or re.fullmatch(r"redacted-[0-9]+", name) for name in explicit_names
+    )
+    for name in explicit_names:
+        _assert_dns1123_label(name)
+    body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
+    for secret in (
+        first_token_name,
+        first_translated_name,
+        second_token_name,
+        second_translated_name,
+    ):
+        assert secret not in body
+
+
+@pytest.mark.unit
 def test_rendered_stack_payload_redacts_token_service_volume_sources_before_translation(
     tmp_path: Path,
 ) -> None:
@@ -567,17 +621,23 @@ services:
     )
 
     assert payload is not None
-    assert payload["services"]["backend"]["volumes"] == [
-        "redacted:/cache-short",
-        {"type": "volume", "source": "redacted", "target": "/cache-source"},
-        {"type": "volume", "src": "redacted", "target": "/cache-src"},
-    ]
-    for volume in payload["services"]["backend"]["volumes"]:
-        source = (
-            volume.partition(":")[0]
-            if isinstance(volume, str)
-            else volume["source" if "source" in volume else "src"]
-        )
+    backend_volumes = payload["services"]["backend"]["volumes"]
+    assert len(backend_volumes) == 3
+    assert backend_volumes[0].partition(":")[2] == "/cache-short"
+    assert backend_volumes[1]["type"] == "volume"
+    assert backend_volumes[1]["target"] == "/cache-source"
+    assert backend_volumes[2]["type"] == "volume"
+    assert backend_volumes[2]["target"] == "/cache-src"
+    sources = {
+        backend_volumes[0].partition(":")[0],
+        backend_volumes[1]["source"],
+        backend_volumes[2]["src"],
+    }
+    assert len(sources) == 3
+    assert all(
+        source == "redacted" or re.fullmatch(r"redacted-[0-9]+", source) for source in sources
+    )
+    for source in sources:
         _assert_dns1123_label(source)
     body = json.dumps(payload, sort_keys=True)
     assert "<redacted>" not in body
@@ -588,6 +648,60 @@ services:
         source_translated_name,
         src_token_name,
         src_translated_name,
+    ):
+        assert secret not in body
+
+
+@pytest.mark.unit
+def test_rendered_stack_payload_disambiguates_redacted_service_only_volume_sources(
+    tmp_path: Path,
+) -> None:
+    """Multiple secret-shaped service-only volume sources must not alias."""
+    first_token_name = "ghp_volumeSecretToken123456"
+    first_translated_name = "ghp-volumesecrettoken123456"
+    second_token_name = "gho_volumeSecretToken123456"
+    second_translated_name = "gho-volumesecrettoken123456"
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - {first_token_name}:/cache-first
+      - type: volume
+        source: {second_token_name}
+        target: /cache-second
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    backend_volumes = payload["services"]["backend"]["volumes"]
+    assert len(backend_volumes) == 2
+    redacted_volume_names = {
+        backend_volumes[0].partition(":")[0],
+        backend_volumes[1]["source"],
+    }
+    assert len(redacted_volume_names) == 2
+    assert all(
+        name == "redacted" or re.fullmatch(r"redacted-[0-9]+", name)
+        for name in redacted_volume_names
+    )
+    for name in redacted_volume_names:
+        _assert_dns1123_label(name)
+    body = json.dumps(payload, sort_keys=True)
+    assert "<redacted>" not in body
+    for secret in (
+        first_token_name,
+        first_translated_name,
+        second_token_name,
+        second_translated_name,
     ):
         assert secret not in body
 

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -389,6 +389,47 @@ volumes:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    ("token_name", "translated_token_name"),
+    [
+        ("ghp_volumeSecretToken123456", "ghp-volumesecrettoken123456"),
+        ("AIzaVolumeSecretToken123456", "aizavolumesecrettoken123456"),
+    ],
+)
+def test_rendered_stack_payload_redacts_token_explicit_volume_name_before_translation(
+    tmp_path: Path,
+    token_name: str,
+    translated_token_name: str,
+) -> None:
+    """Token-shaped explicit volume names must be redacted before normalization."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        f"""
+services:
+  backend:
+    image: backend:latest
+    volumes:
+      - cache:/cache
+volumes:
+  cache:
+    name: {token_name}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert payload["volumes"] == {"cache": {"name": "<redacted>"}}
+    body = json.dumps(payload, sort_keys=True)
+    assert token_name not in body
+    assert translated_token_name not in body
+
+
+@pytest.mark.unit
 def test_rendered_stack_payload_sanitizes_list_environment(tmp_path: Path) -> None:
     """List-form Compose environments preserve shape while removing secrets."""
     compose_file = tmp_path / "compose.yml"

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -11,9 +11,11 @@ import pytest
 from awf.profiles.models import WorkspaceProfile
 from awf.runtime.hosted_delegation_payloads import (
     _hosted_pr_identity_payload,
+    _hosted_validation_attach_rendered_stack,
     _hosted_validation_omit_environment_entries,
     _hosted_validation_profile_payload,
     _hosted_validation_rendered_stack_payload,
+    _hosted_validation_secret_checked_fields,
 )
 
 _DNS1123_LABEL_PATTERN = re.compile(r"^[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?$")
@@ -563,6 +565,66 @@ services:
 
 
 @pytest.mark.unit
+def test_rendered_stack_payload_handles_unusual_volume_shapes(tmp_path: Path) -> None:
+    """Rendered stack metadata preserves odd Compose volume shapes without raw leaks."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  backend:
+    image: backend:latest
+    volumes: not-a-list
+  worker:
+    image: worker:latest
+    volumes:
+      - 42
+      - 'C:\\host\\cache:/windows'
+      - cache
+      - cache:relative
+      - type: volume
+        target: /missing-source
+      - source: ./host-cache
+        target: /host
+      - source: named_data
+        target: /named
+      - type: bind
+        source: bind_data
+        target: /bind
+  agent:
+    image: awf-agent-runtime:latest
+volumes:
+  odd_bool: true
+""".lstrip(),
+        encoding="utf-8",
+    )
+    envelope: dict[str, object] = {}
+
+    _hosted_validation_attach_rendered_stack(
+        envelope,
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+        include_agent_auth_context=True,
+    )
+
+    assert set(envelope) == {"rendered_stack"}
+    stack = envelope["rendered_stack"]
+    assert isinstance(stack, dict)
+    assert "agent_auth" not in envelope
+    assert stack["volumes"] == {"odd-bool": True}
+    assert stack["services"]["backend"]["volumes"] == "not-a-list"
+    assert stack["services"]["worker"]["volumes"] == [
+        42,
+        r"C:\host\cache:/windows",
+        "cache",
+        "cache:relative",
+        {"type": "volume", "target": "/missing-source"},
+        {"source": "./host-cache", "target": "/host"},
+        {"source": "named-data", "target": "/named"},
+        {"type": "bind", "source": "bind_data", "target": "/bind"},
+    ]
+
+
+@pytest.mark.unit
 def test_hosted_profile_environment_omit_ignores_unexpected_container_shapes() -> None:
     """Coverage profile env omission only mutates dict environment containers."""
     list_container: list[object] = []
@@ -880,6 +942,32 @@ def test_hosted_validation_profile_payload_rejects_secret_bearing_healthcheck_ur
     message = str(excinfo.value)
     assert "validation.healthchecks[0].url" in message
     assert "literal-health-url-secret" not in message
+
+
+@pytest.mark.unit
+def test_hosted_validation_secret_field_scan_ignores_malformed_optional_sections() -> None:
+    """Malformed optional command sections are ignored while safe fields remain visible."""
+    payload = {
+        "phases": {"setup": "pytest -q"},
+        "database": {"generated_setup": object()},
+        "validation": {
+            "coverage": {"command": "pytest --cov"},
+            "healthchecks": [
+                {"name": "missing-command"},
+                "not-a-healthcheck",
+                {"name": "app", "url": "https://app.example.test/health"},
+            ],
+        },
+        "services": [
+            "not-a-service",
+            {"name": "worker", "command": "python -m worker"},
+        ],
+    }
+
+    assert list(_hosted_validation_secret_checked_fields(payload)) == [
+        ("validation.healthchecks[2].url", "https://app.example.test/health"),
+        ("services[1].command", "python -m worker"),
+    ]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_2a9a2bb863164aee8a6b5fd2` (agent: `codex`, model: `gpt-5.5`, effort: `xhigh`).

## Summary

Fixes hosted rendered-stack metadata so Compose named volumes are emitted as deterministic DNS-1123 labels before delegated validation reaches AWF Cloud / GKE.

- Normalizes invalid Compose named-volume identifiers such as `postgres_data` while preserving already valid DNS-1123 names.
- Rewrites top-level `rendered_stack.volumes` declarations and supported service volume references through one translation map so declarations and mounts stay consistent.
- Handles collisions and long names deterministically without silently aliasing distinct volumes, while leaving bind mounts and host paths alone.
- Preserves existing hosted payload secret redaction behavior.

## Validation

- `uv run --python 3.12 --extra dev pytest tests/unit/runtime/test_hosted_delegation_payloads.py -q` passed: 33 passed.
- `uv run --python 3.12 --extra dev ruff check src/awf/runtime/hosted_delegation_payloads.py tests/unit/runtime/test_hosted_delegation_payloads.py` passed.
- `uv run --python 3.12 --extra dev mypy src/awf/runtime/hosted_delegation_payloads.py` passed.
- Full AWF/GitHub validation, provenance, coverage gates, PR monitoring, repair, and merge remain owned by AWF after agent completion.

## Release Readiness

Affected AWF Core surfaces: hosted delegation rendered-stack payload generation used by delegated validation / PR monitor flows, plus focused unit coverage. No CLI, console, MCP, profile, Docker lifecycle, cleanup, or project runtime behavior changes are intended. REST behavior is limited to the metadata shape AWF sends to hosted validation runs.

## Security / Secrets

No secrets were added to code, logs, fixtures, screenshots, or PR artifacts. The implementation preserves hosted payload redaction and focused tests cover secret-free output, including token-like volume names/sources and service environment values.

---

### Original Task

Fix the confirmed hosted PR-monitor contract failure seen in GKE on 2026-07-15. AWF Core PR 764 sends rendered Compose stack metadata to AWF Cloud /v1/validation-runs. A real awf-cloud profile renders the named volume `postgres_data`; AWF Cloud correctly rejects it because Kubernetes volume names must be DNS-1123 labels. This causes hosted adopted monitors to fail with HTTP 400 before monitoring begins.

Use strict TDD. In src/awf/runtime/hosted_delegation_payloads.py, add a deterministic bounded translation for Compose named-volume identifiers in the hosted rendered-stack payload. The same translated name must be used in top-level rendered_stack.volumes keys and every supported service volume reference (Compose short syntax and any already-supported mapping shape) so declaration and mount references cannot diverge. Preserve valid DNS-1123 names unchanged. Normalize underscores/invalid runs safely, enforce the 63-character Kubernetes bound, and handle normalization/truncation collisions deterministically and fail closed or disambiguate without silently aliasing distinct volumes. Do not weaken secret redaction or pass bind mounts/host paths as named volumes. Keep this Core-neutral as hosted contract normalization; do not add AWF Cloud tenant concepts.

Add focused unit tests using the exact `postgres_data:/var/lib/postgresql/data` reproduction, declaration/reference consistency, already-valid names, collisions, and long names. Confirm the output is accepted by the documented hosted contract shape and remains secret-free. Run the focused tests, Ruff, and mypy for touched code. Do not push manually; AWF owns commit, PR creation, monitoring, repair, and merge.

---

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the hosted validation payload contract sent to AWF Cloud; incorrect volume mapping could break delegated runs, though scope is limited to rendered-stack sanitization and redaction behavior is heavily tested.
> 
> **Overview**
> Fixes hosted **rendered-stack** metadata so Compose **named volumes** are emitted as deterministic **DNS-1123** labels before delegated validation hits AWF Cloud / GKE (e.g. `postgres_data` no longer causes HTTP 400).
> 
> The payload builder now computes one **volume translation map** from top-level declarations, explicit `name` fields, and supported service mount shapes (short syntax and `type: volume` mappings), then rewrites **`rendered_stack.volumes` keys** and **service volume references** through that map so declarations and mounts stay aligned. Valid labels are left unchanged; invalid or long names are normalized, bounded to 63 characters, and **disambiguated** (hash suffix) when normalization would alias distinct volumes. **Bind mounts and host paths** are not treated as named volumes.
> 
> **Secret-shaped** volume keys/sources are replaced with DNS-safe **`redacted`** placeholders (with numeric suffixes when needed), without weakening existing environment/value redaction. A small follow-up hardens secret-field scanning so **malformed optional profile sections** are skipped instead of breaking the scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 989f0fc0cdbfcfe0e45344fbee77facc08d51778. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hosted rendered-stack payload sanitization for volume names and mount references.
  * Normalized volume names to supported formats while preventing naming collisions.
  * Redacted sensitive volume names, sources, and service environment values from generated payloads.
  * Preserved valid volume names and metadata across supported Compose formats.
  * Improved handling of unusual volume definitions and malformed optional secret sections.

* **Tests**
  * Added comprehensive coverage for volume normalization, collision handling, secret redaction, and Compose volume shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
