### PR TITLE
fix(hosted): delegate merge-conflict preparation

### DIFF
--- a/src/awf/adapters/base.py
+++ b/src/awf/adapters/base.py
@@ -24,6 +24,7 @@ from awf.adapters.runtime_executor import (
     AgentRuntimeExecRequest,
     AgentRuntimeExecResult,
     AgentRuntimeExecutor,
+    AgentRuntimeGitPreparation,
 )
 from awf.adapters.usage import UsageSampleContext, UsageSampler
 from awf.common.commands import (
@@ -349,6 +350,7 @@ class AgentAdapter(ABC):
         workspace_id: str | None = None,
         log_source: str = "agent",
         hosted_pr_identity: dict[str, Any] | None = None,
+        git_preparation: AgentRuntimeGitPreparation | None = None,
         profile: WorkspaceProfile | None = None,
         worktree_path: Path | None = None,
     ) -> AgentRunResult:
@@ -381,6 +383,7 @@ class AgentAdapter(ABC):
                 workspace_id=workspace_id,
                 log_source=log_source,
                 hosted_pr_identity=hosted_pr_identity,
+                git_preparation=git_preparation,
                 profile=profile,
                 worktree_path=worktree_path,
             )
@@ -507,6 +510,7 @@ class AgentAdapter(ABC):
         workspace_id: str | None,
         log_source: str,
         hosted_pr_identity: dict[str, Any] | None,
+        git_preparation: AgentRuntimeGitPreparation | None,
         profile: WorkspaceProfile | None,
         worktree_path: Path | None = None,
     ) -> AgentRunResult:
@@ -682,6 +686,7 @@ class AgentAdapter(ABC):
             head_repo_slug=_hosted_identity_str(hosted_pr_identity, "head_repo_slug"),
             owned_paths=_hosted_identity_str_tuple(hosted_pr_identity, "owned_paths"),
             expected_head_sha=_hosted_identity_str(hosted_pr_identity, "expected_head_sha"),
+            git_preparation=git_preparation,
             on_stdout=on_stdout_cb,
             on_stderr=on_stderr_cb,
         )

--- a/src/awf/adapters/runtime_executor.py
+++ b/src/awf/adapters/runtime_executor.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 
 from awf.common.commands import (
     COMMAND_IDLE_TIMEOUT_REASON,
@@ -42,6 +42,20 @@ _HOSTED_TIMEOUT_RETURN_CODE = 124
 #: distinguish wall-clock vs idle timeouts. Other values are reserved; the
 #: adapter treats any non-empty ``timeout_reason`` as authoritative.
 _HOSTED_TIMEOUT_REASONS = frozenset({COMMAND_TIMEOUT_REASON, COMMAND_IDLE_TIMEOUT_REASON})
+
+
+@dataclass(frozen=True)
+class AgentRuntimeGitPreparation:
+    """Explicit, secret-free checkout preparation for a hosted agent run.
+
+    Normal runs omit this value. ``merge_base`` asks the hosted runtime to
+    merge the trusted base ref pinned to the exact 40-character lowercase SHA
+    Core already fetched.
+    """
+
+    mode: Literal["merge_base"]
+    base_ref: str
+    expected_base_sha: str
 
 
 @dataclass(frozen=True)
@@ -121,6 +135,7 @@ class AgentRuntimeExecRequest:
     head_repo_slug: str | None = None
     owned_paths: tuple[str, ...] = ()
     expected_head_sha: str | None = None
+    git_preparation: AgentRuntimeGitPreparation | None = None
     on_stdout: StreamCallback | None = None
     on_stderr: StreamCallback | None = None
     profile: WorkspaceProfile | None = None

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -10,6 +10,9 @@ Operation state machine for AWF Cloud implementers:
 
 1. Core starts an operation with ``POST {base_url}/v1/agent-runs`` or
    ``POST {base_url}/v1/validation-runs``.
+   Agent runs normally omit ``git_preparation``; a SyncBase conflict may set
+   ``{mode: merge_base, base_ref, expected_base_sha}``, pinned to Core's exact
+   fetched base commit.
 2. The request uses ``Authorization: Bearer <configured token>``. The token is
    never sent in the body or query string.
 3. The start response returns ``operation_id``, ``workspace_id``, and an

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -105,6 +105,12 @@ def _agent_start_payload(request: AgentRuntimeExecRequest) -> dict[str, Any]:
     pr_identity = _agent_pr_identity_payload(request)
     if pr_identity:
         payload["pr_identity"] = pr_identity
+    if request.git_preparation is not None:
+        payload["git_preparation"] = {
+            "mode": request.git_preparation.mode,
+            "base_ref": request.git_preparation.base_ref,
+            "expected_base_sha": request.git_preparation.expected_base_sha,
+        }
     if request.profile is not None:
         agent_profile = request.profile.model_copy(deep=True)
         agent_profile.phases.setup = []

--- a/src/awf/runtime/pr_monitor_runner/agent_service_recovery.py
+++ b/src/awf/runtime/pr_monitor_runner/agent_service_recovery.py
@@ -16,6 +16,7 @@ from awf.adapters.provider_failures import (
     AGENT_TIMEOUT,
     classify_provider_failure,
 )
+from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
 from awf.common.command_evidence import append_command_evidence
 from awf.common.commands import CommandResult
 from awf.common.compose_exec import EXEC_PROCESS_CLEANUP_FAILED, ComposeExecCleanupError
@@ -76,6 +77,7 @@ _AGENT_SERVICE_TIMEOUT_REASON_CODES = frozenset({AGENT_IDLE_TIMEOUT, AGENT_TIMEO
 _AGENT_SERVICE_RESTART_ATTEMPTS = 2
 _MONITOR_AGENT_SERVICE_RESTART_TIMEOUT_SECONDS = 300
 _HOSTED_REMOTE_HEAD_DELTA_UNAVAILABLE_REASON = "HOSTED_REMOTE_HEAD_DELTA_UNAVAILABLE"
+_HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH_REASON = "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH"
 
 
 async def _run_monitor_agent_with_service_recovery(
@@ -89,6 +91,7 @@ async def _run_monitor_agent_with_service_recovery(
     command_evidence: list[str] | None = None,
     operation_start_head: str | None = None,
     state: Any | None = None,
+    git_preparation: AgentRuntimeGitPreparation | None = None,
 ) -> AgentRunResult:
     hosted_pr_identity = (
         await _hosted_pr_identity_for_workspace(self, workspace_id, state=state)
@@ -97,18 +100,40 @@ async def _run_monitor_agent_with_service_recovery(
     )
     restart_attempts = 0
     while True:
+        if self._deps.adapter.is_hosted and git_preparation is not None:
+            trusted_base_ref = _nonblank_str((hosted_pr_identity or {}).get("base_ref"))
+            if trusted_base_ref != git_preparation.base_ref:
+                raise AgentRunError(
+                    agent=self._deps.adapter.name,
+                    result=CommandResult(
+                        returncode=1,
+                        stdout="",
+                        stderr=(
+                            "hosted git preparation base ref does not match "
+                            "the trusted PR base identity"
+                        ),
+                    ),
+                    reason_code=_HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH_REASON,
+                    details={
+                        "preparation_base_ref": git_preparation.base_ref,
+                        "trusted_base_ref": trusted_base_ref,
+                    },
+                )
         try:
             if self._deps.adapter.is_hosted:
-                result = await self._deps.adapter.run(
-                    compose_project=compose_project,
-                    compose_file=compose_file,
-                    prompt=prompt,
-                    workspace_id=workspace_id,
-                    log_source=log_source,
-                    hosted_pr_identity=hosted_pr_identity,
-                    profile=getattr(self, "_workspace_profile", None),
-                    worktree_path=self._worktrees_root / workspace_id,
-                )
+                hosted_run_kwargs: dict[str, Any] = {
+                    "compose_project": compose_project,
+                    "compose_file": compose_file,
+                    "prompt": prompt,
+                    "workspace_id": workspace_id,
+                    "log_source": log_source,
+                    "hosted_pr_identity": hosted_pr_identity,
+                    "profile": getattr(self, "_workspace_profile", None),
+                    "worktree_path": self._worktrees_root / workspace_id,
+                }
+                if git_preparation is not None:
+                    hosted_run_kwargs["git_preparation"] = git_preparation
+                result = await self._deps.adapter.run(**hosted_run_kwargs)
             else:
                 result = await self._deps.adapter.run(
                     compose_project=compose_project,

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 from awf.adapters.base import AgentRunError
+from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
 from awf.common.audit import redact_audit_text
 from awf.common.command_evidence import append_command_evidence
 from awf.common.commands import CommandResult
@@ -118,6 +119,7 @@ _PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON = "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
 _PRE_EXISTING_DIRTY_WORKTREE_REASON = "PRE_EXISTING_DIRTY_WORKTREE"
 _REPAIR_START_HEAD_UNAVAILABLE_REASON = "REPAIR_START_HEAD_UNAVAILABLE"
 _REPAIR_WORKTREE_STATUS_FAILED_REASON = "REPAIR_WORKTREE_STATUS_FAILED"
+_SYNC_BASE_GIT_PREPARATION_FAILED_REASON = "SYNC_BASE_GIT_PREPARATION_FAILED"
 AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE = "AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED"
 _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
 # Orphaned AWF branch refs surface as ``refs/heads/awf/ws_...`` and, for
@@ -203,6 +205,8 @@ class _GitPushResult:
                 _REPAIR_START_HEAD_UNAVAILABLE_REASON,
                 _REPAIR_WORKTREE_STATUS_FAILED_REASON,
                 _REPAIR_DIRTY_COMMIT_FAILED_REASON,
+                _SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
+                "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH",
                 VALIDATION_WORKTREE_CLEANUP_FAILED,
                 VALIDATION_WORKTREE_PRE_EXISTING_DIRTY,
                 VALIDATION_WORKTREE_STATUS_FAILED,
@@ -870,6 +874,29 @@ async def _run_sync_base(
             for line in status_out.splitlines()
             if line.startswith(("UU ", "AA ", "DD ", "AU ", "UA ", "DU ", "UD "))
         )
+        git_preparation: AgentRuntimeGitPreparation | None = None
+        if runner._deps.adapter.is_hosted and conflicting_files:
+            base_sha_rc, base_sha_stdout, _base_sha_stderr = await _git(
+                "rev-parse", f"origin/{base_branch}"
+            )
+            expected_base_sha = base_sha_stdout.strip()
+            if base_sha_rc != 0 or re.fullmatch(r"[0-9a-f]{40}", expected_base_sha) is None:
+                return _GitPushResult(
+                    pushed=False,
+                    failed=True,
+                    returncode=base_sha_rc or 1,
+                    stderr="could not pin the fetched base commit for hosted conflict repair",
+                    reason_code=_SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
+                    details={
+                        "base_ref": base_branch,
+                        "remote_ref": f"origin/{base_branch}",
+                    },
+                )
+            git_preparation = AgentRuntimeGitPreparation(
+                mode="merge_base",
+                base_ref=base_branch,
+                expected_base_sha=expected_base_sha,
+            )
         prompt = sync_base_conflict_prompt(
             pr_number=pr_number,
             repo_slug=repo.slug(),
@@ -921,17 +948,29 @@ async def _run_sync_base(
                     details=repair_details,
                 )
         try:
-            await runner._run_monitor_agent_with_service_recovery(
-                workspace_id=workspace_id,
-                compose_project=compose_project,
-                compose_file=compose_file,
-                prompt=prompt,
-                log_source="recovery",
-                command_evidence=command_evidence,
-                operation_start_head=operation_start_head,
-                state=state,
-            )
+            agent_run_kwargs: dict[str, Any] = {
+                "workspace_id": workspace_id,
+                "compose_project": compose_project,
+                "compose_file": compose_file,
+                "prompt": prompt,
+                "log_source": "recovery",
+                "command_evidence": command_evidence,
+                "operation_start_head": operation_start_head,
+                "state": state,
+            }
+            if git_preparation is not None:
+                agent_run_kwargs["git_preparation"] = git_preparation
+            await runner._run_monitor_agent_with_service_recovery(**agent_run_kwargs)
         except AgentRunError as exc:
+            if exc.reason_code == "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH":
+                return _GitPushResult(
+                    pushed=False,
+                    failed=True,
+                    returncode=exc.result.returncode,
+                    stderr=exc.result.stderr,
+                    reason_code=exc.reason_code,
+                    details=exc.details,
+                )
             agent_run_err = exc
             append_command_evidence(
                 command_evidence,

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -879,9 +879,10 @@ async def _run_sync_base(
             getattr(getattr(runner._deps, "adapter", None), "is_hosted", False)
             and conflicting_files
         ):
-            base_sha_rc, base_sha_stdout, _base_sha_stderr = await _git(
-                "rev-parse", f"origin/{base_branch}"
-            )
+            # The mirror's origin/<base> ref is shared across worktrees and can
+            # advance after this merge. MERGE_HEAD is worktree-local and records
+            # the exact commit that produced the conflict being delegated.
+            base_sha_rc, base_sha_stdout, _base_sha_stderr = await _git("rev-parse", "MERGE_HEAD")
             expected_base_sha = base_sha_stdout.strip()
             if base_sha_rc != 0 or re.fullmatch(r"[0-9a-f]{40}", expected_base_sha) is None:
                 return _GitPushResult(
@@ -892,7 +893,7 @@ async def _run_sync_base(
                     reason_code=_SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
                     details={
                         "base_ref": base_branch,
-                        "remote_ref": f"origin/{base_branch}",
+                        "merge_ref": "MERGE_HEAD",
                     },
                 )
             git_preparation = AgentRuntimeGitPreparation(

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -875,7 +875,10 @@ async def _run_sync_base(
             if line.startswith(("UU ", "AA ", "DD ", "AU ", "UA ", "DU ", "UD "))
         )
         git_preparation: AgentRuntimeGitPreparation | None = None
-        if runner._deps.adapter.is_hosted and conflicting_files:
+        if (
+            getattr(getattr(runner._deps, "adapter", None), "is_hosted", False)
+            and conflicting_files
+        ):
             base_sha_rc, base_sha_stdout, _base_sha_stderr = await _git(
                 "rev-parse", f"origin/{base_branch}"
             )

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -868,17 +868,25 @@ async def _run_sync_base(
         )
     rc, _stdout, stderr = await _git(*merge_args)
     if rc != 0:
-        _rc_status, status_out, _ = await _git("status", "--porcelain")
+        status_rc, status_out, status_stderr = await _git("status", "--porcelain")
+        is_hosted = bool(getattr(getattr(runner._deps, "adapter", None), "is_hosted", False))
+        if is_hosted and status_rc != 0:
+            return _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=status_rc,
+                stderr=status_stderr
+                or "could not inspect conflicts for hosted sync-base preparation",
+                reason_code=_SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
+                details={"base_ref": base_branch},
+            )
         conflicting_files = tuple(
             line[3:]
             for line in status_out.splitlines()
             if line.startswith(("UU ", "AA ", "DD ", "AU ", "UA ", "DU ", "UD "))
         )
         git_preparation: AgentRuntimeGitPreparation | None = None
-        if (
-            getattr(getattr(runner._deps, "adapter", None), "is_hosted", False)
-            and conflicting_files
-        ):
+        if is_hosted and conflicting_files:
             # The mirror's origin/<base> ref is shared across worktrees and can
             # advance after this merge. MERGE_HEAD is worktree-local and records
             # the exact commit that produced the conflict being delegated.

--- a/tests/unit/adapters/test_runtime_executor_seam.py
+++ b/tests/unit/adapters/test_runtime_executor_seam.py
@@ -35,6 +35,7 @@ from awf.adapters.codex import CodexAdapter
 from awf.adapters.runtime_executor import (
     AgentRuntimeExecRequest,
     AgentRuntimeExecResult,
+    AgentRuntimeGitPreparation,
 )
 from awf.common.commands import COMMAND_TIMEOUT_REASON, FakeCommandRunner
 from awf.db.enums import AgentRuntime
@@ -201,6 +202,33 @@ class TestRuntimeExecutorSeam:
         assert request.effort == "xhigh"
         assert request.wall_timeout_seconds is not None and request.wall_timeout_seconds > 0
         assert request.idle_timeout_seconds is not None and request.idle_timeout_seconds > 0
+        assert request.git_preparation is None
+
+    @pytest.mark.unit
+    async def test_injected_executor_receives_explicit_git_preparation_unchanged(
+        self,
+    ) -> None:
+        executor = _RecordingExecutor()
+        adapter = CodexAdapter(
+            runner=FakeCommandRunner(),
+            default_model="gpt-5",
+            runtime_executor=executor,
+        )
+        preparation = AgentRuntimeGitPreparation(
+            mode="merge_base",
+            base_ref="development",
+            expected_base_sha="b" * 40,
+        )
+
+        await adapter.run(
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            prompt=_PROMPT,
+            workspace_id="ws_hosted_conflict",
+            git_preparation=preparation,
+        )
+
+        assert executor.calls[0].git_preparation is preparation
 
     @pytest.mark.unit
     async def test_injected_executor_receives_compose_context(self, tmp_path: Path) -> None:

--- a/tests/unit/runtime/test_hosted_delegation_client.py
+++ b/tests/unit/runtime/test_hosted_delegation_client.py
@@ -11,7 +11,7 @@ from typing import Any
 import httpx
 import pytest
 
-from awf.adapters.runtime_executor import AgentRuntimeExecRequest
+from awf.adapters.runtime_executor import AgentRuntimeExecRequest, AgentRuntimeGitPreparation
 from awf.common.commands import COMMAND_TIMEOUT_REASON
 from awf.common.config import Settings
 from awf.db.enums import AgentRuntime
@@ -24,6 +24,7 @@ from awf.runtime.hosted_delegation import (
     hosted_delegation_config_from_settings,
     hosted_delegation_config_from_values,
 )
+from awf.runtime.hosted_delegation_payloads import _agent_start_payload
 
 
 def _config(**overrides: object) -> HostedDelegationConfig:
@@ -61,6 +62,57 @@ def _agent_request(**overrides: object) -> AgentRuntimeExecRequest:
     }
     values.update(overrides)
     return AgentRuntimeExecRequest(**values)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+def test_agent_payload_serializes_exact_secret_free_git_preparation() -> None:
+    secret = "ghp_should-never-enter-git-preparation"
+    preparation = AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="development",
+        expected_base_sha="b" * 40,
+    )
+
+    payload = _agent_start_payload(
+        _agent_request(
+            prompt_stdin=f"resolve conflict using {secret}".encode(),
+            repo_url=f"https://user:{secret}@github.com/dimileeh/aira-web.git",
+            head_repo_url=f"https://user:{secret}@github.com/dimileeh/aira-web.git",
+            git_preparation=preparation,
+        )
+    )
+
+    assert payload["git_preparation"] == {
+        "mode": "merge_base",
+        "base_ref": "development",
+        "expected_base_sha": "b" * 40,
+    }
+    assert set(payload["git_preparation"]) == {
+        "mode",
+        "base_ref",
+        "expected_base_sha",
+    }
+    assert secret not in json.dumps(payload, sort_keys=True)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("log_source", "prompt"),
+    [
+        ("monitor.review", "Resolve review comments and push the repair."),
+        ("monitor.ci", "Fix CI failures on the pull request."),
+        ("validation.repair", "Repair validation failures before merge."),
+    ],
+)
+def test_agent_payload_ordinary_runs_omit_git_preparation(
+    log_source: str,
+    prompt: str,
+) -> None:
+    payload = _agent_start_payload(
+        _agent_request(log_source=log_source, prompt_stdin=prompt.encode())
+    )
+
+    assert "git_preparation" not in payload
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_client.py
+++ b/tests/unit/runtime/test_hosted_delegation_client.py
@@ -66,7 +66,7 @@ def _agent_request(**overrides: object) -> AgentRuntimeExecRequest:
 
 @pytest.mark.unit
 def test_agent_payload_serializes_exact_secret_free_git_preparation() -> None:
-    secret = "ghp_should-never-enter-git-preparation"
+    url_secret = "ghp_should-never-enter-git-preparation"
     preparation = AgentRuntimeGitPreparation(
         mode="merge_base",
         base_ref="development",
@@ -75,9 +75,9 @@ def test_agent_payload_serializes_exact_secret_free_git_preparation() -> None:
 
     payload = _agent_start_payload(
         _agent_request(
-            prompt_stdin=f"resolve conflict using {secret}".encode(),
-            repo_url=f"https://user:{secret}@github.com/dimileeh/aira-web.git",
-            head_repo_url=f"https://user:{secret}@github.com/dimileeh/aira-web.git",
+            prompt_stdin=b"resolve conflict",
+            repo_url=f"https://user:{url_secret}@github.com/dimileeh/aira-web.git",
+            head_repo_url=f"https://user:{url_secret}@github.com/dimileeh/aira-web.git",
             git_preparation=preparation,
         )
     )
@@ -92,7 +92,7 @@ def test_agent_payload_serializes_exact_secret_free_git_preparation() -> None:
         "base_ref",
         "expected_base_sha",
     }
-    assert secret not in json.dumps(payload, sort_keys=True)
+    assert url_secret not in json.dumps(payload, sort_keys=True)
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_merge_preparation_contract.py
+++ b/tests/unit/runtime/test_hosted_merge_preparation_contract.py
@@ -1,4 +1,4 @@
-"""Focused hosted SyncBase git-preparation contract regressions."""
+"""Focused hosted SyncBase merge-preparation contract regressions."""
 
 from __future__ import annotations
 

--- a/tests/unit/runtime/test_hosted_merge_preparation_contract.py
+++ b/tests/unit/runtime/test_hosted_merge_preparation_contract.py
@@ -27,10 +27,12 @@ class _SyncCommandRunner:
         self,
         *,
         base_result: CommandResult | None = None,
+        status_result: CommandResult | None = None,
         remote_base_sha: str | None = None,
         terminal_head: str = _TERMINAL_HEAD,
     ) -> None:
         self.base_result = base_result or CommandResult(0, f"{_BASE_SHA}\n", "")
+        self.status_result = status_result
         self.remote_base_sha = remote_base_sha
         self.terminal_head = terminal_head
         self.calls: list[list[str]] = []
@@ -54,6 +56,8 @@ class _SyncCommandRunner:
             self.conflicted_index = True
             return CommandResult(1, "", "CONFLICT (content): merge conflict")
         if command == ["status", "--porcelain"]:
+            if self.status_result is not None:
+                return self.status_result
             return CommandResult(0, "UU src/conflict.py\n", "")
         if command == ["rev-parse", "MERGE_HEAD"]:
             return self.base_result
@@ -306,6 +310,42 @@ async def test_hosted_sync_base_conflict_fails_closed_for_unusable_base_sha(
         "base_ref": "development",
         "merge_ref": "MERGE_HEAD",
     }
+    assert harness.agent_calls == []
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("status_stderr", "expected_stderr"),
+    [
+        ("fatal: could not inspect index", "fatal: could not inspect index"),
+        ("", "could not inspect conflicts for hosted sync-base preparation"),
+    ],
+    ids=("preserves-stderr", "fallback-message"),
+)
+async def test_hosted_sync_base_conflict_fails_closed_when_status_inspection_fails(
+    tmp_path: Path,
+    status_stderr: str,
+    expected_stderr: str,
+) -> None:
+    command_runner = _SyncCommandRunner(status_result=CommandResult(73, "", status_stderr))
+    adapter = _HostedAdapter()
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=adapter,
+        command_runner=command_runner,
+        actual_hosted_recovery=True,
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.returncode == 73
+    assert result.stderr == expected_stderr
+    assert result.reason_code == "SYNC_BASE_GIT_PREPARATION_FAILED"
+    assert result.terminal_monitor_failure is True
+    assert result.details == {"base_ref": "development"}
     assert harness.agent_calls == []
     assert adapter.calls == []
 

--- a/tests/unit/runtime/test_hosted_merge_preparation_contract.py
+++ b/tests/unit/runtime/test_hosted_merge_preparation_contract.py
@@ -19,6 +19,7 @@ from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
 _START_HEAD = "a" * 40
 _BASE_SHA = "b" * 40
 _TERMINAL_HEAD = "c" * 40
+_ADVANCED_BASE_SHA = "d" * 40
 
 
 class _SyncCommandRunner:
@@ -26,9 +27,11 @@ class _SyncCommandRunner:
         self,
         *,
         base_result: CommandResult | None = None,
+        remote_base_sha: str | None = None,
         terminal_head: str = _TERMINAL_HEAD,
     ) -> None:
         self.base_result = base_result or CommandResult(0, f"{_BASE_SHA}\n", "")
+        self.remote_base_sha = remote_base_sha
         self.terminal_head = terminal_head
         self.calls: list[list[str]] = []
         self.envs: list[Mapping[str, str] | None] = []
@@ -52,8 +55,12 @@ class _SyncCommandRunner:
             return CommandResult(1, "", "CONFLICT (content): merge conflict")
         if command == ["status", "--porcelain"]:
             return CommandResult(0, "UU src/conflict.py\n", "")
-        if command == ["rev-parse", "origin/development"]:
+        if command == ["rev-parse", "MERGE_HEAD"]:
             return self.base_result
+        if command == ["rev-parse", "origin/development"]:
+            if self.remote_base_sha is None:
+                return self.base_result
+            return CommandResult(0, f"{self.remote_base_sha}\n", "")
         if command == [
             "fetch",
             "--no-tags",
@@ -214,12 +221,37 @@ async def test_hosted_sync_base_conflict_emits_exact_pinned_git_preparation(
     rev_parse_index = next(
         index
         for index, call in enumerate(command_runner.calls)
-        if call[-2:] == ["rev-parse", "origin/development"]
+        if call[-2:] == ["rev-parse", "MERGE_HEAD"]
     )
     rev_parse_env = command_runner.envs[rev_parse_index]
     assert rev_parse_env is not None
     assert "GIT_OBJECT_DIRECTORY" not in rev_parse_env
     assert "GIT_ALTERNATE_OBJECT_DIRECTORIES" not in rev_parse_env
+
+
+@pytest.mark.unit
+async def test_hosted_sync_base_pins_failed_merge_when_remote_ref_advances(
+    tmp_path: Path,
+) -> None:
+    command_runner = _SyncCommandRunner(remote_base_sha=_ADVANCED_BASE_SHA)
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=_HostedAdapter(),
+        command_runner=command_runner,
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.pushed is True
+    assert harness.agent_calls[0]["git_preparation"] == AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="development",
+        expected_base_sha=_BASE_SHA,
+    )
+    assert any(call[-2:] == ["rev-parse", "MERGE_HEAD"] for call in command_runner.calls)
+    assert not any(
+        call[-2:] == ["rev-parse", "origin/development"] for call in command_runner.calls
+    )
 
 
 @pytest.mark.unit
@@ -272,7 +304,7 @@ async def test_hosted_sync_base_conflict_fails_closed_for_unusable_base_sha(
     assert result.terminal_monitor_failure is True
     assert result.details == {
         "base_ref": "development",
-        "remote_ref": "origin/development",
+        "merge_ref": "MERGE_HEAD",
     }
     assert harness.agent_calls == []
     assert adapter.calls == []

--- a/tests/unit/runtime/test_hosted_monitor_sync.py
+++ b/tests/unit/runtime/test_hosted_monitor_sync.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from awf.adapters.base import AgentRunError, AgentRunResult
+from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
 from awf.common.commands import CommandResult
 from awf.common.git_identity import git_safe_directory_config_args
 from awf.control.executor.monitor_handoff import _hosted_handoff_pr_identity
@@ -83,9 +84,11 @@ class _HostedAdapterWithTerminalHead:
     def __init__(self, terminal_head_sha: str) -> None:
         self.terminal_head_sha = terminal_head_sha
         self.hosted_pr_identities: list[dict[str, object] | None] = []
+        self.calls: list[dict[str, object]] = []
         self.worktree_paths: list[object] = []
 
     async def run(self, **kwargs: object) -> AgentRunResult:
+        self.calls.append(dict(kwargs))
         hosted_pr_identity = kwargs.get("hosted_pr_identity")
         identity = hosted_pr_identity if isinstance(hosted_pr_identity, dict) else None
         self.hosted_pr_identities.append(identity)
@@ -125,8 +128,10 @@ class _HostedAdapterRetriesAfterTerminalHead:
     def __init__(self, terminal_head_sha: str) -> None:
         self.terminal_head_sha = terminal_head_sha
         self.hosted_pr_identities: list[dict[str, object] | None] = []
+        self.git_preparations: list[object] = []
 
     async def run(self, **kwargs: object) -> AgentRunResult:
+        self.git_preparations.append(kwargs.get("git_preparation"))
         hosted_pr_identity = kwargs.get("hosted_pr_identity")
         identity = hosted_pr_identity if isinstance(hosted_pr_identity, dict) else None
         self.hosted_pr_identities.append(identity)
@@ -490,6 +495,58 @@ async def test_hosted_agent_success_without_terminal_head_fails_closed(
 
 
 @pytest.mark.unit
+async def test_ordinary_hosted_monitor_run_omits_git_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sha = "b" * 40
+    adapter = _HostedAdapterWithTerminalHead(sha)
+    context = _monitor_context_with_adapter(adapter, worktrees_root=tmp_path)
+
+    async def _sync(*_args: object, **_kwargs: object) -> str:
+        return sha
+
+    monkeypatch.setattr(agent_service_recovery, "_sync_hosted_worktree_to_terminal_head", _sync)
+
+    await _run_monitor_agent_with_service_recovery(
+        context,
+        workspace_id="ws_hosted",
+        compose_project="awf_ws_hosted",
+        compose_file=Path("/tmp/missing-compose.yml"),
+        prompt="fix ordinary review",
+        log_source="monitor.review",
+    )
+
+    assert "git_preparation" not in adapter.calls[0]
+
+
+@pytest.mark.unit
+async def test_hosted_monitor_git_preparation_base_ref_mismatch_fails_closed(
+    tmp_path: Path,
+) -> None:
+    adapter = _HostedAdapterWithTerminalHead("b" * 40)
+    preparation = AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="development",
+        expected_base_sha="c" * 40,
+    )
+
+    with pytest.raises(AgentRunError) as excinfo:
+        await _run_monitor_agent_with_service_recovery(
+            _monitor_context_with_adapter(adapter, worktrees_root=tmp_path),
+            workspace_id="ws_hosted",
+            compose_project="awf_ws_hosted",
+            compose_file=Path("/tmp/missing-compose.yml"),
+            prompt="fix merge conflict",
+            log_source="recovery",
+            git_preparation=preparation,
+        )
+
+    assert excinfo.value.reason_code == "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH"
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
 async def test_hosted_agent_sync_advances_monitor_state_after_terminal_head(
     tmp_path: Path,
 ) -> None:
@@ -671,3 +728,45 @@ async def test_hosted_agent_retry_refreshes_pr_identity_after_terminal_head_sync
     assert state.last_push_sha == sha
     assert adapter.hosted_pr_identities[0]["expected_head_sha"] == "a" * 40
     assert adapter.hosted_pr_identities[1]["expected_head_sha"] == sha
+
+
+@pytest.mark.unit
+async def test_hosted_agent_retry_preserves_explicit_git_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    sha = "abcdef0123456789abcdef0123456789abcdef01"
+    runner = _Runner(fetched_sha=sha)
+    adapter = _HostedAdapterRetriesAfterTerminalHead(sha)
+    context = _monitor_context_with_runner(tmp_path, runner=runner, adapter=adapter)
+    preparation = AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="main",
+        expected_base_sha="c" * 40,
+    )
+
+    async def _recover(*_args: object, **_kwargs: object) -> int:
+        return 1
+
+    async def _skip_guards(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(
+        agent_service_recovery, "_recover_monitor_agent_service_after_error", _recover
+    )
+    monkeypatch.setattr(
+        agent_service_recovery, "_rerun_monitor_agent_pre_launch_guards", _skip_guards
+    )
+
+    await _run_monitor_agent_with_service_recovery(
+        context,
+        workspace_id="ws_hosted",
+        compose_project="awf_ws_hosted",
+        compose_file=Path("/tmp/missing-compose.yml"),
+        prompt="fix merge conflict",
+        log_source="recovery",
+        state=MonitorState(last_push_sha="a" * 40),
+        git_preparation=preparation,
+    )
+
+    assert adapter.git_preparations == [preparation, preparation]

--- a/tests/unit/runtime/test_hosted_sync_base_git_preparation.py
+++ b/tests/unit/runtime/test_hosted_sync_base_git_preparation.py
@@ -1,0 +1,309 @@
+"""Focused hosted SyncBase git-preparation contract regressions."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from awf.adapters.base import AgentRunResult
+from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
+from awf.common.commands import CommandResult
+from awf.common.github_client import RepoRef
+from awf.db.enums import AgentRuntime
+from awf.runtime.pr_monitor_runner import agent_service_recovery, remote_ops
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+
+_START_HEAD = "a" * 40
+_BASE_SHA = "b" * 40
+_TERMINAL_HEAD = "c" * 40
+
+
+class _SyncCommandRunner:
+    def __init__(
+        self,
+        *,
+        base_result: CommandResult | None = None,
+        terminal_head: str = _TERMINAL_HEAD,
+    ) -> None:
+        self.base_result = base_result or CommandResult(0, f"{_BASE_SHA}\n", "")
+        self.terminal_head = terminal_head
+        self.calls: list[list[str]] = []
+        self.envs: list[Mapping[str, str] | None] = []
+        self.conflicted_index = False
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        **_kwargs: object,
+    ) -> CommandResult:
+        self.calls.append(args)
+        self.envs.append(env)
+        command = args[args.index("-C") + 2 :]
+        if command == ["merge", "--abort"]:
+            self.conflicted_index = False
+            return CommandResult(0, "", "")
+        if command[:2] == ["merge", "--no-edit"]:
+            self.conflicted_index = True
+            return CommandResult(1, "", "CONFLICT (content): merge conflict")
+        if command == ["status", "--porcelain"]:
+            return CommandResult(0, "UU src/conflict.py\n", "")
+        if command == ["rev-parse", "origin/development"]:
+            return self.base_result
+        if command == [
+            "fetch",
+            "--no-tags",
+            "git@github.com:example/project.git",
+            "feature/ready",
+        ]:
+            return CommandResult(0, "", "")
+        if command == ["rev-parse", "FETCH_HEAD"]:
+            return CommandResult(0, f"{self.terminal_head}\n", "")
+        if command == ["reset", "--hard", self.terminal_head]:
+            self.conflicted_index = False
+            return CommandResult(0, "reset\n", "")
+        if command == [
+            "diff",
+            "--name-status",
+            "-z",
+            f"{_START_HEAD}..{self.terminal_head}",
+            "--",
+        ]:
+            return CommandResult(0, "", "")
+        return CommandResult(1, "", f"unexpected command: {command!r}")
+
+
+class _HostedAdapter:
+    name = AgentRuntime.codex
+    is_hosted = True
+
+    def __init__(self, terminal_head: str = _TERMINAL_HEAD) -> None:
+        self.terminal_head = terminal_head
+        self.calls: list[dict[str, object]] = []
+
+    async def run(self, **kwargs: object) -> AgentRunResult:
+        self.calls.append(dict(kwargs))
+        return AgentRunResult(
+            returncode=0,
+            stdout="AWF-VERDICT: FIXED: remote conflict repair",
+            stderr="",
+            terminal_head_sha=self.terminal_head,
+        )
+
+
+class _LocalAdapter:
+    name = AgentRuntime.codex
+    is_hosted = False
+
+
+class _SyncBaseHarness:
+    def __init__(
+        self,
+        tmp_path: Path,
+        *,
+        adapter: object,
+        command_runner: _SyncCommandRunner,
+        actual_hosted_recovery: bool = False,
+    ) -> None:
+        self._worktrees_root = tmp_path
+        self._workspace_runtime_context = ""
+        self._deps = SimpleNamespace(runner=command_runner, adapter=adapter)
+        self.actual_hosted_recovery = actual_hosted_recovery
+        self.agent_calls: list[dict[str, object]] = []
+        self.commit_sink_conflict_states: list[bool] = []
+
+    async def _repair_operation_start_head_result(self, **_kwargs: object) -> tuple[str, None]:
+        return _START_HEAD, None
+
+    async def _resolve_task_tag(self, _workspace_id: str) -> None:
+        return None
+
+    async def _fetch_base(self, **_kwargs: object) -> None:
+        return None
+
+    async def _provider_recovery_suppresses_cli(self, _workspace_id: str) -> bool:
+        return False
+
+    async def _run_monitor_agent_with_service_recovery(self, **kwargs: object) -> AgentRunResult:
+        self.agent_calls.append(dict(kwargs))
+        if self.actual_hosted_recovery:
+            return await agent_service_recovery._run_monitor_agent_with_service_recovery(
+                self,
+                **kwargs,
+            )
+        return AgentRunResult(returncode=0, stdout="fixed", stderr="")
+
+    async def _commit_dirty_worktree(self, **_kwargs: object) -> None:
+        self.commit_sink_conflict_states.append(self._deps.runner.conflicted_index)
+
+    async def _protected_scope_push_block(self, **_kwargs: object) -> None:
+        return None
+
+    async def _validated_git_push_result(self, **_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=True, failed=False, returncode=0)
+
+    async def _load_workspace(self, _workspace_id: str) -> SimpleNamespace:
+        return SimpleNamespace(
+            repo_url="git@github.com:example/project.git",
+            pr_url="https://github.com/example/project/pull/17",
+            pr_number=17,
+            branch_base="development",
+            remote_push_branch="feature/ready",
+            owned_paths=[],
+            monitor_last_commit_sha=_START_HEAD,
+            task_policy={
+                "pr_adoption": {
+                    "base_ref": "development",
+                    "head_ref": "feature/ready",
+                    "head_repo_url": "git@github.com:example/project.git",
+                    "head_repo_slug": "example/project",
+                    "head_sha": _START_HEAD,
+                }
+            },
+        )
+
+
+@pytest.fixture(autouse=True)
+def _allow_runtime_ownership_repair(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _repair(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(remote_ops, "repair_agent_runtime_ownership", _repair)
+
+
+async def _run_conflicted_sync(harness: _SyncBaseHarness) -> _GitPushResult:
+    return await remote_ops._run_sync_base(
+        harness,  # type: ignore[arg-type]
+        workspace_id="ws_hosted_conflict",
+        repo=RepoRef(owner="example", name="project"),
+        pr_number=17,
+        pr_head_sha=_START_HEAD,
+        base_branch="development",
+        remote_branch="feature/ready",
+        compose_project="awf_ws_hosted_conflict",
+        compose_file=Path("/tmp/missing-compose.yml"),
+    )
+
+
+@pytest.mark.unit
+async def test_hosted_sync_base_conflict_emits_exact_pinned_git_preparation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/tmp/private-objects")
+    monkeypatch.setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/tmp/private-alternates")
+    command_runner = _SyncCommandRunner()
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=_HostedAdapter(),
+        command_runner=command_runner,
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.pushed is True
+    assert harness.agent_calls[0]["git_preparation"] == AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="development",
+        expected_base_sha=_BASE_SHA,
+    )
+    rev_parse_index = next(
+        index
+        for index, call in enumerate(command_runner.calls)
+        if call[-2:] == ["rev-parse", "origin/development"]
+    )
+    rev_parse_env = command_runner.envs[rev_parse_index]
+    assert rev_parse_env is not None
+    assert "GIT_OBJECT_DIRECTORY" not in rev_parse_env
+    assert "GIT_ALTERNATE_OBJECT_DIRECTORIES" not in rev_parse_env
+
+
+@pytest.mark.unit
+async def test_local_sync_base_conflict_preserves_local_conflicted_worktree_flow(
+    tmp_path: Path,
+) -> None:
+    command_runner = _SyncCommandRunner()
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=_LocalAdapter(),
+        command_runner=command_runner,
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.pushed is True
+    assert "git_preparation" not in harness.agent_calls[0]
+    assert not any(
+        call[-2:] == ["rev-parse", "origin/development"] for call in command_runner.calls
+    )
+    assert harness.commit_sink_conflict_states == [True]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "base_result",
+    [
+        CommandResult(1, "", "fatal: unknown revision"),
+        CommandResult(0, "\n", ""),
+        CommandResult(0, "b" * 39, ""),
+        CommandResult(0, "B" * 40, ""),
+        CommandResult(0, "g" * 40, ""),
+        CommandResult(0, f"{'b' * 40}\n{'c' * 40}\n", ""),
+    ],
+    ids=("command-failure", "blank", "short", "uppercase", "non-hex", "multiline"),
+)
+async def test_hosted_sync_base_conflict_fails_closed_for_unusable_base_sha(
+    tmp_path: Path,
+    base_result: CommandResult,
+) -> None:
+    command_runner = _SyncCommandRunner(base_result=base_result)
+    adapter = _HostedAdapter()
+    harness = _SyncBaseHarness(tmp_path, adapter=adapter, command_runner=command_runner)
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.reason_code == "SYNC_BASE_GIT_PREPARATION_FAILED"
+    assert result.terminal_monitor_failure is True
+    assert result.details == {
+        "base_ref": "development",
+        "remote_ref": "origin/development",
+    }
+    assert harness.agent_calls == []
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
+async def test_hosted_conflict_advanced_head_resets_before_dirty_commit_sink(
+    tmp_path: Path,
+) -> None:
+    command_runner = _SyncCommandRunner()
+    adapter = _HostedAdapter()
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=adapter,
+        command_runner=command_runner,
+        actual_hosted_recovery=True,
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.pushed is True
+    assert adapter.calls[0]["git_preparation"] == AgentRuntimeGitPreparation(
+        mode="merge_base",
+        base_ref="development",
+        expected_base_sha=_BASE_SHA,
+    )
+    assert harness.commit_sink_conflict_states == [False]
+    commands = [call[call.index("-C") + 2 :] for call in command_runner.calls]
+    reset_index = commands.index(["reset", "--hard", _TERMINAL_HEAD])
+    delta_index = commands.index(
+        ["diff", "--name-status", "-z", f"{_START_HEAD}..{_TERMINAL_HEAD}", "--"]
+    )
+    assert reset_index < delta_index
+    assert not any(command and command[0] == "commit" for command in commands)


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_f1bf28953fed4e10a0c31bcf` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Fix the verified hosted PR-monitor merge-conflict contract gap using strict TDD.

Production evidence:
- In GKE hosted mode, PR monitor SyncBase fetched development and ran git merge origin/development in Core's local monitor worktree. The merge conflicted.
- Core then delegated a conflict-resolution prompt to HostedAgentRuntimeExecutor, but AWF Cloud cloned only the clean PR head. Hosted Codex saw no conflicted index, exited 0 with the unchanged terminal head, Core reset its local worktree to that head, and SyncBase retried forever.
- Regular hosted review and CI repair runs must continue cloning a clean PR head. Only the SyncBase merge-conflict path needs explicit preparation.

Required cross-repo contract, with exact field names and values:
- The top-level /v1/agent-runs request may carry optional git_preparation with fields mode equal to merge_base, base_ref equal to the base branch, and expected_base_sha equal to a 40-character lowercase hexadecimal SHA.
- Omit git_preparation entirely for every normal agent run. Do not infer preparation from prompt text or log_source.
- base_ref must equal the trusted PR/base identity branch used by Core. expected_base_sha must be the exact origin/base_ref commit Core fetched before its failed merge.

Core implementation:
1. Add a typed optional hosted git-preparation value through AgentRuntimeExecRequest, adapter.run and _run_hosted, HostedAgentRuntimeExecutor payload serialization, and relevant protocols/helpers. Keep local execution unchanged.
2. In SyncBase only, after fetching the base and when handling a real merge conflict, resolve origin/base_branch to an exact lowercase SHA and pass the exact git_preparation object through _run_monitor_agent_with_service_recovery to the hosted adapter. If the SHA cannot be resolved, fail closed with a structured sync-base failure; do not send an unpinned branch.
3. Preserve the current local conflicted-worktree flow for non-hosted adapters. For hosted adapters, after Cloud returns and pushes terminal_head_sha, retain the existing trusted fetch, SHA verification, protected-scope delta gate, and hard reset that synchronizes Core's local worktree and clears its stale conflicted index.
4. Add strict tests proving conflict repair emits exactly the preparation object; ordinary review, CI, validation repair omits it; malformed or missing base SHA fails closed; payload serialization is secret-free and exact; and a hosted conflict result advancing the head is synchronized without committing the stale Core-local conflict.
5. Update only concise hosted contract documentation/comments needed to explain the optional field. Do not add Cloud-specific tenancy or Kubernetes behavior to public Core.
6. Run focused hosted delegation payload/client and PR-monitor SyncBase tests, ruff, mypy on touched modules if practical, and git diff --check.
7. Keep edits inside declared owned paths or the new focused test file. Git is functional in /workspace; commit before exiting. Do not push, create, or merge the PR; AWF owns lifecycle.

---
Validation: 7 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted PR-monitor SyncBase conflict delegation and the cross-service git contract; mistakes could break merge-conflict repair or allow wrong-base preparation, though scope is narrow (optional field, hosted-only) and heavily tested.
> 
> **Overview**
> Fixes hosted **SyncBase** merge conflicts where AWF Cloud cloned a clean PR head while Core’s monitor worktree still had conflicts, causing no-op repairs and retry loops.
> 
> Introduces **`AgentRuntimeGitPreparation`** (`merge_base`, `base_ref`, `expected_base_sha`) on the hosted agent path: adapter → `AgentRuntimeExecRequest` → `/v1/agent-runs` payload. **Only** the SyncBase conflict branch sets it, pinning **`MERGE_HEAD`** (not a moving `origin/<base>`) before delegating repair; normal review/CI/validation runs leave the field unset.
> 
> **Fail-closed** behavior: unusable base SHA or failed conflict inspection → `SYNC_BASE_GIT_PREPARATION_FAILED`; hosted `base_ref` mismatch vs trusted PR identity → `HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH`. Local adapters keep the existing conflicted-worktree flow unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 342ceb9fdf06581c91ec11dc481d898fa688bc6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hosted synchronization now prepares agent runs against a pinned, trusted merge base when resolving conflicts.
  - Git preparation details are passed securely through hosted execution without exposing repository credentials.
  - Preparation settings are preserved across agent retries.

- **Bug Fixes**
  - Hosted operations now fail safely when the expected base reference or commit cannot be verified.
  - Improved handling and classification of synchronization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->