### PR TITLE
fix(hosted): make clean base sync identity-safe

### DIFF
--- a/docker/agent-runtime.Dockerfile
+++ b/docker/agent-runtime.Dockerfile
@@ -161,7 +161,16 @@ ARG CCUSAGE_VERSION=20.0.3
 # stable standalone version pin for the Linux installer.
 RUN set -eux; \
     install -d -m 0755 /opt/cursor; \
-    curl https://cursor.com/install -fsS | HOME=/opt/cursor bash; \
+    curl --fail --show-error --silent --location \
+      --retry 5 \
+      --retry-delay 2 \
+      --retry-all-errors \
+      --connect-timeout 20 \
+      --max-time 300 \
+      --output /tmp/cursor-install.sh \
+      https://cursor.com/install; \
+    HOME=/opt/cursor bash /tmp/cursor-install.sh; \
+    rm -f /tmp/cursor-install.sh; \
     cursor_path="/opt/cursor/.local/bin/cursor-agent"; \
     if [ ! -e "$cursor_path" ]; then \
       echo "cursor-agent was not installed by the Cursor installer" >&2; \

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -813,11 +813,23 @@ async def _run_sync_base(
     if head_result is not None:
         return head_result
 
-    async def _git(*args: str) -> tuple[int, str, str]:
+    async def _git(
+        *args: str,
+        clear_identity_overrides: bool = False,
+    ) -> tuple[int, str, str]:
         """Run a git command in the sync-base worktree."""
+        env = git_env_without_object_lookup_overrides()
+        if clear_identity_overrides:
+            for key in (
+                "GIT_AUTHOR_NAME",
+                "GIT_AUTHOR_EMAIL",
+                "GIT_COMMITTER_NAME",
+                "GIT_COMMITTER_EMAIL",
+            ):
+                env.pop(key, None)
         r = await runner._deps.runner.run(
             git_worktree_command(worktree_path, *args),
-            env=git_env_without_object_lookup_overrides(),
+            env=env,
         )
         return r.returncode, r.stdout, r.stderr
 
@@ -868,7 +880,11 @@ async def _run_sync_base(
                 f"Merge remote-tracking branch 'origin/{base_branch}'", task_tag
             ),
         )
-    rc, _stdout, stderr = await _git(*git_identity_config_args(), *merge_args)
+    rc, _stdout, stderr = await _git(
+        *git_identity_config_args(),
+        *merge_args,
+        clear_identity_overrides=True,
+    )
     if rc != 0:
         status_rc, status_out, status_stderr = await _git("status", "--porcelain")
         conflicting_files = tuple(

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -250,6 +250,8 @@ class _WorkflowScopePushBlock:
 
 def _git_push_failure_outcome(push_result: _GitPushResult) -> str:
     """Map a push result to the monitor operation outcome label."""
+    if push_result.reason_code == _SYNC_BASE_MERGE_FAILED_REASON:
+        return "sync_base_merge_failed"
     if push_result.reason_code == _PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING_REASON:
         return "pre_push_validation_toolchain_missing"
     if push_result.reason_code in {

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -13,7 +13,7 @@ from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
 from awf.common.audit import redact_audit_text
 from awf.common.command_evidence import append_command_evidence
 from awf.common.commands import CommandResult
-from awf.common.git_identity import git_safe_directory_config_args
+from awf.common.git_identity import git_identity_config_args, git_safe_directory_config_args
 from awf.common.logging import get_logger
 from awf.common.task_tag import commit_message_with_task_tag
 from awf.control.blocked_transition import MONITOR_PROTECTED_SCOPE_SYNC_BASE_RESUME_PHASE
@@ -119,6 +119,7 @@ _PROTECTED_SCOPE_DIFF_UNAVAILABLE_REASON = "PROTECTED_SCOPE_DIFF_UNAVAILABLE"
 _PRE_EXISTING_DIRTY_WORKTREE_REASON = "PRE_EXISTING_DIRTY_WORKTREE"
 _REPAIR_START_HEAD_UNAVAILABLE_REASON = "REPAIR_START_HEAD_UNAVAILABLE"
 _REPAIR_WORKTREE_STATUS_FAILED_REASON = "REPAIR_WORKTREE_STATUS_FAILED"
+_SYNC_BASE_MERGE_FAILED_REASON = "SYNC_BASE_MERGE_FAILED"
 _SYNC_BASE_GIT_PREPARATION_FAILED_REASON = "SYNC_BASE_GIT_PREPARATION_FAILED"
 AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE = "AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED"
 _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
@@ -205,6 +206,7 @@ class _GitPushResult:
                 _REPAIR_START_HEAD_UNAVAILABLE_REASON,
                 _REPAIR_WORKTREE_STATUS_FAILED_REASON,
                 _REPAIR_DIRTY_COMMIT_FAILED_REASON,
+                _SYNC_BASE_MERGE_FAILED_REASON,
                 _SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
                 "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH",
                 VALIDATION_WORKTREE_CLEANUP_FAILED,
@@ -866,27 +868,41 @@ async def _run_sync_base(
                 f"Merge remote-tracking branch 'origin/{base_branch}'", task_tag
             ),
         )
-    rc, _stdout, stderr = await _git(*merge_args)
+    rc, _stdout, stderr = await _git(*git_identity_config_args(), *merge_args)
     if rc != 0:
         status_rc, status_out, status_stderr = await _git("status", "--porcelain")
-        is_hosted = bool(getattr(getattr(runner._deps, "adapter", None), "is_hosted", False))
-        if is_hosted and status_rc != 0:
-            return _GitPushResult(
-                pushed=False,
-                failed=True,
-                returncode=status_rc,
-                stderr=status_stderr
-                or "could not inspect conflicts for hosted sync-base preparation",
-                reason_code=_SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
-                details={"base_ref": base_branch},
-            )
         conflicting_files = tuple(
             line[3:]
             for line in status_out.splitlines()
             if line.startswith(("UU ", "AA ", "DD ", "AU ", "UA ", "DU ", "UD "))
         )
+        if status_rc != 0 or not conflicting_files:
+            diagnostics = [f"sync-base merge failed for origin/{base_branch}"]
+            if stderr.strip():
+                diagnostics.append(f"merge stderr: {stderr.strip()}")
+            if status_rc != 0:
+                diagnostics.append(
+                    f"status stderr: {status_stderr.strip()}"
+                    if status_stderr.strip()
+                    else "git status --porcelain failed without output"
+                )
+            else:
+                diagnostics.append("git status --porcelain found no recognized unmerged entries")
+            return _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=rc,
+                stderr=redact_audit_text("\n".join(diagnostics), limit=2000),
+                reason_code=_SYNC_BASE_MERGE_FAILED_REASON,
+                details={
+                    "base_ref": base_branch,
+                    "merge_returncode": rc,
+                    "status_returncode": status_rc,
+                },
+            )
+        is_hosted = bool(getattr(getattr(runner._deps, "adapter", None), "is_hosted", False))
         git_preparation: AgentRuntimeGitPreparation | None = None
-        if is_hosted and conflicting_files:
+        if is_hosted:
             # The mirror's origin/<base> ref is shared across worktrees and can
             # advance after this merge. MERGE_HEAD is worktree-local and records
             # the exact commit that produced the conflict being delegated.

--- a/tests/unit/runtime/test_hosted_merge_preparation_contract.py
+++ b/tests/unit/runtime/test_hosted_merge_preparation_contract.py
@@ -105,6 +105,7 @@ class _RecordingRealCommandRunner:
     def __init__(self) -> None:
         self._runner = AsyncioSubprocessRunner()
         self.calls: list[list[str]] = []
+        self.envs: list[Mapping[str, str] | None] = []
 
     async def run(
         self,
@@ -114,6 +115,7 @@ class _RecordingRealCommandRunner:
         **kwargs: object,
     ) -> CommandResult:
         self.calls.append(args)
+        self.envs.append(env)
         return await self._runner.run(args, env=env, **kwargs)
 
 
@@ -326,6 +328,14 @@ async def test_clean_sync_base_merge_uses_command_scoped_awf_identity_without_de
 
     worktree = tmp_path / "ws_hosted_conflict"
     base_sha = _seed_cleanly_mergeable_histories(worktree, env=isolated_git_env)
+    inherited_identity = {
+        "GIT_AUTHOR_NAME": "Ambient Author",
+        "GIT_AUTHOR_EMAIL": "ambient-author@example.com",
+        "GIT_COMMITTER_NAME": "Ambient Committer",
+        "GIT_COMMITTER_EMAIL": "ambient-committer@example.com",
+    }
+    for key, value in inherited_identity.items():
+        monkeypatch.setenv(key, value)
     command_runner = _RecordingRealCommandRunner()
     adapter = _HostedAdapter()
     harness = _SyncBaseHarness(
@@ -371,8 +381,12 @@ async def test_clean_sync_base_merge_uses_command_scoped_awf_identity_without_de
     )
     assert local_name.returncode == 1
     merge_call = next(call for call in command_runner.calls if "--no-edit" in call)
+    merge_call_index = command_runner.calls.index(merge_call)
     merge_index = merge_call.index("merge")
     assert merge_call[merge_index - 4 : merge_index] == git_identity_config_args()
+    merge_env = command_runner.envs[merge_call_index]
+    assert merge_env is not None
+    assert inherited_identity.keys().isdisjoint(merge_env)
     assert harness.agent_calls == []
     assert adapter.calls == []
 

--- a/tests/unit/runtime/test_hosted_merge_preparation_contract.py
+++ b/tests/unit/runtime/test_hosted_merge_preparation_contract.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 from collections.abc import Mapping
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,7 +12,12 @@ import pytest
 
 from awf.adapters.base import AgentRunResult
 from awf.adapters.runtime_executor import AgentRuntimeGitPreparation
-from awf.common.commands import CommandResult
+from awf.common.commands import AsyncioSubprocessRunner, CommandResult
+from awf.common.git_identity import (
+    DEFAULT_GIT_AUTHOR_EMAIL,
+    DEFAULT_GIT_AUTHOR_NAME,
+    git_identity_config_args,
+)
 from awf.common.github_client import RepoRef
 from awf.db.enums import AgentRuntime
 from awf.runtime.pr_monitor_runner import agent_service_recovery, remote_ops
@@ -27,11 +34,15 @@ class _SyncCommandRunner:
         self,
         *,
         base_result: CommandResult | None = None,
+        merge_result: CommandResult | None = None,
         status_result: CommandResult | None = None,
         remote_base_sha: str | None = None,
         terminal_head: str = _TERMINAL_HEAD,
     ) -> None:
         self.base_result = base_result or CommandResult(0, f"{_BASE_SHA}\n", "")
+        self.merge_result = merge_result or CommandResult(
+            1, "", "CONFLICT (content): merge conflict"
+        )
         self.status_result = status_result
         self.remote_base_sha = remote_base_sha
         self.terminal_head = terminal_head
@@ -49,12 +60,14 @@ class _SyncCommandRunner:
         self.calls.append(args)
         self.envs.append(env)
         command = args[args.index("-C") + 2 :]
+        while command[:1] == ["-c"]:
+            command = command[2:]
         if command == ["merge", "--abort"]:
             self.conflicted_index = False
             return CommandResult(0, "", "")
         if command[:2] == ["merge", "--no-edit"]:
             self.conflicted_index = True
-            return CommandResult(1, "", "CONFLICT (content): merge conflict")
+            return self.merge_result
         if command == ["status", "--porcelain"]:
             if self.status_result is not None:
                 return self.status_result
@@ -88,6 +101,22 @@ class _SyncCommandRunner:
         return CommandResult(1, "", f"unexpected command: {command!r}")
 
 
+class _RecordingRealCommandRunner:
+    def __init__(self) -> None:
+        self._runner = AsyncioSubprocessRunner()
+        self.calls: list[list[str]] = []
+
+    async def run(
+        self,
+        args: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+        **kwargs: object,
+    ) -> CommandResult:
+        self.calls.append(args)
+        return await self._runner.run(args, env=env, **kwargs)
+
+
 class _HostedAdapter:
     name = AgentRuntime.codex
     is_hosted = True
@@ -117,21 +146,24 @@ class _SyncBaseHarness:
         tmp_path: Path,
         *,
         adapter: object,
-        command_runner: _SyncCommandRunner,
+        command_runner: object,
         actual_hosted_recovery: bool = False,
+        task_tag: str | None = None,
     ) -> None:
         self._worktrees_root = tmp_path
         self._workspace_runtime_context = ""
         self._deps = SimpleNamespace(runner=command_runner, adapter=adapter)
         self.actual_hosted_recovery = actual_hosted_recovery
+        self.task_tag = task_tag
         self.agent_calls: list[dict[str, object]] = []
         self.commit_sink_conflict_states: list[bool] = []
+        self.validated_push_calls = 0
 
     async def _repair_operation_start_head_result(self, **_kwargs: object) -> tuple[str, None]:
         return _START_HEAD, None
 
-    async def _resolve_task_tag(self, _workspace_id: str) -> None:
-        return None
+    async def _resolve_task_tag(self, _workspace_id: str) -> str | None:
+        return self.task_tag
 
     async def _fetch_base(self, **_kwargs: object) -> None:
         return None
@@ -149,12 +181,15 @@ class _SyncBaseHarness:
         return AgentRunResult(returncode=0, stdout="fixed", stderr="")
 
     async def _commit_dirty_worktree(self, **_kwargs: object) -> None:
-        self.commit_sink_conflict_states.append(self._deps.runner.conflicted_index)
+        self.commit_sink_conflict_states.append(
+            bool(getattr(self._deps.runner, "conflicted_index", False))
+        )
 
     async def _protected_scope_push_block(self, **_kwargs: object) -> None:
         return None
 
     async def _validated_git_push_result(self, **_kwargs: object) -> _GitPushResult:
+        self.validated_push_calls += 1
         return _GitPushResult(pushed=True, failed=False, returncode=0)
 
     async def _load_workspace(self, _workspace_id: str) -> SimpleNamespace:
@@ -198,6 +233,209 @@ async def _run_conflicted_sync(harness: _SyncBaseHarness) -> _GitPushResult:
         compose_project="awf_ws_hosted_conflict",
         compose_file=Path("/tmp/missing-compose.yml"),
     )
+
+
+def _git(
+    worktree: Path,
+    *args: str,
+    env: Mapping[str, str],
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        check=check,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _seed_cleanly_mergeable_histories(
+    worktree: Path,
+    *,
+    env: Mapping[str, str],
+) -> str:
+    worktree.mkdir()
+    _git(worktree, "init", "-q", "--initial-branch=feature/ready", env=env)
+    (worktree / "shared.txt").write_text("shared\n", encoding="utf-8")
+    _git(worktree, "add", "shared.txt", env=env)
+    _git(
+        worktree,
+        *git_identity_config_args(name="Fixture Author", email="fixture@example.com"),
+        "commit",
+        "-qm",
+        "root",
+        env=env,
+    )
+    root_sha = _git(worktree, "rev-parse", "HEAD", env=env).stdout.strip()
+
+    base_index = worktree.parent / "base.index"
+    base_env = dict(env)
+    base_env["GIT_INDEX_FILE"] = str(base_index)
+    _git(worktree, "read-tree", root_sha, env=base_env)
+    (worktree / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(worktree, "add", "base.txt", env=base_env)
+    base_tree = _git(worktree, "write-tree", env=base_env).stdout.strip()
+    base_sha = _git(
+        worktree,
+        *git_identity_config_args(name="Fixture Author", email="fixture@example.com"),
+        "commit-tree",
+        base_tree,
+        "-p",
+        root_sha,
+        "-m",
+        "base change",
+        env=base_env,
+    ).stdout.strip()
+    (worktree / "base.txt").unlink()
+    base_index.unlink()
+    _git(worktree, "update-ref", "refs/remotes/origin/development", base_sha, env=env)
+
+    (worktree / "feature.txt").write_text("feature\n", encoding="utf-8")
+    _git(worktree, "add", "feature.txt", env=env)
+    _git(
+        worktree,
+        *git_identity_config_args(name="Fixture Author", email="fixture@example.com"),
+        "commit",
+        "-qm",
+        "feature change",
+        env=env,
+    )
+    return base_sha
+
+
+@pytest.mark.unit
+async def test_clean_sync_base_merge_uses_command_scoped_awf_identity_without_delegation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    global_config = tmp_path / "global.gitconfig"
+    system_config = tmp_path / "system.gitconfig"
+    global_config.touch()
+    system_config.touch()
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(global_config))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(system_config))
+    for key in (
+        "GIT_AUTHOR_NAME",
+        "GIT_AUTHOR_EMAIL",
+        "GIT_COMMITTER_NAME",
+        "GIT_COMMITTER_EMAIL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    isolated_git_env = dict(os.environ)
+
+    worktree = tmp_path / "ws_hosted_conflict"
+    base_sha = _seed_cleanly_mergeable_histories(worktree, env=isolated_git_env)
+    command_runner = _RecordingRealCommandRunner()
+    adapter = _HostedAdapter()
+    harness = _SyncBaseHarness(
+        tmp_path,
+        adapter=adapter,
+        command_runner=command_runner,
+        task_tag="SYNC-4",
+    )
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.pushed is True
+    parents = _git(worktree, "show", "-s", "--format=%P", "HEAD", env=isolated_git_env)
+    assert len(parents.stdout.split()) == 2
+    assert base_sha in parents.stdout.split()
+    metadata = (
+        _git(
+            worktree,
+            "show",
+            "-s",
+            "--format=%an%x00%ae%x00%cn%x00%ce%x00%s",
+            "HEAD",
+            env=isolated_git_env,
+        )
+        .stdout.rstrip("\n")
+        .split("\0")
+    )
+    assert metadata == [
+        DEFAULT_GIT_AUTHOR_NAME,
+        DEFAULT_GIT_AUTHOR_EMAIL,
+        DEFAULT_GIT_AUTHOR_NAME,
+        DEFAULT_GIT_AUTHOR_EMAIL,
+        "SYNC-4 Merge remote-tracking branch 'origin/development'",
+    ]
+    local_name = _git(
+        worktree,
+        "config",
+        "--local",
+        "--get",
+        "user.name",
+        env=isolated_git_env,
+        check=False,
+    )
+    assert local_name.returncode == 1
+    merge_call = next(call for call in command_runner.calls if "--no-edit" in call)
+    merge_index = merge_call.index("merge")
+    assert merge_call[merge_index - 4 : merge_index] == git_identity_config_args()
+    assert harness.agent_calls == []
+    assert adapter.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("adapter_kind", ["hosted", "local"])
+@pytest.mark.parametrize(
+    "status_result",
+    [
+        CommandResult(0, "", ""),
+        CommandResult(0, " M src/dirty.py\n?? scratch.txt\n", ""),
+        CommandResult(
+            73,
+            "",
+            "fatal: token=ghp_abcdefghijklmnopqrstuvwxyz1234567890 while inspecting index",
+        ),
+    ],
+    ids=("clean-status", "ordinary-changes", "status-failure"),
+)
+async def test_non_conflict_sync_base_merge_failure_fails_closed_without_agent_or_push(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    adapter_kind: str,
+    status_result: CommandResult,
+) -> None:
+    def _unexpected_prompt(**_kwargs: object) -> str:
+        raise AssertionError("non-conflict merge failure must not build an agent prompt")
+
+    monkeypatch.setattr(
+        "awf.runtime.monitor_prompts.sync_base_conflict_prompt",
+        _unexpected_prompt,
+    )
+    merge_result = CommandResult(
+        42,
+        "",
+        "fatal: https://build:ghp_abcdefghijklmnopqrstuvwxyz1234567890@github.com/" + "x" * 2500,
+    )
+    command_runner = _SyncCommandRunner(
+        merge_result=merge_result,
+        status_result=status_result,
+    )
+    adapter: object = _HostedAdapter() if adapter_kind == "hosted" else _LocalAdapter()
+    harness = _SyncBaseHarness(tmp_path, adapter=adapter, command_runner=command_runner)
+
+    result = await _run_conflicted_sync(harness)
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.returncode == 42
+    assert result.reason_code == "SYNC_BASE_MERGE_FAILED"
+    assert result.terminal_monitor_failure is True
+    assert result.details == {
+        "base_ref": "development",
+        "merge_returncode": 42,
+        "status_returncode": status_result.returncode,
+    }
+    assert "ghp_abcdefghijklmnopqrstuvwxyz1234567890" not in result.stderr
+    assert "[redacted]" in result.stderr
+    assert len(result.stderr) <= 2014
+    assert "ghp_abcdefghijklmnopqrstuvwxyz1234567890" not in repr(result.details)
+    assert harness.agent_calls == []
+    assert harness.commit_sink_conflict_states == []
+    assert harness.validated_push_calls == 0
 
 
 @pytest.mark.unit
@@ -310,42 +548,6 @@ async def test_hosted_sync_base_conflict_fails_closed_for_unusable_base_sha(
         "base_ref": "development",
         "merge_ref": "MERGE_HEAD",
     }
-    assert harness.agent_calls == []
-    assert adapter.calls == []
-
-
-@pytest.mark.unit
-@pytest.mark.parametrize(
-    ("status_stderr", "expected_stderr"),
-    [
-        ("fatal: could not inspect index", "fatal: could not inspect index"),
-        ("", "could not inspect conflicts for hosted sync-base preparation"),
-    ],
-    ids=("preserves-stderr", "fallback-message"),
-)
-async def test_hosted_sync_base_conflict_fails_closed_when_status_inspection_fails(
-    tmp_path: Path,
-    status_stderr: str,
-    expected_stderr: str,
-) -> None:
-    command_runner = _SyncCommandRunner(status_result=CommandResult(73, "", status_stderr))
-    adapter = _HostedAdapter()
-    harness = _SyncBaseHarness(
-        tmp_path,
-        adapter=adapter,
-        command_runner=command_runner,
-        actual_hosted_recovery=True,
-    )
-
-    result = await _run_conflicted_sync(harness)
-
-    assert result.failed is True
-    assert result.pushed is False
-    assert result.returncode == 73
-    assert result.stderr == expected_stderr
-    assert result.reason_code == "SYNC_BASE_GIT_PREPARATION_FAILED"
-    assert result.terminal_monitor_failure is True
-    assert result.details == {"base_ref": "development"}
     assert harness.agent_calls == []
     assert adapter.calls == []
 

--- a/tests/unit/runtime/test_pr_monitor_remote_ops.py
+++ b/tests/unit/runtime/test_pr_monitor_remote_ops.py
@@ -92,6 +92,14 @@ def test_git_push_failure_outcome_maps_toolchain_missing_separately() -> None:
 
 
 @pytest.mark.unit
+def test_git_push_failure_outcome_maps_sync_base_merge_failure_separately() -> None:
+    assert (
+        _git_push_failure_outcome(_make_push_result("SYNC_BASE_MERGE_FAILED"))
+        == "sync_base_merge_failed"
+    )
+
+
+@pytest.mark.unit
 def test_git_push_terminal_monitor_failure_maps_rollback_failed_as_terminal() -> None:
     """Roll-back failure on pre-push validation should remain terminal."""
     assert _make_push_result("PRE_PUSH_VALIDATION_ROLLBACK_FAILED").terminal_monitor_failure is True

--- a/tests/unit/test_agent_runtime_dockerfile.py
+++ b/tests/unit/test_agent_runtime_dockerfile.py
@@ -107,7 +107,19 @@ def test_agent_runtime_installs_all_supported_coding_clis() -> None:
     assert 'ln -sf "$(command -v node)" /usr/local/bin/node' not in dockerfile
     assert "cursor-agent" in dockerfile
     assert "install -d -m 0755 /opt/cursor" in dockerfile
-    assert "curl https://cursor.com/install -fsS | HOME=/opt/cursor bash" in dockerfile
+    cursor_installer = (
+        "curl --fail --show-error --silent --location \\\n"
+        "      --retry 5 \\\n"
+        "      --retry-delay 2 \\\n"
+        "      --retry-all-errors \\\n"
+        "      --connect-timeout 20 \\\n"
+        "      --max-time 300 \\\n"
+        "      --output /tmp/cursor-install.sh \\\n"
+        "      https://cursor.com/install; \\\n"
+        "    HOME=/opt/cursor bash /tmp/cursor-install.sh; \\\n"
+        "    rm -f /tmp/cursor-install.sh"
+    )
+    assert cursor_installer in dockerfile
     assert 'cursor_path="/opt/cursor/.local/bin/cursor-agent"' in dockerfile
     assert 'ln -sf "$cursor_path" /usr/local/bin/cursor-agent' in dockerfile
     assert 'install -m 0755 "$cursor_path" /usr/local/bin/cursor-agent' not in dockerfile
@@ -118,7 +130,7 @@ def test_agent_runtime_installs_all_supported_coding_clis() -> None:
     assert "cursor-agent --version || true" in dockerfile
     assert dockerfile.index(
         'ln -sf "$(readlink -f "$(command -v node)")" /usr/local/bin/node'
-    ) < dockerfile.index("curl https://cursor.com/install -fsS")
+    ) < dockerfile.index(cursor_installer)
     assert (
         "USER agent\n"
         "WORKDIR /workspace\n\n"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_060845a8f1bf45dea420b47a` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Fix the verified AWF Core hosted PR-monitor clean base-sync bug using strict TDD.\n\nProduction evidence from GKE Autopilot:\n- Hosted adopted workspace ws_b0806c89b14748b9afc961aa monitoring awf-cloud PR 363 selected SyncBase because the PR was 15 commits behind.\n- The Core worker worktree had HEAD 4ac31db6f749f18652716e9c83e24f130524205d and origin/development 9345419365f07e624f31207724452919a0dce05a. A read-only git merge-tree proves the merge is clean.\n- The worker Pod intentionally has no global/local user.name or user.email.\n- Core ran git merge --no-edit origin/development. Git exited nonzero before creating a merge because committer identity was unavailable. git status --porcelain was clean and MERGE_HEAD absent.\n- _run_sync_base currently treats every nonzero merge as a conflict. With no unmerged entries it generated a false conflict prompt, omitted AgentRuntimeGitPreparation, and delegated a clean hosted checkout. Codex correctly reported that no conflict state existed.\n\nRequired behavior:\n1. A clean SyncBase merge must succeed in an identity-less Core worker. Supply a deterministic AWF-owned Git author/committer identity to the merge command itself without depending on host/global Git config. Preserve task-tagged merge-message behavior.\n2. A nonzero merge result is a resolvable conflict only when git status succeeds and the index contains recognized unmerged entries. If status is clean or has no recognized unmerged entries, do not invoke the repair agent and do not generate the conflict prompt. Fail closed with a stable terminal monitor reason code, sanitized stderr/details, and no push.\n3. Keep the existing genuine-conflict path exactly: pin MERGE_HEAD, emit git_preparation={mode: merge_base, base_ref, expected_base_sha}, delegate the hosted agent, validate, and push.\n4. Preserve local/non-hosted behavior for real conflicts and existing protected-scope, mirror-hook, task-tag, retry, and validation semantics.\n5. Add regression tests that reproduce an identity-less clean merge and prove it advances without agent delegation; prove non-conflict merge failures fail closed; and prove genuine hosted conflicts still carry the pinned preparation. Prefer a real temporary Git repository test for the identity failure if practical, plus focused unit tests.\n6. Run the focused tests for sync-base/hosted merge preparation, ruff on touched files, and git diff --check.\n7. Keep all changes inside the declared paths. Git is functional in /workspace; commit before exiting. Do not push, create, or merge the PR; AWF owns lifecycle.

---
Validation: 7 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core PR-monitor sync-base Git merge and failure classification used in hosted production; behavior is well-covered by new regressions but incorrect conflict detection would still block or mis-handle monitoring.
> 
> **Overview**
> Fixes hosted PR-monitor **SyncBase** when a clean merge to `origin/<base>` would fail on identity-less workers and was misread as a conflict.
> 
> **Sync-base merge behavior (`remote_ops._run_sync_base`)**
> - Runs `git merge --no-edit` with **`git_identity_config_args()`** and strips ambient `GIT_*_NAME`/`GIT_*_EMAIL` from the subprocess env so clean merges succeed without global Git config; task-tagged merge messages are unchanged.
> - A failed merge is treated as a **real conflict** only when `git status --porcelain` succeeds and the index has recognized unmerged entries. Otherwise the monitor **fails closed** with reason **`SYNC_BASE_MERGE_FAILED`**, redacted stderr, no agent prompt, no push, and outcome **`sync_base_merge_failed`** (terminal). Genuine hosted conflicts still pin `MERGE_HEAD` and emit `AgentRuntimeGitPreparation` as before.
> - Replaces the prior hosted-only “status inspection failed → `SYNC_BASE_GIT_PREPARATION_FAILED`” branch with this unified non-conflict failure path.
> 
> **Agent-runtime image**
> - Cursor CLI install no longer pipes `curl` straight into `bash`; it downloads the installer script with retries/timeouts, runs it, then deletes the temp file (tests updated).
> 
> **Tests**
> - Real-git regression for identity-less clean merge; parametrized fail-closed cases for merge failures without conflicts; outcome mapping for `SYNC_BASE_MERGE_FAILED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779e4face941158b7a21cecbd4d21cf3eb7fb614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of sync-base merge failures with clearer failure reporting.
  - Prevented further recovery or push actions when merge conflict details are unavailable or the merge fails without conflicts.
  - Ensured sync-base merges use the intended Git identity, independent of ambient configuration.
  - Added a distinct monitor outcome for sync-base merge failures.

- **Tests**
  - Expanded coverage for Git identity handling, task-tag propagation, merge failures, and diagnostic behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->