### PR TITLE
fix(hosted): advance monitor head after base sync

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/loop.py
+++ b/src/awf/runtime/pr_monitor_runner/loop.py
@@ -418,7 +418,7 @@ async def _execute(
                     "status": "failed",
                     "outcome": outcome,
                     "reason_code": reason_code,
-                    "pushed": False,
+                    "pushed": push_result.pushed,
                 },
                 error_code=reason_code,
                 error_message=push_result.error_message,

--- a/src/awf/runtime/pr_monitor_runner/remote_ops.py
+++ b/src/awf/runtime/pr_monitor_runner/remote_ops.py
@@ -121,6 +121,7 @@ _REPAIR_START_HEAD_UNAVAILABLE_REASON = "REPAIR_START_HEAD_UNAVAILABLE"
 _REPAIR_WORKTREE_STATUS_FAILED_REASON = "REPAIR_WORKTREE_STATUS_FAILED"
 _SYNC_BASE_MERGE_FAILED_REASON = "SYNC_BASE_MERGE_FAILED"
 _SYNC_BASE_GIT_PREPARATION_FAILED_REASON = "SYNC_BASE_GIT_PREPARATION_FAILED"
+_SYNC_BASE_PUSHED_HEAD_UNAVAILABLE_REASON = "SYNC_BASE_PUSHED_HEAD_UNAVAILABLE"
 AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE = "AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED"
 _GIT_MIRROR_BROKEN_REF_REPAIR_MAX_ATTEMPTS = 5
 # Orphaned AWF branch refs surface as ``refs/heads/awf/ws_...`` and, for
@@ -208,6 +209,7 @@ class _GitPushResult:
                 _REPAIR_DIRTY_COMMIT_FAILED_REASON,
                 _SYNC_BASE_MERGE_FAILED_REASON,
                 _SYNC_BASE_GIT_PREPARATION_FAILED_REASON,
+                _SYNC_BASE_PUSHED_HEAD_UNAVAILABLE_REASON,
                 "HOSTED_GIT_PREPARATION_BASE_REF_MISMATCH",
                 VALIDATION_WORKTREE_CLEANUP_FAILED,
                 VALIDATION_WORKTREE_PRE_EXISTING_DIRTY,
@@ -252,6 +254,8 @@ def _git_push_failure_outcome(push_result: _GitPushResult) -> str:
     """Map a push result to the monitor operation outcome label."""
     if push_result.reason_code == _SYNC_BASE_MERGE_FAILED_REASON:
         return "sync_base_merge_failed"
+    if push_result.reason_code == _SYNC_BASE_PUSHED_HEAD_UNAVAILABLE_REASON:
+        return "sync_base_pushed_head_unavailable"
     if push_result.reason_code == _PRE_PUSH_VALIDATION_TOOLCHAIN_MISSING_REASON:
         return "pre_push_validation_toolchain_missing"
     if push_result.reason_code in {
@@ -1178,7 +1182,7 @@ async def _run_sync_base(
             stderr=protected_scope_block.message,
             reason_code=protected_scope_block.reason_code,
         )
-    return await runner._validated_git_push_result(
+    push_result = await runner._validated_git_push_result(
         workspace_id=workspace_id,
         worktree_path=worktree_path,
         remote_branch=remote_branch,
@@ -1188,6 +1192,40 @@ async def _run_sync_base(
         state=state,
         operation_start_head=operation_start_head,
     )
+    if (
+        state is None
+        or push_result.paused_into_blocked
+        or push_result.recovered_by_resync
+        or push_result.failed
+        or not push_result.pushed
+    ):
+        return push_result
+
+    pushed_head = await runner._rev_parse_head(worktree_path)
+    if pushed_head is None or re.fullmatch(r"[0-9a-fA-F]{40}", pushed_head) is None:
+        head_resolution = "unavailable" if pushed_head is None else "invalid"
+        details: dict[str, object] = {
+            "phase": "post_sync_base_push_head_resolution",
+            "push_reported_success": True,
+            "head_resolution": head_resolution,
+        }
+        if pushed_head is not None:
+            details["resolved_head_length"] = len(pushed_head)
+        return _GitPushResult(
+            pushed=True,
+            failed=True,
+            returncode=1,
+            stdout=push_result.stdout,
+            stderr=(
+                "SyncBase push succeeded, but the pushed local HEAD could not be "
+                "resolved to a valid full commit SHA."
+            ),
+            reason_code=_SYNC_BASE_PUSHED_HEAD_UNAVAILABLE_REASON,
+            details=details,
+        )
+
+    cast("MonitorState", state).last_push_sha = pushed_head.lower()
+    return push_result
 
 
 async def _refresh_staleness_after_sync_base(

--- a/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_001.py
+++ b/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_001.py
@@ -1048,6 +1048,7 @@ class TestSyncBase:
         cmd.queue_result(returncode=0)  # git fetch origin <base>
         cmd.queue_result(returncode=0)  # git merge --no-edit
         cmd.queue_result(returncode=0)  # git push (sync_base)
+        cmd.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # rev-parse HEAD
         cmd.queue_result(returncode=0, stdout=f"{new_base}\n")  # rev-parse origin/<base>
         # Outer iter 2: clean → merge.
         cmd.queue_result(returncode=0)  # git fetch origin <base>

--- a/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
+++ b/tests/integration/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_002.py
@@ -462,6 +462,7 @@ class TestDirtyConflictResolution:
         cmd.queue_result(returncode=0, stdout="UU src/foo.py\n")  # git status --porcelain
         adapter.queue(stdout="resolved the merge conflict")
         cmd.queue_result(returncode=0)  # git push
+        cmd.queue_result(returncode=0, stdout=("b" * 40) + "\n")  # rev-parse HEAD
         cmd.queue_result(returncode=0, stdout="SYNC-BASE-SHA\n")  # rev-parse origin/<base>
         # Outer iter 2: CLEAN → merge.
         cmd.queue_result(returncode=0)  # git fetch origin <base>

--- a/tests/unit/runtime/test_hosted_sync_base_head_state.py
+++ b/tests/unit/runtime/test_hosted_sync_base_head_state.py
@@ -1,0 +1,424 @@
+"""Regression coverage for hosted SyncBase pushed-head monitor state."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Mapping
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import CommandResult, FakeCommandRunner
+from awf.db.enums import OperationStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    SyncBase,
+)
+from awf.runtime.pr_monitor_runner import loop, remote_ops
+from awf.runtime.pr_monitor_runner.agent_service_recovery import (
+    _hosted_pr_identity_for_workspace,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+_OLD_HEAD = "4ac31db6f749f18652716e9c83e24f130524205d"
+_NEW_HEAD = "2bb16a374667250e685e5bc326d033039f37885d"
+_PUSHED_HEAD_UNAVAILABLE = "SYNC_BASE_PUSHED_HEAD_UNAVAILABLE"
+
+
+class _SuccessfulGitRunner:
+    async def run(
+        self,
+        _args: list[str],
+        *,
+        env: Mapping[str, str] | None = None,
+    ) -> CommandResult:
+        del env
+        return CommandResult(returncode=0, stdout="", stderr="")
+
+
+class _SyncBaseHarness:
+    def __init__(
+        self,
+        *,
+        worktrees_root: Path,
+        push_result: _GitPushResult,
+        resolved_head: str | None,
+    ) -> None:
+        self._worktrees_root = worktrees_root
+        self._push_result = push_result
+        self._resolved_head = resolved_head
+        self.head_resolution_calls: list[Path] = []
+        self._deps = SimpleNamespace(runner=_SuccessfulGitRunner())
+
+    async def _repair_operation_start_head_result(
+        self,
+        **_kwargs: object,
+    ) -> tuple[str, None]:
+        return _OLD_HEAD, None
+
+    async def _resolve_task_tag(self, _workspace_id: str) -> None:
+        return None
+
+    async def _fetch_base(self, **_kwargs: object) -> None:
+        return None
+
+    async def _protected_scope_push_block(self, **_kwargs: object) -> None:
+        return None
+
+    async def _validated_git_push_result(self, **_kwargs: object) -> _GitPushResult:
+        return self._push_result
+
+    async def _rev_parse_head(self, worktree_path: Path) -> str | None:
+        self.head_resolution_calls.append(worktree_path)
+        return self._resolved_head
+
+
+def _workspace_with_stale_hosted_identity() -> SimpleNamespace:
+    return SimpleNamespace(
+        repo_url="git@github.com:dimileeh/agent-workspace-fabric.git",
+        pr_url="https://github.com/dimileeh/agent-workspace-fabric/pull/363",
+        pr_number=363,
+        branch_base="development",
+        remote_push_branch="awf/ws_hosted",
+        owned_paths=["src/awf"],
+        monitor_last_commit_sha=_OLD_HEAD,
+        task_policy={
+            "pr_adoption": {
+                "pr_number": 363,
+                "base_ref": "development",
+                "head_ref": "awf/ws_hosted",
+                "head_sha": _OLD_HEAD,
+            }
+        },
+    )
+
+
+async def _run_sync_base(
+    harness: _SyncBaseHarness,
+    *,
+    state: MonitorState,
+) -> _GitPushResult:
+    return await remote_ops._run_sync_base(
+        harness,  # type: ignore[arg-type]
+        workspace_id="ws_hosted",
+        state=state,
+        repo=SimpleNamespace(slug=lambda: "dimileeh/agent-workspace-fabric"),
+        pr_number=363,
+        pr_head_sha=_OLD_HEAD,
+        base_branch="development",
+        remote_branch="awf/ws_hosted",
+        compose_project="awf_ws_hosted",
+        compose_file=Path("compose.yml"),
+    )
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.mark.unit
+async def test_sync_base_push_advances_immediately_following_hosted_identity(
+    tmp_path: Path,
+) -> None:
+    workspace = _workspace_with_stale_hosted_identity()
+    state = MonitorState(last_push_sha=_OLD_HEAD)
+    harness = _SyncBaseHarness(
+        worktrees_root=tmp_path,
+        push_result=_GitPushResult(pushed=True, failed=False, returncode=0),
+        resolved_head=_NEW_HEAD.upper(),
+    )
+
+    result = await _run_sync_base(harness, state=state)
+
+    async def _load_workspace(_workspace_id: str) -> SimpleNamespace:
+        return workspace
+
+    identity = await _hosted_pr_identity_for_workspace(
+        SimpleNamespace(_load_workspace=_load_workspace),
+        "ws_hosted",
+        state=state,
+    )
+    assert result.pushed is True
+    assert state.last_push_sha == _NEW_HEAD
+    assert identity["expected_head_sha"] == _NEW_HEAD
+    assert workspace.monitor_last_commit_sha == _OLD_HEAD
+    assert workspace.task_policy["pr_adoption"]["head_sha"] == _OLD_HEAD
+    assert harness.head_resolution_calls == [tmp_path / "ws_hosted"]
+
+
+@pytest.mark.unit
+async def test_sync_base_pushed_head_survives_persistence_and_restart(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    workspace_id = await seed_monitoring_workspace(factory, head_sha=_OLD_HEAD)
+    async with factory() as session:
+        workspace = await WorkspaceRepository(session).get(workspace_id)
+        assert workspace is not None
+        workspace.monitor_last_commit_sha = _OLD_HEAD
+        workspace.task_policy = {
+            "pr_adoption": {
+                "pr_number": workspace.pr_number,
+                "base_ref": workspace.branch_base,
+                "head_ref": workspace.remote_push_branch,
+                "head_sha": _OLD_HEAD,
+            }
+        }
+        await session.commit()
+
+    persistence_runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "persistent-worktrees",
+    )
+    state = persistence_runner._load_state(await persistence_runner._load_workspace(workspace_id))
+    sync_harness = _SyncBaseHarness(
+        worktrees_root=tmp_path / "sync-worktrees",
+        push_result=_GitPushResult(pushed=True, failed=False, returncode=0),
+        resolved_head=_NEW_HEAD,
+    )
+
+    await remote_ops._run_sync_base(
+        sync_harness,  # type: ignore[arg-type]
+        workspace_id=workspace_id,
+        state=state,
+        repo=SimpleNamespace(slug=lambda: "dimileeh/agent-workspace-fabric"),
+        pr_number=363,
+        pr_head_sha=_OLD_HEAD,
+        base_branch="development",
+        remote_branch=f"awf/{workspace_id}",
+        compose_project=f"awf_{workspace_id}",
+        compose_file=Path("compose.yml"),
+    )
+    await persistence_runner._persist_state(workspace_id, state)
+
+    async with factory() as session:
+        persisted = await WorkspaceRepository(session).get(workspace_id)
+        assert persisted is not None
+        assert persisted.monitor_last_commit_sha == _NEW_HEAD
+
+    resumed_runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "resumed-worktrees",
+    )
+    resumed_workspace = await resumed_runner._load_workspace(workspace_id)
+    resumed_state = resumed_runner._load_state(resumed_workspace)
+    resumed_identity = await resumed_runner._hosted_pr_identity_for_workspace(
+        workspace_id,
+        state=resumed_state,
+    )
+    assert resumed_state.last_push_sha == _NEW_HEAD
+    assert resumed_identity["expected_head_sha"] == _NEW_HEAD
+
+
+@pytest.mark.parametrize(
+    "push_result",
+    [
+        pytest.param(
+            _GitPushResult(pushed=False, failed=True, returncode=1),
+            id="failed",
+        ),
+        pytest.param(
+            _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=1,
+                reason_code="PROTECTED_SCOPE_REPAIR_FAILED",
+                paused_into_blocked=True,
+            ),
+            id="protected-scope-paused",
+        ),
+        pytest.param(
+            _GitPushResult(
+                pushed=False,
+                failed=True,
+                returncode=1,
+                recovered_by_resync=True,
+            ),
+            id="recovered-by-resync",
+        ),
+        pytest.param(
+            _GitPushResult(pushed=False, failed=False, returncode=0),
+            id="no-op",
+        ),
+    ],
+)
+@pytest.mark.unit
+async def test_sync_base_non_push_outcomes_do_not_advance_head_or_resolve_head(
+    push_result: _GitPushResult,
+    tmp_path: Path,
+) -> None:
+    state = MonitorState(last_push_sha=_OLD_HEAD)
+    harness = _SyncBaseHarness(
+        worktrees_root=tmp_path,
+        push_result=push_result,
+        resolved_head=_NEW_HEAD,
+    )
+
+    result = await _run_sync_base(harness, state=state)
+
+    assert result is push_result
+    assert state.last_push_sha == _OLD_HEAD
+    assert harness.head_resolution_calls == []
+
+
+@pytest.mark.parametrize(
+    ("resolved_head", "resolution"),
+    [
+        pytest.param(None, "unavailable", id="command-failed"),
+        pytest.param("", "invalid", id="blank"),
+        pytest.param("abc123", "invalid", id="short"),
+        pytest.param("g" * 40, "invalid", id="non-hex"),
+    ],
+)
+@pytest.mark.unit
+async def test_sync_base_push_with_untrusted_local_head_fails_closed(
+    resolved_head: str | None,
+    resolution: str,
+    tmp_path: Path,
+) -> None:
+    state = MonitorState(last_push_sha=_OLD_HEAD)
+    harness = _SyncBaseHarness(
+        worktrees_root=tmp_path,
+        push_result=_GitPushResult(
+            pushed=True,
+            failed=False,
+            returncode=0,
+            stdout="push succeeded",
+        ),
+        resolved_head=resolved_head,
+    )
+
+    result = await _run_sync_base(harness, state=state)
+
+    assert result.pushed is True
+    assert result.failed is True
+    assert result.terminal_monitor_failure is True
+    assert result.reason_code == _PUSHED_HEAD_UNAVAILABLE
+    assert state.last_push_sha == _OLD_HEAD
+    assert result.failure_evidence()["phase"] == "post_sync_base_push_head_resolution"
+    assert result.failure_evidence()["push_reported_success"] is True
+    assert result.failure_evidence()["head_resolution"] == resolution
+    assert harness.head_resolution_calls == [tmp_path / "ws_hosted"]
+
+
+class _SyncBaseLoopHarness:
+    def __init__(self, push_result: _GitPushResult) -> None:
+        self.push_result = push_result
+        self.finished: list[dict[str, object]] = []
+        self.audits: list[dict[str, object]] = []
+        self.terminations: list[dict[str, object]] = []
+        self.progress_recorded = False
+        self.staleness_refreshed = False
+
+    async def _write_monitor_log(self, *_args: object, **_kwargs: object) -> None:
+        return None
+
+    async def _clear_workspace_attention(self, _workspace_id: str) -> None:
+        return None
+
+    async def _begin_monitor_operation(self, **_kwargs: object) -> SimpleNamespace:
+        return SimpleNamespace(operation_id="op-sync-base")
+
+    async def _run_sync_base(self, **_kwargs: object) -> _GitPushResult:
+        return self.push_result
+
+    async def _finish_monitor_operation(
+        self,
+        _operation: object,
+        **kwargs: object,
+    ) -> None:
+        self.finished.append(dict(kwargs))
+
+    async def _record_pr_monitor_audit_event(self, **kwargs: object) -> None:
+        self.audits.append(dict(kwargs))
+
+    async def _terminate_failed(self, _workspace_id: str, **kwargs: object) -> None:
+        self.terminations.append(dict(kwargs))
+
+    def _record_sync_base_progress(self, **_kwargs: object) -> None:
+        self.progress_recorded = True
+
+    async def _refresh_staleness_after_sync_base(self, **_kwargs: object) -> None:
+        self.staleness_refreshed = True
+
+
+def _behind_status() -> PRStatus:
+    return PRStatus(
+        number=363,
+        head_sha=_OLD_HEAD,
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=(),
+        unresolved_review_comments=(),
+        base_behind_count=1,
+        merge_state_status=MergeStateStatus.BEHIND,
+    )
+
+
+@pytest.mark.unit
+async def test_sync_base_pushed_head_failure_preserves_structured_loop_evidence() -> None:
+    details = {
+        "phase": "post_sync_base_push_head_resolution",
+        "push_reported_success": True,
+        "head_resolution": "unavailable",
+    }
+    push_result = _GitPushResult(
+        pushed=True,
+        failed=True,
+        returncode=1,
+        stderr="SyncBase push succeeded but its local HEAD could not be verified",
+        reason_code=_PUSHED_HEAD_UNAVAILABLE,
+        details=details,
+    )
+    harness = _SyncBaseLoopHarness(push_result)
+
+    terminal = await loop._execute(
+        harness,  # type: ignore[arg-type]
+        action=SyncBase(),
+        workspace_id="ws_hosted",
+        repo_url="git@github.com:dimileeh/agent-workspace-fabric.git",
+        repo=SimpleNamespace(),  # type: ignore[arg-type]
+        pr_number=363,
+        status=_behind_status(),
+        state=MonitorState(last_push_sha=_OLD_HEAD),
+        base_branch="development",
+        remote_branch="awf/ws_hosted",
+        compose_project="awf_ws_hosted",
+        compose_file=Path("compose.yml"),
+        monitor_log=None,
+    )
+
+    assert terminal is True
+    assert harness.finished[0]["status"] is OperationStatus.failed
+    assert harness.finished[0]["result"] == {
+        "status": "failed",
+        "outcome": "sync_base_pushed_head_unavailable",
+        "reason_code": _PUSHED_HEAD_UNAVAILABLE,
+        "pushed": True,
+    }
+    assert harness.audits[0]["evidence"] == push_result.failure_evidence()
+    assert harness.terminations[0]["details"] == push_result.failure_evidence()
+    assert harness.progress_recorded is False
+    assert harness.staleness_refreshed is False

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_repairs.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_repairs.py
@@ -286,6 +286,7 @@ async def test_sync_base_uses_validated_push(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0)  # merge --abort
     cmd.queue_result(returncode=0)  # merge --no-edit origin/development
+    cmd.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # rev-parse HEAD
     runner = make_runner(
         factory=factory,
         cmd=cmd,

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_repairs_validated_push.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_repairs_validated_push.py
@@ -288,6 +288,7 @@ async def test_sync_base_uses_validated_push(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0)  # merge --abort
     cmd.queue_result(returncode=0)  # merge --no-edit origin/development
+    cmd.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # rev-parse HEAD
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -352,6 +353,7 @@ async def test_sync_base_clean_merge_tags_commit_for_task_tagged_workspace(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0)  # merge --abort
     cmd.queue_result(returncode=0)  # merge --no-edit origin/development -m <tagged>
+    cmd.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # rev-parse HEAD
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -408,6 +410,7 @@ async def test_sync_base_clean_merge_untagged_when_no_task_tag(
     cmd = FakeCommandRunner()
     cmd.queue_result(returncode=0)  # merge --abort
     cmd.queue_result(returncode=0)  # merge --no-edit origin/development
+    cmd.queue_result(returncode=0, stdout=f"{'c' * 40}\n")  # rev-parse HEAD
     runner = make_runner(
         factory=factory,
         cmd=cmd,

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_009.py
@@ -253,10 +253,12 @@ async def test_execute_sync_base_records_branch_push_audit(
 ) -> None:
     cmd = FakeCommandRunner()
     workspace_id = await seed_monitoring_workspace(factory)
+    pushed_head = "b" * 40
     cmd.queue_result(returncode=0)  # merge --abort
     cmd.queue_result(returncode=0)  # fetch
     cmd.queue_result(returncode=0)  # merge
     cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout=f"{pushed_head}\n")  # rev-parse HEAD
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -283,6 +285,7 @@ async def test_execute_sync_base_records_branch_push_audit(
 
     assert terminal is False
     assert state.iter_count == 1
+    assert state.last_push_sha == pushed_head
     async with factory() as s:
         operations = await OperationRepository(s).list_all(workspace_id=workspace_id, limit=20)
         push_events = await WorkspaceEventRepository(s).list(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a15372ff04d34aee9eaa833f` (agent: `codex`, model: `gpt-5.6-sol`, effort: `xhigh`).


### Task
Fix the verified hosted PR-monitor stale-head bug using strict TDD and minimal scope. Live GKE evidence: adopted PR363 workspace ws_a61232cafe484f6a937e49ce successfully merged and pushed development into the PR, advancing the remote head from 4ac31db6f749f18652716e9c83e24f130524205d to 2bb16a374667250e685e5bc326d033039f37885d. The SyncBase operation succeeded with pushed=true, but _record_sync_base_progress only clears no-progress counters and does not advance MonitorState.last_push_sha. hosted_pr_identity_for_workspace therefore continued emitting expected_head_sha=4ac31..., so every subsequent hosted comment-repair Job checked out/reported the old head while GitHub was at 2bb16..., producing HOSTED_REMOTE_HEAD_MISMATCH/service-recovery retries and repeated monitor.cli_nonzero_exit. Required behavior: (1) after a successful SyncBase push, resolve and record the actual pushed local HEAD in state.last_push_sha before state persistence and before the next monitor action; never use the pre-sync PR status head; (2) preserve existing sync-base operation/audit/staleness behavior; (3) failed, paused, recovered-by-resync, and no-op pushes must not falsely advance last_push_sha; (4) fail closed or surface structured evidence if a push reports success but the pushed head cannot be resolved as a valid 40-character SHA, rather than silently keeping stale identity; (5) existing lifecycle persistence must write the new value to monitor_last_commit_sha so restart/resume keeps it; (6) add focused regression tests proving a hosted SyncBase that advances head makes the immediately following hosted comment-repair identity use the new SHA, and proving restart/resume preserves it; (7) cover negative push outcomes; (8) run focused hosted-monitor/sync-base tests, ruff on changed Python, mypy, and git diff --check. Keep the implementation narrow and do not weaken terminal-head CAS/protected-scope validation. Git is functional in /workspace; commit before exiting. Do not push, create, or merge the PR; AWF owns lifecycle.

---
Validation: 9 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SyncBase push completion and hosted PR identity head tracking; incorrect head advancement could still cause remote mismatches, but changes are narrow with fail-closed validation and focused tests.
> 
> **Overview**
> Fixes **hosted PR monitor stale head** after a successful SyncBase: the remote advances but `MonitorState.last_push_sha` stayed on the pre-sync SHA, so hosted comment-repair kept targeting the old commit.
> 
> After a **successful validated SyncBase push**, `_run_sync_base` now **`rev-parse`s local HEAD**, requires a **40-character hex SHA**, and sets **`state.last_push_sha`** (normalized lowercase). Failed, paused, resync-recovered, and no-op pushes **skip** head resolution and do not advance state.
> 
> If git reports push success but HEAD cannot be verified, the flow **fails closed** with **`SYNC_BASE_PUSHED_HEAD_UNAVAILABLE`** (terminal monitor failure, outcome `sync_base_pushed_head_unavailable`, structured evidence including `pushed: true`). The SyncBase loop path records **`pushed` from the push result** on failure instead of always `false`.
> 
> Regression tests cover immediate hosted identity after SyncBase, **persistence/restart** via `monitor_last_commit_sha`, negative push outcomes, and loop audit/termination behavior; existing SyncBase integration tests queue an extra **rev-parse HEAD** after push.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d17c2fbd9e43a9e934c5448ab0eda58008065503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->