### PR TITLE
Fix executor validation failure on Git-clean empty directories

### DIFF
--- a/src/awf/control/executor/execution_validation.py
+++ b/src/awf/control/executor/execution_validation.py
@@ -262,6 +262,7 @@ async def run_validation_and_fix_cycle(
             run_git=git_in_worktree,
             worktree_path=worktree_path,
             ignore_all_ignored=True,
+            remove_empty_untracked_dirs=True,
         )
         validation_run_id = await self._start_validation_run(
             workspace_id=workspace_id,

--- a/src/awf/control/executor/validation_fix_helpers.py
+++ b/src/awf/control/executor/validation_fix_helpers.py
@@ -90,6 +90,7 @@ async def check_post_fix_worktree_clean(
         run_git=git_in_worktree,
         worktree_path=worktree_path,
         ignore_all_ignored=True,
+        remove_empty_untracked_dirs=True,
     )
     if fix_pass_ignored_check.clean:
         return None

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_009.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_009.py
@@ -12,6 +12,7 @@ import pytest
 from awf.common.commands import CommandResult
 from awf.common.compose_exec import ComposeExecCleanupError
 from awf.control.executor import execution_validation as executor_execution_validation
+from awf.control.executor import validation_fix_helpers as executor_validation_fix_helpers
 from awf.control.executor.agent_service_recovery import AGENT_SERVICE_RECOVERY_ABORTED
 from awf.control.executor.constants import (
     POST_VALIDATION_CONFORMANCE_REPORT_CLEANUP_FAILED_REASON_CODE,
@@ -1179,6 +1180,14 @@ async def test_post_validation_conformance_fix_pass_loop_falls_through_to_contin
     workspace = _workspace("ws_conf_fix_loop")
     _patch_profile(monkeypatch, profile)
     _patch_clean_worktree(monkeypatch)
+    post_fix_handoff = AsyncMock(
+        wraps=executor_validation_fix_helpers.check_post_fix_worktree_clean
+    )
+    monkeypatch.setattr(
+        executor_validation_fix_helpers,
+        "check_post_fix_worktree_clean",
+        post_fix_handoff,
+    )
 
     class _Validation:
         async def run_profile_phases(self, **_kwargs: object) -> ValidationResult:
@@ -1243,6 +1252,7 @@ async def test_post_validation_conformance_fix_pass_loop_falls_through_to_contin
     assert conformance_check.await_count == 2
     # The conformance fix pass re-invoked the agent exactly once between checks.
     assert adapter.run.await_count == 1
+    post_fix_handoff.assert_awaited_once()
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_validation_empty_untracked_dirs.py
+++ b/tests/unit/control/test_executor_validation_empty_untracked_dirs.py
@@ -1,0 +1,270 @@
+"""Regression tests for empty-directory cleanup at executor validation handoffs."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import ANY, AsyncMock
+
+import pytest
+
+from awf.common.commands import CommandResult
+from awf.control.executor import execution_validation, validation_fix_helpers
+from awf.profiles.models import WorkspaceProfile
+from awf.runtime.validation_worktree import (
+    VALIDATION_INFRASTRUCTURE_ERROR,
+    VALIDATION_WORKTREE_PRE_EXISTING_DIRTY,
+    ValidationWorktreeCheck,
+    ValidationWorktreeCleanup,
+    check_validation_worktree_clean,
+)
+
+
+def _run_git(worktree: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(worktree), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _init_git_worktree(tmp_path: Path) -> tuple[Path, str]:
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+    _run_git(worktree, "init", "-q")
+    (worktree / "README.md").write_text("baseline\n", encoding="utf-8")
+    _run_git(worktree, "add", "README.md")
+    _run_git(
+        worktree,
+        "-c",
+        "user.name=AWF Test",
+        "-c",
+        "user.email=awf-test@example.invalid",
+        "commit",
+        "-q",
+        "-m",
+        "baseline",
+    )
+    return worktree, _run_git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+
+def _git_runner(worktree: Path) -> Callable[[list[str]], Awaitable[CommandResult]]:
+    async def run(args: list[str]) -> CommandResult:
+        result = subprocess.run(
+            ["git", "-C", str(worktree), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        return CommandResult(result.returncode, result.stdout, result.stderr)
+
+    return run
+
+
+def _workspace(profile: WorkspaceProfile) -> SimpleNamespace:
+    return SimpleNamespace(
+        resolved_profile=profile.model_dump(),
+        requested_profile=None,
+        profile_ref=None,
+        env_profile=None,
+        test_commands=[],
+        task_class=None,
+        operations=[],
+        task_title="Empty directory validation handoff",
+        task_tag=None,
+        agent="codex",
+        owned_paths=(),
+        id="ws_empty_dir_handoff",
+    )
+
+
+def _arrange_worktree_state(worktree: Path, state: str) -> Path:
+    if state == "empty_dir":
+        path = worktree / "deploy" / "gke-canary" / "load-restriction-probe"
+        path.mkdir(parents=True)
+        assert _run_git(worktree, "status", "--short").stdout == ""
+        return path
+    if state == "tracked":
+        path = worktree / "README.md"
+        path.write_text("modified\n", encoding="utf-8")
+        return path
+    path = worktree / "generated" / "out.txt"
+    path.parent.mkdir()
+    path.write_text("untracked\n", encoding="utf-8")
+    return path
+
+
+async def _run_initial_handoff(
+    *,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    worktree: Path,
+    head_sha: str,
+) -> tuple[object, SimpleNamespace, AsyncMock, AsyncMock, AsyncMock]:
+    profile = WorkspaceProfile.model_validate({"name": "empty-dir-handoff"})
+    validation_runner = SimpleNamespace(
+        run_profile_phases=AsyncMock(side_effect=RuntimeError("stop after validation starts"))
+    )
+    executor = SimpleNamespace(
+        _transition_if_current=AsyncMock(return_value=True),
+        _recheck_status=AsyncMock(return_value=True),
+        _config=SimpleNamespace(
+            max_validation_fix_passes=0,
+            planning_max_iterations_default=3,
+            compose_projects_root=tmp_path / "artifacts",
+        ),
+        _capture_workspace_head_sha=AsyncMock(return_value=head_sha),
+        _start_validation_run=AsyncMock(return_value="vr-empty-dir-handoff"),
+        _finish_validation_run=AsyncMock(),
+        _finish_pending_validate_operations=AsyncMock(),
+        _mark_failed=AsyncMock(),
+        _finish_validation_callback_if_terminal=AsyncMock(return_value=False),
+        _update_subphase=AsyncMock(),
+        _validation=validation_runner,
+    )
+
+    async def sync_profile(*_args: object, **_kwargs: object) -> WorkspaceProfile:
+        return profile
+
+    checker_spy = AsyncMock(wraps=check_validation_worktree_clean)
+    cleanup_mock = AsyncMock(
+        return_value=ValidationWorktreeCleanup(
+            cleaned=False,
+            check=ValidationWorktreeCheck(clean=True),
+            restore_ref=head_sha,
+        )
+    )
+    monkeypatch.setattr(
+        execution_validation,
+        "_profile_for_workspace",
+        lambda *_args, **_kwargs: profile,
+    )
+    monkeypatch.setattr(execution_validation, "_sync_resolved_profile", sync_profile)
+    monkeypatch.setattr(
+        execution_validation,
+        "profile_phase_command_plan",
+        lambda *_args, **_kwargs: (),
+    )
+    monkeypatch.setattr(
+        execution_validation,
+        "_validation_tier_for_workspace",
+        lambda *_args, **_kwargs: 1,
+    )
+    monkeypatch.setattr(execution_validation, "check_validation_worktree_clean", checker_spy)
+    monkeypatch.setattr(
+        execution_validation,
+        "cleanup_validation_worktree_side_effects",
+        cleanup_mock,
+    )
+
+    git_in_worktree = _git_runner(worktree)
+    result = await execution_validation.run_validation_and_fix_cycle(
+        executor,
+        workspace_id="ws_empty_dir_handoff",
+        ws=_workspace(profile),  # type: ignore[arg-type]
+        worktree_path=worktree,
+        compose_project="awf_ws_empty_dir_handoff",
+        compose_file=tmp_path / "compose.yml",
+        base_commit=head_sha,
+        expected_branch="awf/ws_empty_dir_handoff",
+        adapter=SimpleNamespace(run=AsyncMock()),  # type: ignore[arg-type]
+        default_model=None,
+        baseline_coverage=None,
+        planning_validation_handoff=None,
+        recovery=None,
+        rebase_recovery_result=None,
+        git_in_worktree=git_in_worktree,
+    )
+    return result, executor, validation_runner.run_profile_phases, checker_spy, cleanup_mock
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("state", ["empty_dir", "tracked", "untracked"])
+async def test_initial_validation_handoff_cleans_only_empty_untracked_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    state: str,
+) -> None:
+    worktree, head_sha = _init_git_worktree(tmp_path)
+    residue = _arrange_worktree_state(worktree, state)
+
+    result, executor, validation_run, checker_spy, cleanup_mock = await _run_initial_handoff(
+        monkeypatch=monkeypatch,
+        tmp_path=tmp_path,
+        worktree=worktree,
+        head_sha=head_sha,
+    )
+
+    assert result.stop
+    assert checker_spy.await_args.kwargs == {
+        "run_git": ANY,
+        "worktree_path": worktree,
+        "ignore_all_ignored": True,
+        "remove_empty_untracked_dirs": True,
+    }
+    if state == "empty_dir":
+        assert not residue.exists()
+        validation_run.assert_awaited_once()
+        cleanup_mock.assert_awaited_once_with(
+            run_git=ANY,
+            worktree_path=worktree,
+            restore_ref=head_sha,
+        )
+        reason_code = VALIDATION_INFRASTRUCTURE_ERROR
+    else:
+        assert residue.exists()
+        validation_run.assert_not_awaited()
+        cleanup_mock.assert_not_awaited()
+        reason_code = VALIDATION_WORKTREE_PRE_EXISTING_DIRTY
+    assert executor._mark_failed.await_args.kwargs["reason_code"] == reason_code
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("state", ["empty_dir", "tracked", "untracked"])
+async def test_shared_fix_pass_handoff_cleans_only_empty_untracked_directories(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    state: str,
+) -> None:
+    worktree, _head_sha = _init_git_worktree(tmp_path)
+    residue = _arrange_worktree_state(worktree, state)
+    checker_spy = AsyncMock(wraps=check_validation_worktree_clean)
+    monkeypatch.setattr(
+        validation_fix_helpers,
+        "check_validation_worktree_clean",
+        checker_spy,
+    )
+    executor = SimpleNamespace(
+        _finish_pending_validate_operations=AsyncMock(),
+        _mark_failed=AsyncMock(),
+    )
+
+    result = await validation_fix_helpers.check_post_fix_worktree_clean(
+        executor,
+        workspace_id="ws_fix_handoff",
+        validation_tier=1,
+        git_in_worktree=_git_runner(worktree),
+        worktree_path=worktree,
+        profile=WorkspaceProfile.model_validate({"name": "fix-handoff"}),
+    )
+
+    assert checker_spy.await_args.kwargs == {
+        "run_git": ANY,
+        "worktree_path": worktree,
+        "ignore_all_ignored": True,
+        "remove_empty_untracked_dirs": True,
+    }
+    if state == "empty_dir":
+        assert result is None
+        assert not residue.exists()
+        executor._mark_failed.assert_not_awaited()
+    else:
+        assert result is not None
+        assert result.stop
+        assert residue.exists()
+        assert executor._mark_failed.await_args.kwargs["reason_code"] == (
+            VALIDATION_WORKTREE_PRE_EXISTING_DIRTY
+        )


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_e86f3644419c4b318dc0f315` (agent: `codex`, model: `gpt-5.6-sol`, effort: `high`).


### Task
Fix the AWF Core regression exposed by failed workspace ws_680c969cf7104948bdf9fd36.

Root cause evidence: an implementation agent briefly created deploy/gke-canary/load-restriction-probe/kustomization.yaml, then legitimately deleted the file after rejecting that design. Git reported the worktree clean, but the now-empty untracked parent directory remained. Normal executor validation called check_validation_worktree_clean without remove_empty_untracked_dirs=True and failed VALIDATION_WORKTREE_PRE_EXISTING_DIRTY. AWF already safely handles this exact condition for PR-monitor pre-push validation (PR #606 / issue #605).

Implement the missing normal-executor coverage using strict TDD:
1. Add focused regression tests proving the initial agent-to-validation handoff removes a Git-clean empty untracked directory and proceeds, while real tracked/untracked dirt still fails closed.
2. Cover the validation/conformance fix-pass handoff too, because it has the same call-site omission.
3. Reuse check_validation_worktree_clean(remove_empty_untracked_dirs=True); do not weaken the guard, do not ignore non-empty directories or files, and do not change post-validation side-effect/provenance cleanup semantics.
4. Make the smallest production change at the two pre-validation/fix-pass call sites.
5. Run focused tests, ruff, mypy, and the repository profile validation appropriate to the touched control-plane surface.
6. Save required local plan/validation artifacts but never commit plans/*_PLAN.md or plans/*_VALIDATION.md. Commit the source and tests before exiting. Do not push; AWF owns PR handoff and monitoring.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two-parameter call-site alignment with existing validation_worktree behavior; guarded cleanup only when status is otherwise clean, with new regression tests covering empty-dir vs real dirt.
> 
> **Overview**
> Fixes false **VALIDATION_WORKTREE_PRE_EXISTING_DIRTY** failures when `git status` is clean but empty untracked directories remain after an agent deletes the last file in a path (e.g. nested deploy folders).
> 
> The normal executor now passes **`remove_empty_untracked_dirs=True`** into `check_validation_worktree_clean` at the **pre-validation** handoff in `run_validation_and_fix_cycle` and at the **post–fix-pass** handoff in `check_post_fix_worktree_clean`, matching PR-monitor pre-push validation. Real tracked or untracked file dirt still fails closed.
> 
> Adds focused regression tests (real git worktrees) for both handoffs and tightens an existing conformance fix-loop test to assert the post-fix worktree check runs once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f64fb5e18d8c7633eab9b51eb1a8fe23c60850af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->