### PR TITLE
Release AWF Core main image pipeline

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,37 @@
+steps:
+  - id: build-core
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --file
+      - docker/control-plane.Dockerfile
+      - --tag
+      - ${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA
+      - .
+
+  - id: build-agent-runtime
+    name: gcr.io/cloud-builders/docker
+    args:
+      - build
+      - --file
+      - docker/agent-runtime.Dockerfile
+      - --tag
+      - ${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA
+      - .
+
+  - id: push-core
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - ${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA
+
+  - id: push-agent-runtime
+    name: gcr.io/cloud-builders/docker
+    args:
+      - push
+      - ${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+
+timeout: 3600s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,14 +9,41 @@ steps:
       - ${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA
       - .
 
-  - id: build-agent-runtime
+  # Agent-runtime must publish linux/amd64 + linux/arm64 (DGX Spark / PRD §18.5).
+  # Plain `docker build` only produces the builder's platform (amd64 on Cloud Build).
+  - id: setup-qemu
     name: gcr.io/cloud-builders/docker
     args:
+      - run
+      - --privileged
+      - --rm
+      - tonistiigi/binfmt
+      - --install
+      - all
+
+  - id: create-buildx-builder
+    name: gcr.io/cloud-builders/docker
+    args:
+      - buildx
+      - create
+      - --use
+      - --name
+      - awf-multiarch
+      - --driver
+      - docker-container
+
+  - id: build-and-push-agent-runtime
+    name: gcr.io/cloud-builders/docker
+    args:
+      - buildx
       - build
+      - --platform
+      - linux/amd64,linux/arm64
       - --file
       - docker/agent-runtime.Dockerfile
       - --tag
       - ${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA
+      - --push
       - .
 
   - id: push-core
@@ -24,12 +51,6 @@ steps:
     args:
       - push
       - ${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA
-
-  - id: push-agent-runtime
-    name: gcr.io/cloud-builders/docker
-    args:
-      - push
-      - ${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA
 
 options:
   logging: CLOUD_LOGGING_ONLY

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,7 +17,8 @@ steps:
       - run
       - --privileged
       - --rm
-      - tonistiigi/binfmt
+      # Pin by digest: privileged helper must not float on :latest.
+      - tonistiigi/binfmt:qemu-v10.2.3@sha256:400a4873b838d1b89194d982c45e5fb3cda4593fbfd7e08a02e76b03b21166f0
       - --install
       - all
 

--- a/tests/unit/test_cloudbuild_contract.py
+++ b/tests/unit/test_cloudbuild_contract.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
+
+_BINFMT_DIGEST_REF = re.compile(r"^tonistiigi/binfmt(?::[A-Za-z0-9._-]+)?@sha256:[0-9a-f]{64}$")
 
 
 def test_cloudbuild_publishes_only_core_owned_images_from_main_sha() -> None:
@@ -56,3 +59,22 @@ def test_cloudbuild_publishes_agent_runtime_multi_arch() -> None:
     assert "push-agent-runtime" not in {
         step.get("id") for step in config["steps"] if isinstance(step, dict)
     }
+
+
+def test_cloudbuild_pins_privileged_binfmt_by_digest() -> None:
+    """Privileged qemu/binfmt helper must not float on a mutable tag."""
+    path = ROOT / "cloudbuild.yaml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    qemu_steps = [
+        step
+        for step in config["steps"]
+        if isinstance(step, dict) and step.get("id") == "setup-qemu"
+    ]
+    assert len(qemu_steps) == 1
+    args = qemu_steps[0].get("args", [])
+    assert args[:3] == ["run", "--privileged", "--rm"]
+    image = args[3]
+    assert _BINFMT_DIGEST_REF.match(image), (
+        f"setup-qemu must pin tonistiigi/binfmt by digest, got {image!r}"
+    )

--- a/tests/unit/test_cloudbuild_contract.py
+++ b/tests/unit/test_cloudbuild_contract.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_cloudbuild_publishes_only_core_owned_images_from_main_sha() -> None:
+    path = ROOT / "cloudbuild.yaml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    text = path.read_text(encoding="utf-8")
+
+    assert config["options"]["logging"] == "CLOUD_LOGGING_ONLY"
+    assert config["timeout"] == "3600s"
+    assert len(config["steps"]) == 4
+    assert "docker/control-plane.Dockerfile" in text
+    assert "docker/agent-runtime.Dockerfile" in text
+    assert "${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA" in text
+    assert "${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA" in text
+    assert "kubectl" not in text
+    assert "gcloud container" not in text
+    assert "aira-agent" not in text
+    assert "aira-web" not in text

--- a/tests/unit/test_cloudbuild_contract.py
+++ b/tests/unit/test_cloudbuild_contract.py
@@ -11,13 +11,20 @@ def test_cloudbuild_publishes_only_core_owned_images_from_main_sha() -> None:
     path = ROOT / "cloudbuild.yaml"
     config = yaml.safe_load(path.read_text(encoding="utf-8"))
     text = path.read_text(encoding="utf-8")
+    core_tag = "${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA"
 
     assert config["options"]["logging"] == "CLOUD_LOGGING_ONLY"
     assert config["timeout"] == "3600s"
     assert "docker/control-plane.Dockerfile" in text
     assert "docker/agent-runtime.Dockerfile" in text
-    assert "${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA" in text
+    assert core_tag in text
     assert "${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA" in text
+    # build-core only tags locally; publish requires an explicit docker push step.
+    push_core_steps = [
+        step for step in config["steps"] if isinstance(step, dict) and step.get("id") == "push-core"
+    ]
+    assert len(push_core_steps) == 1
+    assert push_core_steps[0].get("args") == ["push", core_tag]
     assert "kubectl" not in text
     assert "gcloud container" not in text
     assert "aira-agent" not in text

--- a/tests/unit/test_cloudbuild_contract.py
+++ b/tests/unit/test_cloudbuild_contract.py
@@ -14,7 +14,6 @@ def test_cloudbuild_publishes_only_core_owned_images_from_main_sha() -> None:
 
     assert config["options"]["logging"] == "CLOUD_LOGGING_ONLY"
     assert config["timeout"] == "3600s"
-    assert len(config["steps"]) == 4
     assert "docker/control-plane.Dockerfile" in text
     assert "docker/agent-runtime.Dockerfile" in text
     assert "${_ARTIFACT_REPOSITORY}/awf-core:rc-$COMMIT_SHA" in text
@@ -23,3 +22,30 @@ def test_cloudbuild_publishes_only_core_owned_images_from_main_sha() -> None:
     assert "gcloud container" not in text
     assert "aira-agent" not in text
     assert "aira-web" not in text
+
+
+def test_cloudbuild_publishes_agent_runtime_multi_arch() -> None:
+    """Agent-runtime must ship linux/amd64+linux/arm64 (PRD §18.5 / Dockerfile contract)."""
+    path = ROOT / "cloudbuild.yaml"
+    config = yaml.safe_load(path.read_text(encoding="utf-8"))
+    text = path.read_text(encoding="utf-8")
+
+    runtime_steps = [
+        step
+        for step in config["steps"]
+        if "docker/agent-runtime.Dockerfile" in step.get("args", [])
+    ]
+    assert len(runtime_steps) == 1
+    args = runtime_steps[0]["args"]
+    assert args[0] == "buildx"
+    assert "build" in args
+    assert "--platform" in args
+    platform = args[args.index("--platform") + 1]
+    assert "linux/amd64" in platform
+    assert "linux/arm64" in platform
+    assert "--push" in args
+    assert "${_ARTIFACT_REPOSITORY}/awf-agent-runtime:rc-$COMMIT_SHA" in text
+    # Multi-arch images are published via buildx --push, not a separate docker push.
+    assert "push-agent-runtime" not in {
+        step.get("id") for step in config["steps"] if isinstance(step, dict)
+    }


### PR DESCRIPTION
## Summary

Promote the repository-owned AWF Core Cloud Build contract to `main`.

- build and publish `awf-core` from `docker/control-plane.Dockerfile`
- build and publish `awf-agent-runtime` from `docker/agent-runtime.Dockerfile`
- tag both images as `rc-<COMMIT_SHA>` for AWF Cloud dependency-lock resolution
- retain a publish-only identity with no GKE or Aira authority

## Release policy

This is a development-to-main release PR. AWF should monitor review and CI, then wait for human merge approval; it must not auto-merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/release automation only; no runtime app or auth changes, with behavior guarded by contract tests.
> 
> **Overview**
> Introduces **`cloudbuild.yaml`** as the repo-owned GCP Cloud Build contract for publishing AWF Core images on each main commit, tagged **`rc-$COMMIT_SHA`** for dependency-lock resolution.
> 
> The pipeline **builds and pushes `awf-core`** from `docker/control-plane.Dockerfile` (local build, then a dedicated **`push-core`** step) and **`awf-agent-runtime`** from `docker/agent-runtime.Dockerfile` via **buildx** for **`linux/amd64` and `linux/arm64`**, with QEMU/binfmt setup (digest-pinned) and a multiarch builder. It stays **publish-only**: no kubectl, GKE, or Aira image steps.
> 
> **`tests/unit/test_cloudbuild_contract.py`** encodes that contract—owned images and tags, explicit core push, multi-arch buildx `--push`, digest-pinned privileged binfmt, logging/timeout, and absence of deploy/Aira references.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 893eda8c066f12cc9d4c96e8bb3ffb8abc7081c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->