### PR TITLE
Release development to main

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -41,7 +41,7 @@
 
 - **What:** Move `MergeCandidate` creation earlier so that any workspace holding a `pr_url` also holds
   a candidate row, instead of creating it only on the `-> monitoring_pr` transition
-  (`db/repositories/workspace_repo.py:1036-1050`).
+  (`WorkspaceRepository._sync_merge_candidate_lifecycle`).
 - **Why:** This is the root cause behind the stale merge-queue rows fixed in
   `plans/MERGE_QUEUE_TERMINAL_ROWS_PLAN.md`. PR adoption stamps `pr_url` at workspace creation, but the
   candidate is only created at monitor handoff. A workspace that dies in between (5 did, on 2026-07-21,
@@ -64,7 +64,7 @@
 - **What:** Delete `merged_at` from `MergeQueueItemResponse` (`api/schemas.py:1300`), regenerate
   `openapi.json`, and update the MCP schema mirror plus console types.
 - **Why:** Verified during the merge-queue review: `merged_at` is structurally always null on this
-  endpoint. `mark_workspace_merged` (`db/repositories/quality_repo.py:516-519`) sets `status="merged"`
+  endpoint. `MergeCandidateRepository.mark_workspace_merged` sets `status="merged"`
   and `merged_at` in the same operation, and the queue only ever returns `open` candidates. Live DB
   confirms it: `open|3|0`, `closed|61|0`, `merged|500|500`. The contract advertises a field it can
   never populate.

--- a/TODOS.md
+++ b/TODOS.md
@@ -36,3 +36,64 @@
   the single-blip core ships right-sized. The warm-hold is consistent with how `blocked` already holds
   slots for operator pauses.
 - **Depends on / blocked by:** #612 (in-place retry) shipping first — you'll know the real herd frequency.
+
+## Create the MergeCandidate at PR-adoption time (close the orphan class)
+
+- **What:** Move `MergeCandidate` creation earlier so that any workspace holding a `pr_url` also holds
+  a candidate row, instead of creating it only on the `-> monitoring_pr` transition
+  (`db/repositories/workspace_repo.py:1036-1050`).
+- **Why:** This is the root cause behind the stale merge-queue rows fixed in
+  `plans/MERGE_QUEUE_TERMINAL_ROWS_PLAN.md`. PR adoption stamps `pr_url` at workspace creation, but the
+  candidate is only created at monitor handoff. A workspace that dies in between (5 did, on 2026-07-21,
+  all with `MIRROR_HOOKS_PATH_REPAIR_FAILED`) has a PR and no candidate, so the `-> failed` handler's
+  `close_open_for_workspace()` finds nothing to close and silently no-ops. The query fix hides the
+  symptom; this removes the cause.
+- **Pros:** Eliminates the orphan class outright; makes the legacy fallback query genuinely legacy
+  rather than a live catch-all; gives failed adoptions a real close reason and audit trail.
+- **Cons:** Touches the path currently handling 561 candidate rows correctly (500 merged, 61 closed).
+  Attempt canonicality is decided at monitor handoff today and would need care. Real regression risk
+  for a problem the query fix already makes invisible.
+- **Context:** Deliberately deferred during the `/plan-eng-review` scope gate (decision D1) so the
+  narrow read-path fix could ship focused. Orphan rate is currently zero — the causing infra incident
+  was a single day and has not recurred. This is prevention, not firefighting.
+- **Depends on / blocked by:** The merge-queue query fix landing first, so the operator view is correct
+  while this is designed properly.
+
+## Remove the always-null `merged_at` from the merge-queue API response
+
+- **What:** Delete `merged_at` from `MergeQueueItemResponse` (`api/schemas.py:1300`), regenerate
+  `openapi.json`, and update the MCP schema mirror plus console types.
+- **Why:** Verified during the merge-queue review: `merged_at` is structurally always null on this
+  endpoint. `mark_workspace_merged` (`db/repositories/quality_repo.py:516-519`) sets `status="merged"`
+  and `merged_at` in the same operation, and the queue only ever returns `open` candidates. Live DB
+  confirms it: `open|3|0`, `closed|61|0`, `merged|500|500`. The contract advertises a field it can
+  never populate.
+- **Pros:** Honest contract; removes a field every consumer must handle and none can receive; small
+  and mechanical.
+- **Cons:** Removing a response field is a contract change — OpenAPI drift gate, MCP mirror, console
+  types, existing fixtures. Meaningful churn for a field that is useless rather than harmful.
+- **Context:** The merge-queue fix removed the dead console display but deliberately kept the API
+  field to avoid dragging contract regeneration into a narrow bugfix. The outside voice called the
+  result a "half-cleaned contract," which is fair — this is the other half.
+- **Depends on / blocked by:** Nothing. Independently shippable.
+
+## Define merge-queue membership explicitly (retire the `pr_url IS NOT NULL` predicate)
+
+- **What:** Replace the legacy predicate "has a PR URL and has no candidate" with a stated definition
+  of what belongs in the operator merge queue, and settle whether pre-monitor adoption workspaces
+  (`requested`, `ready`, `running`) count as merge candidates.
+- **Why:** Excluding terminal statuses narrows the symptom without ever defining membership.
+  `pr_url IS NOT NULL` is the weak predicate that admitted the orphans in the first place, and it
+  stays weak after the fix. `docs/REST_API_REFERENCE.md:426` describes the endpoint as listing "merge
+  candidates," which a PR that AWF has not started working on arguably is not.
+- **Pros:** Turns an accidental definition into a deliberate one; makes the endpoint match its
+  documented description; gives the next workspace status an obvious place to be classified.
+- **Cons:** A genuine contract decision, not a cleanup. Needs a real answer on whether an
+  adopted-but-not-yet-started PR is a merge candidate, and that answer changes operator workflow.
+  Getting it wrong costs more than the bug it follows.
+- **Context:** Raised by the Codex outside voice during `/plan-eng-review` as the sharpest criticism of
+  the narrow fix. Test G5 in that plan was deliberately narrowed (asserting only `blocked`,
+  `awaiting_human`, `pushing`, `monitoring_pr` stay visible) specifically so this question stays open
+  rather than being settled by accident inside a bugfix.
+- **Depends on / blocked by:** Best done after candidate-at-adoption-time, which would make the legacy
+  path genuinely legacy and shrink this question considerably.

--- a/apps/console/components/console-dashboard-capacity.tsx
+++ b/apps/console/components/console-dashboard-capacity.tsx
@@ -35,7 +35,6 @@ toneTextClass
 } from "@/lib/format";
 import {
 formatRequiredNextAction,
-mergeQueueMergedAt,
 requiredNextActionTone,
 summarizeReadiness,
 summarizeRecovery,
@@ -433,7 +432,6 @@ export function MergeQueueRow({
   const stale = summarizeStaleReasons(item);
   const validation = summarizeValidation(item);
   const recovery = summarizeRecovery(item);
-  const mergedAt = mergeQueueMergedAt(item);
   return (
     <article className="grid gap-2 border-b border-line pb-2 text-xs last:border-b-0 last:pb-0">
       <div className="flex min-w-0 items-start justify-between gap-2">
@@ -447,7 +445,6 @@ export function MergeQueueRow({
           <div className="mono mt-1 truncate text-[11px] text-fg-muted">{item.workspace_id}</div>
           <div className="mt-1 flex min-w-0 flex-wrap gap-x-2 gap-y-1 text-[11px] text-fg-muted">
             <span className="truncate">created {formatDateTime(item.created_at)}</span>
-            <span className="truncate">merged {formatDateTime(mergedAt)}</span>
             <span className="truncate">
               base <span className="mono text-fg">{item.base_branch}</span>
             </span>
@@ -564,7 +561,6 @@ export function MergeQueueRow({
             <QueueDatum label="Readiness" value={readiness.detail} mono tone={readinessTone(readiness.label)} />
             <QueueDatum label="Mode" value={item.auto_merge ? "auto-merge" : "manual"} />
             <QueueDatum label="Created" value={formatDateTime(item.created_at)} />
-            <QueueDatum label="Merged" value={formatDateTime(mergedAt)} />
             <QueueDatum label="Last event" value={lastEventReason(item.last_event)} mono />
             <QueueDatum label="Blocker" value={item.merge_blocker_reason} mono tone={mergeBlockerTone(item.merge_blocker_reason)} />
             <QueueDatum label="Required tier" value={recovery.requiredTierLabel} />

--- a/apps/console/lib/merge-queue-format.ts
+++ b/apps/console/lib/merge-queue-format.ts
@@ -355,10 +355,6 @@ function summarizeQueueIdentity(
   };
 }
 
-export function mergeQueueMergedAt(item: Pick<MergeQueueItem, "merged_at" | "status" | "updated_at">): string | null {
-  return item.merged_at ?? (item.status === "completed" ? item.updated_at : null);
-}
-
 interface RequiredNextActionDefinition {
   label: string;
   tone: QueueTone;

--- a/apps/console/tests/theme-accessibility.spec.ts
+++ b/apps/console/tests/theme-accessibility.spec.ts
@@ -50,6 +50,9 @@ test("desktop theme screenshots cover dashboard, details, and fullscreen logs", 
   await waitForConsoleReady(page);
 
   await expect(page.getByRole("heading", { name: "Merge Queue" })).toBeVisible();
+  // G6: Merge Queue rows must not render a merged timestamp field/label.
+  await expect(page.getByText(/^merged /i)).toHaveCount(0);
+  await expect(page.getByText("Merged", { exact: true })).toHaveCount(0);
   await expect(page.locator("html")).toHaveAttribute("data-awf-theme", "dark");
   await expectNoViewportOverflow(page);
   await page.screenshot({ path: testInfo.outputPath("desktop-dashboard.png"), fullPage: true });

--- a/src/awf/db/enums.py
+++ b/src/awf/db/enums.py
@@ -75,6 +75,34 @@ class WorkspaceStatus(StrEnum):
     destroyed = "destroyed"
 
 
+WORKSPACE_TEARDOWN_STATUSES: Final[frozenset[str]] = frozenset(
+    {
+        WorkspaceStatus.destroying.value,
+        WorkspaceStatus.destroyed.value,
+    }
+)
+"""Statuses that always leave the operator merge-queue surface.
+
+Used by the candidate-backed queue path. An open MergeCandidate on a
+tearing-down workspace is filtered; an open candidate on a terminal
+(non-teardown) workspace is an invariant breach and must remain visible.
+"""
+
+MERGE_QUEUE_EXCLUDED_STATUSES: Final[frozenset[str]] = WORKSPACE_TEARDOWN_STATUSES | frozenset(
+    {
+        WorkspaceStatus.completed.value,
+        WorkspaceStatus.failed.value,
+        WorkspaceStatus.cancelled.value,
+    }
+)
+"""Blacklist of workspace statuses excluded from the *legacy* merge-queue path.
+
+Deliberately a blacklist: a future unclassified status must fail loud by
+appearing in the queue rather than silently vanishing. Candidate-backed
+``list_queue`` must NOT use this set — see ``WORKSPACE_TEARDOWN_STATUSES``.
+"""
+
+
 class OperationStatus(StrEnum):
     """Lifecycle status of an async control-plane operation."""
 

--- a/src/awf/db/repositories/quality_repo.py
+++ b/src/awf/db/repositories/quality_repo.py
@@ -19,7 +19,7 @@ from awf.common.ids import (
     new_stale_reason_id,
     new_validation_run_id,
 )
-from awf.db.enums import TaskClass, WorkspaceStatus
+from awf.db.enums import WORKSPACE_TEARDOWN_STATUSES, TaskClass, WorkspaceStatus
 from awf.db.models import (
     MergeCandidate,
     PolicyFinding,
@@ -337,12 +337,7 @@ class MergeCandidateRepository:
             .join(Workspace, MergeCandidate.workspace_id == Workspace.id)
             .where(
                 MergeCandidate.status == "open",
-                ~Workspace.status.in_(
-                    (
-                        WorkspaceStatus.destroying.value,
-                        WorkspaceStatus.destroyed.value,
-                    )
-                ),
+                ~Workspace.status.in_(WORKSPACE_TEARDOWN_STATUSES),
             )
             .options(
                 selectinload(MergeCandidate.attempt),

--- a/src/awf/db/repositories/workspace_repo.py
+++ b/src/awf/db/repositories/workspace_repo.py
@@ -25,6 +25,7 @@ from awf.common.ids import (
     new_event_id,
 )
 from awf.db.enums import (
+    MERGE_QUEUE_EXCLUDED_STATUSES,
     AgentRuntime,
     WorkspaceStatus,
 )
@@ -548,50 +549,6 @@ class WorkspaceRepository:
         )
         return list((await self._session.execute(stmt)).scalars())
 
-    async def list_merge_queue(
-        self,
-        *,
-        repo_url: str | None = None,
-        base_branch: str | None = None,
-        status: WorkspaceStatus | str | None = None,
-        before_updated_at: datetime | None = None,
-        before_workspace_id: str | None = None,
-        limit: int = 50,
-    ) -> builtins.list[Workspace]:
-        """List legacy PR workspaces visible in the merge queue."""
-        stmt = (
-            select(Workspace)
-            .where(
-                Workspace.pr_url.is_not(None),
-                Workspace.pr_url != "",
-                ~Workspace.status.in_(
-                    (
-                        WorkspaceStatus.destroying.value,
-                        WorkspaceStatus.destroyed.value,
-                    )
-                ),
-            )
-            .order_by(Workspace.updated_at.desc(), Workspace.id.desc())
-        )
-        if repo_url is not None:
-            stmt = stmt.where(Workspace.repo_url == repo_url)
-        if base_branch is not None:
-            stmt = stmt.where(Workspace.branch_base == base_branch)
-        if status is not None:
-            stmt = stmt.where(Workspace.status == status)
-        if before_updated_at is not None and before_workspace_id is not None:
-            stmt = stmt.where(
-                or_(
-                    Workspace.updated_at < before_updated_at,
-                    and_(
-                        Workspace.updated_at == before_updated_at,
-                        Workspace.id < before_workspace_id,
-                    ),
-                )
-            )
-        stmt = stmt.limit(limit)
-        return list((await self._session.execute(stmt)).scalars())
-
     async def list_merge_queue_without_candidates(
         self,
         *,
@@ -610,12 +567,7 @@ class WorkspaceRepository:
                 MergeCandidate.id.is_(None),
                 Workspace.pr_url.is_not(None),
                 Workspace.pr_url != "",
-                ~Workspace.status.in_(
-                    (
-                        WorkspaceStatus.destroying.value,
-                        WorkspaceStatus.destroyed.value,
-                    )
-                ),
+                ~Workspace.status.in_(MERGE_QUEUE_EXCLUDED_STATUSES),
             )
             .order_by(Workspace.updated_at.desc(), Workspace.id.desc())
         )

--- a/src/awf/service/merge_queue.py
+++ b/src/awf/service/merge_queue.py
@@ -32,7 +32,12 @@ from awf.common.owned_paths import (
     internal_plan_artifact_owned_paths_from_profile,
     interworkspace_owned_paths,
 )
-from awf.db.enums import OperationStatus, OperationType, WorkspaceStatus
+from awf.db.enums import (
+    MERGE_QUEUE_EXCLUDED_STATUSES,
+    OperationStatus,
+    OperationType,
+    WorkspaceStatus,
+)
 from awf.db.models import (
     MergeCandidate,
     Operation,
@@ -406,7 +411,7 @@ def _item_from_legacy_workspace(
         owned_paths=list(workspace.owned_paths),
         created_at=workspace.created_at,
         updated_at=workspace.updated_at,
-        merged_at=_legacy_workspace_merged_at(workspace),
+        merged_at=None,
         last_event=(
             WorkspaceEventResponse.model_validate(latest_event)
             if latest_event is not None
@@ -436,20 +441,6 @@ def _row_workspace(row: MergeCandidate | Workspace) -> Workspace:
 
 def _latest_event(events: list[WorkspaceEvent]) -> WorkspaceEvent | None:
     return events[-1] if events else None
-
-
-def _legacy_workspace_merged_at(workspace: Workspace) -> datetime | None:
-    completed_events = [
-        event.occurred_at
-        for event in workspace.events
-        if event.event_type == "workspace.state_changed"
-        and event.new_state == WorkspaceStatus.completed.value
-    ]
-    if completed_events:
-        return max(completed_events)
-    if WorkspaceStatus(workspace.status) == WorkspaceStatus.completed:
-        return workspace.updated_at
-    return None
 
 
 def _queue_blocker_response(blocker: MergeQueueBlocker) -> MergeQueueBlockerResponse:
@@ -537,9 +528,7 @@ def _merge_blocker_reason_from_workspace(
         return "manual_merge_required", None
     if workspace_status == WorkspaceStatus.pushing:
         return "waiting_for_monitor", None
-    if workspace_status == WorkspaceStatus.completed:
-        return "completed", None
-    if workspace_status in {WorkspaceStatus.failed, WorkspaceStatus.cancelled}:
+    if workspace.status in MERGE_QUEUE_EXCLUDED_STATUSES:
         return "failed_or_cancelled", None
     return "workspace_not_terminal", None
 

--- a/tests/unit/api/test_merge_queue_parts/test_merge_queue_part_001.py
+++ b/tests/unit/api/test_merge_queue_parts/test_merge_queue_part_001.py
@@ -1131,7 +1131,9 @@ class TestMergeQueueListPart001:
         client: AsyncClient,
         engine: AsyncEngine,
     ) -> None:
+        """G2: terminal legacy rows are absent; active legacy rows keep blockers."""
         expected: dict[str, tuple[str, str | None]] = {}
+        absent_ids: set[str] = set()
         for index, (title, status, auto_merge, reason, action) in enumerate(
             [
                 (
@@ -1155,19 +1157,19 @@ class TestMergeQueueListPart001:
                     "waiting_for_monitor",
                     None,
                 ),
-                ("Completed legacy", WorkspaceStatus.completed, True, "completed", None),
+                ("Completed legacy", WorkspaceStatus.completed, True, None, None),
                 (
                     "Failed legacy",
                     WorkspaceStatus.failed,
                     True,
-                    "failed_or_cancelled",
+                    None,
                     None,
                 ),
                 (
                     "Cancelled legacy",
                     WorkspaceStatus.cancelled,
                     True,
-                    "failed_or_cancelled",
+                    None,
                     None,
                 ),
                 (
@@ -1187,7 +1189,10 @@ class TestMergeQueueListPart001:
                 pr_url=f"https://github.com/example/legacy/pull/{90 + index}",
                 updated_at=datetime(2026, 4, 20 + index, 12, 0, tzinfo=UTC),
             )
-            expected[workspace_id] = (reason, action)
+            if reason is None:
+                absent_ids.add(workspace_id)
+            else:
+                expected[workspace_id] = (reason, action)
 
         response = await client.get(
             "/v1/merge-queue",
@@ -1196,7 +1201,8 @@ class TestMergeQueueListPart001:
 
         assert response.status_code == 200
         items = {item["workspace_id"]: item for item in response.json()["items"]}
-        assert set(items) == set(expected)
+        assert absent_ids.isdisjoint(items)
+        assert set(expected) <= set(items)
         for workspace_id, (reason, action) in expected.items():
             item = items[workspace_id]
             assert item["candidate_id"] is None
@@ -1205,10 +1211,7 @@ class TestMergeQueueListPart001:
             assert item["queue_blockers"] == []
             assert item["merge_blocker_reason"] == reason
             assert item["required_next_action"] == action
-            if reason == "completed":
-                assert item["merged_at"] == item["updated_at"]
-            else:
-                assert item["merged_at"] is None
+            assert item["merged_at"] is None
             assert item["last_event"]["event_type"] == "merge_queue.legacy_marker"
 
     @pytest.mark.unit

--- a/tests/unit/api/test_merge_queue_parts/test_merge_queue_part_003.py
+++ b/tests/unit/api/test_merge_queue_parts/test_merge_queue_part_003.py
@@ -1,0 +1,153 @@
+"""Merge queue legacy terminal-exclusion regression tests (G1, G5)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncEngine
+
+from awf.db.enums import AgentRuntime, WorkspaceStatus
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+
+
+async def _create_legacy_queue_workspace(
+    engine: AsyncEngine,
+    *,
+    title: str,
+    status: WorkspaceStatus,
+    pr_url: str,
+    auto_merge: bool = True,
+    updated_at: datetime | None = None,
+    awaiting_human_since: datetime | None = None,
+    awaiting_human_reason: str | None = None,
+) -> str:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/legacy.git",
+            branch_base="main",
+            task_title=title,
+            task_prompt=f"Implement {title}.",
+            task_external_id=f"LEGACY-{title}",
+            task_class="test_task",
+            owned_paths=["legacy/**"],
+            auto_merge=auto_merge,
+            agent=AgentRuntime.codex.value,
+            test_commands=["pytest -q"],
+        )
+        workspace.status = status.value
+        workspace.branch_name = f"codex/{title.lower().replace(' ', '-')}"
+        workspace.pr_url = pr_url
+        workspace.pr_number = int(pr_url.rstrip("/").split("/")[-1])
+        if updated_at is not None:
+            workspace.updated_at = updated_at
+        if awaiting_human_since is not None:
+            workspace.awaiting_human_since = awaiting_human_since
+            workspace.awaiting_human_reason = awaiting_human_reason
+        await repo.add_event(
+            workspace,
+            event_type="merge_queue.legacy_marker",
+            reason_code="TEST",
+            payload={"title": title},
+        )
+        await session.commit()
+        return workspace.id
+
+
+class TestMergeQueueLegacyTerminalExclusion:
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "status",
+        [
+            WorkspaceStatus.failed,
+            WorkspaceStatus.completed,
+            WorkspaceStatus.cancelled,
+        ],
+    )
+    async def test_pr_bearing_terminal_legacy_workspace_absent_from_merge_queue(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+        status: WorkspaceStatus,
+    ) -> None:
+        """G1: PR-bearing terminal workspace with no MergeCandidate is omitted."""
+        workspace_id = await _create_legacy_queue_workspace(
+            engine,
+            title=f"Terminal {status.value}",
+            status=status,
+            pr_url=f"https://github.com/example/legacy/pull/{700 + hash(status.value) % 100}",
+            updated_at=datetime(2026, 5, 1, 12, 0, tzinfo=UTC),
+        )
+
+        response = await client.get(
+            "/v1/merge-queue",
+            params={"repo_url": "git@github.com:example/legacy.git", "limit": 50},
+        )
+
+        assert response.status_code == 200
+        workspace_ids = {item["workspace_id"] for item in response.json()["items"]}
+        assert workspace_id not in workspace_ids
+
+    @pytest.mark.unit
+    async def test_non_terminal_legacy_boundary_statuses_remain_visible(
+        self,
+        client: AsyncClient,
+        engine: AsyncEngine,
+    ) -> None:
+        """G5: blocked, awaiting_human, pushing, monitoring_pr legacy rows remain."""
+        awaiting_since = datetime(2026, 5, 2, 3, 30, tzinfo=UTC)
+        expected: dict[str, WorkspaceStatus] = {}
+        for index, (title, status, auto_merge, human_since, human_reason) in enumerate(
+            [
+                ("Blocked legacy boundary", WorkspaceStatus.blocked, True, None, None),
+                ("Pushing legacy boundary", WorkspaceStatus.pushing, True, None, None),
+                (
+                    "Awaiting human legacy boundary",
+                    WorkspaceStatus.monitoring_pr,
+                    True,
+                    awaiting_since,
+                    "GitHub rejected the merge attempt",
+                ),
+                (
+                    "Monitoring legacy boundary",
+                    WorkspaceStatus.monitoring_pr,
+                    True,
+                    None,
+                    None,
+                ),
+                (
+                    "Manual monitoring legacy boundary",
+                    WorkspaceStatus.monitoring_pr,
+                    False,
+                    None,
+                    None,
+                ),
+            ]
+        ):
+            workspace_id = await _create_legacy_queue_workspace(
+                engine,
+                title=title,
+                status=status,
+                auto_merge=auto_merge,
+                pr_url=f"https://github.com/example/legacy/pull/{800 + index}",
+                updated_at=datetime(2026, 5, 2, index, 0, tzinfo=UTC),
+                awaiting_human_since=human_since,
+                awaiting_human_reason=human_reason,
+            )
+            expected[workspace_id] = status
+
+        response = await client.get(
+            "/v1/merge-queue",
+            params={"repo_url": "git@github.com:example/legacy.git", "limit": 50},
+        )
+
+        assert response.status_code == 200
+        items = {item["workspace_id"]: item for item in response.json()["items"]}
+        assert set(expected) <= set(items)
+        for workspace_id, status in expected.items():
+            assert items[workspace_id]["candidate_id"] is None
+            assert items[workspace_id]["status"] == status.value

--- a/tests/unit/db/test_repository_coverage_parts/test_repository_coverage_part_001.py
+++ b/tests/unit/db/test_repository_coverage_parts/test_repository_coverage_part_001.py
@@ -1338,14 +1338,6 @@ async def test_workspace_queue_listing_and_owned_path_edges(
         repo_url="git@github.com:example/repository-coverage.git",
         limit=10,
     )
-    merge_queue = await repo.list_merge_queue(
-        repo_url="git@github.com:example/repository-coverage.git",
-        base_branch="development",
-        status=WorkspaceStatus.monitoring_pr,
-        before_updated_at=without_attempt.updated_at,
-        before_workspace_id=without_attempt.id,
-        limit=10,
-    )
     merge_queue_without_candidates = await repo.list_merge_queue_without_candidates(
         repo_url="git@github.com:example/repository-coverage.git",
         base_branch="development",
@@ -1355,7 +1347,6 @@ async def test_workspace_queue_listing_and_owned_path_edges(
         limit=10,
     )
     unfiltered_without_attempts = await repo.list_without_task_attempts(limit=10)
-    unfiltered_merge_queue = await repo.list_merge_queue(limit=10)
     unfiltered_without_candidates = await repo.list_merge_queue_without_candidates(limit=10)
     conflicts = await repo.find_active_owned_path_conflicts(
         repo_url="git@github.com:example/repository-coverage.git",
@@ -1370,17 +1361,11 @@ async def test_workspace_queue_listing_and_owned_path_edges(
     zero_limit = await repo.list_schedulable_ids(status=WorkspaceStatus.ready, limit=0)
 
     assert [workspace.id for workspace in without_attempts] == [without_attempt.id]
-    assert [workspace.id for workspace in merge_queue] == [with_attempt.id]
     assert [workspace.id for workspace in merge_queue_without_candidates] == [with_attempt.id]
     assert {workspace.id for workspace in unfiltered_without_attempts} >= {
         without_attempt.id,
         older_without_attempt.id,
         destroyed.id,
-    }
-    assert {workspace.id for workspace in unfiltered_merge_queue} >= {
-        without_attempt.id,
-        with_attempt.id,
-        older_without_attempt.id,
     }
     assert {workspace.id for workspace in unfiltered_without_candidates} >= {
         without_attempt.id,

--- a/tests/unit/service/test_merge_queue_ordering.py
+++ b/tests/unit/service/test_merge_queue_ordering.py
@@ -324,25 +324,6 @@ async def test_workspace_without_candidate_has_no_merge_queue_blockers(
 
 @pytest.mark.unit
 def test_merge_queue_response_helpers_cover_legacy_and_advisory_edges() -> None:
-    now = datetime(2026, 4, 29, 16, 0, tzinfo=UTC)
-    workspace = SimpleNamespace(
-        events=[
-            SimpleNamespace(
-                event_type="workspace.state_changed",
-                new_state=WorkspaceStatus.completed.value,
-                occurred_at=now - timedelta(minutes=1),
-            ),
-            SimpleNamespace(
-                event_type="workspace.state_changed",
-                new_state=WorkspaceStatus.completed.value,
-                occurred_at=now,
-            ),
-        ],
-        status=WorkspaceStatus.completed.value,
-        updated_at=now + timedelta(minutes=1),
-    )
-    assert merge_queue._legacy_workspace_merged_at(workspace) == now
-
     candidate = SimpleNamespace(
         completed=False,
         failed_or_cancelled=False,
@@ -360,6 +341,44 @@ def test_merge_queue_response_helpers_cover_legacy_and_advisory_edges() -> None:
         policy_findings=[],
         queue_blockers=[],
     ) == ("workspace_not_terminal", None)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("status", "auto_merge", "expected_reason"),
+    [
+        (WorkspaceStatus.monitoring_pr, True, "ready_to_merge_or_waiting_for_github"),
+        (WorkspaceStatus.monitoring_pr, False, "manual_merge_required"),
+        (WorkspaceStatus.pushing, True, "waiting_for_monitor"),
+        (WorkspaceStatus.completed, True, "failed_or_cancelled"),
+        (WorkspaceStatus.failed, True, "failed_or_cancelled"),
+        (WorkspaceStatus.cancelled, True, "failed_or_cancelled"),
+        (WorkspaceStatus.destroying, True, "failed_or_cancelled"),
+        (WorkspaceStatus.destroyed, True, "failed_or_cancelled"),
+        (WorkspaceStatus.requested, True, "workspace_not_terminal"),
+        (WorkspaceStatus.provisioning, True, "workspace_not_terminal"),
+        (WorkspaceStatus.blocked, True, "workspace_not_terminal"),
+        (WorkspaceStatus.recovering, True, "workspace_not_terminal"),
+        (WorkspaceStatus.ready, True, "workspace_not_terminal"),
+        (WorkspaceStatus.running, True, "workspace_not_terminal"),
+        (WorkspaceStatus.validating, True, "workspace_not_terminal"),
+    ],
+)
+def test_merge_blocker_reason_from_workspace_covers_excluded_and_active_statuses(
+    status: WorkspaceStatus,
+    auto_merge: bool,
+    expected_reason: str,
+) -> None:
+    """G7: excluded statuses map to failed_or_cancelled; never workspace_not_terminal."""
+    from awf.db.enums import MERGE_QUEUE_EXCLUDED_STATUSES
+
+    workspace = SimpleNamespace(status=status.value, auto_merge=auto_merge)
+    reason, action = merge_queue._merge_blocker_reason_from_workspace(workspace)
+    assert reason == expected_reason
+    assert action is None
+    if status.value in MERGE_QUEUE_EXCLUDED_STATUSES:
+        assert reason == "failed_or_cancelled"
+        assert reason != "workspace_not_terminal"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

- retire terminal workspace rows from the legacy merge-queue fallback
- update merge-queue ordering, repository behavior, console presentation, and regression coverage
- document follow-up work for candidate adoption, merged-at semantics, and queue membership

## Scope

Release the two changes currently on `development` into `main`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes operator-visible merge-queue membership and response semantics (`merged_at`, blocker reasons) on a control-plane read path; risk is mitigated by focused regression tests but wrong status classification would affect workflow.
> 
> **Overview**
> **Merge queue operator view** no longer surfaces PR-bearing legacy workspaces in terminal states (`completed`, `failed`, `cancelled`) or teardown (`destroying`/`destroyed`) via the legacy fallback path. Shared status sets in `awf.db.enums` document the split: candidate-backed listing still only filters teardown, while the legacy `list_merge_queue_without_candidates` query uses a deliberate **blacklist** so unknown future statuses stay visible rather than disappearing silently. The redundant `WorkspaceRepository.list_merge_queue` helper is removed.
> 
> **API/console presentation** stops synthesizing `merged_at` for legacy queue items (always `null` now) and removes the console “merged” timestamps and `mergeQueueMergedAt` helper. Legacy blocker mapping treats excluded statuses as `failed_or_cancelled` instead of a dedicated `completed` reason.
> 
> **Tests and docs**: regression coverage for terminal exclusion, active boundary statuses, blocker classification, and UI absence of merged labels; `TODOS.md` records follow-ups (candidate at PR adoption, removing `merged_at` from the OpenAPI contract, explicit queue membership).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d261f6556588f1713a6c83f5f5c210d3c700186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Merge Queue results now consistently show creation time rather than merged time.
  - Terminal and workspace-teardown items are excluded from active Merge Queue views, while relevant blocked or in-progress items remain visible.

- **Bug Fixes**
  - Removed misleading merged timestamp information from Merge Queue responses and interface details.
  - Improved status handling for legacy queue entries.

- **Tests**
  - Added regression coverage for queue visibility, blocker classification, status boundaries, and timestamp behavior.

- **Documentation**
  - Added follow-up TODOs covering merge-candidate creation, queue membership, API cleanup, and retry protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->