### PR TITLE
[AIRA-T490] AIRA-T490: typed workspace.attention_required/cleared escalation events

### DIFF
--- a/docs/REST_API_REFERENCE.md
+++ b/docs/REST_API_REFERENCE.md
@@ -224,6 +224,11 @@ Events response shape:
 }
 ```
 
+Attention flips also appear on this timeline as first-class events:
+`workspace.attention_required` (enter) and `workspace.attention_cleared`
+(clear). Payload fields and callback subscription details are documented under
+[Create a callback subscription](#create-a-callback-subscription).
+
 ### List workspace events (per-workspace)
 
 ```bash
@@ -578,7 +583,8 @@ curl -H "Authorization: Bearer $AWF_API_TOKEN" \
 Public callback subscriptions accept the wildcards `workspace.*`, `merge.*`,
 and `operation.*`, plus exact public event types such as
 `workspace.created`, `workspace.state_changed`,
-`workspace.secondary_failure_recorded`, `operation.state_changed`, and
+`workspace.secondary_failure_recorded`, `workspace.attention_required`,
+`workspace.attention_cleared`, `operation.state_changed`, and
 `merge.candidate_updated`.
 
 Workspace callback deliveries use a sanitized envelope. For
@@ -613,6 +619,40 @@ event envelope used for other workspace events:
 The internal failure-causality payload keys stored on the workspace event, such
 as `primary_failure`, `secondary_failure`, and `secondary_failures`, are not
 part of the external callback envelope.
+
+`workspace.attention_required` and `workspace.attention_cleared` use the same
+workspace event envelope. They fire once per attention flip (enter or clear),
+not on every monitor poll while attention persists. Internal payload fields on
+the stored workspace event:
+
+| Field | When present | Notes |
+|---|---|---|
+| `source` | always | `"monitoring_pr"` (HUMAN_WAIT) or `"blocked"` (protected-gate pause) |
+| `reason` | usually | Escalation reason, or `block_reason_code` for blocked-source events |
+| `pr_url` | when known | Present for monitoring_pr flips when the workspace row has a PR URL |
+| `block_reason_code` | blocked source | Durable protected-gate reason code |
+| `block_type` | blocked source | e.g. `protected_quality_gate` |
+
+Example monitoring_pr enter payload (timeline event `payload`):
+
+```json
+{
+  "reason": "merge conflict needs human resolution",
+  "source": "monitoring_pr",
+  "pr_url": "https://github.com/example/app/pull/42"
+}
+```
+
+Example blocked enter payload:
+
+```json
+{
+  "reason": "QUALITY_GATE_POLICY_CHANGED",
+  "source": "blocked",
+  "block_reason_code": "QUALITY_GATE_POLICY_CHANGED",
+  "block_type": "protected_quality_gate"
+}
+```
 
 For each outbound delivery, callback target URLs are revalidated before the POST
 is sent:

--- a/src/awf/common/attention_events.py
+++ b/src/awf/common/attention_events.py
@@ -1,0 +1,43 @@
+"""Typed attention WorkspaceEvent constants and payload helpers (AIRA-T490)."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+ATTENTION_REQUIRED_EVENT_TYPE: Final[str] = "workspace.attention_required"
+ATTENTION_CLEARED_EVENT_TYPE: Final[str] = "workspace.attention_cleared"
+ATTENTION_SOURCE_MONITORING_PR: Final[str] = "monitoring_pr"
+ATTENTION_SOURCE_BLOCKED: Final[str] = "blocked"
+
+
+def monitoring_pr_attention_payload(
+    *,
+    reason: str | None,
+    pr_url: str | None = None,
+) -> dict[str, Any]:
+    """Payload for monitoring_pr HUMAN_WAIT attention enter/clear events."""
+    payload: dict[str, Any] = {
+        "reason": reason,
+        "source": ATTENTION_SOURCE_MONITORING_PR,
+    }
+    if pr_url:
+        payload["pr_url"] = pr_url
+    return payload
+
+
+def blocked_attention_payload(
+    *,
+    block_reason_code: str | None,
+    block_type: str | None,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    """Payload for protected-gate blocked attention enter/clear events."""
+    payload: dict[str, Any] = {
+        "source": ATTENTION_SOURCE_BLOCKED,
+        "block_reason_code": block_reason_code,
+        "block_type": block_type,
+    }
+    # Keep parity with monitoring_pr shape: prefer an explicit reason, else the
+    # durable block reason code (no invented operator prose).
+    payload["reason"] = reason if reason is not None else block_reason_code
+    return payload

--- a/src/awf/common/callback_events.py
+++ b/src/awf/common/callback_events.py
@@ -11,6 +11,8 @@ PUBLIC_CALLBACK_EVENT_TYPES: Final[tuple[str, ...]] = (
     "workspace.created",
     "workspace.state_changed",
     "workspace.secondary_failure_recorded",
+    "workspace.attention_required",
+    "workspace.attention_cleared",
     "operation.state_changed",
     "merge.candidate_updated",
 )

--- a/src/awf/control/blocked_transition.py
+++ b/src/awf/control/blocked_transition.py
@@ -25,6 +25,10 @@ from typing import Any
 
 from sqlalchemy.sql.elements import ColumnElement
 
+from awf.common.attention_events import (
+    ATTENTION_REQUIRED_EVENT_TYPE,
+    blocked_attention_payload,
+)
 from awf.control.quality_gates import (
     PROTECTED_QUALITY_GATE_BLOCK_TYPE,
     PROTECTED_VIOLATION_BLOCKED_REASON_CODE,
@@ -146,4 +150,15 @@ async def enter_blocked_for_protected_violation_in_session(
     # instance (grants are epoch-fenced and invalidated by the bumped epoch, but
     # the directive column is not), mirroring the WS-1 executor behavior.
     ws.pending_operator_hint = None
+    # Typed attention event (additive): subscribers see enter-blocked without
+    # polling ``block_*`` / status. ``workspace.state_changed`` from the CAS is
+    # unchanged; this is a same-status informational timeline sibling.
+    await repo.add_event(
+        ws,
+        event_type=ATTENTION_REQUIRED_EVENT_TYPE,
+        payload=blocked_attention_payload(
+            block_reason_code=block_reason_code,
+            block_type=block_type,
+        ),
+    )
     return ws

--- a/src/awf/control/worker/claims.py
+++ b/src/awf/control/worker/claims.py
@@ -19,6 +19,11 @@ from typing import Any, cast
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_REQUIRED_EVENT_TYPE,
+    blocked_attention_payload,
+)
 from awf.control.executor.types import PauseResumeReason
 from awf.control.worker.admission import (
     _acquire_requested_admission_locks,
@@ -840,6 +845,17 @@ async def _claim_paused_for_resume(
         )
         if ws is None:
             return False
+        if reason == "blocked":
+            # Claim clears the protected-gate attention episode; restore will
+            # re-emit attention_required if the resume is abandoned.
+            await repo.add_event(
+                ws,
+                event_type=ATTENTION_CLEARED_EVENT_TYPE,
+                payload=blocked_attention_payload(
+                    block_reason_code=ws.block_reason_code,
+                    block_type=ws.block_type,
+                ),
+            )
         _apply_execution_claim(self, ws, owner_id=self._worker_id)
         await session.commit()
         return True
@@ -885,7 +901,8 @@ async def _restore_paused_resume_claim(
     off for a later safe retry."""
     try:
         async with self._session_factory() as session:
-            ws = await WorkspaceRepository(session).transition_if_current(
+            repo = WorkspaceRepository(session)
+            ws = await repo.transition_if_current(
                 workspace_id,
                 from_status=WorkspaceStatus.running,
                 to=_PAUSED_RESUME_FROM_STATUS[reason],
@@ -893,6 +910,17 @@ async def _restore_paused_resume_claim(
                 extra_conditions=(Workspace.execution_claimed_by == self._worker_id,),
             )
             if ws is not None:
+                if reason == "blocked":
+                    # Claim cleared attention; restoring blocked must re-emit so
+                    # subscribers are not left with a false terminal cleared.
+                    await repo.add_event(
+                        ws,
+                        event_type=ATTENTION_REQUIRED_EVENT_TYPE,
+                        payload=blocked_attention_payload(
+                            block_reason_code=ws.block_reason_code,
+                            block_type=ws.block_type,
+                        ),
+                    )
                 if rearm_recovering_cooldown:
                     rearmed = rearm_recovering_cooldown_task_policy(
                         ws.task_policy, now=datetime.now(UTC)

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -18,6 +18,7 @@ from awf.common.attention_events import (
     ATTENTION_REQUIRED_EVENT_TYPE,
     monitoring_pr_attention_payload,
 )
+from awf.db.enums import WorkspaceStatus
 from awf.db.models import Workspace
 
 # ``Workspace.awaiting_human_reason`` is a ``String(2048)`` column. Escalation
@@ -59,12 +60,15 @@ async def set_workspace_attention(
     """Flag a workspace as awaiting human attention (a HUMAN_WAIT escalation).
 
     Episode start (``awaiting_human_since``) flips only via a guarded UPDATE
-    ``WHERE awaiting_human_since IS NULL``, so concurrent first-time escalations
-    cannot each observe NULL and double-emit. Reason is always refreshed to the
-    latest escalation message (clamped to the column length so an unbounded
-    operator-hint reason cannot abort the write). This is an out-of-band
-    metadata flag on a still-polling ``monitoring_pr`` row — it deliberately
-    does NOT bump ``version`` (it is not a state transition).
+    ``WHERE awaiting_human_since IS NULL AND status = monitoring_pr``, so
+    concurrent first-time escalations cannot each observe NULL and double-emit,
+    and a cancel/stop/destroy that already left ``monitoring_pr`` (and cleared
+    attention) cannot reopen the episode when a blocked enter UPDATE is
+    re-evaluated. Reason is always refreshed to the latest escalation message
+    (clamped to the column length so an unbounded operator-hint reason cannot
+    abort the write). This is an out-of-band metadata flag on a still-polling
+    ``monitoring_pr`` row — it deliberately does NOT bump ``version`` (it is
+    not a state transition).
 
     Emits ``workspace.attention_required`` exactly once when the guarded enter
     UPDATE flips the row. Reason-only refreshes (and lost enter races) do not emit.
@@ -89,6 +93,7 @@ async def set_workspace_attention(
         .where(
             Workspace.id == workspace_id,
             Workspace.awaiting_human_since.is_(None),
+            Workspace.status == WorkspaceStatus.monitoring_pr.value,
         )
         .values(
             awaiting_human_since=now,

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import update
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.attention_events import (
@@ -167,6 +167,12 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     updates the row. A second clear while already clear, or a clear that loses
     to a concurrent clear/replacement, is a no-op for both columns and events.
 
+    The cleared-event reason and ``pr_url`` are taken from the guarded operation
+    itself (``SELECT … FOR UPDATE`` of the fenced episode, then clear returning
+    those pre-clear columns). An unlocked identity-map snapshot of the reason
+    can race a concurrent reason-only refresh and emit a stale reason while the
+    same timestamp fence still clears successfully.
+
     Always refreshes before deciding — never trust a cached clear identity-map
     read alone. guide/remonitor may hold a row loaded while attention was clear;
     another transaction can open an episode before this call, and skipping the
@@ -175,7 +181,7 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     from awf.db.repositories.workspace_repo import WorkspaceRepository
 
     repo = WorkspaceRepository(session)
-    # Refresh so prior reason/pr_url are not taken from a stale identity-map
+    # Refresh so episode-start fencing is not taken from a stale identity-map
     # clear while another transaction has since opened an episode.
     workspace = await repo.get(workspace_id, populate_existing=True)
     if workspace is None:
@@ -183,31 +189,42 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     observed_since = workspace.awaiting_human_since
     if observed_since is None:
         return
-    prior_reason = workspace.awaiting_human_reason
-    pr_url = workspace.pr_url
+    # Lock the fenced episode row and return pre-clear reason/pr_url atomically
+    # with the clear so a concurrent reason-only refresh cannot leave the event
+    # payload behind the episode state at clear time.
+    prior_stmt = select(
+        Workspace.id,
+        Workspace.awaiting_human_reason,
+        Workspace.pr_url,
+    ).where(
+        Workspace.id == workspace_id,
+        Workspace.awaiting_human_since == observed_since,
+    )
+    if repo.dialect_name == "postgresql":
+        prior_stmt = prior_stmt.with_for_update()
+    prior = prior_stmt.cte("attention_clear_prior")
     result = await session.execute(
         update(Workspace)
-        .where(
-            Workspace.id == workspace_id,
-            Workspace.awaiting_human_since == observed_since,
-        )
+        .where(Workspace.id == prior.c.id)
         .values(
             awaiting_human_since=None,
             awaiting_human_reason=None,
         )
+        .returning(prior.c.awaiting_human_reason, prior.c.pr_url)
         .execution_options(synchronize_session=False)
     )
     await session.flush()
-    # Gate the event on the fenced UPDATE flip, not the pre-update identity-map
-    # read: another session may have cleared or replaced the episode, leaving
-    # rowcount 0.
-    rowcount = getattr(result, "rowcount", 0)
-    if rowcount is None or rowcount <= 0:
+    # Gate the event on the fenced clear flip (RETURNING row), not the unlocked
+    # identity-map read: another session may have cleared or replaced the
+    # episode, leaving no returned row.
+    cleared = result.first()
+    if cleared is None:
         # Lost race: do not assign None onto the still-stale pre-UPDATE snapshot.
         # That would dirty the row and can erase a replacement episode opened before
         # the next flush without emitting attention_cleared.
         await repo.get(workspace_id, populate_existing=True)
         return
+    prior_reason, pr_url = cleared
     workspace.awaiting_human_since = None
     workspace.awaiting_human_reason = None
     await repo.add_event(

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -147,12 +147,20 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     Emits ``workspace.attention_cleared`` exactly once when an episode ends
     (a guarded clear updates the row). A second clear while already clear is
     a no-op for both columns and events.
+
+    Always executes the guarded UPDATE — never skip based on a cached
+    ``awaiting_human_since`` read. guide/remonitor may hold an identity-mapped
+    row loaded while attention was clear; another transaction can open an
+    episode before this call, and trusting the stale clear would bypass the
+    atomic guard and leave the persisted flag active.
     """
     from awf.db.repositories.workspace_repo import WorkspaceRepository
 
     repo = WorkspaceRepository(session)
-    workspace = await repo.get(workspace_id)
-    if workspace is None or workspace.awaiting_human_since is None:
+    # Refresh so prior reason/pr_url are not taken from a stale identity-map
+    # clear while another transaction has since opened an episode.
+    workspace = await repo.get(workspace_id, populate_existing=True)
+    if workspace is None:
         return
     prior_reason = workspace.awaiting_human_reason
     pr_url = workspace.pr_url

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from sqlalchemy import func, update
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.attention_events import (
@@ -58,15 +58,16 @@ async def set_workspace_attention(
 ) -> None:
     """Flag a workspace as awaiting human attention (a HUMAN_WAIT escalation).
 
-    ``COALESCE`` keeps the episode start (``awaiting_human_since``) stable
-    across repeated ``NotifyHuman`` for the same ongoing block, while the
-    reason is always refreshed to the latest escalation message (clamped to the
-    column length so an unbounded operator-hint reason cannot abort the write).
-    This is an out-of-band metadata flag on a still-polling ``monitoring_pr``
-    row — it deliberately does NOT bump ``version`` (it is not a state transition).
+    Episode start (``awaiting_human_since``) flips only via a guarded UPDATE
+    ``WHERE awaiting_human_since IS NULL``, so concurrent first-time escalations
+    cannot each observe NULL and double-emit. Reason is always refreshed to the
+    latest escalation message (clamped to the column length so an unbounded
+    operator-hint reason cannot abort the write). This is an out-of-band
+    metadata flag on a still-polling ``monitoring_pr`` row — it deliberately
+    does NOT bump ``version`` (it is not a state transition).
 
-    Emits ``workspace.attention_required`` exactly once when entering an episode
-    (prior ``awaiting_human_since`` was NULL). Reason-only refreshes do not emit.
+    Emits ``workspace.attention_required`` exactly once when the guarded enter
+    UPDATE flips the row. Reason-only refreshes (and lost enter races) do not emit.
     """
     # Late import: ``WorkspaceRepository`` loads this module at class build time.
     from awf.db.repositories.workspace_repo import WorkspaceRepository
@@ -75,26 +76,31 @@ async def set_workspace_attention(
     workspace = await repo.get(workspace_id)
     if workspace is None:
         return
-    # Read flip inputs before the Core UPDATE. synchronize_session=False keeps
-    # the identity-mapped instance from being expired (async lazy-load would
-    # otherwise raise MissingGreenlet when building the event payload).
-    entering = workspace.awaiting_human_since is None
+    # synchronize_session=False keeps the identity-mapped instance from being
+    # expired (async lazy-load would otherwise raise MissingGreenlet when
+    # building the event payload).
     pr_url = workspace.pr_url
     clamped_reason = reason[:_AWAITING_HUMAN_REASON_MAX_LENGTH]
-    await session.execute(
+    enter_result = await session.execute(
         update(Workspace)
-        .where(Workspace.id == workspace_id)
+        .where(
+            Workspace.id == workspace_id,
+            Workspace.awaiting_human_since.is_(None),
+        )
         .values(
-            awaiting_human_since=func.coalesce(Workspace.awaiting_human_since, now),
+            awaiting_human_since=now,
             awaiting_human_reason=clamped_reason,
         )
         .execution_options(synchronize_session=False)
     )
     await session.flush()
-    if entering:
+    # Gate the event on the guarded UPDATE flip, not the pre-update identity-map
+    # read: another session may have already entered, leaving rowcount 0.
+    enter_rowcount = getattr(enter_result, "rowcount", 0)
+    entered = enter_rowcount is not None and enter_rowcount > 0
+    if entered:
         workspace.awaiting_human_since = now
-    workspace.awaiting_human_reason = clamped_reason
-    if entering:
+        workspace.awaiting_human_reason = clamped_reason
         await repo.add_event(
             workspace,
             event_type=ATTENTION_REQUIRED_EVENT_TYPE,
@@ -103,6 +109,18 @@ async def set_workspace_attention(
                 pr_url=pr_url,
             ),
         )
+        return
+
+    # Already in an episode (or lost the enter race): refresh reason only so
+    # episode start stays owned by the winning writer.
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace_id)
+        .values(awaiting_human_reason=clamped_reason)
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    workspace.awaiting_human_reason = clamped_reason
 
 
 async def clear_workspace_attention(session: AsyncSession, workspace_id: str) -> None:

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -199,8 +199,10 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     # read: another session may have already cleared, leaving rowcount 0.
     rowcount = getattr(result, "rowcount", 0)
     if rowcount is None or rowcount <= 0:
-        workspace.awaiting_human_since = None
-        workspace.awaiting_human_reason = None
+        # Lost race: do not assign None onto the still-stale pre-UPDATE snapshot.
+        # That would dirty the row and can erase a replacement episode opened before
+        # the next flush without emitting attention_cleared.
+        await repo.get(workspace_id, populate_existing=True)
         return
     workspace.awaiting_human_since = None
     workspace.awaiting_human_reason = None

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -13,6 +13,11 @@ from datetime import UTC, datetime
 from sqlalchemy import func, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_REQUIRED_EVENT_TYPE,
+    monitoring_pr_attention_payload,
+)
 from awf.db.models import Workspace
 
 # ``Workspace.awaiting_human_reason`` is a ``String(2048)`` column. Escalation
@@ -59,16 +64,45 @@ async def set_workspace_attention(
     column length so an unbounded operator-hint reason cannot abort the write).
     This is an out-of-band metadata flag on a still-polling ``monitoring_pr``
     row — it deliberately does NOT bump ``version`` (it is not a state transition).
+
+    Emits ``workspace.attention_required`` exactly once when entering an episode
+    (prior ``awaiting_human_since`` was NULL). Reason-only refreshes do not emit.
     """
+    # Late import: ``WorkspaceRepository`` loads this module at class build time.
+    from awf.db.repositories.workspace_repo import WorkspaceRepository
+
+    repo = WorkspaceRepository(session)
+    workspace = await repo.get(workspace_id)
+    if workspace is None:
+        return
+    # Read flip inputs before the Core UPDATE. synchronize_session=False keeps
+    # the identity-mapped instance from being expired (async lazy-load would
+    # otherwise raise MissingGreenlet when building the event payload).
+    entering = workspace.awaiting_human_since is None
+    pr_url = workspace.pr_url
+    clamped_reason = reason[:_AWAITING_HUMAN_REASON_MAX_LENGTH]
     await session.execute(
         update(Workspace)
         .where(Workspace.id == workspace_id)
         .values(
             awaiting_human_since=func.coalesce(Workspace.awaiting_human_since, now),
-            awaiting_human_reason=reason[:_AWAITING_HUMAN_REASON_MAX_LENGTH],
+            awaiting_human_reason=clamped_reason,
         )
+        .execution_options(synchronize_session=False)
     )
     await session.flush()
+    if entering:
+        workspace.awaiting_human_since = now
+    workspace.awaiting_human_reason = clamped_reason
+    if entering:
+        await repo.add_event(
+            workspace,
+            event_type=ATTENTION_REQUIRED_EVENT_TYPE,
+            payload=monitoring_pr_attention_payload(
+                reason=clamped_reason,
+                pr_url=pr_url,
+            ),
+        )
 
 
 async def clear_workspace_attention(session: AsyncSession, workspace_id: str) -> None:
@@ -77,7 +111,19 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     Guarded by ``awaiting_human_since IS NOT NULL`` so the per-poll clear is
     a DB-level no-op (no row churn, no spurious ``updated_at`` bump) when the
     flag is already clear.
+
+    Emits ``workspace.attention_cleared`` exactly once when an episode ends
+    (a guarded clear updates the row). A second clear while already clear is
+    a no-op for both columns and events.
     """
+    from awf.db.repositories.workspace_repo import WorkspaceRepository
+
+    repo = WorkspaceRepository(session)
+    workspace = await repo.get(workspace_id)
+    if workspace is None or workspace.awaiting_human_since is None:
+        return
+    prior_reason = workspace.awaiting_human_reason
+    pr_url = workspace.pr_url
     await session.execute(
         update(Workspace)
         .where(
@@ -88,5 +134,13 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
             awaiting_human_since=None,
             awaiting_human_reason=None,
         )
+        .execution_options(synchronize_session=False)
     )
     await session.flush()
+    workspace.awaiting_human_since = None
+    workspace.awaiting_human_reason = None
+    await repo.add_event(
+        workspace,
+        event_type=ATTENTION_CLEARED_EVENT_TYPE,
+        payload=monitoring_pr_attention_payload(reason=prior_reason, pr_url=pr_url),
+    )

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -68,6 +68,9 @@ async def set_workspace_attention(
 
     Emits ``workspace.attention_required`` exactly once when the guarded enter
     UPDATE flips the row. Reason-only refreshes (and lost enter races) do not emit.
+    Reason refreshes are also guarded on ``awaiting_human_since IS NOT NULL`` so a
+    concurrent clear between a lost enter and the refresh cannot orphan reason
+    text on a cleared row.
     """
     # Late import: ``WorkspaceRepository`` loads this module at class build time.
     from awf.db.repositories.workspace_repo import WorkspaceRepository
@@ -112,15 +115,26 @@ async def set_workspace_attention(
         return
 
     # Already in an episode (or lost the enter race): refresh reason only so
-    # episode start stays owned by the winning writer.
-    await session.execute(
+    # episode start stays owned by the winning writer. Guard on an active
+    # episode so a concurrent clear between enter and refresh cannot orphan
+    # awaiting_human_reason while awaiting_human_since is NULL.
+    refresh_result = await session.execute(
         update(Workspace)
-        .where(Workspace.id == workspace_id)
+        .where(
+            Workspace.id == workspace_id,
+            Workspace.awaiting_human_since.is_not(None),
+        )
         .values(awaiting_human_reason=clamped_reason)
         .execution_options(synchronize_session=False)
     )
     await session.flush()
-    workspace.awaiting_human_reason = clamped_reason
+    refresh_rowcount = getattr(refresh_result, "rowcount", 0)
+    if refresh_rowcount is not None and refresh_rowcount > 0:
+        workspace.awaiting_human_reason = clamped_reason
+    else:
+        # Concurrent clear won: keep the identity map aligned with cleared DB.
+        workspace.awaiting_human_since = None
+        workspace.awaiting_human_reason = None
 
 
 async def clear_workspace_attention(session: AsyncSession, workspace_id: str) -> None:

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -158,19 +158,19 @@ async def set_workspace_attention(
 async def clear_workspace_attention(session: AsyncSession, workspace_id: str) -> None:
     """Clear the awaiting-human attention flag once the monitor resumes.
 
-    Guarded by ``awaiting_human_since IS NOT NULL`` so the per-poll clear is
-    a DB-level no-op (no row churn, no spurious ``updated_at`` bump) when the
-    flag is already clear.
+    Fenced to the snapshotted ``awaiting_human_since`` episode start so a stale
+    clear cannot remove a replacement episode entered after a concurrent clear
+    between the snapshot and this UPDATE. When already clear after refresh the
+    call is a no-op (no row churn, no spurious ``updated_at`` bump).
 
-    Emits ``workspace.attention_cleared`` exactly once when an episode ends
-    (a guarded clear updates the row). A second clear while already clear is
-    a no-op for both columns and events.
+    Emits ``workspace.attention_cleared`` exactly once when the fenced clear
+    updates the row. A second clear while already clear, or a clear that loses
+    to a concurrent clear/replacement, is a no-op for both columns and events.
 
-    Always executes the guarded UPDATE — never skip based on a cached
-    ``awaiting_human_since`` read. guide/remonitor may hold an identity-mapped
-    row loaded while attention was clear; another transaction can open an
-    episode before this call, and trusting the stale clear would bypass the
-    atomic guard and leave the persisted flag active.
+    Always refreshes before deciding — never trust a cached clear identity-map
+    read alone. guide/remonitor may hold a row loaded while attention was clear;
+    another transaction can open an episode before this call, and skipping the
+    refresh would leave the persisted flag active.
     """
     from awf.db.repositories.workspace_repo import WorkspaceRepository
 
@@ -180,13 +180,16 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
     workspace = await repo.get(workspace_id, populate_existing=True)
     if workspace is None:
         return
+    observed_since = workspace.awaiting_human_since
+    if observed_since is None:
+        return
     prior_reason = workspace.awaiting_human_reason
     pr_url = workspace.pr_url
     result = await session.execute(
         update(Workspace)
         .where(
             Workspace.id == workspace_id,
-            Workspace.awaiting_human_since.is_not(None),
+            Workspace.awaiting_human_since == observed_since,
         )
         .values(
             awaiting_human_since=None,
@@ -195,8 +198,9 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
         .execution_options(synchronize_session=False)
     )
     await session.flush()
-    # Gate the event on the guarded UPDATE flip, not the pre-update identity-map
-    # read: another session may have already cleared, leaving rowcount 0.
+    # Gate the event on the fenced UPDATE flip, not the pre-update identity-map
+    # read: another session may have cleared or replaced the episode, leaving
+    # rowcount 0.
     rowcount = getattr(result, "rowcount", 0)
     if rowcount is None or rowcount <= 0:
         # Lost race: do not assign None onto the still-stale pre-UPDATE snapshot.

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -72,9 +72,9 @@ async def set_workspace_attention(
 
     Emits ``workspace.attention_required`` exactly once when the guarded enter
     UPDATE flips the row. Reason-only refreshes (and lost enter races) do not emit.
-    Reason refreshes are also guarded on ``awaiting_human_since IS NOT NULL`` so a
-    concurrent clear between a lost enter and the refresh cannot orphan reason
-    text on a cleared row.
+    Reason refreshes are fenced to the episode start observed when enter lost so a
+    concurrent clear (or clear + new episode enter) between lost enter and refresh
+    cannot orphan reason text on a cleared row or overwrite a newer episode's reason.
     """
     # Late import: ``WorkspaceRepository`` loads this module at class build time.
     from awf.db.repositories.workspace_repo import WorkspaceRepository
@@ -88,6 +88,9 @@ async def set_workspace_attention(
     # building the event payload).
     pr_url = workspace.pr_url
     clamped_reason = reason[:_AWAITING_HUMAN_REASON_MAX_LENGTH]
+    # Episode start known before enter; used to fence a later reason-only refresh
+    # to the same attention episode (not a replacement opened after a clear).
+    observed_since = workspace.awaiting_human_since
     enter_result = await session.execute(
         update(Workspace)
         .where(
@@ -120,14 +123,25 @@ async def set_workspace_attention(
         return
 
     # Already in an episode (or lost the enter race): refresh reason only so
-    # episode start stays owned by the winning writer. Guard on an active
-    # episode so a concurrent clear between enter and refresh cannot orphan
-    # awaiting_human_reason while awaiting_human_since is NULL.
+    # episode start stays owned by the winning writer. Fence to the observed
+    # episode start so a concurrent clear (or clear + re-enter) between enter
+    # and refresh cannot orphan reason or overwrite a newer episode.
+    if observed_since is None:
+        # Stale in-memory clear while another session already entered: snapshot
+        # the winner's episode start before the fenced refresh.
+        workspace = await repo.get(workspace_id, populate_existing=True)
+        if workspace is None:
+            return
+        observed_since = workspace.awaiting_human_since
+        if observed_since is None:
+            workspace.awaiting_human_reason = None
+            return
+
     refresh_result = await session.execute(
         update(Workspace)
         .where(
             Workspace.id == workspace_id,
-            Workspace.awaiting_human_since.is_not(None),
+            Workspace.awaiting_human_since == observed_since,
         )
         .values(awaiting_human_reason=clamped_reason)
         .execution_options(synchronize_session=False)
@@ -137,9 +151,8 @@ async def set_workspace_attention(
     if refresh_rowcount is not None and refresh_rowcount > 0:
         workspace.awaiting_human_reason = clamped_reason
     else:
-        # Concurrent clear won: keep the identity map aligned with cleared DB.
-        workspace.awaiting_human_since = None
-        workspace.awaiting_human_reason = None
+        # Episode cleared or replaced: realign from DB (do not assume cleared).
+        workspace = await repo.get(workspace_id, populate_existing=True)
 
 
 async def clear_workspace_attention(session: AsyncSession, workspace_id: str) -> None:

--- a/src/awf/db/repositories/workspace_repo_attention.py
+++ b/src/awf/db/repositories/workspace_repo_attention.py
@@ -124,7 +124,7 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
         return
     prior_reason = workspace.awaiting_human_reason
     pr_url = workspace.pr_url
-    await session.execute(
+    result = await session.execute(
         update(Workspace)
         .where(
             Workspace.id == workspace_id,
@@ -137,6 +137,13 @@ async def clear_workspace_attention(session: AsyncSession, workspace_id: str) ->
         .execution_options(synchronize_session=False)
     )
     await session.flush()
+    # Gate the event on the guarded UPDATE flip, not the pre-update identity-map
+    # read: another session may have already cleared, leaving rowcount 0.
+    rowcount = getattr(result, "rowcount", 0)
+    if rowcount is None or rowcount <= 0:
+        workspace.awaiting_human_since = None
+        workspace.awaiting_human_reason = None
+        return
     workspace.awaiting_human_since = None
     workspace.awaiting_human_reason = None
     await repo.add_event(

--- a/src/awf/runtime/pr_monitor_runner/lifecycle.py
+++ b/src/awf/runtime/pr_monitor_runner/lifecycle.py
@@ -1188,4 +1188,9 @@ async def _terminate_failed(
         if details is not None:
             payload["details"] = redact_audit_value(dict(details))
         await repo.transition(ws, to=WorkspaceStatus.failed, reason_code=rc, payload=payload)
+        # Same as operator cancel/stop: clear monitoring-source HUMAN_WAIT attention
+        # on this terminal exit so awaiting_human_since is not stranded after a
+        # permanent NotifyHuman forge fault (or any other monitor fail) that already
+        # emitted attention_required (PRRT_kwDOSJAM6s6XY5JH).
+        await repo.clear_workspace_attention(workspace_id)
         await s.commit()

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -213,6 +213,7 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
         # ``stop_stack=True`` runs a FULL compose down (containers + network +
         # host port freed), not a bare ``docker stop`` (issue #588 / #583).
         cleanup_result = await self._release_runtime_stack(workspace) if stop_stack else None
+        leaving_blocked = workspace.status == WorkspaceStatus.blocked.value
         if (
             workspace.status != WorkspaceStatus.cancelled.value
             and WorkspaceStateMachine.can_transition(
@@ -226,6 +227,8 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
                 reason_code=_OPERATOR_CANCEL_REASON_CODE,
                 payload=event_payload,
             )
+            if leaving_blocked:
+                await _emit_blocked_attention_cleared(repo, workspace)
         else:
             await repo.add_event(
                 workspace,
@@ -335,8 +338,10 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
         # per-workspace network, and the host port are released (issue #588 /
         # #583) — never a bare ``docker stop`` that leaves them ``Exited``.
         cleanup_result = await self._release_runtime_stack(workspace)
-        if _is_active(WorkspaceStatus(workspace.status)) and WorkspaceStateMachine.can_transition(
-            WorkspaceStatus(workspace.status),
+        current_status = WorkspaceStatus(workspace.status)
+        leaving_blocked = current_status == WorkspaceStatus.blocked
+        if _is_active(current_status) and WorkspaceStateMachine.can_transition(
+            current_status,
             WorkspaceStatus.cancelled,
         ):
             await repo.transition(
@@ -345,6 +350,8 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
                 reason_code=_OPERATOR_STOP_REASON_CODE,
                 payload=event_payload,
             )
+            if leaving_blocked:
+                await _emit_blocked_attention_cleared(repo, workspace)
         elif cleanup_result.ok:
             # ``stack_stopped`` asserts the runtime was actually stopped, so it
             # is only emitted once the compose down succeeds. A failed teardown
@@ -937,12 +944,15 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
         if _is_active(current) and WorkspaceStateMachine.can_transition(
             current, WorkspaceStatus.cancelled
         ):
+            leaving_blocked = current == WorkspaceStatus.blocked
             await repo.transition(
                 workspace,
                 to=WorkspaceStatus.cancelled,
                 reason_code=_OPERATOR_DESTROY_REASON_CODE,
                 payload=event_payload,
             )
+            if leaving_blocked:
+                await _emit_blocked_attention_cleared(repo, workspace)
             current = WorkspaceStatus.cancelled
         if WorkspaceStateMachine.can_transition(current, WorkspaceStatus.destroying):
             await repo.transition(
@@ -1354,6 +1364,7 @@ from awf.service.controls_helpers import (  # noqa: E402
     _control_response,
     _control_warning_payloads,
     _docker_process,
+    _emit_blocked_attention_cleared,
     _event_payload,
     _find_active_operation,
     _finish_stack_stop_failed_operation,

--- a/src/awf/service/controls.py
+++ b/src/awf/service/controls.py
@@ -229,6 +229,12 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
             )
             if leaving_blocked:
                 await _emit_blocked_attention_cleared(repo, workspace)
+            # Terminal exit from monitoring_pr with an active HUMAN_WAIT episode
+            # must clear awaiting_human_since (and emit monitoring-source
+            # attention_cleared). Remonitor/guide already clear; cancel previously
+            # only handled leaving_blocked (PRRT_kwDOSJAM6s6XYW1j). Guarded no-op
+            # when no episode is open.
+            await repo.clear_workspace_attention(workspace_id)
         else:
             await repo.add_event(
                 workspace,
@@ -352,6 +358,10 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
             )
             if leaving_blocked:
                 await _emit_blocked_attention_cleared(repo, workspace)
+            # Same as cancel: clear monitoring-source HUMAN_WAIT attention on
+            # terminal exit so awaiting_human_since is not stranded
+            # (PRRT_kwDOSJAM6s6XYW1j).
+            await repo.clear_workspace_attention(workspace_id)
         elif cleanup_result.ok:
             # ``stack_stopped`` asserts the runtime was actually stopped, so it
             # is only emitted once the compose down succeeds. A failed teardown
@@ -953,6 +963,10 @@ class WorkspaceControlService(_WorkspaceGuideMixin, _WorkspaceStackReleaseMixin)
             )
             if leaving_blocked:
                 await _emit_blocked_attention_cleared(repo, workspace)
+            # Same as cancel/stop: clear monitoring-source HUMAN_WAIT attention on
+            # the active→cancelled hop so force-destroy does not leave a stranded
+            # awaiting_human_since episode (PRRT_kwDOSJAM6s6XYW1j).
+            await repo.clear_workspace_attention(workspace_id)
             current = WorkspaceStatus.cancelled
         if WorkspaceStateMachine.can_transition(current, WorkspaceStatus.destroying):
             await repo.transition(

--- a/src/awf/service/controls_guide.py
+++ b/src/awf/service/controls_guide.py
@@ -14,6 +14,10 @@ from typing import Any, cast
 from sqlalchemy import select
 
 from awf.api.schemas import WorkspaceControlResponse
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    blocked_attention_payload,
+)
 from awf.common.ids import new_operator_grant_id
 from awf.control.blocked_transition import is_monitor_origin_block_resume_phase
 from awf.control.quality_gates import _grant_matches
@@ -748,6 +752,14 @@ async def _guide_monitor_origin_blocked_workspace(
         new_state=WorkspaceStatus.monitoring_pr.value,
         reason_code=_OPERATOR_GUIDE_REASON_CODE,
         payload=event_payload,
+    )
+    await repo.add_event(
+        workspace,
+        event_type=ATTENTION_CLEARED_EVENT_TYPE,
+        payload=blocked_attention_payload(
+            block_reason_code=workspace.block_reason_code,
+            block_type=workspace.block_type,
+        ),
     )
     await _add_control_audit_event(
         repo,

--- a/src/awf/service/controls_helpers.py
+++ b/src/awf/service/controls_helpers.py
@@ -795,3 +795,28 @@ def _is_active(status_value: WorkspaceStatus) -> bool:
         # through ``cancelled`` and the force guard applies.
         WorkspaceStatus.recovering,
     }
+
+
+async def _emit_blocked_attention_cleared(
+    repo: WorkspaceRepository,
+    workspace: Workspace,
+) -> None:
+    """Emit ``workspace.attention_cleared`` for a protected-gate blocked episode end.
+
+    Claim-resume and monitor-origin guide already emit on their exits. Operator
+    cancel/stop/forced-destroy can leave ``blocked`` via ``blocked → cancelled``
+    without those paths — subscribers would otherwise retain an active episode.
+    """
+    from awf.common.attention_events import (
+        ATTENTION_CLEARED_EVENT_TYPE,
+        blocked_attention_payload,
+    )
+
+    await repo.add_event(
+        workspace,
+        event_type=ATTENTION_CLEARED_EVENT_TYPE,
+        payload=blocked_attention_payload(
+            block_reason_code=workspace.block_reason_code,
+            block_type=workspace.block_type,
+        ),
+    )

--- a/tests/unit/common/test_callback_events.py
+++ b/tests/unit/common/test_callback_events.py
@@ -17,6 +17,8 @@ def test_subscription_event_type_policy_accepts_public_exact_and_wildcards() -> 
     assert is_valid_callback_subscription_event_type("workspace.created") is True
     assert is_valid_callback_subscription_event_type("workspace.state_changed") is True
     assert is_valid_callback_subscription_event_type("workspace.secondary_failure_recorded") is True
+    assert is_valid_callback_subscription_event_type("workspace.attention_required") is True
+    assert is_valid_callback_subscription_event_type("workspace.attention_cleared") is True
     assert is_valid_callback_subscription_event_type("workspace.internal") is False
     assert is_valid_callback_subscription_event_type("internal.secret_rotated") is False
     assert is_valid_callback_subscription_event_type("workspace.internal_secret") is False
@@ -43,6 +45,22 @@ def test_subscription_event_matching_requires_public_source_event() -> None:
     assert callback_subscription_matches_event_type(
         "workspace.secondary_failure_recorded",
         "workspace.secondary_failure_recorded",
+    )
+    assert callback_subscription_matches_event_type(
+        "workspace.*",
+        "workspace.attention_required",
+    )
+    assert callback_subscription_matches_event_type(
+        "workspace.*",
+        "workspace.attention_cleared",
+    )
+    assert callback_subscription_matches_event_type(
+        "workspace.attention_required",
+        "workspace.attention_required",
+    )
+    assert callback_subscription_matches_event_type(
+        "workspace.attention_cleared",
+        "workspace.attention_cleared",
     )
     assert callback_subscription_matches_event_type(
         "workspace.created",

--- a/tests/unit/control/test_blocked_attention_events.py
+++ b/tests/unit/control/test_blocked_attention_events.py
@@ -1,0 +1,206 @@
+"""Blocked-source attention enter/clear/restore WorkspaceEvents (AIRA-T490)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_REQUIRED_EVENT_TYPE,
+    ATTENTION_SOURCE_BLOCKED,
+)
+from awf.control.blocked_transition import enter_blocked_for_protected_violation_in_session
+from awf.control.quality_gates import QualityGateViolation
+from awf.control.worker import ControlWorker, WorkerConfig
+from awf.db.enums import WorkspaceStatus
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from awf.db.session import make_session_factory
+from tests.postgres import postgres_test_engine
+
+_VIOLATIONS = [
+    QualityGateViolation(
+        path="pyproject.toml",
+        protected_pattern="pyproject.toml",
+        section="tool.coverage.report.fail_under",
+        line=5,
+        reason="coverage fail_under lowered from 99 to 80",
+    )
+]
+
+
+@pytest.fixture
+async def factory(tmp_path: Path) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    del tmp_path
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+async def _seed_running(factory: async_sessionmaker[AsyncSession]) -> str:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await repo.create(
+            repo_url="git@github.com:example/blocked-attention.git",
+            branch_base="main",
+            task_title="blocked attention events",
+            task_prompt="exercise blocked attention flips",
+            agent="codex",
+            test_commands=[],
+        )
+        ws.status = WorkspaceStatus.running.value
+        ws.execution_claimed_by = "worker-a"
+        ws.block_reason_code = None
+        await session.commit()
+        return ws.id
+
+
+async def _attention_events(session: AsyncSession, workspace_id: str) -> list:
+    events = await WorkspaceEventRepository(session).list(workspace_id=workspace_id, limit=50)
+    return [
+        e
+        for e in events
+        if e.event_type in {ATTENTION_REQUIRED_EVENT_TYPE, ATTENTION_CLEARED_EVENT_TYPE}
+    ]
+
+
+class _TransitioningProvisioner:
+    def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
+        self._session_factory = session_factory
+
+    async def provision_claimed(
+        self, workspace_id: str, execution_claim_epoch: int | None = None
+    ) -> None:  # pragma: no cover
+        del workspace_id, execution_claim_epoch
+
+    def get_worktree_path(self, workspace_id: str) -> Path | None:
+        del workspace_id
+        return None
+
+
+class _RecordingBlockedExecutor:
+    def __init__(self) -> None:
+        self.resume_blocked_calls: list[str] = []
+
+    async def execute(self, workspace_id: str, **_kwargs: object) -> None:  # pragma: no cover
+        del workspace_id
+
+    async def resume_pr_monitor(self, workspace_id: str) -> None:  # pragma: no cover
+        del workspace_id
+
+    async def resume_blocked_execution(self, workspace_id: str, **_kwargs: object) -> None:
+        self.resume_blocked_calls.append(workspace_id)
+
+
+def _worker(session_factory: async_sessionmaker[AsyncSession]) -> ControlWorker:
+    worker = ControlWorker(
+        session_factory=session_factory,
+        provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+        executor=_RecordingBlockedExecutor(),
+        config=WorkerConfig(
+            poll_interval_seconds=0.01,
+            max_concurrent_provisions=1,
+            max_concurrent_executions=1,
+        ),
+    )
+    worker._next_stale_active_execution_scan_at = float("inf")  # noqa: SLF001
+    return worker
+
+
+@pytest.mark.unit
+async def test_enter_blocked_emits_attention_required(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ws_id = await _seed_running(factory)
+
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        ws = await enter_blocked_for_protected_violation_in_session(
+            session,
+            repo,
+            workspace_id=ws_id,
+            from_status=WorkspaceStatus.running,
+            violations=_VIOLATIONS,
+            resume_phase="validation_fix_cycle",
+            execution_owner_id="worker-a",
+        )
+        assert ws is not None
+        await session.commit()
+
+    async with factory() as session:
+        events = await _attention_events(session, ws_id)
+        assert len(events) == 1
+        assert events[0].event_type == ATTENTION_REQUIRED_EVENT_TYPE
+        assert events[0].payload["source"] == ATTENTION_SOURCE_BLOCKED
+        assert events[0].payload["block_reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+        assert events[0].payload["block_type"] == "protected_quality_gate"
+        assert events[0].payload["reason"] == "QUALITY_GATE_POLICY_CHANGED"
+
+
+@pytest.mark.unit
+async def test_claim_blocked_for_resume_emits_attention_cleared(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ws_id = await _seed_running(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        await enter_blocked_for_protected_violation_in_session(
+            session,
+            repo,
+            workspace_id=ws_id,
+            from_status=WorkspaceStatus.running,
+            violations=_VIOLATIONS,
+            resume_phase="validation_fix_cycle",
+            execution_owner_id="worker-a",
+        )
+        await session.commit()
+
+    worker = _worker(factory)
+    assert await worker._claim_blocked_for_resume(ws_id)  # noqa: SLF001
+
+    async with factory() as session:
+        events = await _attention_events(session, ws_id)
+        types = [e.event_type for e in events]
+        assert types.count(ATTENTION_REQUIRED_EVENT_TYPE) == 1
+        assert types.count(ATTENTION_CLEARED_EVENT_TYPE) == 1
+        cleared = next(e for e in events if e.event_type == ATTENTION_CLEARED_EVENT_TYPE)
+        assert cleared.payload["source"] == ATTENTION_SOURCE_BLOCKED
+        assert cleared.payload["block_reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+        assert cleared.payload["block_type"] == "protected_quality_gate"
+
+
+@pytest.mark.unit
+async def test_restore_blocked_resume_reemits_attention_required(
+    factory: async_sessionmaker[AsyncSession],
+) -> None:
+    ws_id = await _seed_running(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        await enter_blocked_for_protected_violation_in_session(
+            session,
+            repo,
+            workspace_id=ws_id,
+            from_status=WorkspaceStatus.running,
+            violations=_VIOLATIONS,
+            resume_phase="validation_fix_cycle",
+            execution_owner_id="worker-a",
+        )
+        await session.commit()
+
+    worker = _worker(factory)
+    assert await worker._claim_blocked_for_resume(ws_id)  # noqa: SLF001
+    await worker._restore_blocked_resume_claim(  # noqa: SLF001
+        ws_id,
+        reason_code="BLOCKED_RESUME_NO_EXECUTOR",
+    )
+
+    async with factory() as session:
+        events = await _attention_events(session, ws_id)
+        types = [e.event_type for e in events]
+        # enter required → claim cleared → restore required
+        assert types.count(ATTENTION_REQUIRED_EVENT_TYPE) == 2
+        assert types.count(ATTENTION_CLEARED_EVENT_TYPE) == 1
+        required = [e for e in events if e.event_type == ATTENTION_REQUIRED_EVENT_TYPE]
+        assert all(e.payload["source"] == ATTENTION_SOURCE_BLOCKED for e in required)

--- a/tests/unit/db/test_workspace_attention.py
+++ b/tests/unit/db/test_workspace_attention.py
@@ -8,7 +8,7 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from awf.db.enums import AgentRuntime
+from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
 from tests.postgres import postgres_test_session
@@ -20,7 +20,12 @@ async def session() -> AsyncIterator[AsyncSession]:
         yield s
 
 
-async def _create_workspace(repo: WorkspaceRepository, session: AsyncSession) -> Workspace:
+async def _create_workspace(
+    repo: WorkspaceRepository,
+    session: AsyncSession,
+    *,
+    status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
+) -> Workspace:
     workspace = await repo.create(
         repo_url="git@github.com:example/app.git",
         branch_base="development",
@@ -29,6 +34,8 @@ async def _create_workspace(repo: WorkspaceRepository, session: AsyncSession) ->
         agent=AgentRuntime.codex.value,
         test_commands=[],
     )
+    # Attention enter is fenced to monitoring_pr; create defaults to requested.
+    workspace.status = status.value
     await session.flush()
     return workspace
 

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -175,3 +175,39 @@ async def test_clear_workspace_attention_skips_event_when_update_matches_zero_ro
     assert [e.event_type for e in events] == [ATTENTION_REQUIRED_EVENT_TYPE]
     assert workspace.awaiting_human_since is None
     assert workspace.awaiting_human_reason is None
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_skips_event_when_enter_update_matches_zero_rows(
+    session: AsyncSession,
+) -> None:
+    """Lost race: stale in-memory clear must not emit a second required event."""
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    episode_start = datetime(2026, 6, 22, 11, 0, tzinfo=UTC)
+    assert workspace.awaiting_human_since is None
+
+    # Simulate another session entering first without refreshing the identity map.
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace.id)
+        .values(
+            awaiting_human_since=episode_start,
+            awaiting_human_reason="first",
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    assert workspace.awaiting_human_since is None
+
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="second",
+        now=datetime(2026, 6, 22, 12, 0, tzinfo=UTC),
+    )
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since == episode_start
+    assert refreshed.awaiting_human_reason == "second"
+    assert await _attention_events(session, workspace.id) == []

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
 
 import pytest
+from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.attention_events import (
@@ -142,3 +143,35 @@ async def test_clear_workspace_attention_when_already_clear_emits_nothing(
     await repo.clear_workspace_attention(workspace.id)
 
     assert await _attention_events(session, workspace.id) == []
+
+
+@pytest.mark.unit
+async def test_clear_workspace_attention_skips_event_when_update_matches_zero_rows(
+    session: AsyncSession,
+) -> None:
+    """Lost race: stale in-memory episode must not emit a second cleared event."""
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="blocking",
+        now=datetime(2026, 6, 22, tzinfo=UTC),
+    )
+    assert workspace.awaiting_human_since is not None
+
+    # Simulate another session clearing first without refreshing the identity map.
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace.id)
+        .values(awaiting_human_since=None, awaiting_human_reason=None)
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    assert workspace.awaiting_human_since is not None
+
+    await repo.clear_workspace_attention(workspace.id)
+
+    events = await _attention_events(session, workspace.id)
+    assert [e.event_type for e in events] == [ATTENTION_REQUIRED_EVENT_TYPE]
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -246,6 +246,70 @@ async def test_clear_workspace_attention_lost_race_does_not_dirty_replacement_ep
 
 
 @pytest.mark.unit
+async def test_clear_workspace_attention_fenced_to_snapshotted_episode(
+    session: AsyncSession,
+) -> None:
+    """Stale clear must not wipe a replacement episode committed before UPDATE.
+
+    After this session snapshots E1, another session can clear E1 and enter E2
+    before the clear UPDATE takes the row lock. A predicate that only requires
+    non-null awaiting_human_since then clears E2 and emits attention_cleared
+    with E1's reason (PRRT_kwDOSJAM6s6XY5JC).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    episode_e1 = datetime(2026, 6, 22, 11, 0, tzinfo=UTC)
+    episode_e2 = datetime(2026, 6, 22, 11, 30, tzinfo=UTC)
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="episode-e1",
+        now=episode_e1,
+    )
+    assert workspace.awaiting_human_since == episode_e1
+
+    real_execute = session.execute
+    clear_updates = 0
+
+    async def execute_replace_before_clear(statement: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal clear_updates
+        if isinstance(statement, Update):
+            clear_updates += 1
+            if clear_updates == 1:
+                # Concurrent clear of E1 + enter of E2 before this session's UPDATE.
+                await real_execute(
+                    update(Workspace)
+                    .where(Workspace.id == workspace.id)
+                    .values(awaiting_human_since=None, awaiting_human_reason=None)
+                    .execution_options(synchronize_session=False)
+                )
+                await session.flush()
+                await real_execute(
+                    update(Workspace)
+                    .where(Workspace.id == workspace.id)
+                    .values(
+                        awaiting_human_since=episode_e2,
+                        awaiting_human_reason="episode-e2",
+                    )
+                    .execution_options(synchronize_session=False)
+                )
+                await session.flush()
+        return await real_execute(statement, *args, **kwargs)
+
+    session.execute = execute_replace_before_clear  # type: ignore[method-assign]
+
+    await repo.clear_workspace_attention(workspace.id)
+    await session.flush()
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since == episode_e2
+    assert refreshed.awaiting_human_reason == "episode-e2"
+    events = await _attention_events(session, workspace.id)
+    assert [e.event_type for e in events] == [ATTENTION_REQUIRED_EVENT_TYPE]
+    assert events[0].payload.get("reason") == "episode-e1"
+
+
+@pytest.mark.unit
 async def test_clear_workspace_attention_clears_when_identity_map_stale_clear(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -15,7 +15,7 @@ from awf.common.attention_events import (
     ATTENTION_REQUIRED_EVENT_TYPE,
     ATTENTION_SOURCE_MONITORING_PR,
 )
-from awf.db.enums import AgentRuntime
+from awf.db.enums import AgentRuntime, WorkspaceStatus
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
 from tests.postgres import postgres_test_session
@@ -32,6 +32,7 @@ async def _create_workspace(
     session: AsyncSession,
     *,
     pr_url: str | None = None,
+    status: WorkspaceStatus = WorkspaceStatus.monitoring_pr,
 ) -> Workspace:
     workspace = await repo.create(
         repo_url="git@github.com:example/app.git",
@@ -41,6 +42,8 @@ async def _create_workspace(
         agent=AgentRuntime.codex.value,
         test_commands=[],
     )
+    # Attention enter is fenced to monitoring_pr; create defaults to requested.
+    workspace.status = status.value
     if pr_url is not None:
         workspace.pr_url = pr_url
     await session.flush()
@@ -223,6 +226,47 @@ async def test_clear_workspace_attention_clears_when_identity_map_stale_clear(
         "source": ATTENTION_SOURCE_MONITORING_PR,
         "pr_url": "https://github.com/example/app/pull/9",
     }
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_skips_enter_when_status_left_monitoring_pr(
+    session: AsyncSession,
+) -> None:
+    """Terminal cancel/stop/destroy race must not reopen attention after clear.
+
+    Control can clear ``awaiting_human_since`` and leave ``monitoring_pr`` while a
+    blocked enter UPDATE waits; on re-evaluation it must not match a terminal
+    row (PRRT_kwDOSJAM6s6XYelT).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    assert workspace.status == WorkspaceStatus.monitoring_pr.value
+    assert workspace.awaiting_human_since is None
+
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace.id)
+        .values(
+            status=WorkspaceStatus.cancelled.value,
+            awaiting_human_since=None,
+            awaiting_human_reason=None,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="blocking review after cancel race",
+        now=datetime(2026, 6, 22, 12, 0, tzinfo=UTC),
+    )
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.status == WorkspaceStatus.cancelled.value
+    assert refreshed.awaiting_human_since is None
+    assert refreshed.awaiting_human_reason is None
+    assert await _attention_events(session, workspace.id) == []
 
 
 @pytest.mark.unit

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -182,6 +182,70 @@ async def test_clear_workspace_attention_skips_event_when_update_matches_zero_ro
 
 
 @pytest.mark.unit
+async def test_clear_workspace_attention_lost_race_does_not_dirty_replacement_episode(
+    session: AsyncSession,
+) -> None:
+    """Lost clear must not dirty ORM so a replacement episode survives flush.
+
+    After refresh sees episode E1, a concurrent clear can make the guarded UPDATE
+    match zero rows. Assigning None onto the still-stale E1 snapshot dirties the
+    row; if E2 is entered before the next flush, SQLAlchemy can erase it without
+    attention_cleared (PRRT_kwDOSJAM6s6XYw7b).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    episode_e1 = datetime(2026, 6, 22, 11, 0, tzinfo=UTC)
+    episode_e2 = datetime(2026, 6, 22, 11, 30, tzinfo=UTC)
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="episode-e1",
+        now=episode_e1,
+    )
+    assert workspace.awaiting_human_since == episode_e1
+
+    real_execute = session.execute
+
+    async def execute_clear_then_replace(statement: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(statement, Update):
+            # Concurrent clear of E1 so this session's guarded clear matches 0.
+            await real_execute(
+                update(Workspace)
+                .where(Workspace.id == workspace.id)
+                .values(awaiting_human_since=None, awaiting_human_reason=None)
+                .execution_options(synchronize_session=False)
+            )
+            await session.flush()
+            result = await real_execute(statement, *args, **kwargs)
+            # Replacement episode entered before lost-race handling returns.
+            await real_execute(
+                update(Workspace)
+                .where(Workspace.id == workspace.id)
+                .values(
+                    awaiting_human_since=episode_e2,
+                    awaiting_human_reason="episode-e2",
+                )
+                .execution_options(synchronize_session=False)
+            )
+            await session.flush()
+            return result
+        return await real_execute(statement, *args, **kwargs)
+
+    session.execute = execute_clear_then_replace  # type: ignore[method-assign]
+
+    await repo.clear_workspace_attention(workspace.id)
+    # Caller (or unit-of-work boundary) may flush dirty ORM state after return.
+    await session.flush()
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since == episode_e2
+    assert refreshed.awaiting_human_reason == "episode-e2"
+    events = await _attention_events(session, workspace.id)
+    assert [e.event_type for e in events] == [ATTENTION_REQUIRED_EVENT_TYPE]
+    assert events[0].payload.get("reason") == "episode-e1"
+
+
+@pytest.mark.unit
 async def test_clear_workspace_attention_clears_when_identity_map_stale_clear(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -1,0 +1,144 @@
+"""Once-per-flip WorkspaceEvent emission for attention set/clear (AIRA-T490)."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_REQUIRED_EVENT_TYPE,
+    ATTENTION_SOURCE_MONITORING_PR,
+)
+from awf.db.enums import AgentRuntime
+from awf.db.models import Workspace
+from awf.db.repositories import WorkspaceEventRepository, WorkspaceRepository
+from tests.postgres import postgres_test_session
+
+
+@pytest.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    async with postgres_test_session() as s:
+        yield s
+
+
+async def _create_workspace(
+    repo: WorkspaceRepository,
+    session: AsyncSession,
+    *,
+    pr_url: str | None = None,
+) -> Workspace:
+    workspace = await repo.create(
+        repo_url="git@github.com:example/app.git",
+        branch_base="development",
+        task_title="attention event test",
+        task_prompt="x",
+        agent=AgentRuntime.codex.value,
+        test_commands=[],
+    )
+    if pr_url is not None:
+        workspace.pr_url = pr_url
+    await session.flush()
+    return workspace
+
+
+async def _attention_events(session: AsyncSession, workspace_id: str) -> list:
+    events = await WorkspaceEventRepository(session).list(workspace_id=workspace_id, limit=50)
+    return [
+        e
+        for e in events
+        if e.event_type in {ATTENTION_REQUIRED_EVENT_TYPE, ATTENTION_CLEARED_EVENT_TYPE}
+    ]
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_emits_required_once_with_pr_url(
+    session: AsyncSession,
+) -> None:
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(
+        repo,
+        session,
+        pr_url="https://github.com/example/app/pull/42",
+    )
+    now = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
+
+    await repo.set_workspace_attention(workspace.id, reason="blocking review", now=now)
+
+    events = await _attention_events(session, workspace.id)
+    assert len(events) == 1
+    event = events[0]
+    assert event.event_type == ATTENTION_REQUIRED_EVENT_TYPE
+    assert event.payload == {
+        "reason": "blocking review",
+        "source": ATTENTION_SOURCE_MONITORING_PR,
+        "pr_url": "https://github.com/example/app/pull/42",
+    }
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_reason_refresh_does_not_reemit(
+    session: AsyncSession,
+) -> None:
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    first = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
+    second = first + timedelta(minutes=5)
+
+    await repo.set_workspace_attention(workspace.id, reason="first", now=first)
+    await repo.set_workspace_attention(workspace.id, reason="second", now=second)
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since == first
+    assert refreshed.awaiting_human_reason == "second"
+
+    events = await _attention_events(session, workspace.id)
+    assert len(events) == 1
+    assert events[0].event_type == ATTENTION_REQUIRED_EVENT_TYPE
+    assert events[0].payload["reason"] == "first"
+
+
+@pytest.mark.unit
+async def test_clear_workspace_attention_emits_cleared_once(session: AsyncSession) -> None:
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(
+        repo,
+        session,
+        pr_url="https://github.com/example/app/pull/7",
+    )
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="merge BLOCKED",
+        now=datetime(2026, 6, 22, tzinfo=UTC),
+    )
+
+    await repo.clear_workspace_attention(workspace.id)
+    await repo.clear_workspace_attention(workspace.id)
+
+    events = await _attention_events(session, workspace.id)
+    assert [e.event_type for e in events] == [
+        ATTENTION_CLEARED_EVENT_TYPE,
+        ATTENTION_REQUIRED_EVENT_TYPE,
+    ]
+    cleared = events[0]
+    assert cleared.payload == {
+        "reason": "merge BLOCKED",
+        "source": ATTENTION_SOURCE_MONITORING_PR,
+        "pr_url": "https://github.com/example/app/pull/7",
+    }
+
+
+@pytest.mark.unit
+async def test_clear_workspace_attention_when_already_clear_emits_nothing(
+    session: AsyncSession,
+) -> None:
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+
+    await repo.clear_workspace_attention(workspace.id)
+
+    assert await _attention_events(session, workspace.id) == []

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -179,6 +179,53 @@ async def test_clear_workspace_attention_skips_event_when_update_matches_zero_ro
 
 
 @pytest.mark.unit
+async def test_clear_workspace_attention_clears_when_identity_map_stale_clear(
+    session: AsyncSession,
+) -> None:
+    """Stale identity-map clear must not skip a concurrently committed episode.
+
+    guide/remonitor may cache the workspace while attention is clear; another
+    transaction can enter attention before clear runs. Skipping on the cached
+    flag would leave the persisted episode active (PRRT_kwDOSJAM6s6XYG7K).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(
+        repo,
+        session,
+        pr_url="https://github.com/example/app/pull/9",
+    )
+    assert workspace.awaiting_human_since is None
+
+    episode_start = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace.id)
+        .values(
+            awaiting_human_since=episode_start,
+            awaiting_human_reason="blocking review",
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+    assert workspace.awaiting_human_since is None
+
+    await repo.clear_workspace_attention(workspace.id)
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since is None
+    assert refreshed.awaiting_human_reason is None
+    events = await _attention_events(session, workspace.id)
+    assert len(events) == 1
+    assert events[0].event_type == ATTENTION_CLEARED_EVENT_TYPE
+    assert events[0].payload == {
+        "reason": "blocking review",
+        "source": ATTENTION_SOURCE_MONITORING_PR,
+        "pr_url": "https://github.com/example/app/pull/9",
+    }
+
+
+@pytest.mark.unit
 async def test_set_workspace_attention_skips_event_when_enter_update_matches_zero_rows(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import pytest
-from sqlalchemy import update
+from sqlalchemy import Update, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.attention_events import (
@@ -210,4 +211,62 @@ async def test_set_workspace_attention_skips_event_when_enter_update_matches_zer
     assert refreshed is not None
     assert refreshed.awaiting_human_since == episode_start
     assert refreshed.awaiting_human_reason == "second"
+    assert await _attention_events(session, workspace.id) == []
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_reason_refresh_skips_when_episode_cleared(
+    session: AsyncSession,
+) -> None:
+    """Lost enter + concurrent clear must not orphan awaiting_human_reason.
+
+    After the guarded enter UPDATE matches zero rows, another transaction may
+    clear awaiting_human_since before the reason-only refresh. Refreshing by id
+    alone would write reason while attention is clear (PRRT_kwDOSJAM6s6XYFS3).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    episode_start = datetime(2026, 6, 22, 11, 0, tzinfo=UTC)
+    await session.execute(
+        update(Workspace)
+        .where(Workspace.id == workspace.id)
+        .values(
+            awaiting_human_since=episode_start,
+            awaiting_human_reason="first",
+        )
+        .execution_options(synchronize_session=False)
+    )
+    await session.flush()
+
+    real_execute = session.execute
+    update_calls = 0
+
+    async def execute_clearing_after_enter(statement: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal update_calls
+        result = await real_execute(statement, *args, **kwargs)
+        if isinstance(statement, Update):
+            update_calls += 1
+            if update_calls == 1:
+                # Concurrent clear between lost-enter and reason refresh.
+                await real_execute(
+                    update(Workspace)
+                    .where(Workspace.id == workspace.id)
+                    .values(awaiting_human_since=None, awaiting_human_reason=None)
+                    .execution_options(synchronize_session=False)
+                )
+                await session.flush()
+        return result
+
+    session.execute = execute_clearing_after_enter  # type: ignore[method-assign]
+
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="second",
+        now=datetime(2026, 6, 22, 12, 0, tzinfo=UTC),
+    )
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since is None
+    assert refreshed.awaiting_human_reason is None
     assert await _attention_events(session, workspace.id) == []

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -246,6 +246,67 @@ async def test_clear_workspace_attention_lost_race_does_not_dirty_replacement_ep
 
 
 @pytest.mark.unit
+async def test_clear_workspace_attention_emits_reason_at_clear_not_stale_snapshot(
+    session: AsyncSession,
+) -> None:
+    """Cleared event must carry the reason present when the guarded clear flips.
+
+    After clear snapshots episode start (and previously the reason), a concurrent
+    reason-only refresh can commit a newer reason for the same awaiting_human_since
+    fence. Emitting the unlocked pre-refresh snapshot would make attention_cleared
+    disagree with the episode state immediately before clear (PRRT_kwDOSJAM6s6XZEFA).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(
+        repo,
+        session,
+        pr_url="https://github.com/example/app/pull/11",
+    )
+    episode_start = datetime(2026, 6, 22, 12, 0, tzinfo=UTC)
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="stale-snapshot-reason",
+        now=episode_start,
+    )
+    assert workspace.awaiting_human_since == episode_start
+
+    real_execute = session.execute
+
+    async def execute_refresh_before_clear(statement: Any, *args: Any, **kwargs: Any) -> Any:
+        if isinstance(statement, Update):
+            await real_execute(
+                update(Workspace)
+                .where(
+                    Workspace.id == workspace.id,
+                    Workspace.awaiting_human_since == episode_start,
+                )
+                .values(awaiting_human_reason="refreshed-reason")
+                .execution_options(synchronize_session=False)
+            )
+            await session.flush()
+        return await real_execute(statement, *args, **kwargs)
+
+    session.execute = execute_refresh_before_clear  # type: ignore[method-assign]
+
+    await repo.clear_workspace_attention(workspace.id)
+
+    events = await _attention_events(session, workspace.id)
+    assert [e.event_type for e in events] == [
+        ATTENTION_CLEARED_EVENT_TYPE,
+        ATTENTION_REQUIRED_EVENT_TYPE,
+    ]
+    assert events[0].payload == {
+        "reason": "refreshed-reason",
+        "source": ATTENTION_SOURCE_MONITORING_PR,
+        "pr_url": "https://github.com/example/app/pull/11",
+    }
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since is None
+    assert refreshed.awaiting_human_reason is None
+
+
+@pytest.mark.unit
 async def test_clear_workspace_attention_fenced_to_snapshotted_episode(
     session: AsyncSession,
 ) -> None:

--- a/tests/unit/db/test_workspace_attention_events.py
+++ b/tests/unit/db/test_workspace_attention_events.py
@@ -361,3 +361,71 @@ async def test_set_workspace_attention_reason_refresh_skips_when_episode_cleared
     assert refreshed.awaiting_human_since is None
     assert refreshed.awaiting_human_reason is None
     assert await _attention_events(session, workspace.id) == []
+
+
+@pytest.mark.unit
+async def test_set_workspace_attention_reason_refresh_fenced_to_observed_episode(
+    session: AsyncSession,
+) -> None:
+    """Lost enter must not refresh a replacement episode's reason.
+
+    After setter A loses enter against episode E1, E1 can be cleared and setter B
+    can open E2 before A's reason refresh. A refresh guarded only by
+    ``awaiting_human_since IS NOT NULL`` overwrites B's reason so the required
+    event and read model disagree (PRRT_kwDOSJAM6s6XYlxN).
+    """
+    repo = WorkspaceRepository(session)
+    workspace = await _create_workspace(repo, session)
+    episode_e1 = datetime(2026, 6, 22, 11, 0, tzinfo=UTC)
+    episode_e2 = datetime(2026, 6, 22, 11, 30, tzinfo=UTC)
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="episode-e1",
+        now=episode_e1,
+    )
+    assert workspace.awaiting_human_since == episode_e1
+
+    real_execute = session.execute
+    update_calls = 0
+
+    async def execute_replace_episode_after_enter(statement: Any, *args: Any, **kwargs: Any) -> Any:
+        nonlocal update_calls
+        result = await real_execute(statement, *args, **kwargs)
+        if isinstance(statement, Update):
+            update_calls += 1
+            if update_calls == 1:
+                # Concurrent clear of E1 + enter of E2 (as setter B) before refresh.
+                await real_execute(
+                    update(Workspace)
+                    .where(Workspace.id == workspace.id)
+                    .values(awaiting_human_since=None, awaiting_human_reason=None)
+                    .execution_options(synchronize_session=False)
+                )
+                await real_execute(
+                    update(Workspace)
+                    .where(Workspace.id == workspace.id)
+                    .values(
+                        awaiting_human_since=episode_e2,
+                        awaiting_human_reason="episode-e2-from-b",
+                    )
+                    .execution_options(synchronize_session=False)
+                )
+                await session.flush()
+        return result
+
+    session.execute = execute_replace_episode_after_enter  # type: ignore[method-assign]
+
+    await repo.set_workspace_attention(
+        workspace.id,
+        reason="stale-reason-from-a",
+        now=datetime(2026, 6, 22, 12, 0, tzinfo=UTC),
+    )
+
+    refreshed = await repo.get(workspace.id, populate_existing=True)
+    assert refreshed is not None
+    assert refreshed.awaiting_human_since == episode_e2
+    assert refreshed.awaiting_human_reason == "episode-e2-from-b"
+    events = await _attention_events(session, workspace.id)
+    assert len(events) == 1
+    assert events[0].event_type == ATTENTION_REQUIRED_EVENT_TYPE
+    assert events[0].payload.get("reason") == "episode-e1"

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_014.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_014.py
@@ -3,12 +3,17 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pytest
 import structlog
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_SOURCE_MONITORING_PR,
+)
 from awf.common.commands import FakeCommandRunner
 from awf.common.forge_errors import ForgeClientError
 from awf.common.github_client import RepoRef
@@ -655,6 +660,60 @@ async def test_terminate_failed_with_matching_monitor_owner_still_fails(
         assert ws is not None
         assert ws.status == "failed"
         assert ws.failure_message == "protected scope blocked"
+
+
+@pytest.mark.unit
+async def test_terminate_failed_clears_persisted_human_attention(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6XY5JH: ``NotifyHuman`` stamps attention before posting the
+    human notification; a permanent forge fault then ``_terminate_failed``s.
+    That terminal exit must null attention columns and emit
+    ``workspace.attention_cleared`` in the same commit — otherwise the failed
+    workspace strands callback consumers with an active episode forever.
+    """
+    workspace_id = await seed_monitoring_workspace(factory)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        await repo.set_workspace_attention(
+            workspace_id,
+            reason="notify human: forge will fail permanently",
+            now=datetime(2026, 8, 7, 12, 0, tzinfo=UTC),
+        )
+        await session.commit()
+        ws = await repo.get(workspace_id)
+        assert ws is not None
+        assert ws.awaiting_human_since is not None
+        assert ws.awaiting_human_reason is not None
+
+    runner = make_runner(
+        factory=factory,
+        cmd=FakeCommandRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    await runner._terminate_failed(
+        workspace_id,
+        message="monitor: github error: permanent notification failure",
+        reason_code="GITHUB_ERROR",
+    )
+
+    async with factory() as session:
+        ws = await WorkspaceRepository(session).get(workspace_id)
+        assert ws is not None
+        assert ws.status == "failed"
+        assert ws.awaiting_human_since is None
+        assert ws.awaiting_human_reason is None
+        cleared = [
+            event
+            for event in ws.events
+            if event.event_type == ATTENTION_CLEARED_EVENT_TYPE
+            and (event.payload or {}).get("source") == ATTENTION_SOURCE_MONITORING_PR
+        ]
+    assert len(cleared) == 1
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_014.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_014.py
@@ -896,6 +896,7 @@ async def test_terminate_failed_locks_row_before_owner_fence(
 
     locked_ids: list[str] = []
     original_get_for_update = WorkspaceRepository.get_for_update
+    original_get = WorkspaceRepository.get
 
     async def _recording_get_for_update(
         self: WorkspaceRepository,
@@ -909,8 +910,14 @@ async def test_terminate_failed_locks_row_before_owner_fence(
     async def _forbidden_get(
         self: WorkspaceRepository,
         requested_workspace_id: str,
+        **kwargs: object,
     ) -> object | None:
-        raise AssertionError("_terminate_failed must lock the row with get_for_update, not get")
+        # Owner-fence load must be locked. Post-lock refreshes (e.g. clear
+        # attention after the failed transition) may use ``get`` in the same
+        # transaction that already holds FOR UPDATE.
+        if not locked_ids:
+            raise AssertionError("_terminate_failed must lock the row with get_for_update, not get")
+        return await original_get(self, requested_workspace_id, **kwargs)
 
     monkeypatch.setattr(WorkspaceRepository, "get_for_update", _recording_get_for_update)
     monkeypatch.setattr(WorkspaceRepository, "get", _forbidden_get)

--- a/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_attention.py
+++ b/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_attention.py
@@ -10,6 +10,12 @@ monitor resume clear — otherwise the workspace row stays stuck with
 ``attention_required=true`` after the operator has already acted (live
 awf-cloud PR231/PR208). A future genuine ``NotifyHuman`` may set a new episode
 later via the monitor; that path is unchanged.
+
+Terminal exits (cancel / stop / force-destroy) from ``monitoring_pr`` must also
+clear the monitoring-source episode: they leave ``monitoring_pr`` without going
+through remonitor/guide, and previously left ``awaiting_human_since`` persisted
+with no ``workspace.attention_cleared`` for callback subscribers
+(PRRT_kwDOSJAM6s6XYW1j).
 """
 
 from __future__ import annotations
@@ -20,15 +26,21 @@ from datetime import UTC, datetime, timedelta
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from awf.common.attention_events import (
+    ATTENTION_CLEARED_EVENT_TYPE,
+    ATTENTION_SOURCE_MONITORING_PR,
+)
 from awf.db.enums import OperationType, WorkspaceStatus
 from awf.db.repositories import WorkspaceRepository
 from awf.runtime.operator_hints import OPERATOR_HINT_STATE_KEY
 from tests.postgres import postgres_test_session
 from tests.unit.service.test_controls_lifecycle_parts.controls_lifecycle_helpers import (
+    RecordingCleaner,
     _events,
     _operations,
     _service,
     _workspace_with_candidate,
+    compose_down_succeeded_result,
 )
 
 
@@ -187,3 +199,139 @@ async def test_guide_no_attention_episode_is_unchanged(session: AsyncSession) ->
     assert workspace.status == WorkspaceStatus.monitoring_pr.value
     assert workspace.awaiting_human_since is None
     assert workspace.awaiting_human_reason is None
+
+
+def _monitoring_attention_cleared(events: list) -> list:
+    return [
+        e
+        for e in events
+        if e.event_type == ATTENTION_CLEARED_EVENT_TYPE
+        and (e.payload or {}).get("source") == ATTENTION_SOURCE_MONITORING_PR
+    ]
+
+
+@pytest.mark.unit
+async def test_cancel_monitoring_pr_clears_persisted_human_attention(
+    session: AsyncSession,
+) -> None:
+    """Cancel from monitoring_pr with HUMAN_WAIT must clear monitoring attention.
+
+    Operator cancel transitions monitoring_pr→cancelled without remonitor/guide;
+    leaving awaiting_human_since set strands callback subscribers with a
+    permanently active monitoring attention episode (PRRT_kwDOSJAM6s6XYW1j).
+    """
+    workspace, _candidate = await _workspace_with_candidate(
+        session,
+        status=WorkspaceStatus.monitoring_pr,
+        title="cancel clears monitoring attention",
+    )
+    await _persist_human_wait_episode(session, workspace.id)
+    await session.refresh(workspace)
+    assert workspace.awaiting_human_since is not None
+    service, _stopper, _cleaner = _service(session)
+
+    await service.cancel_workspace(
+        workspace.id,
+        reason="operator abandoned HUMAN_WAIT",
+        stop_stack=False,
+        idempotency_key="cancel-clears-monitoring-attention",
+        expected_version=workspace.version,
+    )
+    await session.refresh(workspace)
+    events = await _events(session, workspace.id)
+
+    assert workspace.status == WorkspaceStatus.cancelled.value
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None
+    cleared = _monitoring_attention_cleared(events)
+    assert len(cleared) == 1
+
+
+@pytest.mark.unit
+async def test_stop_monitoring_pr_clears_persisted_human_attention(
+    session: AsyncSession,
+) -> None:
+    """Stop from monitoring_pr with HUMAN_WAIT must clear monitoring attention."""
+    workspace, _candidate = await _workspace_with_candidate(
+        session,
+        status=WorkspaceStatus.monitoring_pr,
+        title="stop clears monitoring attention",
+    )
+    await _persist_human_wait_episode(session, workspace.id)
+    await session.refresh(workspace)
+    assert workspace.awaiting_human_since is not None
+    cleaner = RecordingCleaner(result=compose_down_succeeded_result())
+    service, _stopper, _cleaner = _service(session, cleaner=cleaner)
+
+    await service.stop_workspace(
+        workspace.id,
+        reason="halt HUMAN_WAIT monitor",
+        idempotency_key="stop-clears-monitoring-attention",
+        expected_version=workspace.version,
+    )
+    await session.refresh(workspace)
+
+    assert workspace.status == WorkspaceStatus.cancelled.value
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None
+    assert len(_monitoring_attention_cleared(await _events(session, workspace.id))) == 1
+
+
+@pytest.mark.unit
+async def test_destroy_monitoring_pr_with_force_clears_persisted_human_attention(
+    session: AsyncSession,
+) -> None:
+    """Forced destroy from monitoring_pr with HUMAN_WAIT must clear attention."""
+    workspace, _candidate = await _workspace_with_candidate(
+        session,
+        status=WorkspaceStatus.monitoring_pr,
+        title="destroy clears monitoring attention",
+    )
+    await _persist_human_wait_episode(session, workspace.id)
+    await session.refresh(workspace)
+    assert workspace.awaiting_human_since is not None
+    cleaner = RecordingCleaner(result=compose_down_succeeded_result())
+    service, _stopper, _cleaner = _service(session, cleaner=cleaner)
+
+    await service.destroy_workspace(
+        workspace.id,
+        force=True,
+        remove_volumes=True,
+        remove_worktree=True,
+        idempotency_key="destroy-clears-monitoring-attention",
+        expected_version=workspace.version,
+    )
+    await session.refresh(workspace)
+
+    assert workspace.status == WorkspaceStatus.destroyed.value
+    assert workspace.awaiting_human_since is None
+    assert workspace.awaiting_human_reason is None
+    assert len(_monitoring_attention_cleared(await _events(session, workspace.id))) == 1
+
+
+@pytest.mark.unit
+async def test_cancel_monitoring_pr_without_episode_emits_no_attention_cleared(
+    session: AsyncSession,
+) -> None:
+    """Cancel with no HUMAN_WAIT episode must not emit monitoring attention_cleared."""
+    workspace, _candidate = await _workspace_with_candidate(
+        session,
+        status=WorkspaceStatus.monitoring_pr,
+        title="cancel no monitoring episode",
+    )
+    await session.refresh(workspace)
+    assert workspace.awaiting_human_since is None
+    service, _stopper, _cleaner = _service(session)
+
+    await service.cancel_workspace(
+        workspace.id,
+        reason="cancel without episode",
+        stop_stack=False,
+        idempotency_key="cancel-no-monitoring-episode",
+        expected_version=workspace.version,
+    )
+    await session.refresh(workspace)
+
+    assert workspace.status == WorkspaceStatus.cancelled.value
+    assert workspace.awaiting_human_since is None
+    assert _monitoring_attention_cleared(await _events(session, workspace.id)) == []

--- a/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_guide_blocked.py
+++ b/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_guide_blocked.py
@@ -701,6 +701,21 @@ async def test_guide_monitor_origin_blocked_directive_resumes_into_monitor(
     # Claims are force-cleared so the monitor poll can re-claim the row.
     assert workspace.monitor_claimed_by is None
     assert workspace.execution_claimed_by is None
+    # Durable unblock out of protected-gate pause emits attention_cleared once.
+    from awf.common.attention_events import (
+        ATTENTION_CLEARED_EVENT_TYPE,
+        ATTENTION_SOURCE_BLOCKED,
+    )
+
+    cleared = [
+        e
+        for e in await _events(session, workspace.id)
+        if e.event_type == ATTENTION_CLEARED_EVENT_TYPE
+    ]
+    assert len(cleared) == 1
+    assert cleared[0].payload["source"] == ATTENTION_SOURCE_BLOCKED
+    assert cleared[0].payload["block_reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+    assert cleared[0].payload["block_type"] == "protected_quality_gate"
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_part_006.py
+++ b/tests/unit/service/test_controls_lifecycle_parts/test_controls_lifecycle_part_006.py
@@ -597,3 +597,105 @@ async def test_destroy_blocked_workspace_with_force_routes_through_cancelled(
     assert response.status == WorkspaceStatus.destroyed
     assert workspace.status == WorkspaceStatus.destroyed.value
     assert len(cleaner.calls) == 1
+
+
+async def _seed_blocked_attention(session: AsyncSession) -> object:
+    """Blocked workspace with durable protected-gate attention fields set."""
+    workspace = await _workspace(session, status=WorkspaceStatus.blocked)
+    workspace.block_reason_code = "QUALITY_GATE_POLICY_CHANGED"
+    workspace.block_type = "protected_quality_gate"
+    await session.flush()
+    return workspace
+
+
+def _blocked_attention_cleared(events: list) -> list:
+    from awf.common.attention_events import (
+        ATTENTION_CLEARED_EVENT_TYPE,
+        ATTENTION_SOURCE_BLOCKED,
+    )
+
+    return [
+        e
+        for e in events
+        if e.event_type == ATTENTION_CLEARED_EVENT_TYPE
+        and (e.payload or {}).get("source") == ATTENTION_SOURCE_BLOCKED
+    ]
+
+
+@pytest.mark.unit
+async def test_cancel_blocked_workspace_emits_attention_cleared(
+    session: AsyncSession,
+) -> None:
+    """Operator cancel from blocked must clear the blocked attention episode.
+
+    Claim-resume and monitor-origin guide already emit attention_cleared; cancel
+    transitions blocked→cancelled directly and previously left callback
+    subscribers with a permanently active attention episode.
+    """
+    workspace = await _seed_blocked_attention(session)
+    service, _stopper, _cleaner = _service(session)
+
+    await service.cancel_workspace(
+        workspace.id,
+        reason="operator abandoned blocked pause",
+        stop_stack=False,
+    )
+
+    cleared = _blocked_attention_cleared(await _events(session, workspace.id))
+    assert len(cleared) == 1
+    assert cleared[0].payload["block_reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+    assert cleared[0].payload["block_type"] == "protected_quality_gate"
+
+
+@pytest.mark.unit
+async def test_stop_blocked_workspace_emits_attention_cleared(
+    session: AsyncSession,
+) -> None:
+    """Stop from blocked routes through cancelled and must clear blocked attention."""
+    workspace = await _seed_blocked_attention(session)
+    cleaner = RecordingCleaner(result=compose_down_succeeded_result())
+    service, _stopper, _cleaner = _service(session, cleaner=cleaner)
+
+    await service.stop_workspace(workspace.id, reason="halt blocked pause")
+
+    cleared = _blocked_attention_cleared(await _events(session, workspace.id))
+    assert len(cleared) == 1
+    assert cleared[0].payload["source"] == "blocked"
+
+
+@pytest.mark.unit
+async def test_destroy_blocked_workspace_with_force_emits_attention_cleared(
+    session: AsyncSession,
+) -> None:
+    """Forced destroy from blocked routes through cancelled and must clear attention."""
+    workspace = await _seed_blocked_attention(session)
+    cleaner = RecordingCleaner(result=compose_down_succeeded_result())
+    service, _stopper, _cleaner = _service(session, cleaner=cleaner)
+
+    await service.destroy_workspace(
+        workspace.id,
+        force=True,
+        remove_volumes=True,
+        remove_worktree=True,
+    )
+
+    cleared = _blocked_attention_cleared(await _events(session, workspace.id))
+    assert len(cleared) == 1
+    assert cleared[0].payload["block_reason_code"] == "QUALITY_GATE_POLICY_CHANGED"
+
+
+@pytest.mark.unit
+async def test_cancel_non_blocked_workspace_does_not_emit_blocked_attention_cleared(
+    session: AsyncSession,
+) -> None:
+    """Cancel from a non-blocked status must not emit blocked-source attention_cleared."""
+    workspace = await _workspace(session, status=WorkspaceStatus.running)
+    service, _stopper, _cleaner = _service(session)
+
+    await service.cancel_workspace(
+        workspace.id,
+        reason="normal cancel",
+        stop_stack=False,
+    )
+
+    assert _blocked_attention_cleared(await _events(session, workspace.id)) == []


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_5b31af801a2a4458876020b8` (agent: `cursor`, model: `auto`, effort: `xhigh`).


### Task
Environment notes: /workspace is agent-workspace-fabric (AWF Core, FastAPI + async worker + Postgres). Profile handles deps + validation (pytest). Relevant code: workspace attention state lives on the workspace model (db/models.py ~320: awaiting_human_since/awaiting_human_reason; ~252-276: block_reason_code/block_type/block_violations), surfaced on read schemas (api/schemas.py ~980,1205); the monitoring_pr attention flip happens in the monitor/observability path (service/workspace_observability.py ~341; runtime/pr_monitor.py OperatorHint). WorkspaceEvent emission + event types: see the events model/service and common/callback_events.py (public callback allowlist, lines ~12-18).

What to do — AIRA-T490, typed escalation events:
1. Emit a first-class WorkspaceEvent when a workspace ENTERS needs-human attention during monitoring_pr (event_type "workspace.attention_required") and when attention CLEARS ("workspace.attention_cleared"). Payload: {reason, source: "monitoring_pr", pr_url if known}. Emit exactly once per flip (no per-poll re-emission).
2. Also emit "workspace.attention_required" with source "blocked" + {block_reason_code, block_type} when a workspace enters blocked status with those fields set (protected-gate class), and attention_cleared when unblocked/resumed.
3. Add both event types to the public callback event allowlist in common/callback_events.py so callback subscribers can receive them.
4. Keep the existing read-model fields unchanged (attention_required etc. on schemas) — this task adds the EVENT representation only.
5. Document the two event types + payload fields in docs/REST_API_REFERENCE.md alongside the existing event documentation.
6. Tests: event emitted on attention flip (once), on clear, on blocked-with-reason; callback allowlist accepts the new types; no event storm on repeated polls while attention persists.

What to optimize for: match existing event-emission idioms exactly (however workspace.state_changed is emitted, do it that way); additive-only — no schema/read-model changes.

git works in /workspace — commit before exiting. Do not push — AWF handles it.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent attention set/clear, worker claim/restore, and operator terminal paths; logic is concurrency-heavy but additive events with broad unit coverage limit blast radius.
> 
> **Overview**
> Adds **first-class workspace timeline events** for human-attention episodes so integrators can subscribe via callbacks instead of polling `awaiting_human_*` or `block_*` fields.
> 
> **`workspace.attention_required` / `workspace.attention_cleared`** are emitted **once per enter/clear flip** (not on every monitor poll). Payloads are typed via `awf.common.attention_events`: **`source: monitoring_pr`** (`reason`, optional `pr_url`) for HUMAN_WAIT on `monitoring_pr`, and **`source: blocked`** (`block_reason_code`, `block_type`, `reason`) for protected-gate pauses. Both types are on the **public callback allowlist** and documented in `REST_API_REFERENCE.md`.
> 
> Emission is wired through **blocked enter** (`blocked_transition`), **blocked resume claim/restore** (`claims`), **monitoring attention set/clear** (guarded SQL + episode fencing in `workspace_repo_attention`), **operator guide** (blocked clear), **cancel/stop/destroy** (blocked clear helper + monitoring attention clear), and **PR monitor terminal fail** (`clear_workspace_attention`). Existing read-model fields are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6aa67de150f4342be50276b677043cb4a1d492f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->