### PR TITLE
Fix antigravity adapter: prompt transport, default model, auth seeding

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -411,7 +411,7 @@ Default agent models and effort are centralized in
 | `claude_code` | `claude-opus-4-8` | `xhigh` passed through to Claude Code |
 | `codex` | `gpt-5.5` | `xhigh` via `model_reasoning_effort` |
 | `cursor` | `sonnet-4-thinking` | `xhigh` uses the thinking-capable model variant; no separate Cursor effort flag |
-| `antigravity` | `gemini-3.1-pro-preview` | Effort accepted/recorded but unmapped in v1 (`agy --effort` exists; mapping deferred) |
+| `antigravity` | `gemini-3.1-pro-preview` | Effort accepted/recorded but never emitted (`agy` rejects `--effort` in API-key mode; OAuth uses composite slugs) |
 | `gemini` | `gemini-3.1-pro-preview` | `xhigh` mapped to Gemini `HIGH` thinking (deprecated personal path; retained for enterprise) |
 | `opencode` | `ollama/kimi-k2.6:cloud` | `xhigh` maps to OpenCode `--variant max --thinking` plus Ollama `think` |
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -411,7 +411,7 @@ Default agent models and effort are centralized in
 | `claude_code` | `claude-opus-4-8` | `xhigh` passed through to Claude Code |
 | `codex` | `gpt-5.5` | `xhigh` via `model_reasoning_effort` |
 | `cursor` | `sonnet-4-thinking` | `xhigh` uses the thinking-capable model variant; no separate Cursor effort flag |
-| `antigravity` | `gemini-3.1-pro-high` | Effort accepted/recorded but unmapped in v1 (`agy --effort` exists; mapping deferred) |
+| `antigravity` | `gemini-3.1-pro-preview` | Effort accepted/recorded but unmapped in v1 (`agy --effort` exists; mapping deferred) |
 | `gemini` | `gemini-3.1-pro-preview` | `xhigh` mapped to Gemini `HIGH` thinking (deprecated personal path; retained for enterprise) |
 | `opencode` | `ollama/kimi-k2.6:cloud` | `xhigh` maps to OpenCode `--variant max --thinking` plus Ollama `think` |
 

--- a/src/awf/adapters/antigravity.py
+++ b/src/awf/adapters/antigravity.py
@@ -24,9 +24,11 @@ only the inner ``agy`` argv uses the ``$(cat)`` bridge.
 
 Auth: agy 1.1.13 reads only ``GEMINI_API_KEY``. API-key mode requires
 ``settings.json`` ``{"modelProvider":"gemini"}`` **and** a non-empty
-``GEMINI_API_KEY``. The preamble seeds that settings file only when
-``GEMINI_API_KEY`` is set — never on ``ANTIGRAVITY_API_KEY`` alone, and never
-by aliasing credentials across env names.
+``GEMINI_API_KEY``. The preamble seeds that settings file when
+``GEMINI_API_KEY`` is set (create if missing; upsert ``modelProvider`` on an
+existing file while preserving unrelated keys) — never on
+``ANTIGRAVITY_API_KEY`` alone, and never by aliasing credentials across env
+names.
 
 Output uses ``stream-json`` so the idle stdout watchdog sees continuous events
 (``text``/``json`` buffer until completion).
@@ -79,18 +81,27 @@ class AntigravityAdapter(AgentAdapter):
         if selected_model:
             model_flag = f" --model {shlex.quote(selected_model)}"
 
-        # Seed modelProvider=gemini only when GEMINI_API_KEY is present —
+        # Seed/upsert modelProvider=gemini only when GEMINI_API_KEY is present —
         # that mode hard-requires GEMINI_API_KEY (agy does not read
         # ANTIGRAVITY_API_KEY). Do not alias credentials across env names.
+        # Missing file: create minimal settings. Existing file: set
+        # modelProvider via jq and preserve unrelated keys.
         # Prompt transport: awf_prompt=$(cat) then -p "$awf_prompt" last.
         script = (
             "set -eu\n"
             'settings_dir="${HOME}/.gemini/antigravity-cli"\n'
             'mkdir -p "$settings_dir"\n'
-            'if [ -n "${GEMINI_API_KEY:-}" ] '
-            '&& [ ! -f "$settings_dir/settings.json" ]; then\n'
-            "  printf '%s\\n' '{\"modelProvider\":\"gemini\"}' "
+            'if [ -n "${GEMINI_API_KEY:-}" ]; then\n'
+            '  if [ ! -f "$settings_dir/settings.json" ]; then\n'
+            "    printf '%s\\n' '{\"modelProvider\":\"gemini\"}' "
             '> "$settings_dir/settings.json"\n'
+            "  else\n"
+            "    jq '.modelProvider = \"gemini\"' "
+            '"$settings_dir/settings.json" '
+            '> "$settings_dir/settings.json.tmp"\n'
+            '    mv "$settings_dir/settings.json.tmp" '
+            '"$settings_dir/settings.json"\n'
+            "  fi\n"
             "fi\n"
             "awf_prompt=$(cat)\n"
             'if [ -z "$awf_prompt" ]; then\n'

--- a/src/awf/adapters/antigravity.py
+++ b/src/awf/adapters/antigravity.py
@@ -18,6 +18,13 @@ Verified ``agy`` 1.1.13 contract (operator evidence; trust over older docs):
   the preamble fails closed above 100000 bytes rather than surfacing noisy
   ``execve`` ``E2BIG``. Empty prompts also fail closed (agy would otherwise
   idle-chat).
+- API-key mode accepts **exactly** the model slugs in
+  ``ANTIGRAVITY_API_KEY_MODE_MODELS`` (agy hardcodes them; e.g.
+  ``gemini-3.7-flash`` exists in the Gemini API but agy rejects it).
+- ``--effort`` is rejected by agy for **all** models in API-key mode. Effort
+  exists only on the OAuth path as composite model slugs (e.g.
+  ``gemini-3.6-flash-high``). AWF still accepts and records effort on the
+  adapter for policy/observability, but never emits ``--effort``.
 
 AWF still streams the wrapped prompt on docker-exec stdin into ``sh -lc``;
 only the inner ``agy`` argv uses the ``$(cat)`` bridge.
@@ -40,6 +47,28 @@ import shlex
 
 from awf.adapters.base import AgentAdapter, register_adapter
 from awf.db.enums import AgentRuntime
+
+# Exact API-key mode model slugs hardcoded by agy 1.1.13. Mirrors the
+# ANTIGRAVITY_VERSION pin in docker/agent-runtime.Dockerfile — re-verify this
+# frozenset when that pin is bumped (agy may add/remove slugs; Gemini API
+# availability is not authoritative).
+ANTIGRAVITY_API_KEY_MODE_MODELS: frozenset[str] = frozenset(
+    {
+        "gemini-3.1-pro-preview",
+        "gemini-3.5-flash",
+        "gemini-3.6-flash",
+    }
+)
+
+
+def _validate_api_key_mode_model(model: str) -> None:
+    """Fail fast when ``model`` is outside agy's API-key allowlist."""
+    if model in ANTIGRAVITY_API_KEY_MODE_MODELS:
+        return
+    valid = ", ".join(sorted(ANTIGRAVITY_API_KEY_MODE_MODELS))
+    raise ValueError(
+        f"antigravity API-key mode does not accept model {model!r}; valid slugs: {valid}"
+    )
 
 
 @register_adapter
@@ -69,18 +98,20 @@ class AntigravityAdapter(AgentAdapter):
         return ("ANTIGRAVITY_API_KEY", "GEMINI_API_KEY")
 
     def _cli_args(self, *, model: str | None) -> list[str]:
-        """Build the agy print-mode command; prompt bridged via ``$(cat)``."""
+        """Build the agy print-mode command; prompt bridged via ``$(cat)``.
+
+        Effort is accepted and recorded on the adapter (``self._default_effort``)
+        for policy/observability, but never emitted as ``--effort``: agy
+        rejects that flag for every model in API-key mode (OAuth uses
+        composite slugs such as ``gemini-3.6-flash-high`` instead).
+        """
         selected_model = model or self._default_model
-        # Effort is accepted and recorded on the adapter but intentionally
-        # unmapped in v1 (no model_selection mapping yet), even though agy
-        # exposes ``--effort``. Keep that axis out of argv until a deliberate
-        # mapping lands in adapters/model_selection.py.
         _ = self._default_effort
 
         model_flag = ""
         if selected_model:
+            _validate_api_key_mode_model(selected_model)
             model_flag = f" --model {shlex.quote(selected_model)}"
-
         # Seed/upsert modelProvider=gemini only when GEMINI_API_KEY is present —
         # that mode hard-requires GEMINI_API_KEY (agy does not read
         # ANTIGRAVITY_API_KEY). Do not alias credentials across env names.

--- a/src/awf/adapters/antigravity.py
+++ b/src/awf/adapters/antigravity.py
@@ -61,14 +61,10 @@ ANTIGRAVITY_API_KEY_MODE_MODELS: frozenset[str] = frozenset(
 )
 
 
-def _validate_api_key_mode_model(model: str) -> None:
-    """Fail fast when ``model`` is outside agy's API-key allowlist."""
-    if model in ANTIGRAVITY_API_KEY_MODE_MODELS:
-        return
+def _api_key_mode_model_reject_message(model: str) -> str:
+    """Human-readable reject text for a model outside the API-key allowlist."""
     valid = ", ".join(sorted(ANTIGRAVITY_API_KEY_MODE_MODELS))
-    raise ValueError(
-        f"antigravity API-key mode does not accept model {model!r}; valid slugs: {valid}"
-    )
+    return f"antigravity API-key mode does not accept model {model!r}; valid slugs: {valid}"
 
 
 @register_adapter
@@ -104,14 +100,28 @@ class AntigravityAdapter(AgentAdapter):
         for policy/observability, but never emitted as ``--effort``: agy
         rejects that flag for every model in API-key mode (OAuth uses
         composite slugs such as ``gemini-3.6-flash-high`` instead).
+
+        Model allowlisting is API-key-mode only. ``_cli_args`` does not know
+        the credential mode (hosted OAuth injects credentials later), so
+        non-allowlisted models pass through into argv and are rejected only
+        inside the ``GEMINI_API_KEY`` shell branch at runtime.
         """
         selected_model = model or self._default_model
         _ = self._default_effort
 
         model_flag = ""
+        api_key_model_reject = ""
         if selected_model:
-            _validate_api_key_mode_model(selected_model)
             model_flag = f" --model {shlex.quote(selected_model)}"
+            if selected_model not in ANTIGRAVITY_API_KEY_MODE_MODELS:
+                # Gate on GEMINI_API_KEY below — OAuth composite slugs must
+                # still reach the runtime when API-key mode is inactive.
+                api_key_model_reject = (
+                    f"  printf '%s\\n' "
+                    f"{shlex.quote(_api_key_mode_model_reject_message(selected_model))} "
+                    ">&2\n"
+                    "  exit 1\n"
+                )
         # Seed/upsert modelProvider=gemini only when GEMINI_API_KEY is present —
         # that mode hard-requires GEMINI_API_KEY (agy does not read
         # ANTIGRAVITY_API_KEY). Do not alias credentials across env names.
@@ -133,6 +143,7 @@ class AntigravityAdapter(AgentAdapter):
             '    mv "$settings_dir/settings.json.tmp" '
             '"$settings_dir/settings.json"\n'
             "  fi\n"
+            f"{api_key_model_reject}"
             "fi\n"
             "awf_prompt=$(cat)\n"
             'if [ -z "$awf_prompt" ]; then\n'

--- a/src/awf/adapters/antigravity.py
+++ b/src/awf/adapters/antigravity.py
@@ -3,12 +3,30 @@
 Uses the official Antigravity CLI ``agy`` binary in print/headless mode.
 Headless docs: https://antigravity.google/docs/cli/headless
 
-AWF streams the wrapped prompt on stdin. ``agy`` 1.1.x rejects ``-p ""`` as an
-empty prompt and has no ``--prompt-file`` flag; a single ``-p <text>`` argv also
-hits the kernel ``MAX_ARG_STRLEN`` (~128KiB) ceiling for large AWF prompts.
-Bare ``-p`` / ``--print`` (no value) accepts the operator prompt on stdin —
-including large payloads — so the shell preamble only seeds AI Studio settings
-and ``exec``s ``agy`` with stdin inherited.
+Verified ``agy`` 1.1.13 contract (operator evidence; trust over older docs):
+
+- ``-p`` / ``--print`` is a **value-consuming** string flag. ``agy -p --model X``
+  makes the prompt the literal string ``--model`` and turns ``X`` into a
+  positional that stops further flag parsing (later flags silently ignored;
+  stdin never read). ``-p`` with no following token errors "flag needs an
+  argument". ``-p -`` sends an empty prompt (stdin ignored).
+- There is **no** bare-``-p``-reads-stdin mode and **no** ``--prompt-file``.
+- The only stdin-compatible transport is a shell bridge: read the AWF prompt
+  with ``awf_prompt=$(cat)``, then pass ``-p "$awf_prompt"`` as the **last**
+  flag pair after all other options.
+- A single argv string hits the kernel ``MAX_ARG_STRLEN`` (~128KiB) ceiling;
+  the preamble fails closed above 100000 bytes rather than surfacing noisy
+  ``execve`` ``E2BIG``. Empty prompts also fail closed (agy would otherwise
+  idle-chat).
+
+AWF still streams the wrapped prompt on docker-exec stdin into ``sh -lc``;
+only the inner ``agy`` argv uses the ``$(cat)`` bridge.
+
+Auth: agy 1.1.13 reads only ``GEMINI_API_KEY``. API-key mode requires
+``settings.json`` ``{"modelProvider":"gemini"}`` **and** a non-empty
+``GEMINI_API_KEY``. The preamble seeds that settings file only when
+``GEMINI_API_KEY`` is set — never on ``ANTIGRAVITY_API_KEY`` alone, and never
+by aliasing credentials across env names.
 
 Output uses ``stream-json`` so the idle stdout watchdog sees continuous events
 (``text``/``json`` buffer until completion).
@@ -49,7 +67,7 @@ class AntigravityAdapter(AgentAdapter):
         return ("ANTIGRAVITY_API_KEY", "GEMINI_API_KEY")
 
     def _cli_args(self, *, model: str | None) -> list[str]:
-        """Build the agy print-mode command; prompt stays on inherited stdin."""
+        """Build the agy print-mode command; prompt bridged via ``$(cat)``."""
         selected_model = model or self._default_model
         # Effort is accepted and recorded on the adapter but intentionally
         # unmapped in v1 (no model_selection mapping yet), even though agy
@@ -61,22 +79,35 @@ class AntigravityAdapter(AgentAdapter):
         if selected_model:
             model_flag = f" --model {shlex.quote(selected_model)}"
 
-        # Seed modelProvider=gemini when an API key is present so headless
-        # AI Studio auth works without an interactive login. Do not alias
-        # ANTIGRAVITY_API_KEY onto GEMINI_API_KEY (explicit over clever).
-        # Bare ``-p`` (no value) enables print mode and reads the operator
-        # prompt from stdin — do not pass ``-p ""`` (empty-prompt error) or a
-        # tempfile pointer (real task would not be the CLI prompt).
+        # Seed modelProvider=gemini only when GEMINI_API_KEY is present —
+        # that mode hard-requires GEMINI_API_KEY (agy does not read
+        # ANTIGRAVITY_API_KEY). Do not alias credentials across env names.
+        # Prompt transport: awf_prompt=$(cat) then -p "$awf_prompt" last.
         script = (
             "set -eu\n"
             'settings_dir="${HOME}/.gemini/antigravity-cli"\n'
             'mkdir -p "$settings_dir"\n'
-            'if [ -n "${ANTIGRAVITY_API_KEY:-}${GEMINI_API_KEY:-}" ] '
+            'if [ -n "${GEMINI_API_KEY:-}" ] '
             '&& [ ! -f "$settings_dir/settings.json" ]; then\n'
             "  printf '%s\\n' '{\"modelProvider\":\"gemini\"}' "
             '> "$settings_dir/settings.json"\n'
             "fi\n"
-            "exec agy -p --dangerously-skip-permissions --output-format stream-json "
-            f"--print-timeout 24h{model_flag}\n"
+            "awf_prompt=$(cat)\n"
+            'if [ -z "$awf_prompt" ]; then\n'
+            "  printf '%s\\n' \"agy prompt is empty; refusing to start idle chat\" >&2\n"
+            "  exit 1\n"
+            "fi\n"
+            # Portable length check (no bash ${#var}); printf '%s' avoids a
+            # trailing newline that would inflate wc -c.
+            "prompt_len=$(printf '%s' \"$awf_prompt\" | wc -c)\n"
+            'if [ "$prompt_len" -gt 100000 ]; then\n'
+            "  printf '%s\\n' "
+            '"agy prompt exceeds 100000 bytes '
+            "(kernel MAX_ARG_STRLEN ~128KiB single-arg ceiling); "
+            'refusing to exec" >&2\n'
+            "  exit 1\n"
+            "fi\n"
+            "exec agy --dangerously-skip-permissions --output-format stream-json "
+            f'--print-timeout 24h{model_flag} -p "$awf_prompt"\n'
         )
         return ["sh", "-lc", script]

--- a/src/awf/adapters/defaults.py
+++ b/src/awf/adapters/defaults.py
@@ -19,10 +19,10 @@ DEFAULT_AGENT_DEFAULTS: Mapping[AgentRuntime, AgentDefaults] = MappingProxyType(
         # Gemini CLI 0.39+ documents Gemini 3.1 Pro Preview as the direct
         # Pro-class model ID when the account has access.
         AgentRuntime.gemini: AgentDefaults(model="gemini-3.1-pro-preview", effort="xhigh"),
-        # Antigravity CLI headless model list (agy models / docs) uses
-        # gemini-3.1-pro-high as the Pro-class slug. Effort is recorded but
+        # Antigravity CLI headless model list (agy models) uses
+        # gemini-3.1-pro-preview as the Pro-class slug. Effort is recorded but
         # unmapped in v1 (agy --effort exists; mapping deferred).
-        AgentRuntime.antigravity: AgentDefaults(model="gemini-3.1-pro-high", effort="xhigh"),
+        AgentRuntime.antigravity: AgentDefaults(model="gemini-3.1-pro-preview", effort="xhigh"),
         AgentRuntime.opencode: AgentDefaults(model="ollama/kimi-k2.6:cloud", effort="xhigh"),
         # The Grok Build CLI reports grok-build as the current default coding model.
         AgentRuntime.grok: AgentDefaults(model="grok-build", effort="xhigh"),

--- a/src/awf/adapters/defaults.py
+++ b/src/awf/adapters/defaults.py
@@ -19,9 +19,11 @@ DEFAULT_AGENT_DEFAULTS: Mapping[AgentRuntime, AgentDefaults] = MappingProxyType(
         # Gemini CLI 0.39+ documents Gemini 3.1 Pro Preview as the direct
         # Pro-class model ID when the account has access.
         AgentRuntime.gemini: AgentDefaults(model="gemini-3.1-pro-preview", effort="xhigh"),
-        # Antigravity CLI headless model list (agy models) uses
-        # gemini-3.1-pro-preview as the Pro-class slug. Effort is recorded but
-        # unmapped in v1 (agy --effort exists; mapping deferred).
+        # Antigravity API-key mode (agy 1.1.13) accepts exactly the slugs in
+        # ANTIGRAVITY_API_KEY_MODE_MODELS; gemini-3.1-pro-preview is the
+        # Pro-class default. Effort is accepted/recorded but never emitted:
+        # agy rejects --effort for all models in API-key mode (OAuth-only
+        # composite slugs such as gemini-3.6-flash-high).
         AgentRuntime.antigravity: AgentDefaults(model="gemini-3.1-pro-preview", effort="xhigh"),
         AgentRuntime.opencode: AgentDefaults(model="ollama/kimi-k2.6:cloud", effort="xhigh"),
         # The Grok Build CLI reports grok-build as the current default coding model.

--- a/src/awf/adapters/provider_failures.py
+++ b/src/awf/adapters/provider_failures.py
@@ -44,9 +44,10 @@ _AUTH_FAILURE_MARKERS = (
     "cursor api key",
     "cursor auth",
     "cursor authentication",
-    "antigravity_api_key",
-    "antigravity api key",
-    "antigravity auth",
+    # agy 1.1.13 observed stderr (OAuth-only default / missing GEMINI_API_KEY).
+    # Dead antigravity_api_key markers dropped — agy never prints that name.
+    "authentication required. run 'agy' to log in",
+    "gemini_api_key environment variable is not set",
     "gemini_api_key",
     "google_api_key",
     "google_genai_use_vertexai",

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -976,7 +976,7 @@ class TestCentralDefaults:
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.codex].model == "gpt-5.5"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.cursor].model == "sonnet-4-thinking"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.gemini].model == "gemini-3.1-pro-preview"
-        assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.antigravity].model == "gemini-3.1-pro-high"
+        assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.antigravity].model == "gemini-3.1-pro-preview"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.opencode].model == "ollama/kimi-k2.6:cloud"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.grok].model == "grok-build"
         assert {d.effort for d in DEFAULT_AGENT_DEFAULTS.values()} == {"xhigh"}

--- a/tests/unit/adapters/test_antigravity_adapter.py
+++ b/tests/unit/adapters/test_antigravity_adapter.py
@@ -237,29 +237,125 @@ class TestAntigravityAdapter:
         script = _render_cli_script(model=model)
         assert f"--model {model}" in script
         assert "--effort" not in script
+        # Allowlisted models must not embed a GEMINI_API_KEY-gated reject.
+        assert "API-key mode does not accept model" not in script
 
     @pytest.mark.unit
-    def test_api_key_mode_allowlist_rejects_gemini_3_7_flash(self) -> None:
-        """gemini-3.7-flash exists in Gemini API but agy 1.1.13 rejects it."""
-        with pytest.raises(ValueError, match=r"gemini-3\.7-flash") as exc:
-            _render_cli_script(model="gemini-3.7-flash")
-        message = str(exc.value)
-        assert "gemini-3.1-pro-preview" in message
-        assert "gemini-3.5-flash" in message
-        assert "gemini-3.6-flash" in message
+    def test_oauth_composite_model_slug_passes_through_cli_args(self) -> None:
+        """OAuth composite slugs must not be rejected at Python argv-build time."""
+        script = _render_cli_script(model="gemini-3.6-flash-high")
+        assert "--model gemini-3.6-flash-high" in script
+        # Reject is deferred to the GEMINI_API_KEY branch (API-key mode only).
+        assert "API-key mode does not accept model" in script
 
     @pytest.mark.unit
-    def test_api_key_mode_allowlist_rejects_unknown_model(self) -> None:
-        """Unknown model slugs fail fast with the valid allowlist listed."""
-        with pytest.raises(ValueError, match=r"not-a-real-model") as exc:
-            _render_cli_script(model="not-a-real-model")
-        message = str(exc.value)
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-3.7-flash",
+            "not-a-real-model",
+            "gemini-3.6-flash-high",
+        ],
+    )
+    async def test_api_key_mode_allowlist_rejects_outside_slugs_at_runtime(
+        self,
+        tmp_path: Path,
+        model: str,
+    ) -> None:
+        """API-key mode (GEMINI_API_KEY set) rejects models outside the allowlist."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text("#!/bin/sh\nexit 0\n")
+        fake_agy.chmod(0o755)
+
+        script = _render_cli_script(model=model)
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "HOME": str(home),
+                "GEMINI_API_KEY": "test-key-triggers-api-key-mode",
+            }
+        )
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write(b"prompt\n")
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+
+        assert proc.returncode == 1
+        message = stderr.decode()
+        assert model in message
+        assert "API-key mode does not accept model" in message
         for slug in (
             "gemini-3.1-pro-preview",
             "gemini-3.5-flash",
             "gemini-3.6-flash",
         ):
             assert slug in message
+
+    @pytest.mark.unit
+    async def test_oauth_composite_slug_runs_without_gemini_api_key(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Without GEMINI_API_KEY, OAuth composite slugs must reach agy."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        argv_copy = tmp_path / "argv.json"
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "with open(os.environ['AWF_FAKE_AGY_ARGV'], 'w', encoding='utf-8') as fh:\n"
+            "    json.dump(sys.argv[1:], fh)\n"
+        )
+        fake_agy.chmod(0o755)
+
+        script = _render_cli_script(model="gemini-3.6-flash-high")
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.pop("GEMINI_API_KEY", None)
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "HOME": str(home),
+                "AWF_FAKE_AGY_ARGV": str(argv_copy),
+            }
+        )
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write(b"oauth prompt\n")
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+
+        assert proc.returncode == 0, stderr.decode()
+        captured = json.loads(argv_copy.read_text())
+        assert captured[captured.index("--model") + 1] == "gemini-3.6-flash-high"
 
     @pytest.mark.unit
     async def test_sh_stub_receives_prompt_as_final_p_value(self, tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_antigravity_adapter.py
+++ b/tests/unit/adapters/test_antigravity_adapter.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+import os
+import re
+from pathlib import Path
+
 import pytest
 import structlog
 
@@ -19,6 +25,18 @@ from .test_adapters import (
 )
 
 
+def _render_cli_script(*, model: str | None = "gemini-3.1-pro-preview") -> str:
+    """Return the shell preamble from ``_cli_args`` without docker."""
+    adapter = AntigravityAdapter(
+        runner=FakeCommandRunner(),
+        default_model=model,
+        default_effort="xhigh",
+    )
+    args = adapter._cli_args(model=model)
+    assert args[:2] == ["sh", "-lc"]
+    return args[2]
+
+
 class TestAntigravityAdapter:
     """Antigravity adapter contract tests."""
 
@@ -27,7 +45,7 @@ class TestAntigravityAdapter:
         """Antigravity reports its own provider — never google/gemini."""
         adapter = AntigravityAdapter(runner=FakeCommandRunner())
 
-        assert adapter.get_provider("gemini-3.1-pro-high") == "antigravity"
+        assert adapter.get_provider("gemini-3.1-pro-preview") == "antigravity"
 
     @pytest.mark.unit
     def test_hosted_env_passthrough_names_are_antigravity_and_gemini_keys(self) -> None:
@@ -42,11 +60,11 @@ class TestAntigravityAdapter:
 
     @pytest.mark.unit
     async def test_produces_correct_default_cli_invocation(self) -> None:
-        """Default run uses shell preamble, bare -p, skip-permissions, stream-json."""
+        """Default run uses $(cat) prompt bridge; -p is the final flag pair."""
         runner = FakeCommandRunner()
         adapter = AntigravityAdapter(
             runner=runner,
-            default_model="gemini-3.1-pro-high",
+            default_model="gemini-3.1-pro-preview",
             default_effort="xhigh",
         )
 
@@ -60,21 +78,42 @@ class TestAntigravityAdapter:
         _assert_docker_exec_prefix(args)
         assert args[-3:-1] == ["sh", "-lc"]
         script = args[-1]
-        # Bare -p (no argv prompt value): AWF streams the real task on stdin.
-        # Do not use -p "" (agy treats that as an empty prompt) or a tempfile pointer.
+        assert "awf_prompt=$(cat)" in script
+        assert "empty" in script.lower() or "prompt" in script.lower()
+        assert "100000" in script
+        assert "MAX_ARG_STRLEN" in script or "128" in script
         assert 'cat > "$prompt_path"' not in script
         assert "Read and execute the full task prompt" not in script
-        assert "exec agy -p --dangerously-skip-permissions" in script
-        assert 'agy -p "' not in script
-        assert "agy -p ''" not in script
-        assert 'agy -p ""' not in script
+        # Options before -p; prompt last. Never -p immediately followed by a flag.
+        assert re.search(r"(?m)-p\s+--", script) is None
+        assert re.search(r'(?m)exec\s+agy\b.*-p\s+"\$awf_prompt"\s*$', script, re.S)
+        assert "--dangerously-skip-permissions" in script
         assert "--output-format stream-json" in script
         assert "--print-timeout 24h" in script
-        assert "--model gemini-3.1-pro-high" in script
+        assert "--model gemini-3.1-pro-preview" in script
         assert "--effort" not in script
         assert "modelProvider" in script
         _assert_prompt_not_in_argv(args)
         _assert_prompt_sent_on_stdin(runner)
+
+    @pytest.mark.unit
+    def test_cli_script_guards_empty_and_oversize_prompt(self) -> None:
+        """Preamble must fail closed on empty or oversize stdin prompts."""
+        script = _render_cli_script()
+        assert "awf_prompt=$(cat)" in script
+        assert "100000" in script
+        assert "MAX_ARG_STRLEN" in script or "128KiB" in script or "128" in script
+        # Empty guard exits non-zero with a stderr message.
+        assert "printf" in script
+        assert "exit 1" in script or "exit 2" in script
+
+    @pytest.mark.unit
+    def test_settings_seed_keyed_on_gemini_api_key_only(self) -> None:
+        """modelProvider=gemini seed requires GEMINI_API_KEY; not ANTIGRAVITY_API_KEY."""
+        script = _render_cli_script()
+        assert '[ -n "${GEMINI_API_KEY:-}" ]' in script
+        assert "ANTIGRAVITY_API_KEY:-}${GEMINI_API_KEY" not in script
+        assert "${ANTIGRAVITY_API_KEY:-}${GEMINI_API_KEY" not in script
 
     @pytest.mark.unit
     async def test_no_model_omits_model_flag(self) -> None:
@@ -93,12 +132,12 @@ class TestAntigravityAdapter:
         assert "--dangerously-skip-permissions" in script
 
     @pytest.mark.unit
-    async def test_model_override_is_passed_without_prompt_argv(self) -> None:
-        """Explicit models are passed while prompts remain stdin-only."""
+    async def test_model_override_is_passed_without_prompt_in_docker_argv(self) -> None:
+        """Explicit models are passed; docker-exec argv still omits the prompt."""
         runner = FakeCommandRunner()
         adapter = AntigravityAdapter(
             runner=runner,
-            default_model="gemini-3.1-pro-high",
+            default_model="gemini-3.1-pro-preview",
             default_effort="xhigh",
         )
 
@@ -106,13 +145,14 @@ class TestAntigravityAdapter:
             compose_project=_COMPOSE_PROJECT,
             compose_file=_COMPOSE_FILE,
             prompt=_PROMPT,
-            model="gemini-3.7-flash-high",
+            model="gemini-3.6-flash",
         )
 
         args = runner.calls[0].args
         script = args[-1]
-        assert "--model gemini-3.7-flash-high" in script
-        assert "--model gemini-3.1-pro-high" not in script
+        assert "--model gemini-3.6-flash" in script
+        assert "--model gemini-3.1-pro-preview" not in script
+        assert '-p "$awf_prompt"' in script
         _assert_prompt_not_in_argv(args)
         _assert_prompt_sent_on_stdin(runner)
 
@@ -122,7 +162,7 @@ class TestAntigravityAdapter:
         runner = FakeCommandRunner()
         adapter = AntigravityAdapter(
             runner=runner,
-            default_model="gemini-3.1-pro-high",
+            default_model="gemini-3.1-pro-preview",
             default_effort="high",
         )
 
@@ -137,16 +177,135 @@ class TestAntigravityAdapter:
         assert "--effort" not in script
 
     @pytest.mark.unit
+    async def test_sh_stub_receives_prompt_as_final_p_value(self, tmp_path: Path) -> None:
+        """Functional sh bridge: stub agy argv ends with -p <prompt>; flags intact."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        argv_copy = tmp_path / "argv.json"
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, os, sys\n"
+            "with open(os.environ['AWF_FAKE_AGY_ARGV'], 'w', encoding='utf-8') as fh:\n"
+            "    json.dump(sys.argv[1:], fh)\n"
+        )
+        fake_agy.chmod(0o755)
+
+        script = _render_cli_script(model="gemini-3.1-pro-preview")
+        # Skip settings seeding side effects in HOME; use an empty HOME.
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "HOME": str(home),
+                "AWF_FAKE_AGY_ARGV": str(argv_copy),
+                "GEMINI_API_KEY": "test-key-not-used-by-stub",
+            }
+        )
+        # Trailing newlines are stripped by $(cat) (POSIX command substitution);
+        # that matches the verified online agy transport shape.
+        prompt = "line one\nline two with 'quotes' and spaces"
+        # Use sh -c (not -lc): login shells reset PATH and would hit the real agy.
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write((prompt + "\n").encode())
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+
+        assert proc.returncode == 0, stderr.decode()
+        captured = json.loads(argv_copy.read_text())
+        assert captured[-2:] == ["-p", prompt]
+        assert "--dangerously-skip-permissions" in captured
+        assert captured[captured.index("--output-format") + 1] == "stream-json"
+        assert captured[captured.index("--print-timeout") + 1] == "24h"
+        assert captured[captured.index("--model") + 1] == "gemini-3.1-pro-preview"
+
+    @pytest.mark.unit
+    async def test_sh_stub_rejects_empty_prompt(self, tmp_path: Path) -> None:
+        """Empty stdin must exit non-zero before exec'ing agy."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text("#!/bin/sh\necho should-not-run >&2\nexit 0\n")
+        fake_agy.chmod(0o755)
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update({"PATH": f"{bin_dir}:{env['PATH']}", "HOME": str(home)})
+        script = _render_cli_script()
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+        assert proc.returncode != 0
+        assert b"should-not-run" not in stderr
+        assert b"empty" in stderr.lower() or b"prompt" in stderr.lower()
+
+    @pytest.mark.unit
+    async def test_sh_stub_rejects_oversize_prompt(self, tmp_path: Path) -> None:
+        """Oversize stdin must exit non-zero naming the MAX_ARG_STRLEN ceiling."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text("#!/bin/sh\necho should-not-run >&2\nexit 0\n")
+        fake_agy.chmod(0o755)
+        home = tmp_path / "home"
+        home.mkdir()
+        env = os.environ.copy()
+        env.update({"PATH": f"{bin_dir}:{env['PATH']}", "HOME": str(home)})
+        script = _render_cli_script()
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write(b"x" * 100001)
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+        assert proc.returncode != 0
+        assert b"should-not-run" not in stderr
+        assert b"100000" in stderr
+        assert b"MAX_ARG_STRLEN" in stderr or b"128" in stderr
+
+    @pytest.mark.unit
     async def test_auth_failure_classifies_as_agent_auth_failed(self) -> None:
-        """Auth marker text classifies to generic AGENT_AUTH_FAILED (not ANTIGRAVITY_*)."""
+        """Real agy auth marker text classifies to generic AGENT_AUTH_FAILED."""
         runner = FakeCommandRunner()
         runner.queue_result(
             returncode=1,
-            stderr="authentication required: antigravity_api_key rejected",
+            stderr="Error: authentication required. Run 'agy' to log in, then retry.",
         )
         adapter = AntigravityAdapter(
             runner=runner,
-            default_model="gemini-3.1-pro-high",
+            default_model="gemini-3.1-pro-preview",
             default_effort="xhigh",
         )
 
@@ -162,10 +321,11 @@ class TestAntigravityAdapter:
 
         assert exc.value.reason_code == "AGENT_AUTH_FAILED"
         assert exc.value.details["provider"] == "antigravity"
-        assert exc.value.details["model"] == "gemini-3.1-pro-high"
+        assert exc.value.details["model"] == "gemini-3.1-pro-preview"
         provider_recovery = exc.value.details["provider_recovery"]
         assert provider_recovery["provider"] == "antigravity"
         assert any(
-            event.get("event") == "agent.run.start" and event.get("model") == "gemini-3.1-pro-high"
+            event.get("event") == "agent.run.start"
+            and event.get("model") == "gemini-3.1-pro-preview"
             for event in captured
         )

--- a/tests/unit/adapters/test_antigravity_adapter.py
+++ b/tests/unit/adapters/test_antigravity_adapter.py
@@ -116,6 +116,53 @@ class TestAntigravityAdapter:
         assert "${ANTIGRAVITY_API_KEY:-}${GEMINI_API_KEY" not in script
 
     @pytest.mark.unit
+    async def test_settings_updates_existing_non_gemini_provider(self, tmp_path: Path) -> None:
+        """GEMINI_API_KEY mode rewrites modelProvider while preserving other settings."""
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        fake_agy = bin_dir / "agy"
+        fake_agy.write_text("#!/bin/sh\nexit 0\n")
+        fake_agy.chmod(0o755)
+
+        home = tmp_path / "home"
+        settings = home / ".gemini" / "antigravity-cli" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text(
+            '{"modelProvider":"vertexai","other":"preserve"}\n',
+            encoding="utf-8",
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{bin_dir}:{env['PATH']}",
+                "HOME": str(home),
+                "GEMINI_API_KEY": "test-key",
+            }
+        )
+        script = _render_cli_script()
+        proc = await asyncio.create_subprocess_exec(
+            "sh",
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        assert proc.stdin is not None
+        proc.stdin.write(b"ok\n")
+        await proc.stdin.drain()
+        proc.stdin.close()
+        await proc.stdin.wait_closed()
+        _stdout, stderr = await proc.communicate()
+
+        assert proc.returncode == 0, stderr.decode()
+        updated = json.loads(settings.read_text(encoding="utf-8"))
+        assert updated["modelProvider"] == "gemini"
+        assert updated["other"] == "preserve"
+
+    @pytest.mark.unit
     async def test_no_model_omits_model_flag(self) -> None:
         """Without a model default/override, --model is omitted."""
         runner = FakeCommandRunner()

--- a/tests/unit/adapters/test_antigravity_adapter.py
+++ b/tests/unit/adapters/test_antigravity_adapter.py
@@ -205,7 +205,7 @@ class TestAntigravityAdapter:
 
     @pytest.mark.unit
     async def test_effort_is_accepted_but_unmapped_into_cli_args(self) -> None:
-        """Effort is recorded on the adapter but never mapped to --effort in v1."""
+        """Effort is recorded on the adapter but never emitted; agy rejects --effort."""
         runner = FakeCommandRunner()
         adapter = AntigravityAdapter(
             runner=runner,
@@ -222,6 +222,44 @@ class TestAntigravityAdapter:
         assert adapter._default_effort == "high"
         script = runner.calls[0].args[-1]
         assert "--effort" not in script
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "model",
+        [
+            "gemini-3.1-pro-preview",
+            "gemini-3.5-flash",
+            "gemini-3.6-flash",
+        ],
+    )
+    def test_api_key_mode_allowlist_accepts_exact_slugs(self, model: str) -> None:
+        """agy 1.1.13 API-key mode accepts exactly these three model slugs."""
+        script = _render_cli_script(model=model)
+        assert f"--model {model}" in script
+        assert "--effort" not in script
+
+    @pytest.mark.unit
+    def test_api_key_mode_allowlist_rejects_gemini_3_7_flash(self) -> None:
+        """gemini-3.7-flash exists in Gemini API but agy 1.1.13 rejects it."""
+        with pytest.raises(ValueError, match=r"gemini-3\.7-flash") as exc:
+            _render_cli_script(model="gemini-3.7-flash")
+        message = str(exc.value)
+        assert "gemini-3.1-pro-preview" in message
+        assert "gemini-3.5-flash" in message
+        assert "gemini-3.6-flash" in message
+
+    @pytest.mark.unit
+    def test_api_key_mode_allowlist_rejects_unknown_model(self) -> None:
+        """Unknown model slugs fail fast with the valid allowlist listed."""
+        with pytest.raises(ValueError, match=r"not-a-real-model") as exc:
+            _render_cli_script(model="not-a-real-model")
+        message = str(exc.value)
+        for slug in (
+            "gemini-3.1-pro-preview",
+            "gemini-3.5-flash",
+            "gemini-3.6-flash",
+        ):
+            assert slug in message
 
     @pytest.mark.unit
     async def test_sh_stub_receives_prompt_as_final_p_value(self, tmp_path: Path) -> None:

--- a/tests/unit/adapters/test_provider_failures.py
+++ b/tests/unit/adapters/test_provider_failures.py
@@ -13,6 +13,43 @@ from awf.adapters.provider_failures import (
 )
 
 
+def test_classifies_antigravity_agy_auth_required_marker() -> None:
+    """agy 1.1.13 OAuth-only stderr classifies as AGENT_AUTH_FAILED."""
+    classification = classify_provider_failure(
+        reason_code=None,
+        stdout="",
+        stderr="Error: authentication required. Run 'agy' to log in, then retry.",
+        provider="antigravity",
+        model="gemini-3.1-pro-preview",
+    )
+
+    assert classification is not None
+    assert classification.reason_code == AGENT_AUTH_FAILED
+    assert classification.failure_type == "auth"
+    assert classification.provider == "antigravity"
+    assert classification.retryable is True
+
+
+def test_classifies_antigravity_missing_gemini_api_key_marker() -> None:
+    """agy 1.1.13 missing GEMINI_API_KEY stderr classifies as AGENT_AUTH_FAILED."""
+    classification = classify_provider_failure(
+        reason_code=None,
+        stdout="",
+        stderr=(
+            'modelProvider is set to "gemini" in settings.json, but the '
+            "GEMINI_API_KEY environment variable is not set."
+        ),
+        provider="antigravity",
+        model="gemini-3.1-pro-preview",
+    )
+
+    assert classification is not None
+    assert classification.reason_code == AGENT_AUTH_FAILED
+    assert classification.failure_type == "auth"
+    assert classification.provider == "antigravity"
+    assert classification.retryable is True
+
+
 def test_classifies_gemini_auth_failure_and_redacts_secret_fingerprint() -> None:
     classification = classify_provider_failure(
         reason_code=None,

--- a/tests/unit/adapters/test_provider_failures.py
+++ b/tests/unit/adapters/test_provider_failures.py
@@ -30,6 +30,22 @@ def test_classifies_antigravity_agy_auth_required_marker() -> None:
     assert classification.retryable is True
 
 
+def test_classifies_agy_auth_required_without_provider_metadata() -> None:
+    """Command-result path (provider=None, model=None) still classifies agy auth."""
+    classification = classify_provider_failure(
+        reason_code=None,
+        stdout="",
+        stderr="Error: authentication required. Run 'agy' to log in, then retry.",
+        provider=None,
+        model=None,
+    )
+
+    assert classification is not None
+    assert classification.reason_code == AGENT_AUTH_FAILED
+    assert classification.failure_type == "auth"
+    assert classification.retryable is True
+
+
 def test_classifies_antigravity_missing_gemini_api_key_marker() -> None:
     """agy 1.1.13 missing GEMINI_API_KEY stderr classifies as AGENT_AUTH_FAILED."""
     classification = classify_provider_failure(

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
@@ -419,7 +419,7 @@ def test_selected_antigravity_preflight_requires_env_key_and_runtime_cli(
 
     assert result["provider"] == "antigravity"
     assert result["agent"] == "antigravity"
-    assert result["model"] == "gemini-3.1-pro-high"
+    assert result["model"] == "gemini-3.1-pro-preview"
     assert result["readiness_status"] == "ready"
     assert result["auth_status"] == "ok"
     assert result["auth_source"] == "ANTIGRAVITY_API_KEY"
@@ -443,7 +443,7 @@ def test_selected_antigravity_preflight_blocks_missing_env_key(tmp_path: Path) -
 
     assert result["provider"] == "antigravity"
     assert result["agent"] == "antigravity"
-    assert result["model"] == "gemini-3.1-pro-high"
+    assert result["model"] == "gemini-3.1-pro-preview"
     assert result["readiness_status"] == "blocked"
     assert result["auth_status"] == "fail"
     assert result["auth_source"] == "not_observed"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_3393601659b14ae4a04b0427` (agent: `cursor`, model: `auto`, effort: `xhigh`).


### Task
Fix three empirically-verified bugs in the Antigravity (agy) adapter that PR #810 shipped. The operator ran the post-merge dogfood plus an offline/online contract matrix against agy 1.1.13 (the latest release, published 2026-08-14) inside the awf-agent-runtime image; every claim below is observed behavior, not speculation. STRICT TDD: failing test first per bug, then the smallest green change. 99% aggregate coverage stands.

VERIFIED CONTRACT OF agy 1.1.13 (operator evidence, trust over any doc/comment):
- `-p`/`--print` is a VALUE-CONSUMING string flag. `agy -p --model X` makes the prompt the literal string "--model" and turns "X" into a positional arg that STOPS flag parsing (later flags silently ignored; stdin never read). `-p` with no following token errors "flag needs an argument". `-p -` sends an EMPTY prompt (stdin ignored). There is NO bare-`-p`-reads-stdin mode and NO --prompt-file flag. The ONLY stdin-compatible transport is a shell bridge: prompt=$(cat) then pass -p "$prompt" as the LAST flag. Verified end-to-end online: `agy --model gemini-3.1-pro-preview --output-format stream-json --print-timeout 120s -p "$(cat)"` returned stream-json events (init, step_update..., result SUCCESS).
- Model slugs (from `agy models`): gemini-3.1-pro-preview, gemini-3.5-flash, gemini-3.6-flash. The shipped default "gemini-3.1-pro-high" does NOT exist -> every workspace dies with "invalid model selection" (observed in dogfood ws_f88fd425da8f4206b4b202c1, reason AGENT_CLI_FAILED).
- Auth: agy 1.1.13 reads ONLY GEMINI_API_KEY (support added in this very release per its changelog; the string ANTIGRAVITY_API_KEY does not appear in the binary at all). API-key mode requires settings.json {"modelProvider":"gemini"} AND non-empty GEMINI_API_KEY. With modelProvider=gemini but no GEMINI_API_KEY, agy exits with: `modelProvider is set to "gemini" in settings.json, but the GEMINI_API_KEY environment variable is not set.` Without modelProvider=gemini, headless auth fails with: `Error: authentication required. Run 'agy' to log in, then retry.` (OAuth-only default backend).

BUG 1 - src/awf/adapters/antigravity.py _cli_args script, prompt transport:
Current script runs `exec agy -p --dangerously-skip-permissions --output-format stream-json --print-timeout 24h{model_flag}` -> the agent receives the literal prompt "--dangerously-skip-permissions" and the real task on stdin is discarded.
Fix the preamble script to:
  1. read the AWF prompt from stdin into a shell variable: awf_prompt=$(cat)
  2. guard emptiness: empty prompt -> printf a clear error to stderr and exit non-zero (agy would otherwise idle-chat).
  3. guard size: if ${#awf_prompt} exceeds 100000 bytes, printf a clear error naming the kernel MAX_ARG_STRLEN (~128KiB single-arg) ceiling to stderr and exit non-zero (loud failure beats execve E2BIG noise). Use a portable length check (wc -c on a printf, not bashisms - script runs under sh).
  4. exec agy with ALL option flags BEFORE the prompt and the prompt LAST: exec agy --dangerously-skip-permissions --output-format stream-json --print-timeout 24h{model_flag} -p "$awf_prompt"
Rewrite the module docstring to document the verified contract above (value-consuming -p, no stdin mode, no --prompt-file, the $(cat) bridge + size guard rationale) - the current docstring asserts a bare-`-p` stdin mode that does not exist.

BUG 2 - src/awf/adapters/defaults.py: default antigravity model "gemini-3.1-pro-high" -> "gemini-3.1-pro-preview". Update any tests pinning the old slug.

BUG 3 - src/awf/adapters/antigravity.py settings seeding: the preamble currently writes {"modelProvider":"gemini"} when ANTIGRAVITY_API_KEY OR GEMINI_API_KEY is present, but that mode hard-requires GEMINI_API_KEY specifically - with only ANTIGRAVITY_API_KEY set, agy exits with the "GEMINI_API_KEY ... is not set" error. Key the seed on non-empty GEMINI_API_KEY ONLY. Do NOT alias/copy ANTIGRAVITY_API_KEY into GEMINI_API_KEY inside the adapter (operator decision: no credential aliasing across env names - explicit over clever; the operator provisions GEMINI_API_KEY in the service env directly).

ALSO (same evidence, small):
- adapters/provider_failures.py _AUTH_FAILURE_MARKERS: the shipped ANTIGRAVITY_API_KEY marker string can never fire (agy never prints that name). Add the two REAL auth-failure markers observed above: "authentication required. Run 'agy' to log in" and `GEMINI_API_KEY environment variable is not set`. Keep the existing generic markers; you may leave the dead marker in place or drop it - prefer dropping dead code, note the choice in the PR description.
- Keep hosted_env_passthrough_names, clarification env-name maps, compose_auth_env, readiness surfaces AS-IS (both env names). The naming retirement of ANTIGRAVITY_API_KEY across AWF surfaces is a separately-decided follow-up - do not widen into it.

TESTS (failing-first, mirroring tests/unit/adapters/test_antigravity_adapter.py):
- rendered script places -p as the FINAL token pair with the shell variable (regression for Bug 1); asserts no `-p` immediately followed by another flag token anywhere in the script.
- rendered script contains the empty-prompt and oversize-prompt guards.
- default model equals gemini-3.1-pro-preview.
- settings seed conditioned on GEMINI_API_KEY only (regression for Bug 3).
- auth-marker classification for both new marker strings -> AGENT_AUTH_FAILED.
- a functional sh-level test would be ideal if a cheap one exists in the suite's style (e.g. run the rendered script with agy stubbed by a shell script capturing argv, feeding stdin, asserting the prompt arrives as the -p value and flags are intact); follow existing adapter test patterns - do not invent new infra.

CONSTRAINTS: do NOT touch pyproject.toml, .github/workflows/**, .awf/workspace.yml, docker/compose/local-service.yml, .env.example, docker/agent-runtime.Dockerfile (the agy 1.1.13 pin is correct and checksum-verified). Keep files under the 1500-line guardrail. Full local gate before finishing (ruff check, ruff format --check, mypy no-path-args, pytest with coverage). openapi.json should be unchanged (no schema surface touched) - verify with the drift check rather than regenerate blindly. PR description: summarize the three bugs with the observed error strings and the verified transport contract. git works in /workspace - commit per TDD slice; do not push, AWF handles push/PR.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every Antigravity workspace invokes agy and gates API-key auth/models; wrong shell or allowlist logic would break all antigravity runs, but behavior is heavily covered by new contract tests.
> 
> **Overview**
> Aligns the Antigravity adapter with **agy 1.1.13** behavior: `-p` is value-consuming (no bare stdin mode), so the shell preamble now reads `awf_prompt=$(cat)` and runs `exec agy … -p "$awf_prompt"` with options before the prompt. It **fails closed** on empty stdin and prompts over 100k bytes to avoid idle chat and `MAX_ARG_STRLEN` / `E2BIG` failures.
> 
> **Default model** changes from the invalid `gemini-3.1-pro-high` to **`gemini-3.1-pro-preview`** in defaults, docs, and readiness tests. **`settings.json` `modelProvider=gemini`** is seeded or upserted only when **`GEMINI_API_KEY`** is set (not `ANTIGRAVITY_API_KEY` alone); API-key mode rejects models outside **`ANTIGRAVITY_API_KEY_MODE_MODELS`** while OAuth composite slugs still pass through when API-key mode is inactive.
> 
> **Provider failure markers** swap dead `antigravity_api_key` strings for observed agy stderr (`authentication required. Run 'agy' to log in`, missing `GEMINI_API_KEY`). Tests add shell-level stubs for prompt bridging, guards, settings `jq` upsert, allowlist behavior, and auth classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b57bf3fed845102a12cc3f0346f11816a2c74b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the default Antigravity model to `gemini-3.1-pro-preview`.
  - Improved prompt handling by supporting reliable transfer of prompts up to 100,000 bytes.

- **Bug Fixes**
  - Added validation for empty or oversized prompts.
  - Improved authentication error detection, including OAuth and missing API key scenarios.
  - Ensured model overrides and command-line options are handled consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->