### PR TITLE
Docs: add Antigravity to top-level agent rosters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## What this is
 
 AWF (Agent Workspace Fabric) is the **control plane** for running AI coding agents (Codex,
-Claude Code, Cursor, Gemini, OpenCode, Grok) as disciplined contributors. Each coding task gets an isolated
+Claude Code, Cursor, Gemini (deprecated), Antigravity, OpenCode, Grok) as disciplined contributors. Each coding task gets an isolated
 git worktree, a per-workspace Docker Compose stack, profile-driven validation, a created PR,
 and a PR-monitor loop that handles review comments, CI fixes, base sync, and auto-merge gates
 before cleanup. AWF owns lifecycle/policy; the agent owns code changes; profiles own

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 **AWF is an industrial workspace fabric for AI coding agents.**
 
-It gives Codex, Claude Code, Gemini, and future coding agents a repeatable way
+It gives Codex, Claude Code, Antigravity, and future coding agents a repeatable way
 to work like disciplined software contributors: each task gets an isolated
 workspace, a clean checkout, declared services, validation, PR creation, PR
 review monitoring, comment-fix loops, merge gates, artifacts, events, and
@@ -95,7 +95,7 @@ Implemented now:
 - SQLAlchemy control-plane models for workspaces, operations, and events.
 - Profile-driven workspace resolution.
 - Per-workspace Docker Compose stack generation.
-- Codex, Claude Code, Cursor, Gemini, OpenCode, and Grok adapters.
+- Codex, Claude Code, Cursor, Gemini (deprecated), Antigravity, OpenCode, and Grok adapters.
 - Central default model/effort map for agent adapters.
 - AWF-owned Plan -> Execute -> Compare lifecycle policy.
 - Generic phase-based validation.

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -41,7 +41,8 @@
         +------------------------------------+
         | Coding Agent CLI                   |
         |                                    |
-        | codex / claude / cursor / gemini   |
+        | codex / claude / cursor            |
+        | gemini (deprecated) / antigravity  |
         | opencode / grok                    |
         | edits files                        |
         | commits changes                    |
@@ -145,7 +146,7 @@ instead of relying on an agent-specific interactive plan mode:
 4. Iterate execution while the report says plan gaps remain.
 5. Fail the workspace if the plan is not satisfied within the configured budget.
 
-This works the same way for Codex, Claude Code, Cursor, Gemini, OpenCode, Grok,
+This works the same way for Codex, Claude Code, Cursor, Gemini (deprecated), Antigravity, OpenCode, Grok,
 and future adapters because the control plane invokes normal non-interactive agent
 runs for each phase and stores the plan/report inside the workspace.
 
@@ -566,7 +567,7 @@ curl "${AWF_BASE_URL}/release-readiness"
 ```
 
 `awf service status` and `/readyz` include an `agent_readiness` section for
-GitHub, Codex, Claude Code, Cursor, Gemini, OpenCode/Ollama, Grok, and Docker. Each
+GitHub, Codex, Claude Code, Cursor, Gemini, Antigravity, OpenCode/Ollama, Grok, and Docker. Each
 provider reports redacted `credential_sources`, `credential_scope`,
 `isolation`, and structured warnings. Missing optional providers and local
 least-privilege downgrades are warnings by default. Pass `--provider <name>` or

--- a/docs/CONCEPTS.md
+++ b/docs/CONCEPTS.md
@@ -567,7 +567,7 @@ curl "${AWF_BASE_URL}/release-readiness"
 ```
 
 `awf service status` and `/readyz` include an `agent_readiness` section for
-GitHub, Codex, Claude Code, Cursor, Gemini, Antigravity, OpenCode/Ollama, Grok, and Docker. Each
+GitHub, Codex, Claude Code, Cursor, Gemini (deprecated), Antigravity, OpenCode/Ollama, Grok, and Docker. Each
 provider reports redacted `credential_sources`, `credential_scope`,
 `isolation`, and structured warnings. Missing optional providers and local
 least-privilege downgrades are warnings by default. Pass `--provider <name>` or


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_d730ca24526046938a504bfa` (agent: `antigravity`, model: `gemini-3.1-pro-preview`, effort: `xhigh`).


### Task
Docs-only task: PR #810 added Google Antigravity (agy) as a first-class AWF agent runtime and deprecated the gemini runtime (retained for enterprise gemini-cli auth only), but the three top-level docs still show the pre-antigravity agent roster. Bring them current.

Exact stale spots (verify line numbers before editing; they may have drifted):
1. CLAUDE.md line ~8: agent roster "(Codex, Claude Code, Cursor, Gemini, OpenCode, Grok)" — add Antigravity; keep Gemini but it is now deprecated (you may render it as "Gemini (deprecated)").
2. README.md line ~21: "It gives Codex, Claude Code, Gemini, and future coding agents..." — modernize the example roster to name Antigravity instead of Gemini here (this sentence is illustrative, not exhaustive).
3. README.md line ~98: "- Codex, Claude Code, Cursor, Gemini, OpenCode, and Grok adapters." — add Antigravity; mark Gemini deprecated.
4. docs/CONCEPTS.md line ~44: ASCII diagram cell "| codex / claude / cursor / gemini |" — include antigravity; keep the diagram box width/alignment intact (adjust padding so the box edges still line up).
5. docs/CONCEPTS.md line ~148: "This works the same way for Codex, Claude Code, Cursor, Gemini, OpenCode, Grok," — add Antigravity; mark Gemini deprecated.
6. docs/CONCEPTS.md line ~569: readiness provider list "GitHub, Codex, Claude Code, Cursor, Gemini, OpenCode/Ollama, Grok, and Docker." — add Antigravity (it is a distinct readiness provider from Gemini).
Do NOT touch docs/CONCEPTS.md line ~407 ("review threads from Gemini, CodeRabbit, humans...") — that refers to the Gemini GitHub PR-review bot, not the AWF agent runtime.

Also sweep: rg -i 'gemini' across README.md, CLAUDE.md, docs/CONCEPTS.md for any other agent-roster mentions I missed (same rules: roster lists gain Antigravity, gemini stays but marked deprecated; non-roster mentions untouched). Do not edit any other files.

Style: match the surrounding prose exactly — these are terse reference docs, no marketing language. Keep the deprecation note minimal ("deprecated" in parentheses is enough; GETTING_STARTED.md and TROUBLESHOOTING.md already carry the full migration story — do not duplicate it).

Constraints: docs-only diff (README.md, CLAUDE.md, docs/CONCEPTS.md). No code, no pyproject.toml, no .github/workflows/**, no .awf/workspace.yml. Commit with a clear message; do not push — AWF handles push/PR.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or security behavior changes.
> 
> **Overview**
> Updates **CLAUDE.md**, **README.md**, and **docs/CONCEPTS.md** so top-level agent lists match PR #810: **Antigravity** is a first-class runtime and the **gemini** agent adapter is labeled **(deprecated)** where rosters are exhaustive.
> 
> **README** swaps the introductory example from Gemini to Antigravity and extends the implemented-adapters bullet. **CONCEPTS** refreshes the architecture diagram (two-line agent cell), the Plan→Execute→Compare adapter sentence, and the `agent_readiness` provider list. No changes to non-roster Gemini mentions (e.g. the GitHub review bot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e2bc6c045a2f70c5161d55277567e75f409d60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->