### PR TITLE
fix(hosted): omit Core-managed clarification helper from payloads

### DIFF
--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -24,6 +24,9 @@ from awf.common.token_patterns import (
     compile_provider_ref_re,
 )
 from awf.db.enums import AgentRuntime
+from awf.node.compose_manager_clarification import (
+    _is_managed_persisted_clarification_service,
+)
 from awf.profiles.compose_postgres_env import compose_service_env_file_paths
 from awf.profiles.models import WorkspaceProfile
 from awf.runtime.hosted_delegation_payload_volumes import (
@@ -352,7 +355,11 @@ def _hosted_validation_rendered_stack_services(
     payload: dict[str, Any] = {}
     for name, service in services.items():
         service_name = str(name)
-        if service_name == "agent" or not isinstance(service, Mapping):
+        if (
+            service_name == "agent"
+            or not isinstance(service, Mapping)
+            or _is_managed_persisted_clarification_service(service)
+        ):
             continue
         payload[service_name] = _hosted_validation_sanitize_compose_service(
             service,

--- a/tests/unit/runtime/test_hosted_delegation_payloads.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads.py
@@ -1090,6 +1090,50 @@ volumes:
 
 
 @pytest.mark.unit
+def test_rendered_stack_payload_excludes_core_managed_clarification_service(
+    tmp_path: Path,
+) -> None:
+    """Hosted application stacks must not include Core's local helper service."""
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: pgvector/pgvector:pg18
+  project-helper:
+    image: helper:latest
+    profiles:
+      - project-tools
+  clarification:
+    image: awf-agent-runtime:latest
+    x-awf-persisted-clarification-service-managed: true
+    volumes:
+      - /run/awf/hosted-auth-placeholders/codex:/run/awf/clarification-auth/0:ro
+    profiles:
+      - awf-clarification
+    networks:
+      - clarification_egress_net
+    command:
+      - sh
+      - -c
+      - sleep infinity
+    restart: "no"
+  agent:
+    image: awf-agent-runtime:latest
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+    )
+
+    assert payload is not None
+    assert set(payload["services"]) == {"postgres", "project-helper"}
+
+
+@pytest.mark.unit
 def test_hosted_profile_environment_omit_ignores_unexpected_container_shapes() -> None:
     """Coverage profile env omission only mutates dict environment containers."""
     list_container: list[object] = []


### PR DESCRIPTION
## Summary

- exclude Core own persisted clarification helper from hosted rendered application stacks
- identify the helper with Core existing full managed-service signature
- preserve ordinary project services, including services using Compose profiles
- add a realistic regression with Postgres, a project helper, clarification, and agent services

## Validation

- red-then-green regression confirmed
- 28 focused payload tests passed
- 121 related hosted/clarification tests passed
- Ruff and targeted mypy passed
- commit hooks passed formatting, Ruff, mypy, secret detection, and conflict checks
- exact aira-web Core-to-Cloud proof retained only the Postgres sidecar

## Release coordination

This is the Core serializer part of the aira-web dual-mode compatibility fix. The paired aira-web profile and awf-cloud current-Core DTO PRs must also land before the production monitor replay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted payload serialization for compose stacks. Misclassification could drop a real project service or still leak Core’s local helper to Cloud.
> 
> **Overview**
> Hosted rendered application stacks no longer include Core’s local persisted clarification helper. `_hosted_validation_rendered_stack_services` now skips services identified by `_is_managed_persisted_clarification_service`, while still keeping ordinary project services (including those with Compose profiles).
> 
> A regression test covers a mixed stack (Postgres, project helper, managed clarification, agent) and asserts only the application sidecars remain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0a0a8dc664ab949458c7e0aab4bc28b45337793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->