### PR TITLE
fix: default Cursor to Auto and stop cancelled monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- Fixed Cursor's default runtime policy to use portable `auto` with no generic
+  AWF effort mapping. Cursor Auto routing profiles (Cost, Balance, Intelligence)
+  remain provider/team policy or explicit official parameterized model
+  selectors; AWF no longer hard-codes the removed `sonnet-4-thinking` slug.
+- Fixed cancellation of first-run/adopted PR monitors so a monitor coroutine
+  originally tracked as a ready execution stops immediately after durable
+  workspace cancellation instead of retrying against a removed runtime.
 - Fixed local worker/agent Git configuration loss across Docker Desktop
   rewrites and service restarts with immutable, content-addressed config
   bundles that preserve worker relative includes and native-Linux agent

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -413,7 +413,7 @@ Default agent models and effort are centralized in
 | --- | --- | --- |
 | `claude_code` | `claude-opus-5` | `xhigh` passed through to Claude Code |
 | `codex` | `gpt-5.6-sol` | `xhigh` via `model_reasoning_effort` |
-| `cursor` | `sonnet-4-thinking` | `xhigh` uses the thinking-capable model variant; no separate Cursor effort flag |
+| `cursor` | `auto` | Unset. Cursor Auto uses provider-specific Cost, Balance, or Intelligence routing profiles rather than AWF reasoning effort. |
 | `antigravity` | `gemini-3.1-pro-preview` | Effort accepted/recorded but never emitted (`agy` rejects `--effort` in API-key mode; OAuth uses composite slugs) |
 | `opencode` | `ollama/kimi-k2.6:cloud` | `xhigh` maps to OpenCode `--variant max --thinking` plus Ollama `think` |
 
@@ -431,6 +431,13 @@ If a local subscription or provider account cannot use a default model, choose a
 supported model in the task or adapter configuration. In the workspace create
 request, set `task.model` to override the selected agent's default for that
 workspace.
+Cursor Router is currently limited to eligible Teams/Enterprise accounts. Those
+accounts can choose Cost, Balance, or Intelligence through team policy or pass
+Cursor's official parameterized selector (for example,
+`auto-smart[optimize_for=intelligence]`) as the model override. Plain `auto`
+remains the portable fallback and uses the account/team-selected Auto policy.
+See [Cursor Router](https://cursor.com/docs/cursor-router) for availability,
+billing, and the current `optimize_for` values.
 For example, Gemini dogfood tests can use a Flash preview model when Pro is
 unavailable. OpenCode model overrides use the `ollama/<model>` form, for example
 `ollama/glm-5.1:cloud`, `ollama/gemma4:31b-cloud`, or

--- a/src/awf/adapters/cursor.py
+++ b/src/awf/adapters/cursor.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from awf.adapters.base import AgentAdapter, register_adapter
 from awf.adapters.model_selection import (
-    CURSOR_DEFAULT_THINKING_MODEL as CURSOR_DEFAULT_THINKING_MODEL,
+    CURSOR_DEFAULT_MODEL as CURSOR_DEFAULT_MODEL,
 )
 from awf.adapters.model_selection import cursor_selected_model
 from awf.db.enums import AgentRuntime

--- a/src/awf/adapters/defaults.py
+++ b/src/awf/adapters/defaults.py
@@ -6,16 +6,18 @@ from collections.abc import Mapping
 from types import MappingProxyType
 
 from awf.adapters.base import AgentDefaults
-from awf.adapters.model_selection import CURSOR_DEFAULT_THINKING_MODEL
+from awf.adapters.model_selection import CURSOR_DEFAULT_MODEL
 from awf.db.enums import AgentRuntime
 
 DEFAULT_AGENT_DEFAULTS: Mapping[AgentRuntime, AgentDefaults] = MappingProxyType(
     {
         AgentRuntime.claude_code: AgentDefaults(model="claude-opus-5", effort="xhigh"),
         AgentRuntime.codex: AgentDefaults(model="gpt-5.6-sol", effort="xhigh"),
-        # Cursor documents model selection but not a portable effort flag.
-        # Use the thinking-capable Sonnet variant as AWF's high-effort default.
-        AgentRuntime.cursor: AgentDefaults(model=CURSOR_DEFAULT_THINKING_MODEL, effort="xhigh"),
+        # Cursor Auto has provider-specific Cost/Balance/Intelligence routing
+        # profiles, not a portable reasoning-effort flag. The account/team owns
+        # the Auto profile; eligible teams can pass Cursor's parameterized
+        # auto-smart selector as an explicit model override.
+        AgentRuntime.cursor: AgentDefaults(model=CURSOR_DEFAULT_MODEL),
         # Antigravity API-key mode (agy 1.1.13) accepts exactly the slugs in
         # ANTIGRAVITY_API_KEY_MODE_MODELS; gemini-3.1-pro-preview is the
         # Pro-class default. Effort is accepted/recorded but never emitted:

--- a/src/awf/adapters/model_selection.py
+++ b/src/awf/adapters/model_selection.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from awf.db.enums import AgentRuntime
 
-CURSOR_DEFAULT_THINKING_MODEL = "sonnet-4-thinking"
-"""Default Cursor model variant AWF uses when high effort must select a model."""
+CURSOR_DEFAULT_MODEL = "auto"
+"""Portable Cursor default; the provider/team owns Auto routing policy."""
 
 
 def selected_runtime_model_for_defaults(
@@ -36,29 +36,21 @@ def cursor_selected_model(
 ) -> str | None:
     """Return the Cursor model selected for one run.
 
-    Explicit model overrides win first. A custom default model that is not
-    Cursor's thinking default is treated as operator-controlled and bypasses
-    effort mapping, even for high/xhigh efforts. Effort mapping only selects
-    the thinking model when no default is set or the default already matches
-    AWF's Cursor thinking default.
+    Explicit model overrides win first, including Cursor Router's official
+    parameterized ``auto-smart[optimize_for=...]`` selectors. Generic AWF
+    reasoning effort does not select a Cursor model or Auto routing profile.
+    Cursor owns those provider-specific controls through its model selector and
+    team policy.
     """
 
     if model:
         return model
-    if default_model and default_model != CURSOR_DEFAULT_THINKING_MODEL:
-        return default_model
-    if effort is None:
-        return default_model
-    return cursor_model_for_effort(model=None, effort=effort)
+    del effort
+    return default_model
 
 
 def cursor_model_for_effort(*, model: str | None, effort: str | None) -> str | None:
-    """Map AWF effort to Cursor's documented portable model controls."""
+    """Preserve an explicit model without treating effort as a Cursor control."""
 
-    if model:
-        return model
-    if effort is None:
-        return None
-    if effort.strip().lower() in {"high", "xhigh", "max"}:
-        return CURSOR_DEFAULT_THINKING_MODEL
-    return None
+    del effort
+    return model

--- a/src/awf/control/worker/dispatch_methods.py
+++ b/src/awf/control/worker/dispatch_methods.py
@@ -494,12 +494,29 @@ def _tracked_monitor_workspace_ids(self: Any) -> list[str]:
     ]
 
 
+# Execution kinds that can await a long-lived PR monitor without being
+# reclassified to ``MONITOR_RESUME``. Durable operator cancel/destroy must
+# stop these coroutines the same way as an adopted ``MONITOR_RESUME``.
+_EXECUTION_KINDS_CANCELLED_WITH_WORKSPACE = frozenset(
+    {
+        _ExecutionTaskKind.READY,
+        _ExecutionTaskKind.PRESERVED_ACTIVE,
+        _ExecutionTaskKind.BLOCKED_RESUME,
+        _ExecutionTaskKind.RECOVERING_RESUME,
+    }
+)
+
+_CANCELLABLE_EXECUTION_TASK_KINDS = frozenset(
+    {_ExecutionTaskKind.MONITOR_RESUME, *_EXECUTION_KINDS_CANCELLED_WITH_WORKSPACE}
+)
+
+
 def _tracked_cancellable_execution_workspace_ids(self: Any) -> list[str]:
     """Return task ids whose durable cancellation must stop the coroutine."""
     return [
         workspace_id
         for workspace_id, kind in self._execution_task_kinds.items()
-        if kind in {_ExecutionTaskKind.MONITOR_RESUME, _ExecutionTaskKind.READY}
+        if kind in _CANCELLABLE_EXECUTION_TASK_KINDS
     ]
 
 
@@ -525,12 +542,13 @@ async def _reconcile_stale_monitor_execution_tasks(self: Any) -> None:
     blocking a fresh dispatch for the *same* workspace until it truly stops,
     and the existing done-callback drops it once it does.
 
-    Initial/adopted PR monitors retain ``READY`` task kind after their executor
-    hands off to the long-lived monitor. A durable operator cancellation must
-    therefore cancel a tracked ``READY`` task too; otherwise the coroutine keeps
-    attempting repairs against a runtime that cancellation already removed.
-    Healthy ``READY`` tasks and every ``PRESERVED_ACTIVE``/already-draining task
-    remain untouched.
+    Several dispatch paths hand off to a long-lived monitor without
+    reclassifying the tracked kind (``READY`` first-run/adopted monitors,
+    ``PRESERVED_ACTIVE`` recovery validation, ``BLOCKED_RESUME`` /
+    ``RECOVERING_RESUME``). A durable operator cancellation must therefore
+    cancel those kinds too; otherwise the coroutine keeps attempting repairs
+    against a runtime that cancellation already removed. Healthy mid-execution
+    tasks of those kinds, and already-draining tasks, remain untouched.
     """
     cancellable_ids = _tracked_cancellable_execution_workspace_ids(self)
     if not cancellable_ids:
@@ -548,10 +566,10 @@ async def _reconcile_stale_monitor_execution_tasks(self: Any) -> None:
             kind is _ExecutionTaskKind.MONITOR_RESUME
             and status != WorkspaceStatus.monitoring_pr.value
         )
-        cancelled_ready_execution = (
-            kind is _ExecutionTaskKind.READY and status in cancelled_statuses
+        cancelled_handoff_execution = (
+            kind in _EXECUTION_KINDS_CANCELLED_WITH_WORKSPACE and status in cancelled_statuses
         )
-        if not stale_monitor_resume and not cancelled_ready_execution:
+        if not stale_monitor_resume and not cancelled_handoff_execution:
             continue
         task = self._execution_tasks.get(workspace_id)
         if task is None:

--- a/src/awf/control/worker/dispatch_methods.py
+++ b/src/awf/control/worker/dispatch_methods.py
@@ -494,6 +494,15 @@ def _tracked_monitor_workspace_ids(self: Any) -> list[str]:
     ]
 
 
+def _tracked_cancellable_execution_workspace_ids(self: Any) -> list[str]:
+    """Return task ids whose durable cancellation must stop the coroutine."""
+    return [
+        workspace_id
+        for workspace_id, kind in self._execution_task_kinds.items()
+        if kind in {_ExecutionTaskKind.MONITOR_RESUME, _ExecutionTaskKind.READY}
+    ]
+
+
 def _tracked_draining_workspace_ids(self: Any) -> list[str]:
     return [
         workspace_id
@@ -514,17 +523,35 @@ async def _reconcile_stale_monitor_execution_tasks(self: Any) -> None:
     workspace_id. ``cancel()`` is cooperative, so the coroutine can keep
     running afterwards; retaining the tracking reference keeps slot dedup
     blocking a fresh dispatch for the *same* workspace until it truly stops,
-    and the existing done-callback drops it once it does. Only
-    ``MONITOR_RESUME`` tasks are inspected, so ready/preserved-active and
-    already-draining executions are never touched here.
+    and the existing done-callback drops it once it does.
+
+    Initial/adopted PR monitors retain ``READY`` task kind after their executor
+    hands off to the long-lived monitor. A durable operator cancellation must
+    therefore cancel a tracked ``READY`` task too; otherwise the coroutine keeps
+    attempting repairs against a runtime that cancellation already removed.
+    Healthy ``READY`` tasks and every ``PRESERVED_ACTIVE``/already-draining task
+    remain untouched.
     """
-    monitor_ids = self._tracked_monitor_workspace_ids()
-    if not monitor_ids:
+    cancellable_ids = _tracked_cancellable_execution_workspace_ids(self)
+    if not cancellable_ids:
         return
-    statuses = await self._load_workspace_statuses(monitor_ids)
-    for workspace_id in monitor_ids:
+    statuses = await self._load_workspace_statuses(cancellable_ids)
+    cancelled_statuses = {
+        WorkspaceStatus.cancelled.value,
+        WorkspaceStatus.destroying.value,
+        WorkspaceStatus.destroyed.value,
+    }
+    for workspace_id in cancellable_ids:
         status = statuses.get(workspace_id)
-        if status == WorkspaceStatus.monitoring_pr.value:
+        kind = self._execution_task_kinds.get(workspace_id)
+        stale_monitor_resume = (
+            kind is _ExecutionTaskKind.MONITOR_RESUME
+            and status != WorkspaceStatus.monitoring_pr.value
+        )
+        cancelled_ready_execution = (
+            kind is _ExecutionTaskKind.READY and status in cancelled_statuses
+        )
+        if not stale_monitor_resume and not cancelled_ready_execution:
             continue
         task = self._execution_tasks.get(workspace_id)
         if task is None:
@@ -534,6 +561,7 @@ async def _reconcile_stale_monitor_execution_tasks(self: Any) -> None:
             "worker.stale_monitor_execution_task_cancelled",
             workspace_id=workspace_id,
             status=status,
+            task_kind=kind,
         )
         task.cancel()
         self._execution_task_kinds[workspace_id] = _ExecutionTaskKind.MONITOR_DRAINING

--- a/tests/unit/adapters/test_adapters.py
+++ b/tests/unit/adapters/test_adapters.py
@@ -25,7 +25,7 @@ import yaml
 import awf.adapters.registry  # noqa: F401
 from awf.adapters import get_adapter  # noqa: F401 - populates registry via __init__
 from awf.adapters.antigravity import AntigravityAdapter
-from awf.adapters.base import AgentAdapter, AgentRunError
+from awf.adapters.base import AgentAdapter, AgentDefaults, AgentRunError
 from awf.adapters.claude_code import ClaudeCodeAdapter, _claude_effort_for_awf_effort
 from awf.adapters.codex import CodexAdapter
 from awf.adapters.cursor import CursorAdapter
@@ -967,14 +967,21 @@ class TestCentralDefaults:
     """Default model and effort mapping tests."""
 
     @pytest.mark.unit
-    def test_defaults_map_uses_requested_models_and_xhigh_effort(self) -> None:
+    def test_defaults_map_uses_requested_models_and_runtime_specific_effort(self) -> None:
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.claude_code].model == "claude-opus-5"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.codex].model == "gpt-5.6-sol"
-        assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.cursor].model == "sonnet-4-thinking"
+        assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.cursor] == AgentDefaults(
+            model="auto",
+            effort=None,
+        )
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.antigravity].model == "gemini-3.1-pro-preview"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.opencode].model == "ollama/kimi-k2.6:cloud"
         assert DEFAULT_AGENT_DEFAULTS[AgentRuntime.grok].model == "grok-build"
-        assert {d.effort for d in DEFAULT_AGENT_DEFAULTS.values()} == {"xhigh"}
+        assert {
+            defaults.effort
+            for runtime, defaults in DEFAULT_AGENT_DEFAULTS.items()
+            if runtime is not AgentRuntime.cursor
+        } == {"xhigh"}
 
     @pytest.mark.unit
     def test_get_adapter_applies_full_defaults(self) -> None:

--- a/tests/unit/adapters/test_cursor_adapter.py
+++ b/tests/unit/adapters/test_cursor_adapter.py
@@ -36,8 +36,8 @@ class TestCursorAdapter:
         runner = FakeCommandRunner()
         adapter = CursorAdapter(
             runner=runner,
-            default_model="sonnet-4-thinking",
-            default_effort="xhigh",
+            default_model="auto",
+            default_effort=None,
         )
 
         await adapter.run(
@@ -54,7 +54,7 @@ class TestCursorAdapter:
             "-p",
             "--force",
             "--model",
-            "sonnet-4-thinking",
+            "auto",
             "--output-format",
             "text",
         ]
@@ -62,12 +62,12 @@ class TestCursorAdapter:
         _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
-    async def test_lower_effort_without_model_override_omits_thinking_model(self) -> None:
-        """Lower Cursor effort does not inherit the thinking model default."""
+    async def test_generic_effort_does_not_replace_auto_default(self) -> None:
+        """Cursor Auto routing profiles are independent of AWF reasoning effort."""
         runner = FakeCommandRunner()
         adapter = CursorAdapter(
             runner=runner,
-            default_model="sonnet-4-thinking",
+            default_model="auto",
             default_effort="medium",
         )
 
@@ -83,19 +83,21 @@ class TestCursorAdapter:
             "cursor-agent",
             "-p",
             "--force",
+            "--model",
+            "auto",
             "--output-format",
             "text",
         ]
         assert "-m" not in args[cursor_start:]
 
     @pytest.mark.unit
-    async def test_lower_effort_failure_metadata_omits_unselected_thinking_model(self) -> None:
-        """Cursor failure metadata follows the model actually selected for CLI."""
+    async def test_generic_effort_failure_metadata_reports_auto_model(self) -> None:
+        """Cursor failure metadata follows the Auto model actually selected for CLI."""
         runner = FakeCommandRunner()
         runner.queue_result(returncode=1, stderr="cursor-agent failed: cursor auth required")
         adapter = CursorAdapter(
             runner=runner,
-            default_model="sonnet-4-thinking",
+            default_model="auto",
             default_effort="medium",
         )
 
@@ -111,13 +113,12 @@ class TestCursorAdapter:
 
         assert exc.value.reason_code == "AGENT_AUTH_FAILED"
         assert exc.value.details["provider"] == "cursor"
-        assert exc.value.details["model"] == "unknown"
+        assert exc.value.details["model"] == "auto"
         provider_recovery = exc.value.details["provider_recovery"]
         assert provider_recovery["provider"] == "cursor"
-        assert "model" not in provider_recovery
-        assert "sonnet-4-thinking" not in provider_recovery["failure_fingerprint"]
+        assert provider_recovery["model"] == "auto"
         assert any(
-            event.get("event") == "agent.run.start" and event.get("model") is None
+            event.get("event") == "agent.run.start" and event.get("model") == "auto"
             for event in captured
         )
 
@@ -210,6 +211,32 @@ class TestCursorAdapter:
         _assert_prompt_sent_on_stdin(runner)
 
     @pytest.mark.unit
+    async def test_parameterized_router_profile_override_is_passed_unchanged(self) -> None:
+        """Eligible Cursor teams can select an official Auto Router profile."""
+        runner = FakeCommandRunner()
+        adapter = CursorAdapter(runner=runner, default_model="auto")
+        router_model = "auto-smart[optimize_for=intelligence]"
+
+        await adapter.run(
+            compose_project=_COMPOSE_PROJECT,
+            compose_file=_COMPOSE_FILE,
+            prompt=_PROMPT,
+            model=router_model,
+        )
+
+        args = runner.calls[0].args
+        cursor_start = args.index("cursor-agent")
+        assert args[cursor_start:] == [
+            "cursor-agent",
+            "-p",
+            "--force",
+            "--model",
+            router_model,
+            "--output-format",
+            "text",
+        ]
+
+    @pytest.mark.unit
     async def test_no_model_omits_model_flag_but_keeps_force_and_text_output(self) -> None:
         """Cursor omits -m when no model or effort-derived model is selected."""
         runner = FakeCommandRunner()
@@ -233,15 +260,15 @@ class TestCursorAdapter:
         assert "-m" not in args
 
     @pytest.mark.unit
-    def test_effort_mapping_uses_documented_models_not_extra_flags(self) -> None:
-        """Effort mapping selects models instead of undocumented Cursor flags."""
+    def test_generic_effort_never_selects_a_cursor_model_or_router_profile(self) -> None:
+        """Cursor Auto profiles are not generic AWF reasoning-effort levels."""
         assert cursor_model_for_effort(model="gpt-5", effort="xhigh") == "gpt-5"
         assert cursor_model_for_effort(model="sonnet-4", effort="high") == "sonnet-4"
         assert cursor_model_for_effort(model=None, effort=None) is None
         assert cursor_model_for_effort(model=None, effort="medium") is None
-        assert cursor_model_for_effort(model=None, effort="high") == "sonnet-4-thinking"
-        assert cursor_model_for_effort(model=None, effort="xhigh") == "sonnet-4-thinking"
-        assert cursor_model_for_effort(model=None, effort="max") == "sonnet-4-thinking"
+        assert cursor_model_for_effort(model=None, effort="high") is None
+        assert cursor_model_for_effort(model=None, effort="xhigh") is None
+        assert cursor_model_for_effort(model=None, effort="max") is None
 
     @pytest.mark.unit
     def test_custom_default_model_bypasses_effort_mapping(self) -> None:

--- a/tests/unit/adapters/test_defaults.py
+++ b/tests/unit/adapters/test_defaults.py
@@ -54,17 +54,17 @@ def test_selected_runtime_model_for_defaults_explicit() -> None:
 @pytest.mark.unit
 def test_selected_runtime_model_for_defaults_cursor() -> None:
     from awf.adapters.model_selection import (
-        CURSOR_DEFAULT_THINKING_MODEL,
+        CURSOR_DEFAULT_MODEL,
         selected_runtime_model_for_defaults,
     )
 
     res = selected_runtime_model_for_defaults(
         agent=AgentRuntime.cursor,
         explicit_model=None,
-        default_model=None,
+        default_model=CURSOR_DEFAULT_MODEL,
         effort="high",
     )
-    assert res == CURSOR_DEFAULT_THINKING_MODEL
+    assert res == "auto"
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_005.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_005.py
@@ -671,15 +671,15 @@ def test_agent_pr_identity_omits_missing_model_and_effort() -> None:
 
 
 @pytest.mark.unit
-def test_agent_pr_identity_cursor_lower_effort_omits_thinking_model() -> None:
-    defaults = AgentDefaults(model="sonnet-4-thinking", effort="xhigh")
+def test_agent_pr_identity_cursor_effort_does_not_replace_auto_model() -> None:
+    defaults = AgentDefaults(model="auto", effort=None)
 
     assert (
         _agent_pr_identity(  # type: ignore[arg-type]
             SimpleNamespace(agent="cursor", task_policy={"agent_effort": "medium"}),
             defaults=defaults,
         )
-        == "agent: `cursor`, effort: `medium`"
+        == "agent: `cursor`, model: `auto`, effort: `medium`"
     )
 
 

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_part_002.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_part_002.py
@@ -641,12 +641,12 @@ async def test_recovery_skip_push_with_factory_resumes_monitor_runner(
 
 
 @pytest.mark.unit
-async def test_recovery_skip_push_cursor_lower_effort_handoff_uses_implicit_runtime_model(
+async def test_recovery_skip_push_cursor_effort_does_not_replace_auto_model(
     fake: FakeCommandRunner,
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """Cursor lower effort must not hand the monitor a thinking model default."""
+    """Generic effort does not replace Cursor's Auto model during handoff."""
     captured: list[dict[str, object]] = []
 
     class _FakeMonitor:
@@ -693,10 +693,12 @@ async def test_recovery_skip_push_cursor_lower_effort_handoff_uses_implicit_runt
                 "cursor-agent",
                 "-p",
                 "--force",
+                "--model",
+                "auto",
                 "--output-format",
                 "text",
             ],
-            "provider_recovery_default_model": None,
+            "provider_recovery_default_model": "auto",
         }
     ]
 

--- a/tests/unit/control/test_executor_parts/test_executor_part_002.py
+++ b/tests/unit/control/test_executor_parts/test_executor_part_002.py
@@ -707,13 +707,13 @@ class TestHappyPathPart001:
         assert "(agent: `opencode`, model: `ollama/gemma4:31b-cloud`, effort: `xhigh`)." in pr_body
 
     @pytest.mark.unit
-    async def test_cursor_lower_effort_without_model_override_omits_thinking_model(
+    async def test_cursor_generic_effort_without_model_override_keeps_auto_model(
         self,
         executor: WorkspaceExecutor,
         fake: FakeCommandRunner,
         factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """Verify lower Cursor effort does not force the thinking model."""
+        """Verify generic Cursor effort does not replace the Auto model."""
         ws_id = await _seed_ready_workspace(
             factory,
             agent="cursor",
@@ -744,6 +744,8 @@ class TestHappyPathPart001:
             "cursor-agent",
             "-p",
             "--force",
+            "--model",
+            "auto",
             "--output-format",
             "text",
         ]

--- a/tests/unit/control/test_worker_parts/test_worker_part_012.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_012.py
@@ -1105,29 +1105,39 @@ class TestRunOnceExecutionPart005:
             worker._execution_task_kinds.clear()  # noqa: SLF001
 
     @pytest.mark.unit
-    async def test_monitor_reconcile_cancels_ready_task_when_workspace_is_cancelled(
+    @pytest.mark.parametrize(
+        "task_kind",
+        [
+            worker_dispatch_methods._ExecutionTaskKind.READY,
+            worker_dispatch_methods._ExecutionTaskKind.PRESERVED_ACTIVE,
+            worker_dispatch_methods._ExecutionTaskKind.BLOCKED_RESUME,
+            worker_dispatch_methods._ExecutionTaskKind.RECOVERING_RESUME,
+        ],
+    )
+    async def test_monitor_reconcile_cancels_handoff_kind_when_workspace_is_cancelled(
         self,
         session_factory: async_sessionmaker[AsyncSession],
         origin_repo: Path,
+        task_kind: worker_dispatch_methods._ExecutionTaskKind,
     ) -> None:
-        """A first-run PR monitor retains READY kind after handoff and must still stop."""
-        ready_id = await _create_ready(session_factory, origin_repo, "cancelled-ready-monitor")
+        """Kinds that can await monitor.run() without reclassification must stop on cancel."""
+        workspace_id = await _create_ready(
+            session_factory, origin_repo, f"cancelled-{task_kind.value}-monitor"
+        )
         worker = ControlWorker(
             session_factory=session_factory,
             provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
             executor=_RecordingExecutor(),
             config=WorkerConfig(max_concurrent_executions=1),
         )
-        ready_task = asyncio.create_task(_pending_execution_task())
-        worker._execution_tasks[ready_id] = ready_task  # noqa: SLF001
-        worker._execution_task_kinds[ready_id] = (  # noqa: SLF001
-            worker_dispatch_methods._ExecutionTaskKind.READY
-        )
+        execution_task = asyncio.create_task(_pending_execution_task())
+        worker._execution_tasks[workspace_id] = execution_task  # noqa: SLF001
+        worker._execution_task_kinds[workspace_id] = task_kind  # noqa: SLF001
 
         async with session_factory() as session:
             await session.execute(
                 update(Workspace)
-                .where(Workspace.id == ready_id)
+                .where(Workspace.id == workspace_id)
                 .values(status=WorkspaceStatus.cancelled.value)
             )
             await session.commit()
@@ -1138,22 +1148,23 @@ class TestRunOnceExecutionPart005:
 
             assert any(
                 event.get("event") == "worker.stale_monitor_execution_task_cancelled"
-                and event.get("workspace_id") == ready_id
+                and event.get("workspace_id") == workspace_id
                 and event.get("status") == WorkspaceStatus.cancelled.value
+                and event.get("task_kind") == task_kind
                 for event in captured
             )
-            assert ready_task.cancelling() > 0
-            assert worker._execution_tasks[ready_id] is ready_task  # noqa: SLF001
+            assert execution_task.cancelling() > 0
+            assert worker._execution_tasks[workspace_id] is execution_task  # noqa: SLF001
             assert (
-                worker._execution_task_kinds[ready_id]  # noqa: SLF001
+                worker._execution_task_kinds[workspace_id]  # noqa: SLF001
                 is worker_dispatch_methods._ExecutionTaskKind.MONITOR_DRAINING
             )
             assert worker._available_execution_slots() == 1  # noqa: SLF001
         finally:
-            if not ready_task.done():
-                ready_task.cancel()
+            if not execution_task.done():
+                execution_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
-                await asyncio.wait_for(ready_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+                await asyncio.wait_for(execution_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
             worker._execution_tasks.clear()  # noqa: SLF001
             worker._execution_task_kinds.clear()  # noqa: SLF001
 

--- a/tests/unit/control/test_worker_parts/test_worker_part_012.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_012.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import pytest
 import structlog
+from sqlalchemy import update
 from sqlalchemy.exc import InterfaceError
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -1100,6 +1101,59 @@ class TestRunOnceExecutionPart005:
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):
                     await asyncio.wait_for(task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
+            worker._execution_tasks.clear()  # noqa: SLF001
+            worker._execution_task_kinds.clear()  # noqa: SLF001
+
+    @pytest.mark.unit
+    async def test_monitor_reconcile_cancels_ready_task_when_workspace_is_cancelled(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        """A first-run PR monitor retains READY kind after handoff and must still stop."""
+        ready_id = await _create_ready(session_factory, origin_repo, "cancelled-ready-monitor")
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            config=WorkerConfig(max_concurrent_executions=1),
+        )
+        ready_task = asyncio.create_task(_pending_execution_task())
+        worker._execution_tasks[ready_id] = ready_task  # noqa: SLF001
+        worker._execution_task_kinds[ready_id] = (  # noqa: SLF001
+            worker_dispatch_methods._ExecutionTaskKind.READY
+        )
+
+        async with session_factory() as session:
+            await session.execute(
+                update(Workspace)
+                .where(Workspace.id == ready_id)
+                .values(status=WorkspaceStatus.cancelled.value)
+            )
+            await session.commit()
+
+        try:
+            with structlog.testing.capture_logs() as captured:
+                await worker._reconcile_stale_monitor_execution_tasks()  # noqa: SLF001
+
+            assert any(
+                event.get("event") == "worker.stale_monitor_execution_task_cancelled"
+                and event.get("workspace_id") == ready_id
+                and event.get("status") == WorkspaceStatus.cancelled.value
+                for event in captured
+            )
+            assert ready_task.cancelling() > 0
+            assert worker._execution_tasks[ready_id] is ready_task  # noqa: SLF001
+            assert (
+                worker._execution_task_kinds[ready_id]  # noqa: SLF001
+                is worker_dispatch_methods._ExecutionTaskKind.MONITOR_DRAINING
+            )
+            assert worker._available_execution_slots() == 1  # noqa: SLF001
+        finally:
+            if not ready_task.done():
+                ready_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await asyncio.wait_for(ready_task, timeout=WORKER_TEST_TIMEOUT_SECONDS)
             worker._execution_tasks.clear()  # noqa: SLF001
             worker._execution_task_kinds.clear()  # noqa: SLF001
 

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_001.py
@@ -293,7 +293,7 @@ def test_selected_provider_preflight_maps_agents_to_effective_models(
     cases = [
         ("codex", "codex", "gpt-custom", "ok"),
         ("claude_code", "claude_code", "claude-opus-5", "ok"),
-        ("cursor", "cursor", "sonnet-4-thinking", "ok"),
+        ("cursor", "cursor", "auto", "ok"),
         ("antigravity", "antigravity", "gemini-3.1-pro-preview", "ok"),
         ("opencode", "opencode", "ollama/kimi-k2.6:cloud", "ok"),
         ("grok", "grok", "grok-build", "ok"),
@@ -392,7 +392,7 @@ def test_selected_cursor_preflight_requires_env_key_and_runtime_cli(
 
     assert result["provider"] == "cursor"
     assert result["agent"] == "cursor"
-    assert result["model"] == "sonnet-4-thinking"
+    assert result["model"] == "auto"
     assert result["model_source"] == "default"
     assert result["readiness_status"] == "ready"
     assert result["auth_status"] == "ok"
@@ -548,10 +548,10 @@ def test_launch_provider_by_agent_covers_every_agent_runtime() -> None:
 
 
 @pytest.mark.unit
-def test_selected_cursor_preflight_lower_effort_uses_implicit_runtime_model(
+def test_selected_cursor_preflight_effort_does_not_replace_auto_model(
     tmp_path: Path,
 ) -> None:
-    """Lower Cursor effort without a model reports Cursor's implicit runtime model."""
+    """Generic Cursor effort without a model still reports Auto."""
     result = selected_provider_readiness_preflight(
         _settings(tmp_path),
         agent="cursor",
@@ -562,7 +562,7 @@ def test_selected_cursor_preflight_lower_effort_uses_implicit_runtime_model(
 
     assert result["provider"] == "cursor"
     assert result["agent"] == "cursor"
-    assert result["model"] is None
+    assert result["model"] == "auto"
     assert result["model_source"] == "default"
     assert result["readiness_status"] == "ready"
     assert result["probe_status"] == "ok"
@@ -583,7 +583,7 @@ def test_selected_cursor_preflight_blocks_missing_env_key(tmp_path: Path) -> Non
 
     assert result["provider"] == "cursor"
     assert result["agent"] == "cursor"
-    assert result["model"] == "sonnet-4-thinking"
+    assert result["model"] == "auto"
     assert result["readiness_status"] == "blocked"
     assert result["auth_status"] == "fail"
     assert result["auth_source"] == "not_observed"

--- a/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
+++ b/tests/unit/service/test_workspaces_observability_parts/test_workspaces_observability_part_004.py
@@ -396,35 +396,36 @@ def test_parse_memory_gb_handles_blank_units_and_invalid_values(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
-    ("agent", "model"),
+    ("agent", "model", "effort"),
     [
-        (AgentRuntime.codex, "gpt-5.6-sol"),
-        (AgentRuntime.cursor, "sonnet-4-thinking"),
-        (AgentRuntime.antigravity, "gemini-3.1-pro-preview"),
-        (AgentRuntime.claude_code, "claude-opus-5"),
-        (AgentRuntime.opencode, "ollama/kimi-k2.6:cloud"),
+        (AgentRuntime.codex, "gpt-5.6-sol", "xhigh"),
+        (AgentRuntime.cursor, "auto", None),
+        (AgentRuntime.antigravity, "gemini-3.1-pro-preview", "xhigh"),
+        (AgentRuntime.claude_code, "claude-opus-5", "xhigh"),
+        (AgentRuntime.opencode, "ollama/kimi-k2.6:cloud", "xhigh"),
     ],
 )
 def test_effective_agent_identity_uses_central_defaults(
     agent: AgentRuntime,
     model: str,
+    effort: str | None,
 ) -> None:
     identity = effective_agent_identity(agent=agent, task_policy={})
 
     assert identity.model == model
-    assert identity.effort == "xhigh"
+    assert identity.effort == effort
     assert identity.model_source == "default"
-    assert identity.effort_source == "default"
+    assert identity.effort_source == ("default" if effort is not None else "unavailable")
 
 
 @pytest.mark.unit
-def test_effective_agent_identity_cursor_lower_effort_uses_implicit_runtime_model() -> None:
+def test_effective_agent_identity_cursor_effort_does_not_replace_auto_model() -> None:
     identity = effective_agent_identity(
         agent=AgentRuntime.cursor,
         task_policy={"agent_effort": "medium"},
     )
 
-    assert identity.model is None
+    assert identity.model == "auto"
     assert identity.model_source == "default"
     assert identity.effort == "medium"
     assert identity.effort_source == "task_policy"


### PR DESCRIPTION
## Summary

- default Cursor to portable `auto` and remove AWF's generic effort mapping for Cursor Auto
- preserve official parameterized Cursor Router selectors as explicit model overrides
- cancel first-run/adopted monitor coroutines that remain tracked as `READY` after durable workspace cancellation
- document Cursor Cost/Balance/Intelligence routing semantics and account availability

## Root cause

AWF hard-coded `sonnet-4-thinking` whenever Cursor inherited high/xhigh effort, but the current Cursor CLI catalog no longer advertises that slug. Cursor Auto now has provider-specific Cost/Balance/Intelligence profiles; they are not AWF reasoning-effort levels.

The worker's stale-monitor reconciler only inspected `MONITOR_RESUME` tasks. A newly adopted PR starts as a `READY` execution and keeps that task kind after monitor handoff, so cancellation updated the row and removed its runtime while the live coroutine kept retrying comment repairs.

## Validation

- strict TDD: new adapter and worker regressions observed red before implementation
- adapter/default/Cursor tests: 61 passed
- cancelled-ready monitor regression: passed
- adjacent executor, observability, and provider-readiness tests: 166 passed
- worker monitor/draining and adapter suites: 556 passed; optional host Antigravity smoke excluded because host `agy` 1.0.5 is older than repo pin 1.1.13
- `ruff check src/awf tests`: passed
- `mypy src/awf`: passed
- OpenAPI drift check: passed
- `git diff --check`: passed
- no conflicting Cursor default assumptions found in `~/Projects/awf-cloud`

## Baseline test note

The full unit run is currently blocked by an unrelated planning-conformance coverage-edge test that also fails in a clean detached `origin/development` worktree:

`tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_001.py::test_satisfied_post_validation_conformance_stdout_deposits_artifact_before_unlink`

It fails with `POST_VALIDATION_CONFORMANCE_REPORT_CLEANUP_FAILED` on the untouched base. That pre-existing failure is outside this PR's scope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches worker execution-task cancellation (READY/resume kinds) and Cursor model selection for all Cursor workspaces. Incorrect cancel logic could stop healthy runs or leave monitors retrying a removed runtime.
> 
> **Overview**
> Stops hard-coding Cursor’s removed `sonnet-4-thinking` slug. Cursor now defaults to portable `auto` with **no AWF reasoning-effort mapping**; Cost/Balance/Intelligence stay on Cursor team policy or an explicit official selector such as `auto-smart[optimize_for=intelligence]`.
> 
> Also fixes a worker leak: first-run/adopted monitors that stay tracked as `READY` (and related handoff kinds) are now cancelled when the workspace is cancelled/destroyed, instead of retrying against a runtime that was already torn down. Healthy mid-execution tasks of those kinds are left alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1dbe89f218b0daf8fd7a3f48fe81ad7fbca09c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->