### PR TITLE
fix(hosted): validate evidence against materialized command plan

### DIFF
--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -450,25 +450,27 @@ class HostedValidationDelegate:
     ) -> ValidationResult:
         """Delegate selected profile phases to the hosting control plane."""
 
-        expected_commands = _hosted_validation_expected_commands(
-            profile,
-            phase_names,
-            run_healthchecks=run_healthchecks,
-        )
-        expected_command_count = len(expected_commands)
         # Hosted Jobs use their own /workspace/repo checkout; never send a
         # Core-local filesystem path (Cloud rejects non-null worktree_path).
         # Repo-relative profile env_file paths still resolve from the worktree
         # (same base as profile_services), while compose_dir stays for .env image
         # interpolation.
+        profile_payload = _hosted_validation_profile_payload(
+            profile,
+            compose_dir=compose_file.parent,
+            profile_base_path=worktree_path,
+            phase_names=phase_names,
+        )
+        execution_profile = WorkspaceProfile.model_validate(profile_payload)
+        expected_commands = _hosted_validation_expected_commands(
+            execution_profile,
+            phase_names,
+            run_healthchecks=run_healthchecks,
+        )
+        expected_command_count = len(expected_commands)
         payload: dict[str, Any] = {
             "workspace_id": workspace_id,
-            "profile": _hosted_validation_profile_payload(
-                profile,
-                compose_dir=compose_file.parent,
-                profile_base_path=worktree_path,
-                phase_names=phase_names,
-            ),
+            "profile": profile_payload,
             "phase_names": list(phase_names),
             "run_healthchecks": run_healthchecks,
             "worktree_path": None,

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -18,8 +18,13 @@ from awf.runtime.hosted_delegation import (
     HostedDelegationConfig,
     HostedDelegationProtocolError,
     HostedValidationDelegate,
+    _hosted_validation_profile_payload,
 )
-from awf.runtime.validation_setup import DB_REFRESH_PHASE
+from awf.runtime.validation_setup import (
+    DB_GENERATED_SETUP_PHASE,
+    DB_REFRESH_PHASE,
+    profile_phase_command_plan,
+)
 
 
 def _config() -> HostedDelegationConfig:
@@ -32,6 +37,23 @@ def _config() -> HostedDelegationConfig:
         cancel_timeout_seconds=1.0,
         max_output_bytes=100_000,
     )
+
+
+def _terminal_commands_from_expected(
+    expected_commands: tuple[hosted_delegation_mod._HostedValidationExpectedCommand, ...],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "command": command.command,
+            "returncode": 0,
+            "duration_seconds": 1.0,
+            "stdout": "",
+            "stderr": "",
+            "phase": command.phase,
+            "required": command.required,
+        }
+        for command in expected_commands
+    ]
 
 
 @pytest.mark.unit
@@ -192,16 +214,88 @@ async def test_hosted_validation_start_http_failure_reraises_without_cancel(
 
 
 @pytest.mark.unit
+def test_hosted_validation_expected_commands_derive_from_materialized_profile_for_playwright() -> (
+    None
+):
+    """Hosted expected command identities must follow the materialized wire profile."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-expected-commands",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+
+    materialized_plan = profile_phase_command_plan(materialized, ("setup",))
+    source_expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        profile,
+        ("setup",),
+        run_healthchecks=False,
+    )
+    materialized_expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        materialized,
+        ("setup",),
+        run_healthchecks=False,
+    )
+
+    assert ("db_generated_setup", "npx playwright install chromium") in [
+        (step.phase, step.command.command) for step in materialized_plan
+    ]
+    assert ("setup", "npx playwright install chromium") in [
+        (command.phase, command.command) for command in source_expected
+    ]
+    assert [
+        (command.phase, command.command, command.required) for command in materialized_expected
+    ] == [(step.phase, step.command.command, step.command.required) for step in materialized_plan]
+
+
+@pytest.mark.unit
+def test_hosted_validation_expected_commands_setup_generated_setup_then_playwright_order() -> None:
+    """Materialized setup keeps hook and browser install under db_generated_setup."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-three-command-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+
+    expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        materialized,
+        ("setup",),
+        run_healthchecks=False,
+    )
+
+    assert [(command.phase, command.command) for command in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "pnpm install"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+    ]
+
+
+@pytest.mark.unit
 async def test_hosted_validation_setup_materializes_playwright_browser_install_in_payload_and_accepts_evidence(
     tmp_path: Path,
 ) -> None:
-    """Hosted setup with runtime.browsers sends both setup commands and accepts evidence."""
+    """Hosted setup with runtime.browsers accepts Cloud db_generated_setup evidence."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-setup",
             "runtime": {"browsers": ["chromium"]},
             "phases": {"setup": ["npm ci"]},
         }
+    )
+    profile_payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    execution_profile = WorkspaceProfile.model_validate(profile_payload)
+    expected_commands = hosted_delegation_mod._hosted_validation_expected_commands(
+        execution_profile,
+        ("setup",),
+        run_healthchecks=False,
     )
     posted_payload: dict[str, object] | None = None
 
@@ -224,24 +318,7 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
                     "operation_id": "val_playwright",
                     "workspace_id": "ws_hosted",
                     "state": "succeeded",
-                    "commands": [
-                        {
-                            "command": "npm ci",
-                            "returncode": 0,
-                            "duration_seconds": 1.0,
-                            "stdout": "",
-                            "stderr": "",
-                            "phase": "setup",
-                        },
-                        {
-                            "command": "npx playwright install chromium",
-                            "returncode": 0,
-                            "duration_seconds": 2.0,
-                            "stdout": "",
-                            "stderr": "",
-                            "phase": "setup",
-                        },
-                    ],
+                    "commands": _terminal_commands_from_expected(expected_commands),
                 },
             )
         raise AssertionError(f"unexpected request {request.method} {request.url}")
@@ -270,6 +347,66 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
     assert generated_setup_commands == ["npx playwright install chromium"]
     assert result.all_passed
     assert len(result.commands) == 2
+    assert [(command.phase, command.command) for command in result.commands] == [
+        (command.phase, command.command) for command in expected_commands
+    ]
+
+
+@pytest.mark.unit
+async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_terminal_evidence(
+    tmp_path: Path,
+) -> None:
+    """Terminal evidence with setup phase for materialized browser install fails closed."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-wrong-phase",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    profile_payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    execution_profile = WorkspaceProfile.model_validate(profile_payload)
+    expected_commands = hosted_delegation_mod._hosted_validation_expected_commands(
+        execution_profile,
+        ("setup",),
+        run_healthchecks=False,
+    )
+    wrong_phase_commands = _terminal_commands_from_expected(expected_commands)
+    wrong_phase_commands[-1]["phase"] = "setup"
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_wrong_phase",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_wrong_phase",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_wrong_phase":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_wrong_phase",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": wrong_phase_commands,
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        with pytest.raises(HostedDelegationProtocolError, match="command identity mismatch"):
+            await delegate.run_profile_phases(
+                workspace_id="ws_hosted",
+                compose_project="unused",
+                compose_file=tmp_path / "missing-compose.yml",
+                profile=profile,
+                phase_names=("setup",),
+                include_coverage=False,
+            )
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -21,7 +21,7 @@ from awf.runtime.hosted_delegation_payloads import (
     _hosted_validation_secret_checked_fields,
     _is_managed_persisted_clarification_service,
 )
-from awf.runtime.validation_setup import profile_phase_command_plan
+from awf.runtime.validation_setup import DB_GENERATED_SETUP_PHASE, profile_phase_command_plan
 
 
 @pytest.mark.unit
@@ -432,7 +432,7 @@ def _setup_command_strings(payload: dict[str, object]) -> list[str]:
 
 @pytest.mark.unit
 def test_hosted_validation_profile_payload_materializes_playwright_setup_commands() -> None:
-    """Hosted setup payload preserves profile_phase_command_plan execution order."""
+    """Hosted setup payload preserves materialized profile_phase_command_plan order."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-setup-payload",
@@ -442,14 +442,18 @@ def test_hosted_validation_profile_payload_materializes_playwright_setup_command
     )
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
-    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+    materialized = WorkspaceProfile.model_validate(payload)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
     generated_setup = payload["database"]["generated_setup"]
     assert [item["command"] for item in generated_setup] == [
-        expected[-1],
+        expected[-1].command.command,
     ]
-    assert expected == ["npm ci", "npx playwright install chromium"]
+    assert [(step.phase, step.command.command) for step in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+    ]
 
 
 @pytest.mark.unit
@@ -465,14 +469,17 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
     )
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
-    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+    materialized = WorkspaceProfile.model_validate(payload)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
-    assert [item["command"] for item in payload["database"]["generated_setup"]] == expected[1:]
-    assert expected == [
-        "npm ci",
-        "pnpm install",
-        "npx playwright install chromium",
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == [
+        step.command.command for step in expected if step.phase == DB_GENERATED_SETUP_PHASE
+    ]
+    assert [(step.phase, step.command.command) for step in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "pnpm install"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
     ]
 
 


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_8b53c8c132db4d918a53dbcd` (agent: `cursor`, model: `auto`).


### Task
Environment notes:
- The repository is checked out at /workspace and git is functional.
- PR 878 merged to development as e7bd2ea13e869970b3bdd2192b5d433495bf8683, but an independent post-merge audit found its final tree still has a production-blocking hosted command identity mismatch.
- Core _hosted_validation_profile_payload materializes the generated Playwright install into database.generated_setup to preserve execution order after ordinary setup/database hooks. awf-cloud build_validation_plan therefore emits phase db_generated_setup for that command. Core run_profile_phases still derives expected_commands from the original profile, where profile_phase_command_plan labels the generated command setup. _validate_hosted_validation_command_identity requires exact phase equality.
- The PR 878 regression test masks this by mocking terminal evidence with phase setup rather than deriving the terminal command plan from the materialized payload.

What to do:
1. Use strict TDD. Add a failing regression test proving expected command identities are derived from the exact materialized hosted profile/plan, so a browser install serialized under database.generated_setup is expected and accepted as db_generated_setup in the correct order. Do not weaken exact command/phase evidence validation.
2. Implement the minimum Core-owned fix. Prefer deriving hosted expected_commands from the same deep-copied/materialized WorkspaceProfile represented on the wire, while preserving sanitization, secret rejection, source-profile immutability, and the existing local execution plan.
3. Replace or strengthen the misleading PR 878 mock so it cannot pass with an impossible phase. Cover ordinary setup followed by an existing generated_setup hook followed by generated Playwright install, plus no-setup, duplicate, coverage-only, and agent-payload exclusions where needed.
4. Keep the public Core/cloud-neutral boundary. Do not add awf-cloud code or duplicate Cloud planner semantics.
5. Run focused hosted delegation/payload/Playwright tests and adjacent contract tests.
6. Commit only relevant Core source and tests. Never stage plans/*_PLAN.md or plans/*_VALIDATION.md. Do not push; AWF owns push, PR creation, review, CI, and merge.

What to optimize for:
- One materialized wire profile as the authoritative execution/evidence contract.
- Exact fail-closed phase and command identity parity.
- Small source change with a realistic regression test, no unrelated coverage churn.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted validation evidence matching on a production-blocking path; scope is small and bounded to delegation command identity, with expanded contract tests.
> 
> **Overview**
> Fixes a **hosted validation command identity mismatch** where Playwright browser installs are serialized on the wire under `database.generated_setup` (phase `db_generated_setup`) but Core still expected terminal evidence with phase `setup`.
> 
> **`run_profile_phases`** now builds the hosted profile payload once, rehydrates it as an `execution_profile`, and derives **`expected_commands`** from that materialized profile—the same object sent to the control plane—so strict phase/command parity matches what Cloud runs and reports.
> 
> Tests are tightened so mocks derive terminal evidence from the materialized expected plan, assert ordering for setup → `generated_setup` → Playwright, and **fail closed** when Cloud returns the wrong phase for a materialized browser install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7f76175b4bd58ae4e7eb8d3c581d7e52e52d8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->