### PR TITLE
Release: merge development into main

### DIFF
--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -467,6 +467,7 @@ class HostedValidationDelegate:
                 profile,
                 compose_dir=compose_file.parent,
                 profile_base_path=worktree_path,
+                phase_names=phase_names,
             ),
             "phase_names": list(phase_names),
             "run_healthchecks": run_healthchecks,

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -466,7 +466,6 @@ class HostedValidationDelegate:
             execution_profile,
             phase_names,
             run_healthchecks=run_healthchecks,
-            source_profile=profile,
         )
         expected_command_count = len(expected_commands)
         payload: dict[str, Any] = {
@@ -716,7 +715,6 @@ def _hosted_validation_expected_commands(
     phase_names: list[str] | tuple[str, ...],
     *,
     run_healthchecks: bool,
-    source_profile: WorkspaceProfile | None = None,
 ) -> tuple[_HostedValidationExpectedCommand, ...]:
     requested_phases = set(phase_names)
     commands: list[_HostedValidationExpectedCommand] = []
@@ -747,11 +745,7 @@ def _hosted_validation_expected_commands(
         commands.extend(healthcheck_commands)
         healthchecks_pending = False
 
-    for step in profile_phase_command_plan(
-        profile,
-        phase_names,
-        source_profile=source_profile,
-    ):
+    for step in profile_phase_command_plan(profile, phase_names):
         if healthchecks_pending and step.phase == healthcheck_before_phase:
             commands.extend(healthcheck_commands)
             healthchecks_pending = False

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -450,25 +450,27 @@ class HostedValidationDelegate:
     ) -> ValidationResult:
         """Delegate selected profile phases to the hosting control plane."""
 
-        expected_commands = _hosted_validation_expected_commands(
-            profile,
-            phase_names,
-            run_healthchecks=run_healthchecks,
-        )
-        expected_command_count = len(expected_commands)
         # Hosted Jobs use their own /workspace/repo checkout; never send a
         # Core-local filesystem path (Cloud rejects non-null worktree_path).
         # Repo-relative profile env_file paths still resolve from the worktree
         # (same base as profile_services), while compose_dir stays for .env image
         # interpolation.
+        profile_payload = _hosted_validation_profile_payload(
+            profile,
+            compose_dir=compose_file.parent,
+            profile_base_path=worktree_path,
+            phase_names=phase_names,
+        )
+        execution_profile = WorkspaceProfile.model_validate(profile_payload)
+        expected_commands = _hosted_validation_expected_commands(
+            execution_profile,
+            phase_names,
+            run_healthchecks=run_healthchecks,
+        )
+        expected_command_count = len(expected_commands)
         payload: dict[str, Any] = {
             "workspace_id": workspace_id,
-            "profile": _hosted_validation_profile_payload(
-                profile,
-                compose_dir=compose_file.parent,
-                profile_base_path=worktree_path,
-                phase_names=phase_names,
-            ),
+            "profile": profile_payload,
             "phase_names": list(phase_names),
             "run_healthchecks": run_healthchecks,
             "worktree_path": None,

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -466,6 +466,7 @@ class HostedValidationDelegate:
             execution_profile,
             phase_names,
             run_healthchecks=run_healthchecks,
+            source_profile=profile,
         )
         expected_command_count = len(expected_commands)
         payload: dict[str, Any] = {
@@ -715,6 +716,7 @@ def _hosted_validation_expected_commands(
     phase_names: list[str] | tuple[str, ...],
     *,
     run_healthchecks: bool,
+    source_profile: WorkspaceProfile | None = None,
 ) -> tuple[_HostedValidationExpectedCommand, ...]:
     requested_phases = set(phase_names)
     commands: list[_HostedValidationExpectedCommand] = []
@@ -745,7 +747,11 @@ def _hosted_validation_expected_commands(
         commands.extend(healthcheck_commands)
         healthchecks_pending = False
 
-    for step in profile_phase_command_plan(profile, phase_names):
+    for step in profile_phase_command_plan(
+        profile,
+        phase_names,
+        source_profile=source_profile,
+    ):
         if healthchecks_pending and step.phase == healthcheck_before_phase:
             commands.extend(healthcheck_commands)
             healthchecks_pending = False

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -871,13 +871,13 @@ def _hosted_validation_materialize_playwright_setup(
         return
     if playwright_browser_install_already_required(profile, browser_install):
         return
-    database = payload.get("database")
-    if not isinstance(database, dict):
+    phases = payload.get("phases")
+    if not isinstance(phases, dict):
         return
-    generated_setup = database.get("generated_setup")
-    if not isinstance(generated_setup, list):
+    setup = phases.get("setup")
+    if not isinstance(setup, list):
         return
-    generated_setup.append(browser_install.model_dump(mode="json"))
+    setup.append(browser_install.model_dump(mode="json"))
 
 
 def _hosted_validation_profile_payload(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -32,7 +32,10 @@ from awf.runtime.hosted_delegation_payload_volumes import (
     _hosted_validation_sanitize_compose_value,
     _hosted_validation_sanitize_rendered_stack_volumes,
 )
-from awf.runtime.node_playwright_setup import playwright_browser_install_command
+from awf.runtime.node_playwright_setup import (
+    playwright_browser_install_already_required,
+    playwright_browser_install_command,
+)
 from awf.service.environment import (
     ComposeEnvInterpolationError,
     compose_env_file_values,
@@ -866,9 +869,7 @@ def _hosted_validation_materialize_playwright_setup(
     browser_install = playwright_browser_install_command(profile)
     if browser_install is None:
         return
-    existing_commands = {command.command for command in profile.phases.setup}
-    existing_commands.update(command.command for command in profile.database.generated_setup)
-    if browser_install.command in existing_commands:
+    if playwright_browser_install_already_required(profile, browser_install):
         return
     database = payload.get("database")
     if not isinstance(database, dict):

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -871,13 +871,23 @@ def _hosted_validation_materialize_playwright_setup(
         return
     if playwright_browser_install_already_required(profile, browser_install):
         return
+    browser_payload = browser_install.model_dump(mode="json")
+    if profile.database.generated_setup:
+        database = payload.get("database")
+        if not isinstance(database, dict):
+            return
+        generated_setup = database.get("generated_setup")
+        if not isinstance(generated_setup, list):
+            return
+        generated_setup.append(browser_payload)
+        return
     phases = payload.get("phases")
     if not isinstance(phases, dict):
         return
     setup = phases.get("setup")
     if not isinstance(setup, list):
         return
-    setup.append(browser_install.model_dump(mode="json"))
+    setup.append(browser_payload)
 
 
 def _hosted_validation_profile_payload(

--- a/src/awf/runtime/hosted_delegation_payloads.py
+++ b/src/awf/runtime/hosted_delegation_payloads.py
@@ -32,6 +32,7 @@ from awf.runtime.hosted_delegation_payload_volumes import (
     _hosted_validation_sanitize_compose_value,
     _hosted_validation_sanitize_rendered_stack_volumes,
 )
+from awf.runtime.node_playwright_setup import playwright_browser_install_command
 from awf.service.environment import (
     ComposeEnvInterpolationError,
     compose_env_file_values,
@@ -854,12 +855,37 @@ def _strip_pr_identity_url_credentials(value: str) -> str:
     return urlunsplit((parsed.scheme, authority, parsed.path, "", ""))
 
 
+def _hosted_validation_materialize_playwright_setup(
+    payload: dict[str, Any],
+    profile: WorkspaceProfile,
+    phase_names: list[str] | tuple[str, ...],
+) -> None:
+    """Append generated Playwright browser-install after setup hooks when setup is requested."""
+    if "setup" not in phase_names:
+        return
+    browser_install = playwright_browser_install_command(profile)
+    if browser_install is None:
+        return
+    existing_commands = {command.command for command in profile.phases.setup}
+    existing_commands.update(command.command for command in profile.database.generated_setup)
+    if browser_install.command in existing_commands:
+        return
+    database = payload.get("database")
+    if not isinstance(database, dict):
+        return
+    generated_setup = database.get("generated_setup")
+    if not isinstance(generated_setup, list):
+        return
+    generated_setup.append(browser_install.model_dump(mode="json"))
+
+
 def _hosted_validation_profile_payload(
     profile: WorkspaceProfile,
     *,
     omit_runtime_environment: frozenset[str] = frozenset(),
     compose_dir: Path | None = None,
     profile_base_path: Path | None = None,
+    phase_names: list[str] | tuple[str, ...] = (),
 ) -> dict[str, Any]:
     payload = profile.model_dump(mode="json", by_alias=True)
     # Cloud rejects non-empty profile.secrets (no Core-local secret resolution).
@@ -892,6 +918,7 @@ def _hosted_validation_profile_payload(
                 service,
                 inject_postgres_trust=inject_postgres_trust,
             )
+    _hosted_validation_materialize_playwright_setup(payload, profile, phase_names)
     _hosted_validation_reject_secret_bearing_fields(payload)
     return payload
 

--- a/src/awf/runtime/node_playwright_setup.py
+++ b/src/awf/runtime/node_playwright_setup.py
@@ -704,6 +704,20 @@ def _python_playwright_install_command(executable: str, *browsers: str) -> str:
     return f"{executable} -m playwright install {shlex.join(browsers)}"
 
 
+def playwright_browser_install_already_required(
+    profile: WorkspaceProfile,
+    browser_install: ProfileCommand,
+) -> bool:
+    """Return True when setup already declares the same browser-install as required."""
+    for command in profile.phases.setup:
+        if command.command == browser_install.command and command.required:
+            return True
+    for command in profile.database.generated_setup:
+        if command.command == browser_install.command and command.required:
+            return True
+    return False
+
+
 def playwright_browser_install_command(
     profile: WorkspaceProfile,
 ) -> ProfileCommand | None:

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -22,7 +22,6 @@ from urllib.parse import urlparse
 from awf.common.audit import redact_audit_text
 from awf.common.logging import get_logger
 from awf.profiles.models import (
-    ProfileCommand,
     WorkspaceProfile,
 )
 from awf.runtime.node_playwright_setup import (
@@ -200,15 +199,8 @@ def validate_phase_command_strings(profile: WorkspaceProfile) -> list[str]:
 def profile_phase_command_plan(
     profile: WorkspaceProfile,
     phase_names: list[str] | tuple[str, ...],
-    *,
-    source_profile: WorkspaceProfile | None = None,
 ) -> list[ProfileExecutionCommand]:
     """Return normal phase commands plus DB hooks in runtime execution order."""
-    source_generated_setup_commands = (
-        frozenset(command.command for command in source_profile.database.generated_setup)
-        if source_profile is not None
-        else None
-    )
     commands: list[ProfileExecutionCommand] = []
     for phase in sorted(
         phase_names,
@@ -219,13 +211,6 @@ def profile_phase_command_plan(
     ):
         if phase == "setup":
             commands.extend(_phase_commands(profile, "setup"))
-            generated_setup_commands, materialized_browser_install = (
-                _partition_materialized_playwright_browser_install_from_generated_setup(
-                    profile,
-                    profile.database.generated_setup,
-                    source_generated_setup_commands=source_generated_setup_commands,
-                )
-            )
             commands.extend(
                 ProfileExecutionCommand(
                     phase=DB_GENERATED_SETUP_PHASE,
@@ -233,12 +218,8 @@ def profile_phase_command_plan(
                     database_hook=True,
                     hook_kind="generated_setup",
                 )
-                for command in generated_setup_commands
+                for command in profile.database.generated_setup
             )
-            if materialized_browser_install is not None:
-                commands.append(
-                    ProfileExecutionCommand(phase="setup", command=materialized_browser_install)
-                )
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None and not playwright_browser_install_already_required(
                 profile, browser_install
@@ -266,38 +247,6 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
         ProfileExecutionCommand(phase=phase_name, command=command)
         for phase_name, command in profile.phases.commands_for((phase,))
     ]
-
-
-def _partition_materialized_playwright_browser_install_from_generated_setup(
-    profile: WorkspaceProfile,
-    generated_setup_commands: list[ProfileCommand],
-    *,
-    source_generated_setup_commands: frozenset[str] | None = None,
-) -> tuple[list[ProfileCommand], ProfileCommand | None]:
-    """Report a trailing materialized browser-install under the setup phase.
-
-    Hosted payloads append the generated Playwright install after profile
-    ``database.generated_setup`` hooks so Cloud executes dependency installs first,
-    but failures must still use setup retry semantics instead of
-    ``DATABASE_GENERATED_SETUP_*`` reason codes. Only commands materialized by
-    Core are reclassified; explicit trailing profile hooks keep database-hook
-    metadata even when they match the inferred browser-install command.
-    """
-    browser_install = playwright_browser_install_command(profile)
-    if (
-        browser_install is None
-        or source_generated_setup_commands is None
-        or len(generated_setup_commands) < 2
-    ):
-        return generated_setup_commands, None
-    last_command = generated_setup_commands[-1]
-    if (
-        last_command.command == browser_install.command
-        and last_command.required
-        and last_command.command not in source_generated_setup_commands
-    ):
-        return generated_setup_commands[:-1], last_command
-    return generated_setup_commands, None
 
 
 def profile_validation_tool_preflight_findings(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 from awf.common.audit import redact_audit_text
 from awf.common.logging import get_logger
 from awf.profiles.models import (
+    ProfileCommand,
     WorkspaceProfile,
 )
 from awf.runtime.node_playwright_setup import (
@@ -210,14 +211,13 @@ def profile_phase_command_plan(
         ),
     ):
         if phase == "setup":
-            setup_steps = _phase_commands(profile, "setup")
-            immediate_setup, deferred_browser_install = (
-                _partition_deferred_playwright_browser_install_setup_commands(
+            commands.extend(_phase_commands(profile, "setup"))
+            generated_setup_commands, materialized_browser_install = (
+                _partition_materialized_playwright_browser_install_from_generated_setup(
                     profile,
-                    setup_steps,
+                    profile.database.generated_setup,
                 )
             )
-            commands.extend(immediate_setup)
             commands.extend(
                 ProfileExecutionCommand(
                     phase=DB_GENERATED_SETUP_PHASE,
@@ -225,9 +225,12 @@ def profile_phase_command_plan(
                     database_hook=True,
                     hook_kind="generated_setup",
                 )
-                for command in profile.database.generated_setup
+                for command in generated_setup_commands
             )
-            commands.extend(deferred_browser_install)
+            if materialized_browser_install is not None:
+                commands.append(
+                    ProfileExecutionCommand(phase="setup", command=materialized_browser_install)
+                )
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None and not playwright_browser_install_already_required(
                 profile, browser_install
@@ -257,25 +260,24 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
     ]
 
 
-def _partition_deferred_playwright_browser_install_setup_commands(
+def _partition_materialized_playwright_browser_install_from_generated_setup(
     profile: WorkspaceProfile,
-    setup_steps: list[ProfileExecutionCommand],
-) -> tuple[list[ProfileExecutionCommand], list[ProfileExecutionCommand]]:
-    """Defer a trailing materialized browser-install step until after DB hooks.
+    generated_setup_commands: list[ProfileCommand],
+) -> tuple[list[ProfileCommand], ProfileCommand | None]:
+    """Report a trailing materialized browser-install under the setup phase.
 
-    Hosted payloads append the generated Playwright install to ``phases.setup`` so
-    failures use setup retry semantics, but dependency installs in
-    ``database.generated_setup`` must still run first. Only the final setup step is
-    deferred when it matches the generated browser-install command; earlier explicit
-    browser-install hooks stay in profile order for dependent setup commands.
+    Hosted payloads append the generated Playwright install after profile
+    ``database.generated_setup`` hooks so Cloud executes dependency installs first,
+    but failures must still use setup retry semantics instead of
+    ``DATABASE_GENERATED_SETUP_*`` reason codes.
     """
     browser_install = playwright_browser_install_command(profile)
-    if browser_install is None or not setup_steps or not profile.database.generated_setup:
-        return setup_steps, []
-    last_step = setup_steps[-1]
-    if last_step.command.command == browser_install.command and last_step.command.required:
-        return setup_steps[:-1], [last_step]
-    return setup_steps, []
+    if browser_install is None or len(generated_setup_commands) < 2:
+        return generated_setup_commands, None
+    last_command = generated_setup_commands[-1]
+    if last_command.command == browser_install.command and last_command.required:
+        return generated_setup_commands[:-1], last_command
+    return generated_setup_commands, None
 
 
 def profile_validation_tool_preflight_findings(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -210,14 +210,7 @@ def profile_phase_command_plan(
         ),
     ):
         if phase == "setup":
-            setup_steps = _phase_commands(profile, "setup")
-            immediate_setup, deferred_browser_install = (
-                _partition_deferred_playwright_browser_install_setup_commands(
-                    profile,
-                    setup_steps,
-                )
-            )
-            commands.extend(immediate_setup)
+            commands.extend(_phase_commands(profile, "setup"))
             commands.extend(
                 ProfileExecutionCommand(
                     phase=DB_GENERATED_SETUP_PHASE,
@@ -227,7 +220,6 @@ def profile_phase_command_plan(
                 )
                 for command in profile.database.generated_setup
             )
-            commands.extend(deferred_browser_install)
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None and not playwright_browser_install_already_required(
                 profile, browser_install
@@ -255,24 +247,6 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
         ProfileExecutionCommand(phase=phase_name, command=command)
         for phase_name, command in profile.phases.commands_for((phase,))
     ]
-
-
-def _partition_deferred_playwright_browser_install_setup_commands(
-    profile: WorkspaceProfile,
-    setup_steps: list[ProfileExecutionCommand],
-) -> tuple[list[ProfileExecutionCommand], list[ProfileExecutionCommand]]:
-    """Defer required generated Playwright browser-install steps until after DB hooks."""
-    browser_install = playwright_browser_install_command(profile)
-    if browser_install is None:
-        return setup_steps, []
-    immediate: list[ProfileExecutionCommand] = []
-    deferred: list[ProfileExecutionCommand] = []
-    for step in setup_steps:
-        if step.command.command == browser_install.command and step.command.required:
-            deferred.append(step)
-        else:
-            immediate.append(step)
-    return immediate, deferred
 
 
 def profile_validation_tool_preflight_findings(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -210,7 +210,14 @@ def profile_phase_command_plan(
         ),
     ):
         if phase == "setup":
-            commands.extend(_phase_commands(profile, "setup"))
+            setup_steps = _phase_commands(profile, "setup")
+            immediate_setup, deferred_browser_install = (
+                _partition_deferred_playwright_browser_install_setup_commands(
+                    profile,
+                    setup_steps,
+                )
+            )
+            commands.extend(immediate_setup)
             commands.extend(
                 ProfileExecutionCommand(
                     phase=DB_GENERATED_SETUP_PHASE,
@@ -220,6 +227,7 @@ def profile_phase_command_plan(
                 )
                 for command in profile.database.generated_setup
             )
+            commands.extend(deferred_browser_install)
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None and not playwright_browser_install_already_required(
                 profile, browser_install
@@ -247,6 +255,27 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
         ProfileExecutionCommand(phase=phase_name, command=command)
         for phase_name, command in profile.phases.commands_for((phase,))
     ]
+
+
+def _partition_deferred_playwright_browser_install_setup_commands(
+    profile: WorkspaceProfile,
+    setup_steps: list[ProfileExecutionCommand],
+) -> tuple[list[ProfileExecutionCommand], list[ProfileExecutionCommand]]:
+    """Defer a trailing materialized browser-install step until after DB hooks.
+
+    Hosted payloads append the generated Playwright install to ``phases.setup`` so
+    failures use setup retry semantics, but dependency installs in
+    ``database.generated_setup`` must still run first. Only the final setup step is
+    deferred when it matches the generated browser-install command; earlier explicit
+    browser-install hooks stay in profile order for dependent setup commands.
+    """
+    browser_install = playwright_browser_install_command(profile)
+    if browser_install is None or not setup_steps or not profile.database.generated_setup:
+        return setup_steps, []
+    last_step = setup_steps[-1]
+    if last_step.command.command == browser_install.command and last_step.command.required:
+        return setup_steps[:-1], [last_step]
+    return setup_steps, []
 
 
 def profile_validation_tool_preflight_findings(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -210,7 +210,14 @@ def profile_phase_command_plan(
         ),
     ):
         if phase == "setup":
-            commands.extend(_phase_commands(profile, "setup"))
+            setup_steps = _phase_commands(profile, "setup")
+            immediate_setup, deferred_browser_install = (
+                _partition_deferred_playwright_browser_install_setup_commands(
+                    profile,
+                    setup_steps,
+                )
+            )
+            commands.extend(immediate_setup)
             commands.extend(
                 ProfileExecutionCommand(
                     phase=DB_GENERATED_SETUP_PHASE,
@@ -220,6 +227,7 @@ def profile_phase_command_plan(
                 )
                 for command in profile.database.generated_setup
             )
+            commands.extend(deferred_browser_install)
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None and not playwright_browser_install_already_required(
                 profile, browser_install
@@ -247,6 +255,24 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
         ProfileExecutionCommand(phase=phase_name, command=command)
         for phase_name, command in profile.phases.commands_for((phase,))
     ]
+
+
+def _partition_deferred_playwright_browser_install_setup_commands(
+    profile: WorkspaceProfile,
+    setup_steps: list[ProfileExecutionCommand],
+) -> tuple[list[ProfileExecutionCommand], list[ProfileExecutionCommand]]:
+    """Defer required generated Playwright browser-install steps until after DB hooks."""
+    browser_install = playwright_browser_install_command(profile)
+    if browser_install is None:
+        return setup_steps, []
+    immediate: list[ProfileExecutionCommand] = []
+    deferred: list[ProfileExecutionCommand] = []
+    for step in setup_steps:
+        if step.command.command == browser_install.command and step.command.required:
+            deferred.append(step)
+        else:
+            immediate.append(step)
+    return immediate, deferred
 
 
 def profile_validation_tool_preflight_findings(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -221,7 +221,12 @@ def profile_phase_command_plan(
             )
             browser_install = playwright_browser_install_command(profile)
             if browser_install is not None:
-                commands.append(ProfileExecutionCommand(phase="setup", command=browser_install))
+                existing_commands = {command.command for command in profile.phases.setup}
+                existing_commands.update(
+                    command.command for command in profile.database.generated_setup
+                )
+                if browser_install.command not in existing_commands:
+                    commands.append(ProfileExecutionCommand(phase="setup", command=browser_install))
             continue
         if phase == "validate":
             commands.extend(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -25,6 +25,7 @@ from awf.profiles.models import (
     WorkspaceProfile,
 )
 from awf.runtime.node_playwright_setup import (
+    playwright_browser_install_already_required,
     playwright_browser_install_command,
 )
 from awf.runtime.validation_command_probe import (
@@ -220,13 +221,10 @@ def profile_phase_command_plan(
                 for command in profile.database.generated_setup
             )
             browser_install = playwright_browser_install_command(profile)
-            if browser_install is not None:
-                existing_commands = {command.command for command in profile.phases.setup}
-                existing_commands.update(
-                    command.command for command in profile.database.generated_setup
-                )
-                if browser_install.command not in existing_commands:
-                    commands.append(ProfileExecutionCommand(phase="setup", command=browser_install))
+            if browser_install is not None and not playwright_browser_install_already_required(
+                profile, browser_install
+            ):
+                commands.append(ProfileExecutionCommand(phase="setup", command=browser_install))
             continue
         if phase == "validate":
             commands.extend(

--- a/src/awf/runtime/validation_setup.py
+++ b/src/awf/runtime/validation_setup.py
@@ -200,8 +200,15 @@ def validate_phase_command_strings(profile: WorkspaceProfile) -> list[str]:
 def profile_phase_command_plan(
     profile: WorkspaceProfile,
     phase_names: list[str] | tuple[str, ...],
+    *,
+    source_profile: WorkspaceProfile | None = None,
 ) -> list[ProfileExecutionCommand]:
     """Return normal phase commands plus DB hooks in runtime execution order."""
+    source_generated_setup_commands = (
+        frozenset(command.command for command in source_profile.database.generated_setup)
+        if source_profile is not None
+        else None
+    )
     commands: list[ProfileExecutionCommand] = []
     for phase in sorted(
         phase_names,
@@ -216,6 +223,7 @@ def profile_phase_command_plan(
                 _partition_materialized_playwright_browser_install_from_generated_setup(
                     profile,
                     profile.database.generated_setup,
+                    source_generated_setup_commands=source_generated_setup_commands,
                 )
             )
             commands.extend(
@@ -263,19 +271,31 @@ def _phase_commands(profile: WorkspaceProfile, phase: str) -> list[ProfileExecut
 def _partition_materialized_playwright_browser_install_from_generated_setup(
     profile: WorkspaceProfile,
     generated_setup_commands: list[ProfileCommand],
+    *,
+    source_generated_setup_commands: frozenset[str] | None = None,
 ) -> tuple[list[ProfileCommand], ProfileCommand | None]:
     """Report a trailing materialized browser-install under the setup phase.
 
     Hosted payloads append the generated Playwright install after profile
     ``database.generated_setup`` hooks so Cloud executes dependency installs first,
     but failures must still use setup retry semantics instead of
-    ``DATABASE_GENERATED_SETUP_*`` reason codes.
+    ``DATABASE_GENERATED_SETUP_*`` reason codes. Only commands materialized by
+    Core are reclassified; explicit trailing profile hooks keep database-hook
+    metadata even when they match the inferred browser-install command.
     """
     browser_install = playwright_browser_install_command(profile)
-    if browser_install is None or len(generated_setup_commands) < 2:
+    if (
+        browser_install is None
+        or source_generated_setup_commands is None
+        or len(generated_setup_commands) < 2
+    ):
         return generated_setup_commands, None
     last_command = generated_setup_commands[-1]
-    if last_command.command == browser_install.command and last_command.required:
+    if (
+        last_command.command == browser_install.command
+        and last_command.required
+        and last_command.command not in source_generated_setup_commands
+    ):
         return generated_setup_commands[:-1], last_command
     return generated_setup_commands, None
 

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -228,11 +228,7 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
 
-    materialized_plan = profile_phase_command_plan(
-        materialized,
-        ("setup",),
-        source_profile=profile,
-    )
+    materialized_plan = profile_phase_command_plan(materialized, ("setup",))
     source_expected = hosted_delegation_mod._hosted_validation_expected_commands(
         profile,
         ("setup",),
@@ -242,7 +238,6 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
         materialized,
         ("setup",),
         run_healthchecks=False,
-        source_profile=profile,
     )
 
     assert ("setup", "npx playwright install chromium") in [
@@ -258,7 +253,7 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
 
 @pytest.mark.unit
 def test_hosted_validation_expected_commands_setup_generated_setup_then_playwright_order() -> None:
-    """Materialized setup keeps DB hooks before deferred browser install."""
+    """Materialized setup keeps DB hooks before materialized browser install."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-three-command-setup",
@@ -274,13 +269,12 @@ def test_hosted_validation_expected_commands_setup_generated_setup_then_playwrig
         materialized,
         ("setup",),
         run_healthchecks=False,
-        source_profile=profile,
     )
 
     assert [(command.phase, command.command) for command in expected] == [
         ("setup", "npm ci"),
         (DB_GENERATED_SETUP_PHASE, "pnpm install"),
-        ("setup", "npx playwright install chromium"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
     ]
 
 
@@ -302,7 +296,6 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
         execution_profile,
         ("setup",),
         run_healthchecks=False,
-        source_profile=profile,
     )
     posted_payload: dict[str, object] | None = None
 
@@ -360,6 +353,84 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
 
 
 @pytest.mark.unit
+async def test_hosted_validation_setup_with_generated_setup_accepts_db_generated_setup_playwright_evidence(
+    tmp_path: Path,
+) -> None:
+    """Hosted setup with generated_setup hooks accepts Cloud db_generated_setup browser evidence."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-generated-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+    profile_payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    execution_profile = WorkspaceProfile.model_validate(profile_payload)
+    expected_commands = hosted_delegation_mod._hosted_validation_expected_commands(
+        execution_profile,
+        ("setup",),
+        run_healthchecks=False,
+    )
+    posted_payload: dict[str, object] | None = None
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posted_payload
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            posted_payload = json.loads(request.content)
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_playwright_generated_setup",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_playwright_generated_setup",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_playwright_generated_setup"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_playwright_generated_setup",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": _terminal_commands_from_expected(expected_commands),
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("setup",),
+            include_coverage=False,
+        )
+
+    assert posted_payload is not None
+    setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["phases"]["setup"]  # type: ignore[index]
+    ]
+    generated_setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["database"]["generated_setup"]  # type: ignore[index]
+    ]
+    assert setup_commands == ["npm ci"]
+    assert generated_setup_commands == ["pnpm install", "npx playwright install chromium"]
+    assert result.all_passed
+    assert len(result.commands) == 3
+    assert [(command.phase, command.command) for command in result.commands] == [
+        (command.phase, command.command) for command in expected_commands
+    ]
+
+
+@pytest.mark.unit
 async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_terminal_evidence(
     tmp_path: Path,
 ) -> None:
@@ -377,7 +448,6 @@ async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_termina
         execution_profile,
         ("setup",),
         run_healthchecks=False,
-        source_profile=profile,
     )
     wrong_phase_commands = _terminal_commands_from_expected(expected_commands)
     wrong_phase_commands[-1]["phase"] = DB_GENERATED_SETUP_PHASE

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -240,7 +240,7 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
         run_healthchecks=False,
     )
 
-    assert ("db_generated_setup", "npx playwright install chromium") in [
+    assert ("setup", "npx playwright install chromium") in [
         (step.phase, step.command.command) for step in materialized_plan
     ]
     assert ("setup", "npx playwright install chromium") in [
@@ -253,7 +253,7 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
 
 @pytest.mark.unit
 def test_hosted_validation_expected_commands_setup_generated_setup_then_playwright_order() -> None:
-    """Materialized setup keeps hook and browser install under db_generated_setup."""
+    """Materialized setup keeps DB hooks before deferred browser install."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-three-command-setup",
@@ -274,7 +274,7 @@ def test_hosted_validation_expected_commands_setup_generated_setup_then_playwrig
     assert [(command.phase, command.command) for command in expected] == [
         ("setup", "npm ci"),
         (DB_GENERATED_SETUP_PHASE, "pnpm install"),
-        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+        ("setup", "npx playwright install chromium"),
     ]
 
 
@@ -282,7 +282,7 @@ def test_hosted_validation_expected_commands_setup_generated_setup_then_playwrig
 async def test_hosted_validation_setup_materializes_playwright_browser_install_in_payload_and_accepts_evidence(
     tmp_path: Path,
 ) -> None:
-    """Hosted setup with runtime.browsers accepts Cloud db_generated_setup evidence."""
+    """Hosted setup with runtime.browsers accepts Cloud setup-phase browser evidence."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-setup",
@@ -343,8 +343,8 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
         item["command"]
         for item in posted_payload["profile"]["database"]["generated_setup"]  # type: ignore[index]
     ]
-    assert setup_commands == ["npm ci"]
-    assert generated_setup_commands == ["npx playwright install chromium"]
+    assert setup_commands == ["npm ci", "npx playwright install chromium"]
+    assert generated_setup_commands == []
     assert result.all_passed
     assert len(result.commands) == 2
     assert [(command.phase, command.command) for command in result.commands] == [
@@ -356,7 +356,7 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
 async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_terminal_evidence(
     tmp_path: Path,
 ) -> None:
-    """Terminal evidence with setup phase for materialized browser install fails closed."""
+    """Terminal evidence with db_generated_setup phase for browser install fails closed."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-wrong-phase",
@@ -372,7 +372,7 @@ async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_termina
         run_healthchecks=False,
     )
     wrong_phase_commands = _terminal_commands_from_expected(expected_commands)
-    wrong_phase_commands[-1]["phase"] = "setup"
+    wrong_phase_commands[-1]["phase"] = DB_GENERATED_SETUP_PHASE
 
     async def _handler(request: httpx.Request) -> httpx.Response:
         if request.method == "POST" and request.url.path == "/api/v1/validation-runs":

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -18,8 +18,13 @@ from awf.runtime.hosted_delegation import (
     HostedDelegationConfig,
     HostedDelegationProtocolError,
     HostedValidationDelegate,
+    _hosted_validation_profile_payload,
 )
-from awf.runtime.validation_setup import DB_REFRESH_PHASE
+from awf.runtime.validation_setup import (
+    DB_GENERATED_SETUP_PHASE,
+    DB_REFRESH_PHASE,
+    profile_phase_command_plan,
+)
 
 
 def _config() -> HostedDelegationConfig:
@@ -32,6 +37,23 @@ def _config() -> HostedDelegationConfig:
         cancel_timeout_seconds=1.0,
         max_output_bytes=100_000,
     )
+
+
+def _terminal_commands_from_expected(
+    expected_commands: tuple[hosted_delegation_mod._HostedValidationExpectedCommand, ...],
+) -> list[dict[str, object]]:
+    return [
+        {
+            "command": command.command,
+            "returncode": 0,
+            "duration_seconds": 1.0,
+            "stdout": "",
+            "stderr": "",
+            "phase": command.phase,
+            "required": command.required,
+        }
+        for command in expected_commands
+    ]
 
 
 @pytest.mark.unit
@@ -192,16 +214,88 @@ async def test_hosted_validation_start_http_failure_reraises_without_cancel(
 
 
 @pytest.mark.unit
+def test_hosted_validation_expected_commands_derive_from_materialized_profile_for_playwright() -> (
+    None
+):
+    """Hosted expected command identities must follow the materialized wire profile."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-expected-commands",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+
+    materialized_plan = profile_phase_command_plan(materialized, ("setup",))
+    source_expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        profile,
+        ("setup",),
+        run_healthchecks=False,
+    )
+    materialized_expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        materialized,
+        ("setup",),
+        run_healthchecks=False,
+    )
+
+    assert ("db_generated_setup", "npx playwright install chromium") in [
+        (step.phase, step.command.command) for step in materialized_plan
+    ]
+    assert ("setup", "npx playwright install chromium") in [
+        (command.phase, command.command) for command in source_expected
+    ]
+    assert [
+        (command.phase, command.command, command.required) for command in materialized_expected
+    ] == [(step.phase, step.command.command, step.command.required) for step in materialized_plan]
+
+
+@pytest.mark.unit
+def test_hosted_validation_expected_commands_setup_generated_setup_then_playwright_order() -> None:
+    """Materialized setup keeps hook and browser install under db_generated_setup."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-three-command-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+
+    expected = hosted_delegation_mod._hosted_validation_expected_commands(
+        materialized,
+        ("setup",),
+        run_healthchecks=False,
+    )
+
+    assert [(command.phase, command.command) for command in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "pnpm install"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+    ]
+
+
+@pytest.mark.unit
 async def test_hosted_validation_setup_materializes_playwright_browser_install_in_payload_and_accepts_evidence(
     tmp_path: Path,
 ) -> None:
-    """Hosted setup with runtime.browsers sends both setup commands and accepts evidence."""
+    """Hosted setup with runtime.browsers accepts Cloud db_generated_setup evidence."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-setup",
             "runtime": {"browsers": ["chromium"]},
             "phases": {"setup": ["npm ci"]},
         }
+    )
+    profile_payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    execution_profile = WorkspaceProfile.model_validate(profile_payload)
+    expected_commands = hosted_delegation_mod._hosted_validation_expected_commands(
+        execution_profile,
+        ("setup",),
+        run_healthchecks=False,
     )
     posted_payload: dict[str, object] | None = None
 
@@ -224,24 +318,7 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
                     "operation_id": "val_playwright",
                     "workspace_id": "ws_hosted",
                     "state": "succeeded",
-                    "commands": [
-                        {
-                            "command": "npm ci",
-                            "returncode": 0,
-                            "duration_seconds": 1.0,
-                            "stdout": "",
-                            "stderr": "",
-                            "phase": "setup",
-                        },
-                        {
-                            "command": "npx playwright install chromium",
-                            "returncode": 0,
-                            "duration_seconds": 2.0,
-                            "stdout": "",
-                            "stderr": "",
-                            "phase": "setup",
-                        },
-                    ],
+                    "commands": _terminal_commands_from_expected(expected_commands),
                 },
             )
         raise AssertionError(f"unexpected request {request.method} {request.url}")
@@ -270,6 +347,66 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
     assert generated_setup_commands == ["npx playwright install chromium"]
     assert result.all_passed
     assert len(result.commands) == 2
+    assert [(command.phase, command.command) for command in result.commands] == [
+        (command.phase, command.command) for command in expected_commands
+    ]
+
+
+@pytest.mark.unit
+async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_terminal_evidence(
+    tmp_path: Path,
+) -> None:
+    """Terminal evidence with setup phase for materialized browser install fails closed."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-wrong-phase",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    profile_payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    execution_profile = WorkspaceProfile.model_validate(profile_payload)
+    expected_commands = hosted_delegation_mod._hosted_validation_expected_commands(
+        execution_profile,
+        ("setup",),
+        run_healthchecks=False,
+    )
+    wrong_phase_commands = _terminal_commands_from_expected(expected_commands)
+    wrong_phase_commands[-1]["phase"] = "setup"
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_wrong_phase",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_wrong_phase",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_wrong_phase":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_wrong_phase",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": wrong_phase_commands,
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        with pytest.raises(HostedDelegationProtocolError, match="command identity mismatch"):
+            await delegate.run_profile_phases(
+                workspace_id="ws_hosted",
+                compose_project="unused",
+                compose_file=tmp_path / "missing-compose.yml",
+                profile=profile,
+                phase_names=("setup",),
+                include_coverage=False,
+            )
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -410,6 +410,76 @@ async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_termina
 
 
 @pytest.mark.unit
+async def test_hosted_validation_validate_only_payload_excludes_playwright_browser_install(
+    tmp_path: Path,
+) -> None:
+    """Validate-only hosted validation must not materialize setup browser-install."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-validate-playwright",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"], "validate": ["pytest -q"]},
+        }
+    )
+    posted_payload: dict[str, object] | None = None
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posted_payload
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            posted_payload = json.loads(request.content)
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_validate_only",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_validate_only",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_validate_only":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_validate_only",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 0,
+                            "duration_seconds": 1.0,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "validate",
+                            "required": True,
+                        },
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=False,
+        )
+
+    assert posted_payload is not None
+    setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["phases"]["setup"]  # type: ignore[index]
+    ]
+    assert setup_commands == ["npm ci"]
+    assert posted_payload["profile"]["database"]["generated_setup"] == []  # type: ignore[index]
+    body = json.dumps(posted_payload, sort_keys=True)
+    assert "playwright install" not in body
+
+
+@pytest.mark.unit
 async def test_hosted_validation_coverage_payload_excludes_playwright_browser_install(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -228,7 +228,11 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
 
-    materialized_plan = profile_phase_command_plan(materialized, ("setup",))
+    materialized_plan = profile_phase_command_plan(
+        materialized,
+        ("setup",),
+        source_profile=profile,
+    )
     source_expected = hosted_delegation_mod._hosted_validation_expected_commands(
         profile,
         ("setup",),
@@ -238,6 +242,7 @@ def test_hosted_validation_expected_commands_derive_from_materialized_profile_fo
         materialized,
         ("setup",),
         run_healthchecks=False,
+        source_profile=profile,
     )
 
     assert ("setup", "npx playwright install chromium") in [
@@ -269,6 +274,7 @@ def test_hosted_validation_expected_commands_setup_generated_setup_then_playwrig
         materialized,
         ("setup",),
         run_healthchecks=False,
+        source_profile=profile,
     )
 
     assert [(command.phase, command.command) for command in expected] == [
@@ -296,6 +302,7 @@ async def test_hosted_validation_setup_materializes_playwright_browser_install_i
         execution_profile,
         ("setup",),
         run_healthchecks=False,
+        source_profile=profile,
     )
     posted_payload: dict[str, object] | None = None
 
@@ -370,6 +377,7 @@ async def test_hosted_validation_setup_rejects_wrong_playwright_phase_in_termina
         execution_profile,
         ("setup",),
         run_healthchecks=False,
+        source_profile=profile,
     )
     wrong_phase_commands = _terminal_commands_from_expected(expected_commands)
     wrong_phase_commands[-1]["phase"] = DB_GENERATED_SETUP_PHASE

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -483,3 +483,4 @@ async def test_hosted_validation_coverage_payload_excludes_playwright_browser_in
         for item in posted_payload["profile"]["phases"]["setup"]  # type: ignore[index]
     ]
     assert setup_commands == ["npm ci"]
+    assert posted_payload["profile"]["database"]["generated_setup"] == []  # type: ignore[index]

--- a/tests/unit/runtime/test_hosted_delegation_contract_edges.py
+++ b/tests/unit/runtime/test_hosted_delegation_contract_edges.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import httpx
@@ -188,3 +189,160 @@ async def test_hosted_validation_start_http_failure_reraises_without_cancel(
             )
 
     assert seen_paths == ["/api/v1/validation-runs"]
+
+
+@pytest.mark.unit
+async def test_hosted_validation_setup_materializes_playwright_browser_install_in_payload_and_accepts_evidence(
+    tmp_path: Path,
+) -> None:
+    """Hosted setup with runtime.browsers sends both setup commands and accepts evidence."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    posted_payload: dict[str, object] | None = None
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posted_payload
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            posted_payload = json.loads(request.content)
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_playwright",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_playwright",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_playwright":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_playwright",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "npm ci",
+                            "returncode": 0,
+                            "duration_seconds": 1.0,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "setup",
+                        },
+                        {
+                            "command": "npx playwright install chromium",
+                            "returncode": 0,
+                            "duration_seconds": 2.0,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "setup",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("setup",),
+            include_coverage=False,
+        )
+
+    assert posted_payload is not None
+    setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["phases"]["setup"]  # type: ignore[index]
+    ]
+    generated_setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["database"]["generated_setup"]  # type: ignore[index]
+    ]
+    assert setup_commands == ["npm ci"]
+    assert generated_setup_commands == ["npx playwright install chromium"]
+    assert result.all_passed
+    assert len(result.commands) == 2
+
+
+@pytest.mark.unit
+async def test_hosted_validation_coverage_payload_excludes_playwright_browser_install(
+    tmp_path: Path,
+) -> None:
+    """Coverage-only hosted validation must not materialize setup browser-install."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-coverage-playwright",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 1,
+                    "command": "pytest --cov",
+                },
+            },
+        }
+    )
+    posted_payload: dict[str, object] | None = None
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        nonlocal posted_payload
+        if request.method == "POST" and request.url.path == "/api/v1/validation-runs":
+            posted_payload = json.loads(request.content)
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_coverage",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_coverage",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_coverage":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_coverage",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "coverage": {
+                        "provider": "pytest",
+                        "percent": 99.0,
+                        "minimum_percent": 1.0,
+                        "enforce": False,
+                        "status": "passed",
+                        "reason_code": "COVERAGE_OK",
+                        "command_result": {
+                            "command": "pytest --cov",
+                            "returncode": 0,
+                            "duration_seconds": 1.0,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "coverage",
+                        },
+                    },
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(_config(), artifacts_dir=tmp_path, client=client)
+        await delegate.run_profile_coverage(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+        )
+
+    assert posted_payload is not None
+    setup_commands = [
+        item["command"]
+        for item in posted_payload["profile"]["phases"]["setup"]  # type: ignore[index]
+    ]
+    assert setup_commands == ["npm ci"]

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -3,15 +3,25 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
+from awf.adapters.runtime_executor import AgentRuntimeExecRequest
+from awf.db.enums import AgentRuntime
 from awf.profiles.models import WorkspaceProfile
 from awf.runtime.hosted_delegation_payloads import (
+    _agent_start_payload,
     _hosted_pr_identity_payload,
+    _hosted_validation_compose_image_candidates,
+    _hosted_validation_compose_image_is_whole_interpolation,
+    _hosted_validation_env_file_declares_postgres_password,
+    _hosted_validation_materialize_playwright_setup,
     _hosted_validation_profile_payload,
     _hosted_validation_secret_checked_fields,
+    _is_managed_persisted_clarification_service,
 )
+from awf.runtime.validation_setup import profile_phase_command_plan
 
 
 @pytest.mark.unit
@@ -404,3 +414,297 @@ def test_hosted_validation_profile_payload_handles_profiles_without_services() -
 
     assert payload["name"] == "hosted-no-services"
     assert payload["services"] == []
+
+
+def _setup_command_strings(payload: dict[str, object]) -> list[str]:
+    phases = payload.get("phases")
+    if not isinstance(phases, dict):
+        return []
+    setup = phases.get("setup")
+    if not isinstance(setup, list):
+        return []
+    return [
+        str(item["command"])
+        for item in setup
+        if isinstance(item, dict) and isinstance(item.get("command"), str)
+    ]
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_materializes_playwright_setup_commands() -> None:
+    """Hosted setup payload preserves profile_phase_command_plan execution order."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-setup-payload",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+    generated_setup = payload["database"]["generated_setup"]
+    assert [item["command"] for item in generated_setup] == [
+        expected[-1],
+    ]
+    assert expected == ["npm ci", "npx playwright install chromium"]
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_materializes_playwright_after_generated_setup() -> None:
+    """Browser install is appended after database.generated_setup in hosted payloads."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-playwright-generated-setup-order",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == expected[1:]
+    assert expected == [
+        "npm ci",
+        "pnpm install",
+        "npx playwright install chromium",
+    ]
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_setup_without_browsers_unchanged() -> None:
+    """No runtime.browsers leaves setup commands unchanged when setup is requested."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-no-browsers",
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_skips_playwright_without_setup_phase() -> None:
+    """Browser install is not materialized when setup is not in phase_names."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-validate-only",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"], "validate": ["pytest -q"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("validate",))
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+    validate_commands = [
+        str(item["command"]) for item in payload["phases"]["validate"] if isinstance(item, dict)
+    ]
+    assert validate_commands == ["pytest -q"]
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_preserves_source_profile_setup() -> None:
+    """Materializing browser install does not mutate the source WorkspaceProfile."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-immutable-source",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    original_setup = [command.command for command in profile.phases.setup]
+
+    _hosted_validation_profile_payload(profile, phase_names=("setup",))
+
+    assert [command.command for command in profile.phases.setup] == original_setup
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_avoids_duplicate_browser_install() -> None:
+    """Explicit setup containing the generated browser-install command is not duplicated."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-explicit-browser-install",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": ["npm ci", "npx playwright install chromium"],
+            },
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+
+    assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
+    assert payload["database"]["generated_setup"] == []
+    assert expected == ["npm ci", "npx playwright install chromium"]
+
+
+@pytest.mark.unit
+def test_hosted_validation_materialize_playwright_skips_malformed_database() -> None:
+    """Fail-closed materialization ignores payloads whose database section is not a dict."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-malformed-database",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    payload: dict[str, object] = {"database": "not-a-dict"}
+
+    _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
+
+    assert payload == {"database": "not-a-dict"}
+
+
+@pytest.mark.unit
+def test_hosted_validation_materialize_playwright_skips_malformed_generated_setup() -> None:
+    """Fail-closed materialization ignores non-list generated_setup containers."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-malformed-generated-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    payload: dict[str, object] = {"database": {"generated_setup": "not-a-list"}}
+
+    _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
+
+    assert payload["database"] == {"generated_setup": "not-a-list"}
+
+
+@pytest.mark.unit
+def test_compose_image_is_whole_interpolation_rejects_embedded_templates() -> None:
+    """Only full-value ``${...}`` strings count as whole Compose image interpolations."""
+    assert _hosted_validation_compose_image_is_whole_interpolation("postgres:16") is False
+    assert _hosted_validation_compose_image_is_whole_interpolation("${POSTGRES_IMAGE}") is True
+    assert (
+        _hosted_validation_compose_image_is_whole_interpolation(
+            "registry.example.test/${POSTGRES_IMAGE}"
+        )
+        is False
+    )
+
+
+@pytest.mark.unit
+def test_compose_image_candidates_reads_compose_dotenv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compose-dir ``.env`` values participate in hosted image expansion."""
+    monkeypatch.delenv("POSTGRES_IMAGE", raising=False)
+    (tmp_path / ".env").write_text("POSTGRES_IMAGE=postgres:16\n", encoding="utf-8")
+
+    candidates = _hosted_validation_compose_image_candidates(
+        "${POSTGRES_IMAGE}",
+        compose_dir=tmp_path,
+    )
+
+    assert candidates == ("postgres:16",)
+
+
+@pytest.mark.unit
+def test_compose_image_candidates_without_compose_dir_uses_host_environ(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Image expansion without compose_dir still resolves from the host environ."""
+    monkeypatch.setenv("POSTGRES_IMAGE", "pgvector/pgvector:pg18")
+
+    candidates = _hosted_validation_compose_image_candidates(
+        "${POSTGRES_IMAGE}",
+        compose_dir=None,
+    )
+
+    assert candidates == ("pgvector/pgvector:pg18",)
+
+
+@pytest.mark.unit
+def test_compose_image_candidates_required_interpolation_falls_back_to_literal_arm(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whole-value ``:?`` failures still consider the operator-arm literal."""
+    monkeypatch.delenv("POSTGRES_IMAGE", raising=False)
+
+    candidates = _hosted_validation_compose_image_candidates(
+        "${POSTGRES_IMAGE:-${NESTED:?postgres:16}}",
+        compose_dir=None,
+    )
+
+    assert candidates == ("${POSTGRES_IMAGE:-${NESTED:?postgres:16}}", "postgres:16")
+
+
+@pytest.mark.unit
+def test_compose_image_candidates_embedded_interpolation_error_keeps_raw_template(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Embedded interpolation failures do not harvest operator arms from partial templates."""
+    monkeypatch.delenv("POSTGRES_IMAGE", raising=False)
+
+    candidates = _hosted_validation_compose_image_candidates(
+        "registry/${POSTGRES_IMAGE:?postgres:16}",
+        compose_dir=None,
+    )
+
+    assert candidates == ("registry/${POSTGRES_IMAGE:?postgres:16}",)
+
+
+@pytest.mark.unit
+def test_env_file_declares_postgres_password_for_export_bare_line(tmp_path: Path) -> None:
+    """Bare ``export POSTGRES_PASSWORD`` env_file lines count as password sources."""
+    env_file = tmp_path / "postgres.env"
+    env_file.write_text("export POSTGRES_PASSWORD\nPOSTGRES_USER=awf\n", encoding="utf-8")
+
+    assert (
+        _hosted_validation_env_file_declares_postgres_password(
+            "postgres.env",
+            compose_dir=tmp_path,
+        )
+        is True
+    )
+
+
+@pytest.mark.unit
+def test_managed_clarification_service_rejects_non_mapping_service() -> None:
+    """Legacy clarification filtering ignores malformed service entries."""
+    assert _is_managed_persisted_clarification_service("not-a-mapping") is False
+
+
+@pytest.mark.unit
+def test_agent_start_payload_excludes_materialized_playwright_setup() -> None:
+    """Agent-start payloads clear setup and never materialize browser-install commands."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-agent-playwright",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": ["npm ci"],
+                "validate": ["pytest -q"],
+            },
+        }
+    )
+    request = AgentRuntimeExecRequest(
+        workspace_id="ws_hosted",
+        agent_runtime=AgentRuntime.codex,
+        cli_args=("codex", "exec", "-"),
+        prompt_stdin=b"prompt",
+        log_source="monitor.repair",
+        model="gpt-5",
+        effort="high",
+        profile=profile,
+    )
+
+    payload = _agent_start_payload(request)
+
+    assert payload["profile"]["phases"]["setup"] == []
+    body = json.dumps(payload, sort_keys=True)
+    assert "playwright install" not in body

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -512,6 +512,7 @@ def test_hosted_validation_profile_payload_skips_playwright_without_setup_phase(
     payload = _hosted_validation_profile_payload(profile, phase_names=("validate",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
+    assert payload["database"]["generated_setup"] == []
     validate_commands = [
         str(item["command"]) for item in payload["phases"]["validate"] if isinstance(item, dict)
     ]

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -505,6 +505,8 @@ def test_hosted_validation_profile_payload_setup_without_browsers_unchanged() ->
     "phase_names",
     [
         ("validate",),
+        ("post_agent",),
+        ("coverage",),
         (),
     ],
 )
@@ -516,7 +518,17 @@ def test_hosted_validation_profile_payload_keeps_generated_setup_free_of_playwri
         {
             "name": "hosted-generated-setup-negative",
             "runtime": {"browsers": ["chromium"]},
-            "phases": {"setup": ["npm ci"], "validate": ["pytest -q"]},
+            "phases": {
+                "setup": ["npm ci"],
+                "validate": ["pytest -q"],
+                "post_agent": ["echo post"],
+            },
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 1,
+                    "command": "pytest --cov",
+                },
+            },
             "database": {"generated_setup": ["pnpm install"]},
         }
     )
@@ -621,6 +633,56 @@ def test_hosted_validation_profile_payload_preserves_source_profile_setup() -> N
     _hosted_validation_profile_payload(profile, phase_names=("setup",))
 
     assert [command.command for command in profile.phases.setup] == original_setup
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_skips_playwright_when_already_in_generated_setup() -> (
+    None
+):
+    """Required generated_setup browser-install must not be duplicated in hosted payloads."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-generated-setup-browser-install",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["npx playwright install chromium"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+    expected = profile_phase_command_plan(materialized, ("setup",))
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == [
+        "npx playwright install chromium",
+    ]
+    assert [(step.phase, step.command.command) for step in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+    ]
+    body = json.dumps(payload, sort_keys=True)
+    assert body.count("npx playwright install chromium") == 1
+
+
+@pytest.mark.unit
+def test_hosted_validation_profile_payload_keeps_empty_generated_setup_when_materializing_to_setup() -> (
+    None
+):
+    """Explicit empty generated_setup stays empty when browser install materializes to setup."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-empty-generated-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": []},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+
+    assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
+    assert payload["database"]["generated_setup"] == []
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -520,6 +520,59 @@ def test_hosted_validation_profile_payload_skips_playwright_without_setup_phase(
 
 
 @pytest.mark.unit
+def test_hosted_validation_profile_payload_skips_playwright_for_default_phase_names() -> None:
+    """Coverage/default payload generation must not materialize browser-install."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-coverage-default-phases",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 1,
+                    "command": "pytest --cov",
+                },
+            },
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile)
+
+    assert _setup_command_strings(payload) == ["npm ci"]
+    assert payload["database"]["generated_setup"] == []
+    body = json.dumps(payload, sort_keys=True)
+    assert "playwright install" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "phase_names",
+    [
+        ("validate",),
+        ("post_agent",),
+        ("coverage",),
+        (),
+    ],
+)
+def test_hosted_validation_materialize_playwright_skips_excluded_phase_names(
+    phase_names: tuple[str, ...],
+) -> None:
+    """Browser install is not appended when setup is absent from phase_names."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-materialize-skips-excluded-phases",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+        }
+    )
+    payload: dict[str, object] = {"database": {"generated_setup": []}}
+
+    _hosted_validation_materialize_playwright_setup(payload, profile, phase_names)
+
+    assert payload["database"] == {"generated_setup": []}
+
+
+@pytest.mark.unit
 def test_hosted_validation_profile_payload_preserves_source_profile_setup() -> None:
     """Materializing browser install does not mutate the source WorkspaceProfile."""
     profile = WorkspaceProfile.model_validate(

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -443,7 +443,7 @@ def test_hosted_validation_profile_payload_materializes_playwright_setup_command
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    expected = profile_phase_command_plan(materialized, ("setup",))
+    expected = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
 
     assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
     assert payload["database"]["generated_setup"] == []
@@ -467,7 +467,7 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    expected = profile_phase_command_plan(materialized, ("setup",))
+    expected = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
 
     assert _setup_command_strings(payload) == ["npm ci"]
     assert [item["command"] for item in payload["database"]["generated_setup"]] == [
@@ -631,7 +631,7 @@ def test_hosted_validation_profile_payload_materializes_required_browser_install
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    plan = profile_phase_command_plan(materialized, ("setup",))
+    plan = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
 
     assert _setup_command_strings(payload) == [
         "npm ci",

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -488,12 +488,45 @@ def test_hosted_validation_profile_payload_setup_without_browsers_unchanged() ->
         {
             "name": "hosted-no-browsers",
             "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
         }
     )
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == ["pnpm install"]
+    body = json.dumps(payload, sort_keys=True)
+    assert "playwright install" not in body
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "phase_names",
+    [
+        ("validate",),
+        (),
+    ],
+)
+def test_hosted_validation_profile_payload_keeps_generated_setup_free_of_playwright(
+    phase_names: tuple[str, ...],
+) -> None:
+    """Non-setup hosted phases must not append Playwright install to generated_setup."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-generated-setup-negative",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"], "validate": ["pytest -q"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=phase_names)
+
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == ["pnpm install"]
+    assert _setup_command_strings(payload) == ["npm ci"]
+    body = json.dumps(payload, sort_keys=True)
+    assert "playwright install" not in body
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -562,11 +562,14 @@ def test_hosted_validation_materialize_playwright_skips_excluded_phase_names(
             "phases": {"setup": ["npm ci"]},
         }
     )
-    payload: dict[str, object] = {"database": {"generated_setup": []}}
+    payload = profile.model_dump(mode="json", by_alias=True)
 
     _hosted_validation_materialize_playwright_setup(payload, profile, phase_names)
 
-    assert payload["database"] == {"generated_setup": []}
+    assert _setup_command_strings(payload) == ["npm ci"]
+    assert payload["database"]["generated_setup"] == []
+    body = json.dumps(payload, sort_keys=True)
+    assert "playwright install" not in body
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -557,6 +557,46 @@ def test_hosted_validation_profile_payload_avoids_duplicate_browser_install() ->
 
 
 @pytest.mark.unit
+def test_hosted_validation_profile_payload_materializes_required_browser_install_for_advisory_setup() -> (
+    None
+):
+    """Advisory setup browser-install must not suppress materialized required gate."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-advisory-browser-install",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": [
+                    "npm ci",
+                    {"command": "npx playwright install chromium", "required": False},
+                ],
+            },
+        }
+    )
+
+    payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
+    materialized = WorkspaceProfile.model_validate(payload)
+    plan = profile_phase_command_plan(materialized, ("setup",))
+
+    assert _setup_command_strings(payload) == [
+        "npm ci",
+        "npx playwright install chromium",
+    ]
+    assert payload["database"]["generated_setup"] == [
+        {
+            "command": "npx playwright install chromium",
+            "timeout_seconds": 900,
+            "required": True,
+        }
+    ]
+    assert [(step.command.command, step.command.required) for step in plan] == [
+        ("npm ci", True),
+        ("npx playwright install chromium", False),
+        ("npx playwright install chromium", True),
+    ]
+
+
+@pytest.mark.unit
 def test_hosted_validation_materialize_playwright_skips_malformed_database() -> None:
     """Fail-closed materialization ignores payloads whose database section is not a dict."""
     profile = WorkspaceProfile.model_validate(

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -445,14 +445,11 @@ def test_hosted_validation_profile_payload_materializes_playwright_setup_command
     materialized = WorkspaceProfile.model_validate(payload)
     expected = profile_phase_command_plan(materialized, ("setup",))
 
-    assert _setup_command_strings(payload) == ["npm ci"]
-    generated_setup = payload["database"]["generated_setup"]
-    assert [item["command"] for item in generated_setup] == [
-        expected[-1].command.command,
-    ]
+    assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
+    assert payload["database"]["generated_setup"] == []
     assert [(step.phase, step.command.command) for step in expected] == [
         ("setup", "npm ci"),
-        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+        ("setup", "npx playwright install chromium"),
     ]
 
 
@@ -472,14 +469,14 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
     materialized = WorkspaceProfile.model_validate(payload)
     expected = profile_phase_command_plan(materialized, ("setup",))
 
-    assert _setup_command_strings(payload) == ["npm ci"]
+    assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
     assert [item["command"] for item in payload["database"]["generated_setup"]] == [
-        step.command.command for step in expected if step.phase == DB_GENERATED_SETUP_PHASE
+        "pnpm install",
     ]
     assert [(step.phase, step.command.command) for step in expected] == [
         ("setup", "npm ci"),
         (DB_GENERATED_SETUP_PHASE, "pnpm install"),
-        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+        ("setup", "npx playwright install chromium"),
     ]
 
 
@@ -635,14 +632,9 @@ def test_hosted_validation_profile_payload_materializes_required_browser_install
     assert _setup_command_strings(payload) == [
         "npm ci",
         "npx playwright install chromium",
+        "npx playwright install chromium",
     ]
-    assert payload["database"]["generated_setup"] == [
-        {
-            "command": "npx playwright install chromium",
-            "timeout_seconds": 900,
-            "required": True,
-        }
-    ]
+    assert payload["database"]["generated_setup"] == []
     assert [(step.command.command, step.command.required) for step in plan] == [
         ("npm ci", True),
         ("npx playwright install chromium", False),
@@ -651,37 +643,37 @@ def test_hosted_validation_profile_payload_materializes_required_browser_install
 
 
 @pytest.mark.unit
-def test_hosted_validation_materialize_playwright_skips_malformed_database() -> None:
-    """Fail-closed materialization ignores payloads whose database section is not a dict."""
+def test_hosted_validation_materialize_playwright_skips_malformed_phases() -> None:
+    """Fail-closed materialization ignores payloads whose phases section is not a dict."""
     profile = WorkspaceProfile.model_validate(
         {
-            "name": "hosted-malformed-database",
+            "name": "hosted-malformed-phases",
             "runtime": {"browsers": ["chromium"]},
             "phases": {"setup": ["npm ci"]},
         }
     )
-    payload: dict[str, object] = {"database": "not-a-dict"}
+    payload: dict[str, object] = {"phases": "not-a-dict"}
 
     _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
 
-    assert payload == {"database": "not-a-dict"}
+    assert payload == {"phases": "not-a-dict"}
 
 
 @pytest.mark.unit
-def test_hosted_validation_materialize_playwright_skips_malformed_generated_setup() -> None:
-    """Fail-closed materialization ignores non-list generated_setup containers."""
+def test_hosted_validation_materialize_playwright_skips_malformed_setup() -> None:
+    """Fail-closed materialization ignores non-list setup containers."""
     profile = WorkspaceProfile.model_validate(
         {
-            "name": "hosted-malformed-generated-setup",
+            "name": "hosted-malformed-setup",
             "runtime": {"browsers": ["chromium"]},
             "phases": {"setup": ["npm ci"]},
         }
     )
-    payload: dict[str, object] = {"database": {"generated_setup": "not-a-list"}}
+    payload: dict[str, object] = {"phases": {"setup": "not-a-list"}}
 
     _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
 
-    assert payload["database"] == {"generated_setup": "not-a-list"}
+    assert payload["phases"] == {"setup": "not-a-list"}
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -21,7 +21,7 @@ from awf.runtime.hosted_delegation_payloads import (
     _hosted_validation_secret_checked_fields,
     _is_managed_persisted_clarification_service,
 )
-from awf.runtime.validation_setup import profile_phase_command_plan
+from awf.runtime.validation_setup import DB_GENERATED_SETUP_PHASE, profile_phase_command_plan
 
 
 @pytest.mark.unit
@@ -432,7 +432,7 @@ def _setup_command_strings(payload: dict[str, object]) -> list[str]:
 
 @pytest.mark.unit
 def test_hosted_validation_profile_payload_materializes_playwright_setup_commands() -> None:
-    """Hosted setup payload preserves profile_phase_command_plan execution order."""
+    """Hosted setup payload preserves materialized profile_phase_command_plan order."""
     profile = WorkspaceProfile.model_validate(
         {
             "name": "hosted-playwright-setup-payload",
@@ -442,14 +442,18 @@ def test_hosted_validation_profile_payload_materializes_playwright_setup_command
     )
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
-    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+    materialized = WorkspaceProfile.model_validate(payload)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
     generated_setup = payload["database"]["generated_setup"]
     assert [item["command"] for item in generated_setup] == [
-        expected[-1],
+        expected[-1].command.command,
     ]
-    assert expected == ["npm ci", "npx playwright install chromium"]
+    assert [(step.phase, step.command.command) for step in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
+    ]
 
 
 @pytest.mark.unit
@@ -465,14 +469,17 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
     )
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
-    expected = [step.command.command for step in profile_phase_command_plan(profile, ("setup",))]
+    materialized = WorkspaceProfile.model_validate(payload)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
-    assert [item["command"] for item in payload["database"]["generated_setup"]] == expected[1:]
-    assert expected == [
-        "npm ci",
-        "pnpm install",
-        "npx playwright install chromium",
+    assert [item["command"] for item in payload["database"]["generated_setup"]] == [
+        step.command.command for step in expected if step.phase == DB_GENERATED_SETUP_PHASE
+    ]
+    assert [(step.phase, step.command.command) for step in expected] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "pnpm install"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
     ]
 
 

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -443,7 +443,7 @@ def test_hosted_validation_profile_payload_materializes_playwright_setup_command
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    expected = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
     assert payload["database"]["generated_setup"] == []
@@ -467,7 +467,7 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    expected = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
+    expected = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == ["npm ci"]
     assert [item["command"] for item in payload["database"]["generated_setup"]] == [
@@ -477,7 +477,7 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
     assert [(step.phase, step.command.command) for step in expected] == [
         ("setup", "npm ci"),
         (DB_GENERATED_SETUP_PHASE, "pnpm install"),
-        ("setup", "npx playwright install chromium"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
     ]
 
 
@@ -631,7 +631,7 @@ def test_hosted_validation_profile_payload_materializes_required_browser_install
 
     payload = _hosted_validation_profile_payload(profile, phase_names=("setup",))
     materialized = WorkspaceProfile.model_validate(payload)
-    plan = profile_phase_command_plan(materialized, ("setup",), source_profile=profile)
+    plan = profile_phase_command_plan(materialized, ("setup",))
 
     assert _setup_command_strings(payload) == [
         "npm ci",

--- a/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
+++ b/tests/unit/runtime/test_hosted_delegation_payloads_parts/test_hosted_delegation_payloads_part_001.py
@@ -469,9 +469,10 @@ def test_hosted_validation_profile_payload_materializes_playwright_after_generat
     materialized = WorkspaceProfile.model_validate(payload)
     expected = profile_phase_command_plan(materialized, ("setup",))
 
-    assert _setup_command_strings(payload) == ["npm ci", "npx playwright install chromium"]
+    assert _setup_command_strings(payload) == ["npm ci"]
     assert [item["command"] for item in payload["database"]["generated_setup"]] == [
         "pnpm install",
+        "npx playwright install chromium",
     ]
     assert [(step.phase, step.command.command) for step in expected] == [
         ("setup", "npm ci"),
@@ -677,6 +678,42 @@ def test_hosted_validation_materialize_playwright_skips_malformed_setup() -> Non
     _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
 
     assert payload["phases"] == {"setup": "not-a-list"}
+
+
+@pytest.mark.unit
+def test_hosted_validation_materialize_playwright_skips_malformed_database() -> None:
+    """Fail-closed materialization ignores payloads whose database section is not a dict."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-malformed-database",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+    payload: dict[str, object] = {"database": "not-a-dict"}
+
+    _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
+
+    assert payload == {"database": "not-a-dict"}
+
+
+@pytest.mark.unit
+def test_hosted_validation_materialize_playwright_skips_malformed_generated_setup() -> None:
+    """Fail-closed materialization ignores non-list generated_setup containers."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-malformed-generated-setup",
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["pnpm install"]},
+        }
+    )
+    payload: dict[str, object] = {"database": {"generated_setup": "not-a-list"}}
+
+    _hosted_validation_materialize_playwright_setup(payload, profile, ("setup",))
+
+    assert payload["database"] == {"generated_setup": "not-a-list"}
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_002.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_002.py
@@ -1197,6 +1197,41 @@ services:
 
 
 @pytest.mark.unit
+def test_rendered_stack_env_file_export_bare_postgres_password_injects_trust(
+    tmp_path: Path,
+) -> None:
+    """Bare ``export POSTGRES_PASSWORD`` env_file lines must still inject trust."""
+    env_file = tmp_path / "postgres.env"
+    env_file.write_text(
+        "export POSTGRES_PASSWORD\nPOSTGRES_USER=awf\n",
+        encoding="utf-8",
+    )
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: postgres:16
+    env_file:
+      - postgres.env
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+        omit_credential_env_keys=True,
+    )
+
+    assert payload is not None
+    environment = payload["services"]["postgres"]["environment"]
+    assert environment == {"POSTGRES_HOST_AUTH_METHOD": "trust"}
+    body = json.dumps(payload, sort_keys=True)
+    assert "POSTGRES_PASSWORD" not in body
+
+
+@pytest.mark.unit
 def test_rendered_stack_env_file_bare_postgres_password_file_injects_trust(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_006.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_006.py
@@ -601,6 +601,42 @@ def test_hosted_profile_payload_skips_non_list_services(monkeypatch: pytest.Monk
 
 
 @pytest.mark.unit
+def test_rendered_stack_required_image_interpolation_falls_back_to_operator_arm(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Required-image interpolation failures still honor ``:?`` operator-arm literals."""
+    monkeypatch.delenv("POSTGRES_IMAGE", raising=False)
+    compose_file = tmp_path / "compose.yml"
+    compose_file.write_text(
+        """
+services:
+  postgres:
+    image: "${POSTGRES_IMAGE:?postgres:16}"
+    environment:
+      POSTGRES_PASSWORD: literal-postgres-secret
+      POSTGRES_USER: awf
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    payload = _hosted_validation_rendered_stack_payload(
+        compose_project="awf_ws_hosted",
+        compose_file=compose_file,
+        omit_credential_env_keys=True,
+    )
+
+    assert payload is not None
+    assert payload["services"]["postgres"]["environment"] == {
+        "POSTGRES_USER": "awf",
+        "POSTGRES_HOST_AUTH_METHOD": "trust",
+    }
+    body = json.dumps(payload, sort_keys=True)
+    assert "POSTGRES_PASSWORD" not in body
+    assert "literal-postgres-secret" not in body
+
+
+@pytest.mark.unit
 def test_rendered_stack_direct_image_interpolation_uses_host_environ(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/runtime/test_node_playwright_setup.py
+++ b/tests/unit/runtime/test_node_playwright_setup.py
@@ -777,6 +777,57 @@ def test_setup_plan_omits_browser_install_when_already_in_setup() -> None:
 
 
 @pytest.mark.unit
+def test_setup_plan_adds_required_browser_install_when_profile_declares_advisory_duplicate() -> (
+    None
+):
+    """Advisory setup browser-install must not suppress the generated required gate."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": [
+                    "npm ci",
+                    {"command": "npx playwright install chromium", "required": False},
+                ],
+            },
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+
+    assert [(step.command.command, step.command.required) for step in plan] == [
+        ("npm ci", True),
+        ("npx playwright install chromium", False),
+        ("npx playwright install chromium", True),
+    ]
+    assert plan[-1].command.timeout_seconds == _BROWSER_INSTALL_TIMEOUT
+
+
+@pytest.mark.unit
+def test_setup_plan_adds_required_browser_install_when_generated_setup_is_advisory() -> None:
+    """Advisory generated_setup browser-install must not suppress the required gate."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {
+                "generated_setup": [
+                    {"command": "npx playwright install chromium", "required": False},
+                ],
+            },
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+
+    assert [(step.command.command, step.command.required) for step in plan] == [
+        ("npm ci", True),
+        ("npx playwright install chromium", False),
+        ("npx playwright install chromium", True),
+    ]
+
+
+@pytest.mark.unit
 def test_setup_plan_omits_browser_install_when_already_in_generated_setup() -> None:
     """Generated-setup browser-install is not duplicated in the command plan."""
     profile = _profile(

--- a/tests/unit/runtime/test_node_playwright_setup.py
+++ b/tests/unit/runtime/test_node_playwright_setup.py
@@ -14,7 +14,7 @@ from awf.runtime.node_playwright_setup import (
     playwright_browser_install_command,
     playwright_command,
 )
-from awf.runtime.validation_setup import profile_phase_command_plan
+from awf.runtime.validation_setup import DB_GENERATED_SETUP_PHASE, profile_phase_command_plan
 
 _BROWSER_INSTALL_TIMEOUT = 900
 
@@ -850,6 +850,31 @@ def test_setup_plan_adds_required_browser_install_when_generated_setup_is_adviso
         ("npm ci", True),
         ("npx playwright install chromium", False),
         ("npx playwright install chromium", True),
+    ]
+
+
+@pytest.mark.unit
+def test_setup_plan_preserves_explicit_trailing_generated_setup_browser_install() -> None:
+    """Explicit trailing browser-install in generated_setup stays a database hook."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {
+                "generated_setup": [
+                    "python scripts/db_generated_setup.py",
+                    "npx playwright install chromium",
+                ],
+            },
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+
+    assert [(step.phase, step.command.command) for step in plan] == [
+        ("setup", "npm ci"),
+        (DB_GENERATED_SETUP_PHASE, "python scripts/db_generated_setup.py"),
+        (DB_GENERATED_SETUP_PHASE, "npx playwright install chromium"),
     ]
 
 

--- a/tests/unit/runtime/test_node_playwright_setup.py
+++ b/tests/unit/runtime/test_node_playwright_setup.py
@@ -756,3 +756,41 @@ def test_setup_plan_omits_browser_install_when_no_browsers_declared() -> None:
     plan = profile_phase_command_plan(profile, ["setup"])
 
     assert all("playwright install" not in step.command.command for step in plan)
+
+
+@pytest.mark.unit
+def test_setup_plan_omits_browser_install_when_already_in_setup() -> None:
+    """Explicit setup browser-install is not duplicated in the command plan."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": ["npm ci", "npx playwright install chromium"],
+            },
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+    commands = [step.command.command for step in plan]
+
+    assert commands == ["npm ci", "npx playwright install chromium"]
+
+
+@pytest.mark.unit
+def test_setup_plan_omits_browser_install_when_already_in_generated_setup() -> None:
+    """Generated-setup browser-install is not duplicated in the command plan."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {"setup": ["npm ci"]},
+            "database": {"generated_setup": ["npx playwright install chromium"]},
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+    commands = [step.command.command for step in plan]
+
+    assert commands == [
+        "npm ci",
+        "npx playwright install chromium",
+    ]

--- a/tests/unit/runtime/test_node_playwright_setup.py
+++ b/tests/unit/runtime/test_node_playwright_setup.py
@@ -777,6 +777,32 @@ def test_setup_plan_omits_browser_install_when_already_in_setup() -> None:
 
 
 @pytest.mark.unit
+def test_setup_plan_preserves_explicit_browser_install_order_before_dependent_setup() -> None:
+    """Required explicit browser-install must stay before later setup hooks that depend on it."""
+    profile = _profile(
+        {
+            "runtime": {"browsers": ["chromium"]},
+            "phases": {
+                "setup": [
+                    "npx playwright install chromium",
+                    "node scripts/verify-chromium.js",
+                ],
+            },
+            "database": {"generated_setup": ["psql -c 'select 1'"]},
+        }
+    )
+
+    plan = profile_phase_command_plan(profile, ["setup"])
+    commands = [step.command.command for step in plan]
+
+    assert commands == [
+        "npx playwright install chromium",
+        "node scripts/verify-chromium.js",
+        "psql -c 'select 1'",
+    ]
+
+
+@pytest.mark.unit
 def test_setup_plan_adds_required_browser_install_when_profile_declares_advisory_duplicate() -> (
     None
 ):


### PR DESCRIPTION
Automated AWF release PR syncing `development` into `main`.

<!-- AWF:release-merge-policy:start -->
Opened by the `sync_release_pr` task kind and monitored with release/manual behavior (auto-merge disabled). Merging into the release target stays human-gated.
<!-- AWF:release-merge-policy:end -->

## Summary

Release merge of `development` into `main`. Includes hosted-validation fixes so Playwright browser-install commands are materialized in setup payloads, expected command identities are derived from the wire profile, and duplicate browser-install commands are deduplicated during local setup planning.

## Validation

AWF/GitHub CI owns the full validation gate for this release PR (lint, typecheck, unit tests with 99% coverage, console checks).

Focused tests added or extended for this slice:
- `tests/unit/runtime/test_hosted_delegation_payloads_parts/`
- `tests/unit/runtime/test_hosted_delegation_contract_edges.py`
- `tests/unit/runtime/test_hosted_validation_delegate_parts/`
- `tests/unit/runtime/test_node_playwright_setup.py`

## Release Readiness

Affected AWF Core surfaces:
- **Runtime / hosted validation**: `hosted_delegation.py`, `hosted_delegation_payloads.py`, `validation_setup.py`, `node_playwright_setup.py` — setup payload materialization, command identity matching, and Playwright install deduplication.
- **Profile / validation phases**: setup command planning for Playwright browser profiles on hosted (Cloud) runners.

No changes to CLI, REST, MCP, console, Docker compose templates, PR monitor merge policy, or operator docs in this slice.

## Security / Secrets

No secrets were added to code, logs, fixtures, or screenshots. Hosted payload sanitization changes only redact or normalize PostgreSQL credential handling in rendered environment materialization.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hosted validation command planning and evidence matching on the Cloud path; incorrect materialization or identity logic could fail valid runs or accept mismatched evidence.
> 
> **Overview**
> **Hosted validation** now injects the generated Playwright browser-install command into the profile sent to Cloud when `setup` is among the requested phases, placing it after `phases.setup` hooks or at the end of `database.generated_setup` when that path is used. Validate-only, coverage-only, and agent-start payloads do not get this materialization.
> 
> **Command identity matching** is aligned with what Cloud runs: `run_profile_phases` builds the wire profile first, re-parses it as `execution_profile`, and derives `_hosted_validation_expected_commands` from that materialized profile instead of the original source profile—so terminal evidence for browser install is accepted or rejected consistently (wrong phase still fails closed).
> 
> **Local setup planning** shares the same dedup rule via `playwright_browser_install_already_required`: auto-generated browser install is skipped when an equivalent **required** command already exists in setup or `generated_setup`, while advisory duplicates still allow a required generated gate.
> 
> Extensive unit tests cover payload ordering, phase gating, immutability of the source profile, and delegation contract edges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7da39ad56c73ac202c4fe7a067d52f3e5504c658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hosted validation now includes the Playwright browser-install command when setup is requested and configured.
  - Setup commands are correctly ordered, deduplicated, and assigned to the appropriate setup phase.

- **Bug Fixes**
  - Improved hosted environment sanitization for PostgreSQL credentials, including exported password variables and image interpolation fallbacks.
  - Prevented setup-only commands from appearing in agent-start payloads.
  - Excluded browser installation from validation-only and coverage-only payloads.
  - Ensured required browser installation is retained even when an advisory duplicate exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->