### PR TITLE
fix(core): anchor each PR repair pass to its fresh head

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -318,6 +318,25 @@ async def _run_fix_cycle(
         )
 
     for _pass_num in range(self._runner_config.max_fix_cycle_passes):
+        # Snapshot a verified pass-start HEAD before addressing any item. Settle
+        # re-polls return thread path/line coordinates relative to this HEAD, not
+        # the operation-open SHA. Reusing the operation-open SHA as
+        # ``cycle_start_head`` across passes can fail path/line mapping and
+        # misclassify a real FIXED as AGENT_FIXED_WITHOUT_EVIDENCE.
+        try:
+            pass_start_head = await _current_item_operation_start_head()
+        except _MonitorHeadObjectMissingError as exc:
+            for item_id in publish_dependent_ids:
+                _clear_addressed_state_by_id(state, item_id)
+            return await _return_failed_fix_cycle_result(
+                _GitPushResult(
+                    pushed=False,
+                    failed=True,
+                    returncode=1,
+                    stderr=str(exc),
+                    reason_code=exc.reason_code,
+                )
+            )
         # 1) Address each item in the current batch.
         for t in threads:
             try:
@@ -333,7 +352,7 @@ async def _run_fix_cycle(
                     owned_paths=owned_paths,
                     task_tag=task_tag,
                     operation_start_head=item_operation_start_head,
-                    cycle_start_head=operation_start_head,
+                    cycle_start_head=pass_start_head,
                     base_branch=base_branch or "",
                     remote_branch=remote_branch,
                     operation_id=operation_id,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -317,26 +317,17 @@ async def _run_fix_cycle(
             "per-item HEAD unavailable: commit object probe failed",
         )
 
+    # Inline thread path/line coords are relative to the remote PR head from the
+    # status that supplied the batch — not local worktree HEAD. Non-hosted agents
+    # commit locally before push, so local HEAD can advance while settle re-polls
+    # still return coordinates for the unpublished remote tip. Using local HEAD as
+    # ``cycle_start_head`` skips the required remote→local mapping and can
+    # misclassify a real FIXED as AGENT_FIXED_WITHOUT_EVIDENCE
+    # (PRRT_kwDOSJAM6s6dFLGV). Keep one stable remote anchor per batch.
+    batch_anchor_head = pr_head_sha
+
     for _pass_num in range(self._runner_config.max_fix_cycle_passes):
-        # Snapshot a verified pass-start HEAD before addressing any item. Settle
-        # re-polls return thread path/line coordinates relative to this HEAD, not
-        # the operation-open SHA. Reusing the operation-open SHA as
-        # ``cycle_start_head`` across passes can fail path/line mapping and
-        # misclassify a real FIXED as AGENT_FIXED_WITHOUT_EVIDENCE.
-        try:
-            pass_start_head = await _current_item_operation_start_head()
-        except _MonitorHeadObjectMissingError as exc:
-            for item_id in publish_dependent_ids:
-                _clear_addressed_state_by_id(state, item_id)
-            return await _return_failed_fix_cycle_result(
-                _GitPushResult(
-                    pushed=False,
-                    failed=True,
-                    returncode=1,
-                    stderr=str(exc),
-                    reason_code=exc.reason_code,
-                )
-            )
+        pass_anchor_head = batch_anchor_head
         # 1) Address each item in the current batch.
         for t in threads:
             try:
@@ -352,7 +343,7 @@ async def _run_fix_cycle(
                     owned_paths=owned_paths,
                     task_tag=task_tag,
                     operation_start_head=item_operation_start_head,
-                    cycle_start_head=pass_start_head,
+                    cycle_start_head=pass_anchor_head,
                     base_branch=base_branch or "",
                     remote_branch=remote_branch,
                     operation_id=operation_id,
@@ -712,6 +703,10 @@ async def _run_fix_cycle(
         threads = new_threads
         reviews = new_reviews
         independently_addressed_review_ids.update(comment.comment_id for comment in reviews)
+        # Next pass's evidence coords come from this settle status's remote head.
+        next_anchor = (status.head_sha or "").strip()
+        if next_anchor:
+            batch_anchor_head = next_anchor
     # (If we hit max_fix_cycle_passes we still fall through to push —
     # whatever we did commit is worth shipping; next outer loop
     # iteration will re-poll and see what's left.)

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -1,4 +1,4 @@
-"""Regressions: per-settle-pass evidence anchor HEAD in comment-repair fix cycle."""
+"""Regressions: settle-pass evidence anchor uses remote PR head from batch status."""
 
 from __future__ import annotations
 
@@ -51,10 +51,14 @@ def _git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def _clean_status(*, threads: tuple[ReviewThread, ...] = ()) -> PRStatus:
+def _clean_status(
+    *,
+    head_sha: str = "start",
+    threads: tuple[ReviewThread, ...] = (),
+) -> PRStatus:
     return PRStatus(
         number=42,
-        head_sha="start",
+        head_sha=head_sha,
         mergeable=MergeableState.MERGEABLE,
         check_state=CheckState.SUCCESS,
         unresolved_inline_threads=threads,
@@ -65,17 +69,19 @@ def _clean_status(*, threads: tuple[ReviewThread, ...] = ()) -> PRStatus:
 
 
 @pytest.mark.unit
-async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_head(
+async def test_fix_cycle_later_settle_pass_uses_remote_status_head_as_cycle_start_head(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pass-2 evidence anchor must be post-pass-1 HEAD, not the operation-open SHA."""
+    """Pass-2 evidence anchor must be settle status.head_sha, not local HEAD.
+
+    Non-hosted agents commit locally before push, so settle re-poll thread
+    path/line coords stay relative to the remote PR head. Anchoring at the
+    locally advanced HEAD skips remote→local mapping and can misclassify FIXED.
+    """
     cmd = FakeCommandRunner()
-    # Pass-start + per-item cat-file probes (empty queue returns ok; queue explicit ones).
-    cmd.queue_result(returncode=0)  # pass1 start cat-file
     cmd.queue_result(returncode=0)  # pass1 item cat-file
-    cmd.queue_result(returncode=0)  # pass2 start cat-file
     cmd.queue_result(returncode=0)  # pass2 item cat-file
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_pass_anchor"
@@ -87,16 +93,16 @@ async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_h
         sleep_fn=RecordedSleep(),
         worktrees_root=worktrees_root,
     )
-    operation_open = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-    after_pass1 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-    # pass1 start, pass1 item, pass2 start, pass2 item
-    current_heads = iter((operation_open, after_pass1, after_pass1, after_pass1))
+    remote_head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    after_pass1_local = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    # pass1 item, pass2 item (no separate pass-start local probe)
+    current_heads = iter((remote_head, after_pass1_local))
     cycle_start_heads: list[str | None] = []
     address_thread_ids: list[str] = []
     settle_calls = 0
 
     async def _start_head(**_kwargs: object) -> tuple[str, None]:
-        return (operation_open, None)
+        return (remote_head, None)
 
     async def _no_dirty(**_kwargs: object) -> None:
         return None
@@ -115,17 +121,18 @@ async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_h
         settle_calls += 1
         if settle_calls == 1:
             return _clean_status(
+                head_sha=remote_head,
                 threads=(
                     ReviewThread(
                         thread_id="T_later",
                         path="src/foo.py",
                         line=20,
-                        body_excerpt="new feedback after earlier push",
+                        body_excerpt="new feedback after earlier local commit",
                         author="reviewer",
                     ),
-                )
+                ),
             )
-        return _clean_status()
+        return _clean_status(head_sha=remote_head)
 
     async def _no_block(**_kwargs: object) -> None:
         return None
@@ -149,7 +156,7 @@ async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_h
         workspace_id="ws_pass_anchor",
         repo=RepoRef(owner="dimileeh", name="aira-web"),
         pr_number=42,
-        pr_head_sha=operation_open,
+        pr_head_sha=remote_head,
         initial_threads=(
             ReviewThread(
                 thread_id="T_first",
@@ -168,24 +175,19 @@ async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_h
 
     assert result.failed is False
     assert address_thread_ids == ["T_first", "T_later"]
-    assert cycle_start_heads[0] == operation_open
-    # Bug today: pass 2 still gets operation_open. Fix: after_pass1.
-    assert cycle_start_heads[1] == after_pass1
-    assert cycle_start_heads[1] != operation_open
+    assert cycle_start_heads[0] == remote_head
+    # Pass 2 must keep the remote PR head from the settle status, not local tip.
+    assert cycle_start_heads[1] == remote_head
+    assert cycle_start_heads[1] != after_pass1_local
 
 
 @pytest.mark.unit
-async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
+async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Items in one settle pass share the pass snapshot while item heads advance.
-
-    On pass 2 the operation-open SHA differs from the live pass HEAD. Both items
-    must still receive the same ``cycle_start_head`` (pass snapshot), not the
-    stale operation-open SHA and not each item's own advancing HEAD.
-    """
+    """Items in one settle pass share the settle status head while item heads advance."""
     cmd = FakeCommandRunner()
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_stable_pass"
@@ -197,17 +199,17 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
         sleep_fn=RecordedSleep(),
         worktrees_root=worktrees_root,
     )
-    operation_open = "operation-open-head"
-    pass2_anchor = "pass-two-start-head"
+    remote_open = "operation-open-remote-head"
+    remote_settle = "settle-status-remote-head"
     after_first = "after-first-item-head"
-    live_head = {"sha": operation_open}
+    live_head = {"sha": remote_open}
     cycle_start_heads: list[str | None] = []
     operation_start_heads: list[str | None] = []
     address_thread_ids: list[str] = []
     settle_calls = 0
 
     async def _start_head(**_kwargs: object) -> tuple[str, None]:
-        return (operation_open, None)
+        return (remote_open, None)
 
     async def _no_dirty(**_kwargs: object) -> None:
         return None
@@ -221,7 +223,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
         cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
         operation_start_heads.append(cast(str | None, kwargs.get("operation_start_head")))
         if thread.thread_id == "T_pass1":
-            live_head["sha"] = pass2_anchor
+            live_head["sha"] = "local-after-pass1"
         elif thread.thread_id == "T_pass2_a":
             live_head["sha"] = after_first
         return "false_positive" if thread.thread_id == "T_pass1" else "needs_human"
@@ -231,6 +233,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
         settle_calls += 1
         if settle_calls == 1:
             return _clean_status(
+                head_sha=remote_settle,
                 threads=(
                     ReviewThread(
                         thread_id="T_pass2_a",
@@ -246,9 +249,9 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
                         body_excerpt="settle second",
                         author="reviewer",
                     ),
-                )
+                ),
             )
-        return _clean_status()
+        return _clean_status(head_sha=remote_settle)
 
     async def _no_block(**_kwargs: object) -> None:
         return None
@@ -272,7 +275,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
         workspace_id="ws_stable_pass",
         repo=RepoRef(owner="dimileeh", name="aira-web"),
         pr_number=42,
-        pr_head_sha=operation_open,
+        pr_head_sha=remote_open,
         initial_threads=(
             ReviewThread(
                 thread_id="T_pass1",
@@ -290,25 +293,26 @@ async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
     )
 
     assert address_thread_ids == ["T_pass1", "T_pass2_a", "T_pass2_b"]
-    # Pass-2 items share one pass anchor (not operation-open, not per-item HEAD).
-    assert cycle_start_heads[1:] == [pass2_anchor, pass2_anchor]
-    assert operation_open not in cycle_start_heads[1:]
-    assert operation_start_heads[1:] == [pass2_anchor, after_first]
+    assert cycle_start_heads[0] == remote_open
+    # Pass-2 items share the settle remote head (not local tip, not per-item HEAD).
+    assert cycle_start_heads[1:] == [remote_settle, remote_settle]
+    assert "local-after-pass1" not in cycle_start_heads
+    assert after_first not in cycle_start_heads
+    assert operation_start_heads[1:] == ["local-after-pass1", after_first]
 
 
 @pytest.mark.unit
-async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
+async def test_fix_cycle_local_advance_does_not_replace_remote_batch_anchor(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unverifiable pass-start HEAD must abort before addressing that pass."""
+    """Local unpublished commits must not become the settle-pass evidence anchor."""
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=0)  # pass1 start cat-file
-    cmd.queue_result(returncode=0)  # pass1 item cat-file
-    cmd.queue_result(returncode=128, stderr="fatal: Not a valid object name poisoned")
+    cmd.queue_result(returncode=0)  # pass1 item
+    cmd.queue_result(returncode=0)  # pass2 item
     worktrees_root = tmp_path / "worktrees"
-    worktree_path = worktrees_root / "ws_pass_poisoned"
+    worktree_path = worktrees_root / "ws_remote_anchor"
     worktree_path.mkdir(parents=True)
     runner = make_runner(
         factory=factory,
@@ -317,17 +321,14 @@ async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
         sleep_fn=RecordedSleep(),
         worktrees_root=worktrees_root,
     )
-    operation_open = "start"
-    after_pass1 = "after-pass1"
-    poisoned = "poisoned"
-    # pass1 start, pass1 item, pass2 start (poisoned)
-    current_heads = iter((operation_open, after_pass1, poisoned))
+    remote_head = "remote-pr-head-sha"
+    local_advanced = "local-unpublished-head"
+    current_heads = iter((remote_head, local_advanced))
     cycle_start_heads: list[str | None] = []
-    address_thread_ids: list[str] = []
     settle_calls = 0
 
     async def _start_head(**_kwargs: object) -> tuple[str, None]:
-        return (operation_open, None)
+        return (remote_head, None)
 
     async def _no_dirty(**_kwargs: object) -> None:
         return None
@@ -336,8 +337,6 @@ async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
         return next(current_heads)
 
     async def _address(**kwargs: object) -> str:
-        thread = cast(ReviewThread, kwargs["thread"])
-        address_thread_ids.append(thread.thread_id)
         cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
         return "false_positive"
 
@@ -346,17 +345,18 @@ async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
         settle_calls += 1
         if settle_calls == 1:
             return _clean_status(
+                head_sha=remote_head,
                 threads=(
                     ReviewThread(
                         thread_id="T_pass2",
                         path="src/foo.py",
                         line=4,
-                        body_excerpt="settle feedback",
+                        body_excerpt="settle feedback on remote head lines",
                         author="reviewer",
                     ),
-                )
+                ),
             )
-        return _clean_status()
+        return _clean_status(head_sha=remote_head)
 
     async def _no_block(**_kwargs: object) -> None:
         return None
@@ -377,10 +377,10 @@ async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
     monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
 
     result = await runner._run_fix_cycle(
-        workspace_id="ws_pass_poisoned",
+        workspace_id="ws_remote_anchor",
         repo=RepoRef(owner="dimileeh", name="aira-web"),
         pr_number=42,
-        pr_head_sha=operation_open,
+        pr_head_sha=remote_head,
         initial_threads=(
             ReviewThread(
                 thread_id="T_pass1",
@@ -392,17 +392,14 @@ async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
         ),
         initial_reviews=(),
         state=MonitorState(),
-        remote_branch="awf/ws_pass_poisoned",
+        remote_branch="awf/ws_remote_anchor",
         compose_project="proj",
         compose_file=tmp_path / "compose.yml",
     )
 
-    assert result.failed is True
-    assert result.reason_code == "HEAD_OBJECT_MISSING_UNRECOVERABLE"
-    assert "commit object probe failed" in result.stderr
-    # Pass 2 never addressed — no silent fallback to operation-open as cycle_start.
-    assert address_thread_ids == ["T_pass1"]
-    assert cycle_start_heads == [operation_open]
+    assert result.failed is False
+    assert cycle_start_heads == [remote_head, remote_head]
+    assert local_advanced not in cycle_start_heads
 
 
 @pytest.mark.unit
@@ -411,11 +408,11 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Line coords relative to a later pass head must map and accept a real FIXED.
+    """Line coords relative to a newer remote head must map and accept a real FIXED.
 
-    After an earlier pass inserts lines at the top, a settle-thread line is only
-    valid against the newer pass head. Anchoring evidence at the operation-open
-    SHA maps that line to failure (``item_line = -1``) and rejects a real fix.
+    When the remote PR head advances (or coords are already for a later commit),
+    anchoring evidence at that head accepts a line-scoped fix. Anchoring at an
+    older SHA maps that line to failure and rejects a real fix.
     """
     worktree = tmp_path / "worktrees" / "ws_protocol"
     worktree.mkdir(parents=True)

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -1,0 +1,564 @@
+"""Regressions: per-settle-pass evidence anchor HEAD in comment-repair fix cycle."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters.base import AgentRunResult
+from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner import comment_verdict
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    AGENT_FIXED_WITHOUT_EVIDENCE,
+    AgentVerdictProtocolError,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _clean_status(*, threads: tuple[ReviewThread, ...] = ()) -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha="start",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=threads,
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+
+@pytest.mark.unit
+async def test_fix_cycle_later_settle_pass_uses_fresh_pass_head_as_cycle_start_head(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pass-2 evidence anchor must be post-pass-1 HEAD, not the operation-open SHA."""
+    cmd = FakeCommandRunner()
+    # Pass-start + per-item cat-file probes (empty queue returns ok; queue explicit ones).
+    cmd.queue_result(returncode=0)  # pass1 start cat-file
+    cmd.queue_result(returncode=0)  # pass1 item cat-file
+    cmd.queue_result(returncode=0)  # pass2 start cat-file
+    cmd.queue_result(returncode=0)  # pass2 item cat-file
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_pass_anchor"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    operation_open = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    after_pass1 = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    # pass1 start, pass1 item, pass2 start, pass2 item
+    current_heads = iter((operation_open, after_pass1, after_pass1, after_pass1))
+    cycle_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (operation_open, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return next(current_heads)
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                threads=(
+                    ReviewThread(
+                        thread_id="T_later",
+                        path="src/foo.py",
+                        line=20,
+                        body_excerpt="new feedback after earlier push",
+                        author="reviewer",
+                    ),
+                )
+            )
+        return _clean_status()
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    result = await runner._run_fix_cycle(
+        workspace_id="ws_pass_anchor",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=operation_open,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_first",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="please fix first",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_pass_anchor",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert address_thread_ids == ["T_first", "T_later"]
+    assert cycle_start_heads[0] == operation_open
+    # Bug today: pass 2 still gets operation_open. Fix: after_pass1.
+    assert cycle_start_heads[1] == after_pass1
+    assert cycle_start_heads[1] != operation_open
+
+
+@pytest.mark.unit
+async def test_fix_cycle_multi_item_pass_shares_stable_pass_start_cycle_head(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Items in one settle pass share the pass snapshot while item heads advance.
+
+    On pass 2 the operation-open SHA differs from the live pass HEAD. Both items
+    must still receive the same ``cycle_start_head`` (pass snapshot), not the
+    stale operation-open SHA and not each item's own advancing HEAD.
+    """
+    cmd = FakeCommandRunner()
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_stable_pass"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    operation_open = "operation-open-head"
+    pass2_anchor = "pass-two-start-head"
+    after_first = "after-first-item-head"
+    live_head = {"sha": operation_open}
+    cycle_start_heads: list[str | None] = []
+    operation_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (operation_open, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return live_head["sha"]
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        operation_start_heads.append(cast(str | None, kwargs.get("operation_start_head")))
+        if thread.thread_id == "T_pass1":
+            live_head["sha"] = pass2_anchor
+        elif thread.thread_id == "T_pass2_a":
+            live_head["sha"] = after_first
+        return "false_positive" if thread.thread_id == "T_pass1" else "needs_human"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                threads=(
+                    ReviewThread(
+                        thread_id="T_pass2_a",
+                        path="src/a.py",
+                        line=1,
+                        body_excerpt="settle first",
+                        author="reviewer",
+                    ),
+                    ReviewThread(
+                        thread_id="T_pass2_b",
+                        path="src/b.py",
+                        line=2,
+                        body_excerpt="settle second",
+                        author="reviewer",
+                    ),
+                )
+            )
+        return _clean_status()
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    await runner._run_fix_cycle(
+        workspace_id="ws_stable_pass",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=operation_open,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_pass1",
+                path="src/z.py",
+                line=1,
+                body_excerpt="first pass",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_stable_pass",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert address_thread_ids == ["T_pass1", "T_pass2_a", "T_pass2_b"]
+    # Pass-2 items share one pass anchor (not operation-open, not per-item HEAD).
+    assert cycle_start_heads[1:] == [pass2_anchor, pass2_anchor]
+    assert operation_open not in cycle_start_heads[1:]
+    assert operation_start_heads[1:] == [pass2_anchor, after_first]
+
+
+@pytest.mark.unit
+async def test_fix_cycle_fails_closed_when_pass_start_head_object_is_poisoned(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unverifiable pass-start HEAD must abort before addressing that pass."""
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # pass1 start cat-file
+    cmd.queue_result(returncode=0)  # pass1 item cat-file
+    cmd.queue_result(returncode=128, stderr="fatal: Not a valid object name poisoned")
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_pass_poisoned"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    operation_open = "start"
+    after_pass1 = "after-pass1"
+    poisoned = "poisoned"
+    # pass1 start, pass1 item, pass2 start (poisoned)
+    current_heads = iter((operation_open, after_pass1, poisoned))
+    cycle_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (operation_open, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return next(current_heads)
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                threads=(
+                    ReviewThread(
+                        thread_id="T_pass2",
+                        path="src/foo.py",
+                        line=4,
+                        body_excerpt="settle feedback",
+                        author="reviewer",
+                    ),
+                )
+            )
+        return _clean_status()
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    result = await runner._run_fix_cycle(
+        workspace_id="ws_pass_poisoned",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=operation_open,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_pass1",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="first pass",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_pass_poisoned",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is True
+    assert result.reason_code == "HEAD_OBJECT_MISSING_UNRECOVERABLE"
+    assert "commit object probe failed" in result.stderr
+    # Pass 2 never addressed — no silent fallback to operation-open as cycle_start.
+    assert address_thread_ids == ["T_pass1"]
+    assert cycle_start_heads == [operation_open]
+
+
+@pytest.mark.unit
+async def test_later_pass_anchor_accepts_real_item_line_fix(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Line coords relative to a later pass head must map and accept a real FIXED.
+
+    After an earlier pass inserts lines at the top, a settle-thread line is only
+    valid against the newer pass head. Anchoring evidence at the operation-open
+    SHA maps that line to failure (``item_line = -1``) and rejects a real fix.
+    """
+    worktree = tmp_path / "worktrees" / "ws_protocol"
+    worktree.mkdir(parents=True)
+    _git(worktree, "init", "-q")
+    _git(worktree, "config", "user.email", "awf@example.com")
+    _git(worktree, "config", "user.name", "AWF Test")
+    (worktree / "src").mkdir()
+    target = worktree / "src" / "mod.py"
+    target.write_text("line1\nREVIEWED\nline3\n", encoding="utf-8")
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "operation open")
+    operation_open = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Earlier pass: insert five lines so REVIEWED moves from line 2 → line 7.
+    target.write_text(
+        "pad1\npad2\npad3\npad4\npad5\nline1\nREVIEWED\nline3\n",
+        encoding="utf-8",
+    )
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "pass1 insert")
+    pass_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Item-scoped fix at the settle-thread line (7) relative to pass_head.
+    target.write_text(
+        "pad1\npad2\npad3\npad4\npad5\nline1\nREVIEWED fixed\nline3\n",
+        encoding="utf-8",
+    )
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "item line fix")
+    fixed_tip = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=AsyncioSubprocessRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _ok(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(comment_verdict, "repair_agent_runtime_ownership", _ok)
+    monkeypatch.setattr(comment_verdict, "mirror_path_for_worktree", lambda _path: None)
+
+    async def _fixed_agent(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(
+            returncode=0,
+            stdout="AWF-VERDICT: FIXED: updated reviewed line",
+            stderr="",
+        )
+
+    runner._run_monitor_agent_with_service_recovery = _fixed_agent  # type: ignore[method-assign]
+
+    # Fresh pass-head anchor accepts the real line-scoped fix.
+    result = await comment_verdict._invoke_cli_for_verdict_result(
+        runner,
+        workspace_id="ws_protocol",
+        prompt="fix the reviewed line",
+        commit_message="fix: review item",
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=pass_head,
+        evidence_item_path="src/mod.py",
+        evidence_item_line=7,
+        evidence_anchor_head=pass_head,
+        commit_dirty_changes=False,
+    )
+    assert result.verdict == "fix_committed"
+    assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == fixed_tip
+
+    # Stale operation-open anchor must fail-closed for this settle-thread line.
+    with pytest.raises(AgentVerdictProtocolError) as stale:
+        await comment_verdict._invoke_cli_for_verdict_result(
+            runner,
+            workspace_id="ws_protocol",
+            prompt="fix the reviewed line",
+            commit_message="fix: review item",
+            compose_project="awf_ws_protocol",
+            compose_file=Path("compose.yml"),
+            operation_start_head=pass_head,
+            evidence_item_path="src/mod.py",
+            evidence_item_line=7,
+            evidence_anchor_head=operation_open,
+            commit_dirty_changes=False,
+        )
+    assert stale.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+
+
+@pytest.mark.unit
+async def test_no_change_fixed_rejected_with_correct_pass_anchor(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIXED with no item-scoped delta remains rejected when pass anchor is correct."""
+    worktree = tmp_path / "worktrees" / "ws_protocol"
+    worktree.mkdir(parents=True)
+    _git(worktree, "init", "-q")
+    _git(worktree, "config", "user.email", "awf@example.com")
+    _git(worktree, "config", "user.name", "AWF Test")
+    (worktree / "src").mkdir()
+    (worktree / "src" / "mod.py").write_text("unchanged\n", encoding="utf-8")
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "pass start")
+    pass_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=AsyncioSubprocessRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _ok(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(comment_verdict, "repair_agent_runtime_ownership", _ok)
+    monkeypatch.setattr(comment_verdict, "mirror_path_for_worktree", lambda _path: None)
+
+    async def _fixed_agent(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(
+            returncode=0,
+            stdout="AWF-VERDICT: FIXED: claimed without edits",
+            stderr="",
+        )
+
+    runner._run_monitor_agent_with_service_recovery = _fixed_agent  # type: ignore[method-assign]
+
+    with pytest.raises(AgentVerdictProtocolError) as caught:
+        await comment_verdict._invoke_cli_for_verdict_result(
+            runner,
+            workspace_id="ws_protocol",
+            prompt="fix nothing",
+            commit_message="fix: review item",
+            compose_project="awf_ws_protocol",
+            compose_file=Path("compose.yml"),
+            operation_start_head=pass_head,
+            evidence_item_path="src/mod.py",
+            evidence_item_line=1,
+            evidence_anchor_head=pass_head,
+            commit_dirty_changes=False,
+        )
+
+    assert caught.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
@@ -1218,7 +1218,8 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/tmp/private-objects")
     monkeypatch.setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/tmp/private-alternates")
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=0)  # cat-file start^{commit}
+    cmd.queue_result(returncode=0)  # pass-start cat-file start^{commit}
+    cmd.queue_result(returncode=0)  # cat-file start^{commit} for item 1
     cmd.queue_result(returncode=128, stderr="fatal: Not a valid object name poisoned")
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_poisoned_head"
@@ -1254,7 +1255,8 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
-    current_heads = iter(("start", "poisoned"))
+    # Pass-start + item 1 share verified start; item 2 sees poisoned HEAD.
+    current_heads = iter(("start", "start", "poisoned"))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
         return next(current_heads)
@@ -1316,6 +1318,7 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     cat_file_calls = [call for call in cmd.calls if call.args[-3:-1] == ["cat-file", "-e"]]
     assert [call.args[-1] for call in cat_file_calls] == [
         "start^{commit}",
+        "start^{commit}",
         "poisoned^{commit}",
     ]
     assert all(call.env is not None for call in cat_file_calls)
@@ -1331,6 +1334,7 @@ async def test_fix_cycle_fails_closed_when_per_item_rev_parse_fails(
 ) -> None:
     """Empty rev-parse after a prior item must not reuse cycle-start as item start."""
     cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # pass-start cat-file start^{commit}
     cmd.queue_result(returncode=0)  # cat-file start^{commit} for item 1
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_rev_parse_fail"
@@ -1366,7 +1370,8 @@ async def test_fix_cycle_fails_closed_when_per_item_rev_parse_fails(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
-    current_heads = iter(("start", None))
+    # Pass-start + item 1 succeed; item 2 sees empty rev-parse.
+    current_heads = iter(("start", "start", None))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
         return next(current_heads)

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
@@ -1218,7 +1218,6 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/tmp/private-objects")
     monkeypatch.setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/tmp/private-alternates")
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=0)  # pass-start cat-file start^{commit}
     cmd.queue_result(returncode=0)  # cat-file start^{commit} for item 1
     cmd.queue_result(returncode=128, stderr="fatal: Not a valid object name poisoned")
     worktrees_root = tmp_path / "worktrees"
@@ -1255,8 +1254,8 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
-    # Pass-start + item 1 share verified start; item 2 sees poisoned HEAD.
-    current_heads = iter(("start", "start", "poisoned"))
+    # Item 1 verified start; item 2 sees poisoned HEAD (no separate pass-start probe).
+    current_heads = iter(("start", "poisoned"))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
         return next(current_heads)
@@ -1318,7 +1317,6 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     cat_file_calls = [call for call in cmd.calls if call.args[-3:-1] == ["cat-file", "-e"]]
     assert [call.args[-1] for call in cat_file_calls] == [
         "start^{commit}",
-        "start^{commit}",
         "poisoned^{commit}",
     ]
     assert all(call.env is not None for call in cat_file_calls)
@@ -1334,7 +1332,6 @@ async def test_fix_cycle_fails_closed_when_per_item_rev_parse_fails(
 ) -> None:
     """Empty rev-parse after a prior item must not reuse cycle-start as item start."""
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=0)  # pass-start cat-file start^{commit}
     cmd.queue_result(returncode=0)  # cat-file start^{commit} for item 1
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_rev_parse_fail"
@@ -1370,8 +1367,8 @@ async def test_fix_cycle_fails_closed_when_per_item_rev_parse_fails(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
-    # Pass-start + item 1 succeed; item 2 sees empty rev-parse.
-    current_heads = iter(("start", "start", None))
+    # Item 1 succeeds; item 2 sees empty rev-parse (no separate pass-start probe).
+    current_heads = iter(("start", None))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
         return next(current_heads)

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
@@ -490,7 +490,8 @@ async def test_fix_cycle_uses_current_head_as_per_item_recovery_anchor(
     worktree.mkdir(parents=True)
     threaded_heads: list[str | None] = []
     observed_worktrees: list[Path] = []
-    current_heads = iter(("cycle-start-head", "after-thread-fix-head"))
+    # Pass-start probe + per-item probes (pass snapshot then thread, then review).
+    current_heads = iter(("cycle-start-head", "cycle-start-head", "after-thread-fix-head"))
 
     async def _rev_parse_head(worktree_path: Path) -> str | None:
         observed_worktrees.append(worktree_path)
@@ -548,7 +549,7 @@ async def test_fix_cycle_uses_current_head_as_per_item_recovery_anchor(
     )
 
     assert threaded_heads == ["cycle-start-head", "after-thread-fix-head"]
-    assert observed_worktrees == [worktree, worktree]
+    assert observed_worktrees == [worktree, worktree, worktree]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
@@ -490,8 +490,8 @@ async def test_fix_cycle_uses_current_head_as_per_item_recovery_anchor(
     worktree.mkdir(parents=True)
     threaded_heads: list[str | None] = []
     observed_worktrees: list[Path] = []
-    # Pass-start probe + per-item probes (pass snapshot then thread, then review).
-    current_heads = iter(("cycle-start-head", "cycle-start-head", "after-thread-fix-head"))
+    # Per-item probes only (remote batch anchor is cycle_start_head; no local pass-start).
+    current_heads = iter(("cycle-start-head", "after-thread-fix-head"))
 
     async def _rev_parse_head(worktree_path: Path) -> str | None:
         observed_worktrees.append(worktree_path)
@@ -549,7 +549,7 @@ async def test_fix_cycle_uses_current_head_as_per_item_recovery_anchor(
     )
 
     assert threaded_heads == ["cycle-start-head", "after-thread-fix-head"]
-    assert observed_worktrees == [worktree, worktree, worktree]
+    assert observed_worktrees == [worktree, worktree]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_37b9a346ccb74da18d8766cd` (agent: `cursor`, model: `auto`).


### Task
Production hosted PR monitoring exposed a deterministic evidence bug. In a single comment-repair operation, fix_cycle.py passes the original operation_start_head as cycle_start_head on every max_fix_cycle_passes settle pass. Threads fetched after an earlier hosted repair push have path/line coordinates for the newer pass head, so mapping them from the old operation head can fail. A valid FIXED commit is then misclassified AGENT_FIXED_WITHOUT_EVIDENCE and remotely rolled back. Implement the smallest strict-TDD fix so each pass snapshots a fresh verified pass-start HEAD before processing that pass and uses that snapshot as the evidence anchor for every thread in that pass, while each item still uses its own fresh operation_start_head for forward Git evidence. Preserve fail-closed behavior when a pass head cannot be verified, preserve mapping across earlier item commits within the same pass, and do not weaken path/line-scoped evidence generally. Add focused regressions proving: a thread fetched in a later settle pass after a prior push maps from that later pass head and accepts a real item-line fix; multiple items in one pass still map from one stable pass anchor; missing/unreadable pass HEAD fails closed; no-change FIXED remains rejected. Inspect existing tests and patterns first. Keep changes tightly scoped. Git is functional in /workspace; commit before exiting. Do not push; AWF owns push, PR creation, review repair, and merge. Never stage plans/*_PLAN.md or plans/*_VALIDATION.md.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes evidence anchoring for PR comment repair—a correctness-critical path—but scope is narrow with focused regressions; wrong anchors previously caused valid fixes to be rejected and rolled back.
> 
> **Overview**
> Fixes a PR monitor bug where **path/line evidence** for inline review threads was anchored to the wrong Git SHA during multi-pass fix cycles.
> 
> **`fix_cycle.py`** now keeps a **stable remote batch anchor** (`pr_head_sha` on the first pass, then each settle poll’s `status.head_sha`) and passes it as `cycle_start_head` for every thread in that pass. **`operation_start_head`** still tracks the local worktree tip per item for forward commit evidence. That way thread coordinates from GitHub stay tied to the unpublished remote tip even when agents commit locally before push, avoiding false **`AGENT_FIXED_WITHOUT_EVIDENCE`** rollbacks.
> 
> Adds **`test_pr_monitor_fix_cycle_pass_anchor.py`** (multi-pass anchor, shared pass anchor, verdict mapping) and tweaks comments in existing fix-cycle tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c76ea5f2ce90202db3b0c80044f217fc3c455924. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->