### PR TITLE
fix(core): make hosted pre-push validation self-contained

### DIFF
--- a/src/awf/control/executor/helpers.py
+++ b/src/awf/control/executor/helpers.py
@@ -1230,11 +1230,24 @@ def _is_adapter_retired(adapter: Any) -> bool:
     return getattr(adapter, "is_retired", False) is True
 
 
+def _pre_push_validation_phase_names(*, is_hosted: bool) -> tuple[str, ...]:
+    """Return pre-push validation phases for local vs hosted adapters.
+
+    Hosted validation runs in a fresh ephemeral Job, so setup must run in the
+    same request as post_agent/validate (and coverage when requested). Local
+    Compose workspaces already have setup artifacts and keep the historical
+    post_agent+validate split.
+    """
+    if is_hosted:
+        return ("setup", "post_agent", "validate")
+    return ("post_agent", "validate")
+
+
 def _hosted_validate_only_validation_phases(
     *,
     hosted_pr_adoption_validate_only_recovery: bool,
 ) -> tuple[str, ...]:
     """Return validation phases for validate-only recovery on hosted workspaces."""
-    if hosted_pr_adoption_validate_only_recovery:
-        return ("setup", "post_agent", "validate")
-    return ("post_agent", "validate")
+    return _pre_push_validation_phase_names(
+        is_hosted=hosted_pr_adoption_validate_only_recovery,
+    )

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -858,17 +858,30 @@ def _validation_result_from_terminal(
     coverage_command_result_required = (
         coverage_policy is not None and coverage_policy.command is not None
     )
-    coverage = (
-        _coverage_result_from_payload(
+    if coverage_policy is not None and not isinstance(coverage_payload, Mapping):
+        # Fail closed when coverage was requested: absent coverage must not
+        # become ValidationResult(coverage=None), which all_passed treats as OK.
+        # Terminal failures may omit coverage (phases already failed), matching
+        # the coverage-only delegate path.
+        if state not in _HOSTED_VALIDATION_TERMINAL_FAILURES:
+            if coverage_payload is None:
+                raise HostedDelegationProtocolError(
+                    "hosted validation terminal response missing coverage"
+                )
+            raise HostedDelegationProtocolError(
+                "hosted validation terminal response has malformed coverage"
+            )
+        coverage = None
+    elif isinstance(coverage_payload, Mapping):
+        coverage = _coverage_result_from_payload(
             coverage_payload,
             artifacts_dir=artifacts_dir,
             max_output_bytes=max_output_bytes,
             command_result_required=coverage_command_result_required,
             coverage_policy=coverage_policy,
         )
-        if isinstance(coverage_payload, Mapping)
-        else None
-    )
+    else:
+        coverage = None
     return ValidationResult(commands=commands, coverage=coverage)
 
 

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -858,21 +858,26 @@ def _validation_result_from_terminal(
     coverage_command_result_required = (
         coverage_policy is not None and coverage_policy.command is not None
     )
-    if coverage_policy is not None and not isinstance(coverage_payload, Mapping):
-        # Fail closed when coverage was requested: absent coverage must not
-        # become ValidationResult(coverage=None), which all_passed treats as OK.
-        # Terminal failures may omit coverage (phases already failed), matching
-        # the coverage-only delegate path.
-        if state not in _HOSTED_VALIDATION_TERMINAL_FAILURES:
-            if coverage_payload is None:
-                raise HostedDelegationProtocolError(
-                    "hosted validation terminal response missing coverage"
-                )
+    # Coverage evidence is required only when a coverage command was configured
+    # and no preceding command already blocked validation (short-circuit). A
+    # bare ProfileCoverage with command=None (default include_coverage=True)
+    # must not demand a coverage field. Terminal failures either already carry
+    # a blocking command or gain a synthetic one above.
+    coverage_evidence_required = coverage_command_result_required and not any(
+        command.blocks_validation for command in commands
+    )
+    if coverage_evidence_required and not isinstance(coverage_payload, Mapping):
+        # Fail closed when coverage was eligible to run: absent coverage must
+        # not become ValidationResult(coverage=None), which all_passed treats
+        # as OK.
+        if coverage_payload is None:
             raise HostedDelegationProtocolError(
-                "hosted validation terminal response has malformed coverage"
+                "hosted validation terminal response missing coverage"
             )
-        coverage = None
-    elif isinstance(coverage_payload, Mapping):
+        raise HostedDelegationProtocolError(
+            "hosted validation terminal response has malformed coverage"
+        )
+    if isinstance(coverage_payload, Mapping):
         coverage = _coverage_result_from_payload(
             coverage_payload,
             artifacts_dir=artifacts_dir,

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
@@ -12,6 +12,7 @@ from awf.common.audit import redact_audit_text
 from awf.common.compose_exec import ComposeExecCleanupError, cleanup_failure_message
 from awf.common.logging import get_logger
 from awf.control.executor.helpers import (
+    _pre_push_validation_phase_names,
     _profile_for_workspace,
     _should_run_local_coverage,
     _validation_run_command_records,
@@ -529,16 +530,14 @@ async def _pre_push_validation_commands(
     workspace_id: str,
     worktree_path: Path,
 ) -> tuple[str, ...]:
-    """Load the post-agent and validate commands for a workspace profile."""
+    """Load the selected pre-push phase commands for a workspace profile."""
     async with self._deps.session_factory() as session:
         ws = await WorkspaceRepository(session).get(workspace_id)
         if ws is None:
             return ()
         profile = _profile_for_workspace(ws, worktree_path=worktree_path)
-    return tuple(
-        step.command.command
-        for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
-    )
+    phase_names = _pre_push_validation_phase_names(is_hosted=self._deps.adapter.is_hosted)
+    return tuple(step.command.command for step in profile_phase_command_plan(profile, phase_names))
 
 
 async def _pre_push_validation_worktree_check(
@@ -705,6 +704,8 @@ async def _run_pre_push_validation(
         validation_tier = _validation_tier_for_workspace(ws, profile)
         base_commit = ws.base_commit
 
+    is_hosted = self._deps.adapter.is_hosted
+    phase_names = _pre_push_validation_phase_names(is_hosted=is_hosted)
     workspace_head_sha = await self._rev_parse_head(worktree_path)
     mirror_path = mirror_path_for_worktree(worktree_path)
     if mirror_path is not None:
@@ -761,8 +762,7 @@ async def _run_pre_push_validation(
                 message="HEAD object missing before PR monitor pre-push validation",
             )
         command_evidence = tuple(
-            step.command.command
-            for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
+            step.command.command for step in profile_phase_command_plan(profile, phase_names)
         )
         try:
             recovered = await _recover_missing_head_object_from_filesystem(
@@ -991,6 +991,7 @@ async def _run_pre_push_validation(
         self,
         workspace_id=workspace_id,
         profile=profile,
+        phase_names=phase_names,
         base_commit=base_commit,
         workspace_head_sha=workspace_head_sha,
         target_branch=remote_branch,
@@ -1013,19 +1014,19 @@ async def _run_pre_push_validation(
             "compose_project": compose_project,
             "compose_file": compose_file,
             "profile": profile,
-            "phase_names": ("post_agent", "validate"),
+            "phase_names": phase_names,
             "run_healthchecks": True,
             "worktree_path": worktree_path,
-            "include_coverage": False,
+            "include_coverage": is_hosted,
         }
-        if self._deps.adapter.is_hosted:
+        if is_hosted:
             hosted_pr_identity = await self._hosted_pr_identity_for_workspace(
                 workspace_id,
                 state=state,
             )
             validation_kwargs["pr_identity"] = hosted_pr_identity
         result = await self._deps.validation.run_profile_phases(**validation_kwargs)
-        if _should_run_local_coverage(profile) and result.all_passed:
+        if not is_hosted and _should_run_local_coverage(profile) and result.all_passed:
             coverage_kwargs: dict[str, Any] = {
                 "workspace_id": workspace_id,
                 "compose_project": compose_project,
@@ -1034,8 +1035,6 @@ async def _run_pre_push_validation(
                 "phase": "coverage",
                 "worktree_path": worktree_path,
             }
-            if hosted_pr_identity is not None:
-                coverage_kwargs["pr_identity"] = hosted_pr_identity
             coverage_result = await self._deps.validation.run_profile_coverage(**coverage_kwargs)
             if coverage_result is not None:
                 result = replace(result, coverage=coverage_result)
@@ -1268,6 +1267,7 @@ async def _start_pre_push_validation_run(
     *,
     workspace_id: str,
     profile: Any,
+    phase_names: tuple[str, ...],
     base_commit: str | None,
     workspace_head_sha: str,
     target_branch: str,
@@ -1276,7 +1276,7 @@ async def _start_pre_push_validation_run(
     """Create and start a pre-push validation run record."""
     command_records = _validation_run_command_records(
         profile=profile,
-        phase_names=("post_agent", "validate"),
+        phase_names=phase_names,
         run_healthchecks=True,
     )
     async with self._deps.session_factory() as session:

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
@@ -1026,6 +1026,14 @@ async def _run_pre_push_validation(
             )
             validation_kwargs["pr_identity"] = hosted_pr_identity
         result = await self._deps.validation.run_profile_phases(**validation_kwargs)
+        # Hosted combined jobs request coverage in-band. Reject a passing result
+        # that still omits coverage so push cannot proceed without evidence.
+        if (
+            bool(validation_kwargs.get("include_coverage"))
+            and result.all_passed
+            and result.coverage is None
+        ):
+            raise RuntimeError("hosted pre-push validation omitted requested coverage evidence")
         if not is_hosted and _should_run_local_coverage(profile) and result.all_passed:
             coverage_kwargs: dict[str, Any] = {
                 "workspace_id": workspace_id,

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
@@ -1017,7 +1017,7 @@ async def _run_pre_push_validation(
             "phase_names": phase_names,
             "run_healthchecks": True,
             "worktree_path": worktree_path,
-            "include_coverage": is_hosted,
+            "include_coverage": is_hosted and _should_run_local_coverage(profile),
         }
         if is_hosted:
             hosted_pr_identity = await self._hosted_pr_identity_for_workspace(

--- a/tests/unit/runtime/_pre_push_validation_helpers.py
+++ b/tests/unit/runtime/_pre_push_validation_helpers.py
@@ -202,6 +202,7 @@ async def _set_resolved_profile(
     workspace_id: str,
     *,
     include_coverage: bool = False,
+    coverage_final_gate: str = "coverage",
     setup_commands: list[str] | None = None,
     post_agent_commands: list[str] | None = None,
     validate_commands: list[str] | None = None,
@@ -224,7 +225,7 @@ async def _set_resolved_profile(
                 "minimum_percent": 99.0,
                 "command": "coverage run -m pytest && coverage report",
             },
-            "strategy": {"final_gate": "coverage"},
+            "strategy": {"final_gate": coverage_final_gate},
         }
     profile = WorkspaceProfile.model_validate(profile_payload)
     async with factory() as session:

--- a/tests/unit/runtime/_pre_push_validation_helpers.py
+++ b/tests/unit/runtime/_pre_push_validation_helpers.py
@@ -60,6 +60,7 @@ def _command_result(
     command: str = "pytest -q",
     returncode: int | None = None,
     artifact_name: str | None = None,
+    phase: str = "validate",
 ) -> ValidationCommandResult:
     """Build a deterministic validation command result with local artifact paths."""
     if reason_code is None:
@@ -75,6 +76,7 @@ def _command_result(
         duration_seconds=0.1,
         stdout_path=stdout_path,
         stderr_path=stderr_path,
+        phase=phase,
         reason_code=reason_code,
     )
 
@@ -87,10 +89,13 @@ def _validation_result(
     command: str = "pytest -q",
     returncode: int | None = None,
     artifact_name: str | None = None,
+    phase: str = "validate",
+    coverage: ValidationCoverageResult | None = None,
+    commands: list[ValidationCommandResult] | None = None,
 ) -> ValidationResult:
-    """Wrap one command result into a single-command validation result."""
-    return ValidationResult(
-        commands=[
+    """Wrap command result(s) into a validation result, optionally with coverage."""
+    if commands is None:
+        commands = [
             _command_result(
                 tmp_path,
                 ok=ok,
@@ -98,9 +103,10 @@ def _validation_result(
                 command=command,
                 returncode=returncode,
                 artifact_name=artifact_name,
+                phase=phase,
             )
         ]
-    )
+    return ValidationResult(commands=commands, coverage=coverage)
 
 
 class _CommandlessFailureValidationResult(ValidationResult):
@@ -196,11 +202,21 @@ async def _set_resolved_profile(
     workspace_id: str,
     *,
     include_coverage: bool = False,
+    setup_commands: list[str] | None = None,
+    post_agent_commands: list[str] | None = None,
+    validate_commands: list[str] | None = None,
 ) -> None:
     """Attach a simple resolved validation profile to the workspace."""
+    phases: dict[str, object] = {
+        "validate": ["pytest -q"] if validate_commands is None else validate_commands,
+    }
+    if setup_commands is not None:
+        phases["setup"] = setup_commands
+    if post_agent_commands is not None:
+        phases["post_agent"] = post_agent_commands
     profile_payload: dict[str, object] = {
         "name": "test-profile",
-        "phases": {"validate": ["pytest -q"]},
+        "phases": phases,
     }
     if include_coverage:
         profile_payload["validation"] = {

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -287,6 +287,147 @@ async def test_hosted_combined_validation_rejects_success_omitting_coverage(
 
 
 @pytest.mark.unit
+async def test_hosted_combined_validation_allows_omitted_coverage_without_command(
+    tmp_path: Path,
+) -> None:
+    """Default include_coverage must not require evidence when no coverage command exists."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-no-coverage-command",
+            "phases": {"validate": ["pytest -q"]},
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return combined success without a coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_no_cov_cmd",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_no_cov_cmd",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_combined_no_cov_cmd":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_no_cov_cmd",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 0,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "validate",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=True,
+        )
+
+    assert result.all_passed
+    assert result.coverage is None
+
+
+@pytest.mark.unit
+async def test_hosted_combined_validation_allows_coverage_omitted_after_blocking_command(
+    tmp_path: Path,
+) -> None:
+    """A blocking phase failure must keep its reason instead of a coverage protocol error."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-blocked-before-coverage",
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return succeeded operation with a failed validate command and no coverage."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_blocked_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_blocked_cov",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_combined_blocked_cov"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_blocked_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 1,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "1 failed",
+                            "phase": "validate",
+                            "reason_code": "COMMAND_FAILED",
+                            "required": True,
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=True,
+        )
+
+    assert not result.all_passed
+    assert result.coverage is None
+    assert result.first_failure is not None
+    assert result.first_failure.reason_code == "COMMAND_FAILED"
+
+
+@pytest.mark.unit
 async def test_hosted_coverage_uses_profile_enforcement_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -219,6 +219,74 @@ async def test_hosted_combined_validation_rejects_passed_coverage_without_comman
 
 
 @pytest.mark.unit
+async def test_hosted_combined_validation_rejects_success_omitting_coverage(
+    tmp_path: Path,
+) -> None:
+    """Combined hosted success must fail closed when requested coverage is absent."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-missing-coverage",
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return combined success with validate evidence but no coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_omit_cov",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_combined_omit_cov":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 0,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "validate",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        with pytest.raises(HostedDelegationProtocolError, match="missing coverage"):
+            await delegate.run_profile_phases(
+                workspace_id="ws_hosted",
+                compose_project="unused",
+                compose_file=tmp_path / "missing-compose.yml",
+                profile=profile,
+                phase_names=("validate",),
+                include_coverage=True,
+            )
+
+
+@pytest.mark.unit
 async def test_hosted_coverage_uses_profile_enforcement_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
@@ -950,7 +950,7 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """Hosted coverage-only validation should target the adopted PR identity."""
+    """Hosted combined validation should target the adopted PR identity once."""
     workspace_id = await seed_monitoring_workspace(factory, pr_number=277)
     await _set_resolved_profile(factory, workspace_id, include_coverage=True)
     worktree = tmp_path / "worktrees" / workspace_id
@@ -959,9 +959,9 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     local_head = "7" * 40
     cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
     cmd.queue_result(returncode=0, stdout="", stderr="")
+    coverage = _coverage_result(tmp_path)
     validation = _FakeValidation(
-        _validation_result(tmp_path, ok=True),
-        coverage_result=_coverage_result(tmp_path),
+        _validation_result(tmp_path, ok=True, coverage=coverage),
     )
     runner = make_runner(
         factory=factory,
@@ -983,13 +983,16 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     assert result.failed is False
     assert result.pushed is True
     assert len(validation.calls) == 1
-    assert len(validation.coverage_calls) == 1
+    assert len(validation.coverage_calls) == 0
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is True
     phase_pr_identity = validation.calls[0]["pr_identity"]
-    coverage_pr_identity = validation.coverage_calls[0]["pr_identity"]
-    assert coverage_pr_identity == phase_pr_identity
-    assert isinstance(coverage_pr_identity, dict)
-    assert coverage_pr_identity["pr_number"] == 277
-    assert coverage_pr_identity["head_ref"] == f"awf/{workspace_id}"
+    assert isinstance(phase_pr_identity, dict)
+    assert phase_pr_identity["pr_number"] == 277
+    assert phase_pr_identity["head_ref"] == f"awf/{workspace_id}"
+    runs = await _validation_runs(factory, workspace_id)
+    assert runs[-1].coverage is not None
+    assert runs[-1].coverage["percent"] == 99.5
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
@@ -142,6 +142,54 @@ async def test_hosted_pre_push_runs_setup_post_agent_validate_with_coverage_in_o
 
 
 @pytest.mark.unit
+async def test_hosted_pre_push_rejects_passing_result_that_omits_requested_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted include_coverage must not push when the combined result lacks coverage."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "f" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    # Passing phases with coverage=None simulates an incomplete combined response.
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        pre_push_validation_fix_passes=0,
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.reason_code == "PRE_PUSH_VALIDATION_INFRASTRUCTURE_FAILED"
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["include_coverage"] is True
+    assert len(validation.coverage_calls) == 0
+    assert "git push" not in [" ".join(call.args) for call in cmd.calls]
+
+
+@pytest.mark.unit
 async def test_hosted_pre_push_setup_failure_blocks_later_phases_and_coverage(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
@@ -354,12 +354,58 @@ async def test_hosted_pre_push_empty_setup_phase_still_requests_setup(
     assert result.pushed is True
     assert len(validation.calls) == 1
     assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
-    assert validation.calls[0]["include_coverage"] is True
+    assert validation.calls[0]["include_coverage"] is False
     assert len(validation.coverage_calls) == 0
     runs = await _validation_runs(factory, workspace_id)
     phases = [cmd.get("phase") for cmd in runs[-1].commands]
     assert "setup" not in phases
     assert "validate" in phases
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_skips_coverage_when_final_gate_is_none(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted coverage.command without final_gate coverage must not gate pre-push."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        coverage_final_gate="none",
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "e" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["include_coverage"] is False
+    assert len(validation.coverage_calls) == 0
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
@@ -1,0 +1,412 @@
+"""Hosted pre-push validation must run setup+coverage in one ephemeral Job."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.control.executor.helpers import _pre_push_validation_phase_names
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor_runner import pre_push_validation
+from awf.runtime.pr_monitor_runner.constants import (
+    _PROTECTED_SCOPE_REPAIR_FAILED_REASON,
+)
+from awf.runtime.pr_monitor_runner.types import _MonitorPolicyBlockedError
+from awf.runtime.validation_worktree import (
+    ValidationWorktreeCheck,
+    ValidationWorktreeCleanup,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+from tests.unit.runtime._pre_push_validation_helpers import (
+    _coverage_result,
+    _FakeValidation,
+    _mark_git_worktree,
+    _set_resolved_profile,
+    _validation_result,
+    _validation_runs,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Yield a scoped async SQLAlchemy session factory for tests."""
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.mark.unit
+def test_pre_push_validation_phase_names_local_vs_hosted() -> None:
+    """Hosted pre-push includes setup; local keeps post_agent+validate only."""
+    assert _pre_push_validation_phase_names(is_hosted=False) == ("post_agent", "validate")
+    assert _pre_push_validation_phase_names(is_hosted=True) == (
+        "setup",
+        "post_agent",
+        "validate",
+    )
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_runs_setup_post_agent_validate_with_coverage_in_one_job(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted pre-push uses one phases call with setup and include_coverage."""
+    workspace_id = await seed_monitoring_workspace(factory, pr_number=277)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        post_agent_commands=["npm run format"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "a" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    coverage = _coverage_result(tmp_path)
+    validation = _FakeValidation(
+        _validation_result(
+            tmp_path,
+            ok=True,
+            command="npm run lint",
+            coverage=coverage,
+            commands=[
+                _validation_result(
+                    tmp_path, ok=True, command="npm ci", phase="setup", artifact_name="setup"
+                ).commands[0],
+                _validation_result(
+                    tmp_path,
+                    ok=True,
+                    command="npm run format",
+                    phase="post_agent",
+                    artifact_name="post_agent",
+                ).commands[0],
+                _validation_result(
+                    tmp_path,
+                    ok=True,
+                    command="npm run lint",
+                    phase="validate",
+                    artifact_name="validate",
+                ).commands[0],
+            ],
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert len(validation.coverage_calls) == 0
+    phase_call = validation.calls[0]
+    assert phase_call["phase_names"] == ("setup", "post_agent", "validate")
+    assert phase_call["include_coverage"] is True
+    assert phase_call["run_healthchecks"] is True
+    assert isinstance(phase_call["pr_identity"], dict)
+    assert phase_call["pr_identity"]["pr_number"] == 277
+    runs = await _validation_runs(factory, workspace_id)
+    assert runs[-1].status == "succeeded"
+    phases = [cmd.get("phase") for cmd in runs[-1].commands]
+    assert phases[:3] == ["setup", "post_agent", "validate"]
+    assert "coverage" in phases
+    assert runs[-1].coverage is not None
+    assert runs[-1].coverage["percent"] == 99.5
+    assert runs[-1].coverage["reason_code"] == "COVERAGE_OK"
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_setup_failure_blocks_later_phases_and_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A failing hosted setup phase must block push without a coverage Job."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "b" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    validation = _FakeValidation(
+        _validation_result(
+            tmp_path,
+            ok=False,
+            command="npm ci",
+            phase="setup",
+            reason_code="COMMAND_FAILED",
+            artifact_name="setup_fail",
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        pre_push_validation_fix_passes=0,
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.reason_code == "PRE_PUSH_VALIDATION_FAILED"
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is True
+    assert len(validation.coverage_calls) == 0
+    assert "git push" not in [" ".join(call.args) for call in cmd.calls]
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_missing_head_recovery_evidence_includes_setup(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing-HEAD recovery command evidence must include hosted setup commands."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        setup_commands=["npm ci"],
+        post_agent_commands=["npm run format"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    _mark_git_worktree(worktree)
+    recovery_base = "1" * 40
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=f"{recovery_base}\n")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+    recovery_calls: list[dict[str, object]] = []
+
+    async def _verify_head_object_exists(_worktree_path: Path) -> bool:
+        return False
+
+    async def _repair_mirror_hooks_path(_mirror_path: Path) -> bool:
+        return False
+
+    async def _recover_missing_head_object_from_filesystem(
+        self: object,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        operation_start_head: str,
+        task_tag: str | None = None,
+        command_evidence: object = (),
+    ) -> str | None:
+        del self, worktree_path, task_tag
+        assert operation_start_head == recovery_base
+        recovery_calls.append(
+            {
+                "workspace_id": workspace_id,
+                "command_evidence": command_evidence,
+            }
+        )
+        raise _MonitorPolicyBlockedError(
+            "PROTECTED_SCOPE_REPAIR_FAILED (.github/workflows/ci.yml)",
+            reason_code=_PROTECTED_SCOPE_REPAIR_FAILED_REASON,
+        )
+
+    async def _pre_push_validation_cleanup(
+        self: object,
+        *,
+        worktree_path: Path,
+        restore_ref: str,
+    ) -> ValidationWorktreeCleanup:
+        del self, worktree_path
+        return ValidationWorktreeCleanup(
+            cleaned=True,
+            check=ValidationWorktreeCheck(clean=False, paths=("package-lock.json",)),
+            restore_ref=restore_ref,
+            cleaned_paths=("package-lock.json",),
+        )
+
+    monkeypatch.setattr(
+        pre_push_validation,
+        "repair_mirror_hooks_path",
+        _repair_mirror_hooks_path,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "verify_head_object_exists",
+        _verify_head_object_exists,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "_recover_missing_head_object_from_filesystem",
+        _recover_missing_head_object_from_filesystem,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "_pre_push_validation_cleanup",
+        _pre_push_validation_cleanup,
+    )
+
+    result = await pre_push_validation._run_pre_push_validation(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        remote_branch=f"awf/{workspace_id}",
+        operation_start_head=recovery_base,
+    )
+
+    assert result.passed is False
+    assert result.reason_code == _PROTECTED_SCOPE_REPAIR_FAILED_REASON
+    assert recovery_calls == [
+        {
+            "workspace_id": workspace_id,
+            "command_evidence": ("npm ci", "npm run format", "npm run lint"),
+        }
+    ]
+    assert validation.calls == []
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_empty_setup_phase_still_requests_setup(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted profiles without setup commands still request the setup phase once."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        setup_commands=[],
+        validate_commands=["pytest -q"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "c" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is True
+    assert len(validation.coverage_calls) == 0
+    runs = await _validation_runs(factory, workspace_id)
+    phases = [cmd.get("phase") for cmd in runs[-1].commands]
+    assert "setup" not in phases
+    assert "validate" in phases
+
+
+@pytest.mark.unit
+async def test_local_pre_push_unchanged_phases_and_separate_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Local pre-push still skips setup and runs coverage as a separate call."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["pytest -q"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "d" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(
+        _validation_result(tmp_path, ok=True),
+        coverage_result=_coverage_result(tmp_path),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is False
+    assert len(validation.coverage_calls) == 1
+    assert validation.coverage_calls[0]["phase"] == "coverage"


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_f5dc7a81997c4c2a86093796` (agent: `cursor`, model: `auto`).


### Task
Production hosted PR monitoring exposed a deterministic validation isolation bug. Every hosted pre-push validation or coverage request runs in a fresh ephemeral GKE Job. The current PR monitor requests only post_agent and validate with include_coverage false, then requests coverage separately. For aira-web, setup contains npm ci, so the fresh validation Job has no node_modules and fails with eslint missing, an unrelated tsc package fetched by npx, and missing Playwright packages even though earlier repair Jobs ran setup successfully. Implement the smallest public Core fix with strict TDD. For hosted adapters only, run setup, post_agent, and validate in that order in one pre-push validation request and set include_coverage true so configured coverage executes in that same fresh hosted Job. Do not call run_profile_coverage separately for hosted validation. Preserve existing local behavior exactly: local pre-push validation runs post_agent and validate without setup, uses include_coverage false, and invokes local coverage separately once after successful phases. Derive one selected phase tuple and use it consistently for delegated execution, validation-run command provenance, the pre-push command plan, and missing-HEAD recovery command evidence. Persist hosted coverage from the combined result exactly once. Preserve healthchecks, retry and cleanup behavior, strict failure propagation, validation freshness, and profiles with no setup commands. Add focused regressions proving hosted ordered setup/post-agent/validate/coverage provenance, one hosted validation backend invocation with no duplicate setup or coverage Job, setup failure blocks later phases, missing-HEAD recovery evidence includes hosted setup, local behavior remains unchanged, and an empty setup phase remains valid. Do not work around this in awf-cloud, aira-web, or workspace profiles. Inspect existing helpers and tests first and follow their patterns. Keep the implementation tightly scoped. Git is functional in /workspace; commit before exiting. Do not push; AWF owns push, PR creation, review repair, and merge. Never stage plans/*_PLAN.md or plans/*_VALIDATION.md.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes pre-push gating and hosted validation protocol parsing on the PR monitor push path; mistakes could block pushes or accept incomplete coverage, though local paths are explicitly preserved and regressions are covered.
> 
> **Overview**
> **Hosted pre-push validation** now runs **setup → post_agent → validate** in a **single** delegated job (with **in-band coverage** when the profile gates on it), instead of only post_agent/validate in a fresh Job and a separate coverage run. A shared `_pre_push_validation_phase_names` drives phase selection consistently for command plans, validation-run records, execution, and missing-HEAD recovery evidence.
> 
> **Local** behavior is unchanged: **post_agent + validate**, `include_coverage=False`, and a follow-up `run_profile_coverage` after phases pass.
> 
> **Hosted delegation** parsing is stricter: when a coverage command is configured and nothing blocked validation, a successful terminal response **must** include coverage; omitted coverage no longer passes as `coverage=None`. Missing coverage after a blocking command failure still surfaces the phase failure, not a protocol error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92454f943815cd77b22d581a788784bb4d9968d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->