### PR TITLE
fix(core): gate hosted coverage evidence on validate

### DIFF
--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -427,12 +427,20 @@ class HostedValidationDelegate:
                 ),
             ),
         )
+        # Match ValidationRunner / poll-slot eligibility: coverage evidence is
+        # only required when include_coverage and validate were both requested.
+        requested_phases = set(phase_names)
+        coverage_policy = (
+            profile.validation.coverage
+            if include_coverage and "validate" in requested_phases
+            else None
+        )
         return _validation_result_from_terminal(
             terminal,
             artifacts_dir=self._artifacts_dir / workspace_id,
             max_output_bytes=self._config.max_output_bytes,
             expected_commands=expected_commands,
-            coverage_policy=profile.validation.coverage if include_coverage else None,
+            coverage_policy=coverage_policy,
         )
 
     async def run_profile_coverage(
@@ -858,11 +866,12 @@ def _validation_result_from_terminal(
     coverage_command_result_required = (
         coverage_policy is not None and coverage_policy.command is not None
     )
-    # Coverage evidence is required only when a coverage command was configured
-    # and no preceding command already blocked validation (short-circuit). A
-    # bare ProfileCoverage with command=None (default include_coverage=True)
-    # must not demand a coverage field. Terminal failures either already carry
-    # a blocking command or gain a synthetic one above.
+    # Coverage evidence is required only when callers pass a coverage_policy
+    # for validate-phase eligibility (include_coverage and "validate" requested),
+    # a coverage command was configured, and no preceding command already
+    # blocked validation (short-circuit). A bare ProfileCoverage with
+    # command=None must not demand a coverage field. Terminal failures either
+    # already carry a blocking command or gain a synthetic one above.
     coverage_evidence_required = coverage_command_result_required and not any(
         command.blocks_validation for command in commands
     )

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -219,6 +219,96 @@ async def test_hosted_combined_validation_rejects_passed_coverage_without_comman
 
 
 @pytest.mark.unit
+async def test_hosted_setup_pre_agent_allows_omitted_coverage_with_configured_command(
+    tmp_path: Path,
+) -> None:
+    """Setup/pre_agent-only success may omit coverage even when a coverage command exists.
+
+    Coverage eligibility requires both include_coverage and a validate phase. Default
+    include_coverage=True must not demand coverage evidence for non-validate requests.
+    """
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-setup-pre-agent-omit-coverage",
+            "phases": {
+                "setup": ["uv sync --extra dev"],
+                "pre_agent": ["echo pre"],
+                "validate": ["pytest -q"],
+            },
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return setup/pre_agent success with no coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_setup_pre_agent_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_setup_pre_agent_omit_cov",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_setup_pre_agent_omit_cov"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_setup_pre_agent_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "uv sync --extra dev",
+                            "returncode": 0,
+                            "duration_seconds": 0.1,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "setup",
+                        },
+                        {
+                            "command": "echo pre",
+                            "returncode": 0,
+                            "duration_seconds": 0.1,
+                            "stdout": "pre\n",
+                            "stderr": "",
+                            "phase": "pre_agent",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("setup", "pre_agent"),
+            # Default include_coverage=True is the contract edge under test.
+        )
+
+    assert result.all_passed
+    assert result.coverage is None
+
+
+@pytest.mark.unit
 async def test_hosted_combined_validation_rejects_success_omitting_coverage(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_c5b6dcb72ddd4fabbb01dbfe` (agent: `cursor`, model: `auto`).


### Task
PR 884 correctly made hosted pre-push validation self-contained, but its final review exposed one valid contract edge that did not reach the remote branch. HostedValidationDelegate.run_profile_phases defaults include_coverage to true. When a caller requests setup or pre_agent phases without validate and the profile defines a coverage command, the hosted output planner correctly does not run coverage and the terminal payload legitimately omits coverage. The current parser still receives a non-null coverage policy and incorrectly raises a missing-coverage protocol error. Implement the smallest strict-TDD correction. Pass coverage eligibility to the terminal parser only when include_coverage is true and validate is among the requested phase_names, matching the local ValidationRunner and hosted poll-slot planner. Preserve fail-closed missing or malformed coverage behavior when validate and a configured coverage command are genuinely eligible, preserve short-circuit behavior after an earlier blocking command, and preserve profiles without a coverage command. Add a focused regression with a configured coverage command proving a successful hosted setup/pre_agent-only operation may omit coverage, plus negative tests confirming validate-phase requests still require configured coverage evidence. Keep changes limited to hosted delegation and its focused unit tests. Do not alter the PR-monitor phase selection from PR 884. Git is functional in /workspace; commit before exiting. Do not push; AWF owns push, PR creation, review repair, and merge. Never stage plans/*_PLAN.md or plans/*_VALIDATION.md.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow contract fix in hosted validation parsing with focused unit tests; no auth, data, or merge-path changes.
> 
> **Overview**
> **Hosted validation** no longer treats missing terminal `coverage` as a protocol error when callers run **setup/pre_agent only**, even with default `include_coverage=True` and a profile coverage command configured.
> 
> `run_profile_phases` now passes `coverage_policy` into the terminal parser only when **both** `include_coverage` and a **`validate`** phase are requested—the same rule as local `ValidationRunner` and the hosted poll output planner. Fail-closed behavior is unchanged for validate runs that are coverage-eligible (missing or malformed coverage still raises), for short-circuit after an earlier blocking command, and when no coverage command is configured.
> 
> A regression test confirms setup/pre_agent success without a `coverage` field passes; existing tests still enforce coverage when `validate` is requested.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba070e08324a19e631ecd919053fc577c96604ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->