### PR TITLE
Release: merge development into main

### DIFF
--- a/src/awf/control/executor/helpers.py
+++ b/src/awf/control/executor/helpers.py
@@ -1230,11 +1230,24 @@ def _is_adapter_retired(adapter: Any) -> bool:
     return getattr(adapter, "is_retired", False) is True
 
 
+def _pre_push_validation_phase_names(*, is_hosted: bool) -> tuple[str, ...]:
+    """Return pre-push validation phases for local vs hosted adapters.
+
+    Hosted validation runs in a fresh ephemeral Job, so setup must run in the
+    same request as post_agent/validate (and coverage when requested). Local
+    Compose workspaces already have setup artifacts and keep the historical
+    post_agent+validate split.
+    """
+    if is_hosted:
+        return ("setup", "post_agent", "validate")
+    return ("post_agent", "validate")
+
+
 def _hosted_validate_only_validation_phases(
     *,
     hosted_pr_adoption_validate_only_recovery: bool,
 ) -> tuple[str, ...]:
     """Return validation phases for validate-only recovery on hosted workspaces."""
-    if hosted_pr_adoption_validate_only_recovery:
-        return ("setup", "post_agent", "validate")
-    return ("post_agent", "validate")
+    return _pre_push_validation_phase_names(
+        is_hosted=hosted_pr_adoption_validate_only_recovery,
+    )

--- a/src/awf/control/executor/helpers.py
+++ b/src/awf/control/executor/helpers.py
@@ -1233,13 +1233,13 @@ def _is_adapter_retired(adapter: Any) -> bool:
 def _pre_push_validation_phase_names(*, is_hosted: bool) -> tuple[str, ...]:
     """Return pre-push validation phases for local vs hosted adapters.
 
-    Hosted validation runs in a fresh ephemeral Job, so setup must run in the
-    same request as post_agent/validate (and coverage when requested). Local
-    Compose workspaces already have setup artifacts and keep the historical
-    post_agent+validate split.
+    Hosted validation runs in a fresh ephemeral Job, so setup and pre_agent
+    must run in the same request as post_agent/validate (and coverage when
+    requested). Local Compose workspaces already have setup/pre_agent
+    artifacts and keep the historical post_agent+validate split.
     """
     if is_hosted:
-        return ("setup", "post_agent", "validate")
+        return ("setup", "pre_agent", "post_agent", "validate")
     return ("post_agent", "validate")
 
 

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -872,9 +872,11 @@ def _validation_result_from_terminal(
     # blocked validation (short-circuit). A bare ProfileCoverage with
     # command=None must not demand a coverage field. Terminal failures either
     # already carry a blocking command or gain a synthetic one above.
-    coverage_evidence_required = coverage_command_result_required and not any(
-        command.blocks_validation for command in commands
-    )
+    # Skip parsing entirely when a command already blocks: a malformed
+    # coverage mapping must not raise HostedDelegationProtocolError and mask
+    # COMMAND_FAILED (pre-push fix-pass path).
+    has_blocking_command = any(command.blocks_validation for command in commands)
+    coverage_evidence_required = coverage_command_result_required and not has_blocking_command
     if coverage_evidence_required and not isinstance(coverage_payload, Mapping):
         # Fail closed when coverage was eligible to run: absent coverage must
         # not become ValidationResult(coverage=None), which all_passed treats
@@ -886,7 +888,7 @@ def _validation_result_from_terminal(
         raise HostedDelegationProtocolError(
             "hosted validation terminal response has malformed coverage"
         )
-    if isinstance(coverage_payload, Mapping):
+    if isinstance(coverage_payload, Mapping) and not has_blocking_command:
         coverage = _coverage_result_from_payload(
             coverage_payload,
             artifacts_dir=artifacts_dir,

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -858,17 +858,35 @@ def _validation_result_from_terminal(
     coverage_command_result_required = (
         coverage_policy is not None and coverage_policy.command is not None
     )
-    coverage = (
-        _coverage_result_from_payload(
+    # Coverage evidence is required only when a coverage command was configured
+    # and no preceding command already blocked validation (short-circuit). A
+    # bare ProfileCoverage with command=None (default include_coverage=True)
+    # must not demand a coverage field. Terminal failures either already carry
+    # a blocking command or gain a synthetic one above.
+    coverage_evidence_required = coverage_command_result_required and not any(
+        command.blocks_validation for command in commands
+    )
+    if coverage_evidence_required and not isinstance(coverage_payload, Mapping):
+        # Fail closed when coverage was eligible to run: absent coverage must
+        # not become ValidationResult(coverage=None), which all_passed treats
+        # as OK.
+        if coverage_payload is None:
+            raise HostedDelegationProtocolError(
+                "hosted validation terminal response missing coverage"
+            )
+        raise HostedDelegationProtocolError(
+            "hosted validation terminal response has malformed coverage"
+        )
+    if isinstance(coverage_payload, Mapping):
+        coverage = _coverage_result_from_payload(
             coverage_payload,
             artifacts_dir=artifacts_dir,
             max_output_bytes=max_output_bytes,
             command_result_required=coverage_command_result_required,
             coverage_policy=coverage_policy,
         )
-        if isinstance(coverage_payload, Mapping)
-        else None
-    )
+    else:
+        coverage = None
     return ValidationResult(commands=commands, coverage=coverage)
 
 

--- a/src/awf/runtime/hosted_delegation.py
+++ b/src/awf/runtime/hosted_delegation.py
@@ -427,12 +427,20 @@ class HostedValidationDelegate:
                 ),
             ),
         )
+        # Match ValidationRunner / poll-slot eligibility: coverage evidence is
+        # only required when include_coverage and validate were both requested.
+        requested_phases = set(phase_names)
+        coverage_policy = (
+            profile.validation.coverage
+            if include_coverage and "validate" in requested_phases
+            else None
+        )
         return _validation_result_from_terminal(
             terminal,
             artifacts_dir=self._artifacts_dir / workspace_id,
             max_output_bytes=self._config.max_output_bytes,
             expected_commands=expected_commands,
-            coverage_policy=profile.validation.coverage if include_coverage else None,
+            coverage_policy=coverage_policy,
         )
 
     async def run_profile_coverage(
@@ -858,11 +866,12 @@ def _validation_result_from_terminal(
     coverage_command_result_required = (
         coverage_policy is not None and coverage_policy.command is not None
     )
-    # Coverage evidence is required only when a coverage command was configured
-    # and no preceding command already blocked validation (short-circuit). A
-    # bare ProfileCoverage with command=None (default include_coverage=True)
-    # must not demand a coverage field. Terminal failures either already carry
-    # a blocking command or gain a synthetic one above.
+    # Coverage evidence is required only when callers pass a coverage_policy
+    # for validate-phase eligibility (include_coverage and "validate" requested),
+    # a coverage command was configured, and no preceding command already
+    # blocked validation (short-circuit). A bare ProfileCoverage with
+    # command=None must not demand a coverage field. Terminal failures either
+    # already carry a blocking command or gain a synthetic one above.
     coverage_evidence_required = coverage_command_result_required and not any(
         command.blocks_validation for command in commands
     )

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -317,7 +317,17 @@ async def _run_fix_cycle(
             "per-item HEAD unavailable: commit object probe failed",
         )
 
+    # Inline thread path/line coords are relative to the remote PR head from the
+    # status that supplied the batch — not local worktree HEAD. Non-hosted agents
+    # commit locally before push, so local HEAD can advance while settle re-polls
+    # still return coordinates for the unpublished remote tip. Using local HEAD as
+    # ``cycle_start_head`` skips the required remote→local mapping and can
+    # misclassify a real FIXED as AGENT_FIXED_WITHOUT_EVIDENCE
+    # (PRRT_kwDOSJAM6s6dFLGV). Keep one stable remote anchor per batch.
+    batch_anchor_head = pr_head_sha
+
     for _pass_num in range(self._runner_config.max_fix_cycle_passes):
+        pass_anchor_head = batch_anchor_head
         # 1) Address each item in the current batch.
         for t in threads:
             try:
@@ -333,7 +343,7 @@ async def _run_fix_cycle(
                     owned_paths=owned_paths,
                     task_tag=task_tag,
                     operation_start_head=item_operation_start_head,
-                    cycle_start_head=operation_start_head,
+                    cycle_start_head=pass_anchor_head,
                     base_branch=base_branch or "",
                     remote_branch=remote_branch,
                     operation_id=operation_id,
@@ -693,6 +703,10 @@ async def _run_fix_cycle(
         threads = new_threads
         reviews = new_reviews
         independently_addressed_review_ids.update(comment.comment_id for comment in reviews)
+        # Next pass's evidence coords come from this settle status's remote head.
+        next_anchor = (status.head_sha or "").strip()
+        if next_anchor:
+            batch_anchor_head = next_anchor
     # (If we hit max_fix_cycle_passes we still fall through to push —
     # whatever we did commit is worth shipping; next outer loop
     # iteration will re-poll and see what's left.)

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -323,7 +323,9 @@ async def _run_fix_cycle(
     # still return coordinates for the unpublished remote tip. Using local HEAD as
     # ``cycle_start_head`` skips the required remote→local mapping and can
     # misclassify a real FIXED as AGENT_FIXED_WITHOUT_EVIDENCE
-    # (PRRT_kwDOSJAM6s6dFLGV). Keep one stable remote anchor per batch.
+    # (PRRT_kwDOSJAM6s6dFLGV). Keep one stable remote anchor per batch; do not
+    # replace it with an advanced settle tip until that tip is reconciled
+    # (PRRT_kwDOSJAM6s6dIQm6).
     batch_anchor_head = pr_head_sha
 
     for _pass_num in range(self._runner_config.max_fix_cycle_passes):
@@ -700,13 +702,19 @@ async def _run_fix_cycle(
         ]
         if not new_threads and not new_reviews:
             break  # burst settled
+        # Settle thread/review path/line coords are relative to this status's
+        # remote head. Only continue when that head still matches the batch
+        # anchor we already hold: adopting an advanced tip without fetch /
+        # reconcile maps coords from an unavailable or divergent SHA onto
+        # unpublished local history (AGENT_FIXED_WITHOUT_EVIDENCE /
+        # PRRT_kwDOSJAM6s6dIQm6). Blank head is equally unverifiable — break
+        # and push; the outer loop re-enters with abandon/reconcile.
+        next_anchor = (status.head_sha or "").strip()
+        if not next_anchor or next_anchor.lower() != batch_anchor_head.lower():
+            break
         threads = new_threads
         reviews = new_reviews
         independently_addressed_review_ids.update(comment.comment_id for comment in reviews)
-        # Next pass's evidence coords come from this settle status's remote head.
-        next_anchor = (status.head_sha or "").strip()
-        if next_anchor:
-            batch_anchor_head = next_anchor
     # (If we hit max_fix_cycle_passes we still fall through to push —
     # whatever we did commit is worth shipping; next outer loop
     # iteration will re-poll and see what's left.)

--- a/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
+++ b/src/awf/runtime/pr_monitor_runner/pre_push_validation.py
@@ -12,6 +12,7 @@ from awf.common.audit import redact_audit_text
 from awf.common.compose_exec import ComposeExecCleanupError, cleanup_failure_message
 from awf.common.logging import get_logger
 from awf.control.executor.helpers import (
+    _pre_push_validation_phase_names,
     _profile_for_workspace,
     _should_run_local_coverage,
     _validation_run_command_records,
@@ -529,16 +530,14 @@ async def _pre_push_validation_commands(
     workspace_id: str,
     worktree_path: Path,
 ) -> tuple[str, ...]:
-    """Load the post-agent and validate commands for a workspace profile."""
+    """Load the selected pre-push phase commands for a workspace profile."""
     async with self._deps.session_factory() as session:
         ws = await WorkspaceRepository(session).get(workspace_id)
         if ws is None:
             return ()
         profile = _profile_for_workspace(ws, worktree_path=worktree_path)
-    return tuple(
-        step.command.command
-        for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
-    )
+    phase_names = _pre_push_validation_phase_names(is_hosted=self._deps.adapter.is_hosted)
+    return tuple(step.command.command for step in profile_phase_command_plan(profile, phase_names))
 
 
 async def _pre_push_validation_worktree_check(
@@ -705,6 +704,8 @@ async def _run_pre_push_validation(
         validation_tier = _validation_tier_for_workspace(ws, profile)
         base_commit = ws.base_commit
 
+    is_hosted = self._deps.adapter.is_hosted
+    phase_names = _pre_push_validation_phase_names(is_hosted=is_hosted)
     workspace_head_sha = await self._rev_parse_head(worktree_path)
     mirror_path = mirror_path_for_worktree(worktree_path)
     if mirror_path is not None:
@@ -761,8 +762,7 @@ async def _run_pre_push_validation(
                 message="HEAD object missing before PR monitor pre-push validation",
             )
         command_evidence = tuple(
-            step.command.command
-            for step in profile_phase_command_plan(profile, ("post_agent", "validate"))
+            step.command.command for step in profile_phase_command_plan(profile, phase_names)
         )
         try:
             recovered = await _recover_missing_head_object_from_filesystem(
@@ -991,6 +991,7 @@ async def _run_pre_push_validation(
         self,
         workspace_id=workspace_id,
         profile=profile,
+        phase_names=phase_names,
         base_commit=base_commit,
         workspace_head_sha=workspace_head_sha,
         target_branch=remote_branch,
@@ -1013,19 +1014,27 @@ async def _run_pre_push_validation(
             "compose_project": compose_project,
             "compose_file": compose_file,
             "profile": profile,
-            "phase_names": ("post_agent", "validate"),
+            "phase_names": phase_names,
             "run_healthchecks": True,
             "worktree_path": worktree_path,
-            "include_coverage": False,
+            "include_coverage": is_hosted and _should_run_local_coverage(profile),
         }
-        if self._deps.adapter.is_hosted:
+        if is_hosted:
             hosted_pr_identity = await self._hosted_pr_identity_for_workspace(
                 workspace_id,
                 state=state,
             )
             validation_kwargs["pr_identity"] = hosted_pr_identity
         result = await self._deps.validation.run_profile_phases(**validation_kwargs)
-        if _should_run_local_coverage(profile) and result.all_passed:
+        # Hosted combined jobs request coverage in-band. Reject a passing result
+        # that still omits coverage so push cannot proceed without evidence.
+        if (
+            bool(validation_kwargs.get("include_coverage"))
+            and result.all_passed
+            and result.coverage is None
+        ):
+            raise RuntimeError("hosted pre-push validation omitted requested coverage evidence")
+        if not is_hosted and _should_run_local_coverage(profile) and result.all_passed:
             coverage_kwargs: dict[str, Any] = {
                 "workspace_id": workspace_id,
                 "compose_project": compose_project,
@@ -1034,8 +1043,6 @@ async def _run_pre_push_validation(
                 "phase": "coverage",
                 "worktree_path": worktree_path,
             }
-            if hosted_pr_identity is not None:
-                coverage_kwargs["pr_identity"] = hosted_pr_identity
             coverage_result = await self._deps.validation.run_profile_coverage(**coverage_kwargs)
             if coverage_result is not None:
                 result = replace(result, coverage=coverage_result)
@@ -1268,6 +1275,7 @@ async def _start_pre_push_validation_run(
     *,
     workspace_id: str,
     profile: Any,
+    phase_names: tuple[str, ...],
     base_commit: str | None,
     workspace_head_sha: str,
     target_branch: str,
@@ -1276,7 +1284,7 @@ async def _start_pre_push_validation_run(
     """Create and start a pre-push validation run record."""
     command_records = _validation_run_command_records(
         profile=profile,
-        phase_names=("post_agent", "validate"),
+        phase_names=phase_names,
         run_healthchecks=True,
     )
     async with self._deps.session_factory() as session:

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_018.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_018.py
@@ -396,9 +396,15 @@ async def test_hosted_recovery_includes_setup_phase_names_for_all_sources(
 
     assert not result.stop
     assert len(hosted_validation.calls) == 1
-    assert hosted_validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert hosted_validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
     assert executor._start_validation_run.await_args.kwargs["phase_names"] == (
         "setup",
+        "pre_agent",
         "post_agent",
         "validate",
     )
@@ -555,7 +561,12 @@ async def test_hosted_setup_failure_fix_pass_includes_setup_commands_in_context(
         ctx.test_commands == ("npm ci", "npm run lint", "pytest -q")
         for ctx in captured_fix_contexts
     )
-    assert hosted_validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert hosted_validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
 
 
 @pytest.mark.unit
@@ -563,7 +574,7 @@ async def test_hosted_rebase_only_recovery_includes_setup_phase_names(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Rebase-only hosted recovery must run setup, post_agent, and validate."""
+    """Rebase-only hosted recovery must run setup, pre_agent, post_agent, and validate."""
     executor, workspace, hosted_validation = _build_recovery_validation_executor(
         tmp_path=tmp_path,
         hosted=True,
@@ -593,9 +604,15 @@ async def test_hosted_rebase_only_recovery_includes_setup_phase_names(
 
     assert not result.stop
     assert len(hosted_validation.calls) == 1
-    assert hosted_validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert hosted_validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
     assert executor._start_validation_run.await_args.kwargs["phase_names"] == (
         "setup",
+        "pre_agent",
         "post_agent",
         "validate",
     )

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_part_003.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_part_003.py
@@ -962,7 +962,7 @@ async def test_hosted_recovery_validation_routes_through_hosted_delegate(
     assert local_validation.preflight_calls == []
     assert [call["phase_names"] for call in hosted_validation.calls] == [
         ("setup", "pre_agent"),
-        ("setup", "post_agent", "validate"),
+        ("setup", "pre_agent", "post_agent", "validate"),
     ]
     assert len(hosted_validation.preflight_calls) == 1
     setup_kwargs = hosted_validation.calls[0]["kwargs"]

--- a/tests/unit/runtime/_pre_push_validation_helpers.py
+++ b/tests/unit/runtime/_pre_push_validation_helpers.py
@@ -60,6 +60,7 @@ def _command_result(
     command: str = "pytest -q",
     returncode: int | None = None,
     artifact_name: str | None = None,
+    phase: str = "validate",
 ) -> ValidationCommandResult:
     """Build a deterministic validation command result with local artifact paths."""
     if reason_code is None:
@@ -75,6 +76,7 @@ def _command_result(
         duration_seconds=0.1,
         stdout_path=stdout_path,
         stderr_path=stderr_path,
+        phase=phase,
         reason_code=reason_code,
     )
 
@@ -87,10 +89,13 @@ def _validation_result(
     command: str = "pytest -q",
     returncode: int | None = None,
     artifact_name: str | None = None,
+    phase: str = "validate",
+    coverage: ValidationCoverageResult | None = None,
+    commands: list[ValidationCommandResult] | None = None,
 ) -> ValidationResult:
-    """Wrap one command result into a single-command validation result."""
-    return ValidationResult(
-        commands=[
+    """Wrap command result(s) into a validation result, optionally with coverage."""
+    if commands is None:
+        commands = [
             _command_result(
                 tmp_path,
                 ok=ok,
@@ -98,9 +103,10 @@ def _validation_result(
                 command=command,
                 returncode=returncode,
                 artifact_name=artifact_name,
+                phase=phase,
             )
         ]
-    )
+    return ValidationResult(commands=commands, coverage=coverage)
 
 
 class _CommandlessFailureValidationResult(ValidationResult):
@@ -196,11 +202,22 @@ async def _set_resolved_profile(
     workspace_id: str,
     *,
     include_coverage: bool = False,
+    coverage_final_gate: str = "coverage",
+    setup_commands: list[str] | None = None,
+    post_agent_commands: list[str] | None = None,
+    validate_commands: list[str] | None = None,
 ) -> None:
     """Attach a simple resolved validation profile to the workspace."""
+    phases: dict[str, object] = {
+        "validate": ["pytest -q"] if validate_commands is None else validate_commands,
+    }
+    if setup_commands is not None:
+        phases["setup"] = setup_commands
+    if post_agent_commands is not None:
+        phases["post_agent"] = post_agent_commands
     profile_payload: dict[str, object] = {
         "name": "test-profile",
-        "phases": {"validate": ["pytest -q"]},
+        "phases": phases,
     }
     if include_coverage:
         profile_payload["validation"] = {
@@ -208,7 +225,7 @@ async def _set_resolved_profile(
                 "minimum_percent": 99.0,
                 "command": "coverage run -m pytest && coverage report",
             },
-            "strategy": {"final_gate": "coverage"},
+            "strategy": {"final_gate": coverage_final_gate},
         }
     profile = WorkspaceProfile.model_validate(profile_payload)
     async with factory() as session:

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -518,6 +518,85 @@ async def test_hosted_combined_validation_allows_coverage_omitted_after_blocking
 
 
 @pytest.mark.unit
+async def test_hosted_combined_validation_ignores_malformed_coverage_after_blocking_command(
+    tmp_path: Path,
+) -> None:
+    """A blocking command failure must win over a malformed coverage mapping."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-blocked-malformed-coverage",
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return succeeded operation with a failed validate command and empty coverage."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_blocked_malformed_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_blocked_malformed_cov",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_combined_blocked_malformed_cov"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_blocked_malformed_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 1,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "1 failed",
+                            "phase": "validate",
+                            "reason_code": "COMMAND_FAILED",
+                            "required": True,
+                        }
+                    ],
+                    # Empty mapping would raise missing command evidence if parsed.
+                    "coverage": {},
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=True,
+        )
+
+    assert not result.all_passed
+    assert result.coverage is None
+    assert result.first_failure is not None
+    assert result.first_failure.reason_code == "COMMAND_FAILED"
+
+
+@pytest.mark.unit
 async def test_hosted_coverage_uses_profile_enforcement_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -219,6 +219,96 @@ async def test_hosted_combined_validation_rejects_passed_coverage_without_comman
 
 
 @pytest.mark.unit
+async def test_hosted_setup_pre_agent_allows_omitted_coverage_with_configured_command(
+    tmp_path: Path,
+) -> None:
+    """Setup/pre_agent-only success may omit coverage even when a coverage command exists.
+
+    Coverage eligibility requires both include_coverage and a validate phase. Default
+    include_coverage=True must not demand coverage evidence for non-validate requests.
+    """
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-setup-pre-agent-omit-coverage",
+            "phases": {
+                "setup": ["uv sync --extra dev"],
+                "pre_agent": ["echo pre"],
+                "validate": ["pytest -q"],
+            },
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return setup/pre_agent success with no coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_setup_pre_agent_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_setup_pre_agent_omit_cov",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_setup_pre_agent_omit_cov"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_setup_pre_agent_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "uv sync --extra dev",
+                            "returncode": 0,
+                            "duration_seconds": 0.1,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "setup",
+                        },
+                        {
+                            "command": "echo pre",
+                            "returncode": 0,
+                            "duration_seconds": 0.1,
+                            "stdout": "pre\n",
+                            "stderr": "",
+                            "phase": "pre_agent",
+                        },
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("setup", "pre_agent"),
+            # Default include_coverage=True is the contract edge under test.
+        )
+
+    assert result.all_passed
+    assert result.coverage is None
+
+
+@pytest.mark.unit
 async def test_hosted_combined_validation_rejects_success_omitting_coverage(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
+++ b/tests/unit/runtime/test_hosted_validation_delegate_parts/test_hosted_validation_delegate_part_003.py
@@ -219,6 +219,215 @@ async def test_hosted_combined_validation_rejects_passed_coverage_without_comman
 
 
 @pytest.mark.unit
+async def test_hosted_combined_validation_rejects_success_omitting_coverage(
+    tmp_path: Path,
+) -> None:
+    """Combined hosted success must fail closed when requested coverage is absent."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-missing-coverage",
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return combined success with validate evidence but no coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_omit_cov",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_combined_omit_cov":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_omit_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 0,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "validate",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        with pytest.raises(HostedDelegationProtocolError, match="missing coverage"):
+            await delegate.run_profile_phases(
+                workspace_id="ws_hosted",
+                compose_project="unused",
+                compose_file=tmp_path / "missing-compose.yml",
+                profile=profile,
+                phase_names=("validate",),
+                include_coverage=True,
+            )
+
+
+@pytest.mark.unit
+async def test_hosted_combined_validation_allows_omitted_coverage_without_command(
+    tmp_path: Path,
+) -> None:
+    """Default include_coverage must not require evidence when no coverage command exists."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-no-coverage-command",
+            "phases": {"validate": ["pytest -q"]},
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return combined success without a coverage field."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_no_cov_cmd",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_no_cov_cmd",
+                },
+            )
+        if request.method == "GET" and request.url.path == "/v1/operations/val_combined_no_cov_cmd":
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_no_cov_cmd",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 0,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "",
+                            "phase": "validate",
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=True,
+        )
+
+    assert result.all_passed
+    assert result.coverage is None
+
+
+@pytest.mark.unit
+async def test_hosted_combined_validation_allows_coverage_omitted_after_blocking_command(
+    tmp_path: Path,
+) -> None:
+    """A blocking phase failure must keep its reason instead of a coverage protocol error."""
+    profile = WorkspaceProfile.model_validate(
+        {
+            "name": "hosted-combined-blocked-before-coverage",
+            "validation": {
+                "coverage": {
+                    "minimum_percent": 99.0,
+                    "command": "uv run pytest --cov=awf",
+                },
+                "strategy": {"final_gate": "coverage"},
+            },
+        }
+    )
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        """Return succeeded operation with a failed validate command and no coverage."""
+
+        if request.method == "POST" and request.url.path == "/v1/validation-runs":
+            return httpx.Response(
+                202,
+                json={
+                    "operation_id": "val_combined_blocked_cov",
+                    "workspace_id": "ws_hosted",
+                    "operation_url": "/v1/operations/val_combined_blocked_cov",
+                },
+            )
+        if (
+            request.method == "GET"
+            and request.url.path == "/v1/operations/val_combined_blocked_cov"
+        ):
+            return httpx.Response(
+                200,
+                json={
+                    "operation_id": "val_combined_blocked_cov",
+                    "workspace_id": "ws_hosted",
+                    "state": "succeeded",
+                    "commands": [
+                        {
+                            "command": "pytest -q",
+                            "returncode": 1,
+                            "duration_seconds": 0.2,
+                            "stdout": "",
+                            "stderr": "1 failed",
+                            "phase": "validate",
+                            "reason_code": "COMMAND_FAILED",
+                            "required": True,
+                        }
+                    ],
+                },
+            )
+        raise AssertionError(f"unexpected request {request.method} {request.url}")
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        delegate = HostedValidationDelegate(
+            _config(),
+            artifacts_dir=tmp_path,
+            client=client,
+        )
+        result = await delegate.run_profile_phases(
+            workspace_id="ws_hosted",
+            compose_project="unused",
+            compose_file=tmp_path / "missing-compose.yml",
+            profile=profile,
+            phase_names=("validate",),
+            include_coverage=True,
+        )
+
+    assert not result.all_passed
+    assert result.coverage is None
+    assert result.first_failure is not None
+    assert result.first_failure.reason_code == "COMMAND_FAILED"
+
+
+@pytest.mark.unit
 async def test_hosted_coverage_uses_profile_enforcement_policy(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -199,17 +199,16 @@ async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
         sleep_fn=RecordedSleep(),
         worktrees_root=worktrees_root,
     )
-    remote_open = "operation-open-remote-head"
-    remote_settle = "settle-status-remote-head"
+    remote_head = "operation-open-remote-head"
     after_first = "after-first-item-head"
-    live_head = {"sha": remote_open}
+    live_head = {"sha": remote_head}
     cycle_start_heads: list[str | None] = []
     operation_start_heads: list[str | None] = []
     address_thread_ids: list[str] = []
     settle_calls = 0
 
     async def _start_head(**_kwargs: object) -> tuple[str, None]:
-        return (remote_open, None)
+        return (remote_head, None)
 
     async def _no_dirty(**_kwargs: object) -> None:
         return None
@@ -233,7 +232,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
         settle_calls += 1
         if settle_calls == 1:
             return _clean_status(
-                head_sha=remote_settle,
+                head_sha=remote_head,
                 threads=(
                     ReviewThread(
                         thread_id="T_pass2_a",
@@ -251,7 +250,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
                     ),
                 ),
             )
-        return _clean_status(head_sha=remote_settle)
+        return _clean_status(head_sha=remote_head)
 
     async def _no_block(**_kwargs: object) -> None:
         return None
@@ -275,7 +274,7 @@ async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
         workspace_id="ws_stable_pass",
         repo=RepoRef(owner="dimileeh", name="aira-web"),
         pr_number=42,
-        pr_head_sha=remote_open,
+        pr_head_sha=remote_head,
         initial_threads=(
             ReviewThread(
                 thread_id="T_pass1",
@@ -293,12 +292,122 @@ async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
     )
 
     assert address_thread_ids == ["T_pass1", "T_pass2_a", "T_pass2_b"]
-    assert cycle_start_heads[0] == remote_open
-    # Pass-2 items share the settle remote head (not local tip, not per-item HEAD).
-    assert cycle_start_heads[1:] == [remote_settle, remote_settle]
+    assert cycle_start_heads[0] == remote_head
+    # Pass-2 items share the unchanged remote batch head (not local tip).
+    assert cycle_start_heads[1:] == [remote_head, remote_head]
     assert "local-after-pass1" not in cycle_start_heads
     assert after_first not in cycle_start_heads
     assert operation_start_heads[1:] == ["local-after-pass1", after_first]
+
+
+@pytest.mark.unit
+async def test_fix_cycle_breaks_settle_when_remote_head_advances_unreconciled(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Do not adopt an advanced remote tip as evidence anchor mid-settle.
+
+    Another actor can advance the PR while local repairs are still unpublished.
+    Mapping new thread coords from that unfetched/divergent SHA onto local HEAD
+    rejects real FIXED verdicts as AGENT_FIXED_WITHOUT_EVIDENCE (PRRT_kwDOSJAM6s6dIQm6).
+    Break settle and push; the outer loop re-enters with abandon/reconcile.
+    """
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # pass1 item cat-file
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_remote_advance"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    remote_open = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    remote_advanced = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    # Extra HEADs only matter if settle wrongly continues under the advanced tip.
+    current_heads = iter((remote_open, "should-not-reach-second-pass"))
+    cycle_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (remote_open, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return next(current_heads)
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        return _clean_status(
+            head_sha=remote_advanced,
+            threads=(
+                ReviewThread(
+                    thread_id="T_after_advance",
+                    path="src/foo.py",
+                    line=9,
+                    body_excerpt="feedback on advanced remote tip",
+                    author="reviewer",
+                ),
+            ),
+        )
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    result = await runner._run_fix_cycle(
+        workspace_id="ws_remote_advance",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=remote_open,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_first",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="please fix first",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_remote_advance",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert settle_calls == 1
+    assert address_thread_ids == ["T_first"]
+    assert cycle_start_heads == [remote_open]
+    assert remote_advanced not in cycle_start_heads
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -1,0 +1,561 @@
+"""Regressions: settle-pass evidence anchor uses remote PR head from batch status."""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import cast
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.adapters.base import AgentRunResult
+from awf.common.commands import AsyncioSubprocessRunner, FakeCommandRunner
+from awf.common.github_client import RepoRef
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner import comment_verdict
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    AGENT_FIXED_WITHOUT_EVIDENCE,
+    AgentVerdictProtocolError,
+)
+from awf.runtime.pr_monitor_runner.remote_ops import _GitPushResult
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _git(path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(path), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _clean_status(
+    *,
+    head_sha: str = "start",
+    threads: tuple[ReviewThread, ...] = (),
+) -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha=head_sha,
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=threads,
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+    )
+
+
+@pytest.mark.unit
+async def test_fix_cycle_later_settle_pass_uses_remote_status_head_as_cycle_start_head(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pass-2 evidence anchor must be settle status.head_sha, not local HEAD.
+
+    Non-hosted agents commit locally before push, so settle re-poll thread
+    path/line coords stay relative to the remote PR head. Anchoring at the
+    locally advanced HEAD skips remote→local mapping and can misclassify FIXED.
+    """
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # pass1 item cat-file
+    cmd.queue_result(returncode=0)  # pass2 item cat-file
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_pass_anchor"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    remote_head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    after_pass1_local = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    # pass1 item, pass2 item (no separate pass-start local probe)
+    current_heads = iter((remote_head, after_pass1_local))
+    cycle_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (remote_head, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return next(current_heads)
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                head_sha=remote_head,
+                threads=(
+                    ReviewThread(
+                        thread_id="T_later",
+                        path="src/foo.py",
+                        line=20,
+                        body_excerpt="new feedback after earlier local commit",
+                        author="reviewer",
+                    ),
+                ),
+            )
+        return _clean_status(head_sha=remote_head)
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    result = await runner._run_fix_cycle(
+        workspace_id="ws_pass_anchor",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=remote_head,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_first",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="please fix first",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_pass_anchor",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert address_thread_ids == ["T_first", "T_later"]
+    assert cycle_start_heads[0] == remote_head
+    # Pass 2 must keep the remote PR head from the settle status, not local tip.
+    assert cycle_start_heads[1] == remote_head
+    assert cycle_start_heads[1] != after_pass1_local
+
+
+@pytest.mark.unit
+async def test_fix_cycle_multi_item_pass_shares_stable_remote_batch_anchor(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Items in one settle pass share the settle status head while item heads advance."""
+    cmd = FakeCommandRunner()
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_stable_pass"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    remote_open = "operation-open-remote-head"
+    remote_settle = "settle-status-remote-head"
+    after_first = "after-first-item-head"
+    live_head = {"sha": remote_open}
+    cycle_start_heads: list[str | None] = []
+    operation_start_heads: list[str | None] = []
+    address_thread_ids: list[str] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (remote_open, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return live_head["sha"]
+
+    async def _address(**kwargs: object) -> str:
+        thread = cast(ReviewThread, kwargs["thread"])
+        address_thread_ids.append(thread.thread_id)
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        operation_start_heads.append(cast(str | None, kwargs.get("operation_start_head")))
+        if thread.thread_id == "T_pass1":
+            live_head["sha"] = "local-after-pass1"
+        elif thread.thread_id == "T_pass2_a":
+            live_head["sha"] = after_first
+        return "false_positive" if thread.thread_id == "T_pass1" else "needs_human"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                head_sha=remote_settle,
+                threads=(
+                    ReviewThread(
+                        thread_id="T_pass2_a",
+                        path="src/a.py",
+                        line=1,
+                        body_excerpt="settle first",
+                        author="reviewer",
+                    ),
+                    ReviewThread(
+                        thread_id="T_pass2_b",
+                        path="src/b.py",
+                        line=2,
+                        body_excerpt="settle second",
+                        author="reviewer",
+                    ),
+                ),
+            )
+        return _clean_status(head_sha=remote_settle)
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    await runner._run_fix_cycle(
+        workspace_id="ws_stable_pass",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=remote_open,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_pass1",
+                path="src/z.py",
+                line=1,
+                body_excerpt="first pass",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_stable_pass",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert address_thread_ids == ["T_pass1", "T_pass2_a", "T_pass2_b"]
+    assert cycle_start_heads[0] == remote_open
+    # Pass-2 items share the settle remote head (not local tip, not per-item HEAD).
+    assert cycle_start_heads[1:] == [remote_settle, remote_settle]
+    assert "local-after-pass1" not in cycle_start_heads
+    assert after_first not in cycle_start_heads
+    assert operation_start_heads[1:] == ["local-after-pass1", after_first]
+
+
+@pytest.mark.unit
+async def test_fix_cycle_local_advance_does_not_replace_remote_batch_anchor(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local unpublished commits must not become the settle-pass evidence anchor."""
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # pass1 item
+    cmd.queue_result(returncode=0)  # pass2 item
+    worktrees_root = tmp_path / "worktrees"
+    worktree_path = worktrees_root / "ws_remote_anchor"
+    worktree_path.mkdir(parents=True)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=worktrees_root,
+    )
+    remote_head = "remote-pr-head-sha"
+    local_advanced = "local-unpublished-head"
+    current_heads = iter((remote_head, local_advanced))
+    cycle_start_heads: list[str | None] = []
+    settle_calls = 0
+
+    async def _start_head(**_kwargs: object) -> tuple[str, None]:
+        return (remote_head, None)
+
+    async def _no_dirty(**_kwargs: object) -> None:
+        return None
+
+    async def _rev_parse_head(_worktree_path: Path) -> str | None:
+        return next(current_heads)
+
+    async def _address(**kwargs: object) -> str:
+        cycle_start_heads.append(cast(str | None, kwargs.get("cycle_start_head")))
+        return "false_positive"
+
+    async def _settle(**_kwargs: object) -> PRStatus:
+        nonlocal settle_calls
+        settle_calls += 1
+        if settle_calls == 1:
+            return _clean_status(
+                head_sha=remote_head,
+                threads=(
+                    ReviewThread(
+                        thread_id="T_pass2",
+                        path="src/foo.py",
+                        line=4,
+                        body_excerpt="settle feedback on remote head lines",
+                        author="reviewer",
+                    ),
+                ),
+            )
+        return _clean_status(head_sha=remote_head)
+
+    async def _no_block(**_kwargs: object) -> None:
+        return None
+
+    async def _validated(**_kwargs: object) -> _GitPushResult:
+        return _GitPushResult(pushed=False, failed=False, returncode=0)
+
+    async def _resolve_thread(**_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(runner, "_pre_existing_dirty_repair_worktree_result", _no_dirty)
+    monkeypatch.setattr(runner, "_repair_operation_start_head_result", _start_head)
+    monkeypatch.setattr(runner, "_rev_parse_head", _rev_parse_head)
+    monkeypatch.setattr(runner, "_address_thread", _address)
+    monkeypatch.setattr(runner._deps.gh, "fetch_pr_status", _settle)
+    monkeypatch.setattr(runner, "_protected_scope_push_block", _no_block)
+    monkeypatch.setattr(runner, "_validated_git_push_result", _validated)
+    monkeypatch.setattr(runner._deps.gh, "resolve_thread", _resolve_thread)
+
+    result = await runner._run_fix_cycle(
+        workspace_id="ws_remote_anchor",
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha=remote_head,
+        initial_threads=(
+            ReviewThread(
+                thread_id="T_pass1",
+                path="src/foo.py",
+                line=3,
+                body_excerpt="first pass",
+                author="reviewer",
+            ),
+        ),
+        initial_reviews=(),
+        state=MonitorState(),
+        remote_branch="awf/ws_remote_anchor",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert cycle_start_heads == [remote_head, remote_head]
+    assert local_advanced not in cycle_start_heads
+
+
+@pytest.mark.unit
+async def test_later_pass_anchor_accepts_real_item_line_fix(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Line coords relative to a newer remote head must map and accept a real FIXED.
+
+    When the remote PR head advances (or coords are already for a later commit),
+    anchoring evidence at that head accepts a line-scoped fix. Anchoring at an
+    older SHA maps that line to failure and rejects a real fix.
+    """
+    worktree = tmp_path / "worktrees" / "ws_protocol"
+    worktree.mkdir(parents=True)
+    _git(worktree, "init", "-q")
+    _git(worktree, "config", "user.email", "awf@example.com")
+    _git(worktree, "config", "user.name", "AWF Test")
+    (worktree / "src").mkdir()
+    target = worktree / "src" / "mod.py"
+    target.write_text("line1\nREVIEWED\nline3\n", encoding="utf-8")
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "operation open")
+    operation_open = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Earlier pass: insert five lines so REVIEWED moves from line 2 → line 7.
+    target.write_text(
+        "pad1\npad2\npad3\npad4\npad5\nline1\nREVIEWED\nline3\n",
+        encoding="utf-8",
+    )
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "pass1 insert")
+    pass_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    # Item-scoped fix at the settle-thread line (7) relative to pass_head.
+    target.write_text(
+        "pad1\npad2\npad3\npad4\npad5\nline1\nREVIEWED fixed\nline3\n",
+        encoding="utf-8",
+    )
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "item line fix")
+    fixed_tip = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=AsyncioSubprocessRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _ok(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(comment_verdict, "repair_agent_runtime_ownership", _ok)
+    monkeypatch.setattr(comment_verdict, "mirror_path_for_worktree", lambda _path: None)
+
+    async def _fixed_agent(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(
+            returncode=0,
+            stdout="AWF-VERDICT: FIXED: updated reviewed line",
+            stderr="",
+        )
+
+    runner._run_monitor_agent_with_service_recovery = _fixed_agent  # type: ignore[method-assign]
+
+    # Fresh pass-head anchor accepts the real line-scoped fix.
+    result = await comment_verdict._invoke_cli_for_verdict_result(
+        runner,
+        workspace_id="ws_protocol",
+        prompt="fix the reviewed line",
+        commit_message="fix: review item",
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=pass_head,
+        evidence_item_path="src/mod.py",
+        evidence_item_line=7,
+        evidence_anchor_head=pass_head,
+        commit_dirty_changes=False,
+    )
+    assert result.verdict == "fix_committed"
+    assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == fixed_tip
+
+    # Stale operation-open anchor must fail-closed for this settle-thread line.
+    with pytest.raises(AgentVerdictProtocolError) as stale:
+        await comment_verdict._invoke_cli_for_verdict_result(
+            runner,
+            workspace_id="ws_protocol",
+            prompt="fix the reviewed line",
+            commit_message="fix: review item",
+            compose_project="awf_ws_protocol",
+            compose_file=Path("compose.yml"),
+            operation_start_head=pass_head,
+            evidence_item_path="src/mod.py",
+            evidence_item_line=7,
+            evidence_anchor_head=operation_open,
+            commit_dirty_changes=False,
+        )
+    assert stale.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+
+
+@pytest.mark.unit
+async def test_no_change_fixed_rejected_with_correct_pass_anchor(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """FIXED with no item-scoped delta remains rejected when pass anchor is correct."""
+    worktree = tmp_path / "worktrees" / "ws_protocol"
+    worktree.mkdir(parents=True)
+    _git(worktree, "init", "-q")
+    _git(worktree, "config", "user.email", "awf@example.com")
+    _git(worktree, "config", "user.name", "AWF Test")
+    (worktree / "src").mkdir()
+    (worktree / "src" / "mod.py").write_text("unchanged\n", encoding="utf-8")
+    _git(worktree, "add", "src/mod.py")
+    _git(worktree, "commit", "-qm", "pass start")
+    pass_head = _git(worktree, "rev-parse", "HEAD").stdout.strip()
+
+    runner = make_runner(
+        factory=factory,
+        cmd=AsyncioSubprocessRunner(),
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+
+    async def _ok(**_kwargs: object) -> bool:
+        return True
+
+    monkeypatch.setattr(comment_verdict, "repair_agent_runtime_ownership", _ok)
+    monkeypatch.setattr(comment_verdict, "mirror_path_for_worktree", lambda _path: None)
+
+    async def _fixed_agent(**_kwargs: object) -> AgentRunResult:
+        return AgentRunResult(
+            returncode=0,
+            stdout="AWF-VERDICT: FIXED: claimed without edits",
+            stderr="",
+        )
+
+    runner._run_monitor_agent_with_service_recovery = _fixed_agent  # type: ignore[method-assign]
+
+    with pytest.raises(AgentVerdictProtocolError) as caught:
+        await comment_verdict._invoke_cli_for_verdict_result(
+            runner,
+            workspace_id="ws_protocol",
+            prompt="fix nothing",
+            commit_message="fix: review item",
+            compose_project="awf_ws_protocol",
+            compose_file=Path("compose.yml"),
+            operation_start_head=pass_head,
+            evidence_item_path="src/mod.py",
+            evidence_item_line=1,
+            evidence_anchor_head=pass_head,
+            commit_dirty_changes=False,
+        )
+
+    assert caught.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
@@ -984,7 +984,12 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     assert result.pushed is True
     assert len(validation.calls) == 1
     assert len(validation.coverage_calls) == 0
-    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
     assert validation.calls[0]["include_coverage"] is True
     phase_pr_identity = validation.calls[0]["pr_identity"]
     assert isinstance(phase_pr_identity, dict)

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation.py
@@ -950,7 +950,7 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
 ) -> None:
-    """Hosted coverage-only validation should target the adopted PR identity."""
+    """Hosted combined validation should target the adopted PR identity once."""
     workspace_id = await seed_monitoring_workspace(factory, pr_number=277)
     await _set_resolved_profile(factory, workspace_id, include_coverage=True)
     worktree = tmp_path / "worktrees" / workspace_id
@@ -959,9 +959,9 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     local_head = "7" * 40
     cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
     cmd.queue_result(returncode=0, stdout="", stderr="")
+    coverage = _coverage_result(tmp_path)
     validation = _FakeValidation(
-        _validation_result(tmp_path, ok=True),
-        coverage_result=_coverage_result(tmp_path),
+        _validation_result(tmp_path, ok=True, coverage=coverage),
     )
     runner = make_runner(
         factory=factory,
@@ -983,13 +983,16 @@ async def test_hosted_pre_push_validation_passes_pr_identity_to_profile_coverage
     assert result.failed is False
     assert result.pushed is True
     assert len(validation.calls) == 1
-    assert len(validation.coverage_calls) == 1
+    assert len(validation.coverage_calls) == 0
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is True
     phase_pr_identity = validation.calls[0]["pr_identity"]
-    coverage_pr_identity = validation.coverage_calls[0]["pr_identity"]
-    assert coverage_pr_identity == phase_pr_identity
-    assert isinstance(coverage_pr_identity, dict)
-    assert coverage_pr_identity["pr_number"] == 277
-    assert coverage_pr_identity["head_ref"] == f"awf/{workspace_id}"
+    assert isinstance(phase_pr_identity, dict)
+    assert phase_pr_identity["pr_number"] == 277
+    assert phase_pr_identity["head_ref"] == f"awf/{workspace_id}"
+    runs = await _validation_runs(factory, workspace_id)
+    assert runs[-1].coverage is not None
+    assert runs[-1].coverage["percent"] == 99.5
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
@@ -46,10 +46,11 @@ async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
 
 @pytest.mark.unit
 def test_pre_push_validation_phase_names_local_vs_hosted() -> None:
-    """Hosted pre-push includes setup; local keeps post_agent+validate only."""
+    """Hosted pre-push includes setup+pre_agent; local keeps post_agent+validate."""
     assert _pre_push_validation_phase_names(is_hosted=False) == ("post_agent", "validate")
     assert _pre_push_validation_phase_names(is_hosted=True) == (
         "setup",
+        "pre_agent",
         "post_agent",
         "validate",
     )
@@ -126,7 +127,7 @@ async def test_hosted_pre_push_runs_setup_post_agent_validate_with_coverage_in_o
     assert len(validation.calls) == 1
     assert len(validation.coverage_calls) == 0
     phase_call = validation.calls[0]
-    assert phase_call["phase_names"] == ("setup", "post_agent", "validate")
+    assert phase_call["phase_names"] == ("setup", "pre_agent", "post_agent", "validate")
     assert phase_call["include_coverage"] is True
     assert phase_call["run_healthchecks"] is True
     assert isinstance(phase_call["pr_identity"], dict)
@@ -240,7 +241,12 @@ async def test_hosted_pre_push_setup_failure_blocks_later_phases_and_coverage(
     assert result.pushed is False
     assert result.reason_code == "PRE_PUSH_VALIDATION_FAILED"
     assert len(validation.calls) == 1
-    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
     assert validation.calls[0]["include_coverage"] is True
     assert len(validation.coverage_calls) == 0
     assert "git push" not in [" ".join(call.args) for call in cmd.calls]
@@ -401,7 +407,12 @@ async def test_hosted_pre_push_empty_setup_phase_still_requests_setup(
     assert result.failed is False
     assert result.pushed is True
     assert len(validation.calls) == 1
-    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["phase_names"] == (
+        "setup",
+        "pre_agent",
+        "post_agent",
+        "validate",
+    )
     assert validation.calls[0]["include_coverage"] is False
     assert len(validation.coverage_calls) == 0
     runs = await _validation_runs(factory, workspace_id)

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_hosted_phases.py
@@ -1,0 +1,506 @@
+"""Hosted pre-push validation must run setup+coverage in one ephemeral Job."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.control.executor.helpers import _pre_push_validation_phase_names
+from awf.db.session import make_session_factory
+from awf.runtime.pr_monitor_runner import pre_push_validation
+from awf.runtime.pr_monitor_runner.constants import (
+    _PROTECTED_SCOPE_REPAIR_FAILED_REASON,
+)
+from awf.runtime.pr_monitor_runner.types import _MonitorPolicyBlockedError
+from awf.runtime.validation_worktree import (
+    ValidationWorktreeCheck,
+    ValidationWorktreeCleanup,
+)
+from tests.postgres import postgres_test_engine
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+from tests.unit.runtime._pre_push_validation_helpers import (
+    _coverage_result,
+    _FakeValidation,
+    _mark_git_worktree,
+    _set_resolved_profile,
+    _validation_result,
+    _validation_runs,
+)
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """Yield a scoped async SQLAlchemy session factory for tests."""
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+@pytest.mark.unit
+def test_pre_push_validation_phase_names_local_vs_hosted() -> None:
+    """Hosted pre-push includes setup; local keeps post_agent+validate only."""
+    assert _pre_push_validation_phase_names(is_hosted=False) == ("post_agent", "validate")
+    assert _pre_push_validation_phase_names(is_hosted=True) == (
+        "setup",
+        "post_agent",
+        "validate",
+    )
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_runs_setup_post_agent_validate_with_coverage_in_one_job(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted pre-push uses one phases call with setup and include_coverage."""
+    workspace_id = await seed_monitoring_workspace(factory, pr_number=277)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        post_agent_commands=["npm run format"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "a" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    coverage = _coverage_result(tmp_path)
+    validation = _FakeValidation(
+        _validation_result(
+            tmp_path,
+            ok=True,
+            command="npm run lint",
+            coverage=coverage,
+            commands=[
+                _validation_result(
+                    tmp_path, ok=True, command="npm ci", phase="setup", artifact_name="setup"
+                ).commands[0],
+                _validation_result(
+                    tmp_path,
+                    ok=True,
+                    command="npm run format",
+                    phase="post_agent",
+                    artifact_name="post_agent",
+                ).commands[0],
+                _validation_result(
+                    tmp_path,
+                    ok=True,
+                    command="npm run lint",
+                    phase="validate",
+                    artifact_name="validate",
+                ).commands[0],
+            ],
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert len(validation.coverage_calls) == 0
+    phase_call = validation.calls[0]
+    assert phase_call["phase_names"] == ("setup", "post_agent", "validate")
+    assert phase_call["include_coverage"] is True
+    assert phase_call["run_healthchecks"] is True
+    assert isinstance(phase_call["pr_identity"], dict)
+    assert phase_call["pr_identity"]["pr_number"] == 277
+    runs = await _validation_runs(factory, workspace_id)
+    assert runs[-1].status == "succeeded"
+    phases = [cmd.get("phase") for cmd in runs[-1].commands]
+    assert phases[:3] == ["setup", "post_agent", "validate"]
+    assert "coverage" in phases
+    assert runs[-1].coverage is not None
+    assert runs[-1].coverage["percent"] == 99.5
+    assert runs[-1].coverage["reason_code"] == "COVERAGE_OK"
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_rejects_passing_result_that_omits_requested_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted include_coverage must not push when the combined result lacks coverage."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "f" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    # Passing phases with coverage=None simulates an incomplete combined response.
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        pre_push_validation_fix_passes=0,
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.reason_code == "PRE_PUSH_VALIDATION_INFRASTRUCTURE_FAILED"
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["include_coverage"] is True
+    assert len(validation.coverage_calls) == 0
+    assert "git push" not in [" ".join(call.args) for call in cmd.calls]
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_setup_failure_blocks_later_phases_and_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """A failing hosted setup phase must block push without a coverage Job."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "b" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    validation = _FakeValidation(
+        _validation_result(
+            tmp_path,
+            ok=False,
+            command="npm ci",
+            phase="setup",
+            reason_code="COMMAND_FAILED",
+            artifact_name="setup_fail",
+        ),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        pre_push_validation_fix_passes=0,
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is True
+    assert result.pushed is False
+    assert result.reason_code == "PRE_PUSH_VALIDATION_FAILED"
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is True
+    assert len(validation.coverage_calls) == 0
+    assert "git push" not in [" ".join(call.args) for call in cmd.calls]
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_missing_head_recovery_evidence_includes_setup(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing-HEAD recovery command evidence must include hosted setup commands."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        setup_commands=["npm ci"],
+        post_agent_commands=["npm run format"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    _mark_git_worktree(worktree)
+    recovery_base = "1" * 40
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0, stdout=f"{recovery_base}\n")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+    recovery_calls: list[dict[str, object]] = []
+
+    async def _verify_head_object_exists(_worktree_path: Path) -> bool:
+        return False
+
+    async def _repair_mirror_hooks_path(_mirror_path: Path) -> bool:
+        return False
+
+    async def _recover_missing_head_object_from_filesystem(
+        self: object,
+        *,
+        workspace_id: str,
+        worktree_path: Path,
+        operation_start_head: str,
+        task_tag: str | None = None,
+        command_evidence: object = (),
+    ) -> str | None:
+        del self, worktree_path, task_tag
+        assert operation_start_head == recovery_base
+        recovery_calls.append(
+            {
+                "workspace_id": workspace_id,
+                "command_evidence": command_evidence,
+            }
+        )
+        raise _MonitorPolicyBlockedError(
+            "PROTECTED_SCOPE_REPAIR_FAILED (.github/workflows/ci.yml)",
+            reason_code=_PROTECTED_SCOPE_REPAIR_FAILED_REASON,
+        )
+
+    async def _pre_push_validation_cleanup(
+        self: object,
+        *,
+        worktree_path: Path,
+        restore_ref: str,
+    ) -> ValidationWorktreeCleanup:
+        del self, worktree_path
+        return ValidationWorktreeCleanup(
+            cleaned=True,
+            check=ValidationWorktreeCheck(clean=False, paths=("package-lock.json",)),
+            restore_ref=restore_ref,
+            cleaned_paths=("package-lock.json",),
+        )
+
+    monkeypatch.setattr(
+        pre_push_validation,
+        "repair_mirror_hooks_path",
+        _repair_mirror_hooks_path,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "verify_head_object_exists",
+        _verify_head_object_exists,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "_recover_missing_head_object_from_filesystem",
+        _recover_missing_head_object_from_filesystem,
+    )
+    monkeypatch.setattr(
+        pre_push_validation,
+        "_pre_push_validation_cleanup",
+        _pre_push_validation_cleanup,
+    )
+
+    result = await pre_push_validation._run_pre_push_validation(
+        runner,
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+        remote_branch=f"awf/{workspace_id}",
+        operation_start_head=recovery_base,
+    )
+
+    assert result.passed is False
+    assert result.reason_code == _PROTECTED_SCOPE_REPAIR_FAILED_REASON
+    assert recovery_calls == [
+        {
+            "workspace_id": workspace_id,
+            "command_evidence": ("npm ci", "npm run format", "npm run lint"),
+        }
+    ]
+    assert validation.calls == []
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_empty_setup_phase_still_requests_setup(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted profiles without setup commands still request the setup phase once."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        setup_commands=[],
+        validate_commands=["pytest -q"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "c" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("setup", "post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is False
+    assert len(validation.coverage_calls) == 0
+    runs = await _validation_runs(factory, workspace_id)
+    phases = [cmd.get("phase") for cmd in runs[-1].commands]
+    assert "setup" not in phases
+    assert "validate" in phases
+
+
+@pytest.mark.unit
+async def test_hosted_pre_push_skips_coverage_when_final_gate_is_none(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Hosted coverage.command without final_gate coverage must not gate pre-push."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        coverage_final_gate="none",
+        setup_commands=["npm ci"],
+        validate_commands=["npm run lint"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "e" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(_validation_result(tmp_path, ok=True))
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(runtime_executor=object()),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["include_coverage"] is False
+    assert len(validation.coverage_calls) == 0
+
+
+@pytest.mark.unit
+async def test_local_pre_push_unchanged_phases_and_separate_coverage(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Local pre-push still skips setup and runs coverage as a separate call."""
+    workspace_id = await seed_monitoring_workspace(factory)
+    await _set_resolved_profile(
+        factory,
+        workspace_id,
+        include_coverage=True,
+        setup_commands=["npm ci"],
+        validate_commands=["pytest -q"],
+    )
+    worktree = tmp_path / "worktrees" / workspace_id
+    worktree.mkdir(parents=True)
+    cmd = FakeCommandRunner()
+    local_head = "d" * 40
+    cmd.queue_result(returncode=0, stdout=f"{local_head}\n")
+    cmd.queue_result(returncode=0, stdout="", stderr="")
+    validation = _FakeValidation(
+        _validation_result(tmp_path, ok=True),
+        coverage_result=_coverage_result(tmp_path),
+    )
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=FakeAdapter(),
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+    )
+    runner._deps.validation = validation  # type: ignore[assignment]
+
+    result = await runner._validated_git_push_result(
+        workspace_id=workspace_id,
+        worktree_path=worktree,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+
+    assert result.failed is False
+    assert result.pushed is True
+    assert len(validation.calls) == 1
+    assert validation.calls[0]["phase_names"] == ("post_agent", "validate")
+    assert validation.calls[0]["include_coverage"] is False
+    assert len(validation.coverage_calls) == 1
+    assert validation.coverage_calls[0]["phase"] == "coverage"

--- a/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_coverage_edges_parts/test_pr_monitor_runner_coverage_edges_part_002.py
@@ -1218,7 +1218,7 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     monkeypatch.setenv("GIT_OBJECT_DIRECTORY", "/tmp/private-objects")
     monkeypatch.setenv("GIT_ALTERNATE_OBJECT_DIRECTORIES", "/tmp/private-alternates")
     cmd = FakeCommandRunner()
-    cmd.queue_result(returncode=0)  # cat-file start^{commit}
+    cmd.queue_result(returncode=0)  # cat-file start^{commit} for item 1
     cmd.queue_result(returncode=128, stderr="fatal: Not a valid object name poisoned")
     worktrees_root = tmp_path / "worktrees"
     worktree_path = worktrees_root / "ws_poisoned_head"
@@ -1254,6 +1254,7 @@ async def test_fix_cycle_fails_closed_when_per_item_head_object_is_poisoned(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
+    # Item 1 verified start; item 2 sees poisoned HEAD (no separate pass-start probe).
     current_heads = iter(("start", "poisoned"))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:
@@ -1366,6 +1367,7 @@ async def test_fix_cycle_fails_closed_when_per_item_rev_parse_fails(
     async def _no_dirty(**_kwargs: object) -> None:
         return None
 
+    # Item 1 succeeds; item 2 sees empty rev-parse (no separate pass-start probe).
     current_heads = iter(("start", None))
 
     async def _rev_parse_head(_worktree_path: Path) -> str | None:

--- a/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
+++ b/tests/unit/runtime/test_pr_monitor_runner_parts/test_pr_monitor_runner_part_006.py
@@ -490,6 +490,7 @@ async def test_fix_cycle_uses_current_head_as_per_item_recovery_anchor(
     worktree.mkdir(parents=True)
     threaded_heads: list[str | None] = []
     observed_worktrees: list[Path] = []
+    # Per-item probes only (remote batch anchor is cycle_start_head; no local pass-start).
     current_heads = iter(("cycle-start-head", "after-thread-fix-head"))
 
     async def _rev_parse_head(worktree_path: Path) -> str | None:


### PR DESCRIPTION
Automated AWF release PR syncing `development` into `main`.

<!-- AWF:release-merge-policy:start -->
Opened by the `sync_release_pr` task kind and monitored with release/manual behavior (auto-merge disabled). Merging into the release target stays human-gated.
<!-- AWF:release-merge-policy:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect pre-push gates, hosted validation protocol parsing, and fix-cycle evidence anchoring on PR monitor paths—important for merge safety but covered by extensive new and updated tests.
> 
> **Overview**
> **Hosted pre-push validation** now runs `setup`, `pre_agent`, `post_agent`, and `validate` in a single ephemeral job (via `_pre_push_validation_phase_names`), with optional coverage in the same request when the profile’s final gate is coverage. Local workspaces keep `post_agent` + `validate` and still run coverage as a separate call. Pre-push blocks push if a hosted combined run passes but omits requested coverage evidence.
> 
> **Hosted delegation** only treats coverage as required when both `include_coverage` and a `validate` phase are requested; missing or malformed coverage fails closed, while blocking command failures are not masked by coverage protocol errors.
> 
> **PR monitor fix cycles** anchor `cycle_start_head` to the batch’s remote PR head (`pr_head_sha`) for the whole settle pass instead of advancing local HEAD, and stop the settle loop when a re-poll’s `head_sha` no longer matches that anchor—reducing misclassified `AGENT_FIXED_WITHOUT_EVIDENCE` on inline review coordinates.
> 
> Tests and executor recovery expectations are updated for the new hosted phase lists (`pre_agent` included).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 578dd72fa0b0c3dd47bd8faebe1b33b95760c2da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hosted validation now consistently includes setup, pre-agent, post-agent, and validation phases when applicable.
  - Coverage checks can run inline with hosted validation and are preserved in the resulting report.
  - Local validation continues to run coverage separately.

- **Bug Fixes**
  - Validation now fails clearly when required coverage evidence is missing or invalid, while preserving command failures.
  - Fix-cycle results remain linked to the verified remote change, preventing stale or unverifiable evidence from advancing the cycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->