### PR TITLE
fix: restore hosted PR monitor checkout after worker restart

### DIFF
--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -585,6 +585,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf workspace show <workspace_id>`
 **Docs Link:** [docs/REASON_CATALOG.md#monitor_recovery_cancelled](#monitor_recovery_cancelled)
 
+### MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED
+**Problem:** Hosted PR-monitor resume could not restore the managed worktree checkout after a worker pod replacement (missing adoption tip, repo, or git failure).
+**Likely Cause:** The replacement control-worker pod has no pod-local worktree under /tmp/awf-work/git/worktrees, and checkout reconstruction failed closed.
+**Operator Fix:** Confirm the workspace still has durable PR/adoption metadata and that GitHub auth can fetch refs/pull/<n>/head (or the forge-neutral head branch), then remonitor. Do not expect Compose metadata on hosted rows.
+**Related Command:** `awf workspace remonitor <workspace_id>`
+**Docs Link:** [docs/REASON_CATALOG.md#monitor_recovery_checkout_restore_failed](#monitor_recovery_checkout_restore_failed)
+
 ### MONITOR_RECOVERY_SUPERSEDED
 **Problem:** AWF cancelled a PR-monitor recovery operation because another worker claimed the monitor lease and started a replacement recovery operation.
 **Likely Cause:** This worker lost the monitoring_pr claim to another worker that registered a replacement remonitor recovery operation before this worker could finalize.

--- a/src/awf/control/executor/base.py
+++ b/src/awf/control/executor/base.py
@@ -15,7 +15,7 @@ triage. Explicit ``cleanup(workspace_id)`` is a separate operation.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from datetime import datetime
 from typing import Any
 
@@ -60,6 +60,7 @@ class WorkspaceExecutor(ExecutorDelegatesMixin):
         usage_sampler: UsageSampler | None = None,
         agent_runtime_executor: AgentRuntimeExecutor | None = None,
         hosted_validation: Any | None = None,
+        ensure_hosted_monitor_checkout: Callable[[str], Awaitable[None]] | None = None,
     ) -> None:
         """``pr_monitor`` and ``pr_monitor_factory`` are mutually exclusive
         optional hooks that wire the ``monitoring_pr`` stage:
@@ -80,6 +81,10 @@ class WorkspaceExecutor(ExecutorDelegatesMixin):
         is not hard-wired to Docker Compose; the worker does NOT build a
         Kubernetes executor in Core.
 
+        ``ensure_hosted_monitor_checkout`` restores the managed worktree for
+        hosted monitor resume after a pod replacement (provisioner-owned).
+        Local Compose resumes leave it ``None``.
+
         If both are None the monitor stage is skipped and the executor
         preserves the original ``pushing → completed`` contract (the
         executor_tests no-monitor scenarios still pass)."""
@@ -97,6 +102,7 @@ class WorkspaceExecutor(ExecutorDelegatesMixin):
         self._usage_sampler = usage_sampler
         self._agent_runtime_executor = agent_runtime_executor
         self._hosted_validation = hosted_validation
+        self._ensure_hosted_monitor_checkout = ensure_hosted_monitor_checkout
 
     async def execute(
         self: Any,

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -238,6 +238,17 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                     reason_code=exc.reason_code,
                     stderr=redacted_stderr,
                 )
+                # Restore can outlive the monitor lease (mirror clone / pull-head
+                # fetch). Fence on claim owner before the non-owner-gated
+                # ``_mark_failed`` so a superseded resume cannot fail the live
+                # ``monitoring_pr`` row after takeover (PRRT_kwDOSJAM6s6dNITc).
+                if not await self._recheck_status(
+                    workspace_id,
+                    expected=WorkspaceStatus.monitoring_pr,
+                    action="resume_hosted_checkout_restore_failed",
+                    monitor_owner_id=monitor_owner_id,
+                ):
+                    return None
                 await self._mark_failed(
                     workspace_id=workspace_id,
                     from_status=WorkspaceStatus.monitoring_pr,
@@ -259,6 +270,13 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                     "executor.resume_hosted_checkout_restore_failed",
                     workspace_id=workspace_id,
                 )
+                if not await self._recheck_status(
+                    workspace_id,
+                    expected=WorkspaceStatus.monitoring_pr,
+                    action="resume_hosted_checkout_restore_failed",
+                    monitor_owner_id=monitor_owner_id,
+                ):
+                    return None
                 await self._mark_failed(
                     workspace_id=workspace_id,
                     from_status=WorkspaceStatus.monitoring_pr,

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -266,9 +266,10 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                 )
                 return None
             except Exception as exc:
-                _log.exception(
+                _log.error(
                     "executor.resume_hosted_checkout_restore_failed",
                     workspace_id=workspace_id,
+                    redacted_traceback=_redacted_exception_traceback(exc),
                 )
                 if not await self._recheck_status(
                     workspace_id,

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -216,6 +216,17 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
     if workspace_is_hosted:
         ensure_checkout = getattr(self, "_ensure_hosted_monitor_checkout", None)
         if ensure_checkout is not None:
+            # Fence before a potentially slow Git restore so a superseded
+            # recovery does not mutate checkout after lease takeover, and so
+            # restore-error ``_mark_failed`` below can refuse to fail the row
+            # once ``monitor_claimed_by`` no longer matches (PRRT_kwDOSJAM6s6dNBTV).
+            if not await self._recheck_status(
+                workspace_id,
+                expected=WorkspaceStatus.monitoring_pr,
+                action="resume_hosted_checkout",
+                monitor_owner_id=monitor_owner_id,
+            ):
+                return None
             try:
                 await ensure_checkout(workspace_id)
             except GitOperationError as exc:
@@ -240,6 +251,7 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                         if exc.reason_code.startswith("MONITOR_RECOVERY")
                         else "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED"
                     ),
+                    monitor_owner_id=monitor_owner_id,
                 )
                 return None
             except Exception as exc:
@@ -256,6 +268,7 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                         f"{redact_audit_text(repr(exc), limit=1900)}"
                     )[:2000],
                     reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                    monitor_owner_id=monitor_owner_id,
                 )
                 return None
 

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -68,6 +68,7 @@ from awf.node.companion_services import (
     companion_specs_from_task_policy,
 )
 from awf.node.compose_manager import ComposeOperationError
+from awf.node.git_manager import GitOperationError
 from awf.node.stack_launcher import effective_compose_up_timeout_seconds
 from awf.runtime.hosted_pr_identity import hosted_pr_identity_for_workspace
 from awf.runtime.inspection import RuntimeInspector, RuntimeService, RuntimeSnapshot
@@ -211,6 +212,50 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
             reason_code="MONITOR_RECOVERY_METADATA_MISSING",
         )
         return None
+
+    if workspace_is_hosted:
+        ensure_checkout = getattr(self, "_ensure_hosted_monitor_checkout", None)
+        if ensure_checkout is not None:
+            try:
+                await ensure_checkout(workspace_id)
+            except GitOperationError as exc:
+                _log.error(
+                    "executor.resume_hosted_checkout_restore_failed",
+                    workspace_id=workspace_id,
+                    reason_code=exc.reason_code,
+                    stderr=exc.stderr[:1000],
+                )
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.monitoring_pr,
+                    failure_reason=FailureReason.infrastructure_failure,
+                    message=(
+                        "monitor recovery: hosted checkout restore failed: "
+                        f"{exc.stderr or exc.stdout or exc.reason_code}"
+                    )[:2000],
+                    reason_code=(
+                        exc.reason_code
+                        if exc.reason_code.startswith("MONITOR_RECOVERY")
+                        else "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED"
+                    ),
+                )
+                return None
+            except Exception as exc:
+                _log.exception(
+                    "executor.resume_hosted_checkout_restore_failed",
+                    workspace_id=workspace_id,
+                )
+                await self._mark_failed(
+                    workspace_id=workspace_id,
+                    from_status=WorkspaceStatus.monitoring_pr,
+                    failure_reason=FailureReason.infrastructure_failure,
+                    message=(
+                        "monitor recovery: hosted checkout restore failed: "
+                        f"{redact_audit_text(repr(exc), limit=1900)}"
+                    )[:2000],
+                    reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                )
+                return None
 
     compose_project = ws.compose_project_name or f"awf_{workspace_id}"
     compose_file_path = ws.compose_file_path

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -230,8 +230,8 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
             try:
                 await ensure_checkout(workspace_id)
             except GitOperationError as exc:
-                redacted_stderr = redact_audit_text(exc.stderr[:1000], limit=1000)
-                redacted_stdout = redact_audit_text(exc.stdout[:1000], limit=1000)
+                redacted_stderr = redact_audit_text(exc.stderr, limit=1000)
+                redacted_stdout = redact_audit_text(exc.stdout, limit=1000)
                 _log.error(
                     "executor.resume_hosted_checkout_restore_failed",
                     workspace_id=workspace_id,

--- a/src/awf/control/executor/monitor_handoff.py
+++ b/src/awf/control/executor/monitor_handoff.py
@@ -219,11 +219,13 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
             try:
                 await ensure_checkout(workspace_id)
             except GitOperationError as exc:
+                redacted_stderr = redact_audit_text(exc.stderr[:1000], limit=1000)
+                redacted_stdout = redact_audit_text(exc.stdout[:1000], limit=1000)
                 _log.error(
                     "executor.resume_hosted_checkout_restore_failed",
                     workspace_id=workspace_id,
                     reason_code=exc.reason_code,
-                    stderr=exc.stderr[:1000],
+                    stderr=redacted_stderr,
                 )
                 await self._mark_failed(
                     workspace_id=workspace_id,
@@ -231,7 +233,7 @@ async def resume_pr_monitor_handoff(self: Any, workspace_id: str) -> ResumeHando
                     failure_reason=FailureReason.infrastructure_failure,
                     message=(
                         "monitor recovery: hosted checkout restore failed: "
-                        f"{exc.stderr or exc.stdout or exc.reason_code}"
+                        f"{redacted_stderr or redacted_stdout or exc.reason_code}"
                     )[:2000],
                     reason_code=(
                         exc.reason_code

--- a/src/awf/control/executor/state_ops.py
+++ b/src/awf/control/executor/state_ops.py
@@ -410,7 +410,15 @@ async def _mark_failed(
     reason_code: str | None = None,
     details: Mapping[str, Any] | None = None,
     salvage: Mapping[str, Any] | None = None,
+    monitor_owner_id: str | None = None,
 ) -> None:
+    """Mark the workspace failed when still in ``from_status``.
+
+    ``monitor_owner_id`` optionally fences the transition on
+    ``monitor_claimed_by`` so a superseded PR-monitor recovery cannot fail the
+    row underneath a replacement claimant that kept ``monitoring_pr``
+    (PRRT_kwDOSJAM6s6dNBTV).
+    """
     async with self._session_factory() as session:
         repo = WorkspaceRepository(session)
         final_reason_code = reason_code or failure_reason.value.upper()
@@ -427,12 +435,16 @@ async def _mark_failed(
             if salvage is not None:
                 payload["salvage"] = dict(salvage)
 
+        extra_conditions: tuple[Any, ...] = ()
+        if monitor_owner_id is not None:
+            extra_conditions = (Workspace.monitor_claimed_by == monitor_owner_id,)
         ws = await repo.transition_if_current(
             workspace_id,
             from_status=from_status,
             to=WorkspaceStatus.failed,
             reason_code=final_reason_code,
             payload=payload,
+            extra_conditions=extra_conditions,
         )
         if ws is None:
             ws = await repo.get(workspace_id)

--- a/src/awf/control/worker/helpers.py
+++ b/src/awf/control/worker/helpers.py
@@ -34,6 +34,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.common.github_client import RepoRef
+from awf.common.workspace_policy import pr_adoption_is_hosted
 from awf.control.worker.constants import (
     _ACTIVE_EXECUTION_PRESERVED_CLAIM_CLEARED_REASON_CODE,
     _ACTIVE_EXECUTION_PRESERVED_NO_CLAIM_REASON_CODE,
@@ -385,6 +386,7 @@ def _runtime_workspace(candidate: _ActiveExecutionCandidate) -> RuntimeWorkspace
         compose_file_path=candidate.compose_file_path,
         pr_url=candidate.pr_url,
         retry_policy_allows_recovery=retry_policy_allows_runtime_recovery(candidate.task_policy),
+        hosted_pr_adoption=pr_adoption_is_hosted(candidate.task_policy),
     )
 
 

--- a/src/awf/control/worker/recovery_stale.py
+++ b/src/awf/control/worker/recovery_stale.py
@@ -53,6 +53,7 @@ from awf.control.worker.helpers import (
     _execution_claim_is_stale,
     _extract_pr_number,
     _has_running_agent_runtime,
+    _monitor_claim_is_stale,
     _running_monitoring_pr_recovery_finding,
     _runtime_snapshot_payload,
     _runtime_stranding_event_payload,
@@ -437,6 +438,34 @@ async def _recover_hosted_pr_adoption_active_execution(
     self: Any,
     candidate: _ActiveExecutionCandidate,
 ) -> bool:
+    if candidate.status == WorkspaceStatus.monitoring_pr:
+        if not pr_adoption_is_hosted(candidate.task_policy):
+            return False
+        if not has_open_pr_for_remonitor(candidate.status.value, candidate.pr_url):
+            return False
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(candidate.workspace_id)
+            if ws is None or ws.status != candidate.status.value:
+                return True
+            if not pr_adoption_is_hosted(ws.task_policy):
+                return False
+            if not has_open_pr_for_remonitor(ws.status, ws.pr_url):
+                return False
+            # Hosted monitoring_pr has no Compose runtime by design. Leave the
+            # row for normal monitor claim-resume (which restores the checkout).
+            # Do not emit STRANDED_WORKSPACE / runtime_stranded_detected, and do
+            # not clear a live (non-stale) monitor claim.
+            if not _monitor_claim_is_stale(ws, datetime.now(UTC)):
+                return True
+        _log.info(
+            "worker.hosted_pr_adoption_monitoring_pr_healthy_without_compose",
+            workspace_id=candidate.workspace_id,
+            status=candidate.status.value,
+            reason_code="HOSTED_MONITORING_PR_NO_COMPOSE_BY_DESIGN",
+        )
+        return True
+
     if candidate.status == WorkspaceStatus.provisioning:
         if not pr_adoption_is_hosted(candidate.task_policy):
             return False

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -962,17 +962,22 @@ class GitManager:
                         # ``fatal: '<path>' is not a working tree``. If the worktree
                         # ``.git`` file was already removed but mirror metadata still
                         # points to it, Git instead reports that validation failed
-                        # because ``<path>/.git`` does not exist. Both are
-                        # already-removed conditions from git's point of view, not
-                        # failures. Re-raise any genuine removal error (we match only
-                        # these conditions).
+                        # because ``<path>/.git`` does not exist. If the gitfile is
+                        # present but linked admin metadata is corrupt (e.g. missing
+                        # HEAD), Git reports ``.git`` is not a .git file (error
+                        # code 7). All three are reclaimable stale conditions from
+                        # AWF's point of view (standalone ``.git`` dirs are refused
+                        # above). Re-raise any genuine removal error.
                         stderr = exc.stderr.lower()
-                        missing_git_file = (
+                        corrupt_or_missing_git_file = (
                             "validation failed, cannot remove working tree" in stderr
                             and ".git" in stderr
-                            and "does not exist" in stderr
+                            and ("does not exist" in stderr or "is not a .git file" in stderr)
                         )
-                        if "is not a working tree" not in stderr and not missing_git_file:
+                        if (
+                            "is not a working tree" not in stderr
+                            and not corrupt_or_missing_git_file
+                        ):
                             raise
                         # ``git worktree remove`` never ran, so the physical
                         # directory and its contents are still on disk; ``worktree

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -741,6 +741,94 @@ class GitManager:
             branch_name=new_branch,
         )
 
+    async def ensure_worktree(
+        self, *, workspace_id: str, repo_url: str, base_branch: str, new_branch: str
+    ) -> WorktreeLayout:
+        """Idempotently ensure a managed worktree exists at ``base_branch``.
+
+        Used by hosted PR-monitor restart recovery when the pod-local checkout is
+        gone but durable workspace/adoption metadata remains. Behavior:
+
+        - Valid existing worktree → no-op (no prune / no ``add_worktree``).
+        - Missing or corrupt checkout → prune stale AWF-managed worktree metadata,
+          drop a leftover local branch name if present, then recreate via
+          :meth:`add_worktree` under the mirror lock path that method already uses.
+        """
+        worktree_path = self._worktree_path_for(workspace_id)
+        if _worktree_checkout_is_usable(worktree_path):
+            return WorktreeLayout(
+                mirror_path=self._mirror_path(repo_url),
+                worktree_path=worktree_path,
+                branch_name=new_branch,
+            )
+
+        # Clean stale registry entries / leftover dirs before recreate. Missing
+        # mirrors are fine: remove is idempotent and add_worktree ensures the
+        # mirror next.
+        await self.remove_worktree(workspace_id=workspace_id, repo_url=repo_url)
+
+        mirror_path = await self.ensure_mirror(repo_url)
+        await self._delete_local_branch_best_effort(
+            mirror_path=mirror_path,
+            branch_name=new_branch,
+        )
+        try:
+            return await self.add_worktree(
+                workspace_id=workspace_id,
+                repo_url=repo_url,
+                base_branch=base_branch,
+                new_branch=new_branch,
+            )
+        except GitOperationError as exc:
+            # Another concurrent ensure may have created the path between our
+            # remove and add; treat a now-usable checkout as success.
+            if exc.reason_code == "GIT_WORKTREE_ALREADY_EXISTS" and _worktree_checkout_is_usable(
+                worktree_path
+            ):
+                return WorktreeLayout(
+                    mirror_path=mirror_path,
+                    worktree_path=worktree_path,
+                    branch_name=new_branch,
+                )
+            # Branch name collision after a partial prune: delete and retry once.
+            if "already exists" in exc.stderr.lower() and "branch" in exc.stderr.lower():
+                await self._delete_local_branch_best_effort(
+                    mirror_path=mirror_path,
+                    branch_name=new_branch,
+                )
+                return await self.add_worktree(
+                    workspace_id=workspace_id,
+                    repo_url=repo_url,
+                    base_branch=base_branch,
+                    new_branch=new_branch,
+                )
+            raise
+
+    async def _delete_local_branch_best_effort(
+        self, *, mirror_path: Path, branch_name: str
+    ) -> None:
+        """Delete a leftover local branch so ``worktree add -b`` can recreate it."""
+        if not mirror_path.exists():
+            return
+        lock = self._lock_for_mirror(mirror_path)
+        async with lock:
+            try:
+                await self._run(
+                    [
+                        "git",
+                        "--git-dir",
+                        str(mirror_path),
+                        "branch",
+                        "-D",
+                        branch_name,
+                    ],
+                    operation="mirror.branch_delete",
+                )
+            except GitOperationError:
+                # Branch absent or still checked out elsewhere — add_worktree
+                # will surface a real failure if recreation is impossible.
+                return
+
     async def add_detached_worktree_at_commit(
         self, *, workspace_id: str, repo_url: str, commit_sha: str
     ) -> WorktreeLayout:
@@ -1271,6 +1359,16 @@ def linked_worktree_git_dir(worktree_path: Path) -> Path | None:
     if not git_dir.is_absolute():
         git_dir = (worktree_path / git_dir).resolve()
     return git_dir
+
+
+def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
+    """Return whether ``worktree_path`` looks like a usable managed checkout."""
+    if not worktree_path.is_dir():
+        return False
+    git_marker = worktree_path / ".git"
+    if git_marker.is_file():
+        return linked_worktree_git_dir(worktree_path) is not None
+    return git_marker.is_dir()
 
 
 def linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -753,7 +753,14 @@ class GitManager:
         - Missing or corrupt checkout → prune stale AWF-managed worktree metadata,
           drop a leftover local branch name if present, then recreate via
           :meth:`add_worktree` under the mirror lock path that method already uses.
+
+        The full recreate path (remove → branch delete → add) is fenced by the
+        exclusive worktree writer lock so a stale restorer whose lease expired
+        cannot interleave those phases with a takeover and delete the new
+        owner's checkout or branch.
         """
+        from awf.runtime.worktree_writer_lock import hold_exclusive_worktree_writer_lock
+
         worktree_path = self._worktree_path_for(workspace_id)
         if _worktree_checkout_is_usable(worktree_path):
             return WorktreeLayout(
@@ -762,47 +769,62 @@ class GitManager:
                 branch_name=new_branch,
             )
 
-        # Clean stale registry entries / leftover dirs before recreate. Missing
-        # mirrors are fine: remove is idempotent and add_worktree ensures the
-        # mirror next.
-        await self.remove_worktree(workspace_id=workspace_id, repo_url=repo_url)
-
-        mirror_path = await self.ensure_mirror(repo_url)
-        await self._delete_local_branch_best_effort(
-            mirror_path=mirror_path,
-            branch_name=new_branch,
-        )
-        try:
-            return await self.add_worktree(
-                workspace_id=workspace_id,
-                repo_url=repo_url,
-                base_branch=base_branch,
-                new_branch=new_branch,
-            )
-        except GitOperationError as exc:
-            # Another concurrent ensure may have created the path between our
-            # remove and add; treat a now-usable checkout as success.
-            if exc.reason_code == "GIT_WORKTREE_ALREADY_EXISTS" and _worktree_checkout_is_usable(
-                worktree_path
-            ):
+        async with hold_exclusive_worktree_writer_lock(worktree_path):
+            # Another fenced restorer may have finished while we waited.
+            if _worktree_checkout_is_usable(worktree_path):
                 return WorktreeLayout(
-                    mirror_path=mirror_path,
+                    mirror_path=self._mirror_path(repo_url),
                     worktree_path=worktree_path,
                     branch_name=new_branch,
                 )
-            # Branch name collision after a partial prune: delete and retry once.
-            if "already exists" in exc.stderr.lower() and "branch" in exc.stderr.lower():
-                await self._delete_local_branch_best_effort(
-                    mirror_path=mirror_path,
-                    branch_name=new_branch,
-                )
+
+            # Clean stale registry entries / leftover dirs before recreate.
+            # Missing mirrors are fine: remove is idempotent and add_worktree
+            # ensures the mirror next. Caller holds the writer lock so remove
+            # must not re-acquire it.
+            await self.remove_worktree_from_mirror(
+                workspace_id=workspace_id,
+                mirror_path=self._mirror_path(repo_url),
+                writer_lock_held=True,
+            )
+
+            mirror_path = await self.ensure_mirror(repo_url)
+            await self._delete_local_branch_best_effort(
+                mirror_path=mirror_path,
+                branch_name=new_branch,
+            )
+            try:
                 return await self.add_worktree(
                     workspace_id=workspace_id,
                     repo_url=repo_url,
                     base_branch=base_branch,
                     new_branch=new_branch,
                 )
-            raise
+            except GitOperationError as exc:
+                # Another concurrent ensure may have created the path between our
+                # remove and add; treat a now-usable checkout as success.
+                if (
+                    exc.reason_code == "GIT_WORKTREE_ALREADY_EXISTS"
+                    and _worktree_checkout_is_usable(worktree_path)
+                ):
+                    return WorktreeLayout(
+                        mirror_path=mirror_path,
+                        worktree_path=worktree_path,
+                        branch_name=new_branch,
+                    )
+                # Branch name collision after a partial prune: delete and retry once.
+                if "already exists" in exc.stderr.lower() and "branch" in exc.stderr.lower():
+                    await self._delete_local_branch_best_effort(
+                        mirror_path=mirror_path,
+                        branch_name=new_branch,
+                    )
+                    return await self.add_worktree(
+                        workspace_id=workspace_id,
+                        repo_url=repo_url,
+                        base_branch=base_branch,
+                        new_branch=new_branch,
+                    )
+                raise
 
     async def _delete_local_branch_best_effort(
         self, *, mirror_path: Path, branch_name: str
@@ -856,8 +878,16 @@ class GitManager:
         mirror_path = self._mirror_path(repo_url)
         await self.remove_worktree_from_mirror(workspace_id=workspace_id, mirror_path=mirror_path)
 
-    async def remove_worktree_from_mirror(self, *, workspace_id: str, mirror_path: Path) -> None:
-        """Remove a worktree using an already-resolved mirror path."""
+    async def remove_worktree_from_mirror(
+        self, *, workspace_id: str, mirror_path: Path, writer_lock_held: bool = False
+    ) -> None:
+        """Remove a worktree using an already-resolved mirror path.
+
+        When ``writer_lock_held`` is true the caller already owns the exclusive
+        worktree writer lock for this path (e.g. :meth:`ensure_worktree`'s
+        recreate fence). Skip re-acquiring and skip post-remove lock-file cleanup
+        so the outer fence stays intact for the rest of the critical section.
+        """
         from awf.runtime.worktree_writer_lock import (
             hold_exclusive_worktree_writer_lock,
             remove_worktree_writer_lock,
@@ -877,7 +907,7 @@ class GitManager:
             )
         worktree_path = Path(resolved_worktree_path)
 
-        async with hold_exclusive_worktree_writer_lock(worktree_path):
+        async def _remove_under_mirror_lock() -> None:
             lock = self._lock_for_mirror(mirror_path)
             async with lock:
                 if worktree_path.exists():
@@ -935,6 +965,13 @@ class GitManager:
                         ["git", "--git-dir", str(mirror_path), "worktree", "prune"],
                         operation="worktree.prune",
                     )
+
+        if writer_lock_held:
+            await _remove_under_mirror_lock()
+            return
+
+        async with hold_exclusive_worktree_writer_lock(worktree_path):
+            await _remove_under_mirror_lock()
 
         await asyncio.to_thread(remove_worktree_writer_lock, worktree_path)
 

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -964,15 +964,19 @@ class GitManager:
                         # points to it, Git instead reports that validation failed
                         # because ``<path>/.git`` does not exist. If the gitfile is
                         # present but linked admin metadata is corrupt (e.g. missing
-                        # HEAD), Git reports ``.git`` is not a .git file (error
-                        # code 7). All three are reclaimable stale conditions from
-                        # AWF's point of view (standalone ``.git`` dirs are refused
-                        # above). Re-raise any genuine removal error.
+                        # HEAD), Git reports ``.git`` is not a .git file with
+                        # error code 7. Do not treat other codes (e.g. 3 for an
+                        # unreadable gitfile) as reclaimable — that would erase a
+                        # live checkout. Standalone ``.git`` dirs are refused
+                        # above. Re-raise any genuine removal error.
                         stderr = exc.stderr.lower()
                         corrupt_or_missing_git_file = (
                             "validation failed, cannot remove working tree" in stderr
                             and ".git" in stderr
-                            and ("does not exist" in stderr or "is not a .git file" in stderr)
+                            and (
+                                "does not exist" in stderr
+                                or ("is not a .git file" in stderr and "error code 7" in stderr)
+                            )
                         )
                         if (
                             "is not a working tree" not in stderr

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -23,7 +23,6 @@ import hashlib
 import os
 import re
 import shutil
-import subprocess
 import weakref
 from collections.abc import Mapping
 from contextvars import ContextVar, Token
@@ -35,6 +34,7 @@ from awf.common.git_auth import GitAuthNotConfiguredError, verify_bitbucket_git_
 from awf.common.git_identity import git_safe_directory_config_args
 from awf.common.logging import get_logger
 from awf.node import git_manager_detached as _git_manager_detached
+from awf.node import git_manager_linked as _git_manager_linked
 from awf.node import git_manager_ownership as _git_manager_ownership
 from awf.node.git_manager_head_object import verify_head_object_exists as verify_head_object_exists
 
@@ -50,6 +50,18 @@ git_env_without_object_lookup_overrides = (
     _git_manager_ownership.git_env_without_object_lookup_overrides
 )
 TRUSTED_BASE_GIT_CONFIG_ARGS = _git_manager_ownership.TRUSTED_BASE_GIT_CONFIG_ARGS
+
+# Re-export linked-worktree helpers for callers that import from ``git_manager``.
+linked_worktree_git_dir = _git_manager_linked.linked_worktree_git_dir
+linked_worktree_path_from_git_dir = _git_manager_linked.linked_worktree_path_from_git_dir
+_worktree_checkout_is_usable = _git_manager_linked._worktree_checkout_is_usable
+_is_stale_linked_worktree_metadata_error = (
+    _git_manager_linked._is_stale_linked_worktree_metadata_error
+)
+mirror_path_for_worktree = _git_manager_linked.mirror_path_for_worktree
+mirror_path_for_registered_worktree = _git_manager_linked.mirror_path_for_registered_worktree
+_path_within_root = _git_manager_linked._path_within_root
+_is_bare_registered_mirror_candidate = _git_manager_linked._is_bare_registered_mirror_candidate
 
 _GITHUB_PULL_HEAD_REF = re.compile(r"^refs/pull/([1-9][0-9]*)/head$")
 # Path-safety guard for the ``worktrees/<workspace_id>`` sink is containment,
@@ -1241,132 +1253,6 @@ def repair_agent_writable_worktree(
     _chown_targets(tuple(targets), uid, gid)
 
 
-def mirror_path_for_worktree(worktree_path: Path) -> Path | None:
-    """Return the bare mirror path backing a linked worktree, when discoverable."""
-    linked_git_dir = linked_worktree_git_dir(worktree_path)
-    if linked_git_dir is None:
-        return None
-    commondir = linked_git_dir / "commondir"
-    if commondir.is_file():
-        try:
-            raw = commondir.read_text(encoding="utf-8").strip()
-        except OSError:
-            raw = ""
-        if raw:
-            common = Path(raw)
-            if not common.is_absolute():
-                common = linked_git_dir / common
-            return common.resolve()
-    return linked_git_dir.parent.parent.resolve()
-
-
-def _path_within_root(path: Path, root: Path) -> Path | None:
-    """Return ``path`` resolved under ``root``, or ``None`` when it escapes ``root``."""
-    try:
-        resolved_path = path.resolve()
-        resolved_root = root.resolve()
-    except RuntimeError:
-        resolved_path = path.absolute()
-        resolved_root = root.absolute()
-    try:
-        resolved_path.relative_to(resolved_root)
-    except ValueError:
-        return None
-    return resolved_path
-
-
-def mirror_path_for_registered_worktree(worktree_path: Path, mirrors_dir: Path) -> Path | None:
-    """Return the bare mirror path from mirror-side linked-worktree metadata.
-
-    This is the fallback for an AWF-managed worktree directory whose ``.git``
-    file was already removed, but whose bare mirror still has
-    ``worktrees/<id>/gitdir`` pointing back to that directory.
-    """
-    if not mirrors_dir.exists():
-        return None
-    try:
-        mirror_paths = sorted(
-            resolved_path
-            for path in mirrors_dir.iterdir()
-            if path.is_dir()
-            if (resolved_path := _path_within_root(path, mirrors_dir)) is not None
-        )
-    except OSError as exc:
-        raise GitOperationError(
-            operation="mirror_registry_scan",
-            returncode=1,
-            stdout="",
-            stderr=str(exc),
-            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
-        ) from exc
-
-    worktree_name = worktree_path.name
-    try:
-        resolved_worktree = worktree_path.resolve()
-    except OSError as exc:
-        raise GitOperationError(
-            operation="mirror_registry_scan",
-            returncode=1,
-            stdout="",
-            stderr=f"cannot resolve worktree path {worktree_path}: {exc}",
-            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
-        ) from exc
-    except RuntimeError:
-        resolved_worktree = worktree_path.absolute()
-    best_match: tuple[int, Path] | None = None
-    for mirror_path in mirror_paths:
-        linked_git_dir = mirror_path / "worktrees" / worktree_name
-        if not linked_git_dir.is_dir():
-            continue
-        if not _is_bare_registered_mirror_candidate(mirror_path):
-            continue
-        try:
-            registered_worktree = linked_worktree_path_from_git_dir(linked_git_dir)
-        except GitOperationError:
-            continue
-        if registered_worktree == resolved_worktree:
-            try:
-                registered_mtime_ns = linked_git_dir.stat().st_mtime_ns
-            except OSError:
-                registered_mtime_ns = 0
-            if best_match is None or registered_mtime_ns >= best_match[0]:
-                best_match = (registered_mtime_ns, mirror_path)
-    if best_match is not None:
-        return best_match[1]
-    return None
-
-
-def _is_bare_registered_mirror_candidate(mirror_path: Path) -> bool:
-    """Return whether ``mirror_path`` probes as a bare Git repository."""
-    try:
-        probe = subprocess.run(
-            [
-                "git",
-                "--bare",
-                "--git-dir",
-                str(mirror_path),
-                "rev-parse",
-                "--is-bare-repository",
-            ],
-            capture_output=True,
-            check=False,
-            env=git_env_for_bare_repository_probe(),
-            text=True,
-            timeout=_GIT_BARE_PROBE_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        return False
-    except OSError as exc:
-        raise GitOperationError(
-            operation="mirror_registry_scan",
-            returncode=1,
-            stdout="",
-            stderr=f"could not probe bare mirror {mirror_path}: {exc}",
-            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
-        ) from exc
-    return probe.returncode == 0 and probe.stdout.strip() == "true"
-
-
 async def read_mirror_origin_url(mirror_path: Path) -> str | None:
     """Return a bare mirror's configured origin URL, when present."""
     returncode, stdout, _stderr = await _run_git_config(
@@ -1378,90 +1264,6 @@ async def read_mirror_origin_url(mirror_path: Path) -> str | None:
         return None
     repo_url = stdout.strip()
     return repo_url or None
-
-
-def linked_worktree_git_dir(worktree_path: Path) -> Path | None:
-    """Return the Git metadata directory linked from a worktree's ``.git`` file."""
-    git_file = worktree_path / ".git"
-    if not git_file.is_file():
-        return None
-    try:
-        content = git_file.read_text(encoding="utf-8").strip()
-    except OSError:
-        return None
-    prefix = "gitdir: "
-    if not content.startswith(prefix):
-        return None
-    git_dir = Path(content.removeprefix(prefix).strip())
-    if not git_dir.is_absolute():
-        git_dir = (worktree_path / git_dir).resolve()
-    return git_dir
-
-
-def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
-    """Return whether ``worktree_path`` looks like a usable managed checkout."""
-    if not worktree_path.is_dir():
-        return False
-    git_marker = worktree_path / ".git"
-    if git_marker.is_file():
-        return linked_worktree_git_dir(worktree_path) is not None
-    return git_marker.is_dir()
-
-
-def linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
-    """Return the worktree path from Git's linked-worktree back-reference."""
-    metadata_gitdir = linked_git_dir / "gitdir"
-    try:
-        raw_gitdir = metadata_gitdir.read_text(encoding="utf-8").strip()
-        if not raw_gitdir:
-            raise GitOperationError(
-                operation="worktree.hooks_path_probe",
-                returncode=1,
-                stdout="",
-                stderr=f"empty linked-worktree gitdir back-reference at {metadata_gitdir}",
-                reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
-            )
-        git_file = Path(raw_gitdir)
-        if not git_file.is_absolute():
-            git_file = linked_git_dir / git_file
-        return git_file.resolve().parent
-    except FileNotFoundError as exc:
-        # The back-reference file is gone (ENOENT): the linked worktree was
-        # removed out from under us, i.e. genuinely stale metadata that
-        # ``git worktree prune`` can safely clear.
-        raise GitOperationError(
-            operation="worktree.hooks_path_probe",
-            returncode=1,
-            stdout="",
-            stderr=f"cannot read linked-worktree gitdir back-reference at {metadata_gitdir}",
-            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
-        ) from exc
-    except OSError as exc:
-        # The back-reference exists but is unreadable (e.g. permission denied):
-        # this is a live worktree we merely cannot inspect, not stale metadata.
-        # Surface a non-stale error so repair fails closed instead of pruning —
-        # ``git worktree prune`` would delete the live worktree's admin files.
-        raise GitOperationError(
-            operation="worktree.hooks_path_probe",
-            returncode=1,
-            stdout="",
-            stderr=f"cannot access linked-worktree gitdir back-reference at {metadata_gitdir}",
-            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
-        ) from exc
-    except RuntimeError as exc:
-        raise GitOperationError(
-            operation="worktree.hooks_path_probe",
-            returncode=1,
-            stdout="",
-            stderr=f"cannot resolve linked-worktree gitdir back-reference at {metadata_gitdir}",
-            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
-        ) from exc
-
-
-def _is_stale_linked_worktree_metadata_error(exc: GitOperationError) -> bool:
-    return exc.operation == "worktree.hooks_path_probe" and exc.stderr.startswith(
-        "cannot read linked-worktree gitdir back-reference at "
-    )
 
 
 def _chown_targets(targets: tuple[_ChownTarget, ...], uid: int, gid: int) -> None:

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -943,17 +943,19 @@ class GitManager:
                         # ``fatal: '<path>' is not a working tree``. If the worktree
                         # ``.git`` file was already removed but mirror metadata still
                         # points to it, Git instead reports that validation failed
-                        # because ``<path>/.git`` does not exist. Both are
-                        # already-removed conditions from git's point of view, not
-                        # failures. Re-raise any genuine removal error (we match only
-                        # these conditions).
+                        # because ``<path>/.git`` does not exist. If an incomplete
+                        # restore left a standalone clone (``.git`` directory) at the
+                        # managed path, Git reports that ``.git`` is not a ``.git``
+                        # file. All three are reclaimable leftovers, not failures.
+                        # Re-raise any genuine removal error (we match only these
+                        # conditions).
                         stderr = exc.stderr.lower()
-                        missing_git_file = (
+                        reclaimable_git_marker = (
                             "validation failed, cannot remove working tree" in stderr
                             and ".git" in stderr
-                            and "does not exist" in stderr
+                            and ("does not exist" in stderr or "is not a .git file" in stderr)
                         )
-                        if "is not a working tree" not in stderr and not missing_git_file:
+                        if "is not a working tree" not in stderr and not reclaimable_git_marker:
                             raise
                         # ``git worktree remove`` never ran, so the physical
                         # directory and its contents are still on disk; ``worktree

--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -923,6 +923,25 @@ class GitManager:
             lock = self._lock_for_mirror(mirror_path)
             async with lock:
                 if worktree_path.exists():
+                    # A standalone repository (``.git`` as a directory) is not proven
+                    # AWF-linked leftover metadata. Fail closed rather than
+                    # ``rmtree`` — reclaiming would erase unrelated commits or
+                    # uncommitted work (AGENTS.md destructive-git rule; GC likewise
+                    # skips these paths as ``WORKTREE_NOT_GIT_MANAGED``).
+                    git_marker = worktree_path / ".git"
+                    if git_marker.is_dir():
+                        raise GitOperationError(
+                            operation="worktree.remove",
+                            returncode=1,
+                            stdout="",
+                            stderr=(
+                                f"refusing to remove standalone repository at "
+                                f"{worktree_path}: .git is a directory (not a "
+                                "linked-worktree gitfile); quarantine or remove it "
+                                "manually before reclaiming the path"
+                            ),
+                            reason_code="GIT_WORKTREE_STANDALONE_REPO",
+                        )
                     # ``--force`` because a failed task may leave dirty state.
                     try:
                         await self._run(
@@ -943,19 +962,17 @@ class GitManager:
                         # ``fatal: '<path>' is not a working tree``. If the worktree
                         # ``.git`` file was already removed but mirror metadata still
                         # points to it, Git instead reports that validation failed
-                        # because ``<path>/.git`` does not exist. If an incomplete
-                        # restore left a standalone clone (``.git`` directory) at the
-                        # managed path, Git reports that ``.git`` is not a ``.git``
-                        # file. All three are reclaimable leftovers, not failures.
-                        # Re-raise any genuine removal error (we match only these
-                        # conditions).
+                        # because ``<path>/.git`` does not exist. Both are
+                        # already-removed conditions from git's point of view, not
+                        # failures. Re-raise any genuine removal error (we match only
+                        # these conditions).
                         stderr = exc.stderr.lower()
-                        reclaimable_git_marker = (
+                        missing_git_file = (
                             "validation failed, cannot remove working tree" in stderr
                             and ".git" in stderr
-                            and ("does not exist" in stderr or "is not a .git file" in stderr)
+                            and "does not exist" in stderr
                         )
-                        if "is not a working tree" not in stderr and not reclaimable_git_marker:
+                        if "is not a working tree" not in stderr and not missing_git_file:
                             raise
                         # ``git worktree remove`` never ran, so the physical
                         # directory and its contents are still on disk; ``worktree

--- a/src/awf/node/git_manager_linked.py
+++ b/src/awf/node/git_manager_linked.py
@@ -1,0 +1,245 @@
+"""Linked-worktree path discovery and checkout usability helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from awf.node.git_manager_ownership import git_env_for_bare_repository_probe
+
+_GIT_BARE_PROBE_TIMEOUT_SECONDS = 5.0
+
+
+def linked_worktree_git_dir(worktree_path: Path) -> Path | None:
+    """Return the Git metadata directory linked from a worktree's ``.git`` file."""
+    git_file = worktree_path / ".git"
+    if not git_file.is_file():
+        return None
+    try:
+        content = git_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    prefix = "gitdir: "
+    if not content.startswith(prefix):
+        return None
+    git_dir = Path(content.removeprefix(prefix).strip())
+    if not git_dir.is_absolute():
+        git_dir = (worktree_path / git_dir).resolve()
+    return git_dir
+
+
+def linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
+    """Return the worktree path from Git's linked-worktree back-reference."""
+    # Late import: ``git_manager`` loads this module while defining types.
+    from awf.node.git_manager import GitOperationError
+
+    metadata_gitdir = linked_git_dir / "gitdir"
+    try:
+        raw_gitdir = metadata_gitdir.read_text(encoding="utf-8").strip()
+        if not raw_gitdir:
+            raise GitOperationError(
+                operation="worktree.hooks_path_probe",
+                returncode=1,
+                stdout="",
+                stderr=f"empty linked-worktree gitdir back-reference at {metadata_gitdir}",
+                reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+            )
+        git_file = Path(raw_gitdir)
+        if not git_file.is_absolute():
+            git_file = linked_git_dir / git_file
+        return git_file.resolve().parent
+    except FileNotFoundError as exc:
+        # The back-reference file is gone (ENOENT): the linked worktree was
+        # removed out from under us, i.e. genuinely stale metadata that
+        # ``git worktree prune`` can safely clear.
+        raise GitOperationError(
+            operation="worktree.hooks_path_probe",
+            returncode=1,
+            stdout="",
+            stderr=f"cannot read linked-worktree gitdir back-reference at {metadata_gitdir}",
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        ) from exc
+    except OSError as exc:
+        # The back-reference exists but is unreadable (e.g. permission denied):
+        # this is a live worktree we merely cannot inspect, not stale metadata.
+        # Surface a non-stale error so repair fails closed instead of pruning —
+        # ``git worktree prune`` would delete the live worktree's admin files.
+        raise GitOperationError(
+            operation="worktree.hooks_path_probe",
+            returncode=1,
+            stdout="",
+            stderr=f"cannot access linked-worktree gitdir back-reference at {metadata_gitdir}",
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        ) from exc
+    except RuntimeError as exc:
+        raise GitOperationError(
+            operation="worktree.hooks_path_probe",
+            returncode=1,
+            stdout="",
+            stderr=f"cannot resolve linked-worktree gitdir back-reference at {metadata_gitdir}",
+            reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+        ) from exc
+
+
+def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
+    """Return whether ``worktree_path`` looks like a usable managed checkout.
+
+    For linked worktrees, the ``.git`` file may still parse after the mirror-side
+    admin directory is gone. Require the linked Git dir to exist and to
+    reciprocally register this checkout before treating the path as usable.
+    """
+    from awf.node.git_manager import GitOperationError
+
+    if not worktree_path.is_dir():
+        return False
+    git_marker = worktree_path / ".git"
+    if git_marker.is_file():
+        linked_git_dir = linked_worktree_git_dir(worktree_path)
+        if linked_git_dir is None or not linked_git_dir.is_dir():
+            return False
+        try:
+            registered = linked_worktree_path_from_git_dir(linked_git_dir)
+            return registered.resolve() == worktree_path.resolve()
+        except (GitOperationError, OSError):
+            return False
+    return git_marker.is_dir()
+
+
+def _is_stale_linked_worktree_metadata_error(exc: object) -> bool:
+    from awf.node.git_manager import GitOperationError
+
+    if not isinstance(exc, GitOperationError):
+        return False
+    return exc.operation == "worktree.hooks_path_probe" and exc.stderr.startswith(
+        "cannot read linked-worktree gitdir back-reference at "
+    )
+
+
+def mirror_path_for_worktree(worktree_path: Path) -> Path | None:
+    """Return the bare mirror path backing a linked worktree, when discoverable."""
+    linked_git_dir = linked_worktree_git_dir(worktree_path)
+    if linked_git_dir is None:
+        return None
+    commondir = linked_git_dir / "commondir"
+    if commondir.is_file():
+        try:
+            raw = commondir.read_text(encoding="utf-8").strip()
+        except OSError:
+            raw = ""
+        if raw:
+            common = Path(raw)
+            if not common.is_absolute():
+                common = linked_git_dir / common
+            return common.resolve()
+    return linked_git_dir.parent.parent.resolve()
+
+
+def _path_within_root(path: Path, root: Path) -> Path | None:
+    """Return ``path`` resolved under ``root``, or ``None`` when it escapes ``root``."""
+    try:
+        resolved_path = path.resolve()
+        resolved_root = root.resolve()
+    except RuntimeError:
+        resolved_path = path.absolute()
+        resolved_root = root.absolute()
+    try:
+        resolved_path.relative_to(resolved_root)
+    except ValueError:
+        return None
+    return resolved_path
+
+
+def _is_bare_registered_mirror_candidate(mirror_path: Path) -> bool:
+    """Return whether ``mirror_path`` probes as a bare Git repository."""
+    from awf.node.git_manager import GitOperationError
+
+    try:
+        probe = subprocess.run(
+            [
+                "git",
+                "--bare",
+                "--git-dir",
+                str(mirror_path),
+                "rev-parse",
+                "--is-bare-repository",
+            ],
+            capture_output=True,
+            check=False,
+            env=git_env_for_bare_repository_probe(),
+            text=True,
+            timeout=_GIT_BARE_PROBE_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        return False
+    except OSError as exc:
+        raise GitOperationError(
+            operation="mirror_registry_scan",
+            returncode=1,
+            stdout="",
+            stderr=f"could not probe bare mirror {mirror_path}: {exc}",
+            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
+        ) from exc
+    return probe.returncode == 0 and probe.stdout.strip() == "true"
+
+
+def mirror_path_for_registered_worktree(worktree_path: Path, mirrors_dir: Path) -> Path | None:
+    """Return the bare mirror path from mirror-side linked-worktree metadata.
+
+    This is the fallback for an AWF-managed worktree directory whose ``.git``
+    file was already removed, but whose bare mirror still has
+    ``worktrees/<id>/gitdir`` pointing back to that directory.
+    """
+    from awf.node.git_manager import GitOperationError
+
+    if not mirrors_dir.exists():
+        return None
+    try:
+        mirror_paths = sorted(
+            resolved_path
+            for path in mirrors_dir.iterdir()
+            if path.is_dir()
+            if (resolved_path := _path_within_root(path, mirrors_dir)) is not None
+        )
+    except OSError as exc:
+        raise GitOperationError(
+            operation="mirror_registry_scan",
+            returncode=1,
+            stdout="",
+            stderr=str(exc),
+            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
+        ) from exc
+
+    worktree_name = worktree_path.name
+    try:
+        resolved_worktree = worktree_path.resolve()
+    except OSError as exc:
+        raise GitOperationError(
+            operation="mirror_registry_scan",
+            returncode=1,
+            stdout="",
+            stderr=f"cannot resolve worktree path {worktree_path}: {exc}",
+            reason_code="MIRROR_REGISTRY_SCAN_FAILED",
+        ) from exc
+    except RuntimeError:
+        resolved_worktree = worktree_path.absolute()
+    best_match: tuple[int, Path] | None = None
+    for mirror_path in mirror_paths:
+        linked_git_dir = mirror_path / "worktrees" / worktree_name
+        if not linked_git_dir.is_dir():
+            continue
+        if not _is_bare_registered_mirror_candidate(mirror_path):
+            continue
+        try:
+            registered_worktree = linked_worktree_path_from_git_dir(linked_git_dir)
+        except GitOperationError:
+            continue
+        if registered_worktree == resolved_worktree:
+            try:
+                registered_mtime_ns = linked_git_dir.stat().st_mtime_ns
+            except OSError:
+                registered_mtime_ns = 0
+            if best_match is None or registered_mtime_ns >= best_match[0]:
+                best_match = (registered_mtime_ns, mirror_path)
+    if best_match is not None:
+        return best_match[1]
+    return None

--- a/src/awf/node/git_manager_linked.py
+++ b/src/awf/node/git_manager_linked.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+from awf.common.git_identity import git_safe_directory_config_args
 from awf.node.git_manager_ownership import git_env_for_bare_repository_probe
 
 _GIT_BARE_PROBE_TIMEOUT_SECONDS = 5.0
+_GIT_LINKED_CHECKOUT_PROBE_TIMEOUT_SECONDS = 5.0
 
 
 def linked_worktree_git_dir(worktree_path: Path) -> Path | None:
@@ -81,6 +83,35 @@ def linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
         ) from exc
 
 
+def _linked_worktree_rev_parse_probe_ok(worktree_path: Path) -> bool:
+    """Return whether a read-only ``git rev-parse`` resolves HEAD in the checkout.
+
+    Reciprocal ``gitdir`` registration can survive after essential linked-worktree
+    metadata (for example ``HEAD``) is missing or corrupt. Probing before the
+    ``ensure_worktree`` no-op avoids handing a non-repository path to the monitor.
+    """
+    try:
+        probe = subprocess.run(
+            [
+                "git",
+                *git_safe_directory_config_args(worktree_path),
+                "-C",
+                str(worktree_path),
+                "rev-parse",
+                "--verify",
+                "HEAD",
+            ],
+            capture_output=True,
+            check=False,
+            env=git_env_for_bare_repository_probe(),
+            text=True,
+            timeout=_GIT_LINKED_CHECKOUT_PROBE_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return probe.returncode == 0
+
+
 def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
     """Return whether ``worktree_path`` looks like a usable managed checkout.
 
@@ -90,8 +121,9 @@ def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
     monitor would operate on an unrelated checkout.
 
     For linked worktrees, the ``.git`` file may still parse after the mirror-side
-    admin directory is gone. Require the linked Git dir to exist and to
-    reciprocally register this checkout before treating the path as usable.
+    admin directory is gone. Require the linked Git dir to exist, reciprocally
+    register this checkout, and pass a read-only Git HEAD probe before treating
+    the path as usable.
     """
     from awf.node.git_manager import GitOperationError
 
@@ -107,9 +139,11 @@ def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
         return False
     try:
         registered = linked_worktree_path_from_git_dir(linked_git_dir)
-        return registered.resolve() == worktree_path.resolve()
+        if registered.resolve() != worktree_path.resolve():
+            return False
     except (GitOperationError, OSError):
         return False
+    return _linked_worktree_rev_parse_probe_ok(worktree_path)
 
 
 def _is_stale_linked_worktree_metadata_error(exc: object) -> bool:

--- a/src/awf/node/git_manager_linked.py
+++ b/src/awf/node/git_manager_linked.py
@@ -84,6 +84,11 @@ def linked_worktree_path_from_git_dir(linked_git_dir: Path) -> Path:
 def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
     """Return whether ``worktree_path`` looks like a usable managed checkout.
 
+    Only reciprocally registered linked worktrees are usable. A standalone
+    clone (``.git`` directory) — for example after an incomplete external
+    restore — must not take the ``ensure_worktree`` no-op path, or the PR
+    monitor would operate on an unrelated checkout.
+
     For linked worktrees, the ``.git`` file may still parse after the mirror-side
     admin directory is gone. Require the linked Git dir to exist and to
     reciprocally register this checkout before treating the path as usable.
@@ -93,16 +98,18 @@ def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
     if not worktree_path.is_dir():
         return False
     git_marker = worktree_path / ".git"
-    if git_marker.is_file():
-        linked_git_dir = linked_worktree_git_dir(worktree_path)
-        if linked_git_dir is None or not linked_git_dir.is_dir():
-            return False
-        try:
-            registered = linked_worktree_path_from_git_dir(linked_git_dir)
-            return registered.resolve() == worktree_path.resolve()
-        except (GitOperationError, OSError):
-            return False
-    return git_marker.is_dir()
+    if not git_marker.is_file():
+        # Reject standalone repositories (``.git`` as a directory) and missing
+        # markers — AWF managed checkouts are always linked worktrees.
+        return False
+    linked_git_dir = linked_worktree_git_dir(worktree_path)
+    if linked_git_dir is None or not linked_git_dir.is_dir():
+        return False
+    try:
+        registered = linked_worktree_path_from_git_dir(linked_git_dir)
+        return registered.resolve() == worktree_path.resolve()
+    except (GitOperationError, OSError):
+        return False
 
 
 def _is_stale_linked_worktree_metadata_error(exc: object) -> bool:

--- a/src/awf/node/git_manager_linked.py
+++ b/src/awf/node/git_manager_linked.py
@@ -89,7 +89,15 @@ def _linked_worktree_rev_parse_probe_ok(worktree_path: Path) -> bool:
     Reciprocal ``gitdir`` registration can survive after essential linked-worktree
     metadata (for example ``HEAD``) is missing or corrupt. Probing before the
     ``ensure_worktree`` no-op avoids handing a non-repository path to the monitor.
+
+    Confirmed-invalid metadata (non-zero ``rev-parse``) returns ``False`` so
+    ``ensure_worktree`` may reclaim. Probe timeouts and launch/I/O errors are
+    indeterminate: raise instead of returning ``False``, so recovery fails closed
+    rather than force-removing a possibly-live checkout with uncommitted work.
     """
+    # Late import: ``git_manager`` loads this module while defining types.
+    from awf.node.git_manager import GitOperationError
+
     try:
         probe = subprocess.run(
             [
@@ -107,8 +115,25 @@ def _linked_worktree_rev_parse_probe_ok(worktree_path: Path) -> bool:
             text=True,
             timeout=_GIT_LINKED_CHECKOUT_PROBE_TIMEOUT_SECONDS,
         )
-    except (OSError, subprocess.TimeoutExpired):
-        return False
+    except subprocess.TimeoutExpired as exc:
+        raise GitOperationError(
+            operation="worktree.checkout_probe",
+            returncode=1,
+            stdout="",
+            stderr=(
+                f"linked checkout HEAD probe timed out after "
+                f"{_GIT_LINKED_CHECKOUT_PROBE_TIMEOUT_SECONDS:g}s for {worktree_path}"
+            ),
+            reason_code="GIT_COMMAND_FAILED",
+        ) from exc
+    except OSError as exc:
+        raise GitOperationError(
+            operation="worktree.checkout_probe",
+            returncode=1,
+            stdout="",
+            stderr=f"could not probe linked checkout HEAD at {worktree_path}: {exc}",
+            reason_code="GIT_COMMAND_FAILED",
+        ) from exc
     return probe.returncode == 0
 
 
@@ -123,7 +148,8 @@ def _worktree_checkout_is_usable(worktree_path: Path) -> bool:
     For linked worktrees, the ``.git`` file may still parse after the mirror-side
     admin directory is gone. Require the linked Git dir to exist, reciprocally
     register this checkout, and pass a read-only Git HEAD probe before treating
-    the path as usable.
+    the path as usable. An indeterminate HEAD probe raises ``GitOperationError``
+    so callers fail closed instead of reclaiming.
     """
     from awf.node.git_manager import GitOperationError
 

--- a/src/awf/node/provisioner.py
+++ b/src/awf/node/provisioner.py
@@ -58,7 +58,7 @@ from awf.node.compose_manager import (
     ComposeProjectPaths,
 )
 from awf.node.egress_policy import LocalEgressPlan, LocalEgressPolicyError, local_egress_plan
-from awf.node.git_manager import GitManager, GitOperationError
+from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
 from awf.node.provisioner_cursor_preflight import ProvisionerCursorPreflightMixin
 from awf.node.provisioner_host_ports_check import ProvisionerHostPortCheckMixin
 from awf.node.provisioner_launch_cleanup import ProvisionerLaunchCleanupMixin
@@ -222,6 +222,77 @@ class Provisioner(
     def get_worktree_path(self, workspace_id: str) -> Path:
         """Return the node-local worktree path AWF manages for ``workspace_id``."""
         return self._git.get_worktree_path(workspace_id)
+
+    async def ensure_hosted_monitor_worktree(self, workspace_id: str) -> WorktreeLayout:
+        """Restore the managed checkout for a hosted ``monitoring_pr`` resume.
+
+        Loads persisted workspace/adoption fields and recreates the worktree at
+        the current PR head tip via :meth:`GitManager.ensure_worktree` and the
+        shared :func:`_provision_checkout_base_branch` helpers. Callers must
+        only invoke this for hosted adoption workspaces.
+        """
+        async with self._session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            if ws is None:
+                raise GitOperationError(
+                    operation="hosted_monitor.ensure_worktree",
+                    returncode=1,
+                    stdout="",
+                    stderr=f"workspace {workspace_id} not found for checkout restore",
+                    reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                )
+            if not pr_adoption_is_hosted(ws.task_policy):
+                raise GitOperationError(
+                    operation="hosted_monitor.ensure_worktree",
+                    returncode=1,
+                    stdout="",
+                    stderr=(
+                        "ensure_hosted_monitor_worktree requires hosted PR adoption "
+                        f"for workspace {workspace_id}"
+                    ),
+                    reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                )
+            if not ws.repo_url:
+                raise GitOperationError(
+                    operation="hosted_monitor.ensure_worktree",
+                    returncode=1,
+                    stdout="",
+                    stderr=(
+                        "hosted monitor checkout restore missing repo_url for "
+                        f"workspace {workspace_id}"
+                    ),
+                    reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                )
+            branch_name = ws.branch_name or _provision_local_branch_name(
+                ws,
+                workspace_id=workspace_id,
+                branch_prefix=self._config.branch_prefix,
+                task_tag=ws.task_tag,
+            )
+            checkout_base = _provision_checkout_base_branch(ws)
+            repo_url = ws.repo_url
+
+        try:
+            return await self._git.ensure_worktree(
+                workspace_id=workspace_id,
+                repo_url=repo_url,
+                base_branch=checkout_base,
+                new_branch=branch_name,
+            )
+        except GitOperationError as exc:
+            if exc.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED":
+                raise
+            raise GitOperationError(
+                operation="hosted_monitor.ensure_worktree",
+                returncode=exc.returncode,
+                stdout=exc.stdout,
+                stderr=(
+                    "hosted monitor checkout restore failed "
+                    f"(underlying={exc.reason_code}): {exc.stderr or exc.stdout}"
+                ),
+                reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+            ) from exc
 
     async def _provision_claimed_workspace(
         self,

--- a/src/awf/service/doctor/reasons_helpers.py
+++ b/src/awf/service/doctor/reasons_helpers.py
@@ -102,6 +102,23 @@ def get_salvage_and_monitor_reasons(
             "awf workspace show <workspace_id>",
             reason_catalog_link("MONITOR_RECOVERY_SUPERSEDED"),
         ),
+        "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED": reason_text_cls(
+            (
+                "Hosted PR-monitor resume could not restore the managed worktree checkout "
+                "after a worker pod replacement (missing adoption tip, repo, or git failure)."
+            ),
+            (
+                "Confirm the workspace still has durable PR/adoption metadata and that "
+                "GitHub auth can fetch refs/pull/<n>/head (or the forge-neutral head "
+                "branch), then remonitor. Do not expect Compose metadata on hosted rows."
+            ),
+            (
+                "The replacement control-worker pod has no pod-local worktree under "
+                "/tmp/awf-work/git/worktrees, and checkout reconstruction failed closed."
+            ),
+            "awf workspace remonitor <workspace_id>",
+            reason_catalog_link("MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED"),
+        ),
     }
 
 

--- a/src/awf/service/worker.py
+++ b/src/awf/service/worker.py
@@ -492,6 +492,10 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
             _release_forge_client_after_build_error(gh)
             raise
 
+    async def _ensure_hosted_monitor_checkout(workspace_id: str) -> None:
+        """Restore the managed worktree before hosted PR-monitor resume."""
+        await provisioner.ensure_hosted_monitor_worktree(workspace_id)
+
     executor = WorkspaceExecutor(
         session_factory=session_factory,
         runner=runner,
@@ -509,6 +513,9 @@ def build_worker_runtime(settings: ServiceSettings) -> WorkerRuntime:
         # worker does NOT build a Kubernetes executor here.
         agent_runtime_executor=hosted_agent_runtime_executor,
         hosted_validation=hosted_validation_delegate,
+        # Provisioner owns GitManager; hosted monitor resume restores the
+        # pod-local checkout before the monitor loop's first git I/O.
+        ensure_hosted_monitor_checkout=_ensure_hosted_monitor_checkout,
     )
     runtime_driver = LocalRuntimeDriver(
         provisioner=provisioner,

--- a/src/awf/service/workspace_runtime_health.py
+++ b/src/awf/service/workspace_runtime_health.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from awf.common.workspace_policy import pr_adoption_is_hosted
 from awf.db.enums import WorkspaceStatus
 from awf.db.models import Workspace
 from awf.runtime.inspection import RuntimeSnapshot
@@ -60,6 +61,7 @@ class RuntimeWorkspace:
     compose_file_path: str | None = None
     pr_url: str | None = None
     retry_policy_allows_recovery: bool = False
+    hosted_pr_adoption: bool = False
 
 
 @dataclass(frozen=True)
@@ -190,6 +192,7 @@ def runtime_workspace_from_workspace(workspace: Workspace) -> RuntimeWorkspace:
         compose_file_path=workspace.compose_file_path,
         pr_url=workspace.pr_url,
         retry_policy_allows_recovery=retry_policy_allows_runtime_recovery(workspace.task_policy),
+        hosted_pr_adoption=pr_adoption_is_hosted(workspace.task_policy),
     )
 
 
@@ -215,6 +218,7 @@ async def runtime_workspaces_from_session(session: AsyncSession) -> tuple[Runtim
             ),
             pr_url=str(row.pr_url) if row.pr_url is not None else None,
             retry_policy_allows_recovery=retry_policy_allows_runtime_recovery(row.task_policy),
+            hosted_pr_adoption=pr_adoption_is_hosted(row.task_policy),
         )
         for row in rows
     )
@@ -262,6 +266,11 @@ def classify_runtime_snapshot(
     metadata_finding = _metadata_finding(workspace)
     if metadata_finding is not None:
         return metadata_finding
+    if workspace.hosted_pr_adoption and has_open_pr_for_remonitor(
+        workspace.status, workspace.pr_url
+    ):
+        # Hosted monitoring_pr has no Compose runtime by design.
+        return None
 
     services = _snapshot_services(snapshot)
     return _classify_services(workspace, services=services)
@@ -307,6 +316,10 @@ def classify_resource_inventory(
     metadata_finding = _metadata_finding(workspace)
     if metadata_finding is not None:
         return metadata_finding
+    if workspace.hosted_pr_adoption and has_open_pr_for_remonitor(
+        workspace.status, workspace.pr_url
+    ):
+        return None
 
     workspace_resources = tuple(
         resource for resource in resources if _resource_matches_workspace(resource, workspace)
@@ -379,6 +392,11 @@ def _metadata_finding(workspace: RuntimeWorkspace) -> WorkspaceRuntimeFinding | 
     if has_runtime_metadata:
         return None
     if workspace.status in _PRE_PROVISIONED_REQUEST_STATUSES:
+        return None
+    # Hosted PR adoption intentionally has no Compose metadata while monitoring.
+    if workspace.hosted_pr_adoption and has_open_pr_for_remonitor(
+        workspace.status, workspace.pr_url
+    ):
         return None
     return _finding(
         workspace,

--- a/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_005.py
+++ b/tests/unit/control/test_executor_coverage_edges_parts/test_executor_coverage_edges_part_005.py
@@ -1048,7 +1048,9 @@ async def test_stale_terminal_workspace_paths_record_ignored_callbacks(
             to: WorkspaceStatus,
             reason_code: str,
             payload: dict[str, Any] | None = None,
+            extra_conditions: tuple[object, ...] = (),
         ) -> object | None:
+            del extra_conditions
             assert workspace_id == workspace.id
             if workspace.status != from_status.value:
                 return None

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -954,6 +954,68 @@ class TestResumeHandoffHostedCheckoutRestore:
             assert "https://[redacted]@" in (ws.failure_message or "")
 
     @pytest.mark.unit
+    async def test_unexpected_checkout_restore_failure_redacts_exception_log(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Non-GitOperationError restore failures must not log raw credentials.
+
+        ``_log.exception`` embeds the raw exception message/traceback; this path
+        must log only a redacted representation (PRRT_kwDOSJAM6s6dOj6H).
+        """
+        import structlog.testing
+
+        secret_url = "https://x-access-token:ghp_should_not_persist@github.com/org/repo/"
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            raise RuntimeError(f"delegated checkout failed for {secret_url}")
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        with structlog.testing.capture_logs() as captured:
+            await executor_obj.resume_pr_monitor(ws_id)
+
+        restore_logs = [
+            entry
+            for entry in captured
+            if entry.get("event") == "executor.resume_hosted_checkout_restore_failed"
+        ]
+        assert restore_logs
+        assert "ghp_should_not_persist" not in repr(restore_logs)
+        assert not restore_logs[0].get("exc_info")
+        redacted_traceback = str(restore_logs[0].get("redacted_traceback", ""))
+        assert redacted_traceback
+        assert "https://[redacted]@github.com/org/repo/" in redacted_traceback
+        assert "ghp_should_not_persist" not in redacted_traceback
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert "ghp_should_not_persist" not in (ws.failure_message or "")
+            assert "https://[redacted]@github.com/org/repo/" in (ws.failure_message or "")
+
+    @pytest.mark.unit
     async def test_resume_reuses_pending_monitor_comment_operation(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -684,6 +684,136 @@ class TestResumeHandoffHostedCheckoutRestore:
             assert ws.monitor_claimed_by == "worker-new"
 
     @pytest.mark.unit
+    @pytest.mark.parametrize("failure_kind", ["git_operation", "unexpected"])
+    async def test_checkout_restore_failure_does_not_fail_stolen_monitor_claim(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+        failure_kind: str,
+    ) -> None:
+        """Stale restore must not mark_failed after monitor claim takeover.
+
+        Hosted checkout restore can outlive the monitor lease. If another worker
+        reclaims mid-restore, the superseded resume must skip the non-owner-gated
+        ``_mark_failed`` rather than failing the live ``monitoring_pr`` row
+        (PRRT_kwDOSJAM6s6dNITc). Covers both ``GitOperationError`` and unexpected
+        exception restore failure paths.
+        """
+        from awf.db.repositories import WorkspaceEventRepository
+        from awf.node.git_manager import GitOperationError
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "worker-stale"
+            await s.commit()
+
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            async with factory() as s:
+                row = await WorkspaceRepository(s).get(ws_id)
+                assert row is not None
+                row.monitor_claimed_by = "worker-current"
+                await s.commit()
+            if failure_kind == "git_operation":
+                raise GitOperationError(
+                    operation="hosted_monitor.ensure_worktree",
+                    returncode=1,
+                    stdout="",
+                    stderr="mirror clone timed out after lease expiry",
+                    reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+                )
+            raise RuntimeError("unexpected hosted checkout restore failure")
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert monitor.run_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.monitor_claimed_by == "worker-current"
+            events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
+            assert any(event.reason_code == "EXECUTOR_STALE_MONITOR_CLAIM" for event in events)
+            assert not any(
+                event.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED" for event in events
+            )
+
+    @pytest.mark.unit
+    async def test_fail_closed_when_unexpected_checkout_restore_error(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Unexpected restore errors still fail-closed when this worker owns the claim."""
+        from awf.db.repositories import WorkspaceEventRepository
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "worker-stale"
+            await s.commit()
+
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            raise RuntimeError("unexpected hosted checkout restore failure")
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert monitor.run_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert ws.monitor_claimed_by == "worker-stale"
+            events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
+            assert any(
+                event.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED" for event in events
+            )
+
+    @pytest.mark.unit
     async def test_checkout_restore_failure_redacts_git_diagnostics(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -878,6 +878,82 @@ class TestResumeHandoffHostedCheckoutRestore:
             assert "https://[redacted]@github.com/org/repo/" in (ws.failure_message or "")
 
     @pytest.mark.unit
+    async def test_checkout_restore_failure_redacts_before_truncating_long_url_credential(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Credential past byte 1000 must still redact when truncating diagnostics.
+
+        Slicing stderr before redact_audit_text drops the trailing ``@`` that
+        ``_URL_CREDENTIAL_RE`` needs, so the credential prefix would leak into
+        the structured log and persisted failure message (PRRT_kwDOSJAM6s6dNnoq).
+        """
+        import structlog.testing
+
+        from awf.node.git_manager import GitOperationError
+
+        # Non-known-token credential so only ``_URL_CREDENTIAL_RE`` can catch it;
+        # ``_KNOWN_TOKEN_RE`` must not mask a pre-truncate slice bug.
+        secret = "oauth-token-must-not-leak-past-byte-boundary"
+        cred_prefix = f"https://git:{secret}"
+        # Place ``@`` at index 1000 so ``stderr[:1000]`` excludes the delimiter.
+        padding = "x" * (1000 - len(cred_prefix))
+        secret_stderr = f"{padding}{cred_prefix}@github.com/org/repo/"
+        assert secret_stderr[1000] == "@"
+        assert secret in secret_stderr[:1000]
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            raise GitOperationError(
+                operation="hosted_monitor.ensure_worktree",
+                returncode=128,
+                stdout="",
+                stderr=secret_stderr,
+                reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+            )
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        with structlog.testing.capture_logs() as captured:
+            await executor_obj.resume_pr_monitor(ws_id)
+
+        restore_logs = [
+            entry
+            for entry in captured
+            if entry.get("event") == "executor.resume_hosted_checkout_restore_failed"
+        ]
+        assert restore_logs
+        assert secret not in repr(restore_logs)
+        assert "https://[redacted]@" in str(restore_logs[0].get("stderr", ""))
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert secret not in (ws.failure_message or "")
+            assert "https://[redacted]@" in (ws.failure_message or "")
+
+    @pytest.mark.unit
     async def test_resume_reuses_pending_monitor_comment_operation(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -420,7 +420,10 @@ class TestResumeHandoffHostedCheckoutRestore:
         )
         worktree = tmp_path / "work" / "worktrees" / ws_id
         worktree.mkdir(parents=True)
-        (worktree / ".git").write_text("gitdir: /tmp/fake\n", encoding="utf-8")
+        linked = tmp_path / "work" / "git" / "mirrors" / "repo.git" / "worktrees" / ws_id
+        linked.mkdir(parents=True)
+        (worktree / ".git").write_text(f"gitdir: {linked}\n", encoding="utf-8")
+        (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
 
         git = GitManager(tmp_path / "work" / "git")
         add_calls: list[str] = []

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -526,6 +526,70 @@ class TestResumeHandoffHostedCheckoutRestore:
             )
 
     @pytest.mark.unit
+    async def test_checkout_restore_failure_redacts_git_diagnostics(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        import structlog.testing
+
+        from awf.node.git_manager import GitOperationError
+
+        secret_stderr = (
+            "fatal: unable to access "
+            "https://x-access-token:ghp_should_not_persist@github.com/org/repo/"
+        )
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            raise GitOperationError(
+                operation="hosted_monitor.ensure_worktree",
+                returncode=128,
+                stdout="",
+                stderr=secret_stderr,
+                reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+            )
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        with structlog.testing.capture_logs() as captured:
+            await executor_obj.resume_pr_monitor(ws_id)
+
+        restore_logs = [
+            entry
+            for entry in captured
+            if entry.get("event") == "executor.resume_hosted_checkout_restore_failed"
+        ]
+        assert restore_logs
+        assert "ghp_should_not_persist" not in repr(restore_logs)
+        assert "https://[redacted]@github.com/org/repo/" in str(restore_logs[0].get("stderr", ""))
+
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            assert "ghp_should_not_persist" not in (ws.failure_message or "")
+            assert "https://[redacted]@github.com/org/repo/" in (ws.failure_message or "")
+
+    @pytest.mark.unit
     async def test_resume_reuses_pending_monitor_comment_operation(
         self,
         fake: FakeCommandRunner,

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -490,6 +490,11 @@ class TestResumeHandoffHostedCheckoutRestore:
             compose_file_path=None,
             task_kind="sync_feature_pr",
         )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "worker-old"
+            await s.commit()
         monitor = _RecordingMonitor()
 
         async def _restore(_workspace_id: str) -> None:
@@ -524,6 +529,156 @@ class TestResumeHandoffHostedCheckoutRestore:
             assert any(
                 event.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED" for event in events
             )
+
+    @pytest.mark.unit
+    async def test_superseded_restore_failure_does_not_fail_new_owner(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Lease takeover mid-restore must not let the old owner call mark_failed.
+
+        PRRT_kwDOSJAM6s6dNBTV: a slow hosted checkout restore can outlive the
+        monitor lease; if restore then errors, status-only ``_mark_failed`` would
+        fail ``monitoring_pr`` underneath the replacement claimant.
+        """
+        from awf.node.git_manager import GitOperationError
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "worker-old"
+            await s.commit()
+
+        monitor = _RecordingMonitor()
+
+        async def _restore_after_takeover(_workspace_id: str) -> None:
+            async with factory() as s:
+                ws = await WorkspaceRepository(s).get(ws_id)
+                assert ws is not None
+                ws.monitor_claimed_by = "worker-new"
+                await s.commit()
+            raise GitOperationError(
+                operation="hosted_monitor.ensure_worktree",
+                returncode=1,
+                stdout="",
+                stderr="restore raced with takeover",
+                reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+            )
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore_after_takeover,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert monitor.run_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.monitor_claimed_by == "worker-new"
+
+    @pytest.mark.unit
+    async def test_superseded_before_restore_skips_checkout(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        """Pre-restore monitor-owner recheck must skip restore after takeover."""
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            ws.monitor_claimed_by = "worker-old"
+            await s.commit()
+
+        restore_calls: list[str] = []
+
+        async def _restore(workspace_id: str) -> None:
+            restore_calls.append(workspace_id)
+
+        # Capture owner at load, then transfer claim before handoff continues past
+        # the early status recheck by transferring after load via a patched recheck.
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: _RecordingMonitor(),
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        original_recheck = executor_obj._recheck_status
+        saw_pre_restore = False
+
+        async def _recheck(
+            workspace_id: str,
+            *,
+            expected: WorkspaceStatus,
+            action: str,
+            reason_code: str = "EXECUTOR_STALE_STATUS",
+            owner_id: str | None = None,
+            owner_mismatch_reason_code: str = "EXECUTOR_STALE_CLAIM",
+            monitor_owner_id: str | None = None,
+            monitor_owner_mismatch_reason_code: str = "EXECUTOR_STALE_MONITOR_CLAIM",
+        ) -> bool:
+            nonlocal saw_pre_restore
+            if action == "resume_hosted_checkout" and not saw_pre_restore:
+                saw_pre_restore = True
+                async with factory() as s:
+                    ws = await WorkspaceRepository(s).get(ws_id)
+                    assert ws is not None
+                    ws.monitor_claimed_by = "worker-new"
+                    await s.commit()
+            return await original_recheck(
+                workspace_id,
+                expected=expected,
+                action=action,
+                reason_code=reason_code,
+                owner_id=owner_id,
+                owner_mismatch_reason_code=owner_mismatch_reason_code,
+                monitor_owner_id=monitor_owner_id,
+                monitor_owner_mismatch_reason_code=monitor_owner_mismatch_reason_code,
+            )
+
+        executor_obj._recheck_status = _recheck  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert saw_pre_restore
+        assert restore_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            assert ws.monitor_claimed_by == "worker-new"
 
     @pytest.mark.unit
     async def test_checkout_restore_failure_redacts_git_diagnostics(

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -8,6 +8,7 @@ resumes with only the worktree/profile metadata and skips Compose entirely.
 
 from __future__ import annotations
 
+import subprocess
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -408,8 +409,31 @@ class TestResumeHandoffHostedCheckoutRestore:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         from awf.node import provisioner as provisioner_module
-        from awf.node.git_manager import GitManager, WorktreeLayout
+        from awf.node.git_manager import (
+            GitManager,
+            WorktreeLayout,
+            _worktree_checkout_is_usable,
+        )
         from awf.node.provisioner import Provisioner, ProvisionerConfig
+
+        # Real linked checkout (reciprocal gitdir + resolvable HEAD). Planting only
+        # gitdir files is no longer enough after the checkout HEAD probe.
+        origin = tmp_path / "origin"
+        origin.mkdir()
+        for args in (
+            ["init", "-q", "-b", "development"],
+            ["config", "user.name", "AWF Test"],
+            ["config", "user.email", "awf@test.local"],
+        ):
+            subprocess.run(["git", *args], cwd=origin, check=True, capture_output=True)
+        (origin / "README.md").write_text("first\n", encoding="utf-8")
+        subprocess.run(["git", "add", "."], cwd=origin, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "commit", "-q", "-m", "init"],
+            cwd=origin,
+            check=True,
+            capture_output=True,
+        )
 
         ws_id = await _seed_monitoring_pr(
             factory,
@@ -417,15 +441,25 @@ class TestResumeHandoffHostedCheckoutRestore:
             compose_project_name=None,
             compose_file_path=None,
             task_kind="sync_feature_pr",
+            repo_url=str(origin),
         )
-        worktree = tmp_path / "work" / "worktrees" / ws_id
-        worktree.mkdir(parents=True)
-        linked = tmp_path / "work" / "git" / "mirrors" / "repo.git" / "worktrees" / ws_id
-        linked.mkdir(parents=True)
-        (worktree / ".git").write_text(f"gitdir: {linked}\n", encoding="utf-8")
-        (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.branch_name is not None
+            branch_name = ws.branch_name
 
         git = GitManager(tmp_path / "work" / "git")
+        # Point GitManager worktrees at the executor worktrees root layout.
+        git._worktrees_dir = tmp_path / "work" / "worktrees"  # noqa: SLF001
+        layout = await git.add_worktree(
+            workspace_id=ws_id,
+            repo_url=str(origin),
+            base_branch="development",
+            new_branch=branch_name,
+        )
+        assert _worktree_checkout_is_usable(layout.worktree_path)
+
         add_calls: list[str] = []
 
         async def _add_worktree(**kwargs: Any) -> WorktreeLayout:
@@ -438,8 +472,6 @@ class TestResumeHandoffHostedCheckoutRestore:
             git=git,
             config=ProvisionerConfig(node_id="node-a", branch_prefix="awf"),
         )
-        # Point GitManager worktrees at the executor worktrees root layout.
-        git._worktrees_dir = tmp_path / "work" / "worktrees"  # noqa: SLF001
 
         compose = _RecordingCompose()
         monitor = _RecordingMonitor()

--- a/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
+++ b/tests/unit/control/test_executor_monitor_recovery_parts/test_executor_monitor_recovery_hosted_seam.py
@@ -57,11 +57,13 @@ async def _seed_monitoring_pr(
     task_policy: dict[str, Any] | None = None,
     compose_project_name: str | None = "awf_x",
     compose_file_path: str | None = "/tmp/awf/x/compose.yml",
+    task_kind: str = "feature_branch_pr",
+    repo_url: str = "git@github.com:x/y.git",
 ) -> str:
     async with factory() as s:
         repo = WorkspaceRepository(s)
         ws = await repo.create(
-            repo_url="git@github.com:x/y.git",
+            repo_url=repo_url,
             branch_base="development",
             task_title="monitor-resume-hosted",
             task_prompt="p",
@@ -71,10 +73,12 @@ async def _seed_monitoring_pr(
             auto_merge=True,
             task_policy=task_policy,
         )
-        ws.task_kind = "feature_branch_pr"
+        ws.task_kind = task_kind
         await repo.transition(ws, to=WorkspaceStatus.provisioning, reason_code="SEED")
-        ws.branch_name = "awf/x"
-        ws.remote_push_branch = "awf/x"
+        ws.branch_name = (
+            f"feature-sync/{ws.id}" if task_kind == "sync_feature_pr" else f"awf/{ws.id}"
+        )
+        ws.remote_push_branch = ws.branch_name
         ws.base_commit = "a" * 40
         ws.compose_project_name = compose_project_name
         ws.compose_file_path = compose_file_path
@@ -173,6 +177,7 @@ def _make_executor(
     compose: Any,
     pr_monitor_factory: Any,
     agent_runtime_executor: Any = None,
+    ensure_hosted_monitor_checkout: Any = None,
 ) -> WorkspaceExecutor:
     validation = ValidationRunner(runner=fake, artifacts_dir=tmp_path / "artifacts")
     pr = PullRequestCreator(fake)
@@ -194,6 +199,7 @@ def _make_executor(
         ),
         pr_monitor_factory=pr_monitor_factory,
         agent_runtime_executor=agent_runtime_executor,
+        ensure_hosted_monitor_checkout=ensure_hosted_monitor_checkout,
     )
 
 
@@ -328,6 +334,272 @@ class TestResumeHandoffHostedSeam:
         # Local path still restarts compose exactly once.
         assert compose.ensure_project_up_calls == [ws_id]
         assert len(monitor.run_calls) == 1
+
+
+class TestResumeHandoffHostedCheckoutRestore:
+    @pytest.mark.unit
+    async def test_pod_restart_restores_checkout_before_monitor_at_pull_head(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        worktree = tmp_path / "work" / "worktrees" / ws_id
+        assert not worktree.exists()
+
+        order: list[str] = []
+        restore_calls: list[str] = []
+
+        async def _restore(workspace_id: str) -> None:
+            restore_calls.append(workspace_id)
+            order.append("restore")
+            worktree.mkdir(parents=True)
+            (worktree / ".git").write_text("gitdir: /tmp/fake\n", encoding="utf-8")
+
+        class _OrderedMonitor(_RecordingMonitor):
+            async def run(self, **kwargs: Any) -> None:
+                order.append("monitor_run")
+                await super().run(**kwargs)
+
+        compose = _RecordingCompose()
+        monitor = _OrderedMonitor()
+        factory_calls: list[str] = []
+
+        def _factory(*_args: Any, **_kwargs: Any) -> _OrderedMonitor:
+            factory_calls.append("factory")
+            order.append("factory")
+            return monitor
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=_factory,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = compose  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert restore_calls == [ws_id]
+        assert compose.ensure_project_up_calls == []
+        assert order[0] == "restore"
+        assert "factory" in order
+        assert order.index("restore") < order.index("factory")
+        assert order.index("restore") < order.index("monitor_run")
+        assert len(monitor.run_calls) == 1
+
+    @pytest.mark.unit
+    async def test_idempotent_restore_skips_when_worktree_valid(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from awf.node import provisioner as provisioner_module
+        from awf.node.git_manager import GitManager, WorktreeLayout
+        from awf.node.provisioner import Provisioner, ProvisionerConfig
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        worktree = tmp_path / "work" / "worktrees" / ws_id
+        worktree.mkdir(parents=True)
+        (worktree / ".git").write_text("gitdir: /tmp/fake\n", encoding="utf-8")
+
+        git = GitManager(tmp_path / "work" / "git")
+        add_calls: list[str] = []
+
+        async def _add_worktree(**kwargs: Any) -> WorktreeLayout:
+            add_calls.append(str(kwargs.get("workspace_id")))
+            raise AssertionError("add_worktree must not run for a valid checkout")
+
+        monkeypatch.setattr(git, "add_worktree", _add_worktree)
+        provisioner = Provisioner(
+            session_factory=factory,
+            git=git,
+            config=ProvisionerConfig(node_id="node-a", branch_prefix="awf"),
+        )
+        # Point GitManager worktrees at the executor worktrees root layout.
+        git._worktrees_dir = tmp_path / "work" / "worktrees"  # noqa: SLF001
+
+        compose = _RecordingCompose()
+        monitor = _RecordingMonitor()
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=provisioner.ensure_hosted_monitor_worktree,
+        )
+        executor_obj._compose = compose  # type: ignore[method-assign]
+
+        # ensure_worktree path uses git._worktrees_dir; provisioner helper uses
+        # _provision_checkout_base_branch — spy that tip for pull-head coverage.
+        tips: list[str] = []
+        real_checkout_base = provisioner_module._provision_checkout_base_branch
+
+        def _spy_checkout_base(ws: Any) -> str:
+            tip = real_checkout_base(ws)
+            tips.append(tip)
+            return tip
+
+        monkeypatch.setattr(
+            provisioner_module, "_provision_checkout_base_branch", _spy_checkout_base
+        )
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert add_calls == []
+        assert tips == ["refs/pull/42/head"]
+        assert compose.ensure_project_up_calls == []
+        assert len(monitor.run_calls) == 1
+
+    @pytest.mark.unit
+    async def test_fail_closed_when_checkout_restore_impossible(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        from awf.db.repositories import WorkspaceEventRepository
+        from awf.node.git_manager import GitOperationError
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        monitor = _RecordingMonitor()
+
+        async def _restore(_workspace_id: str) -> None:
+            raise GitOperationError(
+                operation="hosted_monitor.ensure_worktree",
+                returncode=1,
+                stdout="",
+                stderr="missing adoption tip",
+                reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+            )
+
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert monitor.run_calls == []
+        async with factory() as s:
+            ws = await WorkspaceRepository(s).get(ws_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.failed.value
+            events = await WorkspaceEventRepository(s).list(workspace_id=ws_id)
+            assert any(
+                event.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED" for event in events
+            )
+
+    @pytest.mark.unit
+    async def test_resume_reuses_pending_monitor_comment_operation(
+        self,
+        fake: FakeCommandRunner,
+        factory: async_sessionmaker[AsyncSession],
+        tmp_path: Path,
+    ) -> None:
+        from awf.db.enums import OperationStatus, OperationType
+        from awf.db.repositories import OperationRepository
+        from awf.runtime.pr_monitor_operations import (
+            create_or_start_monitor_operation,
+            monitor_operation_idempotency_key,
+        )
+
+        ws_id = await _seed_monitoring_pr(
+            factory,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            compose_project_name=None,
+            compose_file_path=None,
+            task_kind="sync_feature_pr",
+        )
+        idempotency_key = monitor_operation_idempotency_key(
+            workspace_id=ws_id,
+            action="address_comments",
+            pr_number=42,
+            reason_code="ADDRESS_COMMENTS",
+            source_head_sha="b" * 40,
+            source_base_sha="a" * 40,
+        )
+        async with factory() as s:
+            handle = await create_or_start_monitor_operation(
+                s,
+                workspace_id=ws_id,
+                operation_type=OperationType.comment_repair,
+                payload={"owner": "pr_monitor", "action": "address_comments"},
+                idempotency_key=idempotency_key,
+                status=OperationStatus.pending,
+            )
+            await s.commit()
+            original_id = handle.operation_id
+
+        async def _restore(workspace_id: str) -> None:
+            path = tmp_path / "work" / "worktrees" / workspace_id
+            path.mkdir(parents=True, exist_ok=True)
+            (path / ".git").write_text("gitdir: /tmp/fake\n", encoding="utf-8")
+
+        monitor = _RecordingMonitor()
+        real_compose = ComposeManager(work_dir=tmp_path / "work", template_path=_TEMPLATE)
+        executor_obj = _make_executor(
+            fake=fake,
+            factory=factory,
+            tmp_path=tmp_path,
+            compose=real_compose,
+            pr_monitor_factory=lambda *_a, **_k: monitor,
+            agent_runtime_executor=_RecordingExecutor(),
+            ensure_hosted_monitor_checkout=_restore,
+        )
+        executor_obj._compose = _RecordingCompose()  # type: ignore[method-assign]
+
+        await executor_obj.resume_pr_monitor(ws_id)
+
+        assert len(monitor.run_calls) == 1
+        async with factory() as s:
+            reused = await create_or_start_monitor_operation(
+                s,
+                workspace_id=ws_id,
+                operation_type=OperationType.comment_repair,
+                payload={"owner": "pr_monitor", "action": "address_comments"},
+                idempotency_key=idempotency_key,
+                status=OperationStatus.running,
+            )
+            ops = await OperationRepository(s).list_for_workspace(ws_id)
+            matching = [op for op in ops if op.idempotency_key == idempotency_key]
+            assert len(matching) == 1
+            assert reused.operation_id == original_id
 
 
 @pytest.mark.unit

--- a/tests/unit/control/test_worker_parts/test_worker_part_057.py
+++ b/tests/unit/control/test_worker_parts/test_worker_part_057.py
@@ -21,6 +21,7 @@ from tests.unit.control.test_worker_parts.test_worker_part_016 import (
     HOSTED_MONITOR_HANDOFF_SETUP_COMPLETED_EVENT_TYPE,
     HOSTED_MONITOR_HANDOFF_SETUP_COMPLETED_REASON_CODE,
     _create_active_execution,
+    _create_monitoring_pr,
     _create_ready,
     _create_requested,
     _RecordingExecutor,
@@ -1097,3 +1098,181 @@ class TestRunOnceStaleActiveExecutionRecoveryPart002HostedAdoption:
         assert salvage_events[0].payload["previous_claim"]["monitor_claimed_by"] == (
             "hosted-monitor-before-restart"
         )
+
+    @pytest.mark.unit
+    async def test_hosted_monitoring_pr_with_null_compose_is_not_stranded(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        task_policy = {"pr_adoption": {"execution": {"mode": "hosted"}}}
+        workspace_id = await _create_monitoring_pr(
+            session_factory,
+            origin_repo,
+            "hosted-monitoring-pr-null-compose",
+            task_policy=task_policy,
+            pr_number=901,
+        )
+        async with session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            ws.compose_project_name = None
+            ws.compose_file_path = None
+            ws.node_id = "node-a"
+            ws.monitor_claimed_by = "hosted-monitor-before-restart"
+            ws.monitor_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        inspector = _RecordingRuntimeInspector(
+            {
+                None: RuntimeSnapshot(
+                    stack_state="stopped",
+                    reason="compose project has no running containers",
+                    services=[],
+                )
+            }
+        )
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=_RecordingExecutor(),
+            runtime_inspector=inspector,
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=0,
+                node_id="node-a",
+            ),
+        )
+
+        await worker._recover_stale_active_execution(  # noqa: SLF001
+            _ActiveExecutionCandidate(
+                workspace_id=workspace_id,
+                status=WorkspaceStatus.monitoring_pr,
+                repo_url=str(origin_repo),
+                compose_project_name=None,
+                compose_file_path=None,
+                pr_url="https://github.com/example/repo/pull/901",
+                task_policy=task_policy,
+            )
+        )
+
+        assert inspector.calls == []
+        async with session_factory() as session:
+            ws = await WorkspaceRepository(session).get(workspace_id)
+            assert ws is not None
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+            runtime_events = await WorkspaceEventRepository(session).list(
+                workspace_id=workspace_id,
+                event_type="workspace.runtime_stranded_detected",
+            )
+        assert runtime_events == []
+
+    @pytest.mark.unit
+    async def test_hosted_monitoring_pr_live_claim_is_not_stolen(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        task_policy = {"pr_adoption": {"execution": {"mode": "hosted"}}}
+        workspace_id = await _create_monitoring_pr(
+            session_factory,
+            origin_repo,
+            "hosted-monitoring-pr-live-claim",
+            task_policy=task_policy,
+            pr_number=902,
+        )
+        live_owner = "live-monitor-owner"
+        async with session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            ws.compose_project_name = None
+            ws.compose_file_path = None
+            ws.node_id = "node-a"
+            ws.monitor_claimed_by = live_owner
+            ws.monitor_claim_expires_at = datetime.now(UTC) + timedelta(hours=1)
+            await session.commit()
+
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=_RecordingRuntimeInspector({}),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=2,
+                node_id="node-a",
+            ),
+        )
+
+        await worker._recover_stale_active_execution(  # noqa: SLF001
+            _ActiveExecutionCandidate(
+                workspace_id=workspace_id,
+                status=WorkspaceStatus.monitoring_pr,
+                repo_url=str(origin_repo),
+                compose_project_name=None,
+                compose_file_path=None,
+                pr_url="https://github.com/example/repo/pull/902",
+                task_policy=task_policy,
+            )
+        )
+        await worker.run_once()
+
+        async with session_factory() as session:
+            ws = await WorkspaceRepository(session).get(workspace_id)
+            assert ws is not None
+            assert ws.monitor_claimed_by == live_owner
+            assert ws.status == WorkspaceStatus.monitoring_pr.value
+        assert executor.resume_calls == []
+
+    @pytest.mark.unit
+    async def test_hosted_monitoring_pr_stale_claim_takeover_resumes_once(
+        self,
+        session_factory: async_sessionmaker[AsyncSession],
+        origin_repo: Path,
+    ) -> None:
+        task_policy = {"pr_adoption": {"execution": {"mode": "hosted"}}}
+        workspace_id = await _create_monitoring_pr(
+            session_factory,
+            origin_repo,
+            "hosted-monitoring-pr-stale-takeover",
+            task_policy=task_policy,
+            pr_number=903,
+        )
+        async with session_factory() as session:
+            repo = WorkspaceRepository(session)
+            ws = await repo.get(workspace_id)
+            assert ws is not None
+            ws.compose_project_name = None
+            ws.compose_file_path = None
+            ws.node_id = "node-a"
+            ws.monitor_claimed_by = "stale-monitor-owner"
+            ws.monitor_claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            await session.commit()
+
+        executor = _RecordingExecutor()
+        worker = ControlWorker(
+            session_factory=session_factory,
+            provisioner=_TransitioningProvisioner(session_factory),  # type: ignore[arg-type]
+            executor=executor,
+            runtime_inspector=_RecordingRuntimeInspector(
+                {
+                    None: RuntimeSnapshot(
+                        stack_state="stopped",
+                        reason="no compose",
+                        services=[],
+                    )
+                }
+            ),
+            config=WorkerConfig(
+                poll_interval_seconds=0.01,
+                max_concurrent_executions=2,
+                node_id="node-a",
+            ),
+        )
+
+        await worker.run_once()
+
+        assert executor.resume_calls == [workspace_id]

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -1312,3 +1312,85 @@ async def test_git_manager_run_terminates_subprocess_on_cancellation(
     finally:
         if _pid_exists(pid):
             os.kill(pid, signal.SIGKILL)
+
+
+class TestEnsureWorktree:
+    """Idempotent worktree restore used by hosted monitor restart recovery."""
+
+    @pytest.mark.unit
+    async def test_ensure_worktree_no_op_when_checkout_valid(
+        self, manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        layout = await manager.add_worktree(
+            workspace_id="ws_ensure_valid",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_valid",
+        )
+        add_calls: list[str] = []
+
+        async def _add(**kwargs: object) -> object:
+            add_calls.append("add")
+            raise AssertionError("add_worktree must not run")
+
+        monkeypatch.setattr(manager, "add_worktree", _add)
+        again = await manager.ensure_worktree(
+            workspace_id="ws_ensure_valid",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_valid",
+        )
+        assert again.worktree_path == layout.worktree_path
+        assert add_calls == []
+
+    @pytest.mark.unit
+    async def test_ensure_worktree_recreates_missing_checkout(
+        self, manager: GitManager, origin_repo: Path
+    ) -> None:
+        layout = await manager.add_worktree(
+            workspace_id="ws_ensure_missing",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_missing",
+        )
+        import shutil
+
+        shutil.rmtree(layout.worktree_path)
+        assert not layout.worktree_path.exists()
+
+        restored = await manager.ensure_worktree(
+            workspace_id="ws_ensure_missing",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_missing",
+        )
+        assert restored.worktree_path.is_dir()
+        assert (restored.worktree_path / ".git").exists()
+        sha = await manager.head_sha(workspace_id="ws_ensure_missing")
+        assert len(sha) == 40
+
+    @pytest.mark.unit
+    async def test_ensure_worktree_prunes_stale_metadata_then_recreates(
+        self, manager: GitManager, origin_repo: Path
+    ) -> None:
+        layout = await manager.add_worktree(
+            workspace_id="ws_ensure_stale",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_stale",
+        )
+        import shutil
+
+        # Delete the directory but leave mirror worktree admin metadata.
+        shutil.rmtree(layout.worktree_path)
+        linked = layout.mirror_path / "worktrees" / "ws_ensure_stale"
+        assert linked.exists() or True  # may already be pruned by git; recreate still works
+
+        restored = await manager.ensure_worktree(
+            workspace_id="ws_ensure_stale",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_stale",
+        )
+        assert restored.worktree_path.is_dir()
+        assert (restored.worktree_path / ".git").exists()

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -847,43 +847,37 @@ class TestRemoveWorktree:
         assert not worktree_path.exists()
 
     @pytest.mark.unit
-    async def test_standalone_git_dir_worktree_validation_failure_is_reclaimed(
+    async def test_standalone_git_dir_at_managed_path_is_not_reclaimed(
         self, manager: GitManager, origin_repo: Path
     ) -> None:
-        """Standalone ``.git`` directory at managed path is reclaimed, not fatal."""
+        """Standalone ``.git`` directory must fail closed, not be erased.
+
+        A plain clone at a managed path is not proven AWF-linked leftover metadata;
+        reclaiming it would destroy unrelated commits or uncommitted work.
+        """
         await manager.ensure_mirror(str(origin_repo))
         worktree_path = manager._worktrees_dir / "ws_standalone_gitdir"
         worktree_path.mkdir(parents=True)
         (worktree_path / ".git").mkdir()
         (worktree_path / "leftover.txt").write_text("orphan\n")
 
-        pruned: list[str] = []
+        async def _unexpected_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+            raise AssertionError(
+                f"git must not run when refusing a standalone repo; got {operation}"
+            )
 
-        async def _stale_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
-            if operation == "worktree.remove":
-                raise GitOperationError(
-                    operation=operation,
-                    returncode=128,
-                    stdout="",
-                    stderr=(
-                        "fatal: validation failed, cannot remove working tree: "
-                        f"'{worktree_path}/.git' is not a .git file, error code 2"
-                    ),
-                )
-            if operation == "worktree.prune":
-                pruned.append(operation)
-                return subprocess.CompletedProcess(args, 0, "", "")
-            raise AssertionError(f"unexpected operation {operation}")
+        manager._run = _unexpected_run  # type: ignore[method-assign]
 
-        manager._run = _stale_run  # type: ignore[method-assign]
+        with pytest.raises(GitOperationError) as excinfo:
+            await manager.remove_worktree(
+                workspace_id="ws_standalone_gitdir",
+                repo_url=str(origin_repo),
+            )
 
-        await manager.remove_worktree(
-            workspace_id="ws_standalone_gitdir",
-            repo_url=str(origin_repo),
-        )
-
-        assert pruned == ["worktree.prune"]
-        assert not worktree_path.exists()
+        assert excinfo.value.reason_code == "GIT_WORKTREE_STANDALONE_REPO"
+        assert worktree_path.exists()
+        assert (worktree_path / ".git").is_dir()
+        assert (worktree_path / "leftover.txt").read_text() == "orphan\n"
 
     @pytest.mark.unit
     async def test_stale_dir_reclaim_failure_propagates(

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -15,7 +15,6 @@ import stat
 import subprocess
 import sys
 import threading
-from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -41,41 +40,6 @@ def _git(args: list[str], cwd: Path) -> None:
         check=True,
         capture_output=True,
     )
-
-
-def _init_bare_mirror(path: Path) -> None:
-    """Test helper for init bare mirror."""
-    path.mkdir(parents=True)
-    (path / "worktrees").mkdir()
-
-
-@pytest.fixture
-def synthetic_bare_mirror(
-    monkeypatch: pytest.MonkeyPatch,
-) -> Callable[[Path], None]:
-    """Synthetic bare mirror."""
-    bare_mirrors: set[Path] = set()
-
-    def _init(path: Path) -> None:
-        """Test helper for init."""
-        _init_bare_mirror(path)
-        bare_mirrors.add(path.resolve())
-
-    def _is_bare(mirror_path: Path) -> bool:
-        return mirror_path.resolve() in bare_mirrors
-
-    # Live callers resolve the helper in git_manager_linked; keep the
-    # git_manager re-export aligned for direct unit assertions.
-    monkeypatch.setattr(
-        "awf.node.git_manager_linked._is_bare_registered_mirror_candidate",
-        _is_bare,
-    )
-    monkeypatch.setattr(
-        git_manager,
-        "_is_bare_registered_mirror_candidate",
-        _is_bare,
-    )
-    return _init
 
 
 @pytest.fixture

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -847,6 +847,55 @@ class TestRemoveWorktree:
         assert not worktree_path.exists()
 
     @pytest.mark.unit
+    async def test_corrupt_gitfile_worktree_validation_failure_is_reclaimed(
+        self, manager: GitManager, origin_repo: Path
+    ) -> None:
+        """Verify corrupt gitfile (missing linked HEAD) validation is reclaimed.
+
+        When the checkout ``.git`` gitfile exists but linked admin metadata is
+        unusable, ``git worktree remove`` reports ``.git`` is not a .git file
+        (error code 7). Ensure reclaim + prune still succeed so
+        ``ensure_worktree`` can recreate.
+        """
+        await manager.ensure_mirror(str(origin_repo))
+        worktree_path = manager._worktrees_dir / "ws_corrupt_gitfile"
+        worktree_path.mkdir(parents=True)
+        (worktree_path / ".git").write_text(
+            "gitdir: /nonexistent/mirror/worktrees/ws_corrupt_gitfile\n",
+            encoding="utf-8",
+        )
+        (worktree_path / "leftover.txt").write_text("stale\n")
+
+        pruned: list[str] = []
+
+        async def _stale_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+            """Test helper for corrupt-gitfile remove."""
+            if operation == "worktree.remove":
+                raise GitOperationError(
+                    operation=operation,
+                    returncode=128,
+                    stdout="",
+                    stderr=(
+                        "fatal: validation failed, cannot remove working tree: "
+                        f"'{worktree_path}/.git' is not a .git file, error code 7"
+                    ),
+                )
+            if operation == "worktree.prune":
+                pruned.append(operation)
+                return subprocess.CompletedProcess(args, 0, "", "")
+            raise AssertionError(f"unexpected operation {operation}")
+
+        manager._run = _stale_run  # type: ignore[method-assign]
+
+        await manager.remove_worktree(
+            workspace_id="ws_corrupt_gitfile",
+            repo_url=str(origin_repo),
+        )
+
+        assert pruned == ["worktree.prune"]
+        assert not worktree_path.exists()
+
+    @pytest.mark.unit
     async def test_standalone_git_dir_at_managed_path_is_not_reclaimed(
         self, manager: GitManager, origin_repo: Path
     ) -> None:

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -874,6 +874,45 @@ class TestRemoveWorktree:
         assert not worktree_path.exists()
 
     @pytest.mark.unit
+    async def test_standalone_git_dir_worktree_validation_failure_is_reclaimed(
+        self, manager: GitManager, origin_repo: Path
+    ) -> None:
+        """Standalone ``.git`` directory at managed path is reclaimed, not fatal."""
+        await manager.ensure_mirror(str(origin_repo))
+        worktree_path = manager._worktrees_dir / "ws_standalone_gitdir"
+        worktree_path.mkdir(parents=True)
+        (worktree_path / ".git").mkdir()
+        (worktree_path / "leftover.txt").write_text("orphan\n")
+
+        pruned: list[str] = []
+
+        async def _stale_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+            if operation == "worktree.remove":
+                raise GitOperationError(
+                    operation=operation,
+                    returncode=128,
+                    stdout="",
+                    stderr=(
+                        "fatal: validation failed, cannot remove working tree: "
+                        f"'{worktree_path}/.git' is not a .git file, error code 2"
+                    ),
+                )
+            if operation == "worktree.prune":
+                pruned.append(operation)
+                return subprocess.CompletedProcess(args, 0, "", "")
+            raise AssertionError(f"unexpected operation {operation}")
+
+        manager._run = _stale_run  # type: ignore[method-assign]
+
+        await manager.remove_worktree(
+            workspace_id="ws_standalone_gitdir",
+            repo_url=str(origin_repo),
+        )
+
+        assert pruned == ["worktree.prune"]
+        assert not worktree_path.exists()
+
+    @pytest.mark.unit
     async def test_stale_dir_reclaim_failure_propagates(
         self, manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -61,10 +61,19 @@ def synthetic_bare_mirror(
         _init_bare_mirror(path)
         bare_mirrors.add(path.resolve())
 
+    def _is_bare(mirror_path: Path) -> bool:
+        return mirror_path.resolve() in bare_mirrors
+
+    # Live callers resolve the helper in git_manager_linked; keep the
+    # git_manager re-export aligned for direct unit assertions.
+    monkeypatch.setattr(
+        "awf.node.git_manager_linked._is_bare_registered_mirror_candidate",
+        _is_bare,
+    )
     monkeypatch.setattr(
         git_manager,
         "_is_bare_registered_mirror_candidate",
-        lambda mirror_path: mirror_path.resolve() in bare_mirrors,
+        _is_bare,
     )
     return _init
 

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -1394,3 +1394,65 @@ class TestEnsureWorktree:
         )
         assert restored.worktree_path.is_dir()
         assert (restored.worktree_path / ".git").exists()
+
+    @pytest.mark.unit
+    async def test_ensure_worktree_fences_concurrent_recreate(
+        self, manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Stale + takeover restore must not interleave remove/delete/add phases."""
+        layout = await manager.add_worktree(
+            workspace_id="ws_ensure_fence",
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch="awf/ws_ensure_fence",
+        )
+        import shutil
+
+        shutil.rmtree(layout.worktree_path)
+
+        original_delete = manager._delete_local_branch_best_effort
+        entered_delete = asyncio.Event()
+        release_delete = asyncio.Event()
+        delete_calls = 0
+
+        async def _gated_delete(**kwargs: object) -> None:
+            nonlocal delete_calls
+            delete_calls += 1
+            if delete_calls == 1:
+                entered_delete.set()
+                await release_delete.wait()
+            await original_delete(**kwargs)
+
+        monkeypatch.setattr(manager, "_delete_local_branch_best_effort", _gated_delete)
+
+        task_a = asyncio.create_task(
+            manager.ensure_worktree(
+                workspace_id="ws_ensure_fence",
+                repo_url=str(origin_repo),
+                base_branch="development",
+                new_branch="awf/ws_ensure_fence",
+            )
+        )
+        await asyncio.wait_for(entered_delete.wait(), timeout=5)
+
+        task_b = asyncio.create_task(
+            manager.ensure_worktree(
+                workspace_id="ws_ensure_fence",
+                repo_url=str(origin_repo),
+                base_branch="development",
+                new_branch="awf/ws_ensure_fence",
+            )
+        )
+        # Without a continuous fence, B can recreate while A is paused between
+        # remove and add; A then deletes B's branch/checkout on resume.
+        await asyncio.sleep(0.1)
+        assert not task_b.done(), "takeover restore raced ahead of fenced recreate"
+
+        release_delete.set()
+        layouts = await asyncio.gather(task_a, task_b)
+        assert layouts[0].worktree_path == layout.worktree_path
+        assert layouts[1].worktree_path == layout.worktree_path
+        assert layout.worktree_path.is_dir()
+        assert (layout.worktree_path / ".git").exists()
+        sha = await manager.head_sha(workspace_id="ws_ensure_fence")
+        assert len(sha) == 40

--- a/tests/unit/node/test_git_manager.py
+++ b/tests/unit/node/test_git_manager.py
@@ -847,55 +847,6 @@ class TestRemoveWorktree:
         assert not worktree_path.exists()
 
     @pytest.mark.unit
-    async def test_corrupt_gitfile_worktree_validation_failure_is_reclaimed(
-        self, manager: GitManager, origin_repo: Path
-    ) -> None:
-        """Verify corrupt gitfile (missing linked HEAD) validation is reclaimed.
-
-        When the checkout ``.git`` gitfile exists but linked admin metadata is
-        unusable, ``git worktree remove`` reports ``.git`` is not a .git file
-        (error code 7). Ensure reclaim + prune still succeed so
-        ``ensure_worktree`` can recreate.
-        """
-        await manager.ensure_mirror(str(origin_repo))
-        worktree_path = manager._worktrees_dir / "ws_corrupt_gitfile"
-        worktree_path.mkdir(parents=True)
-        (worktree_path / ".git").write_text(
-            "gitdir: /nonexistent/mirror/worktrees/ws_corrupt_gitfile\n",
-            encoding="utf-8",
-        )
-        (worktree_path / "leftover.txt").write_text("stale\n")
-
-        pruned: list[str] = []
-
-        async def _stale_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
-            """Test helper for corrupt-gitfile remove."""
-            if operation == "worktree.remove":
-                raise GitOperationError(
-                    operation=operation,
-                    returncode=128,
-                    stdout="",
-                    stderr=(
-                        "fatal: validation failed, cannot remove working tree: "
-                        f"'{worktree_path}/.git' is not a .git file, error code 7"
-                    ),
-                )
-            if operation == "worktree.prune":
-                pruned.append(operation)
-                return subprocess.CompletedProcess(args, 0, "", "")
-            raise AssertionError(f"unexpected operation {operation}")
-
-        manager._run = _stale_run  # type: ignore[method-assign]
-
-        await manager.remove_worktree(
-            workspace_id="ws_corrupt_gitfile",
-            repo_url=str(origin_repo),
-        )
-
-        assert pruned == ["worktree.prune"]
-        assert not worktree_path.exists()
-
-    @pytest.mark.unit
     async def test_standalone_git_dir_at_managed_path_is_not_reclaimed(
         self, manager: GitManager, origin_repo: Path
     ) -> None:

--- a/tests/unit/node/test_git_manager_chown_mirror_registry.py
+++ b/tests/unit/node/test_git_manager_chown_mirror_registry.py
@@ -1015,3 +1015,45 @@ def test_mirror_path_for_registered_worktree_skips_older_duplicate_after_newer(
     os.utime(older_linked, ns=(1, 1))
 
     assert git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir) == newer.resolve()
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_skips_mirrors_without_linked_admin_dir(
+    tmp_path: Path,
+    synthetic_bare_mirror: Callable[[Path], None],
+) -> None:
+    """Bare mirrors lacking ``worktrees/<id>`` are skipped, not scan failures."""
+    mirrors_dir = tmp_path / "mirrors"
+    worktree = tmp_path / "worktrees" / "ws"
+    worktree.mkdir(parents=True)
+    empty_mirror = mirrors_dir / "empty.git"
+    matching = mirrors_dir / "matching.git"
+    synthetic_bare_mirror(empty_mirror)
+    synthetic_bare_mirror(matching)
+    linked = matching / "worktrees" / "ws"
+    linked.mkdir(parents=True)
+    (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+
+    assert (
+        git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir) == matching.resolve()
+    )
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_skips_mismatched_gitdir_backref(
+    tmp_path: Path,
+    synthetic_bare_mirror: Callable[[Path], None],
+) -> None:
+    """Linked admin dirs that point at a different checkout are not matches."""
+    mirrors_dir = tmp_path / "mirrors"
+    worktree = tmp_path / "worktrees" / "ws"
+    other = tmp_path / "worktrees" / "other"
+    worktree.mkdir(parents=True)
+    other.mkdir(parents=True)
+    mirror = mirrors_dir / "repo.git"
+    synthetic_bare_mirror(mirror)
+    linked = mirror / "worktrees" / "ws"
+    linked.mkdir(parents=True)
+    (linked / "gitdir").write_text(f"{other / '.git'}\n", encoding="utf-8")
+
+    assert git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir) is None

--- a/tests/unit/node/test_git_manager_chown_mirror_registry.py
+++ b/tests/unit/node/test_git_manager_chown_mirror_registry.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import pytest
 
 import awf.node.git_manager as git_manager
+import awf.node.git_manager_linked as git_manager_linked
 from awf.node.git_manager import (
     GitOperationError,
 )
@@ -37,10 +38,21 @@ def synthetic_bare_mirror(
         _init_bare_mirror(path)
         bare_mirrors.add(path.resolve())
 
+    def _is_bare(mirror_path: Path) -> bool:
+        return mirror_path.resolve() in bare_mirrors
+
+    # ``mirror_path_for_registered_worktree`` lives in git_manager_linked and
+    # resolves ``_is_bare_registered_mirror_candidate`` there; patching only the
+    # git_manager re-export leaves the live call path on the real probe.
+    monkeypatch.setattr(
+        git_manager_linked,
+        "_is_bare_registered_mirror_candidate",
+        _is_bare,
+    )
     monkeypatch.setattr(
         git_manager,
         "_is_bare_registered_mirror_candidate",
-        lambda mirror_path: mirror_path.resolve() in bare_mirrors,
+        _is_bare,
     )
     return _init
 
@@ -623,7 +635,7 @@ def test_bare_registered_mirror_candidate_returns_false_on_probe_timeout(
         """Test helper for timeout."""
         raise subprocess.TimeoutExpired(cmd=["git"], timeout=5)
 
-    monkeypatch.setattr(git_manager.subprocess, "run", _timeout)
+    monkeypatch.setattr(git_manager_linked.subprocess, "run", _timeout)
 
     assert git_manager._is_bare_registered_mirror_candidate(mirror_path) is False
 

--- a/tests/unit/node/test_git_manager_chown_mirror_registry.py
+++ b/tests/unit/node/test_git_manager_chown_mirror_registry.py
@@ -812,3 +812,206 @@ def test_hooks_path_config_helpers_normalize_git_config_edges(tmp_path: Path) ->
             config_path.parent / relative_include
         ).resolve()
     )
+
+
+@pytest.mark.unit
+def test_is_stale_linked_worktree_metadata_error_rejects_non_git_errors() -> None:
+    """Only GitOperationError instances can qualify as stale linked metadata."""
+    assert git_manager._is_stale_linked_worktree_metadata_error(RuntimeError("nope")) is False
+    assert git_manager._is_stale_linked_worktree_metadata_error(ValueError("nope")) is False
+
+
+@pytest.mark.unit
+def test_is_stale_linked_worktree_metadata_error_matches_backref_read_failure() -> None:
+    """Stale reclaim only when hooks probe reports unread linked gitdir back-ref."""
+    stale = GitOperationError(
+        operation="worktree.hooks_path_probe",
+        returncode=1,
+        stdout="",
+        stderr="cannot read linked-worktree gitdir back-reference at /tmp/x",
+        reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+    )
+    assert git_manager._is_stale_linked_worktree_metadata_error(stale) is True
+
+    wrong_op = GitOperationError(
+        operation="worktree.checkout_probe",
+        returncode=1,
+        stdout="",
+        stderr="cannot read linked-worktree gitdir back-reference at /tmp/x",
+        reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+    )
+    assert git_manager._is_stale_linked_worktree_metadata_error(wrong_op) is False
+
+    wrong_stderr = GitOperationError(
+        operation="worktree.hooks_path_probe",
+        returncode=1,
+        stdout="",
+        stderr="cannot access linked-worktree gitdir back-reference at /tmp/x",
+        reason_code="MIRROR_HOOKS_PATH_REPAIR_FAILED",
+    )
+    assert git_manager._is_stale_linked_worktree_metadata_error(wrong_stderr) is False
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_returns_none_when_mirrors_dir_missing(
+    tmp_path: Path,
+) -> None:
+    """Missing mirrors root is a no-op registry miss, not a scan failure."""
+    worktree = tmp_path / "worktrees" / "ws"
+    worktree.mkdir(parents=True)
+    missing = tmp_path / "no-mirrors"
+    assert git_manager.mirror_path_for_registered_worktree(worktree, missing) is None
+
+
+@pytest.mark.unit
+def test_bare_registered_mirror_candidate_false_when_probe_not_bare(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-bare probe stdout must not be treated as a registered mirror."""
+    mirror_path = tmp_path / "repo.git"
+    mirror_path.mkdir()
+
+    def _not_bare(*_args: object, **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["git"], returncode=0, stdout="false\n", stderr="")
+
+    monkeypatch.setattr(git_manager_linked.subprocess, "run", _not_bare)
+    assert git_manager._is_bare_registered_mirror_candidate(mirror_path) is False
+
+
+@pytest.mark.unit
+def test_path_within_root_falls_back_when_resolve_raises_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Symlink-loop RuntimeError on resolve falls back to absolute() containment."""
+    root = tmp_path / "mirrors"
+    child = root / "repo.git"
+    root.mkdir()
+    child.mkdir()
+    original_resolve = Path.resolve
+
+    def _raise_runtime(path: Path, *args: object, **kwargs: object) -> Path:
+        if path in {root, child}:
+            raise RuntimeError("symlink loop")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _raise_runtime)
+    assert git_manager._path_within_root(child, root) == child.absolute()
+    outside = tmp_path / "outside.git"
+    outside.mkdir()
+    assert git_manager._path_within_root(outside, root) is None
+
+
+@pytest.mark.unit
+def test_bare_registered_mirror_candidate_raises_on_probe_os_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OSError launching the bare-repo probe fails the registry scan closed."""
+    mirror_path = tmp_path / "repo.git"
+    mirror_path.mkdir()
+
+    def _os_error(*_args: object, **_kwargs: object) -> None:
+        raise OSError("git binary missing")
+
+    monkeypatch.setattr(git_manager_linked.subprocess, "run", _os_error)
+    with pytest.raises(GitOperationError) as raised:
+        git_manager._is_bare_registered_mirror_candidate(mirror_path)
+    assert raised.value.operation == "mirror_registry_scan"
+    assert raised.value.reason_code == "MIRROR_REGISTRY_SCAN_FAILED"
+    assert "could not probe bare mirror" in raised.value.stderr
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_falls_back_on_resolve_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_bare_mirror: Callable[[Path], None],
+) -> None:
+    """RuntimeError resolving the worktree path falls back to absolute()."""
+    mirrors_dir = tmp_path / "mirrors"
+    worktree = tmp_path / "worktrees" / "ws"
+    worktree.mkdir(parents=True)
+    mirror = mirrors_dir / "repo.git"
+    synthetic_bare_mirror(mirror)
+    linked = mirror / "worktrees" / "ws"
+    linked.mkdir(parents=True)
+    (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    original_resolve = Path.resolve
+
+    def _raise_for_worktree(path: Path, *args: object, **kwargs: object) -> Path:
+        if path == worktree:
+            raise RuntimeError("symlink loop")
+        return original_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _raise_for_worktree)
+    assert (
+        git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir) == mirror.resolve()
+    )
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_mtime_oserror_treated_as_zero(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    synthetic_bare_mirror: Callable[[Path], None],
+) -> None:
+    """Unstatable linked admin dirs lose the newest-match race (mtime=0)."""
+    mirrors_dir = tmp_path / "mirrors"
+    worktree = tmp_path / "worktrees" / "ws"
+    worktree.mkdir(parents=True)
+    # Lexicographic order: a-unstatable first, then z-ok with a real mtime.
+    unstatable = mirrors_dir / "a-unstatable.git"
+    ok_mirror = mirrors_dir / "z-ok.git"
+    synthetic_bare_mirror(unstatable)
+    synthetic_bare_mirror(ok_mirror)
+    unstatable_linked = unstatable / "worktrees" / "ws"
+    ok_linked = ok_mirror / "worktrees" / "ws"
+    unstatable_linked.mkdir(parents=True)
+    ok_linked.mkdir(parents=True)
+    for linked in (unstatable_linked, ok_linked):
+        (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    os.utime(ok_linked, ns=(5, 5))
+
+    original_stat = Path.stat
+    unstatable_stat_calls = {"n": 0}
+
+    def _stat_fail(path: Path, *args: object, **kwargs: object) -> os.stat_result:
+        # ``is_dir()`` stats first; the mtime read is the second stat on this path.
+        if path == unstatable_linked:
+            unstatable_stat_calls["n"] += 1
+            if unstatable_stat_calls["n"] >= 2:
+                raise OSError("stat failed")
+        return original_stat(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "stat", _stat_fail)
+    assert (
+        git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir)
+        == ok_mirror.resolve()
+    )
+
+
+@pytest.mark.unit
+def test_mirror_path_for_registered_worktree_skips_older_duplicate_after_newer(
+    tmp_path: Path,
+    synthetic_bare_mirror: Callable[[Path], None],
+) -> None:
+    """When a newer match is already chosen, an older later match is ignored."""
+    mirrors_dir = tmp_path / "mirrors"
+    worktree = tmp_path / "worktrees" / "ws"
+    worktree.mkdir(parents=True)
+    newer = mirrors_dir / "a-newer.git"
+    older = mirrors_dir / "z-older.git"
+    synthetic_bare_mirror(newer)
+    synthetic_bare_mirror(older)
+    newer_linked = newer / "worktrees" / "ws"
+    older_linked = older / "worktrees" / "ws"
+    newer_linked.mkdir(parents=True)
+    older_linked.mkdir(parents=True)
+    for linked in (newer_linked, older_linked):
+        (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    os.utime(newer_linked, ns=(9, 9))
+    os.utime(older_linked, ns=(1, 1))
+
+    assert git_manager.mirror_path_for_registered_worktree(worktree, mirrors_dir) == newer.resolve()

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -1,0 +1,93 @@
+"""GitManager ensure_worktree linked-checkout usability regressions."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from awf.node.git_manager import GitManager, _worktree_checkout_is_usable
+
+
+def _git(args: list[str], cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+@pytest.fixture
+def origin_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "origin"
+    repo.mkdir()
+    _git(["init", "-q", "-b", "development"], repo)
+    _git(["config", "user.name", "AWF Test"], repo)
+    _git(["config", "user.email", "awf@test.local"], repo)
+    (repo / "README.md").write_text("first\n")
+    _git(["add", "."], repo)
+    _git(["commit", "-q", "-m", "init"], repo)
+    return repo
+
+
+@pytest.fixture
+def manager(tmp_path: Path) -> GitManager:
+    work_dir = tmp_path / "awf-work"
+    work_dir.mkdir()
+    return GitManager(work_dir)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_recreates_when_linked_git_dir_missing(
+    manager: GitManager, origin_repo: Path
+) -> None:
+    """Checkout dir survives but mirror-side admin dir is gone → reconstruct."""
+    import shutil
+
+    layout = await manager.add_worktree(
+        workspace_id="ws_ensure_dangling",
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch="awf/ws_ensure_dangling",
+    )
+    linked_git_dir = layout.mirror_path / "worktrees" / "ws_ensure_dangling"
+    assert linked_git_dir.is_dir()
+    assert _worktree_checkout_is_usable(layout.worktree_path)
+
+    shutil.rmtree(linked_git_dir)
+    assert layout.worktree_path.is_dir()
+    assert (layout.worktree_path / ".git").is_file()
+    assert not _worktree_checkout_is_usable(layout.worktree_path)
+
+    restored = await manager.ensure_worktree(
+        workspace_id="ws_ensure_dangling",
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch="awf/ws_ensure_dangling",
+    )
+    assert restored.worktree_path.is_dir()
+    assert _worktree_checkout_is_usable(restored.worktree_path)
+    sha = await manager.head_sha(workspace_id="ws_ensure_dangling")
+    assert len(sha) == 40
+
+
+@pytest.mark.unit
+def test_worktree_checkout_usable_requires_reciprocal_registration(tmp_path: Path) -> None:
+    worktree = tmp_path / "worktrees" / "ws_reciprocal"
+    linked = tmp_path / "mirrors" / "repo.git" / "worktrees" / "ws_reciprocal"
+    worktree.mkdir(parents=True)
+    linked.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {linked}\n", encoding="utf-8")
+    # Back-ref points at a different checkout → not usable.
+    other = tmp_path / "worktrees" / "other" / ".git"
+    other.parent.mkdir(parents=True)
+    (linked / "gitdir").write_text(f"{other}\n", encoding="utf-8")
+    assert not _worktree_checkout_is_usable(worktree)
+
+    (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    assert _worktree_checkout_is_usable(worktree)
+
+    (linked / "gitdir").unlink()
+    assert not _worktree_checkout_is_usable(worktree)

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -350,3 +350,216 @@ async def test_ensure_worktree_fails_closed_when_standalone_clone_occupies_path(
     assert excinfo.value.reason_code == "GIT_WORKTREE_STANDALONE_REPO"
     assert (layout.worktree_path / ".git").is_dir()
     assert (layout.worktree_path / "README.md").read_text() == "orphan clone\n"
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_accepts_concurrent_create_when_checkout_usable(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GIT_WORKTREE_ALREADY_EXISTS after a racing recreate is success when usable."""
+    import shutil
+
+    workspace_id = "ws_ensure_race_exists"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    shutil.rmtree(layout.worktree_path)
+    original_add = manager.add_worktree
+
+    async def _racing_add(**kwargs: object) -> object:
+        # Simulate another restorer finishing between our remove and add.
+        restored = await original_add(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+        assert _worktree_checkout_is_usable(restored.worktree_path)
+        raise GitOperationError(
+            operation="worktree.add",
+            returncode=128,
+            stdout="",
+            stderr=f"'{layout.worktree_path}' already exists",
+            reason_code="GIT_WORKTREE_ALREADY_EXISTS",
+        )
+
+    monkeypatch.setattr(manager, "add_worktree", _racing_add)
+    result = await manager.ensure_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert result.worktree_path == layout.worktree_path
+    assert _worktree_checkout_is_usable(result.worktree_path)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_retries_once_on_branch_name_collision(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Leftover branch collision on add deletes the branch and retries once."""
+    import shutil
+
+    from awf.node.git_manager import WorktreeLayout
+
+    workspace_id = "ws_ensure_branch_collision"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    shutil.rmtree(layout.worktree_path)
+
+    calls = {"add": 0}
+    original_add = manager.add_worktree
+    original_delete = manager._delete_local_branch_best_effort
+    deleted: list[str] = []
+
+    async def _colliding_add(**kwargs: object) -> WorktreeLayout:
+        calls["add"] += 1
+        if calls["add"] == 1:
+            raise GitOperationError(
+                operation="worktree.add",
+                returncode=128,
+                stdout="",
+                stderr=f"fatal: a branch named 'awf/{workspace_id}' already exists",
+                reason_code="GIT_WORKTREE_ADD_FAILED",
+            )
+        return await original_add(**kwargs)
+
+    async def _record_delete(*, mirror_path: Path, branch_name: str) -> None:
+        deleted.append(branch_name)
+        await original_delete(mirror_path=mirror_path, branch_name=branch_name)
+
+    monkeypatch.setattr(manager, "add_worktree", _colliding_add)
+    monkeypatch.setattr(manager, "_delete_local_branch_best_effort", _record_delete)
+
+    restored = await manager.ensure_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert calls["add"] == 2
+    # Pre-add cleanup plus the collision-retry delete.
+    assert deleted.count(f"awf/{workspace_id}") >= 2
+    assert restored.worktree_path.is_dir()
+    assert _worktree_checkout_is_usable(restored.worktree_path)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_reraises_already_exists_when_checkout_unusable(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GIT_WORKTREE_ALREADY_EXISTS without a usable checkout must not be treated as success."""
+    import shutil
+
+    workspace_id = "ws_ensure_exists_unusable"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    shutil.rmtree(layout.worktree_path)
+
+    async def _already_exists(**kwargs: object) -> object:
+        layout.worktree_path.mkdir(parents=True)
+        (layout.worktree_path / "stale.txt").write_text("not a worktree\n")
+        raise GitOperationError(
+            operation="worktree.add",
+            returncode=128,
+            stdout="",
+            stderr=f"'{layout.worktree_path}' already exists",
+            reason_code="GIT_WORKTREE_ALREADY_EXISTS",
+        )
+
+    monkeypatch.setattr(manager, "add_worktree", _already_exists)
+    with pytest.raises(GitOperationError) as raised:
+        await manager.ensure_worktree(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+    assert raised.value.reason_code == "GIT_WORKTREE_ALREADY_EXISTS"
+    assert not _worktree_checkout_is_usable(layout.worktree_path)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_reraises_unrelated_add_failure(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-race add failures must propagate unchanged from ensure_worktree."""
+    import shutil
+
+    workspace_id = "ws_ensure_add_fail"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    shutil.rmtree(layout.worktree_path)
+
+    async def _boom(**kwargs: object) -> object:
+        raise GitOperationError(
+            operation="worktree.add",
+            returncode=128,
+            stdout="",
+            stderr="fatal: remote tip vanished",
+            reason_code="GIT_FETCH_BASE_FAILED",
+        )
+
+    monkeypatch.setattr(manager, "add_worktree", _boom)
+    with pytest.raises(GitOperationError) as raised:
+        await manager.ensure_worktree(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+    assert raised.value.reason_code == "GIT_FETCH_BASE_FAILED"
+
+
+@pytest.mark.unit
+async def test_delete_local_branch_best_effort_noop_when_mirror_missing(
+    manager: GitManager, tmp_path: Path
+) -> None:
+    """Missing mirror directories are a no-op so recreate can ensure_mirror next."""
+    missing = tmp_path / "no-such-mirror.git"
+    await manager._delete_local_branch_best_effort(
+        mirror_path=missing,
+        branch_name="awf/ws_gone",
+    )
+    assert not missing.exists()
+
+
+@pytest.mark.unit
+async def test_delete_local_branch_best_effort_swallows_delete_errors(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Absent/checked-out branch delete errors are swallowed for best-effort cleanup."""
+    mirror = await manager.ensure_mirror(str(origin_repo))
+
+    async def _failing_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+        if operation == "mirror.branch_delete":
+            raise GitOperationError(
+                operation=operation,
+                returncode=1,
+                stdout="",
+                stderr="error: branch 'awf/ws_x' not found",
+                reason_code="GIT_BRANCH_DELETE_FAILED",
+            )
+        raise AssertionError(f"unexpected operation {operation}")
+
+    monkeypatch.setattr(manager, "_run", _failing_run)
+    await manager._delete_local_branch_best_effort(
+        mirror_path=mirror,
+        branch_name="awf/ws_x",
+    )

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -181,6 +181,54 @@ async def test_corrupt_gitfile_worktree_validation_failure_is_reclaimed(
 
 
 @pytest.mark.unit
+async def test_unreadable_gitfile_validation_failure_is_not_reclaimed(
+    manager: GitManager, origin_repo: Path
+) -> None:
+    """Unreadable ``.git`` (error code 3) must fail closed, not rmtree.
+
+    Git reports the same ``is not a .git file`` phrase for temporary permission
+    failures (error code 3) as for corrupt linked metadata (error code 7). Only
+    the latter is a proven stale-metadata reclaim case; reclaiming on code 3
+    would erase a live checkout and uncommitted repair.
+    """
+    await manager.ensure_mirror(str(origin_repo))
+    worktree_path = manager._worktrees_dir / "ws_unreadable_gitfile"
+    worktree_path.mkdir(parents=True)
+    (worktree_path / ".git").write_text(
+        "gitdir: /nonexistent/mirror/worktrees/ws_unreadable_gitfile\n",
+        encoding="utf-8",
+    )
+    (worktree_path / "repair.txt").write_text("do-not-delete\n")
+
+    async def _unreadable_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+        """Test helper for unreadable-gitfile remove."""
+        if operation == "worktree.remove":
+            raise GitOperationError(
+                operation=operation,
+                returncode=128,
+                stdout="",
+                stderr=(
+                    "fatal: validation failed, cannot remove working tree: "
+                    f"'{worktree_path}/.git' is not a .git file, error code 3"
+                ),
+            )
+        raise AssertionError(f"unexpected operation {operation}")
+
+    manager._run = _unreadable_run  # type: ignore[method-assign]
+
+    with pytest.raises(GitOperationError) as excinfo:
+        await manager.remove_worktree(
+            workspace_id="ws_unreadable_gitfile",
+            repo_url=str(origin_repo),
+        )
+
+    assert "error code 3" in excinfo.value.stderr
+    assert worktree_path.exists()
+    assert (worktree_path / "repair.txt").read_text() == "do-not-delete\n"
+    assert (worktree_path / ".git").is_file()
+
+
+@pytest.mark.unit
 def test_worktree_checkout_probe_indeterminate_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -91,3 +91,54 @@ def test_worktree_checkout_usable_requires_reciprocal_registration(tmp_path: Pat
 
     (linked / "gitdir").unlink()
     assert not _worktree_checkout_is_usable(worktree)
+
+
+@pytest.mark.unit
+def test_worktree_checkout_rejects_standalone_git_directory(tmp_path: Path) -> None:
+    """A normal clone (.git dir) must not count as a usable managed worktree."""
+    worktree = tmp_path / "worktrees" / "ws_standalone"
+    worktree.mkdir(parents=True)
+    (worktree / ".git").mkdir()
+    assert not _worktree_checkout_is_usable(worktree)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_recreates_when_standalone_clone_occupies_path(
+    manager: GitManager, origin_repo: Path
+) -> None:
+    """Incomplete restore replaced linked checkout with a plain clone → reconstruct."""
+    import shutil
+
+    workspace_id = "ws_ensure_standalone"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert _worktree_checkout_is_usable(layout.worktree_path)
+
+    # Simulate an incomplete external restore: wipe the linked checkout and leave
+    # an unrelated standalone clone at the managed path.
+    shutil.rmtree(layout.worktree_path)
+    layout.worktree_path.mkdir(parents=True)
+    _git(["init", "-q", "-b", "development"], layout.worktree_path)
+    _git(["config", "user.name", "AWF Test"], layout.worktree_path)
+    _git(["config", "user.email", "awf@test.local"], layout.worktree_path)
+    (layout.worktree_path / "README.md").write_text("orphan clone\n")
+    _git(["add", "."], layout.worktree_path)
+    _git(["commit", "-q", "-m", "orphan"], layout.worktree_path)
+    assert (layout.worktree_path / ".git").is_dir()
+    assert not _worktree_checkout_is_usable(layout.worktree_path)
+
+    restored = await manager.ensure_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert restored.worktree_path.is_dir()
+    assert (restored.worktree_path / ".git").is_file()
+    assert _worktree_checkout_is_usable(restored.worktree_path)
+    sha = await manager.head_sha(workspace_id=workspace_id)
+    assert len(sha) == 40

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -86,10 +86,75 @@ def test_worktree_checkout_usable_requires_reciprocal_registration(tmp_path: Pat
     (linked / "gitdir").write_text(f"{other}\n", encoding="utf-8")
     assert not _worktree_checkout_is_usable(worktree)
 
+    # Reciprocal registration alone is insufficient: without resolvable Git
+    # metadata (HEAD), the checkout must not take the ensure_worktree no-op.
     (linked / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
-    assert _worktree_checkout_is_usable(worktree)
+    assert not _worktree_checkout_is_usable(worktree)
 
     (linked / "gitdir").unlink()
+    assert not _worktree_checkout_is_usable(worktree)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_recreates_when_linked_head_missing(
+    manager: GitManager, origin_repo: Path
+) -> None:
+    """Admin dir + reciprocal gitdir survive but HEAD is gone → reconstruct."""
+    workspace_id = "ws_ensure_missing_head"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    linked_git_dir = layout.mirror_path / "worktrees" / workspace_id
+    head_path = linked_git_dir / "HEAD"
+    assert head_path.is_file()
+    assert _worktree_checkout_is_usable(layout.worktree_path)
+
+    head_path.unlink()
+    assert (layout.worktree_path / ".git").is_file()
+    assert linked_git_dir.is_dir()
+    assert (linked_git_dir / "gitdir").is_file()
+    assert not _worktree_checkout_is_usable(layout.worktree_path)
+
+    restored = await manager.ensure_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert restored.worktree_path.is_dir()
+    assert _worktree_checkout_is_usable(restored.worktree_path)
+    sha = await manager.head_sha(workspace_id=workspace_id)
+    assert len(sha) == 40
+
+
+@pytest.mark.unit
+def test_worktree_checkout_rejects_when_git_probe_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Timeout / OSError on the HEAD probe must not count as usable."""
+    import awf.node.git_manager_linked as linked
+
+    worktree = tmp_path / "worktrees" / "ws_probe_fail"
+    linked_dir = tmp_path / "mirrors" / "repo.git" / "worktrees" / "ws_probe_fail"
+    worktree.mkdir(parents=True)
+    linked_dir.mkdir(parents=True)
+    (worktree / ".git").write_text(f"gitdir: {linked_dir}\n", encoding="utf-8")
+    (linked_dir / "gitdir").write_text(f"{worktree / '.git'}\n", encoding="utf-8")
+    (linked_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    def _timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+    monkeypatch.setattr(linked.subprocess, "run", _timeout)
+    assert not _worktree_checkout_is_usable(worktree)
+
+    def _os_error(*_args: object, **_kwargs: object) -> None:
+        raise OSError("git missing")
+
+    monkeypatch.setattr(linked.subprocess, "run", _os_error)
     assert not _worktree_checkout_is_usable(worktree)
 
 

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from awf.node.git_manager import GitManager, _worktree_checkout_is_usable
+from awf.node.git_manager import GitManager, GitOperationError, _worktree_checkout_is_usable
 
 
 def _git(args: list[str], cwd: Path) -> None:
@@ -128,6 +128,56 @@ async def test_ensure_worktree_recreates_when_linked_head_missing(
     assert _worktree_checkout_is_usable(restored.worktree_path)
     sha = await manager.head_sha(workspace_id=workspace_id)
     assert len(sha) == 40
+
+
+@pytest.mark.unit
+async def test_corrupt_gitfile_worktree_validation_failure_is_reclaimed(
+    manager: GitManager, origin_repo: Path
+) -> None:
+    """Corrupt gitfile (missing linked HEAD) validation must be reclaimed.
+
+    When the checkout ``.git`` gitfile exists but linked admin metadata is
+    unusable, ``git worktree remove`` reports ``.git`` is not a .git file
+    (error code 7). Ensure reclaim + prune still succeed so
+    ``ensure_worktree`` can recreate.
+    """
+    await manager.ensure_mirror(str(origin_repo))
+    worktree_path = manager._worktrees_dir / "ws_corrupt_gitfile"
+    worktree_path.mkdir(parents=True)
+    (worktree_path / ".git").write_text(
+        "gitdir: /nonexistent/mirror/worktrees/ws_corrupt_gitfile\n",
+        encoding="utf-8",
+    )
+    (worktree_path / "leftover.txt").write_text("stale\n")
+
+    pruned: list[str] = []
+
+    async def _stale_run(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+        """Test helper for corrupt-gitfile remove."""
+        if operation == "worktree.remove":
+            raise GitOperationError(
+                operation=operation,
+                returncode=128,
+                stdout="",
+                stderr=(
+                    "fatal: validation failed, cannot remove working tree: "
+                    f"'{worktree_path}/.git' is not a .git file, error code 7"
+                ),
+            )
+        if operation == "worktree.prune":
+            pruned.append(operation)
+            return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError(f"unexpected operation {operation}")
+
+    manager._run = _stale_run  # type: ignore[method-assign]
+
+    await manager.remove_worktree(
+        workspace_id="ws_corrupt_gitfile",
+        repo_url=str(origin_repo),
+    )
+
+    assert pruned == ["worktree.prune"]
+    assert not worktree_path.exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -211,11 +211,13 @@ def test_worktree_checkout_rejects_standalone_git_directory(tmp_path: Path) -> N
 
 
 @pytest.mark.unit
-async def test_ensure_worktree_recreates_when_standalone_clone_occupies_path(
+async def test_ensure_worktree_fails_closed_when_standalone_clone_occupies_path(
     manager: GitManager, origin_repo: Path
 ) -> None:
-    """Incomplete restore replaced linked checkout with a plain clone → reconstruct."""
+    """Standalone clone at managed path must not be erased during restore recreate."""
     import shutil
+
+    from awf.node.git_manager import GitOperationError
 
     workspace_id = "ws_ensure_standalone"
     layout = await manager.add_worktree(
@@ -239,14 +241,14 @@ async def test_ensure_worktree_recreates_when_standalone_clone_occupies_path(
     assert (layout.worktree_path / ".git").is_dir()
     assert not _worktree_checkout_is_usable(layout.worktree_path)
 
-    restored = await manager.ensure_worktree(
-        workspace_id=workspace_id,
-        repo_url=str(origin_repo),
-        base_branch="development",
-        new_branch=f"awf/{workspace_id}",
-    )
-    assert restored.worktree_path.is_dir()
-    assert (restored.worktree_path / ".git").is_file()
-    assert _worktree_checkout_is_usable(restored.worktree_path)
-    sha = await manager.head_sha(workspace_id=workspace_id)
-    assert len(sha) == 40
+    with pytest.raises(GitOperationError) as excinfo:
+        await manager.ensure_worktree(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+
+    assert excinfo.value.reason_code == "GIT_WORKTREE_STANDALONE_REPO"
+    assert (layout.worktree_path / ".git").is_dir()
+    assert (layout.worktree_path / "README.md").read_text() == "orphan clone\n"

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -131,11 +131,12 @@ async def test_ensure_worktree_recreates_when_linked_head_missing(
 
 
 @pytest.mark.unit
-def test_worktree_checkout_rejects_when_git_probe_fails(
+def test_worktree_checkout_probe_indeterminate_fails_closed(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Timeout / OSError on the HEAD probe must not count as usable."""
+    """Timeout / OSError on the HEAD probe must fail closed, not pretend corrupt."""
     import awf.node.git_manager_linked as linked
+    from awf.node.git_manager import GitOperationError
 
     worktree = tmp_path / "worktrees" / "ws_probe_fail"
     linked_dir = tmp_path / "mirrors" / "repo.git" / "worktrees" / "ws_probe_fail"
@@ -149,13 +150,55 @@ def test_worktree_checkout_rejects_when_git_probe_fails(
         raise subprocess.TimeoutExpired(cmd="git", timeout=1)
 
     monkeypatch.setattr(linked.subprocess, "run", _timeout)
-    assert not _worktree_checkout_is_usable(worktree)
+    with pytest.raises(GitOperationError) as timeout_info:
+        _worktree_checkout_is_usable(worktree)
+    assert timeout_info.value.operation == "worktree.checkout_probe"
+    assert "timed out" in timeout_info.value.stderr
 
     def _os_error(*_args: object, **_kwargs: object) -> None:
         raise OSError("git missing")
 
     monkeypatch.setattr(linked.subprocess, "run", _os_error)
-    assert not _worktree_checkout_is_usable(worktree)
+    with pytest.raises(GitOperationError) as os_info:
+        _worktree_checkout_is_usable(worktree)
+    assert os_info.value.operation == "worktree.checkout_probe"
+    assert "could not probe" in os_info.value.stderr
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_preserves_checkout_when_head_probe_times_out(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Indeterminate HEAD probe must not force-remove a live linked checkout."""
+    import awf.node.git_manager_linked as linked
+    from awf.node.git_manager import GitOperationError
+
+    workspace_id = "ws_ensure_probe_timeout"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    repair_marker = layout.worktree_path / "uncommitted_monitor_repair.txt"
+    repair_marker.write_text("do not discard\n", encoding="utf-8")
+    assert _worktree_checkout_is_usable(layout.worktree_path)
+
+    def _timeout(*_args: object, **_kwargs: object) -> None:
+        raise subprocess.TimeoutExpired(cmd="git", timeout=1)
+
+    monkeypatch.setattr(linked.subprocess, "run", _timeout)
+    with pytest.raises(GitOperationError) as raised:
+        await manager.ensure_worktree(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+    assert raised.value.operation == "worktree.checkout_probe"
+    assert layout.worktree_path.is_dir()
+    assert repair_marker.is_file()
+    assert repair_marker.read_text(encoding="utf-8") == "do not discard\n"
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_git_manager_head_object.py
+++ b/tests/unit/node/test_git_manager_head_object.py
@@ -295,3 +295,41 @@ class TestVerifyHeadObjectExists:
         bare.mkdir()
         assert head_object._repository_alternates_path_for_worktree(bare) is None
         assert await git_module.verify_head_object_exists(bare) is False
+
+
+@pytest.mark.unit
+async def test_is_ancestor_of_head_reraises_non_exit_one_git_errors(
+    origin_repo: Path,
+    work_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Exit 1 means not-an-ancestor; any other git failure must propagate."""
+    from awf.node.git_manager import GitOperationError
+
+    manager = GitManager(work_dir)
+    await manager.add_worktree(
+        workspace_id="ws_anc_raise",
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch="awf/ws_anc_raise",
+    )
+
+    async def _boom(args: list[str], *, operation: str):  # type: ignore[no-untyped-def]
+        if operation == "worktree.is_ancestor":
+            raise GitOperationError(
+                operation=operation,
+                returncode=128,
+                stdout="",
+                stderr="fatal: Not a valid object name deadbeef",
+                reason_code="GIT_IS_ANCESTOR_FAILED",
+            )
+        raise AssertionError(f"unexpected operation {operation}")
+
+    monkeypatch.setattr(manager, "_run", _boom)
+    with pytest.raises(GitOperationError) as raised:
+        await manager.is_ancestor_of_head(
+            workspace_id="ws_anc_raise",
+            commit="deadbeef",
+        )
+    assert raised.value.returncode == 128
+    assert raised.value.operation == "worktree.is_ancestor"

--- a/tests/unit/node/test_provisioner_hosted_monitor_checkout_restore.py
+++ b/tests/unit/node/test_provisioner_hosted_monitor_checkout_restore.py
@@ -1,0 +1,120 @@
+"""Hosted monitor checkout restore remapping on Provisioner."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.db.repositories import WorkspaceRepository
+from awf.node.git_manager import GitManager, GitOperationError, WorktreeLayout
+from awf.node.provisioner import Provisioner, ProvisionerConfig
+from tests.unit.node.test_provisioner_parts.test_provisioner_part_001 import (
+    git_manager,
+    origin_repo,
+    session_factory,
+)
+
+__all__ = ("git_manager", "origin_repo", "session_factory")
+
+
+async def _seed_hosted_workspace(
+    session_factory: async_sessionmaker[AsyncSession],
+    *,
+    repo_url: str,
+    branch_name: str,
+    pr_number: int,
+) -> str:
+    async with session_factory() as session:
+        ws = await WorkspaceRepository(session).create(
+            repo_url=repo_url,
+            branch_base="development",
+            task_title="hosted restore",
+            task_prompt="p",
+            agent="codex",
+            test_commands=[],
+            requires_database=False,
+            task_policy={"pr_adoption": {"execution": {"mode": "hosted"}}},
+            task_kind="sync_feature_pr",
+        )
+        ws.branch_name = branch_name
+        ws.remote_push_branch = branch_name
+        ws.pr_number = pr_number
+        await session.commit()
+        return ws.id
+
+
+@pytest.mark.unit
+async def test_ensure_hosted_monitor_worktree_remaps_underlying_git_failure(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-restore reason codes from ensure_worktree become MONITOR_RECOVERY_…."""
+    workspace_id = await _seed_hosted_workspace(
+        session_factory,
+        repo_url=str(origin_repo),
+        branch_name="awf/ws_hosted_restore",
+        pr_number=7,
+    )
+
+    async def _failing_ensure(**kwargs: object) -> WorktreeLayout:
+        raise GitOperationError(
+            operation="worktree.add",
+            returncode=128,
+            stdout="",
+            stderr="fatal: couldn't find remote ref refs/pull/7/head",
+            reason_code="GIT_FETCH_BASE_FAILED",
+        )
+
+    monkeypatch.setattr(git_manager, "ensure_worktree", _failing_ensure)
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="node-a", branch_prefix="awf"),
+    )
+    with pytest.raises(GitOperationError) as raised:
+        await provisioner.ensure_hosted_monitor_worktree(workspace_id)
+    assert raised.value.reason_code == "MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED"
+    assert raised.value.operation == "hosted_monitor.ensure_worktree"
+    assert "underlying=GIT_FETCH_BASE_FAILED" in raised.value.stderr
+
+
+@pytest.mark.unit
+async def test_ensure_hosted_monitor_worktree_preserves_restore_reason_code(
+    session_factory: async_sessionmaker[AsyncSession],
+    git_manager: GitManager,
+    origin_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Already-mapped restore failures are re-raised without double wrapping."""
+    workspace_id = await _seed_hosted_workspace(
+        session_factory,
+        repo_url=str(origin_repo),
+        branch_name="awf/ws_hosted_preserve",
+        pr_number=8,
+    )
+
+    original = GitOperationError(
+        operation="hosted_monitor.ensure_worktree",
+        returncode=1,
+        stdout="",
+        stderr="missing adoption tip",
+        reason_code="MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED",
+    )
+    monkeypatch.setattr(
+        git_manager,
+        "ensure_worktree",
+        AsyncMock(side_effect=original),
+    )
+    provisioner = Provisioner(
+        session_factory=session_factory,
+        git=git_manager,
+        config=ProvisionerConfig(node_id="node-a", branch_prefix="awf"),
+    )
+    with pytest.raises(GitOperationError) as raised:
+        await provisioner.ensure_hosted_monitor_worktree(workspace_id)
+    assert raised.value is original

--- a/tests/unit/service/test_worker.py
+++ b/tests/unit/service/test_worker.py
@@ -193,8 +193,10 @@ def test_build_worker_runtime_wires_executor_and_feature_monitor_factory(
             usage_sampler: object = None,
             agent_runtime_executor: object = None,
             hosted_validation: object = None,
+            ensure_hosted_monitor_checkout: object = None,
         ) -> None:
             del hosted_validation
+            del ensure_hosted_monitor_checkout
             created["executor"] = self
             created["executor_session_factory"] = session_factory
             created["executor_runner"] = runner

--- a/tests/unit/service/test_worker_runtime_wiring.py
+++ b/tests/unit/service/test_worker_runtime_wiring.py
@@ -1041,9 +1041,11 @@ def _stub_worker_runtime_dependencies(
             usage_sampler: object = None,
             agent_runtime_executor: object = None,
             hosted_validation: object = None,
+            ensure_hosted_monitor_checkout: object = None,
         ) -> None:
             """Test helper for  init  ."""
             del hosted_validation
+            del ensure_hosted_monitor_checkout
             created["executor_monitor_factory"] = pr_monitor_factory
 
     class _ControlWorker:

--- a/tests/unit/service/test_workspace_runtime_health.py
+++ b/tests/unit/service/test_workspace_runtime_health.py
@@ -69,6 +69,21 @@ def test_runtime_snapshot_ignores_inactive_workspace_and_reports_missing_metadat
 
 
 @pytest.mark.unit
+def test_hosted_monitoring_pr_without_compose_metadata_is_not_stranded() -> None:
+    snapshot = RuntimeSnapshot(stack_state="stopped")
+    finding = classify_runtime_snapshot(
+        RuntimeWorkspace(
+            workspace_id="ws_hosted_monitor",
+            status=WorkspaceStatus.monitoring_pr.value,
+            pr_url="https://github.com/x/y/pull/1",
+            hosted_pr_adoption=True,
+        ),
+        snapshot,
+    )
+    assert finding is None
+
+
+@pytest.mark.unit
 def test_resource_inventory_skips_pre_provisioned_request_without_metadata() -> None:
     requested = RuntimeWorkspace(
         workspace_id="ws_requested",

--- a/tests/unit/service/test_workspace_runtime_health.py
+++ b/tests/unit/service/test_workspace_runtime_health.py
@@ -84,6 +84,33 @@ def test_hosted_monitoring_pr_without_compose_metadata_is_not_stranded() -> None
 
 
 @pytest.mark.unit
+def test_resource_inventory_hosted_monitoring_pr_is_not_stranded_without_containers() -> None:
+    """Hosted monitoring_pr is healthy-by-design even when inventory has no containers.
+
+    ``classify_runtime_snapshot`` already short-circuits hosted open-PR rows;
+    the resource-inventory path must do the same so doctor/runtime scans do
+    not emit STRANDED_WORKSPACE for pod-local Compose absence.
+    """
+    hosted = RuntimeWorkspace(
+        workspace_id="ws_hosted_inventory",
+        status=WorkspaceStatus.monitoring_pr.value,
+        pr_url="https://github.com/x/y/pull/42",
+        hosted_pr_adoption=True,
+        compose_project_name="awf_ws_hosted_inventory",
+        compose_file_path="/tmp/awf/compose.yml",
+    )
+    assert classify_resource_inventory(hosted, resources=()) is None
+
+    hosted_without_compose_meta = RuntimeWorkspace(
+        workspace_id="ws_hosted_inventory_bare",
+        status=WorkspaceStatus.monitoring_pr.value,
+        pr_url="https://github.com/x/y/pull/43",
+        hosted_pr_adoption=True,
+    )
+    assert classify_resource_inventory(hosted_without_compose_meta, resources=()) is None
+
+
+@pytest.mark.unit
 def test_resource_inventory_skips_pre_provisioned_request_without_metadata() -> None:
     requested = RuntimeWorkspace(
         workspace_id="ws_requested",


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_605c42db99f648758cba682d` (agent: `cursor`, model: `auto`).


### Task
Environment notes: This is AWF Core, mounted at /workspace. Follow AGENTS.md and strict TDD. The production AWF Cloud control worker is stateless across GKE pod rollouts; PostgreSQL workspace/operation state is durable, while /tmp/awf-work/git/worktrees is pod-local. Git and GitHub auth are functional. Do not push; AWF handles push and PR monitoring. What to do: Fix hosted PR-monitor restart recovery after a worker pod replacement. A persisted hosted sync_feature_pr can be in monitoring_pr with a null Compose project and an open PR, while its managed worktree directory is absent on the replacement pod. Today monitor takeover skips Compose but immediately uses the missing checkout and fails GIT_FETCH_BASE_FAILED. Restore the checkout before the resumed monitor is built/run, using the existing GitManager/provisioning ownership and persisted adoption metadata so the checkout is at the current PR head (GitHub refs/pull/N/head where applicable, with existing forge-neutral branch behavior preserved). Restoration must be idempotent and race-safe: do nothing to an existing valid worktree, clean only stale AWF-managed worktree metadata as needed, and fail closed with an actionable reason if reconstruction is impossible. Preserve the persisted Core operation and hosted delegation idempotency so restart recovery polls/reuses the same logical comment operation rather than launching duplicate hosted work. Also make stale runtime recovery recognize a hosted monitoring_pr workspace with no Compose runtime as healthy-by-design/recoverable by the monitor, instead of emitting a generic STRANDED_WORKSPACE classification. Keep all local/Compose monitor recovery behavior unchanged. Add focused regression coverage that simulates a pod restart with durable hosted policy/PR metadata, null Compose metadata, and a missing worktree; proves checkout restoration precedes monitor work and lands at the current PR head; proves live claims are not stolen and stale-owner takeover resumes once; proves no duplicate hosted operation; proves hosted monitoring_pr is not falsely classified as stranded; and proves local monitor recovery remains unchanged. Keep changes narrowly in Core-owned provisioning, worker/executor recovery seams and tests. Do not stage plans/*_PLAN.md or plans/*_VALIDATION.md. Commit before exiting.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR-monitor recovery and Git worktree prune/remove paths with concurrency fencing; mistakes could affect live `monitoring_pr` rows or managed checkouts, though fail-closed guards and broad regression tests mitigate that.
> 
> **Overview**
> After a control-worker pod replacement, **hosted** `monitoring_pr` workspaces can keep durable DB state but lose the pod-local worktree under `/tmp/awf-work/git/worktrees`. This PR **restores that checkout before** the resumed PR monitor runs, using persisted adoption metadata and the PR head tip (e.g. `refs/pull/<n>/head` for sync flows).
> 
> **Executor / worker seam:** `WorkspaceExecutor` accepts an optional `ensure_hosted_monitor_checkout` hook; the service worker wires it to `Provisioner.ensure_hosted_monitor_worktree`, which calls **`GitManager.ensure_worktree`** (idempotent: no-op on a valid linked checkout; prune/recreate under the worktree writer lock when metadata or the directory is stale). Failures surface as **`MONITOR_RECOVERY_CHECKOUT_RESTORE_FAILED`** with redacted git diagnostics.
> 
> **Lease safety:** Hosted restore is fenced with monitor-claim rechecks before and after slow git work; **`_mark_failed`** can optionally require `monitor_claimed_by` so a superseded recovery cannot fail a row still owned by a replacement claimant.
> 
> **Runtime classification:** Hosted open-PR rows in `monitoring_pr` **without Compose metadata** are treated as healthy-by-design in runtime health, stale active-execution recovery, and doctor reason text—avoiding false **`STRANDED_WORKSPACE`** when Compose was never expected.
> 
> **Git hardening (supporting restore):** Linked-worktree helpers move to `git_manager_linked.py` with HEAD usability probes; worktree removal refuses standalone `.git` directories and distinguishes corrupt vs unreadable gitfile errors when reclaiming paths.
> 
> Local/Compose monitor resume behavior is unchanged; coverage adds hosted pod-restart, takeover, credential redaction, and `ensure_worktree` edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a22bd2b2ddbe342be6af02181d5f7b9409d39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->