### PR TITLE
fix: offload hosted checkout probes from the event loop

### DIFF
--- a/src/awf/node/git_manager.py
+++ b/src/awf/node/git_manager.py
@@ -774,7 +774,8 @@ class GitManager:
         from awf.runtime.worktree_writer_lock import hold_exclusive_worktree_writer_lock
 
         worktree_path = self._worktree_path_for(workspace_id)
-        if _worktree_checkout_is_usable(worktree_path):
+        # HEAD probe uses blocking subprocess; keep it off the event loop.
+        if await asyncio.to_thread(_worktree_checkout_is_usable, worktree_path):
             return WorktreeLayout(
                 mirror_path=self._mirror_path(repo_url),
                 worktree_path=worktree_path,
@@ -783,7 +784,7 @@ class GitManager:
 
         async with hold_exclusive_worktree_writer_lock(worktree_path):
             # Another fenced restorer may have finished while we waited.
-            if _worktree_checkout_is_usable(worktree_path):
+            if await asyncio.to_thread(_worktree_checkout_is_usable, worktree_path):
                 return WorktreeLayout(
                     mirror_path=self._mirror_path(repo_url),
                     worktree_path=worktree_path,
@@ -815,9 +816,8 @@ class GitManager:
             except GitOperationError as exc:
                 # Another concurrent ensure may have created the path between our
                 # remove and add; treat a now-usable checkout as success.
-                if (
-                    exc.reason_code == "GIT_WORKTREE_ALREADY_EXISTS"
-                    and _worktree_checkout_is_usable(worktree_path)
+                if exc.reason_code == "GIT_WORKTREE_ALREADY_EXISTS" and await asyncio.to_thread(
+                    _worktree_checkout_is_usable, worktree_path
                 ):
                     return WorktreeLayout(
                         mirror_path=mirror_path,

--- a/tests/unit/node/test_git_manager_ensure_worktree_usability.py
+++ b/tests/unit/node/test_git_manager_ensure_worktree_usability.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import subprocess
+import threading
 from pathlib import Path
 
 import pytest
@@ -37,6 +40,65 @@ def manager(tmp_path: Path) -> GitManager:
     work_dir = tmp_path / "awf-work"
     work_dir.mkdir()
     return GitManager(work_dir)
+
+
+@pytest.mark.unit
+async def test_ensure_worktree_usability_probe_does_not_block_event_loop(
+    manager: GitManager, origin_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Checkout usability probes must run off the asyncio event loop.
+
+    A hung HEAD probe (subprocess timeout up to 5s) must not stall unrelated
+    async work on the same loop during hosted monitor recovery.
+    """
+    import awf.node.git_manager as git_manager_mod
+
+    workspace_id = "ws_ensure_probe_offloop"
+    layout = await manager.add_worktree(
+        workspace_id=workspace_id,
+        repo_url=str(origin_repo),
+        base_branch="development",
+        new_branch=f"awf/{workspace_id}",
+    )
+    assert _worktree_checkout_is_usable(layout.worktree_path)
+
+    probe_started = threading.Event()
+    release_probe = threading.Event()
+    observed_event_loop_progress = False
+    real_usable = git_manager_mod._worktree_checkout_is_usable
+
+    def _blocking_usable(path: Path) -> bool:
+        probe_started.set()
+        if not release_probe.wait(timeout=0.5):
+            raise AssertionError("event loop stalled while usability probe was blocked")
+        return real_usable(path)
+
+    monkeypatch.setattr(git_manager_mod, "_worktree_checkout_is_usable", _blocking_usable)
+
+    async def _release_probe_after_loop_progress() -> None:
+        nonlocal observed_event_loop_progress
+        while not probe_started.is_set():
+            await asyncio.sleep(0)
+        observed_event_loop_progress = True
+        release_probe.set()
+
+    releaser = asyncio.create_task(_release_probe_after_loop_progress())
+    try:
+        restored = await manager.ensure_worktree(
+            workspace_id=workspace_id,
+            repo_url=str(origin_repo),
+            base_branch="development",
+            new_branch=f"awf/{workspace_id}",
+        )
+    finally:
+        if not releaser.done():
+            releaser.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await releaser
+
+    assert observed_event_loop_progress is True
+    assert restored.worktree_path == layout.worktree_path
+    assert _worktree_checkout_is_usable(restored.worktree_path)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_be734392b47640cf99ac4d98` (agent: `cursor`, model: `auto`).


### Task
Environment notes: This is AWF Core mounted at /workspace. Follow AGENTS.md and strict TDD. Git and GitHub auth are functional. Do not push; AWF handles push, review repair, and merge. A reviewed residual on PR 887 identified that async GitManager.ensure_worktree calls synchronous _worktree_checkout_is_usable three times; its subprocess-based HEAD probe can block the worker event loop for up to five seconds per call during hosted monitor recovery. What to do: add a focused failing regression proving checkout usability probes do not block unrelated async work, then offload every ensure_worktree usability call from the event loop using the smallest existing asyncio pattern. Preserve the existing writer-lock ordering, fail-closed GitOperationError behavior, race recovery, return values, probe timeout, and all checkout confinement guarantees. Keep the change narrowly in src/awf/node/git_manager.py and tests/unit/node/test_git_manager_ensure_worktree_usability.py. Do not alter the synchronous helper contract unless strictly necessary. Do not stage plans/*_PLAN.md or plans/*_VALIDATION.md. Git is functional in /workspace; commit before exiting.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow threading change around read-only usability checks; behavior and error semantics are preserved with added test coverage.
> 
> **Overview**
> **`GitManager.ensure_worktree`** no longer runs synchronous **`_worktree_checkout_is_usable`** HEAD probes on the asyncio event loop. All three probe sites (initial fast path, post–writer-lock recheck, and **`GIT_WORKTREE_ALREADY_EXISTS`** race recovery) now use **`await asyncio.to_thread(...)`**, so a blocking git subprocess (up to ~5s) during hosted monitor recovery cannot stall unrelated async work.
> 
> A new unit regression **`test_ensure_worktree_usability_probe_does_not_block_event_loop`** asserts the loop can make progress while a patched probe blocks on a thread. Writer-lock ordering, fail-closed probe errors, and existing **`ensure_worktree`** recreate/race behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 824402aedb014d39e17027c157c7abd9f55b216d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->