### PR TITLE
fix(node): unblock Claude auth overlay mount and stop the 1.7 GB/workspace copy leak (#874)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -148,6 +148,12 @@ AWF_AUTO_CLEANUP_ORPHANS=true
 # --execute and never removes the current-signature, live-mounted, or pinned base.
 AWF_CLAUDE_BASE_GC_ENABLED=true
 AWF_CLAUDE_BASE_REAP_SCAN_INTERVAL_SECONDS=3600
+# AppArmor profile for the worker container. Defaults to `unconfined` because
+# Docker's `docker-default` profile denies mount(2) outright, which blocks the
+# shared-base ~/.claude overlay even though the worker holds CAP_SYS_ADMIN
+# (#874). Uncomment to restore confinement; provisioning then falls back to the
+# fully supported per-workspace copy (~1.7 GB per workspace).
+# AWF_WORKER_APPARMOR=docker-default
 # Terminal-workspace auth-dir GC (per-workspace ~1.7 GB auth dirs for
 # completed/cancelled/destroyed workspaces). Driven from the worker (which holds
 # CAP_SYS_ADMIN) so the overlay unmount-before-remove succeeds; failed workspaces

--- a/docker/compose/local-service.yml
+++ b/docker/compose/local-service.yml
@@ -248,6 +248,21 @@ services:
     # the resulting isolation posture (per_workspace_overlay vs per_workspace_copy).
     cap_add:
       - SYS_ADMIN
+    # SYS_ADMIN is necessary but NOT sufficient (#874). Docker applies the
+    # `docker-default` AppArmor profile in *enforce* mode, and that profile
+    # carries a plain `deny mount,` rule which blocks mount(2) regardless of
+    # CAP_SYS_ADMIN. Observed on the operator's host: the worker held CapEff bit
+    # 21, the work dir was ext4 and rshared, kernel overlayfs was present — and
+    # every mount still failed EACCES, surfacing as util-linux's read-only retry
+    # ("cannot mount overlay read-only", exit 32) with no overlayfs dmesg record
+    # and no AppArmor audit line (a plain `deny` rule does not audit). Result:
+    # zero AWF overlay mounts and a 100% copy fallback. Lifting confinement for
+    # the worker alone is what lets mount(2) through; api/migrate deliberately
+    # keep docker-default since they never mount. Set
+    # AWF_WORKER_APPARMOR=docker-default to restore confinement — provisioning
+    # then takes the fully supported per-workspace copy fallback instead.
+    security_opt:
+      - apparmor:${AWF_WORKER_APPARMOR:-unconfined}
     volumes:
       - *awf-docker-sock
       - *awf-service-ssh-agent

--- a/docs/REASON_CATALOG.md
+++ b/docs/REASON_CATALOG.md
@@ -200,6 +200,13 @@ This catalog documents common API/CLI/MCP failures, likely causes, and operator 
 **Related Command:** `awf service doctor`
 **Docs Link:** [docs/REASON_CATALOG.md#claude_auth_missing](#claude_auth_missing)
 
+### CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE
+**Problem:** The per-workspace ``~/.claude`` overlay could not be mounted on a host that should support it, so provisioning fell back to a full per-workspace copy (correct, but ~1.7 GB per workspace).
+**Likely Cause:** A Linux security module denied ``mount(2)`` even though the kernel advertises overlayfs and the worker holds ``CAP_SYS_ADMIN``. Docker's ``docker-default`` AppArmor profile carries a plain, non-auditing ``deny mount,`` rule, so the refusal appears only as ``EACCES`` (util-linux reports ``cannot mount overlay read-only``, exit 32) with no ``dmesg`` or audit record.
+**Operator Fix:** Inspect ``<work_dir>/auth/_shared/overlay-probe.json``. If the worker is AppArmor- or seccomp-confined, allow ``mount(2)`` for it (the compose worker service sets ``security_opt: apparmor:unconfined``); otherwise leave the copy fallback in place.
+**Related Command:** `awf service status --format json`
+**Docs Link:** [docs/REASON_CATALOG.md#claude_auth_overlay_unexpectedly_unavailable](#claude_auth_overlay_unexpectedly_unavailable)
+
 ### CLIENT_CONFIG_CONFLICT
 **Problem:** AWF found a client MCP configuration conflict.
 **Likely Cause:** A Claude or Codex MCP config already contains incompatible AWF server settings.

--- a/src/awf/node/auth_mounts.py
+++ b/src/awf/node/auth_mounts.py
@@ -87,9 +87,15 @@ from awf.node.auth_mounts_claude import (
     teardown_workspace_auth_overlay as teardown_workspace_auth_overlay,
 )
 from awf.node.auth_mounts_overlay_probe import (
+    CLAUDE_AUTH_FORCE_COPY_ENV as CLAUDE_AUTH_FORCE_COPY_ENV,
+)
+from awf.node.auth_mounts_overlay_probe import (
     CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE as CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE,
 )
 from awf.node.auth_mounts_overlay_probe import OverlayProbeResult as OverlayProbeResult
+from awf.node.auth_mounts_overlay_probe import (
+    discard_overlay_probe_evidence as discard_overlay_probe_evidence,
+)
 from awf.node.auth_mounts_overlay_probe import (
     overlay_probe_evidence_path as overlay_probe_evidence_path,
 )

--- a/src/awf/node/auth_mounts.py
+++ b/src/awf/node/auth_mounts.py
@@ -26,9 +26,18 @@ from awf.node.auth_mounts_claude import (
 )
 from awf.node.auth_mounts_claude import _CLAUDE_BASE_BUILD_LOCK_NAME as _CLAUDE_BASE_BUILD_LOCK_NAME
 from awf.node.auth_mounts_claude import _CLAUDE_BASE_DIRNAME as _CLAUDE_BASE_DIRNAME
+from awf.node.auth_mounts_claude import (
+    _CLAUDE_USAGE_HISTORY_DIRS as _CLAUDE_USAGE_HISTORY_DIRS,
+)
 from awf.node.auth_mounts_claude import _OVERLAY_UNMOUNTED_MARKER as _OVERLAY_UNMOUNTED_MARKER
 from awf.node.auth_mounts_claude import _PROC_MOUNTS as _PROC_MOUNTS
 from awf.node.auth_mounts_claude import _SHARED_AUTH_DIRNAME as _SHARED_AUTH_DIRNAME
+from awf.node.auth_mounts_claude import (
+    CLAUDE_COPY_EXCLUDED_TOP_LEVEL as CLAUDE_COPY_EXCLUDED_TOP_LEVEL,
+)
+from awf.node.auth_mounts_claude import (
+    CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL as CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL,
+)
 from awf.node.auth_mounts_claude import (
     OverlayMounter,
     _chown_tree,
@@ -60,7 +69,12 @@ from awf.node.auth_mounts_claude import _safe_overlay_whiteout as _safe_overlay_
 from awf.node.auth_mounts_claude import _safe_stat as _safe_stat
 from awf.node.auth_mounts_claude import _shared_claude_base_dir as _shared_claude_base_dir
 from awf.node.auth_mounts_claude import _SubprocessOverlayMounter as _SubprocessOverlayMounter
+from awf.node.auth_mounts_claude import cached_overlay_probe as cached_overlay_probe
 from awf.node.auth_mounts_claude import claude_auth_isolation_label as claude_auth_isolation_label
+from awf.node.auth_mounts_claude import claude_copy_ignore as claude_copy_ignore
+from awf.node.auth_mounts_claude import (
+    claude_signature_excludes_rel as claude_signature_excludes_rel,
+)
 from awf.node.auth_mounts_claude import default_overlay_mounter as default_overlay_mounter
 from awf.node.auth_mounts_claude import (
     force_copy_isolation_requested as force_copy_isolation_requested,

--- a/src/awf/node/auth_mounts.py
+++ b/src/awf/node/auth_mounts.py
@@ -72,6 +72,22 @@ from awf.node.auth_mounts_claude import (
 from awf.node.auth_mounts_claude import (
     teardown_workspace_auth_overlay as teardown_workspace_auth_overlay,
 )
+from awf.node.auth_mounts_overlay_probe import (
+    CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE as CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE,
+)
+from awf.node.auth_mounts_overlay_probe import OverlayProbeResult as OverlayProbeResult
+from awf.node.auth_mounts_overlay_probe import (
+    overlay_probe_evidence_path as overlay_probe_evidence_path,
+)
+from awf.node.auth_mounts_overlay_probe import (
+    overlay_probe_scratch_root as overlay_probe_scratch_root,
+)
+from awf.node.auth_mounts_overlay_probe import (
+    overlay_unexpectedly_unavailable as overlay_unexpectedly_unavailable,
+)
+from awf.node.auth_mounts_overlay_probe import (
+    read_overlay_probe_evidence as read_overlay_probe_evidence,
+)
 from awf.node.compose_manager import AuthMount
 
 _CONTAINER_HOME = "/home/agent"
@@ -185,6 +201,7 @@ def resolve_service_auth_mounts(
     """
 
     normalized_home = host_home.expanduser()
+    normalized_work_dir = work_dir.expanduser()
     suppressed_target_set = frozenset(suppressed_targets) | legacy_provider_targets(
         suppressed_providers
     )
@@ -196,12 +213,18 @@ def resolve_service_auth_mounts(
     return _workspace_auth_mounts(
         base_mounts,
         workspace_id=workspace_id,
-        work_dir=work_dir.expanduser(),
+        work_dir=normalized_work_dir,
         host_home=normalized_home,
         suppressed_targets=suppressed_target_set,
         workspace_owner_uid=workspace_owner_uid,
         workspace_owner_gid=workspace_owner_gid,
-        overlay_mounter=overlay_mounter or default_overlay_mounter(),
+        # The default mounter probes for a real overlay mount before claiming
+        # support (#874); the probe stages under the shared auth dir, which is
+        # also where it records evidence the API-side status/readiness surfaces
+        # read back (the work dir is bind-mounted at the same absolute path in
+        # both containers).
+        overlay_mounter=overlay_mounter
+        or default_overlay_mounter(scratch_root=overlay_probe_scratch_root(normalized_work_dir)),
     )
 
 

--- a/src/awf/node/auth_mounts_claude.py
+++ b/src/awf/node/auth_mounts_claude.py
@@ -48,6 +48,16 @@ from awf.node.auth_mounts_claude_base import (
     _reap_stale_claude_base_staging as _reap_stale_claude_base_staging,
 )
 from awf.node.auth_mounts_claude_base import _shared_claude_base_dir as _shared_claude_base_dir
+from awf.node.auth_mounts_claude_exclusions import (
+    CLAUDE_COPY_EXCLUDED_TOP_LEVEL as CLAUDE_COPY_EXCLUDED_TOP_LEVEL,
+)
+from awf.node.auth_mounts_claude_exclusions import (
+    CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL as CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL,
+)
+from awf.node.auth_mounts_claude_exclusions import claude_copy_ignore as claude_copy_ignore
+from awf.node.auth_mounts_claude_exclusions import (
+    claude_signature_excludes_rel as claude_signature_excludes_rel,
+)
 from awf.node.auth_mounts_claude_reconcile import (
     _CLAUDE_AUTH_OVERLAY_WHITEOUT_FAILED as _CLAUDE_AUTH_OVERLAY_WHITEOUT_FAILED,
 )
@@ -75,6 +85,16 @@ from awf.node.auth_mounts_overlay_copy import _safe_mtime_ns as _safe_mtime_ns
 from awf.node.auth_mounts_overlay_copy import _safe_overlay_copy as _safe_overlay_copy
 from awf.node.auth_mounts_overlay_copy import _safe_overlay_whiteout as _safe_overlay_whiteout
 from awf.node.auth_mounts_overlay_copy import _safe_stat as _safe_stat
+from awf.node.auth_mounts_overlay_probe import (
+    CLAUDE_AUTH_OVERLAY_UNAVAILABLE as _CLAUDE_AUTH_OVERLAY_UNAVAILABLE,
+)
+from awf.node.auth_mounts_overlay_probe import (
+    OVERLAY_OPTION_RESERVED_CHARS as _OVERLAY_OPTION_RESERVED_CHARS,
+)
+from awf.node.auth_mounts_overlay_probe import cached_overlay_probe as cached_overlay_probe
+from awf.node.auth_mounts_overlay_probe import (
+    log_overlay_unavailable as _log_overlay_unsupported,
+)
 from awf.node.compose_manager import AuthMount
 
 _log = get_logger(__name__)
@@ -87,7 +107,6 @@ _CLAUDE_FILE_TARGET = f"{_CONTAINER_HOME}/.claude.json"
 # dir names, the per-build ``.build.lock`` marker, and the ``CLAUDE_AUTH_SHARED_
 # BASE_FAILED`` reason code — lives in :mod:`awf.node.auth_mounts_claude_base`
 # and is re-imported above so ``awf.node.auth_mounts.<name>`` stays stable.
-_CLAUDE_AUTH_OVERLAY_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_UNAVAILABLE"
 _CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED = "CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED"
 # Logged when a surviving *non-empty* overlay ``upper`` whose base cannot be verified is
 # DISCARDED and rebuilt rather than remounted over a base guessed from the current host
@@ -200,7 +219,6 @@ _CLAUDE_AUTH_FORCE_COPY_ENV = "AWF_CLAUDE_AUTH_FORCE_COPY"
 # auth path carrying either character — inherited from ``AWF_WORK_DIR`` /
 # ``AWF_HOST_WORK_DIR`` — therefore cannot be expressed as an overlay mount option,
 # so the overlay branch degrades to the per-workspace copy fallback on such a host.
-_OVERLAY_OPTION_RESERVED_CHARS = (",", ":")
 _PROC_FILESYSTEMS = Path("/proc/filesystems")
 _ISOLATION_OVERLAY = "per_workspace_overlay"
 _ISOLATION_COPY = "per_workspace_copy"
@@ -317,6 +335,10 @@ class _SubprocessOverlayMounter:
 
     timeout_seconds: float = 30.0
     proc_mounts: Path = _PROC_MOUNTS
+    # Scratch dir for the real overlay probe (``<work_dir>/auth/_shared``).
+    # ``None`` for mounters built without a work-dir context — teardown, which
+    # never calls ``supported()``.
+    scratch_root: Path | None = None
 
     def supported(self) -> bool:
         # An operator/bootstrap force-copy request wins over real overlayfs
@@ -325,7 +347,17 @@ class _SubprocessOverlayMounter:
         # fallback is the only correct posture there.
         if _force_copy_isolation_requested():
             return False
-        return _overlay_filesystem_available() and _has_cap_sys_admin()
+        if not (_overlay_filesystem_available() and _has_cap_sys_admin()):
+            return False
+        if self.scratch_root is None:
+            return True
+        # Cheap gates are necessary but NOT sufficient: they are blind to the LSM
+        # layer, and Docker's ``docker-default`` AppArmor profile denies mount(2)
+        # even to a CAP_SYS_ADMIN-holding root worker (#874). Ask the kernel for
+        # real, once per process per scratch root. Ordering matters: a host
+        # failing a cheap gate never probes, so never records evidence — which is
+        # what keeps the copy fallback silent on hosted/GKE.
+        return cached_overlay_probe(scratch_root=self.scratch_root).ok
 
     def mount(self, *, lowerdir: Path, upperdir: Path, workdir: Path, merged: Path) -> None:
         options = f"lowerdir={lowerdir},upperdir={upperdir},workdir={workdir}"
@@ -353,10 +385,14 @@ class _SubprocessOverlayMounter:
         return _overlay_lowerdir_from_proc_mounts(self.proc_mounts, merged)
 
 
-def default_overlay_mounter() -> OverlayMounter:
-    """Return the production overlay mounter (real ``mount``/``umount``)."""
+def default_overlay_mounter(*, scratch_root: Path | None = None) -> OverlayMounter:
+    """Return the production overlay mounter (real ``mount``/``umount``).
 
-    return _SubprocessOverlayMounter()
+    ``scratch_root`` enables the real overlay probe in ``supported()``; omit it
+    for mounters that never ask (teardown), keeping pre-#874 behavior.
+    """
+
+    return _SubprocessOverlayMounter(scratch_root=scratch_root)
 
 
 def claude_auth_isolation_label(
@@ -492,7 +528,12 @@ def _prepare_isolated_claude_auth(
         # shared-base overlay over it would silently drop those mutations (empty
         # ``upper``, lower seeded from the current host). So normally only reach
         # for the overlay when no legacy copy exists — otherwise keep using that
-        # copy.
+        # copy. #874 deliberately leaves this guard alone even though it strands
+        # ~1.7 GB legacy copies on hosts whose overlay never mounted: flipping it
+        # would route them through ``_forward_fallback_deletions_as_whiteouts``
+        # (gated on ``.claude-complete``, which such hosts *do* carry), a
+        # credential-correctness risk exceeding the disk reclaimed. They drain on
+        # the 168 h retention instead.
         #
         # Exception: a surviving *non-empty* overlay ``upper`` overrides that guard.
         # A transient remount failure preserves ``upper``/``work`` on disk but still
@@ -672,7 +713,8 @@ def _prepare_isolated_claude_auth(
                     shutil.copytree(
                         source_dir,
                         staged_copy,
-                        ignore=shutil.ignore_patterns(*_CLAUDE_USAGE_HISTORY_DIRS),
+                        # Anchored ignore (#874): see ``claude_copy_ignore``.
+                        ignore=claude_copy_ignore(source_dir),
                         ignore_dangling_symlinks=True,
                     )
                     try:
@@ -987,12 +1029,7 @@ def _prepare_claude_overlay_mount(
     """
 
     if not overlay_mounter.supported():
-        _log.info(
-            "claude_auth_overlay_unavailable",
-            reason_code=_CLAUDE_AUTH_OVERLAY_UNAVAILABLE,
-            workspace_auth_root=str(claude_root),
-            reason="overlayfs_unsupported",
-        )
+        _log_overlay_unsupported(claude_root=claude_root, work_dir=work_dir)
         return None
 
     # The overlay paths feed an unescapable ``mount -o lowerdir=..,upperdir=..,

--- a/src/awf/node/auth_mounts_claude.py
+++ b/src/awf/node/auth_mounts_claude.py
@@ -86,12 +86,21 @@ from awf.node.auth_mounts_overlay_copy import _safe_overlay_copy as _safe_overla
 from awf.node.auth_mounts_overlay_copy import _safe_overlay_whiteout as _safe_overlay_whiteout
 from awf.node.auth_mounts_overlay_copy import _safe_stat as _safe_stat
 from awf.node.auth_mounts_overlay_probe import (
+    CLAUDE_AUTH_FORCE_COPY_ENV as CLAUDE_AUTH_FORCE_COPY_ENV,
+)
+from awf.node.auth_mounts_overlay_probe import (
     CLAUDE_AUTH_OVERLAY_UNAVAILABLE as _CLAUDE_AUTH_OVERLAY_UNAVAILABLE,
 )
 from awf.node.auth_mounts_overlay_probe import (
     OVERLAY_OPTION_RESERVED_CHARS as _OVERLAY_OPTION_RESERVED_CHARS,
 )
 from awf.node.auth_mounts_overlay_probe import cached_overlay_probe as cached_overlay_probe
+from awf.node.auth_mounts_overlay_probe import (
+    discard_overlay_probe_evidence as discard_overlay_probe_evidence,
+)
+from awf.node.auth_mounts_overlay_probe import (
+    force_copy_isolation_requested as _probe_force_copy_isolation_requested,
+)
 from awf.node.auth_mounts_overlay_probe import (
     log_overlay_unavailable as _log_overlay_unsupported,
 )
@@ -212,7 +221,9 @@ _CLAUDE_LEGACY_COMPLETE_MARKER = ".claude-complete"
 # (Docker Desktop / virtiofs / grpcfuse), where a worker-mounted overlay would
 # never propagate into the sibling agent container and the agent would see an
 # empty ``~/.claude``. The copy fallback is correct there (no disk saving).
-_CLAUDE_AUTH_FORCE_COPY_ENV = "AWF_CLAUDE_AUTH_FORCE_COPY"
+# Defined in :mod:`awf.node.auth_mounts_overlay_probe` (the probe's posture
+# predicate reads the same flag) and re-exported here as the stable name.
+_CLAUDE_AUTH_FORCE_COPY_ENV = CLAUDE_AUTH_FORCE_COPY_ENV
 # overlayfs's legacy ``mount -o`` API joins options with ``,`` and stacks lower
 # layers with ``:`` inside ``lowerdir=``; neither can be escaped in that payload
 # (only ``/proc/mounts`` *read-back* octal-decodes ``\054``/``\072``). A workspace
@@ -242,11 +253,14 @@ class OverlayUnmountUnverifiableError(RuntimeError):
 
 
 def _force_copy_isolation_requested(host_env: Mapping[str, str] | None = None) -> bool:
-    """Return whether ``AWF_CLAUDE_AUTH_FORCE_COPY`` requests the copy fallback."""
+    """Return whether ``AWF_CLAUDE_AUTH_FORCE_COPY`` requests the copy fallback.
 
-    source = os.environ if host_env is None else host_env
-    value = source.get(_CLAUDE_AUTH_FORCE_COPY_ENV, "")
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    Delegates to the probe module so the mount path and the probe's posture
+    predicate (:func:`awf.node.auth_mounts_overlay_probe.overlay_unexpectedly_unavailable`)
+    read the flag through one definition.
+    """
+
+    return _probe_force_copy_isolation_requested(host_env)
 
 
 def force_copy_isolation_requested(host_env: Mapping[str, str] | None = None) -> bool:
@@ -346,8 +360,10 @@ class _SubprocessOverlayMounter:
         # mount the overlay would never reach the agent container, so the copy
         # fallback is the only correct posture there.
         if _force_copy_isolation_requested():
+            self._discard_stale_probe_evidence()
             return False
         if not (_overlay_filesystem_available() and _has_cap_sys_admin()):
+            self._discard_stale_probe_evidence()
             return False
         if self.scratch_root is None:
             return True
@@ -358,6 +374,17 @@ class _SubprocessOverlayMounter:
         # failing a cheap gate never probes, so never records evidence — which is
         # what keeps the copy fallback silent on hosted/GKE.
         return cached_overlay_probe(scratch_root=self.scratch_root).ok
+
+    def _discard_stale_probe_evidence(self) -> None:
+        # A cheap gate just declined to probe, so this host writes no evidence
+        # this run. Evidence left by an earlier run that *did* probe (and was
+        # refused) describes a posture that no longer holds — a worker restarted
+        # under force-copy, without CAP_SYS_ADMIN, or on a kernel without
+        # overlayfs is on the intended copy fallback. Deleting it restores the
+        # module invariant that a host which does not probe carries no evidence,
+        # therefore never warns.
+        if self.scratch_root is not None:
+            discard_overlay_probe_evidence(self.scratch_root)
 
     def mount(self, *, lowerdir: Path, upperdir: Path, workdir: Path, merged: Path) -> None:
         options = f"lowerdir={lowerdir},upperdir={upperdir},workdir={workdir}"

--- a/src/awf/node/auth_mounts_claude.py
+++ b/src/awf/node/auth_mounts_claude.py
@@ -6,7 +6,10 @@ first-party line limit. This module holds the generic overlayfs primitives
 :class:`OverlayMounter` abstraction) together with the full Claude auth
 subsystem they serve: host-content signature hashing, the shared read-only base
 build/reap, the per-workspace overlay mount, fallback-edit reconciliation, and
-teardown. :mod:`awf.node.auth_mounts` re-exports every public name here so
+teardown. The ``base.signature`` pin helpers and the per-workspace
+``.overlay.lock`` provision lock live in
+:mod:`awf.node.auth_mounts_claude_pin` and are re-imported here.
+:mod:`awf.node.auth_mounts` re-exports every public name here so
 ``awf.node.auth_mounts.<name>`` stays the stable import surface for callers and
 tests.
 """
@@ -14,16 +17,14 @@ tests.
 from __future__ import annotations
 
 import contextlib
-import errno
-import fcntl
 import os
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Callable, Collection, Iterator, Mapping
+from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Protocol
 
 from awf.common.logging import get_logger
 from awf.node.auth_mounts_caps import _has_cap_mknod as _has_cap_mknod
@@ -58,6 +59,23 @@ from awf.node.auth_mounts_claude_exclusions import claude_copy_ignore as claude_
 from awf.node.auth_mounts_claude_exclusions import (
     claude_signature_excludes_rel as claude_signature_excludes_rel,
 )
+from awf.node.auth_mounts_claude_pin import (
+    _CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED as _CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED,
+)
+from awf.node.auth_mounts_claude_pin import (
+    _CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE as _CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE,
+)
+from awf.node.auth_mounts_claude_pin import (
+    _FLOCK_WOULD_BLOCK_ERRNOS as _FLOCK_WOULD_BLOCK_ERRNOS,
+)
+from awf.node.auth_mounts_claude_pin import (
+    _OVERLAY_PROVISION_LOCK_NAME as _OVERLAY_PROVISION_LOCK_NAME,
+)
+from awf.node.auth_mounts_claude_pin import _live_overlay_pin_signature, _overlay_provision_lock
+from awf.node.auth_mounts_claude_pin import _OverlayLockState as _OverlayLockState
+from awf.node.auth_mounts_claude_pin import _pin_matches_signature as _pin_matches_signature
+from awf.node.auth_mounts_claude_pin import _pinned_overlay_base as _pinned_overlay_base
+from awf.node.auth_mounts_claude_pin import _record_overlay_base_pin as _record_overlay_base_pin
 from awf.node.auth_mounts_claude_reconcile import (
     _CLAUDE_AUTH_OVERLAY_WHITEOUT_FAILED as _CLAUDE_AUTH_OVERLAY_WHITEOUT_FAILED,
 )
@@ -115,8 +133,12 @@ _CLAUDE_FILE_TARGET = f"{_CONTAINER_HOME}/.claude.json"
 # The shared read-only overlay base subsystem — its ``_shared``/``claude-base``
 # dir names, the per-build ``.build.lock`` marker, and the ``CLAUDE_AUTH_SHARED_
 # BASE_FAILED`` reason code — lives in :mod:`awf.node.auth_mounts_claude_base`
-# and is re-imported above so ``awf.node.auth_mounts.<name>`` stays stable.
-_CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED = "CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED"
+# and is re-imported above so ``awf.node.auth_mounts.<name>`` stays stable. The
+# ``base.signature`` pin (``CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED``) and the
+# per-workspace ``.overlay.lock`` (its name, the would-block errnos, and
+# ``CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE``) live in
+# :mod:`awf.node.auth_mounts_claude_pin` and are re-imported the same way.
+
 # Logged when a surviving *non-empty* overlay ``upper`` whose base cannot be verified is
 # DISCARDED and rebuilt rather than remounted over a base guessed from the current host
 # (#405). The upper is unverifiable when there is no ``base.signature`` pin, or a pin that
@@ -132,28 +154,6 @@ _CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED = "CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE
 _CLAUDE_AUTH_OVERLAY_UNPINNED_UPPER_DISCARDED_REBUILT = (
     "CLAUDE_AUTH_OVERLAY_UNPINNED_UPPER_DISCARDED_REBUILT"
 )
-# Per-workspace advisory ``flock`` marker that serializes the unpinned-upper
-# discard (#405) against a concurrent same-workspace provision's overlay mount
-# (#418/#419). The #405 discard re-checks ``is_mounted(merged)`` and then
-# ``rmtree``s ``upper``/``work`` — a TOCTOU window in which a racing provision can
-# mount the overlay over those very layers, so the discard then deletes the live
-# overlay's backing dirs and destroys the active workspace's Claude edits. The
-# DB-CAS provisioning claim already bars concurrent same-workspace provisions
-# *except* in the stale-lease-recovery window; this exclusive ``flock`` is the
-# same-host backstop for exactly that window, taken across *both* the discard and
-# the mount so the ``is_mounted``-recheck + ``rmtree`` is atomic against any other
-# provision's ``mount()`` (which must also hold this lock). It lives beside
-# ``upper``/``work``/``merged`` and is left intact by the discard's targeted
-# ``rmtree`` (only the scratch dirs are removed); GC/teardown reap ``target_root``
-# wholesale and take it with them. The kernel frees the lock on ``close``/process
-# death, mirroring the shared-base build lock's crash semantics.
-_OVERLAY_PROVISION_LOCK_NAME = ".overlay.lock"
-# Errnos that mean "the lock is held by someone else" for a non-blocking ``flock``.
-# ``EAGAIN``/``EWOULDBLOCK`` normally surface as ``BlockingIOError``, but some
-# systems/filesystems report the conflict as ``EACCES`` (Python's ``fcntl`` docs call
-# out both forms), which arrives as a plain ``OSError``. All three are genuine
-# contention, not an unsupported-locking signal.
-_FLOCK_WOULD_BLOCK_ERRNOS = frozenset({errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK})
 # Logged when the unpinned-upper discard *and* a fresh off-lock mount are both
 # skipped because a concurrent same-workspace provision holds the overlay lock
 # (the narrow stale-lease window). The racing duplicate either reuses the holder's
@@ -165,12 +165,6 @@ _CLAUDE_AUTH_OVERLAY_DISCARD_LOCK_CONTENDED = "CLAUDE_AUTH_OVERLAY_DISCARD_LOCK_
 # defense-in-depth whose TOCTOU the overlay lock now closes. Kept observable so an
 # operator can see the discard was abandoned in favor of reusing the live overlay.
 _CLAUDE_AUTH_OVERLAY_DISCARD_SKIPPED_LIVE_MOUNT = "CLAUDE_AUTH_OVERLAY_DISCARD_SKIPPED_LIVE_MOUNT"
-# Logged once when the per-workspace overlay lock file could not be created/locked
-# (an FS fault: ENOSPC, EROFS, EPERM). Provisioning proceeds best-effort without
-# serialization; the discard-vs-mount race reopens only under the double fault of
-# (lock-file-uncreatable AND a concurrent provision), which the DB-CAS claim still
-# guards against — so behavior is no worse than before the lock and is audited here.
-_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE"
 # Logged when a reused live overlay's real lowerdir could not be recovered, so the
 # host-recomputed base is untrustworthy: the fallback-edit reconcile (#381) and the
 # legacy-copy reap are both deferred to a later provision that can pin the true base,
@@ -799,225 +793,6 @@ def _prepare_isolated_claude_auth(
         chown_exempt_sources=frozenset(chown_exempt),
         extra_chown_paths=tuple(extra_chown),
     )
-
-
-def _pinned_overlay_base(work_dir: Path, sig_marker: Path) -> Path | None:
-    """Return the base an existing overlay ``upper``/``work`` were built against.
-
-    Reads the ``base.signature`` marker written when the overlay was first
-    created and resolves it back to the shared base dir. Returns ``None`` when no
-    marker exists (a pre-pin overlay, or none at all) or the recorded base is no
-    longer on disk — the caller then rebuilds from the current host. The recorded
-    base normally persists because shared bases are immutable and old signatures
-    are left intact for exactly this case (a still-relevant lowerdir).
-    """
-
-    try:
-        signature = sig_marker.read_text().strip()
-    except (OSError, ValueError):
-        # ValueError covers UnicodeDecodeError from a corrupted/binary marker:
-        # treat an unreadable pin as "no recoverable base" rather than crashing
-        # provisioning, so the caller rebuilds from the current host.
-        return None
-    base = _shared_claude_base_dir(work_dir, signature)
-    return base if base.is_dir() else None
-
-
-def _pin_matches_signature(sig_marker: Path, signature: str) -> bool:
-    """Return whether ``base.signature`` pins exactly the current-host ``signature``.
-
-    A surviving overlay ``upper`` is *verifiable* when either the pinned base is still
-    on disk (:func:`_pinned_overlay_base`) or — even if that base dir was reaped — the
-    pin names the same signature a current-host rebuild would reproduce. This probe is
-    the second case: ``True`` iff the marker exists and its stripped contents equal
-    ``signature``, so rebuilding the base from the current host yields exactly the lower
-    the upper was built against (no guess). An absent or unreadable marker (``OSError``,
-    or ``ValueError``/``UnicodeDecodeError`` from corrupted bytes) is not a match, so the
-    caller treats the upper as unverifiable and discards it (#405).
-    """
-
-    try:
-        return sig_marker.read_text().strip() == signature
-    except (OSError, ValueError):
-        # ValueError covers UnicodeDecodeError from a corrupted/binary marker
-        # (UnicodeDecodeError subclasses ValueError, not OSError): treat an
-        # unreadable marker as "not a match" so the caller discards the
-        # unverifiable upper instead of crashing provisioning (#405).
-        return False
-
-
-def _record_overlay_base_pin(sig_marker: Path, signature: str, claude_root: Path) -> None:
-    """Persist the base-signature pin for an already-established overlay.
-
-    Records which shared base the live ``upper``/``work`` belong to so a later
-    teardown + remount pins them to that exact base instead of recomputing it
-    from a since-changed host ``~/.claude`` (which would trip an upper/base
-    mismatch whose failure path ``rmtree``s the agent's overlay mutations). A
-    failed write only forfeits the pin hint for a future teardown+retry (which
-    then recomputes the base from the host); the overlay is already live and
-    correct for this provision, so never hard-fail provisioning on it.
-    """
-
-    try:
-        sig_marker.write_text(signature)
-    except OSError as exc:
-        # The overlay is already mounted and correct for this provision; only the
-        # base-signature pin write failed. Use a distinct reason code so this
-        # harmless metadata-write failure is not conflated with an actual
-        # mount-unavailable event when operators grep the logs.
-        _log.warning(
-            "claude_auth_overlay_base_pin_write_failed",
-            reason_code=_CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED,
-            workspace_auth_root=str(claude_root),
-            error=str(exc),
-        )
-
-
-def _live_overlay_pin_signature(
-    overlay_mounter: OverlayMounter, merged: Path, work_dir: Path
-) -> str | None:
-    """Resolve the base signature to pin for a *reused* live overlay.
-
-    A retry reaches the live-mount reuse branch when the prior provision was
-    killed after ``mount()`` succeeded but before it recorded ``base.signature``:
-    ``upper`` exists yet the marker is missing. The signature recomputed from the
-    current host is only correct if ``~/.claude`` is unchanged — if the operator
-    edited it since the kill, that value names a *different* base than the one this
-    still-live overlay is actually mounted against, and persisting it would later
-    remount the surviving upper over the wrong base (the exact mismatch whose
-    failure path ``rmtree``s the agent's mutations). So recover the ``lowerdir``
-    the live mount really uses and map it back to its shared-base signature.
-
-    Returns ``None`` — meaning write no pin, leaving a later teardown+retry to
-    recompute from the host — when the live lowerdir cannot be recovered or does
-    not resolve to a shared base under ``work_dir``: no pin is safer than a guess.
-    """
-
-    live_lowerdir = overlay_mounter.active_lowerdir(merged)
-    if live_lowerdir is None:
-        return None
-    signature = live_lowerdir.parent.name
-    shared_base = _shared_claude_base_dir(work_dir, signature)
-    # Compare in *resolved* form: ``active_lowerdir`` reads the live lowerdir from
-    # ``/proc/mounts`` in the kernel-resolved form (the kernel follows symlinks when
-    # recording mount paths), while ``_shared_claude_base_dir`` is built from a
-    # ``work_dir`` that only had ``expanduser()`` applied. When ``AWF_WORK_DIR`` is
-    # reached via a symlink or bind-mount alias the two string forms diverge, so a
-    # valid shared base would fail this equality check and no pin would be recorded —
-    # leaving a later teardown+remount to recompute against a since-changed host. The
-    # GC protection code resolves both sides for exactly this reason.
-    if shared_base.resolve(strict=False) != live_lowerdir.resolve(strict=False):
-        return None
-    # The live overlay keeps serving off kernel-held inodes even after its lowerdir
-    # *path* is removed or renamed on the host, and ``resolve(strict=False)`` above
-    # matches such a stale ``/proc/mounts`` path without proving the dir still exists.
-    # Returning the signature anyway would have the caller realign ``base`` to that
-    # vanished tree, and ``_reconcile_fallback_edits_into_upper`` — which reads a
-    # missing ``base[rel]`` as "legacy is newer than base" — would then copy the whole
-    # legacy tree into the live overlay. Require the base to still be a real directory,
-    # mirroring ``_pinned_overlay_base``'s ``is_dir`` guard; otherwise return ``None`` so
-    # the caller defers the reconcile (and the legacy reap) and writes no pin.
-    if not shared_base.is_dir():
-        return None
-    return signature
-
-
-_OverlayLockState = Literal["acquired", "contended", "unavailable"]
-
-
-@contextlib.contextmanager
-def _overlay_provision_lock(claude_root: Path) -> Iterator[_OverlayLockState]:
-    """Hold the per-workspace overlay ``flock`` for the discard + mount span.
-
-    Yields one of:
-
-    - ``"acquired"`` — this provision exclusively holds ``<claude_root>/.overlay.
-      lock`` for the duration of the ``with`` block, so its unpinned-upper discard
-      (``is_mounted``-recheck + ``rmtree``) is atomic against any other
-      same-workspace provision's overlay ``mount()`` (which must also take this lock).
-    - ``"contended"`` — a concurrent same-workspace provision already holds the lock
-      (``EWOULDBLOCK``/``EAGAIN`` — or ``EACCES`` on systems that report a
-      non-blocking ``flock`` conflict that way — from a non-blocking ``flock``).
-      This is the narrow
-      stale-lease-recovery window the DB-CAS claim does not cover; the caller must
-      neither ``rmtree`` the (in-use) upper nor issue a fresh off-lock mount.
-    - ``"unavailable"`` — the lock file could not be created (an FS fault: ENOSPC,
-      EROFS, EPERM) **or** the FS does not support advisory locking, so ``flock``
-      itself failed (ENOTSUP, ENOSYS, EINVAL). The caller proceeds best-effort
-      without serialization rather than degrading to the legacy copy.
-
-    Acquisition is strictly non-blocking (``LOCK_NB``) so it never wedges the worker;
-    the kernel releases the lock on ``close``/process death, matching the shared-base
-    build lock's crash semantics (:func:`_ensure_shared_claude_base`). ``flock``
-    contention surfaces as ``BlockingIOError`` — or, on systems that report it as
-    ``EACCES``, an ``OSError`` whose ``errno`` is in
-    :data:`_FLOCK_WOULD_BLOCK_ERRNOS` — both mapped to ``"contended"``; any other
-    ``OSError`` means locking is unsupported (``"unavailable"``). Only
-    ``OSError``/``BlockingIOError`` are caught — never a bare ``Exception``
-    (AGENTS.md rule).
-    """
-
-    lock_path = claude_root / _OVERLAY_PROVISION_LOCK_NAME
-    try:
-        lock_fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
-    except OSError as exc:
-        # The FS could not host the lock file (ENOSPC, EROFS, EPERM). There is no fd
-        # to release, so yield ``unavailable`` directly — the caller logs once and
-        # proceeds unserialized.
-        _log.warning(
-            "claude_auth_overlay_provision_lock_unavailable",
-            reason_code=_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE,
-            workspace_auth_root=str(claude_root),
-            error=str(exc),
-        )
-        yield "unavailable"
-        return
-    try:
-        try:
-            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        except BlockingIOError:
-            # ``EWOULDBLOCK``/``EAGAIN``: a concurrent same-workspace provision holds
-            # the lock — the stale-lease window. Only genuine contention is
-            # ``"contended"``; that path may degrade to the legacy copy this round.
-            yield "contended"
-            return
-        except OSError as exc:
-            if exc.errno in _FLOCK_WOULD_BLOCK_ERRNOS:
-                # Some systems/filesystems report a non-blocking ``flock`` conflict as
-                # ``EACCES`` rather than ``EAGAIN``/``EWOULDBLOCK`` (Python's ``fcntl``
-                # docs call out both forms), so it surfaces here as a plain ``OSError``
-                # instead of ``BlockingIOError``. This is still genuine contention — a
-                # concurrent same-workspace provision holds the lock — so treat it like
-                # the ``BlockingIOError`` path above and yield ``"contended"`` rather
-                # than reopening the stale-lease discard-vs-mount race by proceeding
-                # unserialized.
-                yield "contended"
-                return
-            # The FS does not support advisory locking (``ENOTSUP``/``ENOSYS``/
-            # ``EINVAL``). Treat the lock as unavailable and proceed best-effort
-            # (unserialized) rather than degrading every provision to the legacy copy
-            # — overlays would otherwise be permanently disabled on such filesystems.
-            _log.warning(
-                "claude_auth_overlay_provision_lock_unavailable",
-                reason_code=_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE,
-                workspace_auth_root=str(claude_root),
-                error=str(exc),
-            )
-            yield "unavailable"
-            return
-        yield "acquired"
-    finally:
-        # Release explicitly when held (a no-op under ``contended``, suppressed if the
-        # fd's lock state is already gone), then close — the kernel also frees the
-        # lock on this ``close`` and on process death.
-        with contextlib.suppress(OSError):
-            fcntl.flock(lock_fd, fcntl.LOCK_UN)
-        # Suppress ``OSError`` on close too (e.g. ``EIO`` on a flush-on-close over
-        # NFS): a raise from this ``finally`` would mask any exception already
-        # propagating from the ``with`` body. The kernel frees the lock and the fd on
-        # process death regardless.
-        with contextlib.suppress(OSError):
-            os.close(lock_fd)
 
 
 def _prepare_claude_overlay_mount(

--- a/src/awf/node/auth_mounts_claude_base.py
+++ b/src/awf/node/auth_mounts_claude_base.py
@@ -20,6 +20,12 @@ import tempfile
 from pathlib import Path
 
 from awf.common.logging import get_logger
+from awf.node.auth_mounts_claude_exclusions import (
+    claude_copy_ignore as claude_copy_ignore,
+)
+from awf.node.auth_mounts_claude_exclusions import (
+    claude_signature_excludes_rel as claude_signature_excludes_rel,
+)
 from awf.node.auth_mounts_claude_reconcile import (
     _CLAUDE_USAGE_HISTORY_DIRS as _CLAUDE_USAGE_HISTORY_DIRS,
 )
@@ -69,8 +75,14 @@ def _host_claude_signature(host_home: Path) -> str:
     than mounting a stale lowerdir (the legacy per-workspace copy always
     reflected the current host; the shared base must not silently fall behind).
     The usage-history dirs excluded from the copied base are excluded here too,
-    so churn in those transcript trees never forces a needless rebuild. Cheap:
-    ``stat`` only, no file reads.
+    so churn in those transcript trees never forces a needless rebuild. #874
+    widens the *signature* exclusions (never the copy ones) to the known-volatile
+    top-level entries Claude Code rewrites on every interaction — ``history.jsonl``,
+    ``cache``, ``file-history``, … (:mod:`awf.node.auth_mounts_claude_exclusions`).
+    Those are still copied, so the agent gets a frozen snapshot; they simply no
+    longer mint a fresh signature and force a ~1.9 GB base rebuild per provision.
+    Everything unrecognised stays signed — the closed-allowlist rule documented in
+    that module. Cheap: ``stat`` only, no file reads.
 
     Symlinks are followed (``followlinks=True`` + ``stat`` rather than ``lstat``)
     to mirror the copy, which uses ``copytree(symlinks=False)`` and so copies the
@@ -116,7 +128,6 @@ def _host_claude_signature(host_home: Path) -> str:
     """
 
     source = host_home / ".claude"
-    excluded = frozenset(_CLAUDE_USAGE_HISTORY_DIRS)
     entries: list[str] = []
     # Per-branch ancestor identities, keyed by walked path. Seeded with the source's
     # own identity so a child linking straight back to ``~/.claude`` is caught.
@@ -139,9 +150,16 @@ def _host_claude_signature(host_home: Path) -> str:
     for root, dirs, files in os.walk(source, followlinks=True):
         root_path = Path(root)
         root_ancestors = ancestors_by_path.get(os.fspath(root_path), frozenset())
+        at_source_root = root_path == source
         kept: list[str] = []
         for name in dirs:
-            if name in excluded:
+            # Anchored to the top level (#874): a *nested* dir whose basename
+            # collides with an excluded name (``plugins/cache``, ``*/projects``)
+            # is real content, is copied into the base, and must therefore keep
+            # being signed. Only depth-0 entries are skipped, and skipping them
+            # here also prunes the descent — their subtrees are neither signed
+            # nor walked.
+            if at_source_root and claude_signature_excludes_rel(name):
                 continue
             child = root_path / name
             try:
@@ -169,6 +187,14 @@ def _host_claude_signature(host_home: Path) -> str:
         for name in (*dirs, *files):
             entry = root_path / name
             rel = entry.relative_to(source).as_posix()
+            # The dirs loop above prunes excluded *directories*; before #874 the
+            # files loop had no exclusion check at all, so a volatile top-level
+            # *file* such as ``history.jsonl`` could not be dropped by editing the
+            # exclusion set — it was always signed and churned the base on every
+            # Claude Code turn. ``rel`` is the full relative POSIX path, so this
+            # predicate is anchored on its own (nested files never match).
+            if claude_signature_excludes_rel(rel):
+                continue
             try:
                 entry_stat = entry.stat()
             except OSError:
@@ -274,7 +300,10 @@ def _ensure_shared_claude_base(
         shutil.copytree(
             host_home / ".claude",
             staged_base,
-            ignore=shutil.ignore_patterns(*_CLAUDE_USAGE_HISTORY_DIRS),
+            # Anchored ignore (#874): ``shutil.ignore_patterns`` matched by
+            # basename at every depth, which would strip nested ``plugins/cache``
+            # and ``*/projects`` trees from the base as well.
+            ignore=claude_copy_ignore(host_home / ".claude"),
             ignore_dangling_symlinks=True,
         )
         if workspace_owner_uid is not None and workspace_owner_gid is not None:

--- a/src/awf/node/auth_mounts_claude_exclusions.py
+++ b/src/awf/node/auth_mounts_claude_exclusions.py
@@ -1,0 +1,137 @@
+"""Top-level-anchored ``~/.claude`` copy and signature exclusion sets (#874).
+
+Dependency-free leaf shared by the shared-base signature walk
+(:mod:`awf.node.auth_mounts_claude_base`), the legacy per-workspace copy
+(:mod:`awf.node.auth_mounts_claude`) and the fallback-edit reconcile walks
+(:mod:`awf.node.auth_mounts_claude_reconcile`). Those modules re-export the
+public names so ``awf.node.auth_mounts.<name>`` stays the stable import surface.
+
+Two distinct sets, deliberately not one:
+
+**Copy exclusions** — what is left *out of* the per-workspace/base copy. Excluding
+a name here means the agent never sees it, so the membership is exactly the
+pre-#874 usage-history set (``projects``/``todos``/``shell-snapshots``/``statsig``,
+kept out so ``ccusage`` cannot attribute the host's prior usage to the workspace
+run). Keeping it byte-identical means #874 carries zero risk of dropping an auth
+file; only the *matching semantics* narrow (see anchoring below).
+
+**Signature exclusions** — what is left out of the host-content hash that names
+the shared base (:func:`awf.node.auth_mounts_claude_base._host_claude_signature`).
+A strict superset of the copy set: it adds host state that changes on *every*
+Claude Code interaction (``history.jsonl``, ``file-history``, ``cache``, …).
+Those entries are still **copied** — the agent gets a frozen snapshot of them —
+they simply no longer mint a new signature, so a ~1.9 GB base rebuild is not
+triggered by the operator merely using Claude Code on the host (#874 observed 5
+base hashes built and reaped in a single worker lifetime).
+
+**Governing rule (load-bearing, enforced by test):** the signature-exclusion set
+is a **closed allowlist** of known-volatile names. Anything unrecognised — a
+top-level entry a future Claude Code release introduces — is *signed*. The
+failure modes are asymmetric: signing something volatile causes needless base
+churn (annoying, but the workspace still gets correct credentials), whereas
+*not* signing something meaningful reuses a stale base and hands the workspace a
+superseded credential — silent and wrong. So the set only ever grows by an
+explicit, reviewed addition.
+
+**Anchoring (trap (a) of #874):** the pre-#874 constant was consumed via
+``shutil.ignore_patterns`` and a bare ``name in excluded`` check inside
+``os.walk``, both of which match by *basename at every depth*. Widening that set
+would therefore have stripped ``plugins/cache`` (an installed-plugin store,
+~66 MB) and assorted nested ``node_modules`` dirs from every agent's
+``~/.claude``. Every predicate here is anchored to the **top level** of the
+``.claude`` tree: a depth-0 entry only.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Iterable
+from fnmatch import fnmatch
+from pathlib import Path
+
+# Historical usage/transcript dirs kept out of the per-workspace and shared-base
+# copies. Excluding them keeps the workspace from seeing unrelated host
+# transcripts (``ccusage`` reads these local files) and avoids copying large
+# history trees. Membership is unchanged from pre-#874 — only the matching
+# semantics narrowed to the top level.
+CLAUDE_COPY_EXCLUDED_TOP_LEVEL: frozenset[str] = frozenset(
+    {"projects", "todos", "shell-snapshots", "statsig"}
+)
+
+# Known-volatile top-level entries that are copied but not signed. Every name
+# here changes on ordinary Claude Code use on the host, so signing it churns the
+# shared-base signature on essentially every provision. See the closed-allowlist
+# rule in the module docstring before adding to this set.
+_CLAUDE_VOLATILE_TOP_LEVEL: frozenset[str] = frozenset(
+    {
+        "history.jsonl",
+        "file-history",
+        "cache",
+        "paste-cache",
+        "session-env",
+        "sessions",
+        "backups",
+        "debug",
+        "jobs",
+        "tasks",
+    }
+)
+
+CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL: frozenset[str] = (
+    CLAUDE_COPY_EXCLUDED_TOP_LEVEL | _CLAUDE_VOLATILE_TOP_LEVEL
+)
+
+# Volatile top-level entries whose exact name varies per process/run, so they
+# cannot be listed literally. Matched with ``fnmatch`` against a depth-0 entry
+# only. Deliberately narrow: ``*-cache.json`` does not match ``settings.json``
+# and ``daemon*`` does not match any auth/config name.
+CLAUDE_SIGNATURE_EXCLUDED_PATTERNS: tuple[str, ...] = ("daemon*", "*-cache.json")
+
+
+def _is_top_level(rel: str) -> bool:
+    """Return whether ``rel`` (a POSIX-relative entry) sits at the tree root."""
+
+    return bool(rel) and "/" not in rel
+
+
+def claude_copy_excludes_rel(rel: str) -> bool:
+    """Return whether the copy skips ``rel``, a POSIX path relative to ``.claude``.
+
+    Anchored: ``projects`` is excluded, ``plugins/projects`` is not.
+    """
+
+    return _is_top_level(rel) and rel in CLAUDE_COPY_EXCLUDED_TOP_LEVEL
+
+
+def claude_signature_excludes_rel(rel: str) -> bool:
+    """Return whether the host-content signature skips ``rel``.
+
+    Anchored to the top level exactly as :func:`claude_copy_excludes_rel` is, so
+    a nested ``plugins/cache`` or ``skills/cache`` is still signed (and therefore
+    still forces a fresh base when an operator installs or updates a plugin).
+    """
+
+    if not _is_top_level(rel):
+        return False
+    if rel in CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL:
+        return True
+    return any(fnmatch(rel, pattern) for pattern in CLAUDE_SIGNATURE_EXCLUDED_PATTERNS)
+
+
+def claude_copy_ignore(root: Path) -> Callable[[str, Iterable[str]], set[str]]:
+    """Return a ``shutil.copytree(ignore=...)`` callable anchored at ``root``.
+
+    Replaces ``shutil.ignore_patterns(*names)``, which matched at every depth.
+    The returned callable only reports exclusions when ``copytree`` is visiting
+    ``root`` itself, so nested ``plugins/cache``, ``node_modules`` and
+    ``*/projects`` trees are copied normally.
+    """
+
+    anchor = os.path.normpath(os.fspath(root))
+
+    def _ignore(src: str, names: Iterable[str]) -> set[str]:
+        if os.path.normpath(src) != anchor:
+            return set()
+        return {name for name in names if name in CLAUDE_COPY_EXCLUDED_TOP_LEVEL}
+
+    return _ignore

--- a/src/awf/node/auth_mounts_claude_pin.py
+++ b/src/awf/node/auth_mounts_claude_pin.py
@@ -1,0 +1,282 @@
+"""Overlay base-signature pin and per-workspace provision lock for Claude auth.
+
+Split out of :mod:`awf.node.auth_mounts_claude` to keep that module under the
+first-party line limit. This module holds the two mechanisms that decide *which*
+shared base a surviving overlay ``upper`` belongs to and *who* may mutate a
+workspace's overlay scratch at a time: the ``base.signature`` pin
+(read/verify/record, plus live-mount recovery) and the ``.overlay.lock``
+advisory ``flock`` that serializes the unpinned-upper discard against a
+concurrent same-workspace provision's mount. :mod:`awf.node.auth_mounts_claude`
+re-exports every name here, and :mod:`awf.node.auth_mounts` re-exports it in
+turn, so ``awf.node.auth_mounts.<name>`` stays the stable import surface for
+callers and tests.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import fcntl
+import os
+from collections.abc import Iterator
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from awf.common.logging import get_logger
+from awf.node.auth_mounts_claude_base import _shared_claude_base_dir
+
+if TYPE_CHECKING:
+    # Type-only: importing the Protocol at runtime would close an import cycle
+    # (``auth_mounts_claude`` imports this module).
+    from awf.node.auth_mounts_claude import OverlayMounter
+
+_log = get_logger(__name__)
+
+_CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED = "CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED"
+# Per-workspace advisory ``flock`` marker that serializes the unpinned-upper
+# discard (#405) against a concurrent same-workspace provision's overlay mount
+# (#418/#419). The #405 discard re-checks ``is_mounted(merged)`` and then
+# ``rmtree``s ``upper``/``work`` — a TOCTOU window in which a racing provision can
+# mount the overlay over those very layers, so the discard then deletes the live
+# overlay's backing dirs and destroys the active workspace's Claude edits. The
+# DB-CAS provisioning claim already bars concurrent same-workspace provisions
+# *except* in the stale-lease-recovery window; this exclusive ``flock`` is the
+# same-host backstop for exactly that window, taken across *both* the discard and
+# the mount so the ``is_mounted``-recheck + ``rmtree`` is atomic against any other
+# provision's ``mount()`` (which must also hold this lock). It lives beside
+# ``upper``/``work``/``merged`` and is left intact by the discard's targeted
+# ``rmtree`` (only the scratch dirs are removed); GC/teardown reap ``target_root``
+# wholesale and take it with them. The kernel frees the lock on ``close``/process
+# death, mirroring the shared-base build lock's crash semantics.
+_OVERLAY_PROVISION_LOCK_NAME = ".overlay.lock"
+# Errnos that mean "the lock is held by someone else" for a non-blocking ``flock``.
+# ``EAGAIN``/``EWOULDBLOCK`` normally surface as ``BlockingIOError``, but some
+# systems/filesystems report the conflict as ``EACCES`` (Python's ``fcntl`` docs call
+# out both forms), which arrives as a plain ``OSError``. All three are genuine
+# contention, not an unsupported-locking signal.
+_FLOCK_WOULD_BLOCK_ERRNOS = frozenset({errno.EACCES, errno.EAGAIN, errno.EWOULDBLOCK})
+# Logged once when the per-workspace overlay lock file could not be created/locked
+# (an FS fault: ENOSPC, EROFS, EPERM). Provisioning proceeds best-effort without
+# serialization; the discard-vs-mount race reopens only under the double fault of
+# (lock-file-uncreatable AND a concurrent provision), which the DB-CAS claim still
+# guards against — so behavior is no worse than before the lock and is audited here.
+_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE"
+
+
+def _pinned_overlay_base(work_dir: Path, sig_marker: Path) -> Path | None:
+    """Return the base an existing overlay ``upper``/``work`` were built against.
+
+    Reads the ``base.signature`` marker written when the overlay was first
+    created and resolves it back to the shared base dir. Returns ``None`` when no
+    marker exists (a pre-pin overlay, or none at all) or the recorded base is no
+    longer on disk — the caller then rebuilds from the current host. The recorded
+    base normally persists because shared bases are immutable and old signatures
+    are left intact for exactly this case (a still-relevant lowerdir).
+    """
+
+    try:
+        signature = sig_marker.read_text().strip()
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError from a corrupted/binary marker:
+        # treat an unreadable pin as "no recoverable base" rather than crashing
+        # provisioning, so the caller rebuilds from the current host.
+        return None
+    base = _shared_claude_base_dir(work_dir, signature)
+    return base if base.is_dir() else None
+
+
+def _pin_matches_signature(sig_marker: Path, signature: str) -> bool:
+    """Return whether ``base.signature`` pins exactly the current-host ``signature``.
+
+    A surviving overlay ``upper`` is *verifiable* when either the pinned base is still
+    on disk (:func:`_pinned_overlay_base`) or — even if that base dir was reaped — the
+    pin names the same signature a current-host rebuild would reproduce. This probe is
+    the second case: ``True`` iff the marker exists and its stripped contents equal
+    ``signature``, so rebuilding the base from the current host yields exactly the lower
+    the upper was built against (no guess). An absent or unreadable marker (``OSError``,
+    or ``ValueError``/``UnicodeDecodeError`` from corrupted bytes) is not a match, so the
+    caller treats the upper as unverifiable and discards it (#405).
+    """
+
+    try:
+        return sig_marker.read_text().strip() == signature
+    except (OSError, ValueError):
+        # ValueError covers UnicodeDecodeError from a corrupted/binary marker
+        # (UnicodeDecodeError subclasses ValueError, not OSError): treat an
+        # unreadable marker as "not a match" so the caller discards the
+        # unverifiable upper instead of crashing provisioning (#405).
+        return False
+
+
+def _record_overlay_base_pin(sig_marker: Path, signature: str, claude_root: Path) -> None:
+    """Persist the base-signature pin for an already-established overlay.
+
+    Records which shared base the live ``upper``/``work`` belong to so a later
+    teardown + remount pins them to that exact base instead of recomputing it
+    from a since-changed host ``~/.claude`` (which would trip an upper/base
+    mismatch whose failure path ``rmtree``s the agent's overlay mutations). A
+    failed write only forfeits the pin hint for a future teardown+retry (which
+    then recomputes the base from the host); the overlay is already live and
+    correct for this provision, so never hard-fail provisioning on it.
+    """
+
+    try:
+        sig_marker.write_text(signature)
+    except OSError as exc:
+        # The overlay is already mounted and correct for this provision; only the
+        # base-signature pin write failed. Use a distinct reason code so this
+        # harmless metadata-write failure is not conflated with an actual
+        # mount-unavailable event when operators grep the logs.
+        _log.warning(
+            "claude_auth_overlay_base_pin_write_failed",
+            reason_code=_CLAUDE_AUTH_OVERLAY_BASE_PIN_WRITE_FAILED,
+            workspace_auth_root=str(claude_root),
+            error=str(exc),
+        )
+
+
+def _live_overlay_pin_signature(
+    overlay_mounter: OverlayMounter, merged: Path, work_dir: Path
+) -> str | None:
+    """Resolve the base signature to pin for a *reused* live overlay.
+
+    A retry reaches the live-mount reuse branch when the prior provision was
+    killed after ``mount()`` succeeded but before it recorded ``base.signature``:
+    ``upper`` exists yet the marker is missing. The signature recomputed from the
+    current host is only correct if ``~/.claude`` is unchanged — if the operator
+    edited it since the kill, that value names a *different* base than the one this
+    still-live overlay is actually mounted against, and persisting it would later
+    remount the surviving upper over the wrong base (the exact mismatch whose
+    failure path ``rmtree``s the agent's mutations). So recover the ``lowerdir``
+    the live mount really uses and map it back to its shared-base signature.
+
+    Returns ``None`` — meaning write no pin, leaving a later teardown+retry to
+    recompute from the host — when the live lowerdir cannot be recovered or does
+    not resolve to a shared base under ``work_dir``: no pin is safer than a guess.
+    """
+
+    live_lowerdir = overlay_mounter.active_lowerdir(merged)
+    if live_lowerdir is None:
+        return None
+    signature = live_lowerdir.parent.name
+    shared_base = _shared_claude_base_dir(work_dir, signature)
+    # Compare in *resolved* form: ``active_lowerdir`` reads the live lowerdir from
+    # ``/proc/mounts`` in the kernel-resolved form (the kernel follows symlinks when
+    # recording mount paths), while ``_shared_claude_base_dir`` is built from a
+    # ``work_dir`` that only had ``expanduser()`` applied. When ``AWF_WORK_DIR`` is
+    # reached via a symlink or bind-mount alias the two string forms diverge, so a
+    # valid shared base would fail this equality check and no pin would be recorded —
+    # leaving a later teardown+remount to recompute against a since-changed host. The
+    # GC protection code resolves both sides for exactly this reason.
+    if shared_base.resolve(strict=False) != live_lowerdir.resolve(strict=False):
+        return None
+    # The live overlay keeps serving off kernel-held inodes even after its lowerdir
+    # *path* is removed or renamed on the host, and ``resolve(strict=False)`` above
+    # matches such a stale ``/proc/mounts`` path without proving the dir still exists.
+    # Returning the signature anyway would have the caller realign ``base`` to that
+    # vanished tree, and ``_reconcile_fallback_edits_into_upper`` — which reads a
+    # missing ``base[rel]`` as "legacy is newer than base" — would then copy the whole
+    # legacy tree into the live overlay. Require the base to still be a real directory,
+    # mirroring ``_pinned_overlay_base``'s ``is_dir`` guard; otherwise return ``None`` so
+    # the caller defers the reconcile (and the legacy reap) and writes no pin.
+    if not shared_base.is_dir():
+        return None
+    return signature
+
+
+_OverlayLockState = Literal["acquired", "contended", "unavailable"]
+
+
+@contextlib.contextmanager
+def _overlay_provision_lock(claude_root: Path) -> Iterator[_OverlayLockState]:
+    """Hold the per-workspace overlay ``flock`` for the discard + mount span.
+
+    Yields one of:
+
+    - ``"acquired"`` — this provision exclusively holds ``<claude_root>/.overlay.
+      lock`` for the duration of the ``with`` block, so its unpinned-upper discard
+      (``is_mounted``-recheck + ``rmtree``) is atomic against any other
+      same-workspace provision's overlay ``mount()`` (which must also take this lock).
+    - ``"contended"`` — a concurrent same-workspace provision already holds the lock
+      (``EWOULDBLOCK``/``EAGAIN`` — or ``EACCES`` on systems that report a
+      non-blocking ``flock`` conflict that way — from a non-blocking ``flock``).
+      This is the narrow
+      stale-lease-recovery window the DB-CAS claim does not cover; the caller must
+      neither ``rmtree`` the (in-use) upper nor issue a fresh off-lock mount.
+    - ``"unavailable"`` — the lock file could not be created (an FS fault: ENOSPC,
+      EROFS, EPERM) **or** the FS does not support advisory locking, so ``flock``
+      itself failed (ENOTSUP, ENOSYS, EINVAL). The caller proceeds best-effort
+      without serialization rather than degrading to the legacy copy.
+
+    Acquisition is strictly non-blocking (``LOCK_NB``) so it never wedges the worker;
+    the kernel releases the lock on ``close``/process death, matching the shared-base
+    build lock's crash semantics (:func:`_ensure_shared_claude_base`). ``flock``
+    contention surfaces as ``BlockingIOError`` — or, on systems that report it as
+    ``EACCES``, an ``OSError`` whose ``errno`` is in
+    :data:`_FLOCK_WOULD_BLOCK_ERRNOS` — both mapped to ``"contended"``; any other
+    ``OSError`` means locking is unsupported (``"unavailable"``). Only
+    ``OSError``/``BlockingIOError`` are caught — never a bare ``Exception``
+    (AGENTS.md rule).
+    """
+
+    lock_path = claude_root / _OVERLAY_PROVISION_LOCK_NAME
+    try:
+        lock_fd = os.open(lock_path, os.O_CREAT | os.O_WRONLY, 0o600)
+    except OSError as exc:
+        # The FS could not host the lock file (ENOSPC, EROFS, EPERM). There is no fd
+        # to release, so yield ``unavailable`` directly — the caller logs once and
+        # proceeds unserialized.
+        _log.warning(
+            "claude_auth_overlay_provision_lock_unavailable",
+            reason_code=_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE,
+            workspace_auth_root=str(claude_root),
+            error=str(exc),
+        )
+        yield "unavailable"
+        return
+    try:
+        try:
+            fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError:
+            # ``EWOULDBLOCK``/``EAGAIN``: a concurrent same-workspace provision holds
+            # the lock — the stale-lease window. Only genuine contention is
+            # ``"contended"``; that path may degrade to the legacy copy this round.
+            yield "contended"
+            return
+        except OSError as exc:
+            if exc.errno in _FLOCK_WOULD_BLOCK_ERRNOS:
+                # Some systems/filesystems report a non-blocking ``flock`` conflict as
+                # ``EACCES`` rather than ``EAGAIN``/``EWOULDBLOCK`` (Python's ``fcntl``
+                # docs call out both forms), so it surfaces here as a plain ``OSError``
+                # instead of ``BlockingIOError``. This is still genuine contention — a
+                # concurrent same-workspace provision holds the lock — so treat it like
+                # the ``BlockingIOError`` path above and yield ``"contended"`` rather
+                # than reopening the stale-lease discard-vs-mount race by proceeding
+                # unserialized.
+                yield "contended"
+                return
+            # The FS does not support advisory locking (``ENOTSUP``/``ENOSYS``/
+            # ``EINVAL``). Treat the lock as unavailable and proceed best-effort
+            # (unserialized) rather than degrading every provision to the legacy copy
+            # — overlays would otherwise be permanently disabled on such filesystems.
+            _log.warning(
+                "claude_auth_overlay_provision_lock_unavailable",
+                reason_code=_CLAUDE_AUTH_OVERLAY_PROVISION_LOCK_UNAVAILABLE,
+                workspace_auth_root=str(claude_root),
+                error=str(exc),
+            )
+            yield "unavailable"
+            return
+        yield "acquired"
+    finally:
+        # Release explicitly when held (a no-op under ``contended``, suppressed if the
+        # fd's lock state is already gone), then close — the kernel also frees the
+        # lock on this ``close`` and on process death.
+        with contextlib.suppress(OSError):
+            fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        # Suppress ``OSError`` on close too (e.g. ``EIO`` on a flush-on-close over
+        # NFS): a raise from this ``finally`` would mask any exception already
+        # propagating from the ``with`` body. The kernel frees the lock and the fd on
+        # process death regardless.
+        with contextlib.suppress(OSError):
+            os.close(lock_fd)

--- a/src/awf/node/auth_mounts_claude_reconcile.py
+++ b/src/awf/node/auth_mounts_claude_reconcile.py
@@ -22,6 +22,12 @@ from pathlib import Path
 
 from awf.common.logging import get_logger
 from awf.node.auth_mounts_caps import _has_cap_mknod
+from awf.node.auth_mounts_claude_exclusions import (
+    CLAUDE_COPY_EXCLUDED_TOP_LEVEL as CLAUDE_COPY_EXCLUDED_TOP_LEVEL,
+)
+from awf.node.auth_mounts_claude_exclusions import (
+    claude_copy_excludes_rel as claude_copy_excludes_rel,
+)
 from awf.node.auth_mounts_overlay_copy import (
     _legacy_path_confidently_absent as _legacy_path_confidently_absent,
 )
@@ -41,7 +47,12 @@ _log = get_logger(__name__)
 # host's prior usage to the workspace run; baseline/delta still guards totals, but
 # excluding the copy keeps the workspace from seeing unrelated host transcripts and
 # avoids copying potentially large history trees.
-_CLAUDE_USAGE_HISTORY_DIRS = ("projects", "todos", "shell-snapshots", "statsig")
+# Back-compat alias for the canonical, top-level-anchored copy-exclusion set in
+# :mod:`awf.node.auth_mounts_claude_exclusions` (#874 moved the definition there so
+# the signature walk can exclude a strict superset without widening what is copied).
+# Membership is unchanged; ``awf.node.auth_mounts._CLAUDE_USAGE_HISTORY_DIRS`` stays
+# the stable name for callers and tests.
+_CLAUDE_USAGE_HISTORY_DIRS = tuple(sorted(CLAUDE_COPY_EXCLUDED_TOP_LEVEL))
 # Logged once per reconcile when a fallback-era deletion *could* be forwarded as an
 # overlayfs whiteout (host confirms the base copy is unchanged, so the legacy
 # absence is a confident agent deletion) but the worker lacks ``CAP_MKNOD`` to create
@@ -232,7 +243,6 @@ def _forward_fallback_deletions_as_whiteouts(
     credential on the next provision rather than trusting it across reboots.
     """
 
-    excluded = frozenset(_CLAUDE_USAGE_HISTORY_DIRS)
     has_cap_mknod = _has_cap_mknod()
     skipped_for_capability = False
     whiteout_failed_despite_cap = False
@@ -240,7 +250,11 @@ def _forward_fallback_deletions_as_whiteouts(
         root_path = Path(root)
         # Mirror the base copy's usage-history exclusion (kept for symmetry: those
         # dirs are absent from base anyway, so this never prunes a real candidate).
-        dirs[:] = [d for d in dirs if d not in excluded]
+        # Anchored to the walk root (#874): the base *does* hold nested dirs whose
+        # basename collides (``plugins/cache``, ``*/projects``), and pruning those
+        # would skip real deletion candidates.
+        if root_path == base:
+            dirs[:] = [d for d in dirs if not claude_copy_excludes_rel(d)]
         for name in files:
             rel = (root_path / name).relative_to(base)
             # Present in legacy (as anything) → not a deletion; the edit walk owns it.
@@ -471,17 +485,18 @@ def _reconcile_fallback_edits_into_upper(
     toward keeping a credential visible exactly as the other ambiguous cases are.
     """
 
-    excluded = frozenset(_CLAUDE_USAGE_HISTORY_DIRS)
     for root, dirs, files in os.walk(legacy):
         root_path = Path(root)
-        # Mirror the base copy's ``ignore_patterns(*_CLAUDE_USAGE_HISTORY_DIRS)``: the
+        # Mirror the base copy's anchored ``claude_copy_ignore`` exclusion: the
         # shared base never holds these usage-history subtrees, so every file in one
         # reads as ``base_mtime_ns is None`` (an unconditional "fallback edit") and would
         # be forwarded whole. A long fallback session that filled ``projects/`` with
         # multi-GB transcripts would otherwise materialise all of it in the overlay upper,
         # negating the shared-base disk-savings goal. Prune them in place so the walk does
         # not descend, bounding reconcile to the same scope as the base itself.
-        dirs[:] = [d for d in dirs if d not in excluded]
+        # Anchored to the walk root (#874) so nested collisions stay in scope.
+        if root_path == legacy:
+            dirs[:] = [d for d in dirs if not claude_copy_excludes_rel(d)]
         for name in files:
             legacy_file = root_path / name
             if legacy_file.is_symlink():
@@ -568,10 +583,10 @@ def _reconcile_fallback_edits_into_upper(
         # case. Mirror the deletion pass's own base walk (same usage-history pruning): an
         # empty or fully-excluded ``base`` yields no deletion candidate regardless of the
         # marker, so logging there is pure noise.
-        excluded = frozenset(_CLAUDE_USAGE_HISTORY_DIRS)
         has_deletion_candidate = False
         for _root, dirs, files in os.walk(base):
-            dirs[:] = [d for d in dirs if d not in excluded]
+            if Path(_root) == base:
+                dirs[:] = [d for d in dirs if not claude_copy_excludes_rel(d)]
             if files:
                 has_deletion_candidate = True
                 break

--- a/src/awf/node/auth_mounts_overlay_probe.py
+++ b/src/awf/node/auth_mounts_overlay_probe.py
@@ -17,7 +17,7 @@ build entirely and lets the failure be reported honestly.
 The probe performs one scratch ``mount``/``umount`` of an overlay under
 ``<work_dir>/auth/_shared`` and reports:
 
-- ``OVERLAY_PROBE_OK`` — the mount succeeded (whether or not the umount did).
+- ``OVERLAY_PROBE_OK`` — the mount succeeded *and* was confirmed unmounted.
 - ``REFUSED`` — ``mount(8)`` failed. On a host that already passed every cheap
   gate this is the AppArmor/seccomp case: unexpected, and worth surfacing. The
   staging tree is removed, unless the failed helper turns out to have left
@@ -25,14 +25,22 @@ The probe performs one scratch ``mount``/``umount`` of an overlay under
 - ``TIMEOUT`` — ``mount(8)`` did not return within ``timeout_seconds``. Also
   unexpected. The staging tree is retained, because a timed-out helper may still
   have completed the mount.
+- ``UMOUNT_FAILED`` — the mount landed but could not be confirmed torn down
+  (``umount(8)`` missing, denied, timing out, or exiting 0 with ``merged`` still
+  a mount point). Also unexpected. The whole point of the probe is to decide
+  whether *production* may overlay, and a mounter that cannot unmount the
+  scratch overlay cannot unmount a workspace's either: blessing it would leave
+  every per-workspace overlay live at cleanup, pinning its layers. The staging
+  tree is retained rather than recursively deleted through a possibly-live
+  merged view, so there is exactly one path for an operator to reclaim.
 - ``MOUNT_BINARY_MISSING`` — no ``mount(8)`` on ``PATH``.
 - ``SCRATCH_UNAVAILABLE`` — the scratch staging tree could not be created.
 - ``PATH_RESERVED_CHARS`` — the scratch path carries a ``,`` or ``:`` that
   overlayfs's unescapable ``-o`` payload cannot encode.
 
-**Expected vs unexpected is the load-bearing distinction.** Only ``REFUSED`` and
-``TIMEOUT`` are unexpected; every other non-ok reason is a legitimate platform
-property. Combined with the fact that the probe only runs *after* the cheap gates
+**Expected vs unexpected is the load-bearing distinction.** Only ``REFUSED``,
+``TIMEOUT`` and ``UMOUNT_FAILED`` are unexpected; every other non-ok reason is a
+legitimate platform property. Combined with the fact that the probe only runs *after* the cheap gates
 pass (force-copy not requested, kernel overlayfs present, ``CAP_SYS_ADMIN`` held,
 no reserved chars), this is what keeps the copy fallback a first-class,
 non-alarming path: a hosted/GKE control plane — where a pod-level overlay mount
@@ -106,9 +114,10 @@ _DETAIL_LIMIT = 512
 _DEFAULT_RUN: Callable[..., object] = subprocess.run
 
 # Non-ok reasons that indicate a host which *should* have been able to overlay
-# (every cheap gate passed) but was refused anyway — the AppArmor/seccomp case.
-# Every other reason is an expected platform property and stays silent.
-_UNEXPECTED_PROBE_REASONS = frozenset({"REFUSED", "TIMEOUT"})
+# (every cheap gate passed) but was refused anyway — the AppArmor/seccomp case —
+# or that mounted but could not tear the mount back down. Every other reason is
+# an expected platform property and stays silent.
+_UNEXPECTED_PROBE_REASONS = frozenset({"REFUSED", "TIMEOUT", "UMOUNT_FAILED"})
 
 
 @dataclass(frozen=True)
@@ -277,16 +286,33 @@ def probe_overlay_mount(
             timeout=timeout_seconds,
         )
     except (subprocess.SubprocessError, OSError) as exc:
-        # The mount itself worked, which is the whole question the probe asks, so
-        # the answer stays ``ok``. Deliberately do NOT ``rmtree``: the overlay may
-        # still be live, and a recursive delete would descend through ``merged``
-        # into the (empty, but conceptually real) layers underneath. Leaking one
-        # empty staging dir is strictly safer, and the retained path is recorded
-        # so an operator can reclaim it.
+        # The mount landed, but this mounter cannot take it back down — and it is
+        # the same mounter production uses to tear per-workspace overlays down at
+        # cleanup. Reporting ``ok`` would enable overlays that stay live forever
+        # (there is no reaper for them, nor for this staging tree), so the probe
+        # answers "unsupported" and the copy fallback is taken instead.
+        # Deliberately do NOT ``rmtree``: the overlay is presumed still live, and
+        # a recursive delete would descend through ``merged`` into the (empty,
+        # but conceptually real) layers underneath. Leaking one empty staging dir
+        # is strictly safer, and the retained path is recorded so an operator can
+        # reclaim it.
         return OverlayProbeResult(
-            ok=True,
-            reason="OVERLAY_PROBE_OK",
+            ok=False,
+            reason="UMOUNT_FAILED",
             detail=_truncate(f"umount failed ({exc}); retained staging dir {staging}"),
+        )
+
+    if _is_mounted(merged):
+        # ``umount(8)`` exited 0 yet ``merged`` is still a mount point (a lazy or
+        # otherwise deferred detach). Unmount is not *confirmed*, so the same
+        # verdict and the same retain-don't-delete choice apply as above.
+        return OverlayProbeResult(
+            ok=False,
+            reason="UMOUNT_FAILED",
+            detail=_truncate(
+                f"umount reported success but {merged} is still mounted; "
+                f"retained staging dir {staging}"
+            ),
         )
 
     shutil.rmtree(staging, ignore_errors=True)

--- a/src/awf/node/auth_mounts_overlay_probe.py
+++ b/src/awf/node/auth_mounts_overlay_probe.py
@@ -21,7 +21,8 @@ The probe performs one scratch ``mount``/``umount`` of an overlay under
 - ``REFUSED`` — ``mount(8)`` failed. On a host that already passed every cheap
   gate this is the AppArmor/seccomp case: unexpected, and worth surfacing.
 - ``TIMEOUT`` — ``mount(8)`` did not return within ``timeout_seconds``. Also
-  unexpected.
+  unexpected. The staging tree is retained, because a timed-out helper may still
+  have completed the mount.
 - ``MOUNT_BINARY_MISSING`` — no ``mount(8)`` on ``PATH``.
 - ``SCRATCH_UNAVAILABLE`` — the scratch staging tree could not be created.
 - ``PATH_RESERVED_CHARS`` — the scratch path carries a ``,`` or ``:`` that
@@ -192,11 +193,19 @@ def probe_overlay_mount(
             ok=False, reason="MOUNT_BINARY_MISSING", detail="mount(8) not found on PATH"
         )
     except subprocess.TimeoutExpired:
-        shutil.rmtree(staging, ignore_errors=True)
+        # Killing the timed-out helper does NOT undo a ``mount(2)`` that already
+        # landed, so ``merged`` may be a live overlay pinning lower/upper/work.
+        # Same reasoning — and the same choice — as the umount-failure branch
+        # below: retaining one empty staging dir is strictly safer than a
+        # recursive delete that would descend through a live merged view, tear
+        # out the pinned layers, and swallow the resulting ``EBUSY``. The
+        # retained path is recorded so an operator can reclaim it.
         return OverlayProbeResult(
             ok=False,
             reason="TIMEOUT",
-            detail=_truncate(f"mount did not return within {timeout_seconds}s"),
+            detail=_truncate(
+                f"mount did not return within {timeout_seconds}s; retained staging dir {staging}"
+            ),
         )
     except subprocess.CalledProcessError as exc:
         shutil.rmtree(staging, ignore_errors=True)

--- a/src/awf/node/auth_mounts_overlay_probe.py
+++ b/src/awf/node/auth_mounts_overlay_probe.py
@@ -38,6 +38,16 @@ is typically impossible and the copy fallback is the correct posture — never
 reaches the probe, therefore never writes evidence, therefore never warns.
 **Absence of evidence means silence, by construction.**
 
+Evidence is written by the run that probed, so it must not outlive the posture
+that produced it. A host that was refused once and is then restarted under
+``AWF_CLAUDE_AUTH_FORCE_COPY`` (or without ``CAP_SYS_ADMIN``, or on a kernel
+without overlayfs) skips the probe entirely, and the intended posture is now the
+copy fallback — warning about it would be wrong. Two mechanisms keep the file
+honest: the reader refuses evidence while force-copy is requested, and the
+cheap-gate short-circuit in ``_SubprocessOverlayMounter.supported`` discards the
+file whenever it declines to probe. Absence of evidence means silence, so a
+skipped probe makes the evidence absent.
+
 The JSON evidence file is the worker→api channel: the worker is the only service
 that provisions and mounts, but ``awf service status`` / provider readiness are
 usually collected from the API process. The work dir is bind-mounted at the same
@@ -86,6 +96,8 @@ CLAUDE_AUTH_OVERLAY_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_UNAVAILABLE"
 # and the scratch mount was REFUSED or timed out: overlay *should* work on this
 # host and an LSM is blocking it. This one IS cataloged.
 CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+CLAUDE_AUTH_FORCE_COPY_ENV = "AWF_CLAUDE_AUTH_FORCE_COPY"
+_FORCE_COPY_TRUTHY = frozenset({"1", "true", "yes", "on"})
 _PROBE_STAGING_PREFIX = ".overlay-probe-"
 _DEFAULT_TIMEOUT_SECONDS = 10.0
 _DETAIL_LIMIT = 512
@@ -115,6 +127,18 @@ def overlay_probe_expected(result: OverlayProbeResult) -> bool:
     """
 
     return result.ok or result.reason not in _UNEXPECTED_PROBE_REASONS
+
+
+def force_copy_isolation_requested(host_env: Mapping[str, str] | None = None) -> bool:
+    """Return whether ``AWF_CLAUDE_AUTH_FORCE_COPY`` requests the copy fallback.
+
+    Defined here — the bottom of the auth-mount import graph — so the probe's
+    posture predicate and :func:`awf.node.auth_mounts_claude.force_copy_isolation_requested`
+    share one definition of the flag rather than parsing it twice.
+    """
+
+    source = os.environ if host_env is None else host_env
+    return source.get(CLAUDE_AUTH_FORCE_COPY_ENV, "").strip().lower() in _FORCE_COPY_TRUTHY
 
 
 def overlay_probe_scratch_root(work_dir: Path) -> Path:
@@ -258,6 +282,21 @@ def write_overlay_probe_evidence(
         overlay_probe_evidence_path(scratch_root).write_text(json.dumps(payload))
 
 
+def discard_overlay_probe_evidence(scratch_root: Path) -> None:
+    """Delete any recorded evidence under ``scratch_root`` (best-effort).
+
+    Called by the cheap-gate short-circuit when this run will *not* probe:
+    evidence written by an earlier run that did probe describes a posture that no
+    longer holds, and leaving it on disk would keep ``status`` / provider
+    readiness warning about a copy fallback that is now the intended posture.
+    Best-effort like the write (``OSError`` suppressed): losing the delete
+    forfeits accuracy of an advisory signal, never provisioning.
+    """
+
+    with contextlib.suppress(OSError):
+        overlay_probe_evidence_path(scratch_root).unlink(missing_ok=True)
+
+
 def read_overlay_probe_evidence(work_dir: Path) -> Mapping[str, object] | None:
     """Return the probe evidence recorded under ``work_dir``, or ``None``.
 
@@ -280,14 +319,26 @@ def read_overlay_probe_evidence(work_dir: Path) -> Mapping[str, object] | None:
     return payload
 
 
-def overlay_unexpectedly_unavailable(work_dir: Path) -> bool:
+def overlay_unexpectedly_unavailable(
+    work_dir: Path, *, host_env: Mapping[str, str] | None = None
+) -> bool:
     """Return whether recorded evidence says overlay failed where it should not have.
 
     The single predicate the service-layer surfaces (``provider_readiness``,
     ``status``) share. Strict identity checks (``is False``) so a truthy-but-
     non-boolean JSON value never trips a warning.
+
+    A current force-copy request wins over any recorded evidence: it is the first
+    cheap gate, so this run would not probe at all, and the copy fallback it
+    selects is a fully supported posture. Without this, evidence from an earlier
+    run that *was* refused would keep warning after an operator (or the bootstrap
+    propagation preflight) switched the host to force-copy. ``host_env`` defaults
+    to the process environment; callers that resolve the flag from elsewhere (the
+    readiness ``environ``, the compose env-file) pass their own mapping.
     """
 
+    if force_copy_isolation_requested(host_env):
+        return False
     evidence = read_overlay_probe_evidence(work_dir)
     if evidence is None:
         return False

--- a/src/awf/node/auth_mounts_overlay_probe.py
+++ b/src/awf/node/auth_mounts_overlay_probe.py
@@ -1,0 +1,347 @@
+"""Truthful overlayfs preflight: one real scratch mount, cached per process (#874).
+
+The pre-#874 preflight asked two cheap questions — does ``/proc/filesystems``
+advertise ``overlay``, and does the process hold ``CAP_SYS_ADMIN`` — and answered
+"supported" whenever both held. Both are blind to the LSM layer. AWF's worker
+container runs under Docker's ``docker-default`` AppArmor profile in *enforce*
+mode, whose plain (therefore non-auditing) ``deny mount,`` rule blocks
+``mount(2)`` regardless of capability. The worker *did* hold ``CAP_SYS_ADMIN``
+(``CapEff`` bit 21), the work dir *was* ext4 and ``rshared``, and kernel
+overlayfs *was* present — yet every mount failed with ``EACCES``, surfacing as
+util-linux's read-only retry (``cannot mount overlay read-only``, exit 32) with
+no overlayfs ``dmesg`` record and no AppArmor audit line. Because the preflight
+lied, each provision first built a ~1.9 GB shared base, then failed the mount,
+then wrote another ~1.7 GB legacy copy. Probing for real removes the wasted base
+build entirely and lets the failure be reported honestly.
+
+The probe performs one scratch ``mount``/``umount`` of an overlay under
+``<work_dir>/auth/_shared`` and reports:
+
+- ``OVERLAY_PROBE_OK`` — the mount succeeded (whether or not the umount did).
+- ``REFUSED`` — ``mount(8)`` failed. On a host that already passed every cheap
+  gate this is the AppArmor/seccomp case: unexpected, and worth surfacing.
+- ``TIMEOUT`` — ``mount(8)`` did not return within ``timeout_seconds``. Also
+  unexpected.
+- ``MOUNT_BINARY_MISSING`` — no ``mount(8)`` on ``PATH``.
+- ``SCRATCH_UNAVAILABLE`` — the scratch staging tree could not be created.
+- ``PATH_RESERVED_CHARS`` — the scratch path carries a ``,`` or ``:`` that
+  overlayfs's unescapable ``-o`` payload cannot encode.
+
+**Expected vs unexpected is the load-bearing distinction.** Only ``REFUSED`` and
+``TIMEOUT`` are unexpected; every other non-ok reason is a legitimate platform
+property. Combined with the fact that the probe only runs *after* the cheap gates
+pass (force-copy not requested, kernel overlayfs present, ``CAP_SYS_ADMIN`` held,
+no reserved chars), this is what keeps the copy fallback a first-class,
+non-alarming path: a hosted/GKE control plane — where a pod-level overlay mount
+is typically impossible and the copy fallback is the correct posture — never
+reaches the probe, therefore never writes evidence, therefore never warns.
+**Absence of evidence means silence, by construction.**
+
+The JSON evidence file is the worker→api channel: the worker is the only service
+that provisions and mounts, but ``awf service status`` / provider readiness are
+usually collected from the API process. The work dir is bind-mounted at the same
+absolute path into both containers, so ``<work_dir>/auth/_shared/overlay-probe.json``
+is readable from either. Writing it is best-effort (``OSError`` suppressed),
+mirroring :func:`awf.node.auth_mounts_claude._record_overlay_base_pin`: losing
+the evidence forfeits observability, never provisioning.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+from awf.common.logging import get_logger
+from awf.node.auth_mounts_claude_base import _SHARED_AUTH_DIRNAME
+
+# A literal ``,`` would split the ``lowerdir=..,upperdir=..,workdir=..`` option
+# string into spurious options, and a literal ``:`` inside ``lowerdir`` would be
+# misread as the separator between stacked lower layers. ``mount(8)`` offers no
+# escaping for either, so a path carrying one forces the copy fallback.
+# Re-exported as ``_OVERLAY_OPTION_RESERVED_CHARS`` by
+# :mod:`awf.node.auth_mounts_claude` so both the probe and the production mount
+# path share one definition.
+OVERLAY_OPTION_RESERVED_CHARS = (",", ":")
+
+_log = get_logger(__name__)
+
+OVERLAY_PROBE_EVIDENCE_NAME = "overlay-probe.json"
+
+# Logged at INFO whenever the per-workspace ``~/.claude`` overlay is unavailable
+# and the copy fallback is taken. This is a fully supported posture — hosted/GKE,
+# ``AWF_CLAUDE_AUTH_FORCE_COPY``, a worker without ``CAP_SYS_ADMIN`` — so it is
+# deliberately NOT in the reason catalog: documenting it as a fault would make a
+# correct platform choice read as a standing failure.
+CLAUDE_AUTH_OVERLAY_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_UNAVAILABLE"
+# Logged at WARNING only when the probe actually ran (every cheap gate passed)
+# and the scratch mount was REFUSED or timed out: overlay *should* work on this
+# host and an LSM is blocking it. This one IS cataloged.
+CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE = "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+_PROBE_STAGING_PREFIX = ".overlay-probe-"
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+_DETAIL_LIMIT = 512
+_DEFAULT_RUN: Callable[..., object] = subprocess.run
+
+# Non-ok reasons that indicate a host which *should* have been able to overlay
+# (every cheap gate passed) but was refused anyway — the AppArmor/seccomp case.
+# Every other reason is an expected platform property and stays silent.
+_UNEXPECTED_PROBE_REASONS = frozenset({"REFUSED", "TIMEOUT"})
+
+
+@dataclass(frozen=True)
+class OverlayProbeResult:
+    """Outcome of one scratch overlay mount attempt."""
+
+    ok: bool
+    reason: str
+    detail: str = ""
+
+
+def overlay_probe_expected(result: OverlayProbeResult) -> bool:
+    """Return whether ``result`` is an expected posture for this platform.
+
+    ``True`` for success and for every non-ok reason that describes the host
+    rather than a misconfiguration. Only an unexpected result may ever produce an
+    operator-visible warning.
+    """
+
+    return result.ok or result.reason not in _UNEXPECTED_PROBE_REASONS
+
+
+def overlay_probe_scratch_root(work_dir: Path) -> Path:
+    """Return the shared auth dir the probe stages under and writes evidence to."""
+
+    return work_dir / "auth" / _SHARED_AUTH_DIRNAME
+
+
+def overlay_probe_evidence_path(scratch_root: Path) -> Path:
+    """Return the JSON evidence path inside ``scratch_root``."""
+
+    return scratch_root / OVERLAY_PROBE_EVIDENCE_NAME
+
+
+def _truncate(text: str) -> str:
+    return text[:_DETAIL_LIMIT]
+
+
+def _refused_detail(exc: subprocess.CalledProcessError) -> str:
+    stderr = exc.stderr if isinstance(exc.stderr, str) else ""
+    return _truncate(f"exit={exc.returncode}: {stderr.strip()}")
+
+
+def probe_overlay_mount(
+    *,
+    scratch_root: Path,
+    run: Callable[..., object] = _DEFAULT_RUN,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> OverlayProbeResult:
+    """Mount and unmount a scratch overlay under ``scratch_root``; report the outcome.
+
+    ``run`` is injected so unit tests exercise every branch without a real mount
+    (the test container holds no ``CAP_SYS_ADMIN`` and is AppArmor-confined).
+    """
+
+    if any(char in os.fspath(scratch_root) for char in OVERLAY_OPTION_RESERVED_CHARS):
+        return OverlayProbeResult(
+            ok=False,
+            reason="PATH_RESERVED_CHARS",
+            detail=_truncate(f"scratch path is unencodable in mount -o: {scratch_root}"),
+        )
+
+    try:
+        scratch_root.mkdir(parents=True, exist_ok=True)
+        staging = Path(tempfile.mkdtemp(prefix=_PROBE_STAGING_PREFIX, dir=scratch_root))
+    except OSError as exc:
+        return OverlayProbeResult(
+            ok=False, reason="SCRATCH_UNAVAILABLE", detail=_truncate(str(exc))
+        )
+
+    lower = staging / "lower"
+    upper = staging / "upper"
+    work = staging / "work"
+    merged = staging / "merged"
+    try:
+        for layer in (lower, upper, work, merged):
+            layer.mkdir()
+    except OSError as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        return OverlayProbeResult(
+            ok=False, reason="SCRATCH_UNAVAILABLE", detail=_truncate(str(exc))
+        )
+
+    options = f"lowerdir={lower},upperdir={upper},workdir={work}"
+    try:
+        run(
+            ["mount", "-t", "overlay", "overlay", "-o", options, str(merged)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError:
+        shutil.rmtree(staging, ignore_errors=True)
+        return OverlayProbeResult(
+            ok=False, reason="MOUNT_BINARY_MISSING", detail="mount(8) not found on PATH"
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(staging, ignore_errors=True)
+        return OverlayProbeResult(
+            ok=False,
+            reason="TIMEOUT",
+            detail=_truncate(f"mount did not return within {timeout_seconds}s"),
+        )
+    except subprocess.CalledProcessError as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_refused_detail(exc))
+    except (subprocess.SubprocessError, OSError) as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_truncate(str(exc)))
+
+    try:
+        run(
+            ["umount", str(merged)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        # The mount itself worked, which is the whole question the probe asks, so
+        # the answer stays ``ok``. Deliberately do NOT ``rmtree``: the overlay may
+        # still be live, and a recursive delete would descend through ``merged``
+        # into the (empty, but conceptually real) layers underneath. Leaking one
+        # empty staging dir is strictly safer, and the retained path is recorded
+        # so an operator can reclaim it.
+        return OverlayProbeResult(
+            ok=True,
+            reason="OVERLAY_PROBE_OK",
+            detail=_truncate(f"umount failed ({exc}); retained staging dir {staging}"),
+        )
+
+    shutil.rmtree(staging, ignore_errors=True)
+    return OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK")
+
+
+def write_overlay_probe_evidence(
+    scratch_root: Path,
+    result: OverlayProbeResult,
+    *,
+    now: datetime | None = None,
+) -> None:
+    """Persist ``result`` as the worker→api evidence file (best-effort)."""
+
+    payload = {
+        "ok": result.ok,
+        "reason": result.reason,
+        "expected": overlay_probe_expected(result),
+        "detail": result.detail,
+        "checked_at": (now or datetime.now(UTC)).isoformat(),
+    }
+    with contextlib.suppress(OSError):
+        overlay_probe_evidence_path(scratch_root).write_text(json.dumps(payload))
+
+
+def read_overlay_probe_evidence(work_dir: Path) -> Mapping[str, object] | None:
+    """Return the probe evidence recorded under ``work_dir``, or ``None``.
+
+    ``None`` covers every degraded case — no file (the common one: a host that
+    never probed), an unreadable file, malformed JSON, or JSON that is not an
+    object. All of them must read as "no signal", never as a fault.
+    """
+
+    path = overlay_probe_evidence_path(overlay_probe_scratch_root(work_dir))
+    try:
+        raw = path.read_text()
+    except OSError:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, Mapping):
+        return None
+    return payload
+
+
+def overlay_unexpectedly_unavailable(work_dir: Path) -> bool:
+    """Return whether recorded evidence says overlay failed where it should not have.
+
+    The single predicate the service-layer surfaces (``provider_readiness``,
+    ``status``) share. Strict identity checks (``is False``) so a truthy-but-
+    non-boolean JSON value never trips a warning.
+    """
+
+    evidence = read_overlay_probe_evidence(work_dir)
+    if evidence is None:
+        return False
+    return evidence.get("ok") is False and evidence.get("expected") is False
+
+
+_PROBE_CACHE: dict[str, OverlayProbeResult] = {}
+
+
+def cached_overlay_probe(
+    *,
+    scratch_root: Path,
+    run: Callable[..., object] = _DEFAULT_RUN,
+    timeout_seconds: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> OverlayProbeResult:
+    """Probe once per process per ``scratch_root``, recording evidence on the miss.
+
+    ``supported()`` is consulted on every provision; a real mount+umount per call
+    would be wasteful and, worse, would race the shared-base staging sweep. The
+    evidence write happens only on the miss path, so a host that never probes
+    never creates the file.
+    """
+
+    key = os.fspath(scratch_root)
+    cached = _PROBE_CACHE.get(key)
+    if cached is not None:
+        return cached
+    result = probe_overlay_mount(
+        scratch_root=scratch_root, run=run, timeout_seconds=timeout_seconds
+    )
+    _PROBE_CACHE[key] = result
+    write_overlay_probe_evidence(scratch_root, result)
+    return result
+
+
+def reset_overlay_probe_cache() -> None:
+    """Clear the per-process probe cache (the test seam)."""
+
+    _PROBE_CACHE.clear()
+
+
+def log_overlay_unavailable(*, claude_root: Path, work_dir: Path) -> None:
+    """Report an unavailable Claude auth overlay at the severity evidence justifies.
+
+    INFO when there is no probe evidence or the probe passed; WARNING only on
+    recorded unexpected failure. Absence of evidence is silence by construction:
+    hosts that fail a cheap gate never probe and never write evidence.
+    """
+
+    if not overlay_unexpectedly_unavailable(work_dir):
+        _log.info(
+            "claude_auth_overlay_unavailable",
+            reason_code=CLAUDE_AUTH_OVERLAY_UNAVAILABLE,
+            workspace_auth_root=str(claude_root),
+            reason="overlayfs_unsupported",
+        )
+        return
+    evidence = read_overlay_probe_evidence(work_dir) or {}
+    _log.warning(
+        "claude_auth_overlay_unexpectedly_unavailable",
+        reason_code=CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE,
+        workspace_auth_root=str(claude_root),
+        reason="overlay_probe_failed",
+        probe_reason=str(evidence.get("reason", "")),
+        probe_detail=str(evidence.get("detail", "")),
+    )

--- a/src/awf/node/auth_mounts_overlay_probe.py
+++ b/src/awf/node/auth_mounts_overlay_probe.py
@@ -19,7 +19,9 @@ The probe performs one scratch ``mount``/``umount`` of an overlay under
 
 - ``OVERLAY_PROBE_OK`` — the mount succeeded (whether or not the umount did).
 - ``REFUSED`` — ``mount(8)`` failed. On a host that already passed every cheap
-  gate this is the AppArmor/seccomp case: unexpected, and worth surfacing.
+  gate this is the AppArmor/seccomp case: unexpected, and worth surfacing. The
+  staging tree is removed, unless the failed helper turns out to have left
+  ``merged`` mounted, in which case it is retained like the timeout case.
 - ``TIMEOUT`` — ``mount(8)`` did not return within ``timeout_seconds``. Also
   unexpected. The staging tree is retained, because a timed-out helper may still
   have completed the mount.
@@ -157,9 +159,37 @@ def _truncate(text: str) -> str:
     return text[:_DETAIL_LIMIT]
 
 
-def _refused_detail(exc: subprocess.CalledProcessError) -> str:
+def _refused_detail(exc: subprocess.CalledProcessError, suffix: str = "") -> str:
     stderr = exc.stderr if isinstance(exc.stderr, str) else ""
-    return _truncate(f"exit={exc.returncode}: {stderr.strip()}")
+    return _truncate(f"exit={exc.returncode}: {stderr.strip()}{suffix}")
+
+
+def _is_mounted(path: Path) -> bool:
+    """Return whether ``path`` is a mount point (never raises; the test seam)."""
+
+    return path.is_mount()
+
+
+def _discard_staging(staging: Path, merged: Path) -> str:
+    """Remove the staging tree unless ``merged`` turns out to be a live mount.
+
+    A ``mount(8)`` that reports failure almost always means ``mount(2)`` never
+    landed, and the common REFUSED path must still clean up — otherwise every
+    AppArmor-confined worker leaks a staging dir into the shared auth dir. But
+    "the helper failed" and "the syscall failed" are not the same event: a helper
+    killed by a signal after ``mount(2)`` succeeded still exits non-zero. One
+    ``stat`` turns that case from "recursively delete through a live overlay,
+    tear out the pinned layers, strand the mount" into "retain one staging dir",
+    the same choice the timeout and umount-failure branches already make.
+
+    Returns the suffix to append to the result detail, so a retained path is
+    always recorded for the operator who has to reclaim it.
+    """
+
+    if _is_mounted(merged):
+        return f"; retained staging dir {staging}"
+    shutil.rmtree(staging, ignore_errors=True)
+    return ""
 
 
 def probe_overlay_mount(
@@ -232,11 +262,11 @@ def probe_overlay_mount(
             ),
         )
     except subprocess.CalledProcessError as exc:
-        shutil.rmtree(staging, ignore_errors=True)
-        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_refused_detail(exc))
+        retained = _discard_staging(staging, merged)
+        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_refused_detail(exc, retained))
     except (subprocess.SubprocessError, OSError) as exc:
-        shutil.rmtree(staging, ignore_errors=True)
-        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_truncate(str(exc)))
+        retained = _discard_staging(staging, merged)
+        return OverlayProbeResult(ok=False, reason="REFUSED", detail=_truncate(f"{exc}{retained}"))
 
     try:
         run(

--- a/src/awf/service/doctor/reasons.py
+++ b/src/awf/service/doctor/reasons.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from awf.runtime.ownership import AGENT_RUNTIME_OWNERSHIP_REPAIR_FAILED_REASON_CODE
 from awf.service.doctor.models import DiagnosticStatus
 from awf.service.doctor.reasons_helpers import (
+    get_claude_overlay_reasons,
     get_salvage_and_monitor_reasons,
     resolve_reason_text,
 )
@@ -1462,6 +1463,7 @@ _REASON_TEXT: dict[str, _ReasonText] = {
     ),
 }
 _REASON_TEXT.update(get_salvage_and_monitor_reasons(_ReasonText))
+_REASON_TEXT.update(get_claude_overlay_reasons(_ReasonText))
 
 
 def _reason_text(

--- a/src/awf/service/doctor/reasons_helpers.py
+++ b/src/awf/service/doctor/reasons_helpers.py
@@ -16,6 +16,44 @@ def reason_catalog_link(reason_code: str) -> str:
     return f"docs/REASON_CATALOG.md#{reason_code.lower()}"
 
 
+def get_claude_overlay_reasons(
+    reason_text_cls: type[_ReasonText],
+) -> dict[str, _ReasonText]:
+    """Return catalog reason text for the Claude auth overlay probe (#874).
+
+    Only the *unexpected* code is cataloged. ``CLAUDE_AUTH_OVERLAY_UNAVAILABLE``
+    is deliberately left out: it fires correctly at INFO on every hosted/GKE and
+    force-copy host, where the per-workspace copy fallback is the right posture,
+    so documenting it as a fault would turn a supported platform choice into a
+    standing false alarm.
+    """
+    return {
+        "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE": reason_text_cls(
+            (
+                "The per-workspace ``~/.claude`` overlay could not be mounted on a host "
+                "that should support it, so provisioning fell back to a full "
+                "per-workspace copy (correct, but ~1.7 GB per workspace)."
+            ),
+            (
+                "Inspect ``<work_dir>/auth/_shared/overlay-probe.json``. If the worker "
+                "is AppArmor- or seccomp-confined, allow ``mount(2)`` for it (the "
+                "compose worker service sets ``security_opt: apparmor:unconfined``); "
+                "otherwise leave the copy fallback in place."
+            ),
+            (
+                "A Linux security module denied ``mount(2)`` even though the kernel "
+                "advertises overlayfs and the worker holds ``CAP_SYS_ADMIN``. Docker's "
+                "``docker-default`` AppArmor profile carries a plain, non-auditing "
+                "``deny mount,`` rule, so the refusal appears only as ``EACCES`` "
+                "(util-linux reports ``cannot mount overlay read-only``, exit 32) with "
+                "no ``dmesg`` or audit record."
+            ),
+            "awf service status --format json",
+            reason_catalog_link("CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"),
+        ),
+    }
+
+
 def get_salvage_and_monitor_reasons(
     reason_text_cls: type[_ReasonText],
 ) -> dict[str, _ReasonText]:

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -299,7 +299,13 @@ def _check_claude(
     )
     propagation_posture = environ.get("AWF_WORK_DIR_BIND_PROPAGATION")
     file_sources: list[dict[str, str]] = []
-    claude_dir_present = (host_home / ".claude").exists()
+    # ``is_dir``, not ``exists``: the resolver mounts the directory source only
+    # when ``source_dir.is_dir()``, so a regular-file ``~/.claude`` is neither
+    # mounted nor overlaid. Reporting it as a directory source would advertise an
+    # overlay/copy posture the workspace never gets, and — because that host never
+    # calls ``supported()`` — would leave the overlay-fallback warning below
+    # standing forever on evidence nothing refreshes or discards.
+    claude_dir_present = (host_home / ".claude").is_dir()
     if claude_dir_present:
         file_sources.append(
             _credential_source(

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -293,10 +293,6 @@ def _check_claude(
     # degrades to per-workspace copy there, so the label must report copy rather
     # than overstate overlay isolation.
     force_copy_requested = force_copy_isolation_requested(environ)
-    directory_isolation = claude_auth_isolation_label(
-        force_copy_requested=lambda: force_copy_requested,
-        overlay_path_unsupported=lambda: overlay_path_has_reserved_chars(work_dir),
-    )
     propagation_posture = environ.get("AWF_WORK_DIR_BIND_PROPAGATION")
     file_sources: list[dict[str, str]] = []
     # ``is_dir``, not ``exists``: the resolver mounts the directory source only
@@ -306,6 +302,28 @@ def _check_claude(
     # calls ``supported()`` — would leave the overlay-fallback warning below
     # standing forever on evidence nothing refreshes or discards.
     claude_dir_present = (host_home / ".claude").is_dir()
+    # Recorded refusal evidence (``REFUSED``/``TIMEOUT``/``UMOUNT_FAILED`` on a host
+    # that passed every cheap gate) means the worker's ``supported()`` returns False
+    # and *every* ``~/.claude`` provision takes the full-copy fallback. It is
+    # therefore an isolation signal, not just a warning: folded into the label below
+    # so readiness cannot warn about a copy fallback while reporting
+    # ``per_workspace_overlay``. Gating (directory source present, current
+    # force-copy request wins, ``host_env=environ`` over ``os.environ``) is spelled
+    # out where the warning is appended.
+    overlay_unexpected = (
+        claude_dir_present
+        and not force_copy_requested
+        and overlay_unexpectedly_unavailable(work_dir, host_env=environ)
+    )
+    directory_isolation = claude_auth_isolation_label(
+        force_copy_requested=lambda: force_copy_requested,
+        # Both inputs answer the same question — "can an overlay be mounted for
+        # this ``work_dir``?" — one from the path's own characters, one from what
+        # the worker's real probe recorded under it.
+        overlay_path_unsupported=lambda: (
+            overlay_unexpected or overlay_path_has_reserved_chars(work_dir)
+        ),
+    )
     if claude_dir_present:
         file_sources.append(
             _credential_source(
@@ -349,11 +367,7 @@ def _check_claude(
         # suppress valid refusal evidence even when the effective posture is
         # overlay.
         overlay_warnings: list[dict[str, str]] = []
-        if (
-            claude_dir_present
-            and not force_copy_requested
-            and overlay_unexpectedly_unavailable(work_dir, host_env=environ)
-        ):
+        if overlay_unexpected:
             overlay_warnings.append(
                 _security_warning(
                     "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE",

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -292,8 +292,9 @@ def _check_claude(
     # overlayfs's unescapable ``-o`` payload cannot encode. Every overlay mount
     # degrades to per-workspace copy there, so the label must report copy rather
     # than overstate overlay isolation.
+    force_copy_requested = force_copy_isolation_requested(environ)
     directory_isolation = claude_auth_isolation_label(
-        force_copy_requested=lambda: force_copy_isolation_requested(environ),
+        force_copy_requested=lambda: force_copy_requested,
         overlay_path_unsupported=lambda: overlay_path_has_reserved_chars(work_dir),
     )
     propagation_posture = environ.get("AWF_WORK_DIR_BIND_PROPAGATION")
@@ -325,8 +326,11 @@ def _check_claude(
         # ``status`` and ``severity`` are deliberately unchanged, because the
         # per-workspace copy fallback remains a fully supported posture and must
         # never gate readiness.
+        # A host currently requesting force-copy fails the first cheap gate, so it
+        # does not probe: evidence still on disk was written under an earlier
+        # posture and warning about it would fault the intended copy fallback.
         overlay_warnings: list[dict[str, str]] = []
-        if overlay_unexpectedly_unavailable(work_dir):
+        if not force_copy_requested and overlay_unexpectedly_unavailable(work_dir):
             overlay_warnings.append(
                 _security_warning(
                     "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE",

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -21,6 +21,7 @@ from awf.node.auth_mounts import (
     claude_auth_isolation_label,
     force_copy_isolation_requested,
     overlay_path_has_reserved_chars,
+    overlay_unexpectedly_unavailable,
 )
 from awf.service.config import ServiceSettings
 
@@ -316,6 +317,26 @@ def _check_claude(
             )
         )
     if file_sources:
+        # The worker records overlay-probe evidence under ``<work_dir>/auth/_shared``
+        # when — and only when — every cheap gate passed and it still could not
+        # mount (#874, an LSM denying mount(2)). A host that legitimately cannot
+        # overlay (hosted/GKE, force-copy, no CAP_SYS_ADMIN) never probes, so no
+        # evidence exists and this stays silent. Visibility only: ``ok``,
+        # ``status`` and ``severity`` are deliberately unchanged, because the
+        # per-workspace copy fallback remains a fully supported posture and must
+        # never gate readiness.
+        overlay_warnings: list[dict[str, str]] = []
+        if overlay_unexpectedly_unavailable(work_dir):
+            overlay_warnings.append(
+                _security_warning(
+                    "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE",
+                    (
+                        "The per-workspace ~/.claude overlay could not be mounted on a host "
+                        "that supports it; provisioning falls back to a full per-workspace "
+                        "copy. See <work_dir>/auth/_shared/overlay-probe.json."
+                    ),
+                )
+            )
         result = _provider_result(
             ok=True,
             strict=strict,
@@ -326,8 +347,13 @@ def _check_claude(
             credential_sources=file_sources,
             credential_scope="isolated_workspace",
             isolation=file_sources[0]["isolation"],
-            warnings=[],
+            warnings=overlay_warnings,
         )
+        if overlay_warnings:
+            # Flat string, not a nested mapping: doctor's ``_metadata_from_mapping``
+            # + ``_redact_mapping`` is what renders provider metadata, and only a
+            # flat scalar survives it intact.
+            result["claude_auth_overlay"] = "unexpectedly_unavailable"
     elif (signal := _first_present_env(environ, _CLAUDE_ENV_KEYS)) is not None:
         result = _provider_result(
             ok=True,

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -299,7 +299,8 @@ def _check_claude(
     )
     propagation_posture = environ.get("AWF_WORK_DIR_BIND_PROPAGATION")
     file_sources: list[dict[str, str]] = []
-    if (host_home / ".claude").exists():
+    claude_dir_present = (host_home / ".claude").exists()
+    if claude_dir_present:
         file_sources.append(
             _credential_source(
                 type_="path",
@@ -329,8 +330,18 @@ def _check_claude(
         # A host currently requesting force-copy fails the first cheap gate, so it
         # does not probe: evidence still on disk was written under an earlier
         # posture and warning about it would fault the intended copy fallback.
+        # The same applies to a host carrying only ``~/.claude.json``: the resolver
+        # never overlays that file (it is always copied) and, without the
+        # ``~/.claude`` directory, never calls ``supported()`` — so nothing
+        # refreshes or discards evidence left by an earlier posture, and warning
+        # would report a standing overlay fallback for a source that never
+        # overlays. Gate on the directory source, not on any file source.
         overlay_warnings: list[dict[str, str]] = []
-        if not force_copy_requested and overlay_unexpectedly_unavailable(work_dir):
+        if (
+            claude_dir_present
+            and not force_copy_requested
+            and overlay_unexpectedly_unavailable(work_dir)
+        ):
             overlay_warnings.append(
                 _security_warning(
                     "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE",

--- a/src/awf/service/provider_readiness_provider_checks.py
+++ b/src/awf/service/provider_readiness_provider_checks.py
@@ -336,11 +336,17 @@ def _check_claude(
         # refreshes or discards evidence left by an earlier posture, and warning
         # would report a standing overlay fallback for a source that never
         # overlays. Gate on the directory source, not on any file source.
+        #
+        # ``host_env=environ`` for the same reason ``force_copy_requested`` above
+        # reads the passed mapping: the predicate defaults to ``os.environ``, so a
+        # stale truthy ``AWF_CLAUDE_AUTH_FORCE_COPY`` in the CLI process would
+        # suppress valid refusal evidence even when the effective posture is
+        # overlay.
         overlay_warnings: list[dict[str, str]] = []
         if (
             claude_dir_present
             and not force_copy_requested
-            and overlay_unexpectedly_unavailable(work_dir)
+            and overlay_unexpectedly_unavailable(work_dir, host_env=environ)
         ):
             overlay_warnings.append(
                 _security_warning(

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -170,10 +170,18 @@ def _mount_propagation_check_payload(
     # written under an earlier posture and must not warn (#903 review): the copy
     # fallback it now runs is fully supported. The resolved ``fc`` is the richer
     # signal here — it also covers the compose env-file source the predicate's own
-    # environ check cannot see.
+    # environ check cannot see. Feed that resolved value back into the predicate
+    # (which otherwise defaults to ``os.environ``) so a stale truthy
+    # ``AWF_CLAUDE_AUTH_FORCE_COPY`` in the CLI process cannot suppress the
+    # warning for a host whose resolved posture is overlay.
+    resolved_force_copy_env: Mapping[str, str] = (
+        {force_copy_key: force_copy_raw} if force_copy_raw is not None else {}
+    )
     overlay_evidence = (
         read_overlay_probe_evidence(work_dir)
-        if work_dir is not None and not fc and overlay_unexpectedly_unavailable(work_dir)
+        if work_dir is not None
+        and not fc
+        and overlay_unexpectedly_unavailable(work_dir, host_env=resolved_force_copy_env)
         else None
     )
     if propagation is not None:

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -20,6 +20,11 @@ from awf.db.models import Workspace
 from awf.db.repositories import EgressAuditRepository, WorkerHeartbeatRepository
 from awf.db.resilience import db_connection_failure_reason
 from awf.db.session import make_engine, make_session_factory
+from awf.node.auth_mounts import (
+    CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE,
+    overlay_unexpectedly_unavailable,
+    read_overlay_probe_evidence,
+)
 from awf.service.config import (
     COMPOSE_ENV_FILE_OMITTED,
     ComposeEnvFileInput,
@@ -118,6 +123,7 @@ def _mount_propagation_check_payload(
     *,
     environ: Mapping[str, str],
     compose_env_file: Path | None,
+    work_dir: Path | None = None,
 ) -> CheckPayload:
     """Return a status check describing the mount-propagation posture (#400).
 
@@ -125,6 +131,16 @@ def _mount_propagation_check_payload(
     from the passed environ first (the live-truth source during bootstrap), then
     falls back to the compose env-file (when status runs outside bootstrap).
     Reports ``unknown`` when neither source has the posture keys.
+
+    ``work_dir`` opts into the #874 overlay-probe evidence the worker records at
+    ``<work_dir>/auth/_shared/overlay-probe.json`` when every cheap gate passed
+    and the mount was still refused (an LSM denying ``mount(2)``). It only ever
+    changes ``status``/``reason``/``detail``: ``ok`` stays ``True`` in **every**
+    branch, because :func:`collect_service_status` ANDs each check into
+    ``overall_ok`` and ``readiness`` turns a non-ok service status into a
+    release-blocking ``SERVICE_STATUS_NOT_READY``. Overlay is an optimisation,
+    never a requirement — hosted/GKE runs the copy fallback by design, never
+    probes, and so produces a byte-identical payload here.
     """
     propagation_key = "AWF_WORK_DIR_BIND_PROPAGATION"
     force_copy_key = "AWF_CLAUDE_AUTH_FORCE_COPY"
@@ -142,12 +158,17 @@ def _mount_propagation_check_payload(
         if force_copy_raw is None:
             force_copy_raw = file_values.get(force_copy_key)
 
+    overlay_evidence = (
+        read_overlay_probe_evidence(work_dir)
+        if work_dir is not None and overlay_unexpectedly_unavailable(work_dir)
+        else None
+    )
     if propagation is not None:
         if force_copy_raw is not None:
             fc: bool | None = force_copy_raw.strip().lower() in {"1", "on", "true", "yes"}
         else:
             fc = None
-        return {
+        payload: CheckPayload = {
             "ok": True,
             "status": "ok",
             "reason": "MOUNT_PROPAGATION_AVAILABLE",
@@ -155,14 +176,24 @@ def _mount_propagation_check_payload(
             "force_copy": fc,
             "detail": f"propagation={propagation}, force_copy={fc if fc is not None else 'unknown'}",
         }
-    return {
-        "ok": True,
-        "status": "unknown",
-        "reason": "MOUNT_PROPAGATION_UNKNOWN",
-        "propagation": None,
-        "force_copy": None,
-        "detail": "mount-propagation posture not yet persisted",
-    }
+    else:
+        payload = {
+            "ok": True,
+            "status": "unknown",
+            "reason": "MOUNT_PROPAGATION_UNKNOWN",
+            "propagation": None,
+            "force_copy": None,
+            "detail": "mount-propagation posture not yet persisted",
+        }
+    if overlay_evidence is None:
+        return payload
+    payload["status"] = "warn"
+    payload["reason"] = CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE
+    payload["detail"] = (
+        f"{payload['detail']}; overlay probe "
+        f"{overlay_evidence.get('reason', '')}: {overlay_evidence.get('detail', '')}"
+    )
+    return payload
 
 
 async def collect_service_status(
@@ -307,6 +338,7 @@ async def collect_service_status(
     mount_propagation_check = _mount_propagation_check_payload(
         environ=provider_environ,
         compose_env_file=compose_env_file if isinstance(compose_env_file, Path) else None,
+        work_dir=Path(settings.work_dir).expanduser(),
     )
     checks = {
         "api": api_check,

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -125,6 +125,7 @@ def _mount_propagation_check_payload(
     environ: Mapping[str, str],
     compose_env_file: Path | None,
     work_dir: Path | None = None,
+    host_home: Path | None = None,
 ) -> CheckPayload:
     """Return a status check describing the mount-propagation posture (#400).
 
@@ -144,6 +145,13 @@ def _mount_propagation_check_payload(
     probes, and so produces a byte-identical payload here. Evidence is also
     ignored while the resolved posture is force-copy: that host skips the probe,
     so the file describes a posture it no longer runs.
+
+    ``host_home`` supplies the same ``claude_dir_present`` gate provider readiness
+    applies: without a ``~/.claude`` **directory** the resolver never reaches
+    ``supported()``, so nothing refreshes or discards evidence an earlier posture
+    left on disk, and the warning would describe an overlay fallback for a host
+    that does not overlay at all. ``None`` (or a missing/non-directory
+    ``~/.claude``) therefore reads as "no directory source" and stays silent.
     """
     propagation_key = "AWF_WORK_DIR_BIND_PROPAGATION"
     force_copy_key = "AWF_CLAUDE_AUTH_FORCE_COPY"
@@ -177,9 +185,14 @@ def _mount_propagation_check_payload(
     resolved_force_copy_env: Mapping[str, str] = (
         {force_copy_key: force_copy_raw} if force_copy_raw is not None else {}
     )
+    # ``is_dir`` mirrors the resolver's own gate (``(host_home / ".claude").is_dir()``):
+    # a host carrying only ``~/.claude.json`` — or no Claude file auth at all —
+    # never overlays, so it never refreshes or discards the evidence file.
+    claude_dir_present = host_home is not None and (host_home / ".claude").is_dir()
     overlay_evidence = (
         read_overlay_probe_evidence(work_dir)
         if work_dir is not None
+        and claude_dir_present
         and not fc
         and overlay_unexpectedly_unavailable(work_dir, host_env=resolved_force_copy_env)
         else None
@@ -356,6 +369,7 @@ async def collect_service_status(
         environ=provider_environ,
         compose_env_file=compose_env_file if isinstance(compose_env_file, Path) else None,
         work_dir=Path(settings.work_dir).expanduser(),
+        host_home=Path(settings.host_home or "~").expanduser(),
     )
     checks = {
         "api": api_check,

--- a/src/awf/service/status.py
+++ b/src/awf/service/status.py
@@ -22,6 +22,7 @@ from awf.db.resilience import db_connection_failure_reason
 from awf.db.session import make_engine, make_session_factory
 from awf.node.auth_mounts import (
     CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE,
+    force_copy_isolation_requested,
     overlay_unexpectedly_unavailable,
     read_overlay_probe_evidence,
 )
@@ -140,7 +141,9 @@ def _mount_propagation_check_payload(
     ``overall_ok`` and ``readiness`` turns a non-ok service status into a
     release-blocking ``SERVICE_STATUS_NOT_READY``. Overlay is an optimisation,
     never a requirement — hosted/GKE runs the copy fallback by design, never
-    probes, and so produces a byte-identical payload here.
+    probes, and so produces a byte-identical payload here. Evidence is also
+    ignored while the resolved posture is force-copy: that host skips the probe,
+    so the file describes a posture it no longer runs.
     """
     propagation_key = "AWF_WORK_DIR_BIND_PROPAGATION"
     force_copy_key = "AWF_CLAUDE_AUTH_FORCE_COPY"
@@ -158,16 +161,22 @@ def _mount_propagation_check_payload(
         if force_copy_raw is None:
             force_copy_raw = file_values.get(force_copy_key)
 
+    fc: bool | None = (
+        force_copy_isolation_requested({force_copy_key: force_copy_raw})
+        if force_copy_raw is not None
+        else None
+    )
+    # A host currently on force-copy never probes, so any evidence on disk was
+    # written under an earlier posture and must not warn (#903 review): the copy
+    # fallback it now runs is fully supported. The resolved ``fc`` is the richer
+    # signal here — it also covers the compose env-file source the predicate's own
+    # environ check cannot see.
     overlay_evidence = (
         read_overlay_probe_evidence(work_dir)
-        if work_dir is not None and overlay_unexpectedly_unavailable(work_dir)
+        if work_dir is not None and not fc and overlay_unexpectedly_unavailable(work_dir)
         else None
     )
     if propagation is not None:
-        if force_copy_raw is not None:
-            fc: bool | None = force_copy_raw.strip().lower() in {"1", "on", "true", "yes"}
-        else:
-            fc = None
         payload: CheckPayload = {
             "ok": True,
             "status": "ok",

--- a/tests/integration/test_local_service_compose.py
+++ b/tests/integration/test_local_service_compose.py
@@ -370,6 +370,15 @@ def test_local_service_compose_declares_control_plane_stack() -> None:
     assert gitconfig_source["cap_drop"] == ["ALL"]
     assert gitconfig_source["cap_add"] == ["CHOWN", "DAC_OVERRIDE"]
     assert gitconfig_source["security_opt"] == ["no-new-privileges:true"]
+    # #874: SYS_ADMIN alone does not let the worker mount(2) — Docker's
+    # `docker-default` AppArmor profile denies mount outright, so the shared-base
+    # ~/.claude overlay never mounted and every provision took the copy fallback.
+    # Scoped to the worker; api/migrate keep docker-default because they never
+    # mount. AWF_WORKER_APPARMOR=docker-default restores confinement.
+    assert services["worker"]["cap_add"] == ["SYS_ADMIN"]
+    assert services["worker"]["security_opt"] == ["apparmor:${AWF_WORKER_APPARMOR:-unconfined}"]
+    for unconfined_service in ("api", "migrate"):
+        assert "security_opt" not in services[unconfined_service]
     assert gitconfig_source["volumes"] == [
         f"{expected_host_home}/..:/run/awf-host-parent:ro",
         f"{expected_host_home}:/run/awf-host-home:ro",

--- a/tests/unit/node/conftest.py
+++ b/tests/unit/node/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for ``awf.node`` unit tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+from awf.node.auth_mounts_overlay_probe import reset_overlay_probe_cache
+
+
+@pytest.fixture(autouse=True)
+def _reset_overlay_probe_cache() -> Iterator[None]:
+    """Keep the module-level overlay-probe cache from leaking between tests.
+
+    :func:`awf.node.auth_mounts_overlay_probe.cached_overlay_probe` memoizes per
+    ``scratch_root`` for the life of the process. Two tests using the same
+    ``tmp_path``-derived root — or a test asserting the probe is *not* invoked —
+    would otherwise silently observe a previous test's result, which is the most
+    likely source of flaky or unreachable branches here.
+    """
+
+    reset_overlay_probe_cache()
+    yield
+    reset_overlay_probe_cache()

--- a/tests/unit/node/test_claude_auth_exclusions.py
+++ b/tests/unit/node/test_claude_auth_exclusions.py
@@ -1,0 +1,165 @@
+"""Top-level-anchored ``~/.claude`` copy/signature exclusions (#874).
+
+The pre-#874 constant matched excluded names by *basename at every depth*, so
+widening it to cover volatile host state would also have stripped nested
+``plugins/cache`` (an installed-plugin store) and stray ``node_modules`` from
+every agent's ``~/.claude``. These tests pin the anchoring, the closed-allowlist
+governing rule, and the copy-set ⊆ signature-set invariant.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from awf.node.auth_mounts_claude_exclusions import (
+    CLAUDE_COPY_EXCLUDED_TOP_LEVEL,
+    CLAUDE_SIGNATURE_EXCLUDED_PATTERNS,
+    CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL,
+    claude_copy_excludes_rel,
+    claude_copy_ignore,
+    claude_signature_excludes_rel,
+)
+
+# Names that carry auth/config/content the agent must see. None of them may ever
+# be excluded from the *signature*: excluding one means a host credential change
+# would not mint a new base signature and the workspace would mount a stale base.
+_MUST_BE_SIGNED = frozenset(
+    {
+        ".credentials.json",
+        "settings.json",
+        "settings.local.json",
+        "skills",
+        "plugins",
+        "agents",
+        "CLAUDE.md",
+    }
+)
+
+
+@pytest.mark.unit
+def test_copy_exclusions_membership_is_unchanged_from_pre_874() -> None:
+    # Keeping the copy set byte-identical is what makes #874 zero-risk for the
+    # credential path: only the *matching semantics* narrow to the top level.
+    assert set(CLAUDE_COPY_EXCLUDED_TOP_LEVEL) == {
+        "projects",
+        "todos",
+        "shell-snapshots",
+        "statsig",
+    }
+
+
+@pytest.mark.unit
+def test_signature_exclusions_are_a_strict_superset_of_copy_exclusions() -> None:
+    assert CLAUDE_COPY_EXCLUDED_TOP_LEVEL < CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL
+
+
+@pytest.mark.unit
+def test_signature_exclusions_never_cover_auth_or_content_names() -> None:
+    assert _MUST_BE_SIGNED.isdisjoint(CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL)
+    for name in _MUST_BE_SIGNED:
+        assert claude_signature_excludes_rel(name) is False
+
+
+@pytest.mark.unit
+def test_signature_exclusion_set_is_a_closed_allowlist() -> None:
+    # The governing rule: anything unrecognised is SIGNED. A future Claude Code
+    # state dir should cause churn (annoying but correct), never a stale
+    # credential (silent and wrong).
+    assert claude_signature_excludes_rel("future-state-dir") is False
+    assert claude_signature_excludes_rel("future-state.json") is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name",
+    [
+        "history.jsonl",
+        "file-history",
+        "cache",
+        "paste-cache",
+        "session-env",
+        "sessions",
+        "backups",
+        "debug",
+        "jobs",
+        "tasks",
+        "projects",
+        "todos",
+        "shell-snapshots",
+        "statsig",
+    ],
+)
+def test_known_volatile_top_level_names_are_excluded_from_the_signature(name: str) -> None:
+    assert claude_signature_excludes_rel(name) is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("name", ["daemon.sock", "daemon-1.log", "plugin-cache.json"])
+def test_signature_patterns_match_volatile_top_level_names(name: str) -> None:
+    assert claude_signature_excludes_rel(name) is True
+
+
+@pytest.mark.unit
+def test_signature_patterns_are_declared_for_introspection() -> None:
+    assert "daemon*" in CLAUDE_SIGNATURE_EXCLUDED_PATTERNS
+    assert "*-cache.json" in CLAUDE_SIGNATURE_EXCLUDED_PATTERNS
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "rel",
+    [
+        "plugins/cache",
+        "skills/cache",
+        "plugins/repos/x/node_modules",
+        "projects/nested/history.jsonl",
+        "plugins/daemon.sock",
+    ],
+)
+def test_signature_exclusions_are_anchored_to_the_top_level(rel: str) -> None:
+    # Nested paths are never excluded — matching by basename at every depth is
+    # exactly the trap #874 forbids.
+    assert claude_signature_excludes_rel(rel) is False
+
+
+@pytest.mark.unit
+def test_copy_exclusion_predicate_is_anchored_to_the_top_level() -> None:
+    assert claude_copy_excludes_rel("projects") is True
+    assert claude_copy_excludes_rel("plugins/projects") is False
+    assert claude_copy_excludes_rel("history.jsonl") is False
+
+
+@pytest.mark.unit
+def test_copy_ignore_strips_top_level_usage_history_only(tmp_path: Path) -> None:
+    root = tmp_path / ".claude"
+    ignore = claude_copy_ignore(root)
+
+    at_root = ignore(str(root), ["projects", "todos", "skills", "plugins", "settings.json"])
+
+    assert at_root == {"projects", "todos"}
+
+
+@pytest.mark.unit
+def test_copy_ignore_keeps_nested_plugin_cache_and_node_modules(tmp_path: Path) -> None:
+    # The trap-(a) regression: pre-#874 ``ignore_patterns`` matched at every
+    # depth, so a widened set would have stripped ``plugins/cache`` (~66 MB of
+    # installed plugins) and every nested ``node_modules`` from the copy.
+    root = tmp_path / ".claude"
+    ignore = claude_copy_ignore(root)
+
+    nested = ignore(str(root / "plugins"), ["cache", "node_modules", "projects", "repos"])
+
+    assert nested == set()
+
+
+@pytest.mark.unit
+def test_copy_ignore_normalizes_the_visited_directory_path(tmp_path: Path) -> None:
+    # ``shutil.copytree`` passes ``os.fspath(src)``; a non-normalized root must
+    # still compare equal so the top-level exclusion is not silently skipped.
+    root = tmp_path / ".claude"
+
+    ignore = claude_copy_ignore(Path(f"{root}/./"))
+
+    assert ignore(str(root), ["projects", "skills"]) == {"projects"}

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_001.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_001.py
@@ -21,6 +21,7 @@ from structlog.testing import capture_logs
 # ``auth_mounts`` re-exports them. Patch the module that *defines* the helpers so
 # the consumers (which resolve them in that namespace) observe the override.
 from awf.node import auth_mounts_claude as auth_mounts_mod
+from awf.node import auth_mounts_claude_base as claude_base_mod
 from awf.node import auth_mounts_claude_reconcile as reconcile_mod
 from awf.node import auth_mounts_overlay_copy as overlay_copy_mod
 from awf.node.auth_mounts import (
@@ -321,6 +322,7 @@ def test_signature_keeps_dir_whose_stat_races_to_failure(
     host_home = tmp_path / "host-home"
     _seed_host_claude(host_home)
     (host_home / ".claude" / "racingdir").mkdir()
+    unraced = _host_claude_signature(host_home)
 
     base_path_cls = type(Path())
 
@@ -330,11 +332,17 @@ def test_signature_keeps_dir_whose_stat_races_to_failure(
                 raise PermissionError("simulated stat race")
             return super().stat(*args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(auth_mounts_mod, "Path", _StatRacingPath)
+    # Patch the module that *defines* the signature walk: ``_host_claude_signature``
+    # moved to ``auth_mounts_claude_base`` when that split happened, so patching
+    # ``auth_mounts_claude.Path`` silently exercised nothing.
+    monkeypatch.setattr(claude_base_mod, "Path", _StatRacingPath)
 
     signature = _host_claude_signature(host_home)
     assert len(signature) == 16
     assert signature == _host_claude_signature(host_home)
+    # The raced dir is kept and signed as ``missing`` (a distinct entry) rather
+    # than dropped from the walk.
+    assert signature != unraced
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_003.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_003.py
@@ -708,8 +708,9 @@ def test_reconcile_forwards_into_a_preexisting_merged_parent_dir(tmp_path: Path)
 
 @pytest.mark.unit
 def test_reconcile_skips_usage_history_dirs_absent_from_base(tmp_path: Path) -> None:
-    # The shared base is built with ``ignore_patterns(*_CLAUDE_USAGE_HISTORY_DIRS)``, so
-    # ``projects/``, ``todos/``, ``shell-snapshots/`` and ``statsig/`` never exist in it.
+    # The shared base is built with the top-level-anchored ``claude_copy_ignore(host_home
+    # / ".claude")`` exclusion (#874), so top-level ``projects/``, ``todos/``,
+    # ``shell-snapshots/`` and ``statsig/`` never exist in it.
     # A fallback session's Claude process re-creates them and can fill ``projects/`` with
     # large transcripts; because the base lacks them they all read as ``base_mtime_ns is
     # None`` fallback edits. Reconcile must mirror the base exclusion and not forward those

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_007.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_007.py
@@ -28,6 +28,10 @@ from structlog.testing import capture_logs
 
 # Patch the module that defines the overlay/Claude helpers (see part_001 header).
 from awf.node import auth_mounts_claude as auth_mounts_mod
+
+# ``_overlay_provision_lock`` and its ``fcntl`` import live in the pin+lock module
+# (re-exported through ``auth_mounts_claude``), so ``flock`` must be patched there.
+from awf.node import auth_mounts_claude_pin as auth_mounts_pin_mod
 from awf.node.auth_mounts import (
     _host_claude_signature,
     _shared_claude_base_dir,
@@ -335,7 +339,7 @@ def test_flock_unsupported_proceeds_best_effort_not_contended(
         return real_flock(fd, operation)
 
     monkeypatch.setattr(auth_mounts_mod.os, "open", _track_overlay_lock_fd)
-    monkeypatch.setattr(auth_mounts_mod.fcntl, "flock", _flock_unsupported)
+    monkeypatch.setattr(auth_mounts_pin_mod.fcntl, "flock", _flock_unsupported)
 
     with capture_logs() as logs:
         mounts = resolve_service_auth_mounts(
@@ -417,7 +421,7 @@ def test_flock_eacces_treated_as_contended_not_unavailable(
             raise OSError(would_block_errno, os.strerror(would_block_errno))
         return real_flock(fd, operation)
 
-    monkeypatch.setattr(auth_mounts_mod.fcntl, "flock", _flock_would_block)
+    monkeypatch.setattr(auth_mounts_pin_mod.fcntl, "flock", _flock_would_block)
 
     with (
         capture_logs() as logs,

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
@@ -100,6 +100,22 @@ def test_signature_ignores_volatile_top_level_state(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+def test_signature_is_stable_when_host_claude_is_absent(tmp_path: Path) -> None:
+    # ``source.stat()`` raises on a host with no ``~/.claude``; the walk records a
+    # ``missing`` root marker instead of failing, and stays deterministic.
+    host_home = tmp_path / "empty-home"
+    host_home.mkdir()
+    seeded_home = tmp_path / "seeded-home"
+    _seed_signature_host(seeded_home)
+
+    signature = _host_claude_signature(host_home)
+
+    assert len(signature) == 16
+    assert signature == _host_claude_signature(host_home)
+    assert signature != _host_claude_signature(seeded_home)
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize("relative", ["settings.json", ".credentials.json", "CLAUDE.md"])
 def test_signature_changes_when_auth_or_config_changes(tmp_path: Path, relative: str) -> None:
     host_home = tmp_path / "host-home"

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
@@ -410,12 +410,35 @@ def test_unsupported_overlay_never_builds_the_shared_base(tmp_path: Path) -> Non
 
 
 @pytest.mark.unit
-def test_usage_history_exclusion_alias_still_exported(tmp_path: Path) -> None:
+def test_usage_history_exclusion_alias_still_exported() -> None:
     # ``awf.node.auth_mounts.<name>`` is the stable import surface; the legacy
-    # tuple name stays available and keeps its pre-#874 membership.
-    assert set(auth_mounts_mod._CLAUDE_USAGE_HISTORY_DIRS) == {  # noqa: SLF001
+    # tuple name stays available there and keeps its pre-#874 membership.
+    assert set(auth_mounts_facade._CLAUDE_USAGE_HISTORY_DIRS) == {  # noqa: SLF001
         "projects",
         "todos",
         "shell-snapshots",
         "statsig",
     }
+    assert (
+        auth_mounts_facade._CLAUDE_USAGE_HISTORY_DIRS  # noqa: SLF001
+        is auth_mounts_mod._CLAUDE_USAGE_HISTORY_DIRS  # noqa: SLF001
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "name",
+    [
+        "CLAUDE_COPY_EXCLUDED_TOP_LEVEL",
+        "CLAUDE_SIGNATURE_EXCLUDED_TOP_LEVEL",
+        "claude_copy_ignore",
+        "claude_signature_excludes_rel",
+        "cached_overlay_probe",
+    ],
+)
+def test_exclusion_and_probe_names_reexported_through_facade(name: str) -> None:
+    # ``auth_mounts_claude`` re-exports every public name of its leaf modules and
+    # ``auth_mounts`` re-exports every public name of ``auth_mounts_claude`` — the
+    # #874 additions must not break that documented import surface.
+    assert hasattr(auth_mounts_facade, name)
+    assert getattr(auth_mounts_facade, name) is getattr(auth_mounts_mod, name)

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
@@ -1,0 +1,405 @@
+"""Shared-base signature stability and overlay-probe wiring (part 8, #874).
+
+Two coupled #874 concerns:
+
+* the host-content signature must ignore top-level state that changes on every
+  Claude Code interaction (so a ~1.9 GB base is not rebuilt and reaped on every
+  provision) while still signing everything else, including *nested* dirs whose
+  basename happens to collide with an excluded top-level name;
+* ``_SubprocessOverlayMounter.supported()`` must consult the real scratch-mount
+  probe instead of trusting ``/proc/filesystems`` + ``CAP_SYS_ADMIN``, which are
+  blind to the AppArmor ``deny mount,`` rule that made every mount fail.
+
+No test here performs a real mount: the probe is driven through an injected
+``run`` callable and the mounter through monkeypatched cheap gates.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from structlog.testing import capture_logs
+
+from awf.node import auth_mounts as auth_mounts_facade
+from awf.node import auth_mounts_claude as auth_mounts_mod
+from awf.node.auth_mounts import (
+    _host_claude_signature,
+    default_overlay_mounter,
+    resolve_service_auth_mounts,
+)
+from awf.node.auth_mounts_claude import _ensure_shared_claude_base
+from awf.node.auth_mounts_overlay_probe import (
+    OverlayProbeResult,
+    overlay_probe_evidence_path,
+    overlay_probe_scratch_root,
+    overlay_unexpectedly_unavailable,
+    write_overlay_probe_evidence,
+)
+
+from .test_claude_auth_overlay_part_001 import FakeOverlayMounter
+
+_VOLATILE_TOP_LEVEL_DIRS = (
+    "file-history",
+    "cache",
+    "paste-cache",
+    "session-env",
+    "sessions",
+    "backups",
+    "debug",
+    "jobs",
+    "tasks",
+)
+
+
+def _seed_signature_host(host_home: Path) -> Path:
+    """Seed a ``~/.claude`` carrying auth, content, volatile state and a nested cache."""
+
+    claude = host_home / ".claude"
+    claude.mkdir(parents=True)
+    (claude / "settings.json").write_text('{"theme": "dark"}\n')
+    (claude / ".credentials.json").write_text('{"token": "t0"}\n')
+    (claude / "CLAUDE.md").write_text("# rules\n")
+    (claude / "skills" / "demo").mkdir(parents=True)
+    (claude / "skills" / "demo" / "SKILL.md").write_text("# demo\n")
+    # An installed-plugin store whose basename collides with a volatile top-level
+    # name — it must keep being signed and copied (#874 trap (a)).
+    (claude / "plugins" / "cache").mkdir(parents=True)
+    (claude / "plugins" / "cache" / "pkg.tgz").write_text("plugin payload\n")
+    (claude / "projects" / "repo").mkdir(parents=True)
+    (claude / "projects" / "repo" / "session.jsonl").write_text('{"usage": "historical"}\n')
+    (claude / "history.jsonl").write_text('{"turn": 1}\n')
+    for name in _VOLATILE_TOP_LEVEL_DIRS:
+        (claude / name).mkdir()
+        (claude / name / "state").write_text("v1\n")
+    (claude / "daemon.sock").write_text("")
+    (claude / "plugin-cache.json").write_text("{}\n")
+    return claude
+
+
+@pytest.mark.unit
+def test_signature_ignores_volatile_top_level_state(tmp_path: Path) -> None:
+    # #874: ``history.jsonl`` and the per-interaction state dirs churn on every
+    # Claude Code turn on the host. Signing them rebuilt (and reaped) a ~1.9 GB
+    # shared base on essentially every provision.
+    host_home = tmp_path / "host-home"
+    claude = _seed_signature_host(host_home)
+    before = _host_claude_signature(host_home)
+
+    # ``history.jsonl`` is the trap-(b) case: the signature walk filtered only
+    # ``dirs``, so no edit to the exclusion constant alone could ever drop it.
+    (claude / "history.jsonl").write_text('{"turn": 1}\n{"turn": 2}\n')
+    for name in _VOLATILE_TOP_LEVEL_DIRS:
+        (claude / name / "state").write_text("v2 — churned\n")
+        (claude / name / "extra").write_text("new volatile entry\n")
+    (claude / "daemon.sock").write_text("pid=2\n")
+    (claude / "plugin-cache.json").write_text('{"warm": true}\n')
+    (claude / "projects" / "repo" / "session.jsonl").write_text('{"usage": "more"}\n')
+
+    assert _host_claude_signature(host_home) == before
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("relative", ["settings.json", ".credentials.json", "CLAUDE.md"])
+def test_signature_changes_when_auth_or_config_changes(tmp_path: Path, relative: str) -> None:
+    host_home = tmp_path / "host-home"
+    claude = _seed_signature_host(host_home)
+    before = _host_claude_signature(host_home)
+
+    (claude / relative).write_text('{"rotated": true, "padding": "xxxxxxxx"}\n')
+
+    assert _host_claude_signature(host_home) != before
+
+
+@pytest.mark.unit
+def test_signature_changes_for_nested_cache_dir(tmp_path: Path) -> None:
+    # The anchoring guarantee from the signature side: ``plugins/cache`` is an
+    # installed-plugin store, not host usage state, so updating a plugin must
+    # still mint a fresh base.
+    host_home = tmp_path / "host-home"
+    claude = _seed_signature_host(host_home)
+    before = _host_claude_signature(host_home)
+
+    (claude / "plugins" / "cache" / "pkg.tgz").write_text("updated plugin payload\n")
+
+    assert _host_claude_signature(host_home) != before
+
+
+@pytest.mark.unit
+def test_shared_base_copy_keeps_nested_cache_and_omits_top_level_usage_history(
+    tmp_path: Path,
+) -> None:
+    # ``shutil.ignore_patterns`` matched at every depth; the anchored ignore must
+    # strip only the top-level usage-history dirs.
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+
+    base = _ensure_shared_claude_base(
+        host_home=host_home,
+        work_dir=work_dir,
+        signature=_host_claude_signature(host_home),
+        workspace_owner_uid=None,
+        workspace_owner_gid=None,
+    )
+
+    assert (base / "plugins" / "cache" / "pkg.tgz").read_text() == "plugin payload\n"
+    assert not (base / "projects").exists()
+    # Volatile state is *copied* (the agent gets a frozen snapshot); it is only
+    # left out of the signature.
+    assert (base / "history.jsonl").exists()
+    assert (base / "cache" / "state").exists()
+
+
+@pytest.mark.unit
+def test_shared_base_copy_keeps_nested_usage_history_dirs(tmp_path: Path) -> None:
+    host_home = tmp_path / "host-home"
+    claude = _seed_signature_host(host_home)
+    (claude / "plugins" / "projects").mkdir()
+    (claude / "plugins" / "projects" / "manifest.json").write_text("{}\n")
+    work_dir = tmp_path / "work"
+
+    base = _ensure_shared_claude_base(
+        host_home=host_home,
+        work_dir=work_dir,
+        signature=_host_claude_signature(host_home),
+        workspace_owner_uid=None,
+        workspace_owner_gid=None,
+    )
+
+    assert (base / "plugins" / "projects" / "manifest.json").read_text() == "{}\n"
+
+
+def _all_cheap_gates_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(auth_mounts_mod, "_force_copy_isolation_requested", lambda *_a: False)
+    monkeypatch.setattr(auth_mounts_mod, "_overlay_filesystem_available", lambda *_a: True)
+    monkeypatch.setattr(auth_mounts_mod, "_has_cap_sys_admin", lambda *_a: True)
+
+
+class _RecordingProbe:
+    """Stands in for ``cached_overlay_probe``; records whether it ran at all."""
+
+    def __init__(self, result: OverlayProbeResult) -> None:
+        self.result = result
+        self.scratch_roots: list[Path] = []
+
+    def __call__(self, *, scratch_root: Path) -> OverlayProbeResult:
+        self.scratch_roots.append(scratch_root)
+        return self.result
+
+
+@pytest.mark.unit
+def test_supported_short_circuits_when_no_scratch_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The teardown-constructed mounter has no work-dir context and only calls
+    # ``is_mounted``/``unmount``; it must keep the pre-#874 behavior and never
+    # attempt a probe.
+    _all_cheap_gates_pass(monkeypatch)
+    probe = _RecordingProbe(OverlayProbeResult(ok=False, reason="REFUSED"))
+    monkeypatch.setattr(auth_mounts_mod, "cached_overlay_probe", probe)
+
+    assert auth_mounts_mod._SubprocessOverlayMounter().supported() is True  # noqa: SLF001
+    assert probe.scratch_roots == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("failing_gate", ["force_copy", "kernel_overlay", "cap_sys_admin"])
+def test_cheap_gates_short_circuit_before_the_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failing_gate: str
+) -> None:
+    # The awf-cloud/GKE constraint, made explicit: a host that fails any cheap
+    # gate never probes, therefore never writes evidence, therefore can never
+    # produce a standing warning. Absence of evidence means silence, by
+    # construction — not by accident.
+    _all_cheap_gates_pass(monkeypatch)
+    gates = {
+        "force_copy": ("_force_copy_isolation_requested", True),
+        "kernel_overlay": ("_overlay_filesystem_available", False),
+        "cap_sys_admin": ("_has_cap_sys_admin", False),
+    }
+    attribute, value = gates[failing_gate]
+    monkeypatch.setattr(auth_mounts_mod, attribute, lambda *_a, _v=value: _v)
+    probe = _RecordingProbe(OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK"))
+    monkeypatch.setattr(auth_mounts_mod, "cached_overlay_probe", probe)
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+
+    mounter = auth_mounts_mod._SubprocessOverlayMounter(scratch_root=scratch_root)  # noqa: SLF001
+
+    assert mounter.supported() is False
+    assert probe.scratch_roots == []
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+    assert not overlay_probe_evidence_path(scratch_root).exists()
+
+
+@pytest.mark.unit
+def test_supported_is_false_when_the_probe_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _all_cheap_gates_pass(monkeypatch)
+    probe = _RecordingProbe(OverlayProbeResult(ok=False, reason="REFUSED", detail="exit=32"))
+    monkeypatch.setattr(auth_mounts_mod, "cached_overlay_probe", probe)
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+
+    mounter = auth_mounts_mod._SubprocessOverlayMounter(scratch_root=scratch_root)  # noqa: SLF001
+
+    assert mounter.supported() is False
+    assert probe.scratch_roots == [scratch_root]
+
+
+@pytest.mark.unit
+def test_supported_is_true_when_the_probe_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _all_cheap_gates_pass(monkeypatch)
+    probe = _RecordingProbe(OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK"))
+    monkeypatch.setattr(auth_mounts_mod, "cached_overlay_probe", probe)
+
+    mounter = auth_mounts_mod._SubprocessOverlayMounter(  # noqa: SLF001
+        scratch_root=overlay_probe_scratch_root(tmp_path)
+    )
+
+    assert mounter.supported() is True
+
+
+@pytest.mark.unit
+def test_default_overlay_mounter_threads_the_scratch_root(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+
+    mounter = default_overlay_mounter(scratch_root=scratch_root)
+
+    assert isinstance(mounter, auth_mounts_mod._SubprocessOverlayMounter)  # noqa: SLF001
+    assert mounter.scratch_root == scratch_root
+    assert default_overlay_mounter().scratch_root is None
+
+
+@pytest.mark.unit
+def test_resolver_builds_the_default_mounter_with_the_shared_auth_scratch_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+    recorded: list[Path | None] = []
+
+    def _fake_default(*, scratch_root: Path | None = None) -> FakeOverlayMounter:
+        recorded.append(scratch_root)
+        return FakeOverlayMounter(supported=False)
+
+    monkeypatch.setattr(auth_mounts_facade, "default_overlay_mounter", _fake_default)
+
+    resolve_service_auth_mounts(
+        host_home=host_home,
+        work_dir=work_dir,
+        workspace_id="ws_probe",
+        host_env={},
+    )
+
+    assert recorded == [work_dir / "auth" / "_shared"]
+
+
+@pytest.mark.unit
+def test_unsupported_overlay_logs_info_without_probe_evidence(tmp_path: Path) -> None:
+    # GKE / force-copy hosts: the copy fallback is correct and expected, so the
+    # log must stay INFO and carry the unchanged reason code.
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+
+    with capture_logs() as logs:
+        resolve_service_auth_mounts(
+            host_home=host_home,
+            work_dir=work_dir,
+            workspace_id="ws_copy",
+            host_env={},
+            overlay_mounter=FakeOverlayMounter(supported=False),
+        )
+
+    events = [entry for entry in logs if entry["event"].startswith("claude_auth_overlay")]
+    assert [entry["event"] for entry in events] == ["claude_auth_overlay_unavailable"]
+    assert events[0]["log_level"] == "info"
+    assert events[0]["reason_code"] == "CLAUDE_AUTH_OVERLAY_UNAVAILABLE"
+    assert events[0]["reason"] == "overlayfs_unsupported"
+
+
+@pytest.mark.unit
+def test_unsupported_overlay_warns_on_unexpected_probe_evidence(tmp_path: Path) -> None:
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+    scratch_root = overlay_probe_scratch_root(work_dir)
+    scratch_root.mkdir(parents=True)
+    write_overlay_probe_evidence(
+        scratch_root,
+        OverlayProbeResult(ok=False, reason="REFUSED", detail="exit=32: denied"),
+    )
+
+    with capture_logs() as logs:
+        resolve_service_auth_mounts(
+            host_home=host_home,
+            work_dir=work_dir,
+            workspace_id="ws_refused",
+            host_env={},
+            overlay_mounter=FakeOverlayMounter(supported=False),
+        )
+
+    events = [entry for entry in logs if entry["event"].startswith("claude_auth_overlay")]
+    assert [entry["event"] for entry in events] == ["claude_auth_overlay_unexpectedly_unavailable"]
+    assert events[0]["log_level"] == "warning"
+    assert events[0]["reason_code"] == "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+    assert events[0]["probe_reason"] == "REFUSED"
+    assert "denied" in events[0]["probe_detail"]
+
+
+@pytest.mark.unit
+def test_unsupported_overlay_stays_info_for_expected_probe_failure(tmp_path: Path) -> None:
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+    scratch_root = overlay_probe_scratch_root(work_dir)
+    scratch_root.mkdir(parents=True)
+    write_overlay_probe_evidence(
+        scratch_root, OverlayProbeResult(ok=False, reason="MOUNT_BINARY_MISSING")
+    )
+
+    with capture_logs() as logs:
+        resolve_service_auth_mounts(
+            host_home=host_home,
+            work_dir=work_dir,
+            workspace_id="ws_no_mount_bin",
+            host_env={},
+            overlay_mounter=FakeOverlayMounter(supported=False),
+        )
+
+    events = [entry for entry in logs if entry["event"].startswith("claude_auth_overlay")]
+    assert [entry["event"] for entry in events] == ["claude_auth_overlay_unavailable"]
+    assert events[0]["log_level"] == "info"
+
+
+@pytest.mark.unit
+def test_unsupported_overlay_never_builds_the_shared_base(tmp_path: Path) -> None:
+    # The ~1.9 GB copytree used to run *before* the mount attempt, so an
+    # AppArmor-blocked host paid for a base it could never mount (#874).
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+
+    resolve_service_auth_mounts(
+        host_home=host_home,
+        work_dir=work_dir,
+        workspace_id="ws_no_base",
+        host_env={},
+        overlay_mounter=FakeOverlayMounter(supported=False),
+    )
+
+    assert not (work_dir / "auth" / "_shared" / "claude-base").exists()
+
+
+@pytest.mark.unit
+def test_usage_history_exclusion_alias_still_exported(tmp_path: Path) -> None:
+    # ``awf.node.auth_mounts.<name>`` is the stable import surface; the legacy
+    # tuple name stays available and keeps its pre-#874 membership.
+    assert set(auth_mounts_mod._CLAUDE_USAGE_HISTORY_DIRS) == {  # noqa: SLF001
+        "projects",
+        "todos",
+        "shell-snapshots",
+        "statsig",
+    }

--- a/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
+++ b/tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_008.py
@@ -247,6 +247,70 @@ def test_cheap_gates_short_circuit_before_the_probe(
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("failing_gate", ["force_copy", "kernel_overlay", "cap_sys_admin"])
+def test_cheap_gate_short_circuit_discards_evidence_from_an_earlier_posture(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, failing_gate: str
+) -> None:
+    # A worker that was refused once wrote evidence; it is then restarted under
+    # force-copy (or without CAP_SYS_ADMIN, or on a kernel without overlayfs) and
+    # no longer probes. The stale file would otherwise keep status and provider
+    # readiness reporting CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE for what is
+    # now an intentional, fully supported copy-fallback posture.
+    _all_cheap_gates_pass(monkeypatch)
+    gates = {
+        "force_copy": ("_force_copy_isolation_requested", True),
+        "kernel_overlay": ("_overlay_filesystem_available", False),
+        "cap_sys_admin": ("_has_cap_sys_admin", False),
+    }
+    attribute, value = gates[failing_gate]
+    monkeypatch.setattr(auth_mounts_mod, attribute, lambda *_a, _v=value: _v)
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+    write_overlay_probe_evidence(
+        scratch_root, OverlayProbeResult(ok=False, reason="REFUSED", detail="exit=32: denied")
+    )
+    assert overlay_unexpectedly_unavailable(tmp_path) is True
+
+    mounter = auth_mounts_mod._SubprocessOverlayMounter(scratch_root=scratch_root)  # noqa: SLF001
+
+    assert mounter.supported() is False
+    assert not overlay_probe_evidence_path(scratch_root).exists()
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+
+
+@pytest.mark.unit
+def test_unsupported_overlay_logs_info_under_force_copy_despite_old_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The same staleness at the node log surface: with force-copy requested the
+    # copy fallback is the intended posture, so the provision log stays INFO on
+    # the uncataloged reason code rather than warning on the cataloged one.
+    host_home = tmp_path / "host-home"
+    _seed_signature_host(host_home)
+    work_dir = tmp_path / "work"
+    scratch_root = overlay_probe_scratch_root(work_dir)
+    scratch_root.mkdir(parents=True)
+    write_overlay_probe_evidence(
+        scratch_root, OverlayProbeResult(ok=False, reason="REFUSED", detail="exit=32: denied")
+    )
+    monkeypatch.setenv("AWF_CLAUDE_AUTH_FORCE_COPY", "true")
+
+    with capture_logs() as logs:
+        resolve_service_auth_mounts(
+            host_home=host_home,
+            work_dir=work_dir,
+            workspace_id="ws_forced_copy",
+            host_env={},
+            overlay_mounter=FakeOverlayMounter(supported=False),
+        )
+
+    events = [entry for entry in logs if entry["event"].startswith("claude_auth_overlay")]
+    assert [entry["event"] for entry in events] == ["claude_auth_overlay_unavailable"]
+    assert events[0]["log_level"] == "info"
+    assert events[0]["reason_code"] == "CLAUDE_AUTH_OVERLAY_UNAVAILABLE"
+
+
+@pytest.mark.unit
 def test_supported_is_false_when_the_probe_is_refused(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -434,6 +498,8 @@ def test_usage_history_exclusion_alias_still_exported() -> None:
         "claude_copy_ignore",
         "claude_signature_excludes_rel",
         "cached_overlay_probe",
+        "discard_overlay_probe_evidence",
+        "CLAUDE_AUTH_FORCE_COPY_ENV",
     ],
 )
 def test_exclusion_and_probe_names_reexported_through_facade(name: str) -> None:

--- a/tests/unit/node/test_overlay_probe.py
+++ b/tests/unit/node/test_overlay_probe.py
@@ -177,7 +177,11 @@ def test_probe_reports_missing_mount_binary(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
-def test_probe_reports_timeout(tmp_path: Path) -> None:
+def test_probe_keeps_staging_when_mount_times_out(tmp_path: Path) -> None:
+    # Killing the timed-out ``mount(8)`` does not undo a ``mount(2)`` that already
+    # landed, so ``merged`` may be a live overlay pinning lower/upper/work. Same
+    # reasoning as the umount-failure branch: retain rather than recursively
+    # delete through a possibly-live merged view.
     scratch_root = tmp_path / "auth" / "_shared"
     run = _FakeRun(mount_error=subprocess.TimeoutExpired(["mount"], 10.0))
 
@@ -185,7 +189,9 @@ def test_probe_reports_timeout(tmp_path: Path) -> None:
 
     assert result.ok is False
     assert result.reason == "TIMEOUT"
-    assert _staging_dirs(scratch_root) == []
+    retained = _staging_dirs(scratch_root)
+    assert len(retained) == 1
+    assert str(retained[0]) in result.detail
 
 
 @pytest.mark.unit

--- a/tests/unit/node/test_overlay_probe.py
+++ b/tests/unit/node/test_overlay_probe.py
@@ -150,6 +150,35 @@ def test_probe_refused_on_os_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(
+    "mount_error",
+    [
+        pytest.param(subprocess.CalledProcessError(-9, ["mount"], stderr=""), id="signalled"),
+        pytest.param(PermissionError("operation not permitted"), id="os-error"),
+    ],
+)
+def test_probe_keeps_staging_when_failed_mount_left_merged_mounted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mount_error: BaseException
+) -> None:
+    # A ``mount(8)`` that reports failure normally means ``mount(2)`` never
+    # landed, but the two are not the same event: a helper killed by a signal
+    # after the syscall succeeded still exits non-zero. Recursively deleting then
+    # would descend through a live overlay, so staging is retained whenever
+    # ``merged`` is still a mount point.
+    scratch_root = tmp_path / "auth" / "_shared"
+    monkeypatch.setattr(probe_mod, "_is_mounted", lambda path: path.name == "merged")
+    run = _FakeRun(mount_error=mount_error)
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "REFUSED"
+    retained = _staging_dirs(scratch_root)
+    assert len(retained) == 1
+    assert str(retained[0]) in result.detail
+
+
+@pytest.mark.unit
 def test_probe_keeps_staging_when_umount_fails(tmp_path: Path) -> None:
     # Never ``rmtree`` under a possibly-live mount: the probe succeeded, so the
     # host *can* overlay; leaking one empty staging dir is strictly safer than

--- a/tests/unit/node/test_overlay_probe.py
+++ b/tests/unit/node/test_overlay_probe.py
@@ -179,17 +179,50 @@ def test_probe_keeps_staging_when_failed_mount_left_merged_mounted(
 
 
 @pytest.mark.unit
-def test_probe_keeps_staging_when_umount_fails(tmp_path: Path) -> None:
-    # Never ``rmtree`` under a possibly-live mount: the probe succeeded, so the
-    # host *can* overlay; leaking one empty staging dir is strictly safer than
-    # recursively deleting through a live overlay's merged view.
+@pytest.mark.parametrize(
+    "umount_error",
+    [
+        pytest.param(subprocess.CalledProcessError(1, ["umount"], stderr="busy"), id="refused"),
+        pytest.param(subprocess.TimeoutExpired(["umount"], 10.0), id="timeout"),
+        pytest.param(FileNotFoundError("umount"), id="binary-missing"),
+    ],
+)
+def test_probe_rejects_a_mount_it_cannot_unmount(
+    tmp_path: Path, umount_error: BaseException
+) -> None:
+    # A mounter that cannot tear the scratch overlay down cannot tear production
+    # overlays down either, so reporting ``ok`` would enable overlays that leak
+    # live mounts at workspace cleanup. Never ``rmtree`` under a possibly-live
+    # mount either: the staging tree is retained and its path recorded.
     scratch_root = tmp_path / "auth" / "_shared"
-    run = _FakeRun(umount_error=subprocess.CalledProcessError(1, ["umount"], stderr="busy"))
+    run = _FakeRun(umount_error=umount_error)
 
     result = probe_overlay_mount(scratch_root=scratch_root, run=run)
 
-    assert result.ok is True
-    assert result.reason == "OVERLAY_PROBE_OK"
+    assert result.ok is False
+    assert result.reason == "UMOUNT_FAILED"
+    retained = _staging_dirs(scratch_root)
+    assert len(retained) == 1
+    assert str(retained[0]) in result.detail
+
+
+@pytest.mark.unit
+def test_probe_rejects_a_mount_still_live_after_a_successful_umount(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # ``umount(8)`` exiting 0 is not the same event as the mount being gone (a
+    # lazy/deferred detach still leaves it live). The mount must be *confirmed*
+    # unmounted before the probe blesses production overlays — and before the
+    # staging tree is recursively deleted through the merged view.
+    scratch_root = tmp_path / "auth" / "_shared"
+    monkeypatch.setattr(probe_mod, "_is_mounted", lambda path: path.name == "merged")
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "UMOUNT_FAILED"
+    assert run.commands == ["mount", "umount"]
     retained = _staging_dirs(scratch_root)
     assert len(retained) == 1
     assert str(retained[0]) in result.detail
@@ -300,6 +333,7 @@ def test_probe_reports_reserved_chars_without_touching_the_filesystem(
         ("OVERLAY_PROBE_OK", True, True),
         ("REFUSED", False, False),
         ("TIMEOUT", False, False),
+        ("UMOUNT_FAILED", False, False),
         ("MOUNT_BINARY_MISSING", False, True),
         ("SCRATCH_UNAVAILABLE", False, True),
         ("PATH_RESERVED_CHARS", False, True),
@@ -594,6 +628,7 @@ def test_module_documents_every_reason() -> None:
         "OVERLAY_PROBE_OK",
         "REFUSED",
         "TIMEOUT",
+        "UMOUNT_FAILED",
         "MOUNT_BINARY_MISSING",
         "SCRATCH_UNAVAILABLE",
         "PATH_RESERVED_CHARS",

--- a/tests/unit/node/test_overlay_probe.py
+++ b/tests/unit/node/test_overlay_probe.py
@@ -1,0 +1,499 @@
+"""Real scratch overlay mount probe and its worker→api evidence channel (#874).
+
+The pre-#874 preflight grepped ``/proc/filesystems`` and the ``CAP_SYS_ADMIN``
+bit, both blind to the LSM layer. On a worker confined by Docker's
+``docker-default`` AppArmor profile — whose plain, non-auditing ``deny mount,``
+rule blocks ``mount(2)`` regardless of capability — it reported "supported" and
+every mount then failed, after a ~1.9 GB shared-base copy had already been built.
+
+No test here performs a real mount: the container running these tests has no
+``CAP_SYS_ADMIN`` and is itself AppArmor-confined. Everything is driven through
+the injected ``run`` callable, ``monkeypatch`` and ``tmp_path``.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Sequence
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from awf.node import auth_mounts_overlay_probe as probe_mod
+from awf.node.auth_mounts_overlay_probe import (
+    OverlayProbeResult,
+    cached_overlay_probe,
+    overlay_probe_evidence_path,
+    overlay_probe_expected,
+    overlay_probe_scratch_root,
+    overlay_unexpectedly_unavailable,
+    probe_overlay_mount,
+    read_overlay_probe_evidence,
+    reset_overlay_probe_cache,
+    write_overlay_probe_evidence,
+)
+
+
+class _FakeRun:
+    """Records ``mount``/``umount`` invocations and raises the configured error."""
+
+    def __init__(
+        self,
+        *,
+        mount_error: BaseException | None = None,
+        umount_error: BaseException | None = None,
+    ) -> None:
+        self.mount_error = mount_error
+        self.umount_error = umount_error
+        self.calls: list[list[str]] = []
+
+    def __call__(self, args: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        self.calls.append(list(args))
+        if args[0] == "mount" and self.mount_error is not None:
+            raise self.mount_error
+        if args[0] == "umount" and self.umount_error is not None:
+            raise self.umount_error
+        return subprocess.CompletedProcess(list(args), 0, "", "")
+
+    @property
+    def commands(self) -> list[str]:
+        return [call[0] for call in self.calls]
+
+
+def _staging_dirs(scratch_root: Path) -> list[Path]:
+    if not scratch_root.is_dir():
+        return []
+    return sorted(scratch_root.glob(".overlay-probe-*"))
+
+
+def _refused_error() -> subprocess.CalledProcessError:
+    # util-linux retries read-only after ``EACCES``; exit 32 with this stderr is
+    # exactly what the operator's AppArmor-confined worker produced.
+    return subprocess.CalledProcessError(
+        32,
+        ["mount"],
+        output="",
+        stderr="mount: /scratch/merged: cannot mount overlay read-only.\n",
+    )
+
+
+@pytest.mark.unit
+def test_probe_reports_ok_and_cleans_up_staging(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result == OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK", detail="")
+    assert run.commands == ["mount", "umount"]
+    assert _staging_dirs(scratch_root) == []
+
+
+@pytest.mark.unit
+def test_probe_mount_options_reference_the_staging_layers(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun()
+
+    probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    mount_call = run.calls[0]
+    assert mount_call[:5] == ["mount", "-t", "overlay", "overlay", "-o"]
+    options = mount_call[5]
+    assert "lowerdir=" in options
+    assert "upperdir=" in options
+    assert "workdir=" in options
+    assert mount_call[6].endswith("/merged")
+
+
+@pytest.mark.unit
+def test_probe_reports_refused_with_stderr_detail(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(mount_error=_refused_error())
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "REFUSED"
+    assert "cannot mount overlay read-only" in result.detail
+    assert "32" in result.detail
+    assert run.commands == ["mount"]
+    assert _staging_dirs(scratch_root) == []
+
+
+@pytest.mark.unit
+def test_probe_refused_detail_is_truncated(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(
+        mount_error=subprocess.CalledProcessError(32, ["mount"], stderr="x" * 5_000),
+    )
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.reason == "REFUSED"
+    assert len(result.detail) <= 512
+
+
+@pytest.mark.unit
+def test_probe_refused_on_os_error(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(mount_error=PermissionError("operation not permitted"))
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "REFUSED"
+    assert "operation not permitted" in result.detail
+
+
+@pytest.mark.unit
+def test_probe_keeps_staging_when_umount_fails(tmp_path: Path) -> None:
+    # Never ``rmtree`` under a possibly-live mount: the probe succeeded, so the
+    # host *can* overlay; leaking one empty staging dir is strictly safer than
+    # recursively deleting through a live overlay's merged view.
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(umount_error=subprocess.CalledProcessError(1, ["umount"], stderr="busy"))
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is True
+    assert result.reason == "OVERLAY_PROBE_OK"
+    retained = _staging_dirs(scratch_root)
+    assert len(retained) == 1
+    assert str(retained[0]) in result.detail
+
+
+@pytest.mark.unit
+def test_probe_reports_missing_mount_binary(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(mount_error=FileNotFoundError("mount"))
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "MOUNT_BINARY_MISSING"
+    assert _staging_dirs(scratch_root) == []
+
+
+@pytest.mark.unit
+def test_probe_reports_timeout(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(mount_error=subprocess.TimeoutExpired(["mount"], 10.0))
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "TIMEOUT"
+    assert _staging_dirs(scratch_root) == []
+
+
+@pytest.mark.unit
+def test_probe_reports_scratch_unavailable_when_root_is_a_file(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "not-a-dir"
+    scratch_root.write_text("occupied\n")
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "SCRATCH_UNAVAILABLE"
+    assert run.calls == []
+
+
+@pytest.mark.unit
+def test_probe_reports_scratch_unavailable_when_mkdtemp_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+
+    def _boom(*_args: object, **_kwargs: object) -> str:
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr(probe_mod.tempfile, "mkdtemp", _boom)
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "SCRATCH_UNAVAILABLE"
+    assert "no space left on device" in result.detail
+    assert run.calls == []
+
+
+@pytest.mark.unit
+def test_probe_reports_scratch_unavailable_when_layer_creation_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    vanished = tmp_path / "vanished-staging"
+
+    monkeypatch.setattr(probe_mod.tempfile, "mkdtemp", lambda **_kwargs: str(vanished))
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "SCRATCH_UNAVAILABLE"
+    assert run.calls == []
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("segment", ["comma,dir", "colon:dir"])
+def test_probe_reports_reserved_chars_without_touching_the_filesystem(
+    tmp_path: Path, segment: str
+) -> None:
+    # ``mount -o`` offers no escaping for ``,``/``:``; such a host is a *expected*
+    # copy-fallback platform, not a misconfiguration.
+    scratch_root = tmp_path / segment / "auth" / "_shared"
+    run = _FakeRun()
+
+    result = probe_overlay_mount(scratch_root=scratch_root, run=run)
+
+    assert result.ok is False
+    assert result.reason == "PATH_RESERVED_CHARS"
+    assert run.calls == []
+    assert not scratch_root.exists()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("reason", "ok", "expected"),
+    [
+        ("OVERLAY_PROBE_OK", True, True),
+        ("REFUSED", False, False),
+        ("TIMEOUT", False, False),
+        ("MOUNT_BINARY_MISSING", False, True),
+        ("SCRATCH_UNAVAILABLE", False, True),
+        ("PATH_RESERVED_CHARS", False, True),
+    ],
+)
+def test_expected_classification(reason: str, ok: bool, expected: bool) -> None:
+    # Only a refusal/timeout on a host that passed every cheap gate is
+    # *unexpected*. Everything else is a legitimate platform property and must
+    # stay silent (the awf-cloud/GKE constraint).
+    assert overlay_probe_expected(OverlayProbeResult(ok=ok, reason=reason)) is expected
+
+
+@pytest.mark.unit
+def test_cached_probe_runs_once_per_scratch_root(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    other_root = tmp_path / "other" / "_shared"
+    run = _FakeRun()
+
+    first = cached_overlay_probe(scratch_root=scratch_root, run=run)
+    second = cached_overlay_probe(scratch_root=scratch_root, run=run)
+
+    assert first == second
+    assert run.commands == ["mount", "umount"]
+
+    cached_overlay_probe(scratch_root=other_root, run=run)
+
+    assert run.commands == ["mount", "umount", "mount", "umount"]
+
+
+@pytest.mark.unit
+def test_reset_overlay_probe_cache_forces_a_reprobe(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun()
+
+    cached_overlay_probe(scratch_root=scratch_root, run=run)
+    reset_overlay_probe_cache()
+    cached_overlay_probe(scratch_root=scratch_root, run=run)
+
+    assert run.commands == ["mount", "umount", "mount", "umount"]
+
+
+@pytest.mark.unit
+def test_cached_probe_writes_evidence_once(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    run = _FakeRun(mount_error=_refused_error())
+
+    cached_overlay_probe(scratch_root=scratch_root, run=run)
+    evidence_path = overlay_probe_evidence_path(scratch_root)
+    first = evidence_path.read_text()
+    cached_overlay_probe(scratch_root=scratch_root, run=run)
+
+    assert evidence_path.read_text() == first
+    payload = json.loads(first)
+    assert payload["ok"] is False
+    assert payload["reason"] == "REFUSED"
+    assert payload["expected"] is False
+
+
+@pytest.mark.unit
+def test_evidence_round_trip_records_injected_timestamp(tmp_path: Path) -> None:
+    scratch_root = tmp_path / "auth" / "_shared"
+    scratch_root.mkdir(parents=True)
+    checked_at = datetime(2026, 8, 30, 12, 0, 0, tzinfo=UTC)
+
+    write_overlay_probe_evidence(
+        scratch_root,
+        OverlayProbeResult(ok=False, reason="REFUSED", detail="exit=32"),
+        now=checked_at,
+    )
+    evidence = read_overlay_probe_evidence(tmp_path)
+
+    assert evidence == {
+        "ok": False,
+        "reason": "REFUSED",
+        "expected": False,
+        "detail": "exit=32",
+        "checked_at": "2026-08-30T12:00:00+00:00",
+    }
+
+
+@pytest.mark.unit
+def test_evidence_defaults_checked_at_to_now(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+
+    write_overlay_probe_evidence(
+        scratch_root, OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK")
+    )
+    evidence = read_overlay_probe_evidence(tmp_path)
+
+    assert evidence is not None
+    assert datetime.fromisoformat(str(evidence["checked_at"])).tzinfo is not None
+
+
+@pytest.mark.unit
+def test_evidence_write_is_suppressed_when_the_directory_is_missing(tmp_path: Path) -> None:
+    # Best-effort, mirroring ``_record_overlay_base_pin``: a failed write only
+    # forfeits observability; it must never fail provisioning.
+    scratch_root = tmp_path / "absent" / "_shared"
+
+    write_overlay_probe_evidence(
+        scratch_root, OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK")
+    )
+
+    assert read_overlay_probe_evidence(tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_evidence_returns_none_when_absent(tmp_path: Path) -> None:
+    assert read_overlay_probe_evidence(tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_evidence_returns_none_on_invalid_json(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+    overlay_probe_evidence_path(scratch_root).write_text("{not json")
+
+    assert read_overlay_probe_evidence(tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_evidence_returns_none_on_non_mapping_json(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+    overlay_probe_evidence_path(scratch_root).write_text("[1, 2]")
+
+    assert read_overlay_probe_evidence(tmp_path) is None
+
+
+@pytest.mark.unit
+def test_read_evidence_returns_none_on_unreadable_file(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+    evidence_path = overlay_probe_evidence_path(scratch_root)
+    evidence_path.write_text("{}")
+    evidence_path.chmod(0o000)
+
+    assert read_overlay_probe_evidence(tmp_path) is None
+
+
+def _write_evidence(work_dir: Path, payload: object) -> None:
+    scratch_root = overlay_probe_scratch_root(work_dir)
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    overlay_probe_evidence_path(scratch_root).write_text(json.dumps(payload))
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("payload", "unexpected"),
+    [
+        ({"ok": False, "expected": False}, True),
+        ({"ok": False, "expected": True}, False),
+        ({"ok": True, "expected": True}, False),
+        ({"ok": True, "expected": False}, False),
+        ({"reason": "REFUSED"}, False),
+        ({"ok": "false", "expected": "false"}, False),
+    ],
+)
+def test_overlay_unexpectedly_unavailable_truth_table(
+    tmp_path: Path, payload: dict[str, object], unexpected: bool
+) -> None:
+    _write_evidence(tmp_path, payload)
+
+    assert overlay_unexpectedly_unavailable(tmp_path) is unexpected
+
+
+@pytest.mark.unit
+def test_overlay_unexpectedly_unavailable_is_false_without_evidence(tmp_path: Path) -> None:
+    # The awf-cloud/GKE regression, at its source: absence of evidence means
+    # silence, by construction.
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+
+
+@pytest.mark.unit
+def test_overlay_unexpectedly_unavailable_is_false_on_corrupt_evidence(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    scratch_root.mkdir(parents=True)
+    overlay_probe_evidence_path(scratch_root).write_text("nonsense")
+
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+
+
+@pytest.mark.unit
+def test_scratch_root_is_the_shared_auth_dir(tmp_path: Path) -> None:
+    # The work dir is bind-mounted at the same absolute path into worker and api,
+    # which is what makes this a valid cross-container evidence channel.
+    assert overlay_probe_scratch_root(tmp_path) == tmp_path / "auth" / "_shared"
+    assert (
+        overlay_probe_evidence_path(overlay_probe_scratch_root(tmp_path))
+        == tmp_path / "auth" / "_shared" / "overlay-probe.json"
+    )
+
+
+@pytest.mark.unit
+def test_probe_result_is_frozen() -> None:
+    result = OverlayProbeResult(ok=True, reason="OVERLAY_PROBE_OK")
+
+    with pytest.raises(AttributeError):
+        result.ok = False  # type: ignore[misc]
+
+
+@pytest.mark.unit
+def test_probe_passes_the_timeout_through(tmp_path: Path) -> None:
+    captured: list[object] = []
+
+    def _run(args: Sequence[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured.append(kwargs.get("timeout"))
+        return subprocess.CompletedProcess(list(args), 0, "", "")
+
+    probe_overlay_mount(scratch_root=tmp_path / "s", run=_run, timeout_seconds=2.5)
+
+    assert captured == [2.5, 2.5]
+
+
+@pytest.mark.unit
+def test_probe_default_run_is_subprocess_run() -> None:
+    # Guards the injection seam: production must not silently lose the real
+    # ``mount(8)`` call, and tests must always be the ones overriding it.
+    assert probe_mod._DEFAULT_RUN is subprocess.run  # noqa: SLF001
+
+
+@pytest.mark.unit
+def test_module_documents_every_reason() -> None:
+    docstring = probe_mod.__doc__ or ""
+    for reason in (
+        "OVERLAY_PROBE_OK",
+        "REFUSED",
+        "TIMEOUT",
+        "MOUNT_BINARY_MISSING",
+        "SCRATCH_UNAVAILABLE",
+        "PATH_RESERVED_CHARS",
+    ):
+        assert reason in docstring

--- a/tests/unit/node/test_overlay_probe.py
+++ b/tests/unit/node/test_overlay_probe.py
@@ -25,6 +25,8 @@ from awf.node import auth_mounts_overlay_probe as probe_mod
 from awf.node.auth_mounts_overlay_probe import (
     OverlayProbeResult,
     cached_overlay_probe,
+    discard_overlay_probe_evidence,
+    force_copy_isolation_requested,
     overlay_probe_evidence_path,
     overlay_probe_expected,
     overlay_probe_scratch_root,
@@ -450,6 +452,71 @@ def test_overlay_unexpectedly_unavailable_is_false_on_corrupt_evidence(tmp_path:
     overlay_probe_evidence_path(scratch_root).write_text("nonsense")
 
     assert overlay_unexpectedly_unavailable(tmp_path) is False
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("flag", ["1", "true", "TRUE", " yes ", "on"])
+def test_force_copy_posture_ignores_evidence_from_an_earlier_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: str
+) -> None:
+    # A host refused once, then restarted under force-copy: it fails the first
+    # cheap gate and never probes again, so the file on disk describes a posture
+    # it no longer runs. The copy fallback it now takes is fully supported and
+    # must not surface as CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE.
+    _write_evidence(tmp_path, {"ok": False, "expected": False, "reason": "REFUSED"})
+    assert overlay_unexpectedly_unavailable(tmp_path) is True
+
+    monkeypatch.setenv("AWF_CLAUDE_AUTH_FORCE_COPY", flag)
+
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+    assert overlay_unexpectedly_unavailable(tmp_path, host_env={}) is True
+    assert (
+        overlay_unexpectedly_unavailable(tmp_path, host_env={"AWF_CLAUDE_AUTH_FORCE_COPY": "true"})
+        is False
+    )
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("value", "requested"),
+    [("1", True), ("on", True), ("Yes", True), ("false", False), ("", False), ("0", False)],
+)
+def test_force_copy_isolation_requested_parses_the_flag(value: str, requested: bool) -> None:
+    assert force_copy_isolation_requested({"AWF_CLAUDE_AUTH_FORCE_COPY": value}) is requested
+    assert force_copy_isolation_requested({}) is False
+
+
+@pytest.mark.unit
+def test_discard_evidence_removes_the_file_and_tolerates_absence(tmp_path: Path) -> None:
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    _write_evidence(tmp_path, {"ok": False, "expected": False, "reason": "REFUSED"})
+
+    discard_overlay_probe_evidence(scratch_root)
+
+    assert not overlay_probe_evidence_path(scratch_root).exists()
+    assert overlay_unexpectedly_unavailable(tmp_path) is False
+    # Idempotent: the common case is a host that never wrote evidence at all.
+    discard_overlay_probe_evidence(scratch_root)
+    discard_overlay_probe_evidence(tmp_path / "never-created")
+
+
+@pytest.mark.unit
+def test_discard_evidence_suppresses_os_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Best-effort, exactly like the write: losing the delete forfeits accuracy of
+    # an advisory signal, never provisioning.
+    scratch_root = overlay_probe_scratch_root(tmp_path)
+    _write_evidence(tmp_path, {"ok": False, "expected": False, "reason": "REFUSED"})
+
+    def _boom(self: Path, missing_ok: bool = False) -> None:
+        raise PermissionError("read-only mount")
+
+    monkeypatch.setattr(Path, "unlink", _boom)
+
+    discard_overlay_probe_evidence(scratch_root)
+
+    assert overlay_probe_evidence_path(scratch_root).exists()
 
 
 @pytest.mark.unit

--- a/tests/unit/service/test_doctor_reasons.py
+++ b/tests/unit/service/test_doctor_reasons.py
@@ -200,3 +200,21 @@ def test_reason_catalog_is_synchronized_with_python_source() -> None:
         "docs/REASON_CATALOG.md is out of sync with src/awf/service/doctor/reasons.py. "
         "Please run `uv run python scripts/generate_reason_catalog.py` to update it."
     )
+
+
+@pytest.mark.unit
+def test_claude_overlay_unexpected_reason_is_cataloged() -> None:
+    text = _REASON_TEXT["CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"]
+
+    assert "overlay" in text.message.lower()
+    assert text.related_command == "awf service status --format json"
+    assert text.docs_link.endswith("#claude_auth_overlay_unexpectedly_unavailable")
+
+
+@pytest.mark.unit
+def test_expected_claude_overlay_fallback_is_deliberately_not_cataloged() -> None:
+    # ``CLAUDE_AUTH_OVERLAY_UNAVAILABLE`` is logged at INFO on every hosted/GKE
+    # and force-copy host, where the per-workspace copy fallback is the correct
+    # posture. Documenting it as a fault would turn a supported platform choice
+    # into a standing false alarm, so it must stay out of the catalog (#874).
+    assert "CLAUDE_AUTH_OVERLAY_UNAVAILABLE" not in _REASON_TEXT

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -1018,6 +1018,35 @@ def test_claude_readiness_ignores_probe_evidence_under_force_copy(tmp_path: Path
 
 
 @pytest.mark.unit
+def test_claude_readiness_warns_despite_stale_force_copy_in_process_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The effective ``environ`` — not the CLI process environment — is the
+    # force-copy truth: bootstrap folds the operator override into the readiness
+    # environ dict. A stale truthy ``AWF_CLAUDE_AUTH_FORCE_COPY`` left in the
+    # process must not suppress refusal evidence when the posture actually in
+    # force (the passed mapping) is overlay.
+    monkeypatch.setenv("AWF_CLAUDE_AUTH_FORCE_COPY", "true")
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_CLAUDE_AUTH_FORCE_COPY": "false"},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert [warning["reason"] for warning in claude["warnings"]] == [
+        "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+    ]
+    assert claude["claude_auth_overlay"] == "unexpectedly_unavailable"
+
+
+@pytest.mark.unit
 def test_claude_readiness_ignores_probe_evidence_without_claude_directory(tmp_path: Path) -> None:
     # ``~/.claude.json`` is *always* a per-workspace copy — the resolver never
     # overlays it — and without ``~/.claude`` it never calls ``supported()``, so

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -905,3 +905,114 @@ def test_provider_readiness_opencode_all_ollama_candidates_fail_reports_redacted
     assert "HTTP 503: busy <redacted>" in caplog.text
     assert "sk-proj-ollama-terminal-secret" not in caplog.text
     assert "ghp_ollama_terminal_secret" not in caplog.text
+
+
+def _seed_claude_dir(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True)
+    (home / ".claude" / "settings.json").write_text('{"theme":"dark"}')
+
+
+def _write_probe_evidence(tmp_path: Path, payload: dict[str, object]) -> None:
+    scratch_root = tmp_path / "work" / "auth" / "_shared"
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    (scratch_root / "overlay-probe.json").write_text(json.dumps(payload))
+
+
+@pytest.mark.unit
+def test_claude_readiness_is_silent_without_overlay_probe_evidence(tmp_path: Path) -> None:
+    # The awf-cloud/GKE regression. In Kubernetes a pod-level overlay mount is
+    # typically impossible, the copy fallback is the correct posture, and no
+    # probe ever runs — so no evidence file exists and readiness must say
+    # nothing at all. Absence of evidence means silence.
+    _seed_claude_dir(tmp_path)
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["ok"] is True
+    assert claude["status"] == "ok"
+    assert claude["warnings"] == []
+    assert "claude_auth_overlay" not in claude
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        {"ok": False, "expected": True, "reason": "MOUNT_BINARY_MISSING"},
+        {"ok": True, "expected": True, "reason": "OVERLAY_PROBE_OK"},
+        {"garbage": True},
+    ],
+)
+def test_claude_readiness_is_silent_for_expected_probe_outcomes(
+    tmp_path: Path, evidence: dict[str, object]
+) -> None:
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(tmp_path, evidence)
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["warnings"] == []
+    assert "claude_auth_overlay" not in claude
+
+
+@pytest.mark.unit
+def test_claude_readiness_warns_on_unexpected_overlay_probe_failure(tmp_path: Path) -> None:
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    # Visibility only: the copy fallback stays a fully supported path, so the
+    # provider verdict must not move.
+    assert claude["ok"] is True
+    assert claude["status"] == "ok"
+    assert claude["severity"] == "ok"
+    assert claude["reason"] == "CLAUDE_FILE_AUTH_PRESENT"
+    assert payload["status"] == "ok"
+    assert [warning["reason"] for warning in claude["warnings"]] == [
+        "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+    ]
+    assert claude["claude_auth_overlay"] == "unexpectedly_unavailable"
+
+
+@pytest.mark.unit
+def test_claude_readiness_overlay_field_survives_doctor_metadata_mapping(tmp_path: Path) -> None:
+    # Flat, not nested: doctor's ``_metadata_from_mapping`` + ``_redact_mapping``
+    # is what the diagnostic surface renders, and a nested payload would not
+    # survive it. The diagnostic itself must stay ``ok``.
+    from awf.service import doctor as doctor_mod
+
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(
+        tmp_path, {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32"}
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+    claude = payload["providers"]["claude_code"]
+    metadata = doctor_mod._metadata_from_mapping(claude, secrets=frozenset())  # noqa: SLF001
+
+    assert metadata["claude_auth_overlay"] == "unexpectedly_unavailable"
+    assert doctor_mod._status_from_provider(claude) == "ok"  # noqa: SLF001

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -995,6 +995,61 @@ def test_claude_readiness_warns_on_unexpected_overlay_probe_failure(tmp_path: Pa
 
 
 @pytest.mark.unit
+def test_claude_readiness_reports_copy_isolation_on_unexpected_probe_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Recorded refusal evidence means the worker's ``supported()`` returns False,
+    # so every ``~/.claude`` provision takes the full-copy fallback. The label
+    # must fold that in or readiness warns about a copy fallback while
+    # simultaneously reporting ``per_workspace_overlay`` isolation.
+    import awf.node.auth_mounts_claude as auth_mounts_claude
+
+    monkeypatch.setattr(auth_mounts_claude, "_overlay_filesystem_available", lambda: True)
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["claude_auth_overlay"] == "unexpectedly_unavailable"
+    assert claude["isolation"] == "per_workspace_copy"
+    isolation_by_signal = {
+        source["signal"]: source["isolation"] for source in claude["credential_sources"]
+    }
+    assert isolation_by_signal == {"~/.claude": "per_workspace_copy"}
+
+
+@pytest.mark.unit
+def test_claude_readiness_keeps_overlay_isolation_for_expected_probe_outcomes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The mirror of the case above: a probe that passed leaves the worker on the
+    # overlay posture, so evidence must not drag the label down to copy.
+    import awf.node.auth_mounts_claude as auth_mounts_claude
+
+    monkeypatch.setattr(auth_mounts_claude, "_overlay_filesystem_available", lambda: True)
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(tmp_path, {"ok": True, "expected": True, "reason": "OVERLAY_PROBE_OK"})
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["warnings"] == []
+    assert claude["isolation"] == "per_workspace_overlay"
+
+
+@pytest.mark.unit
 def test_claude_readiness_ignores_probe_evidence_under_force_copy(tmp_path: Path) -> None:
     # Evidence recorded before the host switched to force-copy describes a
     # posture it no longer runs: it now fails the first cheap gate and never

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -1018,6 +1018,34 @@ def test_claude_readiness_ignores_probe_evidence_under_force_copy(tmp_path: Path
 
 
 @pytest.mark.unit
+def test_claude_readiness_ignores_probe_evidence_without_claude_directory(tmp_path: Path) -> None:
+    # ``~/.claude.json`` is *always* a per-workspace copy — the resolver never
+    # overlays it — and without ``~/.claude`` it never calls ``supported()``, so
+    # nothing ever refreshes or discards evidence written by an earlier posture.
+    # Warning here would report a standing overlay fallback for an auth source
+    # that does not use overlays at all.
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude.json").write_text("{}")
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["reason"] == "CLAUDE_FILE_AUTH_PRESENT"
+    assert claude["warnings"] == []
+    assert "claude_auth_overlay" not in claude
+    assert claude["isolation"] == "per_workspace_copy"
+
+
+@pytest.mark.unit
 def test_claude_readiness_overlay_field_survives_doctor_metadata_mapping(tmp_path: Path) -> None:
     # Flat, not nested: doctor's ``_metadata_from_mapping`` + ``_redact_mapping``
     # is what the diagnostic surface renders, and a nested payload would not

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -1075,6 +1075,38 @@ def test_claude_readiness_ignores_probe_evidence_without_claude_directory(tmp_pa
 
 
 @pytest.mark.unit
+def test_claude_readiness_ignores_probe_evidence_when_claude_is_not_a_directory(
+    tmp_path: Path,
+) -> None:
+    # The resolver gates the directory source on ``source_dir.is_dir()``, so a
+    # regular-file ``~/.claude`` is never mounted, never overlaid, and never
+    # calls ``supported()`` — nothing refreshes or discards evidence an earlier
+    # posture left behind. ``exists()`` here would list an unusable directory
+    # source and warn about an overlay the host cannot even attempt.
+    home = tmp_path / "home"
+    home.mkdir(parents=True)
+    (home / ".claude").write_text("not a directory")
+    (home / ".claude.json").write_text("{}")
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["reason"] == "CLAUDE_FILE_AUTH_PRESENT"
+    assert claude["signals"] == ["~/.claude.json"]
+    assert claude["warnings"] == []
+    assert "claude_auth_overlay" not in claude
+    assert claude["isolation"] == "per_workspace_copy"
+
+
+@pytest.mark.unit
 def test_claude_readiness_overlay_field_survives_doctor_metadata_mapping(tmp_path: Path) -> None:
     # Flat, not nested: doctor's ``_metadata_from_mapping`` + ``_redact_mapping``
     # is what the diagnostic surface renders, and a nested payload would not

--- a/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
+++ b/tests/unit/service/test_provider_readiness_parts/test_provider_readiness_part_002.py
@@ -995,6 +995,29 @@ def test_claude_readiness_warns_on_unexpected_overlay_probe_failure(tmp_path: Pa
 
 
 @pytest.mark.unit
+def test_claude_readiness_ignores_probe_evidence_under_force_copy(tmp_path: Path) -> None:
+    # Evidence recorded before the host switched to force-copy describes a
+    # posture it no longer runs: it now fails the first cheap gate and never
+    # probes, so readiness must report the copy fallback without a warning.
+    _seed_claude_dir(tmp_path)
+    _write_probe_evidence(
+        tmp_path,
+        {"ok": False, "expected": False, "reason": "REFUSED", "detail": "exit=32: denied"},
+    )
+
+    payload = collect_agent_readiness(
+        _settings(tmp_path),
+        environ={"AWF_CLAUDE_AUTH_FORCE_COPY": "true"},
+        run_subprocess=_unexpected_subprocess,
+    )
+
+    claude = payload["providers"]["claude_code"]
+    assert claude["warnings"] == []
+    assert "claude_auth_overlay" not in claude
+    assert claude["isolation"] == "per_workspace_copy"
+
+
+@pytest.mark.unit
 def test_claude_readiness_overlay_field_survives_doctor_metadata_mapping(tmp_path: Path) -> None:
     # Flat, not nested: doctor's ``_metadata_from_mapping`` + ``_redact_mapping``
     # is what the diagnostic surface renders, and a nested payload would not

--- a/tests/unit/service/test_status_parts/test_status_mount_propagation.py
+++ b/tests/unit/service/test_status_parts/test_status_mount_propagation.py
@@ -307,6 +307,41 @@ def test_mount_propagation_warns_on_unexpected_overlay_probe_evidence(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(
+    ("environ", "env_file_body"),
+    [
+        ({"AWF_WORK_DIR_BIND_PROPAGATION": "rprivate", "AWF_CLAUDE_AUTH_FORCE_COPY": "true"}, None),
+        ({}, "AWF_WORK_DIR_BIND_PROPAGATION=rprivate\nAWF_CLAUDE_AUTH_FORCE_COPY=true\n"),
+    ],
+)
+def test_mount_propagation_ignores_probe_evidence_under_force_copy(
+    tmp_path: Path, environ: dict[str, str], env_file_body: str | None
+) -> None:
+    # Stale evidence from a run that *did* probe must not warn once the host is
+    # on force-copy: it now fails the first cheap gate, never probes, and the
+    # copy fallback it takes is a fully supported posture. Resolved from the
+    # environ and from the compose env-file alike.
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, _UNEXPECTED_EVIDENCE)
+    env_file: Path | None = None
+    if env_file_body is not None:
+        env_file = tmp_path / ".env"
+        env_file.write_text(env_file_body, encoding="utf-8")
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ=environ,
+        compose_env_file=env_file,
+        work_dir=work_dir,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "ok"
+    assert payload["reason"] == "MOUNT_PROPAGATION_AVAILABLE"
+    assert payload["force_copy"] is True
+    assert "overlay probe" not in str(payload["detail"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
     "evidence",
     [
         {"ok": False, "expected": True, "reason": "MOUNT_BINARY_MISSING"},

--- a/tests/unit/service/test_status_parts/test_status_mount_propagation.py
+++ b/tests/unit/service/test_status_parts/test_status_mount_propagation.py
@@ -238,6 +238,12 @@ def _write_probe_evidence(work_dir: Path, payload: dict[str, object]) -> None:
     (scratch_root / "overlay-probe.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _home_with_claude_dir(tmp_path: Path) -> Path:
+    home = tmp_path / "home"
+    (home / ".claude").mkdir(parents=True, exist_ok=True)
+    return home
+
+
 _UNEXPECTED_EVIDENCE: dict[str, object] = {
     "ok": False,
     "expected": False,
@@ -269,6 +275,7 @@ def test_mount_propagation_payload_is_unchanged_without_probe_evidence(
         environ=environ,
         compose_env_file=None,
         work_dir=tmp_path / "work",
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert with_work_dir == baseline
@@ -293,6 +300,7 @@ def test_mount_propagation_warns_on_unexpected_overlay_probe_evidence(
         environ=environ,
         compose_env_file=None,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     # ``ok`` MUST stay True in every branch: ``collect_service_status`` ANDs each
@@ -320,11 +328,73 @@ def test_mount_propagation_warns_despite_stale_force_copy_in_process_environ(
         environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared", "AWF_CLAUDE_AUTH_FORCE_COPY": "false"},
         compose_env_file=None,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert payload["ok"] is True
     assert payload["status"] == "warn"
     assert payload["reason"] == "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "prepare_home",
+    [
+        pytest.param(lambda home: home.mkdir(parents=True), id="empty-home"),
+        pytest.param(
+            lambda home: (home.mkdir(parents=True), (home / ".claude.json").touch()),
+            id="claude-json-only",
+        ),
+        pytest.param(
+            lambda home: (home.mkdir(parents=True), (home / ".claude").touch()),
+            id="claude-not-a-dir",
+        ),
+        pytest.param(lambda _home: None, id="home-absent"),
+    ],
+)
+def test_mount_propagation_ignores_probe_evidence_without_claude_dir(
+    tmp_path: Path, prepare_home: Any
+) -> None:
+    # Without a ``~/.claude`` directory the resolver never calls ``supported()``,
+    # so nothing refreshes or discards evidence an earlier posture left behind.
+    # Warning here would report a standing overlay fallback for a host that does
+    # not overlay at all — gate on the directory source, like provider readiness.
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, _UNEXPECTED_EVIDENCE)
+    home = tmp_path / "home"
+    prepare_home(home)
+    baseline = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+    )
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+        work_dir=work_dir,
+        host_home=home,
+    )
+
+    assert payload == baseline
+
+
+@pytest.mark.unit
+def test_mount_propagation_ignores_probe_evidence_without_a_host_home(tmp_path: Path) -> None:
+    # No host home to inspect means no evidence that a directory source is active.
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, _UNEXPECTED_EVIDENCE)
+    baseline = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+    )
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    assert payload == baseline
 
 
 @pytest.mark.unit
@@ -353,6 +423,7 @@ def test_mount_propagation_ignores_probe_evidence_under_force_copy(
         environ=environ,
         compose_env_file=env_file,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert payload["ok"] is True
@@ -384,6 +455,7 @@ def test_mount_propagation_ignores_expected_probe_outcomes(
         environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
         compose_env_file=None,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert payload == baseline
@@ -405,6 +477,7 @@ def test_mount_propagation_ignores_corrupt_probe_evidence(tmp_path: Path, body: 
         environ={},
         compose_env_file=None,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert payload == baseline
@@ -423,6 +496,7 @@ def test_mount_propagation_ignores_unreadable_probe_evidence(tmp_path: Path) -> 
         environ={},
         compose_env_file=None,
         work_dir=work_dir,
+        host_home=_home_with_claude_dir(tmp_path),
     )
 
     assert payload["ok"] is True
@@ -433,7 +507,7 @@ def test_mount_propagation_ignores_unreadable_probe_evidence(tmp_path: Path) -> 
 def test_collect_service_status_passes_the_work_dir_to_the_check(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    recorded: list[Path | None] = []
+    recorded: list[tuple[Path | None, Path | None]] = []
     real = status_mod._mount_propagation_check_payload  # noqa: SLF001
 
     def _spy(
@@ -441,9 +515,15 @@ def test_collect_service_status_passes_the_work_dir_to_the_check(
         environ: dict[str, str],
         compose_env_file: Path | None,
         work_dir: Path | None = None,
+        host_home: Path | None = None,
     ) -> object:
-        recorded.append(work_dir)
-        return real(environ=environ, compose_env_file=compose_env_file, work_dir=work_dir)
+        recorded.append((work_dir, host_home))
+        return real(
+            environ=environ,
+            compose_env_file=compose_env_file,
+            work_dir=work_dir,
+            host_home=host_home,
+        )
 
     monkeypatch.setattr(status_mod, "_mount_propagation_check_payload", _spy)
     settings = _settings(tmp_path)
@@ -461,4 +541,6 @@ def test_collect_service_status_passes_the_work_dir_to_the_check(
         )
     )
 
-    assert recorded == [Path(settings.work_dir).expanduser()]
+    assert recorded == [
+        (Path(settings.work_dir).expanduser(), Path(settings.host_home).expanduser())
+    ]

--- a/tests/unit/service/test_status_parts/test_status_mount_propagation.py
+++ b/tests/unit/service/test_status_parts/test_status_mount_propagation.py
@@ -306,6 +306,28 @@ def test_mount_propagation_warns_on_unexpected_overlay_probe_evidence(
 
 
 @pytest.mark.unit
+def test_mount_propagation_warns_despite_stale_force_copy_in_process_environ(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The resolved posture (passed environ, then compose env-file) is the truth
+    # here; a stale truthy ``AWF_CLAUDE_AUTH_FORCE_COPY`` in the CLI process must
+    # not silently suppress refusal evidence for a host running overlays.
+    monkeypatch.setenv("AWF_CLAUDE_AUTH_FORCE_COPY", "true")
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, _UNEXPECTED_EVIDENCE)
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared", "AWF_CLAUDE_AUTH_FORCE_COPY": "false"},
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "warn"
+    assert payload["reason"] == "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("environ", "env_file_body"),
     [

--- a/tests/unit/service/test_status_parts/test_status_mount_propagation.py
+++ b/tests/unit/service/test_status_parts/test_status_mount_propagation.py
@@ -2,12 +2,48 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import pytest
 
 from awf.service import status as status_mod
 from awf.service.config import ServiceSettings
+from awf.service.orphans import WorkspaceIdView
+
+
+@dataclass(frozen=True)
+class _DiskUsage:
+    total: int
+    used: int
+    free: int
+
+
+class _Response:
+    status_code = 200
+
+    @staticmethod
+    def json() -> dict[str, str]:
+        return {"status": "ok"}
+
+
+async def _api_get(_url: str, *, timeout: float) -> _Response:
+    return _Response()
+
+
+async def _db_probe(_database_url: str) -> dict[str, Any]:
+    return {"ok": True, "status": "ok", "reason": "DB_REACHABLE"}
+
+
+async def _empty_workspace_view(_database_url: str) -> WorkspaceIdView:
+    return WorkspaceIdView(active_ids=frozenset(), terminal_ids=frozenset(), available=True)
+
+
+def _run_subprocess_missing_docker(_args: list[str], **_kwargs: object) -> Any:
+    raise FileNotFoundError("docker")
 
 
 def _settings(tmp_path: Path) -> ServiceSettings:
@@ -194,3 +230,178 @@ def test_mount_propagation_check_unreadable_env_file(tmp_path: Path) -> None:
     assert payload["ok"] is True
     assert payload["status"] == "unknown"
     assert payload["propagation"] is None
+
+
+def _write_probe_evidence(work_dir: Path, payload: dict[str, object]) -> None:
+    scratch_root = work_dir / "auth" / "_shared"
+    scratch_root.mkdir(parents=True, exist_ok=True)
+    (scratch_root / "overlay-probe.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+_UNEXPECTED_EVIDENCE: dict[str, object] = {
+    "ok": False,
+    "expected": False,
+    "reason": "REFUSED",
+    "detail": "exit=32: cannot mount overlay read-only",
+}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "environ",
+    [
+        {"AWF_WORK_DIR_BIND_PROPAGATION": "rshared", "AWF_CLAUDE_AUTH_FORCE_COPY": "false"},
+        {},
+    ],
+)
+def test_mount_propagation_payload_is_unchanged_without_probe_evidence(
+    tmp_path: Path, environ: dict[str, str]
+) -> None:
+    # The awf-cloud/GKE regression at the status surface: a host that never
+    # probed must produce a byte-identical payload, in both the AVAILABLE and
+    # UNKNOWN branches.
+    baseline = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ=environ,
+        compose_env_file=None,
+    )
+
+    with_work_dir = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ=environ,
+        compose_env_file=None,
+        work_dir=tmp_path / "work",
+    )
+
+    assert with_work_dir == baseline
+    assert with_work_dir["ok"] is True
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "environ",
+    [
+        {"AWF_WORK_DIR_BIND_PROPAGATION": "rshared", "AWF_CLAUDE_AUTH_FORCE_COPY": "false"},
+        {},
+    ],
+)
+def test_mount_propagation_warns_on_unexpected_overlay_probe_evidence(
+    tmp_path: Path, environ: dict[str, str]
+) -> None:
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, _UNEXPECTED_EVIDENCE)
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ=environ,
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    # ``ok`` MUST stay True in every branch: ``collect_service_status`` ANDs each
+    # check into ``overall_ok`` and ``readiness`` turns a non-ok service status
+    # into a release-blocking SERVICE_STATUS_NOT_READY. Visibility flows through
+    # ``status``/``reason`` instead.
+    assert payload["ok"] is True
+    assert payload["status"] == "warn"
+    assert payload["reason"] == "CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE"
+    assert "cannot mount overlay read-only" in str(payload["detail"])
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "evidence",
+    [
+        {"ok": False, "expected": True, "reason": "MOUNT_BINARY_MISSING"},
+        {"ok": True, "expected": True, "reason": "OVERLAY_PROBE_OK"},
+    ],
+)
+def test_mount_propagation_ignores_expected_probe_outcomes(
+    tmp_path: Path, evidence: dict[str, object]
+) -> None:
+    work_dir = tmp_path / "work"
+    _write_probe_evidence(work_dir, evidence)
+    baseline = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+    )
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={"AWF_WORK_DIR_BIND_PROPAGATION": "rshared"},
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    assert payload == baseline
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("body", ["{not json", "[1, 2]"])
+def test_mount_propagation_ignores_corrupt_probe_evidence(tmp_path: Path, body: str) -> None:
+    work_dir = tmp_path / "work"
+    scratch_root = work_dir / "auth" / "_shared"
+    scratch_root.mkdir(parents=True)
+    (scratch_root / "overlay-probe.json").write_text(body, encoding="utf-8")
+    baseline = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={},
+        compose_env_file=None,
+    )
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={},
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    assert payload == baseline
+
+
+@pytest.mark.unit
+def test_mount_propagation_ignores_unreadable_probe_evidence(tmp_path: Path) -> None:
+    work_dir = tmp_path / "work"
+    scratch_root = work_dir / "auth" / "_shared"
+    scratch_root.mkdir(parents=True)
+    evidence_path = scratch_root / "overlay-probe.json"
+    evidence_path.write_text(json.dumps(_UNEXPECTED_EVIDENCE), encoding="utf-8")
+    evidence_path.chmod(0o000)
+
+    payload = status_mod._mount_propagation_check_payload(  # noqa: SLF001
+        environ={},
+        compose_env_file=None,
+        work_dir=work_dir,
+    )
+
+    assert payload["ok"] is True
+    assert payload["status"] == "unknown"
+
+
+@pytest.mark.unit
+def test_collect_service_status_passes_the_work_dir_to_the_check(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    recorded: list[Path | None] = []
+    real = status_mod._mount_propagation_check_payload  # noqa: SLF001
+
+    def _spy(
+        *,
+        environ: dict[str, str],
+        compose_env_file: Path | None,
+        work_dir: Path | None = None,
+    ) -> object:
+        recorded.append(work_dir)
+        return real(environ=environ, compose_env_file=compose_env_file, work_dir=work_dir)
+
+    monkeypatch.setattr(status_mod, "_mount_propagation_check_payload", _spy)
+    settings = _settings(tmp_path)
+
+    asyncio.run(
+        status_mod.collect_service_status(
+            settings,
+            api_get=_api_get,
+            db_probe=_db_probe,
+            run_subprocess=_run_subprocess_missing_docker,
+            socket_exists=lambda _path: True,
+            disk_usage=lambda _path: _DiskUsage(total=1000, used=700, free=300),
+            workspace_id_lookup=_empty_workspace_view,
+            provider_environ={},
+        )
+    )
+
+    assert recorded == [Path(settings.work_dir).expanduser()]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_9c633d208c6b42d1a22e9bf2` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #874: the per-workspace Claude auth overlay never mounts, so every workspace
silently falls back to a ~1.7 GB full copy of ~/.claude. Read issue #874 and its companion #875
for background, but the root cause below is ALREADY CONFIRMED — do not re-investigate it.

## Environment notes

/workspace is the agent-workspace-fabric repo (AWF control plane) on a branch off `development`.
Python 3.12 via `uv`. Standard gate: `uv sync --extra dev`, then ruff check / ruff format --check /
mypy / pytest. Coverage gate is a HARD 99% (`pyproject.toml fail_under = 99`).
Read AGENTS.md and CLAUDE.md first — they carry binding rules (strict TDD, no bare `except
Exception`, reason codes must flow end-to-end, state transitions via the state machine).

IMPORTANT: your container has no CAP_SYS_ADMIN and is itself AppArmor-confined. You CANNOT perform a
real overlay mount, and no test may attempt one. Everything must be tested through injected fakes.

## Confirmed root cause — do not re-derive

The AWF worker container runs under Docker's `docker-default` AppArmor profile in **enforce** mode.
That profile contains a plain `deny mount,` rule, which blocks `mount(2)` **regardless of
CAP_SYS_ADMIN**. Evidence gathered on the operator's host:

- `docker inspect` -> `AppArmorProfile=docker-default`; in-container `/proc/self/attr/current` ->
  `docker-default (enforce)`; host AppArmor `enabled=Y`
- worker DOES hold CAP_SYS_ADMIN (`CapEff: 00000000a82425fb`, bit 21 set) — capability is NOT the problem
- work dir is ext4, `rw`, propagation `shared`/`rshared` — NOT the problem
- kernel overlayfs present in `/proc/filesystems` on host and in container — NOT the problem
- NO overlayfs error in dmesg at failure time -> the mount never reached overlayfs, i.e. the LSM blocked it
- NO AppArmor audit record -> consistent, because a plain `deny` rule is non-auditing
- `mount: ...: cannot mount overlay read-only` (exit 32) is util-linux's read-only retry after EACCES
- zero AWF overlay mounts in `/proc/mounts` -> 100% copy fallback

So the assumption in the comment at `docker/compose/local-service.yml:243-248` (that `cap_add:
SYS_ADMIN` is enough to "let the root worker call mount(2)") is the bug: necessary, not sufficient.

Additional finding: `_ensure_shared_claude_base` (a ~1.9 GB copytree) runs at
`src/awf/node/auth_mounts_claude.py:1174` BEFORE the mount attempt at line 1258. So each provision
writes ~1.9 GB for a base, fails the mount, then writes another ~1.7 GB legacy copy. A truthful
preflight removes the wasted base build entirely.

## Hard constraints

1. **Must not break AWF Core, and must not break awf-cloud (AWF running in GKE).** In hosted/GKE the
   control plane runs in Kubernetes, not Compose, and pod-level overlay mounts are typically
   impossible. The copy fallback MUST remain a fully supported, non-alarming path: overlay must never
   become mandatory, absence of overlay must NEVER block readiness, and platforms that legitimately
   cannot overlay must emit NO standing warnings.
2. `src/awf/service/status.py`'s `mount_propagation` check MUST keep `ok=True` in every branch.
   `status.py:324-326` ANDs every check into `overall_ok`, and `readiness.py:379-392` turns a non-ok
   status into a release-blocking `SERVICE_STATUS_NOT_READY`. Surface visibility via
   `status`/`reason`/extra fields instead (`status: "warn"` is safe — doctor's
   `_service_status_diagnostics` does not consume this check).
3. Line-limit guardrail is 1500 (`tests/unit/test_core_decomposition_maintainability.py:31`).
   `auth_mounts_claude.py` is at 1454 and `service/doctor/reasons.py` at 1482 — NEW MODULES ARE
   MANDATORY, not stylistic.

## What to do — three coupled defects, one PR

### 1. Unblock the mount
- `docker/compose/local-service.yml`: on the **worker service only**, beside the existing
  `cap_add: [SYS_ADMIN]`, add `security_opt: ["apparmor:${AWF_WORKER_APPARMOR:-unconfined}"]`.
  `api`/`migrate` deliberately keep docker-default (they never mount). Add a comment recording the
  evidence above and noting `AWF_WORKER_APPARMOR=docker-default` restores confinement at the cost of
  the overlay.
- Do NOT add `AWF_WORKER_APPARMOR` to the shared `&awf-environment` anchor — it is a compose
  render-time variable, not a container env var; keeping it out leaves `service/config.py:433-459`
  untouched.
- `.env.example`: add a commented-out `AWF_WORKER_APPARMOR=docker-default` restore knob near the
  existing `AWF_CLAUDE_BASE_GC_ENABLED` line.
- Only `tests/integration/test_local_service_compose.py` pins the worker block (other
  compose-referencing tests use synthetic fixtures). Update it; mirror the existing `security_opt`
  assertion style already used there for `gitconfig-source`.

### 2. Replace the lying preflight with a real probe, and surface failure honestly
`_SubprocessOverlayMounter.supported()` (`auth_mounts_claude.py:321-328`) only greps
`/proc/filesystems` and checks the CapEff bit (`auth_mounts_caps.py:49`). It is blind to
AppArmor/seccomp, so it returns True and the real mount then fails 100% of the time.

- NEW module `src/awf/node/auth_mounts_overlay_probe.py`: `probe_overlay_mount(*, scratch_root,
  run=subprocess.run, timeout_seconds=10.0)` performs ONE scratch overlay mount+umount under
  `auth/_shared/`, returning a frozen `OverlayProbeResult(ok, reason, detail)` with reasons
  `OVERLAY_PROBE_OK | REFUSED | TIMEOUT | MOUNT_BINARY_MISSING | SCRATCH_UNAVAILABLE |
  PATH_RESERVED_CHARS`. Requirements: never `rmtree` under a live mount (if umount fails, keep
  ok=True but retain the staging dir); per-process cache keyed on scratch_root with
  `reset_overlay_probe_cache()` as the test seam; handle `FileNotFoundError` (no mount binary) and
  `subprocess.TimeoutExpired`; leave no scratch state otherwise.
- Write evidence to `<work_dir>/auth/_shared/overlay-probe.json`, best-effort (suppress OSError —
  mirror how `_record_overlay_base_pin` handles write failure). This is the worker->api channel: the
  work dir is bind-mounted at the same absolute path into both containers. Include at least
  `{ok, reason, expected, detail, checked_at}`.
- Wire it into `_SubprocessOverlayMounter` via a new `scratch_root` attribute; `supported()` keeps
  the existing cheap gates first and then returns `cached_overlay_probe(...).ok`. `scratch_root=None`
  must short-circuit to today's behavior (the teardown-constructed mounter has no work-dir context).
  Thread `scratch_root` through `default_overlay_mounter()` and `src/awf/node/auth_mounts.py:204`.
- Do NOT extend the `OverlayMounter` Protocol with a `probe()` method — folding the probe into
  `supported()` keeps `FakeOverlayMounter(supported=...)` in
  `tests/unit/node/test_claude_auth_overlay_parts/test_claude_auth_overlay_part_001.py:56-104`
  unchanged, so no test can ever perform a real mount.
- Upgrade the `supported()`-false log at `auth_mounts_claude.py:989-996`: when the probe result is
  absent or ok, keep today's INFO `overlayfs_unsupported`; when the probe failed, emit a WARNING with
  a new reason code `CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE`.

**The expected-vs-unexpected distinction is what satisfies constraint 1, and it falls out for free:**
the probe only runs when every cheap gate (force-copy not set, kernel overlay present, CAP_SYS_ADMIN
present, no reserved chars) already passed. GKE / force-copy / no-CAP_SYS_ADMIN hosts never reach the
probe, never write evidence, and therefore never warn — **absence of evidence must mean silence, by
construction.** Make that an explicit test, not an implicit property.

- `src/awf/service/provider_readiness_provider_checks.py` (~line 318-330): attach a
  `CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE` warning to the `CLAUDE_FILE_AUTH_PRESENT` result
  ONLY when evidence says `ok=false, expected=false`. `ok`/`status`/`severity` must stay unchanged
  (verify non-blocking through `_provider_result`, `blocks_launch`, and doctor's
  `_metadata_from_mapping`). Also add a flat string field `result["claude_auth_overlay"]` for
  observability (flat, not nested — it must survive doctor's redaction/metadata mapping).
- `src/awf/service/status.py:117-165`: `_mount_propagation_check_payload` gains an optional
  keyword `work_dir` (defaulted so existing tests keep passing). On unexpected evidence set
  `status="warn"` plus a new `reason`, KEEPING `ok=True` (constraint 2). Absent/unreadable/corrupt
  evidence -> payload byte-identical to today.
- Reason catalog: add exactly ONE entry, `CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE`, via a new
  `get_claude_overlay_reasons()` helper in `src/awf/service/doctor/reasons_helpers.py` (reasons.py has
  only ~18 lines of headroom), then regenerate `docs/REASON_CATALOG.md` with
  `uv run python scripts/generate_reason_catalog.py`. Deliberately DO NOT catalog
  `CLAUDE_AUTH_OVERLAY_UNAVAILABLE` — it fires correctly at INFO on every GKE/force-copy host, and
  documenting it as a fault is exactly the false alarm constraint 1 forbids.
- **LEAVE the `legacy_claude_copy.exists()` guard at `auth_mounts_claude.py:485-517` ALONE.** Flipping
  it would route existing legacy copies through `_forward_fallback_deletions_as_whiteouts` (gated on
  `.claude-complete`, which IS present on the operator's host) — a credential-correctness risk far
  exceeding the disk reclaimed. Those dirs drain on the 168h retention. Add a short comment at ~line
  495 pointing at #874 explaining the deliberate choice.

### 3. Stop the shared-base signature churn
`_host_claude_signature` (`src/awf/node/auth_mounts_claude_base.py:64-181`) hashes
size/mtime_ns/ctime_ns/mode for every entry under `~/.claude`, excluding only
`_CLAUDE_USAGE_HISTORY_DIRS = ("projects","todos","shell-snapshots","statsig")`. Volatile state that
changes on EVERY Claude Code interaction (`history.jsonl`, `file-history/`, `cache/`, `paste-cache/`,
`session-env/`, `backups/`, `debug/`) is included, so the signature churns, a new
`claude-base/<hash>` is built (~1.9 GB copytree) and the old one is superseded and reaped. #874
observed 5 base hashes built and reaped in one worker lifetime.

TWO SUBTLE TRAPS — both must be handled:
- (a) `_CLAUDE_USAGE_HISTORY_DIRS` currently matches **by basename at every depth**, in both the
  signature walk and `shutil.ignore_patterns`. Naively widening it would strip `plugins/cache/`
  (an installed-plugin store, ~66 MB) and assorted `node_modules` dirs from every agent's `~/.claude`.
  **All exclusion matching must be anchored to the top level of the `.claude` tree.**
- (b) `history.jsonl` cannot be excluded by editing the constant at all: the signature walk filters
  only `dirs` (lines 142-168); the files loop at line 169 has NO exclusion check. Add one.

Implement:
- NEW dependency-free leaf module `src/awf/node/auth_mounts_claude_exclusions.py` with TWO
  top-level-anchored sets plus helpers (`claude_copy_ignore(root)`, `claude_signature_excludes_rel`):
  - copy-exclusion set: membership UNCHANGED from today (`projects, todos, shell-snapshots,
    statsig`) — only the matching semantics narrow to top-level. Keeping the copy set byte-identical
    means zero risk of dropping an auth file.
  - signature-exclusion set: a strict SUPERSET adding top-level volatile entries (`history.jsonl`,
    `file-history`, `cache`, `paste-cache`, `session-env`, `sessions`, `backups`, `debug`, `jobs`,
    `tasks`, `daemon*`, `*-cache.json`, and similar). These are still COPIED (the agent gets a frozen
    snapshot); they just no longer mint a new signature.
  - Governing rule, stated in the docstring AND enforced by a test: the signature-exclusion set is a
    **closed allowlist** of known-volatile names; anything unrecognised is signed. A future Claude
    Code state dir should cause churn (annoying but correct), never a stale credential (silent and wrong).
  - Guardrail tests: `copy_set <= signature_set`, and
    `{".credentials.json","settings.json","settings.local.json","skills","plugins","agents","CLAUDE.md"}`
    is disjoint from the signature set.
- `auth_mounts_claude_base.py`: anchor the `dirs` filter to the walk root, ADD the missing files
  filter, swap the copytree `ignore` to `claude_copy_ignore()`.
- `auth_mounts_claude.py:675` and `auth_mounts_claude_reconcile.py` (3 call sites, ~lines 235, 474,
  571): same swap, each anchored to its own walk root.
- Keep a re-export alias so `awf.node.auth_mounts.<name>` stays the stable public surface (see the
  convention documented at `auth_mounts_claude.py:9-11`).
- In the PR body, record this REJECTED alternative so nobody re-proposes it: making base rebuilds
  cheap via `copytree(copy_function=os.link)` is unsafe because `_chown_tree`
  (`auth_mounts_claude_base.py:280`) would chown the operator's REAL `~/.claude` to uid 1000 through
  the hardlinks. Reflink has the same flaw.

## Testing

Strict TDD — failing test first, then the smallest green change. NO test may perform a real mount;
drive everything through an injected `run` callable, monkeypatch, and tmp_path fixtures.

Required coverage includes: probe refused / ok / umount-fail-retains-staging / mount-binary-missing /
timeout / scratch-OSError / reserved-chars / cache-hit / cache-reset; evidence round-trip plus
missing-file, invalid-JSON and non-mapping-JSON returning None; the `plugins/cache` top-level-anchoring
regression; signature stability (rewrite `history.jsonl` and touch every volatile dir -> signature
UNCHANGED; rewrite `settings.json` or `.credentials.json` -> signature CHANGES); and the GKE
regression in BOTH readiness and status: **no evidence file => zero warnings and ok is True**.

Add an autouse `reset_overlay_probe_cache()` fixture so the module-level cache never leaks between
tests — a leaked cache is the most likely source of flaky or uncovered branches.

## What to optimize for

Correctness of the credential path over disk savings — never drop an auth file to save bytes.
Coverage over cleverness: the 99% gate is enforced, and the right way to meet it is more tests, never
loosening `fail_under` or any coverage config. Keep AWF core generic; this is Core-local behavior and
must stay safe for the hosted/GKE path. Prefer existing patterns in `src/awf` over new abstractions —
the only new modules are the two the line-limit guardrail forces.

git is functional in /workspace — commit your work before exiting. Do NOT push; AWF handles push and
PR creation.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes worker container security posture (AppArmor) and Claude credential isolation paths; behavior is heavily tested and copy fallback remains supported, but misconfiguration could affect mount success or disk use on self-hosted installs.
> 
> **Overview**
> Fixes **#874**: the worker could not mount per-workspace `~/.claude` overlays because Docker’s `docker-default` AppArmor profile denies `mount(2)` even with `CAP_SYS_ADMIN`, so every provision fell back to ~1.7 GB copies (often after building a ~1.9 GB shared base that never mounted).
> 
> The **worker** compose service now defaults to `security_opt: apparmor:unconfined` (override with `AWF_WORKER_APPARMOR=docker-default` to keep confinement and the copy fallback). Overlay support is no longer inferred from `/proc/filesystems` + capabilities alone: a **cached scratch overlay probe** under `<work_dir>/auth/_shared` runs once per process, writes `overlay-probe.json` for API/status, and drives `supported()`. Unexpected LSM refusals surface as **`CLAUDE_AUTH_OVERLAY_UNEXPECTEDLY_UNAVAILABLE`** (WARNING logs, provider readiness warning, mount-propagation `status: warn` with **`ok` still true**); expected copy-fallback hosts never probe and stay silent.
> 
> **Signature churn** is reduced via top-level-anchored copy vs signature exclusion sets (`auth_mounts_claude_exclusions.py`), so volatile host files like `history.jsonl` no longer force constant shared-base rebuilds while nested paths such as `plugins/cache` remain signed and copied. Pin/lock helpers move to `auth_mounts_claude_pin.py` for line limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2001dac9ef771651543007cbb00a02b4ace21029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->