### PR TITLE
feat(adoption): seed re-adopted PR monitors from the terminal predecessor and accept an operator hint (#911)

### DIFF
--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -215,8 +215,14 @@ uv run --python 3.12 --extra dev awf workspace adopt-pr \
   --auto-merge \
   --external-id CLOUD-TASK-42 \
   --task-class test_task \
+  --hint "do NOT edit .github/workflows/*" \
   --reason "attach AWF to existing PR"
 ```
+
+`--hint` is an optional operator directive. It is armed on the new workspace as
+a pending operator hint, so the monitor's first decision cycle addresses it
+before any PR review comments. It is ignored when the request attaches to an
+already-live adoption — use `awf workspace guide` for that.
 
 The same `--agent cursor --cursor-auto-mode cost|balance|intelligence` selection
 is available for local PR monitor adoption. Hosted adoption rejects the mode

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -220,8 +220,11 @@ uv run --python 3.12 --extra dev awf workspace adopt-pr \
 ```
 
 `--hint` is an optional operator directive. It is armed on the new workspace as
-a pending operator hint, so the monitor's first decision cycle addresses it
-before any PR review comments. It is ignored when the request attaches to an
+a pending operator hint, addressed ahead of PR review comments but behind base
+synchronization: an adopted PR that is behind its base (or BEHIND / DIRTY) syncs
+first — including, on DIRTY, a conflict-resolution agent pass — and consumes the
+hint on a later cycle, so the hint steers repair work rather than constraining
+what base synchronization touches. It is ignored when the request attaches to an
 already-live adoption — use `awf workspace guide` for that.
 
 The same `--agent cursor --cursor-auto-mode cost|balance|intelligence` selection

--- a/docs/MCP_REFERENCE.md
+++ b/docs/MCP_REFERENCE.md
@@ -163,9 +163,14 @@ Example `awf_adopt_pull_request_monitor` arguments:
   "task_class": "test_task",
   "agent": "cursor",
   "cursor_auto_mode": "intelligence",
+  "hint": "do NOT edit .github/workflows/*",
   "reason": "attach AWF to existing PR"
 }
 ```
+
+Optional `hint` arms an operator directive on the new workspace so the monitor
+addresses it before any PR review comments; it is ignored on the attach path
+(use `awf_guide_workspace` for a live workspace).
 
 Adoption maps to `POST /v1/workspaces/adopt-pr` and returns
 `PullRequestMonitorAdoptionResponse`. Optional `external_id` and `task_class`

--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -247,12 +247,16 @@ stale-state hygiene re-triages it on the first cycle; review-comment and
 
 Optional adoption `hint`: pass `hint` (REST/MCP) or `--hint` (CLI) to arm an
 operator directive on the new workspace as a pending operator hint with reason
-code `PR_ADOPTION_OPERATOR_HINT`. The monitor's first `decide()` returns
-`AddressOperatorHint` before any `AddressComments`, so the directive steers the
-re-adoption from its first cycle. It is recorded on the adoption operation and
-the `workspace.pr_monitor_adoption_requested` event, and is ignored when the
-request attaches to an already-live adoption (`attached_existing=true`) — use
-the `guide` control for a live workspace.
+code `PR_ADOPTION_OPERATOR_HINT`. `decide()` returns `AddressOperatorHint` at
+gate 2 — ahead of `AddressComments` and every gate after it, but *behind* gate
+1's `SyncBase`. An adopted PR that is behind its base (or BEHIND / DIRTY)
+therefore integrates the base first — including, on DIRTY, a
+conflict-resolution agent pass — and consumes the hint on a later cycle. The
+hint steers the repair work; it is not a first-cycle path constraint and cannot
+restrict what base synchronization touches. It is recorded on the adoption
+operation and the `workspace.pr_monitor_adoption_requested` event, and is
+ignored when the request attaches to an already-live adoption
+(`attached_existing=true`) — use the `guide` control for a live workspace.
 
 Closed or merged GitHub PRs are rejected before workspace creation with
 structured errors such as `PR_ALREADY_CLOSED` and `PR_ALREADY_MERGED`.

--- a/docs/PR_MONITOR_ADOPTION.md
+++ b/docs/PR_MONITOR_ADOPTION.md
@@ -229,6 +229,31 @@ explicit `external_id` supersedes the prior row's external-id slot so the fresh
 monitor can reclaim that identity; an omitted `external_id` on terminal retry
 mints a generated generation rather than reusing a stale owned slot.
 
+Seeding from the terminal predecessor: when a terminal row is superseded, AWF
+copies an allowlisted subset of its `monitor_threads_addressed` onto the fresh
+workspace so the successor does not re-disposition comments its predecessor
+already triaged. Exactly three marker classes cross that boundary — thread /
+review-comment / `issue:<id>` verdicts, `__review_comment_body_hash__:*`
+evidence, and `__deferred_issue_filed__:*` markers. Everything else (protected
+block state, awaiting-check timestamps, operator-hint bookkeeping, merge-block
+and workflow-scope markers) is deliberately left behind and re-derived from the
+live PR. A copy appends a `workspace.pr_monitor_adoption_seeded` event with
+reason code `PR_ADOPTION_SEEDED_FROM_PREDECESSOR`, the predecessor workspace id,
+and the copied keys; no copy means no event. Note that
+`__review_thread_body_hash__:*` is *not* in the allowlist, so a seeded inline
+*thread* verdict arrives without its companion body hash and the monitor's
+stale-state hygiene re-triages it on the first cycle; review-comment and
+`issue:<id>` verdicts (the common re-adoption case) do persist.
+
+Optional adoption `hint`: pass `hint` (REST/MCP) or `--hint` (CLI) to arm an
+operator directive on the new workspace as a pending operator hint with reason
+code `PR_ADOPTION_OPERATOR_HINT`. The monitor's first `decide()` returns
+`AddressOperatorHint` before any `AddressComments`, so the directive steers the
+re-adoption from its first cycle. It is recorded on the adoption operation and
+the `workspace.pr_monitor_adoption_requested` event, and is ignored when the
+request attaches to an already-live adoption (`attached_existing=true`) — use
+the `guide` control for a live workspace.
+
 Closed or merged GitHub PRs are rejected before workspace creation with
 structured errors such as `PR_ALREADY_CLOSED` and `PR_ALREADY_MERGED`.
 

--- a/docs/REST_API_REFERENCE.md
+++ b/docs/REST_API_REFERENCE.md
@@ -840,9 +840,16 @@ curl -X POST "http://localhost:8000/v1/workspaces/adopt-pr" \
     "task_class": "test_task",
     "agent": "cursor",
     "cursor_auto_mode": "intelligence",
+    "hint": "do NOT edit .github/workflows/*",
     "reason": "attach AWF to existing PR"
   }'
 ```
+
+Optional `hint` (max 1024 chars) is an operator directive armed on the new
+workspace as a pending operator hint, so the monitor's first decision cycle
+addresses it before any PR review comments. It is ignored when the request
+attaches to an already-live adoption (`attached_existing=true`); use the
+`guide` control for a live workspace.
 
 The response is `PullRequestMonitorAdoptionResponse` and includes the adopted
 `workspace_id`, `monitor_policy`, `validation_provenance`, `status_url`,

--- a/docs/REST_API_REFERENCE.md
+++ b/docs/REST_API_REFERENCE.md
@@ -846,8 +846,11 @@ curl -X POST "http://localhost:8000/v1/workspaces/adopt-pr" \
 ```
 
 Optional `hint` (max 1024 chars) is an operator directive armed on the new
-workspace as a pending operator hint, so the monitor's first decision cycle
-addresses it before any PR review comments. It is ignored when the request
+workspace as a pending operator hint, addressed ahead of PR review comments but
+behind base synchronization: an adopted PR that is behind its base (or BEHIND /
+DIRTY) syncs first — including, on DIRTY, a conflict-resolution agent pass — and
+consumes the hint on a later cycle, so the hint steers repair work rather than
+constraining what base synchronization touches. It is ignored when the request
 attaches to an already-live adoption (`attached_existing=true`); use the
 `guide` control for a live workspace.
 

--- a/openapi.json
+++ b/openapi.json
@@ -4192,7 +4192,7 @@
                 "type": "null"
               }
             ],
-            "description": "Optional operator directive armed on the adopted workspace as a pending operator hint, so the monitor's first decision cycle addresses it before any PR review comments. Use it to steer the re-adoption (e.g. 'do not edit .github/workflows/*'). Ignored when the request attaches to an already-live adoption; use the guide control for that.",
+            "description": "Optional operator directive armed on the adopted workspace as a pending operator hint, addressed ahead of PR review comments but behind base synchronization: an adopted PR that is behind its base (or BEHIND / DIRTY) syncs first -- including, on DIRTY, a conflict-resolution agent pass -- and consumes the hint on a later cycle. It is a repair directive for the agent, not a first-cycle path constraint, so it cannot restrict what base synchronization touches. Use it to steer the repair work (e.g. 'do not edit .github/workflows/*'). Ignored when the request attaches to an already-live adoption; use the guide control for that.",
             "title": "Hint"
           },
           "initial_review_grace_period_seconds": {

--- a/openapi.json
+++ b/openapi.json
@@ -4182,6 +4182,19 @@
             "description": "Optional external task id persisted on the adopted workspace and task for join/policy parity with workspace create. Omit to use the generated repo/PR adoption identity. Changing this on a live adoption returns PR_ADOPTION_POLICY_CONFLICT; an id owned by another task scope returns TASK_EXTERNAL_ID_CONFLICT.",
             "title": "External Id"
           },
+          "hint": {
+            "anyOf": [
+              {
+                "maxLength": 1024,
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Optional operator directive armed on the adopted workspace as a pending operator hint, so the monitor's first decision cycle addresses it before any PR review comments. Use it to steer the re-adoption (e.g. 'do not edit .github/workflows/*'). Ignored when the request attaches to an already-live adoption; use the guide control for that.",
+            "title": "Hint"
+          },
           "initial_review_grace_period_seconds": {
             "anyOf": [
               {

--- a/src/awf/api/schemas.py
+++ b/src/awf/api/schemas.py
@@ -13,6 +13,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from awf.api import schemas_operations as _schemas_operations
+from awf.api import schemas_pr_adoption as _schemas_pr_adoption
 from awf.api import schemas_responses as _schemas_responses
 from awf.api import schemas_workspace_io as _schemas_workspace_io
 from awf.api.cursor_auto import CursorAutoModeResponseMixin, CursorAutoModeSelectionMixin
@@ -51,7 +52,8 @@ OperationResponse = _schemas_operations.OperationResponse
 log_stream_ids = _schemas_operations.log_stream_ids
 merge_log_stream_ref_value = _schemas_operations.merge_log_stream_ref_value
 
-# Leaf schemas live in ``schemas_responses``; PR monitor request contracts stay canonical here.
+# Leaf schemas live in ``schemas_responses``; PR monitor adoption request
+# contracts live in ``schemas_pr_adoption`` (re-exported below).
 CallbackSubscriptionCreateRequest = _schemas_responses.CallbackSubscriptionCreateRequest
 CallbackSubscriptionResponse = _schemas_responses.CallbackSubscriptionResponse
 CallbackSubscriptionListResponse = _schemas_responses.CallbackSubscriptionListResponse
@@ -89,112 +91,18 @@ ValidationProvenanceItemResponse = _schemas_workspace_io.ValidationProvenanceIte
 ValidationProvenanceListResponse = _schemas_workspace_io.ValidationProvenanceListResponse
 RuntimeServiceResponse = _schemas_workspace_io.RuntimeServiceResponse
 
+# PR-monitor adoption *request* contracts live in ``schemas_pr_adoption``; the
+# response model below stays here because it composes response leaves defined in
+# this module.
+ADOPTION_HINT_MAX_LENGTH = _schemas_pr_adoption.ADOPTION_HINT_MAX_LENGTH
+PullRequestMonitorExecutionPolicy = _schemas_pr_adoption.PullRequestMonitorExecutionPolicy
+PullRequestMonitorAdoptionRequest = _schemas_pr_adoption.PullRequestMonitorAdoptionRequest
+
 _MAX_LOG_STREAM_REF_DEPTH = 64
 _DEFAULT_REPO_BASE_BRANCH = "main"
 _LEGACY_FLAT_REPO_BASE_BRANCH_DEFAULT = "development"
 _LEGACY_DATABASE_PROFILE_REF = "aira"
 PUBLIC_DIRECT_CREATE_TASK_KINDS = _schemas_operations.PUBLIC_DIRECT_CREATE_TASK_KINDS
-
-
-class PullRequestMonitorExecutionPolicy(BaseModel):
-    """Execution placement policy for adopted PR monitor repair/validation."""
-
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
-
-    mode: Literal["local", "hosted"] = Field(
-        default="local",
-        description=(
-            "Where Core should run PR-monitor repair and post-repair validation. "
-            "'local' preserves Docker Compose execution; 'hosted' requires "
-            "configured hosted delegation and never starts local Compose."
-        ),
-    )
-
-
-class PullRequestMonitorAdoptionRequest(CursorAutoModeSelectionMixin):
-    """Input for adopting an already-open GitHub PR into AWF monitoring."""
-
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
-
-    repo_url: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
-    repo_slug: Annotated[str | None, Field(default=None, min_length=1, max_length=256)] = None
-    pr_number: int | None = Field(default=None, ge=1)
-    pr_url: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
-
-    agent: AgentRuntime = Field(default=AgentRuntime.codex)
-    model: Annotated[str | None, Field(default=None, min_length=1, max_length=128)] = None
-    effort: Annotated[str | None, Field(default=None, min_length=1, max_length=64)] = None
-    profile_ref: Annotated[str | None, Field(default="auto", max_length=128)] = "auto"
-    profile: WorkspaceProfile | None = None
-    owned_paths: list[OwnedPath] = Field(default_factory=list, max_length=128)
-    auto_merge: bool | None = Field(
-        default=None,
-        description=(
-            "Tri-state auto-merge intent for the adopted PR. True/False set it "
-            "explicitly; omit (null) to fall through to the repo profile "
-            "(monitor.auto_merge) and the uniform default (off). When resolved "
-            "off the monitor reports readiness without merging (manual gate)."
-        ),
-    )
-    execution: PullRequestMonitorExecutionPolicy = Field(
-        default_factory=PullRequestMonitorExecutionPolicy,
-        description=(
-            "Explicit PR monitor execution policy. Hosted mode is never inferred "
-            "from environment or Docker availability."
-        ),
-    )
-    initial_review_grace_period_seconds: float | None = Field(default=None, ge=0, le=86400)
-    task_title: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
-    task_prompt: Annotated[str | None, Field(default=None, min_length=1, max_length=16384)] = None
-    task_tag: Annotated[
-        str | None,
-        Field(
-            default=None,
-            max_length=64,
-            description=(
-                "Optional issue/task key linked into the PR title and "
-                "AWF-authored monitor commits. Accepts a Jira issue key "
-                "(PROJ-123) or an Aira task entity key (PROJ-T123). Pass bare "
-                "keys; bracketed [PROJ-T123] is accepted and normalized, but "
-                "bare is recommended because [ is a shell glob character."
-            ),
-        ),
-    ] = None
-    external_id: Annotated[
-        str | None,
-        Field(
-            default=None,
-            max_length=128,
-            description=(
-                "Optional external task id persisted on the adopted workspace and "
-                "task for join/policy parity with workspace create. Omit to use the "
-                "generated repo/PR adoption identity. Changing this on a live "
-                "adoption returns PR_ADOPTION_POLICY_CONFLICT; an id owned by "
-                "another task scope returns TASK_EXTERNAL_ID_CONFLICT."
-            ),
-        ),
-    ] = None
-    task_class: TaskClass | None = Field(
-        default=None,
-        description=(
-            "Optional task class for scheduling and policy parity with workspace "
-            "create. Omit to leave unset. Changing this on a live adoption returns "
-            "PR_ADOPTION_POLICY_CONFLICT."
-        ),
-    )
-    reason: Annotated[str | None, Field(default=None, max_length=512)] = None
-
-    @field_validator("task_tag")
-    @classmethod
-    def _validate_task_tag(cls, value: str | None) -> str | None:
-        """Normalize and validate an optional task tag; ``None`` when absent."""
-        return validate_task_tag(value)
-
-    @field_validator("external_id")
-    @classmethod
-    def _validate_external_id(cls, value: str | None) -> str | None:
-        """Reject ASCII controls so malformed ids fail as 422, not at DB flush."""
-        return validate_external_id(value)
 
 
 class MergeCandidateReadinessResponse(BaseModel):

--- a/src/awf/api/schemas_pr_adoption.py
+++ b/src/awf/api/schemas_pr_adoption.py
@@ -1,0 +1,159 @@
+"""PR-monitor adoption *request* contracts.
+
+Split out of :mod:`awf.api.schemas` to keep that module under the
+maintainability line limit. These are the request-side models for
+``POST /v1/workspaces/adopt-pr``; they are re-exported from ``awf.api.schemas``
+so ``from awf.api.schemas import PullRequestMonitorAdoptionRequest`` keeps
+working for the REST app, the CLI contract tests, and the MCP server.
+
+``PullRequestMonitorAdoptionResponse`` deliberately stays in ``schemas`` because
+it composes response leaves defined there.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from awf.api import schemas_operations as _schemas_operations
+from awf.api.cursor_auto import CursorAutoModeSelectionMixin
+from awf.common.external_id import validate_external_id
+from awf.common.task_tag import validate_task_tag
+from awf.db.enums import AgentRuntime, TaskClass
+from awf.profiles.models import WorkspaceProfile
+
+OwnedPath = _schemas_operations.OwnedPath
+
+# Mirrors ``WorkspaceGuideRequest.directive``: the adoption ``hint`` is armed as
+# the same kind of pending operator directive, so it carries the same bound.
+ADOPTION_HINT_MAX_LENGTH = 1024
+
+
+class PullRequestMonitorExecutionPolicy(BaseModel):
+    """Execution placement policy for adopted PR monitor repair/validation."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    mode: Literal["local", "hosted"] = Field(
+        default="local",
+        description=(
+            "Where Core should run PR-monitor repair and post-repair validation. "
+            "'local' preserves Docker Compose execution; 'hosted' requires "
+            "configured hosted delegation and never starts local Compose."
+        ),
+    )
+
+
+class PullRequestMonitorAdoptionRequest(CursorAutoModeSelectionMixin):
+    """Input for adopting an already-open GitHub PR into AWF monitoring."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    repo_url: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
+    repo_slug: Annotated[str | None, Field(default=None, min_length=1, max_length=256)] = None
+    pr_number: int | None = Field(default=None, ge=1)
+    pr_url: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
+
+    agent: AgentRuntime = Field(default=AgentRuntime.codex)
+    model: Annotated[str | None, Field(default=None, min_length=1, max_length=128)] = None
+    effort: Annotated[str | None, Field(default=None, min_length=1, max_length=64)] = None
+    profile_ref: Annotated[str | None, Field(default="auto", max_length=128)] = "auto"
+    profile: WorkspaceProfile | None = None
+    owned_paths: list[OwnedPath] = Field(default_factory=list, max_length=128)
+    auto_merge: bool | None = Field(
+        default=None,
+        description=(
+            "Tri-state auto-merge intent for the adopted PR. True/False set it "
+            "explicitly; omit (null) to fall through to the repo profile "
+            "(monitor.auto_merge) and the uniform default (off). When resolved "
+            "off the monitor reports readiness without merging (manual gate)."
+        ),
+    )
+    execution: PullRequestMonitorExecutionPolicy = Field(
+        default_factory=PullRequestMonitorExecutionPolicy,
+        description=(
+            "Explicit PR monitor execution policy. Hosted mode is never inferred "
+            "from environment or Docker availability."
+        ),
+    )
+    initial_review_grace_period_seconds: float | None = Field(default=None, ge=0, le=86400)
+    task_title: Annotated[str | None, Field(default=None, min_length=1, max_length=512)] = None
+    task_prompt: Annotated[str | None, Field(default=None, min_length=1, max_length=16384)] = None
+    task_tag: Annotated[
+        str | None,
+        Field(
+            default=None,
+            max_length=64,
+            description=(
+                "Optional issue/task key linked into the PR title and "
+                "AWF-authored monitor commits. Accepts a Jira issue key "
+                "(PROJ-123) or an Aira task entity key (PROJ-T123). Pass bare "
+                "keys; bracketed [PROJ-T123] is accepted and normalized, but "
+                "bare is recommended because [ is a shell glob character."
+            ),
+        ),
+    ] = None
+    external_id: Annotated[
+        str | None,
+        Field(
+            default=None,
+            max_length=128,
+            description=(
+                "Optional external task id persisted on the adopted workspace and "
+                "task for join/policy parity with workspace create. Omit to use the "
+                "generated repo/PR adoption identity. Changing this on a live "
+                "adoption returns PR_ADOPTION_POLICY_CONFLICT; an id owned by "
+                "another task scope returns TASK_EXTERNAL_ID_CONFLICT."
+            ),
+        ),
+    ] = None
+    task_class: TaskClass | None = Field(
+        default=None,
+        description=(
+            "Optional task class for scheduling and policy parity with workspace "
+            "create. Omit to leave unset. Changing this on a live adoption returns "
+            "PR_ADOPTION_POLICY_CONFLICT."
+        ),
+    )
+    reason: Annotated[str | None, Field(default=None, max_length=512)] = None
+    hint: Annotated[
+        str | None,
+        Field(
+            default=None,
+            max_length=ADOPTION_HINT_MAX_LENGTH,
+            description=(
+                "Optional operator directive armed on the adopted workspace as a "
+                "pending operator hint, so the monitor's first decision cycle "
+                "addresses it before any PR review comments. Use it to steer the "
+                "re-adoption (e.g. 'do not edit .github/workflows/*'). Ignored "
+                "when the request attaches to an already-live adoption; use the "
+                "guide control for that."
+            ),
+        ),
+    ] = None
+
+    @field_validator("task_tag")
+    @classmethod
+    def _validate_task_tag(cls, value: str | None) -> str | None:
+        """Normalize and validate an optional task tag; ``None`` when absent."""
+        return validate_task_tag(value)
+
+    @field_validator("external_id")
+    @classmethod
+    def _validate_external_id(cls, value: str | None) -> str | None:
+        """Reject ASCII controls so malformed ids fail as 422, not at DB flush."""
+        return validate_external_id(value)
+
+    @field_validator("hint")
+    @classmethod
+    def _normalize_hint(cls, value: str | None) -> str | None:
+        """Collapse a blank directive to ``None``.
+
+        ``str_strip_whitespace`` already trims, so a whitespace-only hint arrives
+        as ``""``. Normalizing it away keeps a hollow hint from arming a pending
+        ``AddressOperatorHint`` cycle with nothing for the agent to act on --
+        the same invariant ``guide_workspace`` enforces with
+        ``WorkspaceGuideEmptyDirectiveError``.
+        """
+        return value or None

--- a/src/awf/api/schemas_pr_adoption.py
+++ b/src/awf/api/schemas_pr_adoption.py
@@ -124,11 +124,16 @@ class PullRequestMonitorAdoptionRequest(CursorAutoModeSelectionMixin):
             max_length=ADOPTION_HINT_MAX_LENGTH,
             description=(
                 "Optional operator directive armed on the adopted workspace as a "
-                "pending operator hint, so the monitor's first decision cycle "
-                "addresses it before any PR review comments. Use it to steer the "
-                "re-adoption (e.g. 'do not edit .github/workflows/*'). Ignored "
-                "when the request attaches to an already-live adoption; use the "
-                "guide control for that."
+                "pending operator hint, addressed ahead of PR review comments but "
+                "behind base synchronization: an adopted PR that is behind its "
+                "base (or BEHIND / DIRTY) syncs first -- including, on DIRTY, a "
+                "conflict-resolution agent pass -- and consumes the hint on a "
+                "later cycle. It is a repair directive for the agent, not a "
+                "first-cycle path constraint, so it cannot restrict what base "
+                "synchronization touches. Use it to steer the repair work (e.g. "
+                "'do not edit .github/workflows/*'). Ignored when the request "
+                "attaches to an already-live adoption; use the guide control for "
+                "that."
             ),
         ),
     ] = None

--- a/src/awf/cli/workspace_commands.py
+++ b/src/awf/cli/workspace_commands.py
@@ -950,6 +950,15 @@ def workspace_adopt_pr(
         help="Optional task class for scheduling/policy parity with workspace create.",
     ),
     reason: str | None = typer.Option(None, "--reason", help="Operator audit reason."),
+    hint: str | None = typer.Option(
+        None,
+        "--hint",
+        help=(
+            "Optional operator directive armed on the adopted workspace, addressed "
+            "by the monitor before any PR review comments. Ignored when the request "
+            "attaches to an already-live adoption (use 'awf workspace guide')."
+        ),
+    ),
     api_token: str | None = _api_token_option(),
     base_url: str | None = typer.Option(None, "--base-url"),
     fmt: OutputFormat = typer.Option(OutputFormat.json, "--format"),
@@ -1003,6 +1012,9 @@ def workspace_adopt_pr(
         body["task_class"] = _option_value(task_class)
     if owned_paths is not None:
         body["owned_paths"] = owned_paths
+    hint = _option_default(hint)
+    if hint is not None:
+        body["hint"] = hint
     response = _call(
         "POST",
         "/v1/workspaces/adopt-pr",

--- a/src/awf/mcp/control_tools.py
+++ b/src/awf/mcp/control_tools.py
@@ -21,6 +21,7 @@ from pydantic import AliasChoices, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from awf.api.schemas import (
+    ADOPTION_HINT_MAX_LENGTH,
     OperationResponse,
     OwnedPath,
     PullRequestMonitorAdoptionRequest,
@@ -243,6 +244,16 @@ def register_control_tools(
             max_length=512,
             description="Optional operator audit reason.",
         ),
+        hint: str | None = Field(
+            default=None,
+            max_length=ADOPTION_HINT_MAX_LENGTH,
+            description=(
+                "Optional operator directive armed on the adopted workspace as a "
+                "pending operator hint, so the monitor addresses it before any PR "
+                "review comments. Ignored when the request attaches to an "
+                "already-live adoption; use awf_guide_workspace for that."
+            ),
+        ),
     ) -> StructuredToolResult:
         """Operator control: adopt an existing GitHub PR into AWF monitoring; this is not shell access."""
         try:
@@ -268,6 +279,7 @@ def register_control_tools(
                     external_id=external_id,
                     task_class=task_class,
                     reason=reason,
+                    hint=hint,
                 )
             )
         except PRMonitorAdoptionError as exc:

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -147,6 +147,7 @@ from awf.service.pr_monitor_adoption_seed import (
     PR_ADOPTION_OPERATOR_HINT_REASON,
     PR_ADOPTION_SEEDED_EVENT_TYPE,
     PR_ADOPTION_SEEDED_REASON,
+    head_continuity_established,
     seedable_monitor_state,
 )
 from awf.service.scheduler import scheduler_score_from_workspace
@@ -717,10 +718,21 @@ class PullRequestMonitorAdoptionService:
         Returns the sorted copied keys (empty when there is no predecessor or it
         held nothing copyable) so the caller can decide whether the seeded event
         is warranted — the event is evidence of a *copy*, not of a supersede.
+
+        ``workspace.monitor_last_commit_sha`` is the freshly fetched PR head and
+        the predecessor's is the head it last processed; when they diverge the
+        branch moved under the predecessor's verdicts, so the head-dependent
+        ``fix_committed`` entries are dropped and re-triaged rather than trusted.
         """
         if superseded_workspace is None:
             return []
-        seeded = seedable_monitor_state(superseded_workspace.monitor_threads_addressed)
+        seeded = seedable_monitor_state(
+            superseded_workspace.monitor_threads_addressed,
+            head_continuity=head_continuity_established(
+                adopted_head_sha=workspace.monitor_last_commit_sha,
+                predecessor_head_sha=superseded_workspace.monitor_last_commit_sha,
+            ),
+        )
         if not seeded:
             return []
         monitor_state = dict(workspace.monitor_threads_addressed or {})

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -25,7 +25,7 @@ from awf.common.github_client import (
 )
 from awf.common.workspace_policy import pr_adoption_execution_policy
 from awf.db.enums import OperationStatus, OperationType
-from awf.db.models import MergeCandidate, Task, Workspace
+from awf.db.models import MergeCandidate, Operation, Task, Workspace
 from awf.db.repositories import (
     MergeCandidateRepository,
     OperationRepository,
@@ -37,6 +37,12 @@ from awf.db.repositories import (
     ValidationRunRepository,
     WorkspaceRepository,
 )
+from awf.runtime.operator_hints import (
+    build_pending_operator_hint_payload,
+    persist_operator_hint,
+    utcnow,
+)
+from awf.runtime.pr_monitor import OperatorHint
 from awf.service.node_identity import effective_worker_node_id
 from awf.service.pr_monitor_adoption_cursor_preflight import (
     _cursor_auto_mode_provider_preflight,
@@ -136,6 +142,12 @@ from awf.service.pr_monitor_adoption_helpers import (
 )
 from awf.service.pr_monitor_adoption_helpers import (
     pr_adoption_idempotency_key as pr_adoption_idempotency_key,
+)
+from awf.service.pr_monitor_adoption_seed import (
+    PR_ADOPTION_OPERATOR_HINT_REASON,
+    PR_ADOPTION_SEEDED_EVENT_TYPE,
+    PR_ADOPTION_SEEDED_REASON,
+    seedable_monitor_state,
 )
 from awf.service.scheduler import scheduler_score_from_workspace
 from awf.service.validation_observability import validation_freshness_summary
@@ -608,6 +620,29 @@ class PullRequestMonitorAdoptionService:
             idempotency_key=idempotency_key,
             payload=operation_payload,
         )
+        # Seed the successor's monitor state and arm the operator hint inside the
+        # same adoption savepoint as the row insert: the request transaction has
+        # not committed yet, so the worker cannot poll/claim this workspace until
+        # both are durable. The hint needs ``operation.id`` (it is what
+        # ``mark_operator_hint_processed`` records), hence the post-create spot.
+        seeded_keys = self._seed_monitor_state_from_predecessor(
+            workspace,
+            superseded_workspace=superseded_workspace,
+        )
+        pending_operator_hint = self._arm_adoption_operator_hint(
+            workspace,
+            hint_text=request.hint,
+            operation=operation,
+        )
+        if pending_operator_hint is not None:
+            # Assign a NEW dict rather than mutating ``operation_payload``: the ORM
+            # holds that very object as ``operation.payload``, so an in-place edit
+            # would make the pre-flush "committed" value compare equal to the new
+            # one and the UPDATE would be skipped.
+            operation.payload = {
+                **operation_payload,
+                "pending_operator_hint": pending_operator_hint,
+            }
         event_payload: dict[str, Any] = {
             "operation_id": operation.id,
             "repo_slug": repo.slug(),
@@ -628,12 +663,35 @@ class PullRequestMonitorAdoptionService:
         }
         if superseded_payload is not None:
             event_payload["superseded_adoption"] = superseded_payload
+        if pending_operator_hint is not None:
+            event_payload["pending_operator_hint"] = pending_operator_hint
         await workspace_repo.add_event(
             workspace,
             event_type=PR_ADOPTION_REQUESTED_EVENT_TYPE,
             reason_code=PR_ADOPTION_REQUESTED_REASON,
             payload=event_payload,
         )
+        if seeded_keys and superseded_workspace is not None:
+            seeded_payload: dict[str, Any] = {
+                "reason_code": PR_ADOPTION_SEEDED_REASON,
+                "predecessor_workspace_id": superseded_workspace.id,
+                "copied_keys": seeded_keys,
+                "copied_key_count": len(seeded_keys),
+                "repo_slug": repo.slug(),
+                "pr_number": metadata.number,
+                "operation_id": operation.id,
+            }
+            await workspace_repo.add_event(
+                workspace,
+                event_type=PR_ADOPTION_SEEDED_EVENT_TYPE,
+                reason_code=PR_ADOPTION_SEEDED_REASON,
+                payload=seeded_payload,
+            )
+            _log.info(
+                "pr_monitor_adoption.seeded_from_predecessor",
+                workspace_id=workspace.id,
+                **seeded_payload,
+            )
         if superseded_workspace is not None and superseded_payload is not None:
             await workspace_repo.add_event(
                 superseded_workspace,
@@ -647,6 +705,66 @@ class PullRequestMonitorAdoptionService:
             )
         await self._session.flush()
         return workspace
+
+    def _seed_monitor_state_from_predecessor(
+        self,
+        workspace: Workspace,
+        *,
+        superseded_workspace: Workspace | None,
+    ) -> list[str]:
+        """Copy the allowlisted comment dispositions from a terminal predecessor.
+
+        Returns the sorted copied keys (empty when there is no predecessor or it
+        held nothing copyable) so the caller can decide whether the seeded event
+        is warranted — the event is evidence of a *copy*, not of a supersede.
+        """
+        if superseded_workspace is None:
+            return []
+        seeded = seedable_monitor_state(superseded_workspace.monitor_threads_addressed)
+        if not seeded:
+            return []
+        monitor_state = dict(workspace.monitor_threads_addressed or {})
+        monitor_state.update(seeded)
+        workspace.monitor_threads_addressed = monitor_state
+        return list(seeded)
+
+    def _arm_adoption_operator_hint(
+        self,
+        workspace: Workspace,
+        *,
+        hint_text: str | None,
+        operation: Operation,
+    ) -> dict[str, object] | None:
+        """Arm the optional adoption ``hint`` as a PENDING monitor operator hint.
+
+        Mirrors ``guide_workspace``: the directive lands in
+        ``monitor_threads_addressed`` so the monitor's first ``decide()`` returns
+        ``AddressOperatorHint`` (gate 2) before any ``AddressComments`` (gate 3).
+        The schema already normalizes a blank directive to ``None``, so a hollow
+        hint can never arm a cycle with nothing for the agent to act on.
+        """
+        if not hint_text:
+            return None
+        hint = OperatorHint(
+            reason=hint_text,
+            directive=hint_text,
+            operation_id=operation.id,
+            requested_at=utcnow().isoformat(),
+            reason_code=PR_ADOPTION_OPERATOR_HINT_REASON,
+            status="pending",
+        )
+        monitor_state = dict(workspace.monitor_threads_addressed or {})
+        persist_operator_hint(monitor_state, hint)
+        workspace.monitor_threads_addressed = monitor_state
+        payload = build_pending_operator_hint_payload(hint)
+        # Operator-authored free text reaches the audit trail here; redact the two
+        # text fields the way the adoption ``reason`` is redacted. Both are built
+        # from the same non-empty ``hint_text``, so one redaction covers both. The
+        # PERSISTED hint stays verbatim — it is the agent's instruction.
+        redacted_hint_text = _redacted_optional_text(hint_text)
+        payload["reason"] = redacted_hint_text
+        payload["directive"] = redacted_hint_text
+        return payload
 
     async def _response(
         self,

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -722,7 +722,8 @@ class PullRequestMonitorAdoptionService:
         ``workspace.monitor_last_commit_sha`` is the freshly fetched PR head and
         the predecessor's is the head it last processed; when they diverge the
         branch moved under the predecessor's verdicts, so the head-dependent
-        ``fix_committed`` entries are dropped and re-triaged rather than trusted.
+        ``fix_committed`` / ``false_positive`` entries are dropped and re-triaged
+        rather than trusted.
         """
         if superseded_workspace is None:
             return []

--- a/src/awf/service/pr_monitor_adoption.py
+++ b/src/awf/service/pr_monitor_adoption.py
@@ -750,8 +750,18 @@ class PullRequestMonitorAdoptionService:
         """Arm the optional adoption ``hint`` as a PENDING monitor operator hint.
 
         Mirrors ``guide_workspace``: the directive lands in
-        ``monitor_threads_addressed`` so the monitor's first ``decide()`` returns
-        ``AddressOperatorHint`` (gate 2) before any ``AddressComments`` (gate 3).
+        ``monitor_threads_addressed`` so ``decide()`` returns
+        ``AddressOperatorHint`` at gate 2 — ahead of ``AddressComments``
+        (gate 3) and every gate after it, but *behind* gate 1's ``SyncBase``.
+        An adopted PR that is behind its base (or BEHIND / DIRTY) therefore
+        integrates the base first — including, on DIRTY, a conflict-resolution
+        agent pass — and consumes the hint on a later iteration. The hint is a
+        repair directive for the agent, not a pre-sync policy constraint, and it
+        cannot restrict what base synchronization touches. That ordering is
+        deliberate: a hint repair commit pushed onto a stale head is rejected
+        non-fast-forward, so the hint would re-enter the same cycle forever. It
+        is pinned by
+        ``test_pending_operator_hint_does_not_block_sync_base_for_stale_pr``.
         The schema already normalizes a blank directive to ``None``, so a hollow
         hint can never arm a cycle with nothing for the agent to act on.
         """

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -14,11 +14,12 @@ is an **allowlist**, not a denylist: only comment/thread verdicts and the two
 evidence-marker classes that keep those verdicts honest are copied, so a marker
 class added later is dropped by default rather than silently inherited.
 
-The allowlist is additionally gated on *head continuity*: ``fix_committed`` claims
-the fix is in the branch, which stops being true if the PR was force-pushed or the
-fix reverted before re-adoption, so it crosses only when the adopted head is the
-head the predecessor processed. The remaining verdicts judge the comment rather
-than the branch and cross either way.
+The allowlist is additionally gated on *head continuity*: ``fix_committed`` and
+``false_positive`` are both claims about the code at one particular head -- the fix
+is in the branch, or the branch already refutes the reviewer -- and a force-push or
+a revert before re-adoption can invalidate either, so they cross only when the
+adopted head is the head the predecessor processed. The remaining verdicts judge
+the feedback rather than the code and cross either way.
 
 Deliberately never copied: protected-block state, awaiting-required-checks
 timestamps, operator-hint bookkeeping, awaiting-workflow-scope / merge-block
@@ -37,21 +38,24 @@ PR_ADOPTION_SEEDED_EVENT_TYPE = "workspace.pr_monitor_adoption_seeded"
 PR_ADOPTION_SEEDED_REASON = "PR_ADOPTION_SEEDED_FROM_PREDECESSOR"
 PR_ADOPTION_OPERATOR_HINT_REASON = "PR_ADOPTION_OPERATOR_HINT"
 
-# ``fix_committed`` is the one seedable verdict that asserts something about the
-# *branch* rather than about the comment: it means "the predecessor's fix is in
-# the PR head". A force-push or a revert between the predecessor's last poll and
-# re-adoption can drop that fix while leaving the comment byte-identical, so the
-# successor would suppress still-valid feedback (and, because ``fix_committed``
-# does not block the merge gate, auto-merge over it). It is therefore inherited
-# only when head continuity is established -- see :func:`head_continuity_established`.
-_HEAD_DEPENDENT_VERDICTS = frozenset({"fix_committed"})
+# The seedable verdicts that assert something about the *code at a head* rather
+# than about the feedback: ``fix_committed`` means "the predecessor's fix is in the
+# PR head", and ``false_positive`` means "the code at that head already refutes the
+# reviewer" (AWF's own verdict guidance routes an already-satisfied comment to
+# FALSE POSITIVE rather than FIXED, so the verdict rests on branch content too). A
+# force-push or a revert between the predecessor's last poll and re-adoption can
+# invalidate either while leaving the comment byte-identical, so the successor
+# would suppress still-valid feedback -- and, since neither verdict re-enters
+# ``AddressComments`` nor blocks the merge gate, auto-merge over it. Both are
+# therefore inherited only when head continuity is established -- see
+# :func:`head_continuity_established`.
+_HEAD_DEPENDENT_VERDICTS = frozenset({"fix_committed", "false_positive"})
 
-# Verdicts that judge the *comment*, not the branch state, and so survive a head
-# that moved: ``false_positive`` / ``defer`` / ``needs_human`` are dispositions of
-# the feedback itself, and ``agent_failed`` re-queues either way.
+# Verdicts that judge the *feedback*, not the code, and so survive a head that
+# moved: ``defer`` / ``needs_human`` are dispositions of the reviewer's ask (and
+# both block the merge gate), and ``agent_failed`` re-queues either way.
 _HEAD_INDEPENDENT_VERDICTS = frozenset(
     {
-        "false_positive",
         "defer",
         "needs_human",
         # ``needs_comment_attention`` still re-queues ``agent_failed``, so seeding
@@ -94,9 +98,10 @@ def head_continuity_established(
     Adoption has no git or ancestry oracle in this transaction, so continuity is
     only *established* by SHA equality. Any moved head -- force-push, revert, or
     plain new commits on top -- reads as "not established", which is deliberately
-    conservative: the cost is that the successor re-triages the ``fix_committed``
-    items, while the alternative is inheriting a fix that may no longer exist in
-    the branch and merging over the reviewer's still-open feedback.
+    conservative: the cost is that the successor re-triages the code-dependent
+    items, while the alternative is inheriting a fix -- or a refutation -- that may
+    no longer exist in the branch and merging over the reviewer's still-open
+    feedback.
     """
     if not adopted_head_sha or not predecessor_head_sha:
         return False
@@ -112,8 +117,9 @@ def seedable_monitor_state(
 
     ``head_continuity`` states whether the head the successor adopts still carries
     the predecessor's processed head (:func:`head_continuity_established`). It
-    fails closed: without it, the head-dependent ``fix_committed`` verdicts are
-    dropped and re-triaged, while the head-independent dispositions still cross.
+    fails closed: without it, the head-dependent ``fix_committed`` /
+    ``false_positive`` verdicts are dropped and re-triaged, while the
+    head-independent dispositions still cross.
 
     The result is key-sorted (deterministic ``copied_keys`` in the seeded event)
     and is always a fresh dict, so callers may mutate it -- e.g. to arm a pending

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -1,0 +1,92 @@
+"""Allowlisted monitor-state carried across a PR re-adoption (issue #911).
+
+When :class:`~awf.service.pr_monitor_adoption.PullRequestMonitorAdoptionService`
+supersedes a *terminal* predecessor for the same repo/PR
+(``PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE``) the successor used to start with
+an empty ``monitor_threads_addressed`` and re-dispositioned every comment the
+predecessor had already triaged (observed on aira-infra PR #229: successor
+``ws_6fee851e74804257958b159b`` re-triaged ``5120013294``, ``issue:5549804922``
+and ``issue:5549805025`` after ``ws_8742af8348794904b3ce5ac5`` had already marked
+them ``false_positive``).
+
+This module owns the pure, I/O-free policy for what may cross that boundary. It
+is an **allowlist**, not a denylist: only comment/thread verdicts and the two
+evidence-marker classes that keep those verdicts honest are copied, so a marker
+class added later is dropped by default rather than silently inherited.
+
+Deliberately never copied: protected-block state, awaiting-required-checks
+timestamps, operator-hint bookkeeping, awaiting-workflow-scope / merge-block
+markers, notify/settle/grace bookkeeping, and defer/needs-human reason text.
+Those describe the *previous run's* position on a PR that has since moved; the
+fresh monitor must re-derive them from the live PR.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+PR_ADOPTION_SEEDED_EVENT_TYPE = "workspace.pr_monitor_adoption_seeded"
+PR_ADOPTION_SEEDED_REASON = "PR_ADOPTION_SEEDED_FROM_PREDECESSOR"
+PR_ADOPTION_OPERATOR_HINT_REASON = "PR_ADOPTION_OPERATOR_HINT"
+
+# The comment-disposition vocabulary written by the monitor's feedback policy
+# (``awf.runtime.feedback_policy`` / ``MonitorState.mark_addressed``). A bare-id
+# key whose value falls outside it is some other bookkeeping entry and is not
+# seeded -- the allowlist gates on the value as well as the key shape.
+_SEEDABLE_VERDICTS = frozenset(
+    {
+        "fix_committed",
+        "false_positive",
+        "defer",
+        "needs_human",
+        # ``needs_comment_attention`` still re-queues ``agent_failed``, so seeding
+        # it inherits the lineage without suppressing a retry.
+        "agent_failed",
+    }
+)
+
+# A verdict key is a bare review-thread id (``PRRT_...``), a bare numeric
+# review-comment id, or an ``issue:<id>`` issue-comment id. The leading
+# ``[A-Za-z0-9]`` makes every ``__...__`` reserved marker structurally
+# ineligible, so a new reserved marker can never be mistaken for a verdict.
+_VERDICT_KEY_RE = re.compile(r"^(?:issue:)?[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+# Evidence markers that must travel with a copied verdict. The body hash lets the
+# runner re-queue a comment whose body changed since the predecessor triaged it;
+# the deferred-issue marker prevents filing a duplicate follow-up issue.
+_COPIED_MARKER_PREFIXES = (
+    "__review_comment_body_hash__:",
+    "__deferred_issue_filed__:",
+)
+
+
+def seedable_monitor_state(previous: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return the allowlisted subset of a predecessor's monitor state.
+
+    The result is key-sorted (deterministic ``copied_keys`` in the seeded event)
+    and is always a fresh dict, so callers may mutate it -- e.g. to arm a pending
+    operator hint -- without touching the predecessor's persisted state.
+    """
+    if not previous:
+        return {}
+    seeded = {
+        key: value
+        for key, value in previous.items()
+        if isinstance(value, str)
+        and (_is_verdict_entry(key, value) or _is_copied_marker(key, value))
+    }
+    return dict(sorted(seeded.items()))
+
+
+def _is_verdict_entry(key: str, value: str) -> bool:
+    return value in _SEEDABLE_VERDICTS and _VERDICT_KEY_RE.match(key) is not None
+
+
+def _is_copied_marker(key: str, value: str) -> bool:
+    if not value:
+        return False
+    return any(
+        key.startswith(prefix) and len(key) > len(prefix) for prefix in _COPIED_MARKER_PREFIXES
+    )

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -14,6 +14,12 @@ is an **allowlist**, not a denylist: only comment/thread verdicts and the two
 evidence-marker classes that keep those verdicts honest are copied, so a marker
 class added later is dropped by default rather than silently inherited.
 
+The allowlist is additionally gated on *head continuity*: ``fix_committed`` claims
+the fix is in the branch, which stops being true if the PR was force-pushed or the
+fix reverted before re-adoption, so it crosses only when the adopted head is the
+head the predecessor processed. The remaining verdicts judge the comment rather
+than the branch and cross either way.
+
 Deliberately never copied: protected-block state, awaiting-required-checks
 timestamps, operator-hint bookkeeping, awaiting-workflow-scope / merge-block
 markers, notify/settle/grace bookkeeping, and defer/needs-human reason text.
@@ -31,13 +37,20 @@ PR_ADOPTION_SEEDED_EVENT_TYPE = "workspace.pr_monitor_adoption_seeded"
 PR_ADOPTION_SEEDED_REASON = "PR_ADOPTION_SEEDED_FROM_PREDECESSOR"
 PR_ADOPTION_OPERATOR_HINT_REASON = "PR_ADOPTION_OPERATOR_HINT"
 
-# The comment-disposition vocabulary written by the monitor's feedback policy
-# (``awf.runtime.feedback_policy`` / ``MonitorState.mark_addressed``). A bare-id
-# key whose value falls outside it is some other bookkeeping entry and is not
-# seeded -- the allowlist gates on the value as well as the key shape.
-_SEEDABLE_VERDICTS = frozenset(
+# ``fix_committed`` is the one seedable verdict that asserts something about the
+# *branch* rather than about the comment: it means "the predecessor's fix is in
+# the PR head". A force-push or a revert between the predecessor's last poll and
+# re-adoption can drop that fix while leaving the comment byte-identical, so the
+# successor would suppress still-valid feedback (and, because ``fix_committed``
+# does not block the merge gate, auto-merge over it). It is therefore inherited
+# only when head continuity is established -- see :func:`head_continuity_established`.
+_HEAD_DEPENDENT_VERDICTS = frozenset({"fix_committed"})
+
+# Verdicts that judge the *comment*, not the branch state, and so survive a head
+# that moved: ``false_positive`` / ``defer`` / ``needs_human`` are dispositions of
+# the feedback itself, and ``agent_failed`` re-queues either way.
+_HEAD_INDEPENDENT_VERDICTS = frozenset(
     {
-        "fix_committed",
         "false_positive",
         "defer",
         "needs_human",
@@ -46,6 +59,12 @@ _SEEDABLE_VERDICTS = frozenset(
         "agent_failed",
     }
 )
+
+# The comment-disposition vocabulary written by the monitor's feedback policy
+# (``awf.runtime.feedback_policy`` / ``MonitorState.mark_addressed``). A bare-id
+# key whose value falls outside it is some other bookkeeping entry and is not
+# seeded -- the allowlist gates on the value as well as the key shape.
+_SEEDABLE_VERDICTS = _HEAD_DEPENDENT_VERDICTS | _HEAD_INDEPENDENT_VERDICTS
 
 # A verdict key is exactly one of the three forms the adoption contract names: a
 # GraphQL review-thread id (``PRRT_...``), a bare numeric review-comment id, or
@@ -65,8 +84,36 @@ _COPIED_MARKER_PREFIXES = (
 )
 
 
-def seedable_monitor_state(previous: Mapping[str, Any] | None) -> dict[str, str]:
+def head_continuity_established(
+    *,
+    adopted_head_sha: str | None,
+    predecessor_head_sha: str | None,
+) -> bool:
+    """True when the adopted PR head is provably the head the predecessor processed.
+
+    Adoption has no git or ancestry oracle in this transaction, so continuity is
+    only *established* by SHA equality. Any moved head -- force-push, revert, or
+    plain new commits on top -- reads as "not established", which is deliberately
+    conservative: the cost is that the successor re-triages the ``fix_committed``
+    items, while the alternative is inheriting a fix that may no longer exist in
+    the branch and merging over the reviewer's still-open feedback.
+    """
+    if not adopted_head_sha or not predecessor_head_sha:
+        return False
+    return adopted_head_sha.strip().lower() == predecessor_head_sha.strip().lower()
+
+
+def seedable_monitor_state(
+    previous: Mapping[str, Any] | None,
+    *,
+    head_continuity: bool = False,
+) -> dict[str, str]:
     """Return the allowlisted subset of a predecessor's monitor state.
+
+    ``head_continuity`` states whether the head the successor adopts still carries
+    the predecessor's processed head (:func:`head_continuity_established`). It
+    fails closed: without it, the head-dependent ``fix_committed`` verdicts are
+    dropped and re-triaged, while the head-independent dispositions still cross.
 
     The result is key-sorted (deterministic ``copied_keys`` in the seeded event)
     and is always a fresh dict, so callers may mutate it -- e.g. to arm a pending
@@ -78,13 +125,17 @@ def seedable_monitor_state(previous: Mapping[str, Any] | None) -> dict[str, str]
         key: value
         for key, value in previous.items()
         if isinstance(value, str)
-        and (_is_verdict_entry(key, value) or _is_copied_marker(key, value))
+        and (
+            _is_verdict_entry(key, value, head_continuity=head_continuity)
+            or _is_copied_marker(key, value)
+        )
     }
     return dict(sorted(seeded.items()))
 
 
-def _is_verdict_entry(key: str, value: str) -> bool:
-    return value in _SEEDABLE_VERDICTS and _VERDICT_KEY_RE.match(key) is not None
+def _is_verdict_entry(key: str, value: str, *, head_continuity: bool) -> bool:
+    seedable = _SEEDABLE_VERDICTS if head_continuity else _HEAD_INDEPENDENT_VERDICTS
+    return value in seedable and _VERDICT_KEY_RE.match(key) is not None
 
 
 def _is_copied_marker(key: str, value: str) -> bool:

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -87,6 +87,14 @@ _COPIED_MARKER_PREFIXES = (
     "__deferred_issue_filed__:",
 )
 
+# A head SHA counts as continuity evidence only in its full 40-hex form. An
+# abbreviation is a prefix, not a commit identity: two equal abbreviations can
+# name different commits, so comparing them would establish continuity without
+# proving it. A value that is whitespace-only, empty after stripping, or
+# otherwise non-hex is not a commit identifier at all -- and two such values
+# would compare equal to each other. Both read as "not established".
+_FULL_COMMIT_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+
 
 def head_continuity_established(
     *,
@@ -102,10 +110,20 @@ def head_continuity_established(
     items, while the alternative is inheriting a fix -- or a refutation -- that may
     no longer exist in the branch and merging over the reviewer's still-open
     feedback.
+
+    Both sides are normalized (surrounding whitespace and case are forge noise,
+    not a discontinuity) *before* they are validated, and only a full 40-hex
+    commit SHA is accepted as evidence. An abbreviated, blank, whitespace-only,
+    or otherwise non-hex value on either side is not proof of identity and fails
+    closed -- equality between two such values must not establish continuity.
     """
-    if not adopted_head_sha or not predecessor_head_sha:
+    adopted = (adopted_head_sha or "").strip().lower()
+    predecessor = (predecessor_head_sha or "").strip().lower()
+    if _FULL_COMMIT_SHA_RE.match(adopted) is None:
         return False
-    return adopted_head_sha.strip().lower() == predecessor_head_sha.strip().lower()
+    if _FULL_COMMIT_SHA_RE.match(predecessor) is None:
+        return False
+    return adopted == predecessor
 
 
 def seedable_monitor_state(

--- a/src/awf/service/pr_monitor_adoption_seed.py
+++ b/src/awf/service/pr_monitor_adoption_seed.py
@@ -47,11 +47,14 @@ _SEEDABLE_VERDICTS = frozenset(
     }
 )
 
-# A verdict key is a bare review-thread id (``PRRT_...``), a bare numeric
-# review-comment id, or an ``issue:<id>`` issue-comment id. The leading
-# ``[A-Za-z0-9]`` makes every ``__...__`` reserved marker structurally
-# ineligible, so a new reserved marker can never be mistaken for a verdict.
-_VERDICT_KEY_RE = re.compile(r"^(?:issue:)?[A-Za-z0-9][A-Za-z0-9_-]*$")
+# A verdict key is exactly one of the three forms the adoption contract names: a
+# GraphQL review-thread id (``PRRT_...``), a bare numeric review-comment id, or
+# an ``issue:<numeric-id>`` issue-comment id. The pattern is closed rather than
+# "any identifier-ish key", so a malformed, legacy, or future bookkeeping entry
+# cannot cross the supersede boundary just by holding a verdict-shaped value.
+# None of the three alternatives can begin with ``_``, which keeps every
+# ``__...__`` reserved marker structurally ineligible as well.
+_VERDICT_KEY_RE = re.compile(r"^(?:PRRT_[A-Za-z0-9_-]+|[0-9]+|issue:[0-9]+)$")
 
 # Evidence markers that must travel with a copied verdict. The body hash lets the
 # runner re-queue a comment whose body changed since the predecessor triaged it;

--- a/tests/unit/api/test_pr_monitor_adoption.py
+++ b/tests/unit/api/test_pr_monitor_adoption.py
@@ -20,11 +20,13 @@ from awf.db.models import Task, TaskAttempt, Workspace
 from awf.db.repositories import TaskRepository, WorkspaceRepository
 from awf.db.session import make_session_factory
 from awf.runtime.hosted_delegation import HostedDelegationConfigError
+from awf.runtime.operator_hints import operator_hint_from_threads
 from awf.service import pr_monitor_adoption_helpers as adoption_helpers
 from awf.service.pr_monitor_adoption import (
     _adoption_external_id,
     pr_adoption_idempotency_key,
 )
+from awf.service.pr_monitor_adoption_seed import PR_ADOPTION_OPERATOR_HINT_REASON
 
 
 @pytest.fixture(autouse=True)
@@ -1053,3 +1055,90 @@ async def test_adopt_pr_colliding_explicit_external_id_leaves_db_unchanged(
     assert task.external_id == unrelated_external_id
     assert task.title == unrelated_title
     assert by_key is None
+
+
+@pytest.mark.unit
+def test_adoption_request_schema_accepts_optional_bounded_hint() -> None:
+    payload = PullRequestMonitorAdoptionRequest(
+        repo_slug="dimileeh/aira-web",
+        pr_number=277,
+        hint="  do NOT edit .github/workflows/*  ",
+    )
+    omitted = PullRequestMonitorAdoptionRequest(
+        repo_slug="dimileeh/aira-web",
+        pr_number=277,
+    )
+    blank = PullRequestMonitorAdoptionRequest(
+        repo_slug="dimileeh/aira-web",
+        pr_number=277,
+        hint="   ",
+    )
+    at_bound = PullRequestMonitorAdoptionRequest(
+        repo_slug="dimileeh/aira-web",
+        pr_number=277,
+        hint="x" * 1024,
+    )
+
+    assert payload.hint == "do NOT edit .github/workflows/*"
+    assert omitted.hint is None
+    assert blank.hint is None
+    assert at_bound.hint == "x" * 1024
+
+    with pytest.raises(ValidationError):
+        PullRequestMonitorAdoptionRequest(
+            repo_slug="dimileeh/aira-web",
+            pr_number=277,
+            hint="x" * 1025,
+        )
+
+    schema = create_app(use_lifespan=False).openapi()
+    props = schema["components"]["schemas"]["PullRequestMonitorAdoptionRequest"]["properties"]
+    assert _optional_string_schema(props["hint"])["maxLength"] == 1024
+
+
+@pytest.mark.unit
+async def test_adopt_pr_arms_pending_operator_hint_from_request(
+    adoption_client: tuple[AsyncClient, _MetadataFetcher],
+    engine: AsyncEngine,
+) -> None:
+    client, _fetcher = adoption_client
+
+    response = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers={"Authorization": "Bearer secret"},
+        json={
+            "repo_slug": "dimileeh/aira-web",
+            "pr_number": 277,
+            "hint": "do NOT edit .github/workflows/*",
+        },
+    )
+
+    assert response.status_code == 202
+    session_factory = make_session_factory(engine)
+    async with session_factory() as session:
+        workspace = (await session.execute(select(Workspace))).scalar_one()
+    hint = operator_hint_from_threads(workspace.monitor_threads_addressed or {})
+    assert hint is not None
+    assert hint.status == "pending"
+    assert hint.directive == "do NOT edit .github/workflows/*"
+    assert hint.reason_code == PR_ADOPTION_OPERATOR_HINT_REASON
+
+
+@pytest.mark.unit
+async def test_adopt_pr_without_hint_leaves_monitor_state_empty(
+    adoption_client: tuple[AsyncClient, _MetadataFetcher],
+    engine: AsyncEngine,
+) -> None:
+    client, _fetcher = adoption_client
+
+    response = await client.post(
+        "/v1/workspaces/adopt-pr",
+        headers={"Authorization": "Bearer secret"},
+        json={"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+    )
+
+    assert response.status_code == 202
+    session_factory = make_session_factory(engine)
+    async with session_factory() as session:
+        workspace = (await session.execute(select(Workspace))).scalar_one()
+    assert workspace.monitor_threads_addressed in (None, {})

--- a/tests/unit/api/test_task_tag_schema.py
+++ b/tests/unit/api/test_task_tag_schema.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
+from awf.api import schemas as api_schemas
 from awf.api import schemas_responses
 from awf.api.schemas import (
     PullRequestMonitorAdoptionRequest,
@@ -34,8 +35,19 @@ def _create_request(task_tag: str | None | object = "__unset__") -> WorkspaceCre
 
 @pytest.mark.unit
 def test_pr_monitor_request_models_are_owned_by_api_schemas() -> None:
-    assert PullRequestMonitorExecutionPolicy.__module__ == "awf.api.schemas"
-    assert PullRequestMonitorAdoptionRequest.__module__ == "awf.api.schemas"
+    """PR-monitor *request* contracts must never be filed under response leaves.
+
+    PRRT_kwDOSJAM6s6S7WnD rejected parking these request models in
+    ``schemas_responses`` (the response-leaf module). Issue #911 moved them into
+    the purpose-named ``schemas_pr_adoption`` because ``schemas`` had reached the
+    1500-line maintainability cap; the ownership rule is unchanged — they are
+    reachable from ``awf.api.schemas`` (the single import surface for REST + MCP)
+    and stay out of ``schemas_responses``.
+    """
+    assert PullRequestMonitorExecutionPolicy.__module__ == "awf.api.schemas_pr_adoption"
+    assert PullRequestMonitorAdoptionRequest.__module__ == "awf.api.schemas_pr_adoption"
+    assert api_schemas.PullRequestMonitorExecutionPolicy is PullRequestMonitorExecutionPolicy
+    assert api_schemas.PullRequestMonitorAdoptionRequest is PullRequestMonitorAdoptionRequest
     assert not hasattr(schemas_responses, "PullRequestMonitorExecutionPolicy")
     assert not hasattr(schemas_responses, "PullRequestMonitorAdoptionRequest")
 

--- a/tests/unit/cli/test_cli_parts/test_cli_part_002.py
+++ b/tests/unit/cli/test_cli_parts/test_cli_part_002.py
@@ -47,6 +47,7 @@ def _assert_adopt_pr_help_exposes_model_and_effort(stdout: str) -> None:
     assert "--external-id" in visible_help
     assert "--task-class" in visible_help
     assert "--cursor-auto-mode" in visible_help
+    assert "--hint" in visible_help
 
 
 def _assert_workspace_create_help_exposes_model_and_effort(stdout: str) -> None:
@@ -435,6 +436,42 @@ class TestWorkspaceAdoptPr:
         assert result.exit_code == 0
         _assert_adopt_pr_help_exposes_model_and_effort(result.stdout)
         assert typer_rich_utils.MAX_WIDTH == 30
+
+    @pytest.mark.unit
+    def test_emits_operator_hint_to_adoption_request(self) -> None:
+        response = _mock_response(status_code=202, payload={"workspace_id": "ws_hint"})
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "adopt-pr",
+                    "--pr-url",
+                    "https://github.com/x/y/pull/1",
+                    "--hint",
+                    "do NOT edit .github/workflows/*",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert mock.call_args.kwargs["json"]["hint"] == "do NOT edit .github/workflows/*"
+
+    @pytest.mark.unit
+    def test_omits_hint_from_adoption_request_when_not_supplied(self) -> None:
+        response = _mock_response(status_code=202, payload={"workspace_id": "ws_no_hint"})
+        with patch("awf.cli.main.httpx.request", return_value=response) as mock:
+            result = _runner.invoke(
+                app,
+                [
+                    "workspace",
+                    "adopt-pr",
+                    "--pr-url",
+                    "https://github.com/x/y/pull/1",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "hint" not in mock.call_args.kwargs["json"]
 
     @pytest.mark.unit
     def test_posts_pr_url_without_repo_fields(self) -> None:

--- a/tests/unit/contracts/_capabilities.py
+++ b/tests/unit/contracts/_capabilities.py
@@ -540,6 +540,7 @@ _CAPABILITIES: tuple[ContractCapability, ...] = (
                 "external_id",
                 "task_class",
                 "reason",
+                "hint",
             }
         ),
         mcp_request_fields=frozenset(
@@ -564,6 +565,7 @@ _CAPABILITIES: tuple[ContractCapability, ...] = (
                 "external_id",
                 "task_class",
                 "reason",
+                "hint",
             }
         ),
         cli_options=frozenset(
@@ -585,6 +587,7 @@ _CAPABILITIES: tuple[ContractCapability, ...] = (
                 "--external-id",
                 "--task-class",
                 "--reason",
+                "--hint",
                 "--api-token",
             }
         ),

--- a/tests/unit/contracts/test_request_payload_alignment.py
+++ b/tests/unit/contracts/test_request_payload_alignment.py
@@ -579,6 +579,7 @@ async def test_mcp_adoption_hydrates_canonical_request_model() -> None:
         "task_prompt": None,
         "task_tag": "PROJ-123",
         "reason": None,
+        "hint": "do NOT edit .github/workflows/*",
     }
     rest_request = PullRequestMonitorAdoptionRequest.model_validate(rest_payload)
 
@@ -601,6 +602,7 @@ async def test_mcp_adoption_hydrates_canonical_request_model() -> None:
             "task_prompt": None,
             "task_tag": "PROJ-123",
             "reason": None,
+            "hint": "do NOT edit .github/workflows/*",
         },
     )
     assert getattr(result, "isError", False) is False

--- a/tests/unit/mcp/test_mcp_server_parts/test_mcp_server_part_001.py
+++ b/tests/unit/mcp/test_mcp_server_parts/test_mcp_server_part_001.py
@@ -583,6 +583,55 @@ class TestToolRegistration:
         assert service.request.task_class.value == "test_task"
 
     @pytest.mark.unit
+    async def test_adopt_pull_request_monitor_tool_forwards_operator_hint(self) -> None:
+        class _CaptureService:
+            def __init__(self) -> None:
+                self.request = None
+
+            async def adopt_pull_request_monitor(self, request):  # type: ignore[no-untyped-def]
+                self.request = request
+                return PullRequestMonitorAdoptionResponse(
+                    workspace_id="ws_adopt",
+                    status=WorkspaceStatus.requested,
+                    version=1,
+                    repo_slug="dimileeh/aira-web",
+                    repo_url="git@github.com:dimileeh/aira-web.git",
+                    pr_number=277,
+                    pr_url="https://github.com/dimileeh/aira-web/pull/277",
+                    head_ref="feature/ready",
+                    base_ref="development",
+                    auto_merge=True,
+                    attached_existing=False,
+                    status_url="/v1/workspaces/ws_adopt",
+                    events_url="/v1/workspaces/ws_adopt/events",
+                    logs_url="/v1/workspaces/ws_adopt/logs",
+                )
+
+        service = _CaptureService()
+        mcp = build_mcp_server(service=service)  # type: ignore[arg-type]
+
+        payload = await _call(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {
+                "repo_slug": "dimileeh/aira-web",
+                "pr_number": 277,
+                "hint": "do NOT edit .github/workflows/*",
+            },
+        )
+
+        assert isinstance(payload, dict)
+        assert service.request is not None
+        assert service.request.hint == "do NOT edit .github/workflows/*"
+
+        await _call(
+            mcp,
+            "awf_adopt_pull_request_monitor",
+            {"repo_slug": "dimileeh/aira-web", "pr_number": 277},
+        )
+        assert service.request.hint is None
+
+    @pytest.mark.unit
     async def test_adopt_pull_request_monitor_tool_ignores_destroyed_prior_adoption(
         self,
         factory: async_sessionmaker[AsyncSession],
@@ -946,6 +995,9 @@ class TestToolRegistration:
         external_id_schema = _optional_string_schema(adopt_props["external_id"])
         assert external_id_schema["maxLength"] == 128
         assert "task_class" in adopt_props
+        hint_schema = _optional_string_schema(adopt_props["hint"])
+        assert hint_schema["maxLength"] == 1024
+        assert adopt_props["hint"]["default"] is None
 
         create_props = tools["awf_create_workspace"].inputSchema["properties"]
         create_model_schema = _optional_string_schema(create_props["model"])

--- a/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
+++ b/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
@@ -103,12 +103,14 @@ def _request(**overrides: Any) -> PullRequestMonitorAdoptionRequest:
 
 async def _adopt(
     factory: async_sessionmaker[AsyncSession],
+    *,
+    head_sha: str = "h" * 40,
     **overrides: Any,
 ) -> str:
     async with factory() as session:
         response = await PullRequestMonitorAdoptionService(
             session,
-            metadata_fetcher=_MetadataFetcher(_metadata()),
+            metadata_fetcher=_MetadataFetcher(_metadata(head_sha=head_sha)),
         ).adopt(_request(**overrides))
         await session.commit()
     return response.workspace_id
@@ -200,6 +202,34 @@ class TestPullRequestMonitorAdoptionSeedingPart011:
         assert payload["copied_key_count"] == len(_SEEDABLE_PREDECESSOR_STATE)
         assert payload["repo_slug"] == REPO_SLUG
         assert payload["pr_number"] == PR_NUMBER
+
+    @pytest.mark.unit
+    async def test_moved_head_drops_inherited_fix_committed_only(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        """A force-push / revert before re-adoption invalidates ``fix_committed``.
+
+        The fix the predecessor recorded need not exist in the head the successor
+        adopts, while the comment itself is unchanged — inheriting the verdict
+        would suppress live feedback and let auto-merge run over it. Dispositions
+        of the *comment* (``false_positive`` and friends) are head-independent and
+        still cross.
+        """
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(factory, previous_id, _SEEDABLE_PREDECESSOR_STATE)
+
+        fresh_id = await _adopt(factory, head_sha="f" * 40)
+
+        expected = {
+            key: value
+            for key, value in _SEEDABLE_PREDECESSOR_STATE.items()
+            if value != "fix_committed"
+        }
+        assert "PRRT_kwDOSJAM6s6fNhZo" not in expected
+        assert await _monitor_state(factory, fresh_id) == expected
+        events = await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE)
+        assert (events[0].payload or {})["copied_keys"] == sorted(expected)
 
     @pytest.mark.unit
     async def test_first_adoption_seeds_nothing_and_emits_no_seeded_event(

--- a/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
+++ b/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
@@ -69,7 +69,10 @@ async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
         yield make_session_factory(engine)
 
 
-def _metadata(*, head_sha: str = "h" * 40) -> PullRequestAdoptionMetadata:
+# Head SHAs are full 40-hex commit ids: head continuity is established only by
+# real commit identifiers, so a placeholder outside the hex alphabet would fail
+# closed and silently stop exercising the inherited-verdict path.
+def _metadata(*, head_sha: str = "a" * 40) -> PullRequestAdoptionMetadata:
     return PullRequestAdoptionMetadata(
         number=PR_NUMBER,
         head_ref="feature/ready",
@@ -106,7 +109,7 @@ def _request(**overrides: Any) -> PullRequestMonitorAdoptionRequest:
 async def _adopt(
     factory: async_sessionmaker[AsyncSession],
     *,
-    head_sha: str = "h" * 40,
+    head_sha: str = "a" * 40,
     **overrides: Any,
 ) -> str:
     async with factory() as session:

--- a/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
+++ b/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
@@ -47,6 +47,8 @@ _SEEDABLE_PREDECESSOR_STATE: dict[str, str] = {
     "issue:5549804922": "false_positive",
     "issue:5549805025": "false_positive",
     "PRRT_kwDOSJAM6s6fNhZo": "fix_committed",
+    # A head-independent disposition, so the moved-head case still proves those cross.
+    "issue:5549805026": "defer",
     "__review_comment_body_hash__:5120013294": "a" * 64,
     "__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123": f"{REPO_SLUG}#42",
 }
@@ -204,17 +206,18 @@ class TestPullRequestMonitorAdoptionSeedingPart011:
         assert payload["pr_number"] == PR_NUMBER
 
     @pytest.mark.unit
-    async def test_moved_head_drops_inherited_fix_committed_only(
+    async def test_moved_head_drops_inherited_code_dependent_verdicts_only(
         self,
         factory: async_sessionmaker[AsyncSession],
     ) -> None:
-        """A force-push / revert before re-adoption invalidates ``fix_committed``.
+        """A force-push / revert before re-adoption invalidates code-dependent verdicts.
 
-        The fix the predecessor recorded need not exist in the head the successor
-        adopts, while the comment itself is unchanged — inheriting the verdict
-        would suppress live feedback and let auto-merge run over it. Dispositions
-        of the *comment* (``false_positive`` and friends) are head-independent and
-        still cross.
+        Neither the fix the predecessor recorded (``fix_committed``) nor the code
+        that refuted the reviewer (``false_positive``) need exist in the head the
+        successor adopts, while the comment itself is unchanged — inheriting either
+        would suppress live feedback and let auto-merge run over it. Dispositions of
+        the *feedback* (``defer`` / ``needs_human`` / ``agent_failed``) and the
+        evidence markers are head-independent and still cross.
         """
         previous_id = await _adopt(factory)
         await _fail_with_monitor_state(factory, previous_id, _SEEDABLE_PREDECESSOR_STATE)
@@ -224,9 +227,10 @@ class TestPullRequestMonitorAdoptionSeedingPart011:
         expected = {
             key: value
             for key, value in _SEEDABLE_PREDECESSOR_STATE.items()
-            if value != "fix_committed"
+            if value not in {"fix_committed", "false_positive"}
         }
         assert "PRRT_kwDOSJAM6s6fNhZo" not in expected
+        assert "5120013294" not in expected
         assert await _monitor_state(factory, fresh_id) == expected
         events = await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE)
         assert (events[0].payload or {})["copied_keys"] == sorted(expected)

--- a/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
+++ b/tests/unit/service/test_pr_monitor_adoption_parts/test_pr_monitor_adoption_part_011.py
@@ -1,0 +1,349 @@
+"""Adoption seeding from a terminal predecessor + operator hint (issue #911)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.api.schemas import PullRequestMonitorAdoptionRequest
+from awf.common.github_client import PullRequestAdoptionMetadata, RepoRef
+from awf.db.enums import WorkspaceStatus
+from awf.db.models import Operation, Workspace, WorkspaceEvent
+from awf.db.repositories import WorkspaceRepository
+from awf.db.session import make_session_factory
+from awf.runtime.operator_hints import OPERATOR_HINT_STATE_KEY, operator_hint_from_threads
+from awf.runtime.pr_monitor import (
+    AddressOperatorHint,
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorConfig,
+    MonitorState,
+    PRStatus,
+    decide,
+)
+from awf.runtime.pr_monitor_models import ReviewComment
+from awf.service.pr_monitor_adoption import PullRequestMonitorAdoptionService
+from awf.service.pr_monitor_adoption_helpers import PR_ADOPTION_REQUESTED_EVENT_TYPE
+from awf.service.pr_monitor_adoption_seed import (
+    PR_ADOPTION_OPERATOR_HINT_REASON,
+    PR_ADOPTION_SEEDED_EVENT_TYPE,
+    PR_ADOPTION_SEEDED_REASON,
+)
+from tests.postgres import postgres_test_engine
+
+REPO_SLUG = "dimileeh/aira-infra"
+PR_NUMBER = 229
+
+# The aira-infra PR #229 shape: verdicts the predecessor already dispositioned,
+# their evidence markers, plus run-local bookkeeping that must stay behind.
+_SEEDABLE_PREDECESSOR_STATE: dict[str, str] = {
+    "5120013294": "false_positive",
+    "issue:5549804922": "false_positive",
+    "issue:5549805025": "false_positive",
+    "PRRT_kwDOSJAM6s6fNhZo": "fix_committed",
+    "__review_comment_body_hash__:5120013294": "a" * 64,
+    "__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123": f"{REPO_SLUG}#42",
+}
+_NEVER_COPIED_PREDECESSOR_STATE: dict[str, str] = {
+    "__awf_protected_block_preserved_head__": "d" * 40,
+    "__awf_protected_block__:PRRT_kwDOSJAM6s6fNhZo": "blocked",
+    f"__awf_awaiting_required_checks_first_seen__:{PR_NUMBER}:" + "d" * 40: "1700000000",
+    OPERATOR_HINT_STATE_KEY: json.dumps({"reason": "prior directive", "status": "pending"}),
+    "__awf_operator_hint_processed__:op_prior": "processed",
+    f"__awf_awaiting_workflow_scope__:{PR_NUMBER}": "armed",
+    f"__awf_merge_block_attention__:{PR_NUMBER}": "notified",
+}
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+def _metadata(*, head_sha: str = "h" * 40) -> PullRequestAdoptionMetadata:
+    return PullRequestAdoptionMetadata(
+        number=PR_NUMBER,
+        head_ref="feature/ready",
+        head_repo_slug=REPO_SLUG,
+        base_ref="main",
+        head_sha=head_sha,
+        base_sha="b" * 40,
+        state="OPEN",
+        is_draft=False,
+        closed=False,
+        merged=False,
+        author="octocat",
+        url=f"https://github.com/{REPO_SLUG}/pull/{PR_NUMBER}",
+        title="fix: hardening",
+    )
+
+
+class _MetadataFetcher:
+    def __init__(self, metadata: PullRequestAdoptionMetadata) -> None:
+        self.metadata = metadata
+
+    async def __call__(self, *, repo: RepoRef, pr_number: int) -> PullRequestAdoptionMetadata:
+        return self.metadata
+
+
+def _request(**overrides: Any) -> PullRequestMonitorAdoptionRequest:
+    return PullRequestMonitorAdoptionRequest(
+        repo_slug=REPO_SLUG,
+        pr_number=PR_NUMBER,
+        **overrides,
+    )
+
+
+async def _adopt(
+    factory: async_sessionmaker[AsyncSession],
+    **overrides: Any,
+) -> str:
+    async with factory() as session:
+        response = await PullRequestMonitorAdoptionService(
+            session,
+            metadata_fetcher=_MetadataFetcher(_metadata()),
+        ).adopt(_request(**overrides))
+        await session.commit()
+    return response.workspace_id
+
+
+async def _fail_with_monitor_state(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    monitor_state: dict[str, str],
+) -> None:
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        workspace.monitor_threads_addressed = dict(monitor_state)
+        await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        await session.commit()
+
+
+async def _monitor_state(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+) -> dict[str, str]:
+    async with factory() as session:
+        workspace = await session.get(Workspace, workspace_id)
+        assert workspace is not None
+        return dict(workspace.monitor_threads_addressed or {})
+
+
+async def _events(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    event_type: str,
+) -> list[WorkspaceEvent]:
+    async with factory() as session:
+        return list(
+            (
+                await session.execute(
+                    select(WorkspaceEvent)
+                    .where(
+                        WorkspaceEvent.workspace_id == workspace_id,
+                        WorkspaceEvent.event_type == event_type,
+                    )
+                    .order_by(WorkspaceEvent.occurred_at.asc(), WorkspaceEvent.event_order.asc())
+                )
+            ).scalars()
+        )
+
+
+class TestPullRequestMonitorAdoptionSeedingPart011:
+    @pytest.mark.unit
+    async def test_seeds_only_allowlisted_keys_from_terminal_predecessor(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(
+            factory,
+            previous_id,
+            {**_SEEDABLE_PREDECESSOR_STATE, **_NEVER_COPIED_PREDECESSOR_STATE},
+        )
+
+        fresh_id = await _adopt(factory)
+
+        assert fresh_id != previous_id
+        assert await _monitor_state(factory, fresh_id) == _SEEDABLE_PREDECESSOR_STATE
+
+    @pytest.mark.unit
+    async def test_seeded_event_records_predecessor_and_copied_keys(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(
+            factory,
+            previous_id,
+            {**_SEEDABLE_PREDECESSOR_STATE, **_NEVER_COPIED_PREDECESSOR_STATE},
+        )
+
+        fresh_id = await _adopt(factory)
+
+        events = await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE)
+        assert len(events) == 1
+        event = events[0]
+        assert event.reason_code == PR_ADOPTION_SEEDED_REASON
+        payload = event.payload or {}
+        assert payload["predecessor_workspace_id"] == previous_id
+        assert payload["copied_keys"] == sorted(_SEEDABLE_PREDECESSOR_STATE)
+        assert payload["copied_key_count"] == len(_SEEDABLE_PREDECESSOR_STATE)
+        assert payload["repo_slug"] == REPO_SLUG
+        assert payload["pr_number"] == PR_NUMBER
+
+    @pytest.mark.unit
+    async def test_first_adoption_seeds_nothing_and_emits_no_seeded_event(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        fresh_id = await _adopt(factory)
+
+        assert await _monitor_state(factory, fresh_id) == {}
+        assert await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE) == []
+
+    @pytest.mark.unit
+    async def test_predecessor_without_copyable_state_emits_no_seeded_event(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(factory, previous_id, _NEVER_COPIED_PREDECESSOR_STATE)
+
+        fresh_id = await _adopt(factory)
+
+        assert await _monitor_state(factory, fresh_id) == {}
+        assert await _events(factory, fresh_id, PR_ADOPTION_SEEDED_EVENT_TYPE) == []
+
+    @pytest.mark.unit
+    async def test_attaching_to_live_adoption_neither_seeds_nor_emits_event(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        first_id = await _adopt(factory)
+
+        async with factory() as session:
+            attached = await PullRequestMonitorAdoptionService(
+                session,
+                metadata_fetcher=_MetadataFetcher(_metadata()),
+            ).adopt(_request(hint="ignored on the attach path"))
+            await session.commit()
+
+        assert attached.attached_existing is True
+        assert attached.workspace_id == first_id
+        assert await _monitor_state(factory, first_id) == {}
+        assert await _events(factory, first_id, PR_ADOPTION_SEEDED_EVENT_TYPE) == []
+
+    @pytest.mark.unit
+    async def test_hint_arms_pending_operator_hint_bound_to_the_adoption_operation(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        directive = "do NOT edit .github/workflows/*"
+
+        workspace_id = await _adopt(factory, hint=directive)
+
+        state = await _monitor_state(factory, workspace_id)
+        assert OPERATOR_HINT_STATE_KEY in state
+        payload = json.loads(state[OPERATOR_HINT_STATE_KEY])
+        assert payload["status"] == "pending"
+        assert payload["directive"] == directive
+        assert payload["reason_code"] == PR_ADOPTION_OPERATOR_HINT_REASON
+        async with factory() as session:
+            operation = (
+                await session.execute(
+                    select(Operation).where(Operation.workspace_id == workspace_id)
+                )
+            ).scalar_one()
+            operation_payload = dict(operation.payload or {})
+        assert payload["operation_id"] == operation.id
+        assert operation_payload["pending_operator_hint"]["directive"] == directive
+        hint = operator_hint_from_threads(state)
+        assert hint is not None
+        assert hint.directive == directive
+        assert hint.status == "pending"
+
+    @pytest.mark.unit
+    async def test_adoption_event_payload_records_pending_operator_hint(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        directive = "revert the workflow edit"
+
+        workspace_id = await _adopt(factory, hint=directive)
+
+        events = await _events(factory, workspace_id, PR_ADOPTION_REQUESTED_EVENT_TYPE)
+        assert len(events) == 1
+        pending = (events[0].payload or {})["pending_operator_hint"]
+        assert pending["directive"] == directive
+        assert pending["status"] == "pending"
+        assert pending["reason_code"] == PR_ADOPTION_OPERATOR_HINT_REASON
+
+    @pytest.mark.unit
+    async def test_adoption_without_hint_omits_pending_operator_hint_from_payloads(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        workspace_id = await _adopt(factory)
+
+        events = await _events(factory, workspace_id, PR_ADOPTION_REQUESTED_EVENT_TYPE)
+        assert "pending_operator_hint" not in (events[0].payload or {})
+        async with factory() as session:
+            operation = (
+                await session.execute(
+                    select(Operation).where(Operation.workspace_id == workspace_id)
+                )
+            ).scalar_one()
+        assert "pending_operator_hint" not in dict(operation.payload or {})
+
+    @pytest.mark.unit
+    async def test_hint_and_seeded_verdicts_coexist_on_the_new_row(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        previous_id = await _adopt(factory)
+        await _fail_with_monitor_state(factory, previous_id, _SEEDABLE_PREDECESSOR_STATE)
+
+        fresh_id = await _adopt(factory, hint="keep the deferred issues closed")
+
+        state = await _monitor_state(factory, fresh_id)
+        assert OPERATOR_HINT_STATE_KEY in state
+        assert {
+            key: value for key, value in state.items() if key != OPERATOR_HINT_STATE_KEY
+        } == _SEEDABLE_PREDECESSOR_STATE
+
+    @pytest.mark.unit
+    async def test_seeded_hint_decides_before_unaddressed_comments(
+        self,
+        factory: async_sessionmaker[AsyncSession],
+    ) -> None:
+        workspace_id = await _adopt(factory, hint="rewrite the failing migration first")
+
+        state = await _monitor_state(factory, workspace_id)
+        monitor_state = MonitorState(threads_addressed_ids=dict(state))
+        monitor_state.pending_operator_hint = operator_hint_from_threads(state)
+        status = PRStatus(
+            number=PR_NUMBER,
+            head_sha="h" * 40,
+            mergeable=MergeableState.MERGEABLE,
+            check_state=CheckState.SUCCESS,
+            unresolved_inline_threads=(),
+            unresolved_review_comments=(
+                ReviewComment(comment_id="C_new", body_excerpt="please fix", author="reviewer"),
+            ),
+            base_behind_count=0,
+            merge_state_status=MergeStateStatus.CLEAN,
+        )
+
+        action = decide(status, monitor_state, MonitorConfig(auto_merge=True))
+
+        assert isinstance(action, AddressOperatorHint)

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -212,8 +212,19 @@ def test_result_is_key_sorted_and_does_not_alias_the_input() -> None:
         (" " + "a" * 40 + "\n", "a" * 40, True),
         # Force-push / revert / plain new commits: continuity is not established.
         ("a" * 40, "c" * 40, False),
-        # An abbreviated prefix is not proof of identity -- fail closed.
+        # An abbreviated prefix is not proof of identity -- fail closed, even
+        # when both sides carry the *same* abbreviation.
         ("a" * 40, "a" * 7, False),
+        ("a" * 7, "a" * 40, False),
+        ("a" * 7, "a" * 7, False),
+        # A whitespace-only value strips to empty and is not a commit id; two of
+        # them must not compare equal into established continuity.
+        ("   ", " ", False),
+        ("\n\t", "\n\t", False),
+        ("   ", "a" * 40, False),
+        ("a" * 40, "   ", False),
+        # Non-hex junk of the right length is not a commit id either.
+        ("z" * 40, "z" * 40, False),
         # Missing evidence on either side fails closed too.
         (None, "a" * 40, False),
         ("a" * 40, None, False),

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -22,12 +22,8 @@ from awf.service.pr_monitor_adoption_seed import (
 )
 
 # One entry per copyable marker class named by issue #911, minus the
-# head-dependent ``fix_committed`` (see ``_HEAD_DEPENDENT_COPIED_CASES``).
+# head-dependent verdicts (see ``_HEAD_DEPENDENT_COPIED_CASES``).
 _COPIED_CASES: list[tuple[str, str]] = [
-    # Bare GraphQL review-thread id -> verdict.
-    ("PRRT_kwDOSJAM6s6fNhZo", "false_positive"),
-    # Bare numeric review-comment id -> verdict (aira-infra PR #229).
-    ("5120013294", "false_positive"),
     # ``issue:<id>`` issue-comment verdicts (aira-infra PR #229).
     ("issue:5549804922", "defer"),
     ("issue:5549805025", "needs_human"),
@@ -38,12 +34,18 @@ _COPIED_CASES: list[tuple[str, str]] = [
     ("__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123", "dimileeh/aira-infra#42"),
 ]
 
-# ``fix_committed`` asserts the fix is in the branch, so it crosses only when the
-# adopted head is still the head the predecessor processed.
+# ``fix_committed`` asserts the fix is in the branch and ``false_positive`` asserts
+# the branch already refutes the reviewer, so both cross only when the adopted head
+# is still the head the predecessor processed.
 _HEAD_DEPENDENT_COPIED_CASES: list[tuple[str, str]] = [
     ("PRRT_kwDOSJAM6s6fNhZp", "fix_committed"),
     ("5120013295", "fix_committed"),
     ("issue:5549805027", "fix_committed"),
+    # Bare GraphQL review-thread id -> verdict.
+    ("PRRT_kwDOSJAM6s6fNhZo", "false_positive"),
+    # Bare numeric review-comment id -> verdict (aira-infra PR #229).
+    ("5120013294", "false_positive"),
+    ("issue:5549805028", "false_positive"),
 ]
 
 # Every other marker class observed in ``monitor_threads_addressed``.
@@ -84,16 +86,18 @@ def test_allowlisted_marker_classes_are_copied(
 
 @pytest.mark.unit
 @pytest.mark.parametrize(("key", "value"), _HEAD_DEPENDENT_COPIED_CASES)
-def test_fix_committed_crosses_only_with_head_continuity(key: str, value: str) -> None:
+def test_code_dependent_verdicts_cross_only_with_head_continuity(key: str, value: str) -> None:
     assert seedable_monitor_state({key: value}, head_continuity=True) == {key: value}
     # Force-pushed / reverted head: the inherited fix may be gone from the branch,
-    # so the successor must re-triage the comment instead of suppressing it.
+    # and the code that refuted the reviewer may be gone with it, so the successor
+    # must re-triage the comment instead of suppressing it.
     assert seedable_monitor_state({key: value}, head_continuity=False) == {}
 
 
 @pytest.mark.unit
-def test_head_continuity_fails_closed_when_unspecified() -> None:
-    assert seedable_monitor_state({"5120013295": "fix_committed"}) == {}
+@pytest.mark.parametrize("verdict", ["fix_committed", "false_positive"])
+def test_head_continuity_fails_closed_when_unspecified(verdict: str) -> None:
+    assert seedable_monitor_state({"5120013295": verdict}) == {}
 
 
 @pytest.mark.unit
@@ -166,7 +170,9 @@ def test_prefix_only_marker_keys_are_dropped(key: str) -> None:
     ],
 )
 def test_non_verdict_key_shapes_are_dropped(key: str) -> None:
-    assert seedable_monitor_state({key: "false_positive"}) == {}
+    # ``head_continuity=True`` keeps the value seedable, so the key shape alone
+    # is what decides the drop.
+    assert seedable_monitor_state({key: "false_positive"}, head_continuity=True) == {}
 
 
 @pytest.mark.unit
@@ -188,7 +194,7 @@ def test_result_is_key_sorted_and_does_not_alias_the_input() -> None:
         "PRRT_kwDOSJAM6s6fNhZo": "false_positive",
     }
 
-    seeded = seedable_monitor_state(previous)
+    seeded = seedable_monitor_state(previous, head_continuity=True)
 
     assert list(seeded) == sorted(previous)
     seeded["extra"] = "false_positive"

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -1,0 +1,154 @@
+"""Allowlist policy for seeding a re-adopted PR monitor from its predecessor.
+
+Issue #911: only thread/review-comment verdicts, review-comment body hashes and
+deferred-issue markers may cross the supersede boundary. Everything else --
+protected-block state, awaiting-check timestamps, operator-hint bookkeeping,
+merge-block/workflow-scope markers -- must stay behind so the fresh monitor
+re-derives it from the live PR.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from awf.service.pr_monitor_adoption_seed import (
+    PR_ADOPTION_OPERATOR_HINT_REASON,
+    PR_ADOPTION_SEEDED_EVENT_TYPE,
+    PR_ADOPTION_SEEDED_REASON,
+    seedable_monitor_state,
+)
+
+# One entry per copyable marker class named by issue #911.
+_COPIED_CASES: list[tuple[str, str]] = [
+    # Bare GraphQL review-thread id -> verdict.
+    ("PRRT_kwDOSJAM6s6fNhZo", "false_positive"),
+    # Bare numeric review-comment id -> verdict (aira-infra PR #229).
+    ("5120013294", "fix_committed"),
+    # ``issue:<id>`` issue-comment verdicts (aira-infra PR #229).
+    ("issue:5549804922", "defer"),
+    ("issue:5549805025", "needs_human"),
+    ("issue:5549805026", "agent_failed"),
+    # Review-comment body hash companion of a copied comment verdict.
+    ("__review_comment_body_hash__:5120013294", "a" * 64),
+    # Deferred-issue marker.
+    ("__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123", "dimileeh/aira-infra#42"),
+]
+
+# Every other marker class observed in ``monitor_threads_addressed``.
+_DROPPED_CASES: list[tuple[str, str]] = [
+    ("__awf_protected_block_preserved_head__", "d" * 40),
+    ("__awf_protected_block__:PRRT_kwDOSJAM6s6fNhZo", "blocked"),
+    ("__awf_awaiting_required_checks_first_seen__:229:" + "d" * 40, "1700000000"),
+    ("__awf_pending_operator_hint__", '{"reason":"prior","status":"pending"}'),
+    ("__awf_operator_hint_processed__:op_1", "processed"),
+    ("__awf_awaiting_workflow_scope__:229:" + "d" * 40, "armed"),
+    ("__awf_merge_block_attention__:229", "notified"),
+    ("__awf_merge_method_blocked__:229:" + "d" * 40, "squash"),
+    ("__awf_merge_queue_wait__:229", "waiting"),
+    ("__awf_notify__:229", "sent"),
+    ("__awf_pending_check_stale__:229", "stale"),
+    ("__awf_initial_review_grace_started__:229", "1700000000"),
+    ("__awf_non_check_reviewer_settle_done__:229:" + "d" * 40, "elapsed"),
+    ("__awf_outdated_resolve_requeued__:PRRT_kwDOSJAM6s6fNhZo", "requeued"),
+    ("__awf_unpublished_abandon_event_pending__", "pending"),
+    ("__awf_protected_history_directive_reblocked__", "reblocked"),
+    ("__defer_reason__:PRRT_kwDOSJAM6s6fNhZo", "waiting on reviewer"),
+    ("__needs_human_reason__:5120013294", "ambiguous"),
+    ("__review_thread_body_hash__:PRRT_kwDOSJAM6s6fNhZo", "b" * 64),
+    ("__truncated__", "true"),
+]
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("key", "value"), _COPIED_CASES)
+def test_allowlisted_marker_classes_are_copied(key: str, value: str) -> None:
+    assert seedable_monitor_state({key: value}) == {key: value}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("key", "value"), _DROPPED_CASES)
+def test_never_copied_marker_classes_are_dropped(key: str, value: str) -> None:
+    assert seedable_monitor_state({key: value}) == {}
+
+
+@pytest.mark.unit
+def test_mixed_state_copies_only_the_allowlisted_subset() -> None:
+    previous = dict(_COPIED_CASES + _DROPPED_CASES)
+
+    assert seedable_monitor_state(previous) == dict(_COPIED_CASES)
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("verdict", ["elapsed", "", "processed", '{"status":"pending"}'])
+def test_bare_id_key_with_non_verdict_value_is_dropped(verdict: str) -> None:
+    assert seedable_monitor_state({"5120013294": verdict}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("value", [None, 1, {"verdict": "false_positive"}])
+def test_non_string_values_are_dropped(value: Any) -> None:
+    assert seedable_monitor_state({"5120013294": value}) == {}
+    assert seedable_monitor_state({"__review_comment_body_hash__:5120013294": value}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "key",
+    ["__review_comment_body_hash__:", "__deferred_issue_filed__:"],
+)
+def test_prefix_only_marker_keys_are_dropped(key: str) -> None:
+    assert seedable_monitor_state({key: "a" * 64}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "key",
+    [
+        # Fail closed: a reserved marker is never a verdict entry even when its
+        # value happens to match the verdict vocabulary.
+        "__awf_protected_block__:PRRT_kwDOSJAM6s6fNhZo",
+        "__truncated__",
+        # ``issue:`` with no id, and other non-id key shapes.
+        "issue:",
+        "",
+        "not a bare id",
+        "issue:5549804922:extra",
+    ],
+)
+def test_non_verdict_key_shapes_are_dropped(key: str) -> None:
+    assert seedable_monitor_state({key: "false_positive"}) == {}
+
+
+@pytest.mark.unit
+def test_empty_marker_values_are_dropped() -> None:
+    assert seedable_monitor_state({"__review_comment_body_hash__:5120013294": ""}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("previous", [None, {}])
+def test_absent_predecessor_state_seeds_nothing(previous: Any) -> None:
+    assert seedable_monitor_state(previous) == {}
+
+
+@pytest.mark.unit
+def test_result_is_key_sorted_and_does_not_alias_the_input() -> None:
+    previous = {
+        "issue:5549804922": "defer",
+        "5120013294": "false_positive",
+        "PRRT_kwDOSJAM6s6fNhZo": "false_positive",
+    }
+
+    seeded = seedable_monitor_state(previous)
+
+    assert list(seeded) == sorted(previous)
+    seeded["extra"] = "false_positive"
+    assert "extra" not in previous
+
+
+@pytest.mark.unit
+def test_reason_codes_and_event_type_are_stable() -> None:
+    assert PR_ADOPTION_SEEDED_EVENT_TYPE == "workspace.pr_monitor_adoption_seeded"
+    assert PR_ADOPTION_SEEDED_REASON == "PR_ADOPTION_SEEDED_FROM_PREDECESSOR"
+    assert PR_ADOPTION_OPERATOR_HINT_REASON == "PR_ADOPTION_OPERATOR_HINT"

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -115,6 +115,17 @@ def test_prefix_only_marker_keys_are_dropped(key: str) -> None:
         "",
         "not a bare id",
         "issue:5549804922:extra",
+        # The allowlist is closed to the three contract forms: a bookkeeping key
+        # that merely *looks* like an identifier never crosses the boundary,
+        # however verdict-shaped its value is.
+        "foo",
+        "thread-1",
+        "issue:abc",
+        "issue:5549804922x",
+        "5120013294-1",
+        "PRRT",
+        "PRRT_",
+        "prrt_kwDOSJAM6s6fNhZo",
     ],
 )
 def test_non_verdict_key_shapes_are_dropped(key: str) -> None:

--- a/tests/unit/service/test_pr_monitor_adoption_seed.py
+++ b/tests/unit/service/test_pr_monitor_adoption_seed.py
@@ -17,15 +17,17 @@ from awf.service.pr_monitor_adoption_seed import (
     PR_ADOPTION_OPERATOR_HINT_REASON,
     PR_ADOPTION_SEEDED_EVENT_TYPE,
     PR_ADOPTION_SEEDED_REASON,
+    head_continuity_established,
     seedable_monitor_state,
 )
 
-# One entry per copyable marker class named by issue #911.
+# One entry per copyable marker class named by issue #911, minus the
+# head-dependent ``fix_committed`` (see ``_HEAD_DEPENDENT_COPIED_CASES``).
 _COPIED_CASES: list[tuple[str, str]] = [
     # Bare GraphQL review-thread id -> verdict.
     ("PRRT_kwDOSJAM6s6fNhZo", "false_positive"),
     # Bare numeric review-comment id -> verdict (aira-infra PR #229).
-    ("5120013294", "fix_committed"),
+    ("5120013294", "false_positive"),
     # ``issue:<id>`` issue-comment verdicts (aira-infra PR #229).
     ("issue:5549804922", "defer"),
     ("issue:5549805025", "needs_human"),
@@ -34,6 +36,14 @@ _COPIED_CASES: list[tuple[str, str]] = [
     ("__review_comment_body_hash__:5120013294", "a" * 64),
     # Deferred-issue marker.
     ("__deferred_issue_filed__:PRRT_kwDOSJAM6s6fNhZo:abc123", "dimileeh/aira-infra#42"),
+]
+
+# ``fix_committed`` asserts the fix is in the branch, so it crosses only when the
+# adopted head is still the head the predecessor processed.
+_HEAD_DEPENDENT_COPIED_CASES: list[tuple[str, str]] = [
+    ("PRRT_kwDOSJAM6s6fNhZp", "fix_committed"),
+    ("5120013295", "fix_committed"),
+    ("issue:5549805027", "fix_committed"),
 ]
 
 # Every other marker class observed in ``monitor_threads_addressed``.
@@ -62,22 +72,49 @@ _DROPPED_CASES: list[tuple[str, str]] = [
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("head_continuity", [True, False])
 @pytest.mark.parametrize(("key", "value"), _COPIED_CASES)
-def test_allowlisted_marker_classes_are_copied(key: str, value: str) -> None:
-    assert seedable_monitor_state({key: value}) == {key: value}
+def test_allowlisted_marker_classes_are_copied(
+    key: str,
+    value: str,
+    head_continuity: bool,
+) -> None:
+    assert seedable_monitor_state({key: value}, head_continuity=head_continuity) == {key: value}
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize(("key", "value"), _HEAD_DEPENDENT_COPIED_CASES)
+def test_fix_committed_crosses_only_with_head_continuity(key: str, value: str) -> None:
+    assert seedable_monitor_state({key: value}, head_continuity=True) == {key: value}
+    # Force-pushed / reverted head: the inherited fix may be gone from the branch,
+    # so the successor must re-triage the comment instead of suppressing it.
+    assert seedable_monitor_state({key: value}, head_continuity=False) == {}
+
+
+@pytest.mark.unit
+def test_head_continuity_fails_closed_when_unspecified() -> None:
+    assert seedable_monitor_state({"5120013295": "fix_committed"}) == {}
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("head_continuity", [True, False])
 @pytest.mark.parametrize(("key", "value"), _DROPPED_CASES)
-def test_never_copied_marker_classes_are_dropped(key: str, value: str) -> None:
-    assert seedable_monitor_state({key: value}) == {}
+def test_never_copied_marker_classes_are_dropped(
+    key: str,
+    value: str,
+    head_continuity: bool,
+) -> None:
+    assert seedable_monitor_state({key: value}, head_continuity=head_continuity) == {}
 
 
 @pytest.mark.unit
 def test_mixed_state_copies_only_the_allowlisted_subset() -> None:
-    previous = dict(_COPIED_CASES + _DROPPED_CASES)
+    previous = dict(_COPIED_CASES + _HEAD_DEPENDENT_COPIED_CASES + _DROPPED_CASES)
 
-    assert seedable_monitor_state(previous) == dict(_COPIED_CASES)
+    assert seedable_monitor_state(previous, head_continuity=True) == dict(
+        _COPIED_CASES + _HEAD_DEPENDENT_COPIED_CASES
+    )
+    assert seedable_monitor_state(previous, head_continuity=False) == dict(_COPIED_CASES)
 
 
 @pytest.mark.unit
@@ -156,6 +193,41 @@ def test_result_is_key_sorted_and_does_not_alias_the_input() -> None:
     assert list(seeded) == sorted(previous)
     seeded["extra"] = "false_positive"
     assert "extra" not in previous
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("adopted", "predecessor", "established"),
+    [
+        # Same head: the predecessor's fix is still what the PR points at.
+        ("a" * 40, "a" * 40, True),
+        # Case/whitespace noise from the forge is not a discontinuity.
+        (("a" * 39) + "B", ("a" * 39) + "b", True),
+        (" " + "a" * 40 + "\n", "a" * 40, True),
+        # Force-push / revert / plain new commits: continuity is not established.
+        ("a" * 40, "c" * 40, False),
+        # An abbreviated prefix is not proof of identity -- fail closed.
+        ("a" * 40, "a" * 7, False),
+        # Missing evidence on either side fails closed too.
+        (None, "a" * 40, False),
+        ("a" * 40, None, False),
+        ("", "a" * 40, False),
+        ("a" * 40, "", False),
+        (None, None, False),
+    ],
+)
+def test_head_continuity_is_established_only_by_sha_equality(
+    adopted: str | None,
+    predecessor: str | None,
+    established: bool,
+) -> None:
+    assert (
+        head_continuity_established(
+            adopted_head_sha=adopted,
+            predecessor_head_sha=predecessor,
+        )
+        is established
+    )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_a13f481203a6484e809f979b` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Implement https://github.com/dimileeh/agent-workspace-fabric/issues/911 exactly as scoped there (read the issue body). Strict TDD: failing tests first, then the smallest green change. Keep the 99 % coverage gate and the OpenAPI drift gate (`uv run --python 3.12 --extra dev python scripts/generate_openapi.py` after schema changes). Do not touch `src/awf/runtime/pr_monitor_runner/` — the runner-side fix is issue #910, handled by a separate workspace.

## Part 1 — seed from the terminal predecessor

In `src/awf/service/pr_monitor_adoption.py`, the path that supersedes a terminal previous workspace for the same repo/PR (`PR_ADOPTION_SUPERSEDED_TERMINAL_WORKSPACE`, see `pr_monitor_adoption_helpers.PR_ADOPTION_SUPERSEDED_REASON`) currently carries nothing over. Copy into the new workspace's `monitor_threads_addressed` ONLY these marker classes from the predecessor's `monitor_threads_addressed`:

- thread / review-comment verdict entries: keys that are a bare thread id (e.g. `PRRT_…`), a numeric review-comment id, or `issue:<id>` whose value is a verdict string;
- `__review_comment_body_hash__:*`;
- `__deferred_issue_filed__:*`.

Explicitly never copy `__awf_protected_block_preserved_head__`, `__awf_protected_block__:*`, `__awf_awaiting_required_checks_first_seen__:*`, `__awf_pending_operator_hint__`, awaiting-workflow-scope / merge-block markers, or any key outside the allowlist — implement it as an allowlist, not a denylist. Append a `WorkspaceEvent` `workspace.pr_monitor_adoption_seeded` (reason code e.g. `PR_ADOPTION_SEEDED_FROM_PREDECESSOR`) with the predecessor workspace id and the list of copied keys. Real-world reference: on aira-infra PR #229 the successor `ws_6fee851e74804257958b159b` re-dispositioned `5120013294`, `issue:5549804922`, `issue:5549805025` that its predecessor `ws_8742af8348794904b3ce5ac5` had already marked `false_positive`.

## Part 2 — optional operator hint at adoption

Add an optional `hint: str | None` (directive text, bounded length like other text fields) to `PullRequestMonitorAdoptionRequest` in `src/awf/api/schemas.py`, thread it through the service, expose it as `awf workspace adopt --hint` in the CLI and in the MCP adoption tool (keep REST/CLI/MCP in lockstep as CLAUDE.md requires). Persist it as the pending operator hint using the existing helpers `persist_operator_hint` / `build_pending_operator_hint_payload` (see `src/awf/service/controls_guide.py`) on the new row before the workspace becomes claimable, and record it in the adoption event payload the way `guide` does, so the monitor's first `decide()` returns `AddressOperatorHint` before any `AddressComments`.

## Tests

- Adoption service: seeding copies exactly the allowlisted keys (parametrise over every marker class above, including the never-copy ones), records the seeded event, and is a no-op when there is no terminal predecessor.
- `hint`: request schema validation, service persistence (`__awf_pending_operator_hint__` present with status `pending`), CLI flag wiring, MCP tool wiring, and the adoption event payload.
- Regenerate `openapi.json`; run ruff, ruff format, mypy and the full pytest suite before pushing.

Follow AGENTS.md and CLAUDE.md (plan under `plans/`, reason codes end-to-end, no bare `except Exception`).

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor adoption persistence and comment-disposition inheritance at re-adoption; incorrect allowlist or head-continuity logic could suppress or re-open review work, while operator hints affect agent repair ordering after sync.
> 
> **Overview**
> **Re-adoption** after superseding a terminal monitor workspace now **seeds** an allowlisted slice of the predecessor’s `monitor_threads_addressed` (comment/thread verdicts, review-comment body hashes, deferred-issue markers) onto the new row, with **`fix_committed` / `false_positive` only when the adopted head SHA matches** the predecessor’s last processed head. A **`workspace.pr_monitor_adoption_seeded`** event records copied keys; run-local bookkeeping (protected blocks, operator hints, merge/workflow markers, etc.) is **not** carried over.
> 
> **Optional `hint`** (max 1024 chars) on PR monitor adoption is exposed on **REST, CLI `--hint`, and MCP**, armed as a **pending operator hint** on **new** adoptions (same persistence as `guide`), reflected on the adoption operation/event payloads, and scheduled **after base sync** in `decide()` — **ignored** when attaching to an already-live adoption. Adoption request models move to **`schemas_pr_adoption`** with re-exports from `schemas`; **OpenAPI** and docs updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1389643737742979fb0435898c41e3e8176af07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional operator hints to PR monitor adoption through the CLI, MCP, and REST API.
  * Hints are limited to 1,024 characters and guide repair work after required base synchronization and conflict resolution.
  * Successor adoptions retain selected review decisions and deferred-issue markers from terminal predecessors when applicable.
  * Existing live workspace attachments ignore hints.

* **Documentation**
  * Updated CLI, MCP, REST API, and PR adoption references to clarify hint timing, behavior, and limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->