### PR TITLE
fix: preserve hosted execution authentication on adoption retry

### DIFF
--- a/src/awf/common/github_client.py
+++ b/src/awf/common/github_client.py
@@ -46,6 +46,9 @@ from awf.common.github_client_adoption import (
     list_open_pull_requests_for_branch as list_open_pull_requests_for_branch,
 )
 from awf.common.github_client_adoption import (
+    parse_forge_pull_request_url as parse_forge_pull_request_url,
+)
+from awf.common.github_client_adoption import (
     parse_github_pull_request_url as parse_github_pull_request_url,
 )
 from awf.common.github_client_reconcile import (

--- a/src/awf/common/github_client_adoption.py
+++ b/src/awf/common/github_client_adoption.py
@@ -259,6 +259,42 @@ def parse_github_pull_request_url(pr_url: str) -> tuple[RepoRef, int]:
     return RepoRef(owner=parts[0], name=parts[1]), number
 
 
+def parse_forge_pull_request_url(pr_url: str, *, forge: str) -> tuple[RepoRef, int]:
+    """Parse a PR web URL for ``forge`` into ``(repo, number)``.
+
+    Dispatches on the trusted source forge so Bitbucket ``/pull-requests/<n>``
+    URLs are accepted the same way GitHub ``/pull/<n>`` URLs are. Hosted retry
+    identity must stay forge-neutral (AWF core is generic — AGENTS.md).
+    """
+    if forge == "github":
+        return parse_github_pull_request_url(pr_url)
+    if forge == "bitbucket":
+        return _parse_bitbucket_pull_request_url(pr_url)
+    raise ValueError(f"Unsupported forge for pull request URL parse: {forge!r}")
+
+
+def _parse_bitbucket_pull_request_url(pr_url: str) -> tuple[RepoRef, int]:
+    """Parse a canonical Bitbucket PR URL into ``(repo, number)``."""
+    from urllib.parse import urlsplit
+
+    from awf.common.github_client import RepoRef
+
+    parsed = urlsplit(pr_url.strip())
+    host = (parsed.hostname or "").lower()
+    if parsed.scheme not in {"http", "https"} or host != "bitbucket.org":
+        raise ValueError(f"Cannot parse Bitbucket pull request URL: {pr_url!r}")
+    parts = [part for part in parsed.path.strip("/").split("/") if part]
+    if len(parts) < 4 or parts[2] != "pull-requests":
+        raise ValueError(f"Cannot parse Bitbucket pull request URL: {pr_url!r}")
+    try:
+        number = int(parts[3])
+    except ValueError as exc:
+        raise ValueError(f"Cannot parse Bitbucket pull request URL: {pr_url!r}") from exc
+    if number <= 0:
+        raise ValueError(f"Cannot parse Bitbucket pull request URL: {pr_url!r}")
+    return RepoRef(owner=parts[0], name=parts[1], forge="bitbucket"), number
+
+
 class BranchOpenPullRequestResolver:
     """Resolve open PRs for a branch using the GitHub CLI."""
 

--- a/src/awf/service/workspaces.py
+++ b/src/awf/service/workspaces.py
@@ -80,6 +80,7 @@ from awf.service.workspace_runtime_health import (
     runtime_workspace_from_workspace,
 )
 from awf.service.workspaces_retry_errors import (
+    WorkspaceHostedDelegationNotConfiguredError,
     WorkspaceRetryError,
     WorkspaceRetryPrAlreadyMergedError,
     WorkspaceRetryPrStateUnavailableError,
@@ -1362,6 +1363,7 @@ __all__ = [
     "WorkspaceRetrySalvageUnavailableError",
     "WorkspaceRetryPrAlreadyMergedError",
     "WorkspaceRetryPrStateUnavailableError",
+    "WorkspaceHostedDelegationNotConfiguredError",
     "WorkspaceProviderReadinessBlockedError",
     "WorkspaceUnsupportedAgentRuntimeError",
     "WorkspaceCreateIdempotencyConflictError",

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -20,7 +20,10 @@ from awf.common.forge import concrete_forge_for_repo, make_forge_client
 from awf.common.forge_errors import ForgeClientError
 from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
 from awf.common.github_client import RepoRef, parse_github_pull_request_url
-from awf.common.workspace_policy import pr_adoption_is_hosted
+from awf.common.workspace_policy import (
+    PR_ADOPTION_EXECUTION_MODE_LOCAL,
+    pr_adoption_is_hosted,
+)
 from awf.db.enums import OperationStatus, OperationType, TaskKind, WorkspaceStatus
 from awf.db.models import (
     Task,
@@ -525,6 +528,29 @@ def _raise_if_hosted_delegation_unconfigured_for_retry(settings: Settings) -> No
         ) from exc
 
 
+def _downgrade_unqualified_hosted_adoption_to_local(task_policy: dict[str, Any]) -> None:
+    """Convert hosted execution to local when hosted retry qualification failed.
+
+    Hosted mode may only survive when ``_is_retained_open_hosted_pr_adoption_retry``
+    admits the auth bypass. Falling through to local preflight while leaving
+    ``execution.mode=hosted`` would provision and execute as hosted with
+    incomplete/inconsistent identity and skip hosted-delegation gates.
+    Closed-PR fallback still clears adoption later; this only normalizes mode.
+    """
+    if not pr_adoption_is_hosted(task_policy):
+        return
+    adoption = task_policy.get("pr_adoption")
+    if not isinstance(adoption, dict):
+        return
+    execution = adoption.get("execution")
+    updated_execution = (
+        {**execution, "mode": PR_ADOPTION_EXECUTION_MODE_LOCAL}
+        if isinstance(execution, dict)
+        else {"mode": PR_ADOPTION_EXECUTION_MODE_LOCAL}
+    )
+    task_policy["pr_adoption"] = {**adoption, "execution": updated_execution}
+
+
 async def _load_retry_preview_outside_request_session(
     session: AsyncSession,
     workspace_id: str,
@@ -830,11 +856,14 @@ async def retry_workspace_row(
     # preflight: Core has no local coding credential by design, and Cloud leases
     # credentials to hosted execution jobs. Qualification requires explicit hosted
     # mode + open prefetch so a closed-PR fallback cannot bypass local auth.
+    # Unqualified hosted policies must downgrade to local before that fallthrough
+    # so a successful local preflight/override cannot retain mode=hosted.
     preflight: dict[str, Any] | None
     if _is_retained_open_hosted_pr_adoption_retry(source, prefetched_feature_pr):
         _raise_if_hosted_delegation_unconfigured_for_retry(resolved_settings)
         preflight = None
     else:
+        _downgrade_unqualified_hosted_adoption_to_local(retried_task_policy)
         preflight_environ = workspaces_create.overlay_profile_provider_credentials(
             workspaces_create.overlay_profile_ollama_base_url(
                 provider_environ if provider_environ is not None else os.environ,

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -5,15 +5,14 @@ from __future__ import annotations
 import asyncio
 import os
 import re
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
 
-from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT
 from awf.common.commands import AsyncioSubprocessRunner
 from awf.common.config import Settings, get_settings
 from awf.common.forge import concrete_forge_for_repo, make_forge_client
@@ -25,18 +24,12 @@ from awf.common.workspace_policy import (
     pr_adoption_is_hosted,
 )
 from awf.db.enums import OperationStatus, OperationType, TaskKind, WorkspaceStatus
-from awf.db.models import (
-    Task,
-    TaskAttempt,
-    Workspace,
-    WorkspaceEvent,
-)
+from awf.db.models import Workspace, WorkspaceEvent
 from awf.db.repositories import (
     OperationRepository,
     QueueDecisionRepository,
     ResourceReservationRepository,
     TaskAttemptRepository,
-    TaskRepository,
     WorkspaceRepository,
 )
 from awf.db.repositories.base import (
@@ -46,14 +39,11 @@ from awf.db.repositories.base import (
 )
 from awf.db.session import make_session_factory
 from awf.runtime.hosted_delegation import HostedDelegationConfigError
-from awf.runtime.planning import (
-    AGENT_PLAN_PHASE_SCOPE_VIOLATION,
-    PLAN_CONFORMANCE_UNSATISFIED,
-    build_planning_scope_retry_prompt,
-)
+from awf.runtime.planning import build_planning_scope_retry_prompt
 from awf.runtime.pr_monitor_actions import AbortReason
 from awf.runtime.pr_push_remote import retained_fork_pr_adoption
 from awf.service import workspaces_retry_payloads as _retry_payloads
+from awf.service import workspaces_retry_recovery as _retry_recovery
 from awf.service.config import (
     hosted_delegation_config_from_service_settings,
     resolve_service_settings,
@@ -66,10 +56,7 @@ from awf.service.conformance_salvage import (
     build_conformance_salvage_retry_prompt,
     capture_conformance_salvage,
 )
-from awf.service.coordination import (
-    owned_path_overlap_coordination_warnings,
-    task_policy_with_coordination_warnings,
-)
+from awf.service.coordination import owned_path_overlap_coordination_warnings
 from awf.service.node_identity import effective_worker_node_id
 from awf.service.provider_readiness import (
     HttpGet,
@@ -77,17 +64,9 @@ from awf.service.provider_readiness import (
 )
 from awf.service.scheduler import (
     SCHEDULER_POLICY_KEY,
-    scheduler_retry_policy_context,
     scheduler_score_from_workspace,
 )
 from awf.service.workspaces_retry_errors import WorkspaceHostedDelegationNotConfiguredError
-
-if TYPE_CHECKING:
-    from awf.service.workspaces import (
-        _AgentTimeoutRetryContext,
-        _ConformanceRetryContext,
-        _PlanningScopeRetryContext,
-    )
 
 # Re-export payload helpers so ``workspaces.py`` lazy proxies and existing
 # ``from awf.service.workspaces_retry import …`` sites keep working.
@@ -101,6 +80,19 @@ _latest_failed_state_event = _retry_payloads._latest_failed_state_event
 _optional_retry_evidence_str = _retry_payloads._optional_retry_evidence_str
 _payload_str = _retry_payloads._payload_str
 _retry_evidence_gaps = _retry_payloads._retry_evidence_gaps
+
+# Re-export recovery helpers for import compatibility and monkeypatch targets.
+_agent_timeout_retry_context = _retry_recovery._agent_timeout_retry_context
+_agent_timeout_salvage_recovery_payload = _retry_recovery._agent_timeout_salvage_recovery_payload
+_conformance_retry_context = _retry_recovery._conformance_retry_context
+_conformance_salvage_recovery_payload = _retry_recovery._conformance_salvage_recovery_payload
+_is_plan_conformance_unsatisfied = _retry_recovery._is_plan_conformance_unsatisfied
+_planning_scope_recovery_payload = _retry_recovery._planning_scope_recovery_payload
+_planning_scope_retry_context = _retry_recovery._planning_scope_retry_context
+_prune_and_migrate_retired_agent = _retry_recovery._prune_and_migrate_retired_agent
+_prune_retired_fallbacks = _retry_recovery._prune_retired_fallbacks
+_retry_task_for_source = _retry_recovery._retry_task_for_source
+_retry_task_policy = _retry_recovery._retry_task_policy
 
 
 _PR_NUMBER_RE = re.compile(r"/pull(?:-requests)?/(\d+)(?=[/?#]|$)")
@@ -1414,292 +1406,4 @@ async def retry_workspace_row(
         new_workspace=retried,
         operation=operation,
         attempt_number=attempt.attempt_number,
-    )
-
-
-def _prune_and_migrate_retired_agent(
-    policy: dict[str, Any],
-    current_agent: str | None = None,
-) -> tuple[dict[str, Any], str | None]:
-    """Prune retired or unsupported fallback entries from a cloned retry policy,
-    and promote a launchable fallback if current_agent is retired.
-
-    Replacing retired slots with None placeholders preserves fallback attempt indexes.
-    If current_agent is retired/unlaunchable and a remaining approved launchable
-    fallback exists (respecting provider_recovery_state and max_fallback_attempts),
-    promotes that fallback as the new primary agent, updates agent_model, and sets
-    its slot in fallbacks to None.
-    """
-    recovery = policy.get("provider_recovery")
-    if not isinstance(recovery, Mapping):
-        return policy, current_agent
-    raw_fallbacks = recovery.get("fallbacks")
-    if not isinstance(raw_fallbacks, Sequence) or isinstance(raw_fallbacks, str):
-        return policy, current_agent
-
-    from awf.service.provider_readiness import is_launchable_agent
-
-    is_primary_launchable = True if current_agent is None else is_launchable_agent(current_agent)
-    promoted_index: int | None = None
-    target_agent = current_agent
-
-    if not is_primary_launchable:
-        from awf.service.provider_recovery import (
-            PROVIDER_RECOVERY_STATE_KEY,
-            _select_fallback_target_with_index,
-            parse_provider_recovery_policy,
-            parse_provider_recovery_state,
-        )
-
-        rec_policy = parse_provider_recovery_policy(policy)
-        rec_state = parse_provider_recovery_state(policy)
-        fallback_target, target_index = _select_fallback_target_with_index(rec_policy, rec_state)
-        if fallback_target is not None:
-            promoted_index = target_index
-            target_agent = fallback_target.agent
-            policy["agent_model"] = fallback_target.model
-
-            raw_state = policy.get(PROVIDER_RECOVERY_STATE_KEY)
-            state_dict = dict(raw_state) if isinstance(raw_state, Mapping) else {}
-            state_dict["fallback_attempt_number"] = target_index + 1
-            state_dict["launched_fallback_attempts"] = rec_state.launched_fallback_attempts + 1
-            state_dict["retry_attempt_number"] = 0
-            policy[PROVIDER_RECOVERY_STATE_KEY] = state_dict
-
-    pruned: list[Any] = []
-    for idx, item in enumerate(raw_fallbacks):
-        if idx == promoted_index:
-            pruned.append(None)
-        elif isinstance(item, Mapping):
-            fb_agent = item.get("agent")
-            if fb_agent is not None and is_launchable_agent(fb_agent):
-                pruned.append(item)
-            else:
-                pruned.append(None)
-        else:
-            pruned.append(None)
-
-    updated_recovery = dict(recovery)
-    updated_recovery["fallbacks"] = pruned
-    policy["provider_recovery"] = updated_recovery
-    return policy, target_agent
-
-
-def _prune_retired_fallbacks(policy: dict[str, Any]) -> dict[str, Any]:
-    """Prune retired or unsupported fallback entries from a cloned retry policy."""
-    pruned_policy, _ = _prune_and_migrate_retired_agent(policy, current_agent=None)
-    return pruned_policy
-
-
-def _retry_task_policy(
-    source: Workspace,
-    coordination_warnings: Sequence[Mapping[str, Any]],
-    *,
-    planning_scope_context: _PlanningScopeRetryContext | None,
-) -> tuple[dict[str, Any], str]:
-    """Build the task policy dict and target agent for a retried workspace."""
-    policy = task_policy_with_coordination_warnings(
-        scheduler_retry_policy_context(
-            deepcopy(source.task_policy),
-            source_workspace_id=source.id,
-            parent_failure_reason=source.failure_reason,
-        ),
-        coordination_warnings,
-    )
-    policy, target_agent = _prune_and_migrate_retired_agent(policy, current_agent=source.agent)
-    effective_agent = target_agent or source.agent
-    if (
-        planning_scope_context is not None
-        and planning_scope_context.fallback_model is not None
-        and effective_agent == source.agent
-    ):
-        # Same mutual exclusion as provider recovery: a fixed fallback must
-        # clear retained Cursor Auto mode or executor helpers keep preferring
-        # auto-smart[...] and silently ignore the approved pin.
-        from awf.service.provider_recovery import _install_fixed_recovery_model
-
-        policy = _install_fixed_recovery_model(
-            policy,
-            planning_scope_context.fallback_model["model"],
-        )
-    return policy, effective_agent
-
-
-def _planning_scope_recovery_payload(
-    context: _PlanningScopeRetryContext,
-) -> dict[str, Any]:
-    """Build the planning-scope recovery payload dict from a retry context."""
-    payload: dict[str, Any] = {
-        "source_reason_code": context.reason_code,
-        "planning_scope_evidence_ref": context.evidence_ref,
-        "recovery_strategy": context.recovery_strategy,
-        "salvage_policy": context.salvage_policy,
-    }
-    if context.salvage is not None:
-        payload["salvage"] = context.salvage
-    if context.fallback_model is not None:
-        payload["fallback_model"] = context.fallback_model
-    return payload
-
-
-def _conformance_salvage_recovery_payload(
-    *,
-    conformance_context: _ConformanceRetryContext | None,
-    salvage: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Build the conformance-salvage recovery payload dict for a retry."""
-    payload: dict[str, Any] = {
-        "source_reason_code": PLAN_CONFORMANCE_UNSATISFIED,
-        "conformance_salvage": dict(salvage),
-    }
-    remaining_gaps = _compact_string_list(salvage.get("remaining_gaps"))
-    if remaining_gaps:
-        payload["remaining_gaps"] = remaining_gaps
-    if conformance_context is not None:
-        payload["conformance_evidence_ref"] = conformance_context.evidence_ref
-    elif salvage.get("conformance_evidence_ref") is not None:
-        payload["conformance_evidence_ref"] = salvage.get("conformance_evidence_ref")
-    return payload
-
-
-def _agent_timeout_salvage_recovery_payload(
-    *,
-    context: _AgentTimeoutRetryContext,
-    salvage: Mapping[str, Any],
-) -> dict[str, Any]:
-    """Build retry payload metadata for an agent-timeout salvage continuation."""
-    payload: dict[str, Any] = {
-        "source_reason_code": context.reason_code,
-        "recovery_strategy": "continue_from_timeout_salvage",
-        "conformance_salvage": dict(salvage),
-        "agent_timeout_evidence_ref": context.evidence_ref,
-    }
-    message = _optional_retry_evidence_str(context.evidence.get("message"))
-    if message is not None:
-        payload["source_failure_message"] = message
-    return payload
-
-
-async def _retry_task_for_source(
-    session: AsyncSession,
-    source: Workspace,
-    *,
-    source_attempt: TaskAttempt | None = None,
-) -> Task:
-    """Retrieve or create the task associated with a source workspace for retry."""
-    if source_attempt is None:
-        source_attempt = await TaskAttemptRepository(session).get_by_workspace_id(source.id)
-    if source_attempt is not None:
-        task = await TaskRepository(session).get(source_attempt.task_id)
-        if task is not None:
-            return task
-
-    fallback_idempotency_key = f"retry-source-workspace:{source.id}"
-    return await TaskRepository(session).create_or_get(
-        repo_url=source.repo_url,
-        base_branch=source.branch_base,
-        title=source.task_title,
-        prompt=source.task_prompt,
-        external_id=source.task_external_id,
-        idempotency_key=fallback_idempotency_key,
-        task_class=source.task_class,
-        owned_paths=list(source.owned_paths),
-    )
-
-
-def _is_plan_conformance_unsatisfied(workspace: Workspace) -> bool:
-    """Check whether the workspace's latest failure is a plan-conformance-unsatisfied reason."""
-    details = workspace_failure_details_payload(workspace)
-    if details is None:
-        return False
-    return details.get("reason_code") == PLAN_CONFORMANCE_UNSATISFIED
-
-
-def _agent_timeout_retry_context(workspace: Workspace) -> Any:
-    """Build a timeout retry context from the workspace's failure details if applicable."""
-    workspaces = _workspace_service()
-    details = workspace_failure_details_payload(workspace)
-    if details is None:
-        return None
-    reason_code = details.get("reason_code")
-    if reason_code not in {AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT}:
-        return None
-    message = _optional_retry_evidence_str(details.get("message"))
-    evidence: dict[str, Any] = {
-        "reason_code": reason_code,
-        "gaps": [
-            "The previous agent run timed out before it could finish.",
-            "Continue from the recovered implementation diff and complete the original task.",
-        ],
-    }
-    if message is not None:
-        evidence["message"] = message
-    return workspaces._AgentTimeoutRetryContext(
-        reason_code=str(reason_code),
-        evidence=evidence,
-        evidence_ref={
-            "source_workspace_id": workspace.id,
-            "event_type": "workspace.state_changed",
-            "reason_code": str(reason_code),
-        },
-    )
-
-
-def _conformance_retry_context(workspace: Workspace) -> Any:
-    """Build a conformance retry context from the workspace's failure details if applicable."""
-    workspaces = _workspace_service()
-    details = workspace_failure_details_payload(workspace)
-    if details is None or details.get("reason_code") != PLAN_CONFORMANCE_UNSATISFIED:
-        return None
-    evidence = details.get("conformance")
-    if not isinstance(evidence, Mapping):
-        return None
-    return workspaces._ConformanceRetryContext(
-        reason_code=PLAN_CONFORMANCE_UNSATISFIED,
-        evidence=evidence,
-        evidence_ref={
-            "source_workspace_id": workspace.id,
-            "event_type": "workspace.state_changed",
-            "reason_code": PLAN_CONFORMANCE_UNSATISFIED,
-        },
-    )
-
-
-def _planning_scope_retry_context(workspace: Workspace) -> Any:
-    """Build a planning-scope retry context from the workspace's failure details if applicable."""
-    workspaces = _workspace_service()
-    details = workspace_failure_details_payload(workspace)
-    if details is None or details.get("reason_code") != AGENT_PLAN_PHASE_SCOPE_VIOLATION:
-        return None
-    evidence = details.get("planning_scope")
-    if not isinstance(evidence, Mapping):
-        return None
-    recovery_strategy_value = details.get("recovery_strategy")
-    recovery_strategy = (
-        recovery_strategy_value
-        if isinstance(recovery_strategy_value, str)
-        else "discard_and_replan"
-    )
-    salvage_policy_value = details.get("salvage_policy")
-    salvage_policy = (
-        salvage_policy_value
-        if isinstance(salvage_policy_value, str)
-        else "explicit_salvage_required"
-    )
-    fallback_model = workspaces._approved_planning_scope_fallback_model(workspace)
-    evidence_payload = dict(evidence)
-    if fallback_model is not None:
-        evidence_payload["fallback_model"] = fallback_model
-    return workspaces._PlanningScopeRetryContext(
-        reason_code=AGENT_PLAN_PHASE_SCOPE_VIOLATION,
-        evidence=evidence_payload,
-        evidence_ref={
-            "source_workspace_id": workspace.id,
-            "event_type": "workspace.state_changed",
-            "reason_code": AGENT_PLAN_PHASE_SCOPE_VIOLATION,
-        },
-        recovery_strategy=recovery_strategy,
-        salvage_policy=salvage_policy,
-        salvage=_compact_salvage_payload(details.get("salvage")),
-        fallback_model=fallback_model,
     )

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -19,7 +19,7 @@ from awf.common.config import Settings, get_settings
 from awf.common.forge import concrete_forge_for_repo, make_forge_client
 from awf.common.forge_errors import ForgeClientError
 from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
-from awf.common.github_client import RepoRef
+from awf.common.github_client import RepoRef, parse_github_pull_request_url
 from awf.common.workspace_policy import pr_adoption_is_hosted
 from awf.db.enums import OperationStatus, OperationType, TaskKind, WorkspaceStatus
 from awf.db.models import (
@@ -396,8 +396,13 @@ def _retained_hosted_adoption_identity_is_complete_and_consistent(
     Hosted retry may skip local provider authentication, so admission must not
     trust a hosted marker plus generic workspace PR columns. The adoption block
     must include repo/PR/head/base identity (including ``head_sha``), and that
-    identity must agree with the prefetched open PR (and any PR number already
-    resolved on the row).
+    identity must agree with the trusted source repository and the prefetched
+    open PR (and any PR number already resolved on the row).
+
+    Target identity is ``repo_slug`` + parseable ``pr_url`` for the *base*
+    repository. Optional fork ``head_repo_slug`` is distinct and is not required
+    to match the target. Live forge head/base SHAs may advance after adoption,
+    so this gate does not demand equality with the original snapshot SHAs.
     """
     adoption = _sync_feature_pr_adoption(source)
     if adoption is None:
@@ -433,8 +438,24 @@ def _retained_hosted_adoption_identity_is_complete_and_consistent(
     if resolved_pr_number is not None and resolved_pr_number != adoption_pr_number:
         return False
 
-    url_pr_number = _pr_number_from_url(values["pr_url"])
-    return url_pr_number is None or url_pr_number == adoption_pr_number
+    try:
+        source_repo = RepoRef.from_url(source.repo_url)
+        adoption_repo = RepoRef.from_url(values["repo_slug"])
+        url_repo, url_pr_number = parse_github_pull_request_url(values["pr_url"])
+    except ValueError:
+        return False
+
+    if url_pr_number != adoption_pr_number:
+        return False
+    if (
+        adoption_repo.forge != source_repo.forge
+        or adoption_repo.slug().lower() != source_repo.slug().lower()
+    ):
+        return False
+    return (
+        url_repo.forge == source_repo.forge
+        and url_repo.slug().lower() == source_repo.slug().lower()
+    )
 
 
 def _is_retained_open_hosted_pr_adoption_retry(

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -362,15 +362,34 @@ def _clear_closed_sync_feature_pr_adoption(
     return TaskKind.feature_branch_pr.value
 
 
-def _is_existing_feature_pr_preserve_candidate(source: Workspace) -> bool:
-    """Return whether retry should consult live forge state for this source PR."""
-    if _planning_scope_retry_context(source) is not None:
-        return False
+def _has_existing_feature_pr_identity(source: Workspace) -> bool:
+    """Return whether the source carries feature/sync PR number + URL identity."""
     pr_number = _existing_feature_pr_number(source)
     return (
         source.task_kind in {TaskKind.feature_branch_pr.value, TaskKind.sync_feature_pr.value}
         and _existing_feature_pr_url(source) is not None
         and pr_number is not None
+    )
+
+
+def _is_existing_feature_pr_preserve_candidate(source: Workspace) -> bool:
+    """Return whether retry should consult live forge state for this source PR."""
+    if _planning_scope_retry_context(source) is not None:
+        return False
+    return _has_existing_feature_pr_identity(source)
+
+
+def _is_hosted_adoption_forge_prefetch_candidate(source: Workspace) -> bool:
+    """Return whether hosted auth-bypass qualification needs forge prefetch.
+
+    Planning-scope retries deliberately skip preserve-existing-PR live rebinding,
+    but retained hosted sync adoptions still need an open-PR forge check so Core
+    without local credentials can skip Codex preflight.
+    """
+    return (
+        source.task_kind == TaskKind.sync_feature_pr.value
+        and pr_adoption_is_hosted(source.task_policy)
+        and _has_existing_feature_pr_identity(source)
     )
 
 
@@ -471,12 +490,16 @@ def _is_retained_open_hosted_pr_adoption_retry(
     ``sync_feature_pr`` adoption that lacks complete, consistent identity must
     likewise fall through — later retry code can fill missing head/base from
     workspace columns, so identity must be proven before the auth bypass.
+
+    Planning-scope retries are not preserve candidates, but they still retain
+    hosted sync adoption; qualification therefore keys off PR identity + forge
+    prefetch rather than ``_is_existing_feature_pr_preserve_candidate``.
     """
     if source.task_kind != TaskKind.sync_feature_pr.value:
         return False
     if not pr_adoption_is_hosted(source.task_policy):
         return False
-    if not _is_existing_feature_pr_preserve_candidate(source):
+    if not _has_existing_feature_pr_identity(source):
         return False
     if prefetched_feature_pr is None:
         return False
@@ -530,16 +553,20 @@ async def _prefetch_existing_feature_pr_state(
 ) -> _PrefetchedFeaturePrState | None:
     """Fetch forge PR lifecycle/snapshot before acquiring the source row lock.
 
-    Returns ``None`` when the unlocked source is not a preserve-existing-feature-PR
-    candidate. Raises the same ``WorkspaceRetry*`` errors as the former in-lock path
-    for lookup failure or an already-merged PR.
+    Returns ``None`` when the unlocked source is neither a preserve-existing-
+    feature-PR candidate nor a hosted adoption that needs forge state for the
+    local-auth bypass. Raises the same ``WorkspaceRetry*`` errors as the former
+    in-lock path for lookup failure or an already-merged PR.
     """
     workspaces = _workspace_service()
     if WorkspaceStatus(source.status) == WorkspaceStatus.recovering:
         return None
     if WorkspaceStatus(source.status) not in workspaces.RETRYABLE_WORKSPACE_STATUSES:
         return None
-    if not _is_existing_feature_pr_preserve_candidate(source):
+    if not (
+        _is_existing_feature_pr_preserve_candidate(source)
+        or _is_hosted_adoption_forge_prefetch_candidate(source)
+    ):
         return None
 
     pr_number = _existing_feature_pr_number(source)

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -107,6 +107,7 @@ HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON = "HOSTED_PR_ADOPTION_LOCAL_P
 def _hosted_open_adoption_local_preflight_bypass(
     *,
     source_workspace_id: str,
+    agent: str,
 ) -> dict[str, Any]:
     """Build the readiness snapshot that preserves the hosted local-auth bypass.
 
@@ -116,12 +117,38 @@ def _hosted_open_adoption_local_preflight_bypass(
     ``cursor_auto_mode`` is present, causing provision-time Router probing
     without Core credentials. A nonblocking snapshot replaces any stale
     ``blocks_launch=true`` source copy and documents the intentional bypass.
+
+    The snapshot must include every field required by
+    ``ProviderReadinessPreflightResponse`` so retry/GET responses can serialize
+    it after admission (incomplete payloads raise ValidationError).
     """
     from datetime import UTC, datetime
 
+    from awf.db.enums import AgentRuntime
+    from awf.service.provider_readiness import _LAUNCH_PROVIDER_BY_AGENT
+
+    try:
+        runtime = AgentRuntime(agent)
+    except ValueError:
+        agent_name = str(agent)
+        provider: str = "unknown"
+    else:
+        agent_name = runtime.value
+        provider = _LAUNCH_PROVIDER_BY_AGENT.get(runtime, "unknown")
+
     return {
-        "blocks_launch": False,
+        "provider": provider,
+        "agent": agent_name,
+        "model": None,
+        "model_source": None,
         "readiness_status": "ready",
+        # Local auth was intentionally not probed; credentials are leased to
+        # hosted execution. Mirror the no-provider_result defaults from
+        # ``_launch_preflight_payload``.
+        "auth_status": "unknown",
+        "auth_source": "not_observed",
+        "credential_scope": "not_observed",
+        "isolation": "none",
         "probe_status": "skipped",
         "reason_code": HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON,
         "message": (
@@ -131,7 +158,9 @@ def _hosted_open_adoption_local_preflight_bypass(
         "override_required": False,
         "override_requested": False,
         "override_used": False,
+        "blocks_launch": False,
         "checked_at": datetime.now(UTC).isoformat(),
+        "credential_sources": [],
         "source_workspace_id": source_workspace_id,
     }
 
@@ -896,6 +925,7 @@ async def retry_workspace_row(
         _raise_if_hosted_delegation_unconfigured_for_retry(resolved_settings)
         preflight = _hosted_open_adoption_local_preflight_bypass(
             source_workspace_id=source.id,
+            agent=target_agent,
         )
     else:
         _downgrade_unqualified_hosted_adoption_to_local(retried_task_policy)

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -112,6 +112,7 @@ class _PrefetchedFeaturePrState:
     lifecycle: PullRequestLifecycle
     head_ref: str | None = None
     base_sha: str | None = None
+    head_sha: str | None = None
     from_snapshot: bool = False
 
 
@@ -216,6 +217,11 @@ def _existing_feature_pr_adoption_head_ref(source: Workspace) -> str | None:
     return _adoption_policy_str(source, "head_ref")
 
 
+def _existing_feature_pr_adoption_head_sha(source: Workspace) -> str | None:
+    """Return the adopted PR head SHA from ``pr_adoption.head_sha``."""
+    return _adoption_policy_str(source, "head_sha")
+
+
 def _existing_feature_pr_adoption_base_sha(source: Workspace) -> str | None:
     """Return the adopted PR base SHA from ``pr_adoption.base_sha``."""
     return _adoption_policy_str(source, "base_sha")
@@ -226,6 +232,7 @@ def _sync_retried_adoption_live_refs(
     *,
     head_ref: str | None,
     base_sha: str | None,
+    head_sha: str | None = None,
 ) -> None:
     """Keep ``pr_adoption`` head/base aligned with live forge refs on retry.
 
@@ -233,6 +240,11 @@ def _sync_retried_adoption_live_refs(
     via ``_provision_remote_push_branch``. If retry only updates the column and
     leaves a stale adoption head (e.g. after a forge rename), provision
     overwrites the live push target and sends fixes to the wrong branch.
+
+    Hosted identity similarly reads ``pr_adoption.head_sha`` as
+    ``expected_head_sha``. After a hosted repair advances the tip, retry must
+    refresh that OID or an enforcing delegate rejects / validates the wrong
+    revision.
     """
     adoption = task_policy.get("pr_adoption")
     if not isinstance(adoption, dict):
@@ -241,6 +253,8 @@ def _sync_retried_adoption_live_refs(
         adoption["head_ref"] = head_ref.strip()
     if isinstance(base_sha, str) and base_sha.strip():
         adoption["base_sha"] = base_sha.strip()
+    if isinstance(head_sha, str) and head_sha.strip():
+        adoption["head_sha"] = head_sha.strip()
 
 
 _PROFILE_TRUSTED_BASE_SHA_KEY = "profile_trusted_base_sha"
@@ -381,14 +395,22 @@ def _retained_hosted_adoption_identity_is_complete_and_consistent(
 
     Hosted retry may skip local provider authentication, so admission must not
     trust a hosted marker plus generic workspace PR columns. The adoption block
-    must include repo/PR/head/base identity, and that identity must agree with
-    the prefetched open PR (and any PR number already resolved on the row).
+    must include repo/PR/head/base identity (including ``head_sha``), and that
+    identity must agree with the prefetched open PR (and any PR number already
+    resolved on the row).
     """
     adoption = _sync_feature_pr_adoption(source)
     if adoption is None:
         return False
 
-    required_strings = ("repo_slug", "pr_url", "head_ref", "base_ref", "base_sha")
+    required_strings = (
+        "repo_slug",
+        "pr_url",
+        "head_ref",
+        "base_ref",
+        "base_sha",
+        "head_sha",
+    )
     values: dict[str, str] = {}
     for key in required_strings:
         raw = adoption.get(key)
@@ -397,6 +419,8 @@ def _retained_hosted_adoption_identity_is_complete_and_consistent(
         values[key] = raw.strip()
 
     if not _is_exact_full_commit_sha(values["base_sha"]):
+        return False
+    if not _is_exact_full_commit_sha(values["head_sha"]):
         return False
 
     adoption_pr_number = _adoption_identity_pr_number(adoption)
@@ -510,6 +534,7 @@ async def _prefetch_existing_feature_pr_state(
                 lifecycle=snapshot.lifecycle,
                 head_ref=snapshot.head_ref,
                 base_sha=snapshot.base_sha,
+                head_sha=snapshot.head_sha,
                 from_snapshot=True,
             )
     except (ForgeClientError, OSError, TimeoutError, ValueError) as exc:
@@ -553,7 +578,7 @@ async def _live_pr_lifecycle(source: Workspace, pr_number: int) -> PullRequestLi
 
 
 async def _live_pr_snapshot(source: Workspace, pr_number: int) -> PullRequestSnapshot:
-    """Return the source PR's current lifecycle and head ref from its forge."""
+    """Return the source PR's current lifecycle, head ref, and SHAs from its forge."""
     repo = RepoRef.from_url(source.repo_url)
     forge = concrete_forge_for_repo(
         (source.resolved_profile or {}).get("forge"),
@@ -937,6 +962,7 @@ async def retry_workspace_row(
     closed_existing_feature_pr = existing_feature_pr and _source_pr_closed_externally(source)
     live_pr_head_ref: str | None = None
     live_pr_base_commit: str | None = None
+    live_pr_head_sha: str | None = None
     retry_base_commit: str | None = None
     if preserve_existing_feature_pr:
         assert existing_feature_pr_number is not None
@@ -959,6 +985,7 @@ async def retry_workspace_row(
         if prefetched_feature_pr.from_snapshot:
             live_pr_head_ref = prefetched_feature_pr.head_ref
             live_pr_base_commit = prefetched_feature_pr.base_sha
+            live_pr_head_sha = prefetched_feature_pr.head_sha
         # Merged PRs are rejected during prefetch (before the row lock).
         preserve_existing_feature_pr = existing_pr_lifecycle is PullRequestLifecycle.open
         closed_existing_feature_pr = not preserve_existing_feature_pr
@@ -1099,13 +1126,24 @@ async def retry_workspace_row(
                     "reason_code": "PR_BASE_COMMIT_UNAVAILABLE",
                 },
             )
+        candidate_head_shas = (
+            live_pr_head_sha,
+            _existing_feature_pr_adoption_head_sha(source),
+            source.monitor_last_commit_sha,
+        )
+        retry_head_sha = next(
+            (head_sha.strip() for head_sha in candidate_head_shas if head_sha and head_sha.strip()),
+            None,
+        )
         # Provisioning prefers pr_adoption.head_ref over remote_push_branch.
         # Keep the adoption policy in lockstep with the live forge refs so a
         # renamed PR head is not overwritten back to the stale adoption value.
+        # Hosted expected_head_sha likewise reads pr_adoption.head_sha.
         _sync_retried_adoption_live_refs(
             retried_task_policy,
             head_ref=retry_remote_push_branch,
             base_sha=retry_base_commit,
+            head_sha=retry_head_sha,
         )
 
     retry_resolved_profile = deepcopy(source.resolved_profile)

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -18,7 +18,7 @@ from awf.common.config import Settings, get_settings
 from awf.common.forge import concrete_forge_for_repo, make_forge_client
 from awf.common.forge_errors import ForgeClientError
 from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
-from awf.common.github_client import RepoRef, parse_github_pull_request_url
+from awf.common.github_client import RepoRef, parse_forge_pull_request_url
 from awf.common.workspace_policy import (
     PR_ADOPTION_EXECUTION_MODE_LOCAL,
     pr_adoption_is_hosted,
@@ -521,7 +521,18 @@ def _retained_hosted_adoption_identity_is_complete_and_consistent(
     try:
         source_repo = RepoRef.from_url(source.repo_url)
         adoption_repo = RepoRef.from_url(values["repo_slug"])
-        url_repo, url_pr_number = parse_github_pull_request_url(values["pr_url"])
+        # Bare ``owner/repo`` slugs default to github in RepoRef.from_url; bind
+        # forge from the trusted source so Bitbucket adoptions compare correctly.
+        if "github.com" not in values["repo_slug"] and "bitbucket.org" not in values["repo_slug"]:
+            adoption_repo = RepoRef(
+                owner=adoption_repo.owner,
+                name=adoption_repo.name,
+                forge=source_repo.forge,
+            )
+        url_repo, url_pr_number = parse_forge_pull_request_url(
+            values["pr_url"],
+            forge=source_repo.forge,
+        )
     except ValueError:
         return False
 

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -98,6 +98,43 @@ _retry_task_policy = _retry_recovery._retry_task_policy
 _PR_NUMBER_RE = re.compile(r"/pull(?:-requests)?/(\d+)(?=[/?#]|$)")
 PrLifecycleChecker = Callable[[Workspace, int], Awaitable[PullRequestLifecycle]]
 
+# Explicit nonblocking readiness reason for retained open hosted PR-adoption
+# retries that intentionally skip local Codex/CLI/Router probes. Must keep
+# ``blocks_launch`` false so deferred Cursor Auto preflight does not re-probe.
+HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON = "HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED"
+
+
+def _hosted_open_adoption_local_preflight_bypass(
+    *,
+    source_workspace_id: str,
+) -> dict[str, Any]:
+    """Build the readiness snapshot that preserves the hosted local-auth bypass.
+
+    Hosted open-adoption retries skip local provider probes. Leaving
+    ``provider_readiness_preflight`` absent would still make
+    ``_needs_deferred_cursor_auto_router_preflight`` true whenever
+    ``cursor_auto_mode`` is present, causing provision-time Router probing
+    without Core credentials. A nonblocking snapshot replaces any stale
+    ``blocks_launch=true`` source copy and documents the intentional bypass.
+    """
+    from datetime import UTC, datetime
+
+    return {
+        "blocks_launch": False,
+        "readiness_status": "ready",
+        "probe_status": "skipped",
+        "reason_code": HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON,
+        "message": (
+            "Retained open hosted PR adoption skips local provider readiness; "
+            "credentials are leased to hosted execution."
+        ),
+        "override_required": False,
+        "override_requested": False,
+        "override_used": False,
+        "checked_at": datetime.now(UTC).isoformat(),
+        "source_workspace_id": source_workspace_id,
+    }
+
 
 @dataclass(frozen=True, slots=True)
 class _PrefetchedFeaturePrState:
@@ -848,12 +885,18 @@ async def retry_workspace_row(
     # preflight: Core has no local coding credential by design, and Cloud leases
     # credentials to hosted execution jobs. Qualification requires explicit hosted
     # mode + open prefetch so a closed-PR fallback cannot bypass local auth.
+    # Record an explicit nonblocking bypass snapshot (not a missing key) so a
+    # retained ``cursor_auto_mode`` cannot re-enter deferred Router preflight
+    # during provisioning, and so a stale source ``blocks_launch=true`` copy
+    # cannot trip the provisioner defense-in-depth path.
     # Unqualified hosted policies must downgrade to local before that fallthrough
     # so a successful local preflight/override cannot retain mode=hosted.
-    preflight: dict[str, Any] | None
+    preflight: dict[str, Any]
     if _is_retained_open_hosted_pr_adoption_retry(source, prefetched_feature_pr):
         _raise_if_hosted_delegation_unconfigured_for_retry(resolved_settings)
-        preflight = None
+        preflight = _hosted_open_adoption_local_preflight_bypass(
+            source_workspace_id=source.id,
+        )
     else:
         _downgrade_unqualified_hosted_adoption_to_local(retried_task_policy)
         preflight_environ = workspaces_create.overlay_profile_provider_credentials(
@@ -962,15 +1005,10 @@ async def retry_workspace_row(
                 context=agent_timeout_context,
                 salvage=conformance_salvage,
             )
-    # Fresh probe result always wins. When hosted open adoption skips a local
-    # probe (preflight is None), drop any source deepcopy snapshot — a prior
-    # blocks_launch=true (e.g. deferred Cursor Router failure) would otherwise
-    # survive and trip the provisioner's defense-in-depth path.
+    # Fresh probe or hosted-bypass snapshot always wins over a source deepcopy
+    # (including a prior blocks_launch=true deferred Cursor Router failure).
     retried_task_policy = dict(retried_task_policy)
-    if preflight is not None:
-        retried_task_policy["provider_readiness_preflight"] = preflight
-    else:
-        retried_task_policy.pop("provider_readiness_preflight", None)
+    retried_task_policy["provider_readiness_preflight"] = preflight
 
     host_ports: list[int] = []
     host_ports.extend(

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -360,6 +360,59 @@ def _is_existing_feature_pr_preserve_candidate(source: Workspace) -> bool:
     )
 
 
+def _adoption_identity_pr_number(adoption: Mapping[str, Any]) -> int | None:
+    """Return a positive PR number from the adoption block itself (not columns)."""
+    raw = adoption.get("pr_number")
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, int):
+        return raw if raw > 0 else None
+    if isinstance(raw, str) and raw.strip().isdigit():
+        parsed = int(raw.strip())
+        return parsed if parsed > 0 else None
+    return None
+
+
+def _retained_hosted_adoption_identity_is_complete_and_consistent(
+    source: Workspace,
+    prefetched_feature_pr: _PrefetchedFeaturePrState,
+) -> bool:
+    """Return whether ``pr_adoption`` itself carries a complete retained identity.
+
+    Hosted retry may skip local provider authentication, so admission must not
+    trust a hosted marker plus generic workspace PR columns. The adoption block
+    must include repo/PR/head/base identity, and that identity must agree with
+    the prefetched open PR (and any PR number already resolved on the row).
+    """
+    adoption = _sync_feature_pr_adoption(source)
+    if adoption is None:
+        return False
+
+    required_strings = ("repo_slug", "pr_url", "head_ref", "base_ref", "base_sha")
+    values: dict[str, str] = {}
+    for key in required_strings:
+        raw = adoption.get(key)
+        if not isinstance(raw, str) or not raw.strip():
+            return False
+        values[key] = raw.strip()
+
+    if not _is_exact_full_commit_sha(values["base_sha"]):
+        return False
+
+    adoption_pr_number = _adoption_identity_pr_number(adoption)
+    if adoption_pr_number is None:
+        return False
+    if adoption_pr_number != prefetched_feature_pr.pr_number:
+        return False
+
+    resolved_pr_number = _existing_feature_pr_number(source)
+    if resolved_pr_number is not None and resolved_pr_number != adoption_pr_number:
+        return False
+
+    url_pr_number = _pr_number_from_url(values["pr_url"])
+    return url_pr_number is None or url_pr_number == adoption_pr_number
+
+
 def _is_retained_open_hosted_pr_adoption_retry(
     source: Workspace,
     prefetched_feature_pr: _PrefetchedFeaturePrState | None,
@@ -369,7 +422,10 @@ def _is_retained_open_hosted_pr_adoption_retry(
     Qualification is strict and must key off prefetched forge state as well as
     source policy. A closed PR with a stale hosted marker falls through to the
     local provider preflight (and then closed-PR feature-task fallback), so a
-    hosted marker alone must never skip local auth.
+    hosted marker alone must never skip local auth. A malformed or spoofed
+    ``sync_feature_pr`` adoption that lacks complete, consistent identity must
+    likewise fall through — later retry code can fill missing head/base from
+    workspace columns, so identity must be proven before the auth bypass.
     """
     if source.task_kind != TaskKind.sync_feature_pr.value:
         return False
@@ -382,7 +438,12 @@ def _is_retained_open_hosted_pr_adoption_retry(
     pr_number = _existing_feature_pr_number(source)
     if pr_number is None or prefetched_feature_pr.pr_number != pr_number:
         return False
-    return prefetched_feature_pr.lifecycle is PullRequestLifecycle.open
+    if prefetched_feature_pr.lifecycle is not PullRequestLifecycle.open:
+        return False
+    return _retained_hosted_adoption_identity_is_complete_and_consistent(
+        source,
+        prefetched_feature_pr,
+    )
 
 
 def _raise_if_hosted_delegation_unconfigured_for_retry(settings: Settings) -> None:

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -920,8 +920,15 @@ async def retry_workspace_row(
     # cannot trip the provisioner defense-in-depth path.
     # Unqualified hosted policies must downgrade to local before that fallthrough
     # so a successful local preflight/override cannot retain mode=hosted.
+    # The same qualification omits local host-port admission below: hosted
+    # provisioning only renders the stack (no local compose launch / bind), and
+    # initial hosted adoption reserves no local ports.
     preflight: dict[str, Any]
-    if _is_retained_open_hosted_pr_adoption_retry(source, prefetched_feature_pr):
+    retained_open_hosted_pr_adoption = _is_retained_open_hosted_pr_adoption_retry(
+        source,
+        prefetched_feature_pr,
+    )
+    if retained_open_hosted_pr_adoption:
         _raise_if_hosted_delegation_unconfigured_for_retry(resolved_settings)
         preflight = _hosted_open_adoption_local_preflight_bypass(
             source_workspace_id=source.id,
@@ -1041,34 +1048,37 @@ async def retry_workspace_row(
     retried_task_policy["provider_readiness_preflight"] = preflight
 
     host_ports: list[int] = []
-    host_ports.extend(
-        workspaces.host_ports_from_task_policy_companions(
-            retried_task_policy,
+    if not retained_open_hosted_pr_adoption:
+        host_ports.extend(
+            workspaces.host_ports_from_task_policy_companions(
+                retried_task_policy,
+            )
         )
-    )
-    # TOCTOU note: source.resolved_profile reflects the profile resolved
-    # when the source workspace was originally provisioned.  Legacy rows may
-    # still have an inline requested_profile but no resolved_profile snapshot,
-    # so fall back to that requested profile for admission-time source runtime
-    # and conflict checks.  If the repository's auto-resolved profile changed
-    # between the source run and this retry (e.g. .awf.yml was updated), the
-    # ports checked here may not match what the provisioner will actually use.
-    # The provisioner's _check_auto_resolved_profile_host_ports serves as the
-    # definitive gate, so a conflict missed here surfaces as an
-    # INFRASTRUCTURE_FAILURE inside the provisioner rather than a 409 at
-    # dispatch.  This is an inherent limitation of auto-resolved profiles at
-    # dispatch time.
-    source_profile_for_port_admission = (
-        source.resolved_profile if source.resolved_profile is not None else source.requested_profile
-    )
-    host_ports.extend(
-        workspaces.host_ports_from_resolved_profile(source_profile_for_port_admission),
-    )
-    _seen: set[int] = set()
-    for _hp in host_ports:
-        if _hp in _seen:
-            raise workspaces.WorkspaceCreateDuplicateHostPortError(host_port=_hp)
-        _seen.add(_hp)
+        # TOCTOU note: source.resolved_profile reflects the profile resolved
+        # when the source workspace was originally provisioned.  Legacy rows may
+        # still have an inline requested_profile but no resolved_profile snapshot,
+        # so fall back to that requested profile for admission-time source runtime
+        # and conflict checks.  If the repository's auto-resolved profile changed
+        # between the source run and this retry (e.g. .awf.yml was updated), the
+        # ports checked here may not match what the provisioner will actually use.
+        # The provisioner's _check_auto_resolved_profile_host_ports serves as the
+        # definitive gate, so a conflict missed here surfaces as an
+        # INFRASTRUCTURE_FAILURE inside the provisioner rather than a 409 at
+        # dispatch.  This is an inherent limitation of auto-resolved profiles at
+        # dispatch time.
+        source_profile_for_port_admission = (
+            source.resolved_profile
+            if source.resolved_profile is not None
+            else source.requested_profile
+        )
+        host_ports.extend(
+            workspaces.host_ports_from_resolved_profile(source_profile_for_port_admission),
+        )
+        _seen: set[int] = set()
+        for _hp in host_ports:
+            if _hp in _seen:
+                raise workspaces.WorkspaceCreateDuplicateHostPortError(host_port=_hp)
+            _seen.add(_hp)
     latest_source_reservation = await ResourceReservationRepository(session).list_for_workspace(
         source.id, limit=1
     )

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -941,10 +941,15 @@ async def retry_workspace_row(
                 context=agent_timeout_context,
                 salvage=conformance_salvage,
             )
-    retried_task_policy = {
-        **retried_task_policy,
-        **({"provider_readiness_preflight": preflight} if preflight is not None else {}),
-    }
+    # Fresh probe result always wins. When hosted open adoption skips a local
+    # probe (preflight is None), drop any source deepcopy snapshot — a prior
+    # blocks_launch=true (e.g. deferred Cursor Router failure) would otherwise
+    # survive and trip the provisioner's defense-in-depth path.
+    retried_task_policy = dict(retried_task_policy)
+    if preflight is not None:
+        retried_task_policy["provider_readiness_preflight"] = preflight
+    else:
+        retried_task_policy.pop("provider_readiness_preflight", None)
 
     host_ports: list[int] = []
     host_ports.extend(

--- a/src/awf/service/workspaces_retry.py
+++ b/src/awf/service/workspaces_retry.py
@@ -20,6 +20,7 @@ from awf.common.forge import concrete_forge_for_repo, make_forge_client
 from awf.common.forge_errors import ForgeClientError
 from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
 from awf.common.github_client import RepoRef
+from awf.common.workspace_policy import pr_adoption_is_hosted
 from awf.db.enums import OperationStatus, OperationType, TaskKind, WorkspaceStatus
 from awf.db.models import (
     Task,
@@ -41,6 +42,7 @@ from awf.db.repositories.base import (
     has_terminal_runtime_released_event,
 )
 from awf.db.session import make_session_factory
+from awf.runtime.hosted_delegation import HostedDelegationConfigError
 from awf.runtime.planning import (
     AGENT_PLAN_PHASE_SCOPE_VIOLATION,
     PLAN_CONFORMANCE_UNSATISFIED,
@@ -49,6 +51,10 @@ from awf.runtime.planning import (
 from awf.runtime.pr_monitor_actions import AbortReason
 from awf.runtime.pr_push_remote import retained_fork_pr_adoption
 from awf.service import workspaces_retry_payloads as _retry_payloads
+from awf.service.config import (
+    hosted_delegation_config_from_service_settings,
+    resolve_service_settings,
+)
 from awf.service.conformance_salvage import (
     CONFORMANCE_SALVAGE_POLICY_KEY,
     SALVAGE_NO_IMPLEMENTATION_DIFF,
@@ -71,6 +77,7 @@ from awf.service.scheduler import (
     scheduler_retry_policy_context,
     scheduler_score_from_workspace,
 )
+from awf.service.workspaces_retry_errors import WorkspaceHostedDelegationNotConfiguredError
 
 if TYPE_CHECKING:
     from awf.service.workspaces import (
@@ -351,6 +358,42 @@ def _is_existing_feature_pr_preserve_candidate(source: Workspace) -> bool:
         and _existing_feature_pr_url(source) is not None
         and pr_number is not None
     )
+
+
+def _is_retained_open_hosted_pr_adoption_retry(
+    source: Workspace,
+    prefetched_feature_pr: _PrefetchedFeaturePrState | None,
+) -> bool:
+    """Return whether retry admits a retained open hosted PR adoption.
+
+    Qualification is strict and must key off prefetched forge state as well as
+    source policy. A closed PR with a stale hosted marker falls through to the
+    local provider preflight (and then closed-PR feature-task fallback), so a
+    hosted marker alone must never skip local auth.
+    """
+    if source.task_kind != TaskKind.sync_feature_pr.value:
+        return False
+    if not pr_adoption_is_hosted(source.task_policy):
+        return False
+    if not _is_existing_feature_pr_preserve_candidate(source):
+        return False
+    if prefetched_feature_pr is None:
+        return False
+    pr_number = _existing_feature_pr_number(source)
+    if pr_number is None or prefetched_feature_pr.pr_number != pr_number:
+        return False
+    return prefetched_feature_pr.lifecycle is PullRequestLifecycle.open
+
+
+def _raise_if_hosted_delegation_unconfigured_for_retry(settings: Settings) -> None:
+    """Fail closed when hosted adoption retry lacks delegation configuration."""
+    try:
+        service_settings = resolve_service_settings(settings)
+        hosted_delegation_config_from_service_settings(service_settings, required=True)
+    except HostedDelegationConfigError as exc:
+        raise WorkspaceHostedDelegationNotConfiguredError(
+            detail=exc.detail(),
+        ) from exc
 
 
 async def _load_retry_preview_outside_request_session(
@@ -648,25 +691,35 @@ async def retry_workspace_row(
     # mirroring the create-time overlay in workspaces_create.create_workspace_row.
     # Also overlay any profile-declared provider API key the agent receives so the
     # non-Ollama credential gate does not block on a profile-only credential.
-    preflight_environ = workspaces_create.overlay_profile_provider_credentials(
-        workspaces_create.overlay_profile_ollama_base_url(
-            provider_environ if provider_environ is not None else os.environ,
+    #
+    # Retained open hosted PR adoptions intentionally skip local Codex/CLI
+    # preflight: Core has no local coding credential by design, and Cloud leases
+    # credentials to hosted execution jobs. Qualification requires explicit hosted
+    # mode + open prefetch so a closed-PR fallback cannot bypass local auth.
+    preflight: dict[str, Any] | None
+    if _is_retained_open_hosted_pr_adoption_retry(source, prefetched_feature_pr):
+        _raise_if_hosted_delegation_unconfigured_for_retry(resolved_settings)
+        preflight = None
+    else:
+        preflight_environ = workspaces_create.overlay_profile_provider_credentials(
+            workspaces_create.overlay_profile_ollama_base_url(
+                provider_environ if provider_environ is not None else os.environ,
+                source.resolved_profile,
+            ),
             source.resolved_profile,
-        ),
-        source.resolved_profile,
-    )
-    preflight = await workspaces_create._selected_provider_preflight_for_task_async(
-        resolved_settings,
-        agent=target_agent,
-        task_policy=retried_task_policy,
-        override=provider_readiness_override,
-        override_reason=provider_readiness_override_reason,
-        provider_environ=preflight_environ,
-        run_subprocess=run_subprocess,
-        http_get=http_get,
-    )
-    preflight = {**preflight, "source_workspace_id": source.id}
-    workspaces_create._raise_if_provider_preflight_blocks(preflight)
+        )
+        preflight = await workspaces_create._selected_provider_preflight_for_task_async(
+            resolved_settings,
+            agent=target_agent,
+            task_policy=retried_task_policy,
+            override=provider_readiness_override,
+            override_reason=provider_readiness_override_reason,
+            provider_environ=preflight_environ,
+            run_subprocess=run_subprocess,
+            http_get=http_get,
+        )
+        preflight = {**preflight, "source_workspace_id": source.id}
+        workspaces_create._raise_if_provider_preflight_blocks(preflight)
     conformance_salvage: dict[str, Any] | None = None
     salvage_recovery_payload: dict[str, Any] | None = None
     if conformance_retry_requested:
@@ -756,7 +809,7 @@ async def retry_workspace_row(
             )
     retried_task_policy = {
         **retried_task_policy,
-        "provider_readiness_preflight": preflight,
+        **({"provider_readiness_preflight": preflight} if preflight is not None else {}),
     }
 
     host_ports: list[int] = []
@@ -1137,8 +1190,9 @@ async def retry_workspace_row(
         "source_workspace_id": source.id,
         "new_workspace_id": retried.id,
         "attempt_number": attempt.attempt_number,
-        "provider_readiness_preflight": preflight,
     }
+    if preflight is not None:
+        event_payload["provider_readiness_preflight"] = preflight
     if planning_scope_context is not None:
         event_payload.update(_planning_scope_recovery_payload(planning_scope_context))
     if salvage_recovery_payload is not None:
@@ -1155,7 +1209,8 @@ async def retry_workspace_row(
         reason_code="RETRY_CREATED",
         payload=event_payload,
     )
-    await workspaces_create._record_provider_readiness_preflight(repo, retried, preflight)
+    if preflight is not None:
+        await workspaces_create._record_provider_readiness_preflight(repo, retried, preflight)
     await workspaces_create._record_owned_path_overlap_risk(repo, retried, overlaps)
     await operation_repo.finish(
         operation,

--- a/src/awf/service/workspaces_retry_errors.py
+++ b/src/awf/service/workspaces_retry_errors.py
@@ -33,3 +33,10 @@ class WorkspaceRetryPrAlreadyMergedError(WorkspaceRetryError):
     """Raised when retry discovers that the source PR is already merged."""
 
     error_code = "PR_ALREADY_MERGED"
+
+
+class WorkspaceHostedDelegationNotConfiguredError(WorkspaceRetryError):
+    """Raised when hosted PR-adoption retry lacks hosted delegation settings."""
+
+    error_code = "HOSTED_DELEGATION_NOT_CONFIGURED"
+    message = "Hosted PR adoption retry requires configured hosted delegation settings."

--- a/src/awf/service/workspaces_retry_recovery.py
+++ b/src/awf/service/workspaces_retry_recovery.py
@@ -1,0 +1,340 @@
+"""Recovery/policy helpers for workspace retry flows.
+
+Mechanically extracted from ``awf.service.workspaces_retry`` so that module stays
+under the first-party line-count guardrail. Retry-row orchestration remains in
+``workspaces_retry``; this module owns policy pruning, recovery payloads, and
+failure-context builders. Re-exported from ``workspaces_retry`` for import
+compatibility and test monkeypatches.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from awf.adapters.provider_failures import AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT
+from awf.db.models import Task, TaskAttempt, Workspace
+from awf.db.repositories import TaskAttemptRepository, TaskRepository
+from awf.runtime.planning import (
+    AGENT_PLAN_PHASE_SCOPE_VIOLATION,
+    PLAN_CONFORMANCE_UNSATISFIED,
+)
+from awf.service.coordination import task_policy_with_coordination_warnings
+from awf.service.scheduler import scheduler_retry_policy_context
+from awf.service.workspaces_retry_payloads import (
+    _compact_salvage_payload,
+    _compact_string_list,
+    _optional_retry_evidence_str,
+)
+
+if TYPE_CHECKING:
+    from awf.service.workspaces import (
+        _AgentTimeoutRetryContext,
+        _ConformanceRetryContext,
+        _PlanningScopeRetryContext,
+    )
+
+
+def _workspace_service() -> Any:
+    """Import workspace service symbols lazily to avoid module-level cycles."""
+    from awf.service import workspaces
+
+    return workspaces
+
+
+def workspace_failure_details_payload(workspace: Workspace) -> dict[str, Any] | None:
+    """Import the response helper lazily to avoid a module-load cycle."""
+    from awf.service.workspaces_response import workspace_failure_details_payload as _payload
+
+    return _payload(workspace)
+
+
+def _prune_and_migrate_retired_agent(
+    policy: dict[str, Any],
+    current_agent: str | None = None,
+) -> tuple[dict[str, Any], str | None]:
+    """Prune retired or unsupported fallback entries from a cloned retry policy,
+    and promote a launchable fallback if current_agent is retired.
+
+    Replacing retired slots with None placeholders preserves fallback attempt indexes.
+    If current_agent is retired/unlaunchable and a remaining approved launchable
+    fallback exists (respecting provider_recovery_state and max_fallback_attempts),
+    promotes that fallback as the new primary agent, updates agent_model, and sets
+    its slot in fallbacks to None.
+    """
+    recovery = policy.get("provider_recovery")
+    if not isinstance(recovery, Mapping):
+        return policy, current_agent
+    raw_fallbacks = recovery.get("fallbacks")
+    if not isinstance(raw_fallbacks, Sequence) or isinstance(raw_fallbacks, str):
+        return policy, current_agent
+
+    from awf.service.provider_readiness import is_launchable_agent
+
+    is_primary_launchable = True if current_agent is None else is_launchable_agent(current_agent)
+    promoted_index: int | None = None
+    target_agent = current_agent
+
+    if not is_primary_launchable:
+        from awf.service.provider_recovery import (
+            PROVIDER_RECOVERY_STATE_KEY,
+            _select_fallback_target_with_index,
+            parse_provider_recovery_policy,
+            parse_provider_recovery_state,
+        )
+
+        rec_policy = parse_provider_recovery_policy(policy)
+        rec_state = parse_provider_recovery_state(policy)
+        fallback_target, target_index = _select_fallback_target_with_index(rec_policy, rec_state)
+        if fallback_target is not None:
+            promoted_index = target_index
+            target_agent = fallback_target.agent
+            policy["agent_model"] = fallback_target.model
+
+            raw_state = policy.get(PROVIDER_RECOVERY_STATE_KEY)
+            state_dict = dict(raw_state) if isinstance(raw_state, Mapping) else {}
+            state_dict["fallback_attempt_number"] = target_index + 1
+            state_dict["launched_fallback_attempts"] = rec_state.launched_fallback_attempts + 1
+            state_dict["retry_attempt_number"] = 0
+            policy[PROVIDER_RECOVERY_STATE_KEY] = state_dict
+
+    pruned: list[Any] = []
+    for idx, item in enumerate(raw_fallbacks):
+        if idx == promoted_index:
+            pruned.append(None)
+        elif isinstance(item, Mapping):
+            fb_agent = item.get("agent")
+            if fb_agent is not None and is_launchable_agent(fb_agent):
+                pruned.append(item)
+            else:
+                pruned.append(None)
+        else:
+            pruned.append(None)
+
+    updated_recovery = dict(recovery)
+    updated_recovery["fallbacks"] = pruned
+    policy["provider_recovery"] = updated_recovery
+    return policy, target_agent
+
+
+def _prune_retired_fallbacks(policy: dict[str, Any]) -> dict[str, Any]:
+    """Prune retired or unsupported fallback entries from a cloned retry policy."""
+    pruned_policy, _ = _prune_and_migrate_retired_agent(policy, current_agent=None)
+    return pruned_policy
+
+
+def _retry_task_policy(
+    source: Workspace,
+    coordination_warnings: Sequence[Mapping[str, Any]],
+    *,
+    planning_scope_context: _PlanningScopeRetryContext | None,
+) -> tuple[dict[str, Any], str]:
+    """Build the task policy dict and target agent for a retried workspace."""
+    policy = task_policy_with_coordination_warnings(
+        scheduler_retry_policy_context(
+            deepcopy(source.task_policy),
+            source_workspace_id=source.id,
+            parent_failure_reason=source.failure_reason,
+        ),
+        coordination_warnings,
+    )
+    policy, target_agent = _prune_and_migrate_retired_agent(policy, current_agent=source.agent)
+    effective_agent = target_agent or source.agent
+    if (
+        planning_scope_context is not None
+        and planning_scope_context.fallback_model is not None
+        and effective_agent == source.agent
+    ):
+        # Same mutual exclusion as provider recovery: a fixed fallback must
+        # clear retained Cursor Auto mode or executor helpers keep preferring
+        # auto-smart[...] and silently ignore the approved pin.
+        from awf.service.provider_recovery import _install_fixed_recovery_model
+
+        policy = _install_fixed_recovery_model(
+            policy,
+            planning_scope_context.fallback_model["model"],
+        )
+    return policy, effective_agent
+
+
+def _planning_scope_recovery_payload(
+    context: _PlanningScopeRetryContext,
+) -> dict[str, Any]:
+    """Build the planning-scope recovery payload dict from a retry context."""
+    payload: dict[str, Any] = {
+        "source_reason_code": context.reason_code,
+        "planning_scope_evidence_ref": context.evidence_ref,
+        "recovery_strategy": context.recovery_strategy,
+        "salvage_policy": context.salvage_policy,
+    }
+    if context.salvage is not None:
+        payload["salvage"] = context.salvage
+    if context.fallback_model is not None:
+        payload["fallback_model"] = context.fallback_model
+    return payload
+
+
+def _conformance_salvage_recovery_payload(
+    *,
+    conformance_context: _ConformanceRetryContext | None,
+    salvage: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build the conformance-salvage recovery payload dict for a retry."""
+    payload: dict[str, Any] = {
+        "source_reason_code": PLAN_CONFORMANCE_UNSATISFIED,
+        "conformance_salvage": dict(salvage),
+    }
+    remaining_gaps = _compact_string_list(salvage.get("remaining_gaps"))
+    if remaining_gaps:
+        payload["remaining_gaps"] = remaining_gaps
+    if conformance_context is not None:
+        payload["conformance_evidence_ref"] = conformance_context.evidence_ref
+    elif salvage.get("conformance_evidence_ref") is not None:
+        payload["conformance_evidence_ref"] = salvage.get("conformance_evidence_ref")
+    return payload
+
+
+def _agent_timeout_salvage_recovery_payload(
+    *,
+    context: _AgentTimeoutRetryContext,
+    salvage: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Build retry payload metadata for an agent-timeout salvage continuation."""
+    payload: dict[str, Any] = {
+        "source_reason_code": context.reason_code,
+        "recovery_strategy": "continue_from_timeout_salvage",
+        "conformance_salvage": dict(salvage),
+        "agent_timeout_evidence_ref": context.evidence_ref,
+    }
+    message = _optional_retry_evidence_str(context.evidence.get("message"))
+    if message is not None:
+        payload["source_failure_message"] = message
+    return payload
+
+
+async def _retry_task_for_source(
+    session: AsyncSession,
+    source: Workspace,
+    *,
+    source_attempt: TaskAttempt | None = None,
+) -> Task:
+    """Retrieve or create the task associated with a source workspace for retry."""
+    if source_attempt is None:
+        source_attempt = await TaskAttemptRepository(session).get_by_workspace_id(source.id)
+    if source_attempt is not None:
+        task = await TaskRepository(session).get(source_attempt.task_id)
+        if task is not None:
+            return task
+
+    fallback_idempotency_key = f"retry-source-workspace:{source.id}"
+    return await TaskRepository(session).create_or_get(
+        repo_url=source.repo_url,
+        base_branch=source.branch_base,
+        title=source.task_title,
+        prompt=source.task_prompt,
+        external_id=source.task_external_id,
+        idempotency_key=fallback_idempotency_key,
+        task_class=source.task_class,
+        owned_paths=list(source.owned_paths),
+    )
+
+
+def _is_plan_conformance_unsatisfied(workspace: Workspace) -> bool:
+    """Check whether the workspace's latest failure is a plan-conformance-unsatisfied reason."""
+    details = workspace_failure_details_payload(workspace)
+    if details is None:
+        return False
+    return details.get("reason_code") == PLAN_CONFORMANCE_UNSATISFIED
+
+
+def _agent_timeout_retry_context(workspace: Workspace) -> Any:
+    """Build a timeout retry context from the workspace's failure details if applicable."""
+    workspaces = _workspace_service()
+    details = workspace_failure_details_payload(workspace)
+    if details is None:
+        return None
+    reason_code = details.get("reason_code")
+    if reason_code not in {AGENT_IDLE_TIMEOUT, AGENT_TIMEOUT}:
+        return None
+    message = _optional_retry_evidence_str(details.get("message"))
+    evidence: dict[str, Any] = {
+        "reason_code": reason_code,
+        "gaps": [
+            "The previous agent run timed out before it could finish.",
+            "Continue from the recovered implementation diff and complete the original task.",
+        ],
+    }
+    if message is not None:
+        evidence["message"] = message
+    return workspaces._AgentTimeoutRetryContext(
+        reason_code=str(reason_code),
+        evidence=evidence,
+        evidence_ref={
+            "source_workspace_id": workspace.id,
+            "event_type": "workspace.state_changed",
+            "reason_code": str(reason_code),
+        },
+    )
+
+
+def _conformance_retry_context(workspace: Workspace) -> Any:
+    """Build a conformance retry context from the workspace's failure details if applicable."""
+    workspaces = _workspace_service()
+    details = workspace_failure_details_payload(workspace)
+    if details is None or details.get("reason_code") != PLAN_CONFORMANCE_UNSATISFIED:
+        return None
+    evidence = details.get("conformance")
+    if not isinstance(evidence, Mapping):
+        return None
+    return workspaces._ConformanceRetryContext(
+        reason_code=PLAN_CONFORMANCE_UNSATISFIED,
+        evidence=evidence,
+        evidence_ref={
+            "source_workspace_id": workspace.id,
+            "event_type": "workspace.state_changed",
+            "reason_code": PLAN_CONFORMANCE_UNSATISFIED,
+        },
+    )
+
+
+def _planning_scope_retry_context(workspace: Workspace) -> Any:
+    """Build a planning-scope retry context from the workspace's failure details if applicable."""
+    workspaces = _workspace_service()
+    details = workspace_failure_details_payload(workspace)
+    if details is None or details.get("reason_code") != AGENT_PLAN_PHASE_SCOPE_VIOLATION:
+        return None
+    evidence = details.get("planning_scope")
+    if not isinstance(evidence, Mapping):
+        return None
+    recovery_strategy_value = details.get("recovery_strategy")
+    recovery_strategy = (
+        recovery_strategy_value
+        if isinstance(recovery_strategy_value, str)
+        else "discard_and_replan"
+    )
+    salvage_policy_value = details.get("salvage_policy")
+    salvage_policy = (
+        salvage_policy_value
+        if isinstance(salvage_policy_value, str)
+        else "explicit_salvage_required"
+    )
+    fallback_model = workspaces._approved_planning_scope_fallback_model(workspace)
+    evidence_payload = dict(evidence)
+    if fallback_model is not None:
+        evidence_payload["fallback_model"] = fallback_model
+    return workspaces._PlanningScopeRetryContext(
+        reason_code=AGENT_PLAN_PHASE_SCOPE_VIOLATION,
+        evidence=evidence_payload,
+        evidence_ref={
+            "source_workspace_id": workspace.id,
+            "event_type": "workspace.state_changed",
+            "reason_code": AGENT_PLAN_PHASE_SCOPE_VIOLATION,
+        },
+        recovery_strategy=recovery_strategy,
+        salvage_policy=salvage_policy,
+        salvage=_compact_salvage_payload(details.get("salvage")),
+        fallback_model=fallback_model,
+    )

--- a/tests/unit/api/test_workspace_retry.py
+++ b/tests/unit/api/test_workspace_retry.py
@@ -461,3 +461,165 @@ async def test_retry_endpoint_override_records_preflight(
     assert preflight["source_workspace_id"] == original_id
     assert preflight["override_used"] is True
     assert preflight["override_reason"] == "operator verified local auth"
+
+
+async def _seed_hosted_adoption_workspace(
+    engine: AsyncEngine,
+    *,
+    status: WorkspaceStatus,
+    execution_mode: str = "hosted",
+    external_id: str = "TICKET-API-HOSTED-RETRY",
+) -> str:
+    factory = make_session_factory(engine)
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.create(
+            repo_url="git@github.com:example/retry-api.git",
+            branch_base="development",
+            task_title="Hosted adoption retry",
+            task_prompt="Continue monitoring the adopted PR.",
+            task_external_id=external_id,
+            task_class="test_task",
+            owned_paths=["src/awf/api/hosted_retry.py"],
+            auto_merge=True,
+            initial_review_grace_period_seconds=30,
+            agent="codex",
+            profile_ref="python",
+            requested_profile={"source": "retry-api-hosted"},
+            resolved_profile={"source": "retry-api-hosted"},
+            test_commands=[],
+            task_kind="sync_feature_pr",
+            task_policy={
+                "task_kind": "sync_feature_pr",
+                "pr_adoption": {
+                    "repo_slug": "example/retry-api",
+                    "pr_number": 42,
+                    "pr_url": "https://github.com/example/retry-api/pull/42",
+                    "head_ref": "contributors/hosted-head",
+                    "base_ref": "development",
+                    "head_sha": "b" * 40,
+                    "base_sha": "a" * 40,
+                    "execution": {"mode": execution_mode},
+                },
+            },
+        )
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        workspace.branch_name = "feature-sync/hosted-api"
+        workspace.remote_push_branch = "contributors/hosted-head"
+        workspace.pr_number = 42
+        workspace.compose_project_name = None
+        workspace.compose_file_path = None
+        if status is WorkspaceStatus.failed:
+            workspace.failure_reason = "validation_failure"
+            workspace.failure_message = "hosted validation failed"
+            await repo.transition(workspace, to=WorkspaceStatus.failed, reason_code="TEST_FAIL")
+        else:
+            await repo.transition(workspace, to=status, reason_code="TEST_CANCEL")
+        await repo.add_event(
+            workspace,
+            event_type="workspace.terminal_runtime_released",
+            reason_code="TERMINAL_RUNTIME_RELEASED",
+        )
+        await session.commit()
+        return workspace.id
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("status", [WorkspaceStatus.failed, WorkspaceStatus.cancelled])
+async def test_retry_endpoint_admits_hosted_adoption_without_local_codex(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    api_auth_headers: dict[str, str],
+    tmp_path,
+    status: WorkspaceStatus,
+) -> None:  # type: ignore[no-untyped-def]
+    from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
+
+    original_id = await _seed_hosted_adoption_workspace(
+        engine,
+        status=status,
+        external_id=f"TICKET-API-HOSTED-{status.value}",
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "get_settings",
+        lambda: Settings(
+            _env_file=None,
+            host_home=str(tmp_path / "home"),
+            docker_host="",
+            hosted_delegation_base_url="https://hosted.example.test",
+            hosted_delegation_bearer_token="hosted-token",
+        ),
+    )
+
+    async def _open_snapshot(_source: object, _pr_number: int) -> PullRequestSnapshot:
+        return PullRequestSnapshot(
+            lifecycle=PullRequestLifecycle.open,
+            head_ref="contributors/hosted-head",
+            base_sha="a" * 40,
+        )
+
+    monkeypatch.setattr(workspace_service, "_live_pr_snapshot", _open_snapshot)
+
+    response = await client.post(
+        f"/v1/workspaces/{original_id}/retry",
+        headers=api_auth_headers,
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["source_workspace_id"] == original_id
+    assert body["new_workspace_id"] != original_id
+    assert body["status"] == "requested"
+    assert body["provider_readiness_preflight"] is None
+
+    detail = await client.get(
+        f"/v1/workspaces/{body['new_workspace_id']}",
+        headers=api_auth_headers,
+    )
+    assert detail.status_code == 200
+    workspace = detail.json()
+    assert workspace["task_kind"] == "sync_feature_pr"
+    assert workspace["pr_number"] == 42
+    assert workspace["task_policy"]["pr_adoption"]["execution"] == {"mode": "hosted"}
+
+
+@pytest.mark.unit
+async def test_retry_endpoint_hosted_open_fails_closed_without_delegation(
+    client: AsyncClient,
+    engine: AsyncEngine,
+    monkeypatch: pytest.MonkeyPatch,
+    api_auth_headers: dict[str, str],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
+
+    original_id = await _seed_hosted_adoption_workspace(
+        engine,
+        status=WorkspaceStatus.failed,
+        external_id="TICKET-API-HOSTED-NO-DELEGATION",
+    )
+    monkeypatch.setattr(
+        workspace_service,
+        "get_settings",
+        lambda: Settings(_env_file=None, host_home=str(tmp_path / "home"), docker_host=""),
+    )
+
+    async def _open_snapshot(_source: object, _pr_number: int) -> PullRequestSnapshot:
+        return PullRequestSnapshot(
+            lifecycle=PullRequestLifecycle.open,
+            head_ref="contributors/hosted-head",
+            base_sha="a" * 40,
+        )
+
+    monkeypatch.setattr(workspace_service, "_live_pr_snapshot", _open_snapshot)
+
+    response = await client.post(
+        f"/v1/workspaces/{original_id}/retry",
+        headers=api_auth_headers,
+    )
+
+    assert response.status_code == 409
+    body = response.json()
+    assert body["error_code"] == "HOSTED_DELEGATION_NOT_CONFIGURED"

--- a/tests/unit/api/test_workspace_retry.py
+++ b/tests/unit/api/test_workspace_retry.py
@@ -572,7 +572,14 @@ async def test_retry_endpoint_admits_hosted_adoption_without_local_codex(
     assert body["source_workspace_id"] == original_id
     assert body["new_workspace_id"] != original_id
     assert body["status"] == "requested"
-    assert body["provider_readiness_preflight"] is None
+    preflight = body["provider_readiness_preflight"]
+    assert isinstance(preflight, dict)
+    assert preflight["blocks_launch"] is False
+    assert preflight["reason_code"] == "HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED"
+    assert preflight["agent"] == "codex"
+    assert preflight["provider"] == "codex"
+    assert preflight["auth_status"]
+    assert preflight["auth_source"]
 
     detail = await client.get(
         f"/v1/workspaces/{body['new_workspace_id']}",
@@ -583,6 +590,9 @@ async def test_retry_endpoint_admits_hosted_adoption_without_local_codex(
     assert workspace["task_kind"] == "sync_feature_pr"
     assert workspace["pr_number"] == 42
     assert workspace["task_policy"]["pr_adoption"]["execution"] == {"mode": "hosted"}
+    assert workspace["provider_readiness_preflight"]["reason_code"] == (
+        "HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED"
+    )
 
 
 @pytest.mark.unit

--- a/tests/unit/common/test_github_client_parts/test_github_client_part_001.py
+++ b/tests/unit/common/test_github_client_parts/test_github_client_part_001.py
@@ -266,6 +266,68 @@ class TestPullRequestUrlParsing:
         with pytest.raises(ValueError):
             parse_github_pull_request_url(pr_url)
 
+    @pytest.mark.unit
+    def test_forge_dispatch_parses_bitbucket_pr_url(self) -> None:
+        from awf.common.github_client import parse_forge_pull_request_url
+
+        repo, number = parse_forge_pull_request_url(
+            "https://bitbucket.org/example/retryable/pull-requests/42",
+            forge="bitbucket",
+        )
+
+        assert repo.forge == "bitbucket"
+        assert repo.slug() == "example/retryable"
+        assert number == 42
+
+    @pytest.mark.unit
+    def test_forge_dispatch_rejects_github_url_for_bitbucket_forge(self) -> None:
+        from awf.common.github_client import parse_forge_pull_request_url
+
+        with pytest.raises(ValueError):
+            parse_forge_pull_request_url(
+                "https://github.com/example/retryable/pull/42",
+                forge="bitbucket",
+            )
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "pr_url",
+        [
+            "https://bitbucket.org/example/retryable/pull/42",
+            "https://bitbucket.org/example/retryable/issues/42",
+            "https://bitbucket.org/example/retryable/pull-requests/0",
+            "https://bitbucket.org/example/retryable/pull-requests/not-a-number",
+        ],
+    )
+    def test_forge_dispatch_rejects_invalid_bitbucket_pr_urls(self, pr_url: str) -> None:
+        from awf.common.github_client import parse_forge_pull_request_url
+
+        with pytest.raises(ValueError):
+            parse_forge_pull_request_url(pr_url, forge="bitbucket")
+
+    @pytest.mark.unit
+    def test_forge_dispatch_rejects_unsupported_forge(self) -> None:
+        from awf.common.github_client import parse_forge_pull_request_url
+
+        with pytest.raises(ValueError, match="Unsupported forge"):
+            parse_forge_pull_request_url(
+                "https://github.com/example/retryable/pull/42",
+                forge="gitlab",  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.unit
+    def test_forge_dispatch_parses_github_via_forge_param(self) -> None:
+        from awf.common.github_client import parse_forge_pull_request_url
+
+        repo, number = parse_forge_pull_request_url(
+            "https://github.com/example/retryable/pull/7",
+            forge="github",
+        )
+
+        assert repo.forge == "github"
+        assert repo.slug() == "example/retryable"
+        assert number == 7
+
 
 class TestFetchPullRequestAdoptionMetadata:
     @pytest.mark.unit

--- a/tests/unit/service/_workspace_retry_helpers.py
+++ b/tests/unit/service/_workspace_retry_helpers.py
@@ -436,30 +436,42 @@ async def _seed_failed_source_workspace(
     factory: async_sessionmaker[AsyncSession],
     *,
     task_kind: str,
+    execution_mode: str | None = "local",
+    auto_merge: bool = False,
+    task_policy_overrides: dict[str, object] | None = None,
 ) -> str:
     """Persist a source workspace for a task kind that bypasses direct create.
 
     ``sync_feature_pr`` is created through the PR-adoption flow (via
     ``WorkspaceRepository.create``), not the public request path, so retry
     coverage seeds the row the same way instead of building a rejected request.
+
+    ``execution_mode`` controls ``pr_adoption.execution.mode`` for sync-feature
+    rows. Pass ``None`` to omit the execution block (legacy local default).
     """
     async with factory() as session:
         repo = WorkspaceRepository(session)
         task_policy = None
         if task_kind == "sync_feature_pr":
+            adoption: dict[str, object] = {
+                "repo_slug": "example/retryable",
+                "pr_number": 42,
+                "pr_url": "https://github.com/example/retryable/pull/42",
+                "head_ref": "contributors/fix-123",
+                "base_ref": "development",
+                "head_sha": "b" * 40,
+                "base_sha": "a" * 40,
+            }
+            if execution_mode is not None:
+                adoption["execution"] = {"mode": execution_mode}
             task_policy = {
                 "task_kind": task_kind,
-                "pr_adoption": {
-                    "repo_slug": "example/retryable",
-                    "pr_number": 42,
-                    "pr_url": "https://github.com/example/retryable/pull/42",
-                    "head_ref": "contributors/fix-123",
-                    "base_ref": "development",
-                    "head_sha": "b" * 40,
-                    "base_sha": "a" * 40,
-                    "execution": {"mode": "local"},
-                },
+                "pr_adoption": adoption,
             }
+            if task_policy_overrides:
+                task_policy.update(task_policy_overrides)
+        elif task_policy_overrides:
+            task_policy = dict(task_policy_overrides)
         source = await repo.create(
             repo_url="git@github.com:example/retryable.git",
             branch_base="development",
@@ -468,7 +480,7 @@ async def _seed_failed_source_workspace(
             task_external_id="TICKET-RETRY",
             task_class="test_task",
             owned_paths=["src/awf/retry/**"],
-            auto_merge=False,
+            auto_merge=auto_merge,
             initial_review_grace_period_seconds=30,
             agent=AgentRuntime.codex.value,
             profile_ref="python",
@@ -480,6 +492,50 @@ async def _seed_failed_source_workspace(
         )
         await session.commit()
         return source.id
+
+
+async def _mark_cancelled(
+    factory: async_sessionmaker[AsyncSession],
+    workspace_id: str,
+    *,
+    branch_name: str = "codex/old-attempt",
+    remote_push_branch: str | None = None,
+    release_runtime: bool = True,
+    pr_url: str | None = None,
+) -> None:
+    """Mark a workspace as cancelled with shared evidence for retry tests."""
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        workspace = await repo.get(workspace_id)
+        assert workspace is not None
+        await repo.transition(workspace, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        workspace.branch_name = branch_name
+        workspace.remote_push_branch = remote_push_branch
+        workspace.pr_url = pr_url
+        workspace.compose_project_name = "awf_old_attempt"
+        await repo.transition(
+            workspace,
+            to=WorkspaceStatus.cancelled,
+            reason_code="TEST_CANCEL",
+        )
+        if release_runtime:
+            await repo.add_event(
+                workspace,
+                event_type="workspace.terminal_runtime_released",
+                reason_code="TERMINAL_RUNTIME_RELEASED",
+            )
+        await session.commit()
+
+
+def _settings_with_hosted_delegation(tmp_path: Path) -> Settings:
+    """Settings with hosted delegation configured and an empty host home."""
+    return Settings(
+        _env_file=None,
+        host_home=str(tmp_path / "home"),
+        docker_host="",
+        hosted_delegation_base_url="https://hosted.example.test",
+        hosted_delegation_bearer_token="hosted-token",
+    )
 
 
 def _live_pr_state(

--- a/tests/unit/service/test_workspace_retry_feature_pr.py
+++ b/tests/unit/service/test_workspace_retry_feature_pr.py
@@ -815,6 +815,7 @@ async def test_retry_persists_live_head_into_adopted_sync_feature_pr_policy(
             lifecycle=PullRequestLifecycle.open,
             head_ref="contributors/renamed-live-head",
             base_sha="d" * 40,
+            head_sha="e" * 40,
         )
 
     monkeypatch.setattr(workspaces_retry_service, "_live_pr_snapshot", live_snapshot)
@@ -836,5 +837,6 @@ async def test_retry_persists_live_head_into_adopted_sync_feature_pr_policy(
     adoption = retried.task_policy["pr_adoption"]
     assert adoption["head_ref"] == "contributors/renamed-live-head"
     assert adoption["base_sha"] == "d" * 40
+    assert adoption["head_sha"] == "e" * 40
     assert _provision_remote_push_branch(retried) == "contributors/renamed-live-head"
     assert _provision_checkout_base_branch(retried) == "refs/pull/42/head"

--- a/tests/unit/service/test_workspace_retry_feature_pr_freeze.py
+++ b/tests/unit/service/test_workspace_retry_feature_pr_freeze.py
@@ -303,21 +303,41 @@ async def test_retry_clears_stamped_freeze_when_adopted_base_advances(
 
 
 @pytest.mark.parametrize(
-    ("task_policy", "head_ref", "base_sha", "expected"),
+    ("task_policy", "head_ref", "base_sha", "head_sha", "expected"),
     [
-        ({}, "live/head", "a" * 40, {}),
-        ({"pr_adoption": "not-a-dict"}, "live/head", "a" * 40, {"pr_adoption": "not-a-dict"}),
+        ({}, "live/head", "a" * 40, "c" * 40, {}),
         (
-            {"pr_adoption": {"head_ref": "stale", "base_sha": "b" * 40}},
-            "  ",
-            None,
-            {"pr_adoption": {"head_ref": "stale", "base_sha": "b" * 40}},
+            {"pr_adoption": "not-a-dict"},
+            "live/head",
+            "a" * 40,
+            "c" * 40,
+            {"pr_adoption": "not-a-dict"},
         ),
         (
-            {"pr_adoption": {"head_ref": "stale", "base_sha": "b" * 40}},
+            {"pr_adoption": {"head_ref": "stale", "base_sha": "b" * 40, "head_sha": "d" * 40}},
+            "  ",
+            None,
+            None,
+            {
+                "pr_adoption": {
+                    "head_ref": "stale",
+                    "base_sha": "b" * 40,
+                    "head_sha": "d" * 40,
+                }
+            },
+        ),
+        (
+            {"pr_adoption": {"head_ref": "stale", "base_sha": "b" * 40, "head_sha": "d" * 40}},
             " live/head ",
             " c" + ("0" * 39),
-            {"pr_adoption": {"head_ref": "live/head", "base_sha": "c" + ("0" * 39)}},
+            " e" + ("0" * 39),
+            {
+                "pr_adoption": {
+                    "head_ref": "live/head",
+                    "base_sha": "c" + ("0" * 39),
+                    "head_sha": "e" + ("0" * 39),
+                }
+            },
         ),
     ],
 )
@@ -325,12 +345,14 @@ def test_sync_retried_adoption_live_refs_updates_only_valid_adoption_dicts(
     task_policy: dict,
     head_ref: str | None,
     base_sha: str | None,
+    head_sha: str | None,
     expected: dict,
 ) -> None:
     workspaces_retry_service._sync_retried_adoption_live_refs(
         task_policy,
         head_ref=head_ref,
         base_sha=base_sha,
+        head_sha=head_sha,
     )
     assert task_policy == expected
 

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -8,8 +8,11 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import awf.service.workspaces_create as workspaces_create
-from awf.common.forge_lifecycle import PullRequestLifecycle
+import awf.service.workspaces_retry as workspaces_retry_service
+from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
+from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
+from awf.runtime.hosted_pr_identity import hosted_pr_identity_for_workspace
 from awf.service.workspaces import (
     WorkspaceHostedDelegationNotConfiguredError,
     WorkspaceProviderReadinessBlockedError,
@@ -115,6 +118,96 @@ async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
         assert retried.resolved_profile == {"source": "frozen:test-profile"}
     else:
         assert retried.resolved_profile == {"source": "retry-test-profile"}
+
+
+async def test_hosted_open_adoption_retry_syncs_live_head_sha_into_adoption(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Advanced forge head must refresh pr_adoption.head_sha on hosted retry.
+
+    After a hosted repair advances the PR tip and later fails validation, retry
+    must not keep the original adoption head_sha as expected_head_sha
+    (PRRT_kwDOSJAM6s6fjQ0r).
+    """
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    stale_head_sha = "b" * 40
+    live_head_sha = "c" * 40
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        assert source.task_policy["pr_adoption"]["head_sha"] == stale_head_sha
+        await session.commit()
+
+    async def live_snapshot(_source: Workspace, _pr_number: int) -> PullRequestSnapshot:
+        return PullRequestSnapshot(
+            lifecycle=PullRequestLifecycle.open,
+            head_ref="contributors/fix-123",
+            base_sha="a" * 40,
+            head_sha=live_head_sha,
+        )
+
+    monkeypatch.setattr(workspaces_retry_service, "_live_pr_snapshot", live_snapshot)
+    calls: list[dict[str, Any]] = []
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+        )
+
+    assert calls == []
+    adoption = retry.new_workspace.task_policy["pr_adoption"]
+    assert adoption["head_sha"] == live_head_sha
+    assert adoption["head_sha"] != stale_head_sha
+    identity = hosted_pr_identity_for_workspace(retry.new_workspace)
+    assert identity["expected_head_sha"] == live_head_sha
+
+
+async def test_hosted_adoption_missing_head_sha_does_not_bypass_local_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    """Hosted bypass requires a complete adoption identity including head_sha."""
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        del adoption["head_sha"]
+        policy["pr_adoption"] = adoption
+        source.task_policy = policy
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
 
 
 async def test_local_adoption_retry_still_requires_codex_auth(

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -13,10 +13,16 @@ from awf.common.forge_lifecycle import PullRequestLifecycle, PullRequestSnapshot
 from awf.db.models import Workspace
 from awf.db.repositories import WorkspaceRepository
 from awf.runtime.hosted_pr_identity import hosted_pr_identity_for_workspace
+from awf.service.pr_monitor_adoption_cursor_preflight import (
+    _needs_deferred_cursor_auto_router_preflight,
+)
 from awf.service.workspaces import (
     WorkspaceHostedDelegationNotConfiguredError,
     WorkspaceProviderReadinessBlockedError,
     retry_workspace_row,
+)
+from awf.service.workspaces_retry import (
+    HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON,
 )
 from tests.unit.service._workspace_retry_helpers import (
     _live_pr_state,
@@ -32,6 +38,15 @@ from tests.unit.service._workspace_retry_helpers import (
 pytestmark = pytest.mark.unit
 
 __all__ = ["factory"]
+
+
+def _assert_hosted_local_preflight_bypass(task_policy: dict[str, Any]) -> None:
+    """Hosted open retry must record a nonblocking bypass, not omit the snapshot."""
+    snapshot = task_policy.get("provider_readiness_preflight")
+    assert isinstance(snapshot, dict)
+    assert snapshot.get("blocks_launch") is False
+    assert snapshot.get("reason_code") == HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON
+    assert _needs_deferred_cursor_auto_router_preflight(task_policy) is False
 
 
 async def _prepare_hosted_open_source(
@@ -113,7 +128,7 @@ async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
     assert adoption["execution"] == {"mode": "hosted"}
     assert adoption["pr_number"] == 42
     assert adoption["head_ref"] == "contributors/fix-123"
-    assert "provider_readiness_preflight" not in retried.task_policy
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
     # Failed paths freeze resolved_profile; cancelled keeps the seeded snapshot.
     if terminal == "failed":
         assert retried.resolved_profile == {"source": "frozen:test-profile"}
@@ -130,10 +145,10 @@ async def test_hosted_open_adoption_retry_clears_stale_blocking_preflight(
 
     A prior deferred Cursor Router failure leaves
     ``provider_readiness_preflight.blocks_launch=true`` on the source policy.
-    ``_retry_task_policy`` deepcopies that key; when hosted admission sets
-    ``preflight=None``, expanding an empty overlay would leave the blocking
-    snapshot on the replacement and the provisioner defense-in-depth path would
-    fail again (PRRT_kwDOSJAM6s6fjWEC).
+    ``_retry_task_policy`` deepcopies that key; hosted admission must replace it
+    with an explicit nonblocking bypass so the provisioner defense-in-depth path
+    and deferred Cursor Auto Router gate stay skipped (PRRT_kwDOSJAM6s6fjWEC,
+    PRRT_kwDOSJAM6s6fjwe_).
     """
     settings = _settings_with_hosted_delegation(tmp_path)
     blocking_preflight = {
@@ -183,7 +198,74 @@ async def test_hosted_open_adoption_retry_clears_stale_blocking_preflight(
         )
 
     retried = retry.new_workspace
-    assert "provider_readiness_preflight" not in retried.task_policy
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
+    assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
+
+
+async def test_hosted_open_adoption_retry_preserves_cursor_auto_bypass_through_provision(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Hosted + cursor_auto_mode must not re-enter deferred Router preflight.
+
+    Popping the readiness key selects ``_needs_deferred_cursor_auto_router_preflight``
+    whenever ``cursor_auto_mode`` is present, so provision would probe Router
+    locally and fail without Core credentials (PRRT_kwDOSJAM6s6fjwe_).
+    """
+    settings = _settings_with_hosted_delegation(tmp_path)
+    blocking_preflight = {
+        "blocks_launch": True,
+        "reason_code": "CURSOR_ROUTER_UNAVAILABLE",
+        "message": "Router probe failed on prior hosted Cursor Auto attempt.",
+    }
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="hosted",
+        auto_merge=True,
+        task_policy_overrides={
+            "cursor_auto_mode": "intelligence",
+            "provider_readiness_preflight": blocking_preflight,
+        },
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/hosted-cursor-auto",
+        remote_push_branch="contributors/fix-123",
+        pr_url=None,
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.agent = "cursor"
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    retried = retry.new_workspace
+    assert retried.task_policy.get("cursor_auto_mode") == "intelligence"
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
     assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
 
 
@@ -250,7 +332,7 @@ async def test_hosted_planning_scope_retry_skips_local_codex_preflight(
     adoption = retried.task_policy["pr_adoption"]
     assert adoption["execution"] == {"mode": "hosted"}
     assert adoption["pr_number"] == 42
-    assert "provider_readiness_preflight" not in retried.task_policy
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
 
 
 async def test_hosted_open_adoption_retry_syncs_live_head_sha_into_adoption(

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -602,6 +602,60 @@ async def test_hosted_open_adoption_retry_allows_distinct_fork_head_repo_slug(
     assert adoption["head_repo_slug"] == "fork-owner/retryable"
 
 
+async def test_hosted_bitbucket_open_adoption_retry_skips_local_codex_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Bitbucket PR URLs must keep hosted retry identity forge-neutral.
+
+    A hosted Bitbucket adoption (repo_url/pr_number + forge-aware metadata)
+    persists ``bitbucket.org/.../pull-requests/<n>``. Parsing that URL with the
+    GitHub-only helper would fail identity and downgrade to local preflight
+    (PRRT_kwDOSJAM6s6fj83p).
+    """
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    bitbucket_pr_url = "https://bitbucket.org/example/retryable/pull-requests/42"
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.repo_url = "git@bitbucket.org:example/retryable.git"
+        source.pr_url = bitbucket_pr_url
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        adoption["pr_url"] = bitbucket_pr_url
+        policy["pr_adoption"] = adoption
+        source.task_policy = policy
+        await session.commit()
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError(
+            "local provider preflight must not run for hosted Bitbucket open adoption"
+        )
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    retried = retry.new_workspace
+    assert retried.repo_url == "git@bitbucket.org:example/retryable.git"
+    assert retried.pr_url == bitbucket_pr_url
+    assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
+
+
 async def test_local_adoption_retry_still_requires_codex_auth(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -22,6 +22,7 @@ from tests.unit.service._workspace_retry_helpers import (
     _live_pr_state,
     _mark_cancelled,
     _mark_failed,
+    _mark_planning_scope_failed,
     _seed_failed_source_workspace,
     _settings_with_host_home,
     _settings_with_hosted_delegation,
@@ -118,6 +119,72 @@ async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
         assert retried.resolved_profile == {"source": "frozen:test-profile"}
     else:
         assert retried.resolved_profile == {"source": "retry-test-profile"}
+
+
+async def test_hosted_planning_scope_retry_skips_local_codex_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Planning-scope hosted sync must still qualify for the local-auth bypass.
+
+    ``_is_existing_feature_pr_preserve_candidate`` returns false for
+    AGENT_PLAN_PHASE_SCOPE_VIOLATION so live preserve is skipped, but hosted
+    adoption + open forge state must still prefetch and skip Codex preflight
+    (PRRT_kwDOSJAM6s6fjWEB).
+    """
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="hosted",
+        auto_merge=True,
+    )
+    await _mark_planning_scope_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/hosted-planning-scope",
+        remote_push_branch="contributors/fix-123",
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+
+    calls: list[dict[str, Any]] = []
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError(
+            "local provider preflight must not run for hosted planning-scope adoption"
+        )
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    assert calls == []
+    retried = retry.new_workspace
+    assert retried.task_kind == "sync_feature_pr"
+    assert retried.remote_push_branch == "contributors/fix-123"
+    adoption = retried.task_policy["pr_adoption"]
+    assert adoption["execution"] == {"mode": "hosted"}
+    assert adoption["pr_number"] == 42
+    assert "provider_readiness_preflight" not in retried.task_policy
 
 
 async def test_hosted_open_adoption_retry_syncs_live_head_sha_into_adoption(

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -1,0 +1,374 @@
+"""Hosted PR-adoption retry admission regressions (no local Codex gate)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import awf.service.workspaces_create as workspaces_create
+from awf.common.forge_lifecycle import PullRequestLifecycle
+from awf.db.repositories import WorkspaceRepository
+from awf.service.workspaces import (
+    WorkspaceHostedDelegationNotConfiguredError,
+    WorkspaceProviderReadinessBlockedError,
+    retry_workspace_row,
+)
+from tests.unit.service._workspace_retry_helpers import (
+    _live_pr_state,
+    _mark_cancelled,
+    _mark_failed,
+    _seed_failed_source_workspace,
+    _settings_with_host_home,
+    _settings_with_hosted_delegation,
+    factory,
+)
+
+pytestmark = pytest.mark.unit
+
+__all__ = ["factory"]
+
+
+async def _prepare_hosted_open_source(
+    factory: async_sessionmaker[AsyncSession],
+    *,
+    terminal: str = "failed",
+    auto_merge: bool = True,
+) -> str:
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="hosted",
+        auto_merge=auto_merge,
+    )
+    if terminal == "cancelled":
+        await _mark_cancelled(
+            factory,
+            first_id,
+            branch_name="feature-sync/hosted-open",
+            remote_push_branch="contributors/fix-123",
+            pr_url=None,
+        )
+    else:
+        await _mark_failed(
+            factory,
+            first_id,
+            branch_name="feature-sync/hosted-open",
+            remote_push_branch="contributors/fix-123",
+            pr_url=None,
+        )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+    return first_id
+
+
+@pytest.mark.parametrize("terminal", ["failed", "cancelled"])
+async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+    terminal: str,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory, terminal=terminal)
+    calls: list[dict[str, Any]] = []
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append({"args": args, "kwargs": kwargs})
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    assert calls == []
+    retried = retry.new_workspace
+    assert retried.task_kind == "sync_feature_pr"
+    assert retried.pr_number == 42
+    assert retried.pr_url == "https://github.com/example/retryable/pull/42"
+    assert retried.remote_push_branch == "contributors/fix-123"
+    assert retried.auto_merge is True
+    adoption = retried.task_policy["pr_adoption"]
+    assert adoption["execution"] == {"mode": "hosted"}
+    assert adoption["pr_number"] == 42
+    assert adoption["head_ref"] == "contributors/fix-123"
+    assert "provider_readiness_preflight" not in retried.task_policy
+    # Failed paths freeze resolved_profile; cancelled keeps the seeded snapshot.
+    if terminal == "failed":
+        assert retried.resolved_profile == {"source": "frozen:test-profile"}
+    else:
+        assert retried.resolved_profile == {"source": "retry-test-profile"}
+
+
+async def test_local_adoption_retry_still_requires_codex_auth(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="local",
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/local",
+        remote_push_branch="contributors/fix-123",
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    preflight = exc_info.value.detail["provider_readiness_preflight"]
+    assert preflight["reason_code"] == "CODEX_AUTH_MISSING"
+    assert preflight["blocks_launch"] is True
+
+
+async def test_legacy_adoption_without_execution_block_requires_codex_auth(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode=None,
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/legacy",
+        remote_push_branch="contributors/fix-123",
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
+
+
+@pytest.mark.parametrize(
+    "execution",
+    [
+        {"mode": "Hosted"},
+        "hosted",
+        {"mode": ["hosted"]},
+    ],
+)
+async def test_malformed_execution_mode_does_not_bypass_local_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    execution: object,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="local",
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/malformed",
+        remote_push_branch="contributors/fix-123",
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        adoption["execution"] = execution
+        policy["pr_adoption"] = adoption
+        source.task_policy = policy
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
+
+
+async def test_spoofed_hosted_marker_on_feature_branch_still_requires_codex(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="feature_branch_pr",
+        task_policy_overrides={
+            "pr_adoption": {
+                "repo_slug": "example/retryable",
+                "pr_number": 42,
+                "pr_url": "https://github.com/example/retryable/pull/42",
+                "execution": {"mode": "hosted"},
+            }
+        },
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="awf/spoofed-hosted",
+        remote_push_branch="contributors/fix-123",
+        pr_url="https://github.com/example/retryable/pull/42",
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
+
+
+async def test_closed_hosted_pr_fallback_does_not_skip_local_auth(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    """Stale hosted marker on a closed PR must not bypass Codex preflight."""
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory, terminal="failed")
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.closed),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
+
+
+async def test_closed_hosted_pr_fallback_with_override_clears_adoption(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory, terminal="failed")
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            provider_readiness_override=True,
+            provider_readiness_override_reason="closed hosted falls back to feature",
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.closed),
+        )
+
+    retried = retry.new_workspace
+    assert retried.task_kind == "feature_branch_pr"
+    assert "pr_adoption" not in (retried.task_policy or {})
+    assert (retried.task_policy or {}).get("task_kind") == "feature_branch_pr"
+
+
+async def test_hosted_open_retry_fails_closed_without_delegation_config(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    settings = _settings_with_host_home(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("must fail closed on delegation before local preflight")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceHostedDelegationNotConfiguredError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.error_code == "HOSTED_DELEGATION_NOT_CONFIGURED"
+    assert isinstance(exc_info.value.detail, dict)
+    assert "missing" in exc_info.value.detail

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -121,6 +121,72 @@ async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
         assert retried.resolved_profile == {"source": "retry-test-profile"}
 
 
+async def test_hosted_open_adoption_retry_clears_stale_blocking_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Hosted bypass must not inherit a source blocks_launch snapshot.
+
+    A prior deferred Cursor Router failure leaves
+    ``provider_readiness_preflight.blocks_launch=true`` on the source policy.
+    ``_retry_task_policy`` deepcopies that key; when hosted admission sets
+    ``preflight=None``, expanding an empty overlay would leave the blocking
+    snapshot on the replacement and the provisioner defense-in-depth path would
+    fail again (PRRT_kwDOSJAM6s6fjWEC).
+    """
+    settings = _settings_with_hosted_delegation(tmp_path)
+    blocking_preflight = {
+        "blocks_launch": True,
+        "reason_code": "CURSOR_ROUTER_UNAVAILABLE",
+        "message": "Router probe failed on prior hosted attempt.",
+    }
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="hosted",
+        auto_merge=True,
+        task_policy_overrides={"provider_readiness_preflight": blocking_preflight},
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/hosted-stale-preflight",
+        remote_push_branch="contributors/fix-123",
+        pr_url=None,
+    )
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        assert source.task_policy["provider_readiness_preflight"]["blocks_launch"] is True
+        await session.commit()
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    retried = retry.new_workspace
+    assert "provider_readiness_preflight" not in retried.task_policy
+    assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
+
+
 async def test_hosted_planning_scope_retry_skips_local_codex_preflight(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -248,6 +248,65 @@ async def test_malformed_execution_mode_does_not_bypass_local_preflight(
     )
 
 
+@pytest.mark.parametrize(
+    "mutate_adoption",
+    [
+        # Incomplete: PR identity present for preserve-candidacy, but head/base absent.
+        # Later retry code would otherwise fill head/base from workspace columns.
+        lambda adoption: {
+            "repo_slug": adoption["repo_slug"],
+            "pr_number": adoption["pr_number"],
+            "pr_url": adoption["pr_url"],
+            "execution": {"mode": "hosted"},
+        },
+        # Spoofed: adoption PR identity disagrees with workspace/prefetched PR.
+        lambda adoption: {
+            **adoption,
+            "pr_number": 99,
+            "pr_url": "https://github.com/example/retryable/pull/99",
+            "execution": {"mode": "hosted"},
+        },
+    ],
+)
+async def test_malformed_sync_feature_hosted_adoption_does_not_bypass_local_preflight(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    mutate_adoption: object,
+) -> None:  # type: ignore[no-untyped-def]
+    """Same-kind hosted rows need complete, consistent adoption identity."""
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        assert callable(mutate_adoption)
+        policy["pr_adoption"] = mutate_adoption(adoption)
+        source.task_policy = policy
+        # Workspace columns still look like a preserve-existing-PR candidate and
+        # could backfill missing adoption head/base after a hosted bypass.
+        source.pr_number = 42
+        source.pr_url = "https://github.com/example/retryable/pull/42"
+        source.remote_push_branch = "contributors/fix-123"
+        source.base_commit = "a" * 40
+        await session.commit()
+
+    async with factory() as session:
+        with pytest.raises(WorkspaceProviderReadinessBlockedError) as exc_info:
+            await retry_workspace_row(
+                session,
+                first_id,
+                settings=settings,
+                provider_environ={},
+                pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+            )
+
+    assert exc_info.value.detail["provider_readiness_preflight"]["reason_code"] == (
+        "CODEX_AUTH_MISSING"
+    )
+
+
 async def test_spoofed_hosted_marker_on_feature_branch_still_requires_codex(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -148,6 +148,130 @@ async def test_hosted_open_adoption_retry_skips_local_codex_preflight(
         assert retried.resolved_profile == {"source": "retry-test-profile"}
 
 
+async def test_hosted_open_adoption_retry_skips_local_host_port_admission(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Hosted open retry must not reject on local host-port conflicts.
+
+    Hosted provisioning only renders the stack and never binds local ports;
+    initial hosted adoption reserves none. A peer local workspace holding a
+    companion or profile host port must not block hosted retry admission
+    (PRRT_kwDOSJAM6s6fj4mC).
+    """
+    from awf.db.enums import WorkspaceStatus
+
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _seed_failed_source_workspace(
+        factory,
+        task_kind="sync_feature_pr",
+        execution_mode="hosted",
+        auto_merge=True,
+        task_policy_overrides={
+            "companions": [
+                {
+                    "name": "sidecar",
+                    "repo_url": "git@github.com:example/sidecar.git",
+                    "base_branch": "main",
+                    "ports": [[5432, 15432]],
+                },
+            ],
+        },
+    )
+    await _mark_failed(
+        factory,
+        first_id,
+        branch_name="feature-sync/hosted-ports",
+        remote_push_branch="contributors/fix-123",
+        pr_url=None,
+    )
+    async with factory() as session:
+        repo = WorkspaceRepository(session)
+        source = await repo.get(first_id)
+        assert source is not None
+        source.pr_number = 42
+        source.compose_project_name = None
+        source.compose_file_path = None
+        source.resolved_profile = {
+            "source": "retry-test-profile",
+            "services": [
+                {
+                    "name": "postgres",
+                    "image": "postgres:16",
+                    "ports": [[5432, 25432]],
+                }
+            ],
+        }
+        blocker = await repo.create(
+            repo_url="git@github.com:example/blocker.git",
+            branch_base="main",
+            task_title="Block hosted ports",
+            task_prompt="noop",
+            task_external_id=None,
+            task_class="test_task",
+            owned_paths=[],
+            task_policy={
+                "companions": [
+                    {"name": "blocker-svc", "ports": [[5432, 15432], [5432, 25432]]},
+                ],
+            },
+            auto_merge=False,
+            initial_review_grace_period_seconds=0,
+            agent="codex",
+            env_profile=None,
+            profile_ref=None,
+            requested_profile=None,
+            resolved_profile=None,
+            test_commands=[],
+            requires_database=False,
+            idempotency_key=None,
+            task_kind="feature_branch_pr",
+            remote_push_branch=None,
+        )
+        blocker.node_id = "local"
+        await repo.transition(blocker, to=WorkspaceStatus.provisioning, reason_code="TEST")
+        await repo.transition(blocker, to=WorkspaceStatus.ready, reason_code="TEST")
+        await repo.transition(blocker, to=WorkspaceStatus.running, reason_code="TEST")
+        await session.commit()
+
+    lock_calls: list[list[int]] = []
+    original_lock = WorkspaceRepository.acquire_host_port_admission_lock
+
+    async def _spy_lock(self: WorkspaceRepository, *, host_ports: list[int]) -> None:
+        lock_calls.append(list(host_ports))
+        await original_lock(self, host_ports=host_ports)
+
+    monkeypatch.setattr(
+        WorkspaceRepository,
+        "acquire_host_port_admission_lock",
+        _spy_lock,
+    )
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    assert lock_calls == []
+    retried = retry.new_workspace
+    assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
+    _assert_hosted_local_preflight_bypass(retried.task_policy)
+
+
 async def test_hosted_open_adoption_retry_clears_stale_blocking_preflight(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -210,6 +210,47 @@ async def test_hosted_adoption_missing_head_sha_does_not_bypass_local_preflight(
     )
 
 
+async def test_hosted_open_adoption_retry_allows_distinct_fork_head_repo_slug(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:  # type: ignore[no-untyped-def]
+    """Fork head_repo_slug must not be confused with the target repo identity."""
+    settings = _settings_with_hosted_delegation(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        adoption["head_repo_slug"] = "fork-owner/retryable"
+        policy["pr_adoption"] = adoption
+        source.task_policy = policy
+        await session.commit()
+
+    async def _spy_preflight(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("local provider preflight must not run for hosted open adoption")
+
+    monkeypatch.setattr(
+        workspaces_create,
+        "_selected_provider_preflight_for_task_async",
+        _spy_preflight,
+    )
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    adoption = retry.new_workspace.task_policy["pr_adoption"]
+    assert adoption["repo_slug"] == "example/retryable"
+    assert adoption["head_repo_slug"] == "fork-owner/retryable"
+
+
 async def test_local_adoption_retry_still_requires_codex_auth(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,
@@ -357,6 +398,24 @@ async def test_malformed_execution_mode_does_not_bypass_local_preflight(
             **adoption,
             "pr_number": 99,
             "pr_url": "https://github.com/example/retryable/pull/99",
+            "execution": {"mode": "hosted"},
+        },
+        # Spoofed target repo slug (distinct from optional fork head_repo_slug).
+        lambda adoption: {
+            **adoption,
+            "repo_slug": "foreign/project",
+            "execution": {"mode": "hosted"},
+        },
+        # Spoofed PR URL points at a different target repository.
+        lambda adoption: {
+            **adoption,
+            "pr_url": "https://github.com/foreign/project/pull/42",
+            "execution": {"mode": "hosted"},
+        },
+        # Unparseable PR URL must not pass (presence + numeric suffix is insufficient).
+        lambda adoption: {
+            **adoption,
+            "pr_url": "not-a-pull-request-url",
             "execution": {"mode": "hosted"},
         },
     ],

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -40,13 +40,25 @@ pytestmark = pytest.mark.unit
 __all__ = ["factory"]
 
 
-def _assert_hosted_local_preflight_bypass(task_policy: dict[str, Any]) -> None:
-    """Hosted open retry must record a nonblocking bypass, not omit the snapshot."""
+def _assert_hosted_local_preflight_bypass(
+    task_policy: dict[str, Any],
+    *,
+    agent: str = "codex",
+) -> None:
+    """Hosted open retry must record a schema-valid nonblocking bypass snapshot."""
+    from awf.api.schemas import ProviderReadinessPreflightResponse
+
     snapshot = task_policy.get("provider_readiness_preflight")
     assert isinstance(snapshot, dict)
     assert snapshot.get("blocks_launch") is False
     assert snapshot.get("reason_code") == HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON
     assert _needs_deferred_cursor_auto_router_preflight(task_policy) is False
+    # Must serialize as WorkspaceRetryResponse / WorkspaceResponse preflight
+    # (PRRT_kwDOSJAM6s6fjz5r): missing provider/agent/auth_* fields raise 500.
+    validated = ProviderReadinessPreflightResponse.model_validate(snapshot)
+    assert validated.agent == agent
+    assert validated.blocks_launch is False
+    assert validated.reason_code == HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED_REASON
 
 
 async def _prepare_hosted_open_source(
@@ -265,7 +277,7 @@ async def test_hosted_open_adoption_retry_preserves_cursor_auto_bypass_through_p
 
     retried = retry.new_workspace
     assert retried.task_policy.get("cursor_auto_mode") == "intelligence"
-    _assert_hosted_local_preflight_bypass(retried.task_policy)
+    _assert_hosted_local_preflight_bypass(retried.task_policy, agent="cursor")
     assert retried.task_policy["pr_adoption"]["execution"] == {"mode": "hosted"}
 
 

--- a/tests/unit/service/test_workspace_retry_hosted_adoption.py
+++ b/tests/unit/service/test_workspace_retry_hosted_adoption.py
@@ -592,6 +592,51 @@ async def test_malformed_sync_feature_hosted_adoption_does_not_bypass_local_pref
     )
 
 
+async def test_unqualified_hosted_adoption_override_downgrades_to_local(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    """Failed hosted qualification must not retain execution.mode=hosted.
+
+    Incomplete adoption identity falls through to local preflight. With an
+    operator override (or local credentials), retry must convert to a valid
+    local policy rather than provision/execute as hosted without delegation
+    qualification (PRRT_kwDOSJAM6s6fjbwg).
+    """
+    # No hosted delegation configured: hosted path would fail closed, but the
+    # unqualified fallthrough must become local and admit via override.
+    settings = _settings_with_host_home(tmp_path)
+    first_id = await _prepare_hosted_open_source(factory)
+    async with factory() as session:
+        source = await WorkspaceRepository(session).get(first_id)
+        assert source is not None
+        policy = dict(source.task_policy)
+        adoption = dict(policy["pr_adoption"])
+        del adoption["head_sha"]
+        policy["pr_adoption"] = adoption
+        source.task_policy = policy
+        source.pr_number = 42
+        source.pr_url = "https://github.com/example/retryable/pull/42"
+        source.remote_push_branch = "contributors/fix-123"
+        source.base_commit = "a" * 40
+        await session.commit()
+
+    async with factory() as session:
+        retry = await retry_workspace_row(
+            session,
+            first_id,
+            provider_readiness_override=True,
+            provider_readiness_override_reason="unqualified hosted must become local",
+            settings=settings,
+            provider_environ={},
+            pr_lifecycle_checker=_live_pr_state(PullRequestLifecycle.open),
+        )
+
+    adoption = retry.new_workspace.task_policy["pr_adoption"]
+    assert adoption["execution"] == {"mode": "local"}
+    assert retry.new_workspace.task_kind == "sync_feature_pr"
+
+
 async def test_spoofed_hosted_marker_on_feature_branch_still_requires_codex(
     factory: async_sessionmaker[AsyncSession],
     tmp_path,


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_5de74e9adf5d423e884d1ffa` (agent: `cursor`, model: `auto`).

**External task ID**: awf-pr592-hosted-retry-auth-20260905

### Task
Environment notes
This is a narrowly scoped AWF Core hosted-adoption retry bugfix at /workspace. Read AGENTS.md and follow the local plan/validation protocol. Use strict TDD and the normal repository workspace profile. Git is functional; commit before exiting. Do not push; AWF owns branch/PR lifecycle. Never commit plans/*_PLAN.md or plans/*_VALIDATION.md.

Production evidence
Cloud native MCP retry of cancelled PR592 monitor ws_e8ec3f0f4a8a45379e9421e8 reached POST /v1/workspaces/{id}/retry and Core returned 409; no replacement was created. Read-only reproduction in the production Core API, with the persisted agent/profile/policy and the same credential-overlay/preflight functions, returns CODEX_AUTH_MISSING and blocks_launch=true. The source is sync_feature_pr with explicit pr_adoption.execution.mode=hosted. Core API has no local Codex credential by design; Cloud leases credentials to hosted execution jobs. Original hosted adoption, validation and agent execution already worked. The actual 600-second validation deadline was independently fixed and deployed in Cloud; this failure happens before starting a retry.

What to implement
Make the smallest correction in src/awf/service/workspaces_retry.py (reuse existing workspace_policy helpers) so retry admission for a valid retained hosted PR adoption does not demand local Codex credentials or a local coding CLI. Preserve actual delegated provider-auth/config validation and do not fabricate ready credentials or use provider_readiness_override. Use existing hosted execution semantics, not a new provider/protocol.

Qualification must be strict: persisted explicit hosted mode, appropriate adoption task kind, valid retained adoption identity and the already-prefetched still-open PR. Legacy/local retries and non-adoption tasks must retain the existing local provider preflight. Pay special attention to closed-PR fallback to a new feature task: a stale hosted marker must NOT bypass local authentication on that path. Missing/malformed execution mode must not confer hosted behavior. Do not infer hosted mode from missing auth, missing Compose, or environment alone. Ensure the normal retry result preserves branch, PR identity, trusted profile provenance, execution mode and merge policy and actually routes the replacement back through hosted execution.

TDD and validation
Add focused service/route regressions for failed and cancelled hosted retry with no local Codex credentials, plus local/legacy/malformed/spoofed/closed-PR negative cases. Assert no local provider agent execution is selected for hosted retries, and missing delegated configuration/auth remains fail-closed at its existing correct owner. Test through the existing retry service with fake forge/delegation dependencies, not only a tiny predicate. Focused tests run with pytest-xdist parallelism where supported, then normal AWF profile validation, no command/tier overrides or weakened gates.

Keep scope tight
Own retry service and focused retry/adoption tests only; small related helper edits only when required by existing patterns. No broad refactor, generated test splitting, coverage threshold/CI/profile changes, transport/staging ref work, scheduler/GKE health work, publish/merge-policy changes, or Cloud/infra modifications. Do not resurrect PR908 work. If a necessary fix requires broader scope, provide exact evidence instead of expanding. Summarize evidence and test results in the PR.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes retry admission, authentication bypass rules, and hosted delegation gating for PR-adoption workspaces—security- and execution-path sensitive—with strict qualification but many edge-case branches.
> 
> **Overview**
> **Hosted adoption retries** no longer require local Codex/CLI readiness when admission can prove a **retained, still-open** `sync_feature_pr` with explicit `pr_adoption.execution.mode=hosted`, complete consistent adoption identity (including `head_sha`), and prefetched open forge state. Those retries record a **nonblocking** `provider_readiness_preflight` (`HOSTED_PR_ADOPTION_LOCAL_PREFLIGHT_BYPASSED`) so stale `blocks_launch` snapshots and deferred Cursor Router probes do not block provisioning, and they **require configured hosted delegation** or fail with `HOSTED_DELEGATION_NOT_CONFIGURED`. Unqualified hosted markers are **downgraded to local** before normal preflight; closed PRs, spoofed/incomplete identity, wrong task kinds, and local/legacy rows still run the existing local gate (and **skip local host-port admission** only on the qualified hosted path).
> 
> **Forge-neutral PR URL parsing** (`parse_forge_pull_request_url`, including Bitbucket `/pull-requests/<n>`) supports hosted identity checks on retry. Retries also **refresh `pr_adoption.head_sha`** (and related refs) from live forge snapshots for hosted validation.
> 
> Recovery/policy helpers were **moved to** `workspaces_retry_recovery.py` (re-exported from `workspaces_retry.py`) to keep module size down; behavior is covered by new service/API regressions in `test_workspace_retry_hosted_adoption.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96d3ca7cfa432d7c1bda06e5502d2a61c1e12b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Hosted pull request adoption workspaces can be retried without local provider readiness checks when delegation and adoption details are valid.
  - Retries preserve hosted task details for failed or cancelled workspaces.
  - Hosted pull request identity now includes synchronized branch, base, head, and repository information, including supported fork scenarios.

- **Bug Fixes**
  - Invalid, incomplete, legacy, malformed, spoofed, or closed pull request scenarios continue through local readiness checks.
  - Retries now provide a clear configuration error when hosted delegation is not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->