### PR TITLE
Fix #925: verdict protocol discards legitimate fixes and strands threads

### DIFF
--- a/src/awf/runtime/feedback_policy.py
+++ b/src/awf/runtime/feedback_policy.py
@@ -33,6 +33,12 @@ _REQUEUE_ON_BODY_CHANGE_VERDICTS = CLOSED_OUTDATED_THREAD_VERDICTS | frozenset(
     {"defer", "needs_human"}
 )
 
+# Verdicts whose threads may be resolved on the forge. ``needs_human`` and
+# ``agent_failed`` must keep the thread open. Single home for the taxonomy: the
+# fix cycle's in-cycle resolve loop and its stranded-thread invariant both read
+# it, so they can never drift apart.
+RESOLVABLE_THREAD_VERDICTS = frozenset({"defer", "false_positive", "fix_committed"})
+
 
 def needs_comment_attention(verdict: str | None) -> bool:
     """Return True when an unresolved PR comment still needs the agent.
@@ -214,6 +220,21 @@ def thread_enters_address_comments(state_map: Mapping[str, str], thread: ReviewT
     if recorded is None:
         return False
     return not recorded_review_thread_body_matches(recorded, thread)
+
+
+def thread_resolution_pending(state_map: Mapping[str, str], thread: ReviewThread) -> bool:
+    """True when AWF owes this still-unresolved thread a ``resolve_thread`` call.
+
+    A resolvable verdict plus a recorded body hash that still matches the live
+    conversation means the disposition is current: the thread is not waiting on
+    more agent work, it is waiting on resolution. Anything left in that state at
+    the end of a fix cycle is a silent merge blocker (#925), so callers must
+    resolve it, hand it to a demonstrable owner, or escalate.
+    """
+    if state_map.get(thread.thread_id) not in RESOLVABLE_THREAD_VERDICTS:
+        return False
+    recorded = state_map.get(review_thread_body_state_key(thread.thread_id))
+    return recorded_review_thread_body_matches(recorded, thread)
 
 
 def outdated_thread_has_fresh_feedback(state_map: Mapping[str, str], thread: ReviewThread) -> bool:

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict.py
@@ -30,6 +30,9 @@ from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     AGENT_NON_FIX_CITES_OWN_COMMIT as AGENT_NON_FIX_CITES_OWN_COMMIT,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    correction_reason_cites_own_item_commit as correction_reason_cites_own_item_commit,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     correction_self_citation_outcome as correction_self_citation_outcome,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
@@ -1185,10 +1188,12 @@ async def _invoke_cli_for_verdict_result(
                             if (
                                 fixed_without_evidence_correction
                                 and parsed.verdict in ("false_positive", "defer")
-                                and verdict_reason_cites_own_commit(
-                                    parsed.reason,
-                                    attempt_tip=verified_attempt_tip,
+                                and await correction_reason_cites_own_item_commit(
+                                    runner,
+                                    reason=parsed.reason,
+                                    worktree_path=worktree_path,
                                     item_start_head=item_start_head,
+                                    attempt_tip=verified_attempt_tip,
                                 )
                             ):
                                 # #925 D2: the correction prompt puts this item's

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict.py
@@ -26,6 +26,18 @@ from awf.runtime.ownership import (
     MONITOR_AGENT_RUNTIME_OWNERSHIP_REPAIR_EVENT_NAME,
     repair_agent_runtime_ownership,
 )
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    AGENT_NON_FIX_CITES_OWN_COMMIT as AGENT_NON_FIX_CITES_OWN_COMMIT,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    correction_self_citation_outcome as correction_self_citation_outcome,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    path_level_item_fix_evidence as path_level_item_fix_evidence,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    verdict_reason_cites_own_commit as verdict_reason_cites_own_commit,
+)
 from awf.runtime.pr_monitor_runner.comment_verdict_residue import (
     _correction_authored_mutation_vs_start,
     _fingerprint_has_pr_worthy_path_residue,
@@ -36,8 +48,15 @@ from awf.runtime.pr_monitor_runner.comment_verdict_residue import (
 from awf.runtime.pr_monitor_runner.comment_verdict_residue_fingerprint import (
     read_protocol_attempt_start_head,
 )
+
+# ``_item_fix_evidence`` is re-exported (``X as X``) because the correction
+# path resolves it back through this module at call time, so a monkeypatch on
+# ``comment_verdict`` reaches both the line-anchored and the escalated
+# path-level evidence check (#925).
 from awf.runtime.pr_monitor_runner.comment_verdict_rollback import (
-    _item_fix_evidence,
+    _item_fix_evidence as _item_fix_evidence,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_rollback import (
     _repair_mirror_hooks_or_raise,
     _rollback_or_classify_failure,
     _rollback_unaccepted_protocol_retry_changes,
@@ -138,8 +157,11 @@ _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT = (
     "Your previous FIXED record could not be accepted because this review item "
     "made no new item-scoped Git change after its start commit. Do not repeat "
     "FIXED unless you make a contentful change for this item. If the issue is a "
-    "duplicate or was already addressed by an earlier review item or commit, "
-    "choose FALSE POSITIVE and state that reason."
+    "duplicate of a different review item, or was already addressed by a commit "
+    "made before this item started, choose FALSE POSITIVE and state that reason. "
+    "A commit you already made for this review item does not count as such an "
+    "earlier commit: do not cite it as the reason for FALSE POSITIVE or DEFER — "
+    "repeat FIXED and describe that change instead (#925)."
 )
 
 
@@ -223,7 +245,13 @@ async def _invoke_cli_for_verdict_result(
     Both protocol attempts share the item-start HEAD. FIXED evidence is
     recomputed from the final candidate HEAD after each attempt, not OR-
     accumulated across attempts, so a correction retry that reverts an
-    unaccepted first-attempt commit cannot inherit stale evidence. A corrected
+    unaccepted first-attempt commit cannot inherit stale evidence. Evidence
+    escalates only inside the ``AGENT_FIXED_WITHOUT_EVIDENCE`` correction: after
+    that explicit rejection a contentful commit touching the anchored path
+    counts even when it misses the anchored line, and a corrected ``FALSE
+    POSITIVE`` / ``DEFER`` whose reason cites this item's own attempt-0 commit is
+    never accepted as a non-fix — the commit is kept and the item returns
+    ``fix_committed`` (path evidence) or ``needs_human`` (#925). A corrected
     non-FIXED verdict is accepted only when the correction attempt itself did
     not advance HEAD, commit dirty changes it authored, leave new PR-worthy
     uncommitted residue after a False commit sink, or otherwise mutate relative
@@ -338,6 +366,10 @@ async def _invoke_cli_for_verdict_result(
     # None means the baseline probe failed (fail closed on mutation signals).
     correction_start_residue_fp: str | None = None
     correction_authored_mutation = False
+    # True once attempt 0 has been rejected specifically for missing line-anchored
+    # FIXED evidence. Only that correction attempt relaxes evidence to the
+    # anchored path and refuses to roll back a self-citing non-fix (#925).
+    fixed_without_evidence_correction = False
 
     for protocol_attempt in range(2):
         dirty_changes_committed = False
@@ -794,6 +826,29 @@ async def _invoke_cli_for_verdict_result(
                     state=state,
                     dirty_changes_committed=dirty_changes_committed,
                 )
+                if (
+                    not logical_fix_evidence
+                    and fixed_without_evidence_correction
+                    and item_path is not None
+                    and item_line is not None
+                    and item_line > 0
+                ):
+                    # Escalating evidence (#925 D1): attempt 0 already failed the
+                    # strict line-anchored gate, so a contentful commit touching
+                    # the anchored *path* now counts. A real fix often lands off
+                    # the anchor (helper above the caller, guard at the call
+                    # site); rejecting it discarded legitimate work on PR #922.
+                    # ``item_line <= 0`` is the unmappable-anchor sentinel from
+                    # the path/line remap above: those stay fail-closed on both
+                    # attempts (PRRT_kwDOSJAM6s6dFLGV).
+                    logical_fix_evidence = await path_level_item_fix_evidence(
+                        runner,
+                        worktree_path=worktree_path,
+                        item_start_head=item_start_head,
+                        item_path=item_path,
+                        state=state,
+                        dirty_changes_committed=dirty_changes_committed,
+                    )
             except (
                 ProviderRecoveryRetryError,
                 ProviderRecoveryFallbackError,
@@ -1127,6 +1182,28 @@ async def _invoke_cli_for_verdict_result(
                                 if pre_sink_probe_exc is not None:
                                     raise mutation_error from pre_sink_probe_exc
                                 raise mutation_error
+                            if (
+                                fixed_without_evidence_correction
+                                and parsed.verdict in ("false_positive", "defer")
+                                and verdict_reason_cites_own_commit(
+                                    parsed.reason,
+                                    attempt_tip=verified_attempt_tip,
+                                    item_start_head=item_start_head,
+                                )
+                            ):
+                                # #925 D2: the correction prompt puts this item's
+                                # own attempt-0 commit at HEAD, so the agent can
+                                # answer "already addressed by <that sha>". Never
+                                # roll a fix back on the strength of a verdict
+                                # that cites it — keep the commit and either
+                                # accept FIXED (path-level evidence) or escalate.
+                                return correction_self_citation_outcome(
+                                    workspace_id=workspace_id,
+                                    verdict=parsed.verdict,
+                                    reason=parsed.reason,
+                                    attempt_tip=verified_attempt_tip,
+                                    has_path_evidence=logical_fix_evidence,
+                                )
                         rollback_ok = await _rollback_or_classify_failure(
                             runner,
                             workspace_id=workspace_id,
@@ -1213,9 +1290,12 @@ async def _invoke_cli_for_verdict_result(
                 workspace_id=workspace_id,
                 reason_code=protocol_error.reason_code,
             )
+            fixed_without_evidence_correction = (
+                protocol_error.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+            )
             correction_context = (
                 f"\n\n{_FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT}"
-                if protocol_error.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+                if fixed_without_evidence_correction
                 else ""
             )
             current_prompt = f"{prompt}{correction_context}{_VERDICT_PROTOCOL_CORRECTION_SUFFIX}"

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict.py
@@ -1185,6 +1185,24 @@ async def _invoke_cli_for_verdict_result(
                                 if pre_sink_probe_exc is not None:
                                     raise mutation_error from pre_sink_probe_exc
                                 raise mutation_error
+                            # ``verified_attempt_tip`` stays unset when the
+                            # post-attempt tip probe returns None, even though the
+                            # correction-start probe can recover the same attempt-0
+                            # commit into ``attempt_start_head``
+                            # (PRRT_kwDOSJAM6s6fmmha). Prefer that verified
+                            # correction-start HEAD when it advanced past
+                            # ``item_start_head``: everything in that range belongs
+                            # to attempt 0 of this item, so citing it is
+                            # self-citation. An equal (or unknown-baseline) head is
+                            # left to ``verified_attempt_tip`` so citing a
+                            # genuinely earlier commit stays non-self-citing.
+                            self_citation_tip = verified_attempt_tip
+                            if (
+                                attempt_start_head is not None
+                                and item_start_head is not None
+                                and attempt_start_head.lower() != item_start_head.lower()
+                            ):
+                                self_citation_tip = attempt_start_head
                             if (
                                 fixed_without_evidence_correction
                                 and parsed.verdict in ("false_positive", "defer")
@@ -1193,7 +1211,7 @@ async def _invoke_cli_for_verdict_result(
                                     reason=parsed.reason,
                                     worktree_path=worktree_path,
                                     item_start_head=item_start_head,
-                                    attempt_tip=verified_attempt_tip,
+                                    attempt_tip=self_citation_tip,
                                 )
                             ):
                                 # #925 D2: the correction prompt puts this item's
@@ -1206,7 +1224,7 @@ async def _invoke_cli_for_verdict_result(
                                     workspace_id=workspace_id,
                                     verdict=parsed.verdict,
                                     reason=parsed.reason,
-                                    attempt_tip=verified_attempt_tip,
+                                    attempt_tip=self_citation_tip,
                                     has_path_evidence=logical_fix_evidence,
                                 )
                         rollback_ok = await _rollback_or_classify_failure(

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
@@ -1,0 +1,146 @@
+"""Correction-path helpers for the comment verdict protocol (#925).
+
+Kept separate so ``comment_verdict`` stays under the first-party line budget;
+re-exported from ``comment_verdict`` for callers and tests.
+
+Two policies live here, both scoped to the retry that follows an explicit
+``AGENT_FIXED_WITHOUT_EVIDENCE`` rejection:
+
+* **Escalating evidence** — attempt 0 keeps the strict line-anchored gate, but
+  once that gate has already rejected a FIXED claim, a contentful attempt-0
+  commit touching the anchored *path* is accepted as evidence. A legitimate fix
+  that lands elsewhere in the reviewed file (a helper above the caller, a guard
+  at the call site) is a real fix, not an unsubstantiated claim.
+* **No rollback on a self-citing non-fix** — the correction prompt puts the
+  item's own attempt-0 commit at HEAD, so an agent can answer ``FALSE POSITIVE:
+  already addressed by commit <its own sha>``. Accepting that as a non-fix and
+  rolling the commit back discards the fix and strands the review thread
+  (issue #925, observed six times on PR #922).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from awf.common.logging import get_logger
+
+if TYPE_CHECKING:
+    from awf.runtime.pr_monitor import MonitorState
+    from awf.runtime.pr_monitor_runner import PullRequestMonitorRunner
+    from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
+
+_log = get_logger(__name__)
+
+# A non-FIXED correction verdict whose reason cites the commit this item just
+# made. Never a rollback trigger; either the fix is kept as FIXED (path-level
+# evidence) or the item escalates to ``needs_human`` with the commit preserved.
+AGENT_NON_FIX_CITES_OWN_COMMIT = "AGENT_NON_FIX_CITES_OWN_COMMIT"
+
+# Abbreviated-or-full commit references. Seven hex chars is Git's own minimum
+# abbreviation, which keeps ordinary prose ("fix 1234ab") from matching.
+_COMMIT_REFERENCE = re.compile(r"[0-9a-fA-F]{7,40}")
+
+_MAX_CORRECTION_REASON_LENGTH = 500
+
+
+def verdict_reason_cites_own_commit(
+    reason: str | None,
+    *,
+    attempt_tip: str | None,
+    item_start_head: str | None,
+) -> bool:
+    """True when ``reason`` names the commit attempt 0 made for this item.
+
+    ``attempt_tip`` is the HEAD verified after attempt 0. When it is unknown, or
+    equals ``item_start_head`` (attempt 0 never advanced HEAD), there is no own
+    commit to cite and today's behaviour stands. Citing ``item_start_head`` — a
+    genuinely earlier commit — is deliberately not self-citation.
+    """
+    if not reason or not attempt_tip:
+        return False
+    tip = attempt_tip.lower()
+    if item_start_head is not None and tip == item_start_head.lower():
+        return False
+    for match in _COMMIT_REFERENCE.finditer(reason):
+        token = match.group(0).lower()
+        if tip.startswith(token) or token.startswith(tip):
+            return True
+    return False
+
+
+async def path_level_item_fix_evidence(
+    runner: PullRequestMonitorRunner,
+    *,
+    worktree_path: Path,
+    item_start_head: str | None,
+    item_path: str | None,
+    state: MonitorState | None,
+    dirty_changes_committed: bool,
+) -> bool:
+    """Re-run the FIXED evidence check without the line anchor (#925 D1).
+
+    Resolved through ``comment_verdict`` at call time, like the rest of the
+    split-out verdict helpers, so monkeypatches on that module still reach the
+    escalated check as well as the line-anchored one.
+    """
+    from awf.runtime.pr_monitor_runner import comment_verdict
+
+    return await comment_verdict._item_fix_evidence(
+        runner,
+        worktree_path=worktree_path,
+        item_start_head=item_start_head,
+        item_path=item_path,
+        item_line=None,
+        state=state,
+        dirty_changes_committed=dirty_changes_committed,
+    )
+
+
+def correction_self_citation_outcome(
+    *,
+    workspace_id: str,
+    verdict: str,
+    reason: str | None,
+    attempt_tip: str | None,
+    has_path_evidence: bool,
+) -> VerdictResult:
+    """Disposition for a self-citing non-FIXED correction verdict (#925 D2).
+
+    With path-level evidence the item is what the agent said it was on its first
+    attempt — FIXED — so the commit stays and the thread can be resolved. Without
+    it, the commit is still preserved (rolling back a change the agent points at
+    as the fix is exactly the #925 defect) and the item escalates to
+    ``needs_human`` so the merge gate keeps blocking with a reason code.
+    """
+    from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
+
+    short_tip = (attempt_tip or "")[:12]
+    _log.warning(
+        "monitor.agent_verdict_correction_cites_own_commit",
+        workspace_id=workspace_id,
+        reason_code=AGENT_NON_FIX_CITES_OWN_COMMIT,
+        verdict=verdict,
+        attempt_tip=attempt_tip,
+        has_path_evidence=has_path_evidence,
+    )
+    if has_path_evidence:
+        outcome = (
+            f"Accepted as FIXED: the correction verdict cited this item's own "
+            f"commit {short_tip}, which changes the reviewed file. "
+            f"Agent reason: {reason}"
+        )
+        return VerdictResult(verdict="fix_committed", reason=_bounded(outcome))
+    outcome = (
+        f"Correction verdict cited this item's own commit {short_tip} without "
+        f"item-scoped fix evidence; the commit is preserved for human review. "
+        f"Agent reason: {reason}"
+    )
+    return VerdictResult(verdict="needs_human", reason=_bounded(outcome))
+
+
+def _bounded(reason: str) -> str:
+    if len(reason) <= _MAX_CORRECTION_REASON_LENGTH:
+        return reason
+    return f"{reason[: _MAX_CORRECTION_REASON_LENGTH - 1].rstrip()}…"

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
@@ -27,6 +27,8 @@ from typing import TYPE_CHECKING
 from awf.common.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from awf.runtime.pr_monitor import MonitorState
     from awf.runtime.pr_monitor_runner import PullRequestMonitorRunner
     from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
@@ -44,30 +46,140 @@ _COMMIT_REFERENCE = re.compile(r"[0-9a-fA-F]{7,40}")
 
 _MAX_CORRECTION_REASON_LENGTH = 500
 
+# Upper bound on the attempt-0 commit range listing. An item attempt makes one
+# or two commits (agent self-commit, dirty-worktree sink); the cap only stops a
+# pathological range from producing unbounded output.
+_MAX_ATTEMPT_COMMITS = 50
+
 
 def verdict_reason_cites_own_commit(
     reason: str | None,
     *,
     attempt_tip: str | None,
     item_start_head: str | None,
+    attempt_commits: Sequence[str] | None = None,
 ) -> bool:
-    """True when ``reason`` names the commit attempt 0 made for this item.
+    """True when ``reason`` names a commit attempt 0 made for this item.
 
     ``attempt_tip`` is the HEAD verified after attempt 0. When it is unknown, or
     equals ``item_start_head`` (attempt 0 never advanced HEAD), there is no own
     commit to cite and today's behaviour stands. Citing ``item_start_head`` — a
     genuinely earlier commit — is deliberately not self-citation.
+
+    ``attempt_commits`` carries the rest of the ``item_start_head``..tip range
+    (PRRT_kwDOSJAM6s6fmmKY): an attempt can leave an agent-authored fix commit
+    *under* the dirty-worktree sink commit, and citing that earlier own commit
+    is still self-citation.
     """
     if not reason or not attempt_tip:
         return False
     tip = attempt_tip.lower()
     if item_start_head is not None and tip == item_start_head.lower():
         return False
+    start = item_start_head.lower() if item_start_head is not None else None
+    candidates = [tip]
+    for commit in attempt_commits or ():
+        candidate = commit.strip().lower()
+        if candidate and candidate != start and candidate not in candidates:
+            candidates.append(candidate)
     for match in _COMMIT_REFERENCE.finditer(reason):
         token = match.group(0).lower()
-        if tip.startswith(token) or token.startswith(tip):
+        if any(
+            candidate.startswith(token) or token.startswith(candidate) for candidate in candidates
+        ):
             return True
     return False
+
+
+async def attempt_commit_shas(
+    runner: PullRequestMonitorRunner,
+    *,
+    worktree_path: Path,
+    item_start_head: str | None,
+    attempt_tip: str | None,
+) -> list[str]:
+    """Commits the attempt added in ``item_start_head``..``attempt_tip``.
+
+    Returns ``[]`` when the range is empty, unknown, or Git cannot list it. The
+    caller always compares against ``attempt_tip`` itself, so a failed listing
+    only restores the previous tip-only comparison rather than widening it.
+    """
+    from awf.runtime.pr_monitor_runner.comment_verdict_residue import (
+        _RESIDUE_ORDINARY_GIT_TIMEOUT_SECONDS,
+    )
+    from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
+    from awf.runtime.pr_monitor_runner.pre_push_validation_fix_pass_ancestry import (
+        _git_env_for_merge_safety_object_lookup,
+    )
+
+    if not attempt_tip or not item_start_head:
+        return []
+    if attempt_tip.lower() == item_start_head.lower():
+        return []
+    if not worktree_path.exists():
+        return []
+    try:
+        result = await runner._deps.runner.run(
+            git_worktree_command(
+                worktree_path,
+                "rev-list",
+                "--first-parent",
+                f"--max-count={_MAX_ATTEMPT_COMMITS}",
+                f"{item_start_head}..{attempt_tip}",
+            ),
+            env=_git_env_for_merge_safety_object_lookup(),
+            timeout_seconds=_RESIDUE_ORDINARY_GIT_TIMEOUT_SECONDS,
+        )
+    except (TimeoutError, OSError, RuntimeError) as exc:
+        _log.warning(
+            "monitor.agent_verdict_attempt_commit_range_unreadable",
+            item_start_head=item_start_head,
+            attempt_tip=attempt_tip,
+            exc_type=type(exc).__name__,
+        )
+        return []
+    if not result.ok:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+async def correction_reason_cites_own_item_commit(
+    runner: PullRequestMonitorRunner,
+    *,
+    reason: str | None,
+    worktree_path: Path,
+    item_start_head: str | None,
+    attempt_tip: str | None,
+) -> bool:
+    """True when ``reason`` cites any commit this item made (#925 D2).
+
+    Checks the verified tip first — the common shape and the only case that
+    needs no Git — then widens to the whole ``item_start_head``..tip range so a
+    non-tip agent commit is not mistaken for an earlier, foreign one
+    (PRRT_kwDOSJAM6s6fmmKY).
+    """
+    if not reason or not attempt_tip:
+        return False
+    if verdict_reason_cites_own_commit(
+        reason,
+        attempt_tip=attempt_tip,
+        item_start_head=item_start_head,
+    ):
+        return True
+    attempt_commits = await attempt_commit_shas(
+        runner,
+        worktree_path=worktree_path,
+        item_start_head=item_start_head,
+        attempt_tip=attempt_tip,
+    )
+    if not attempt_commits:
+        return False
+    return verdict_reason_cites_own_commit(
+        reason,
+        attempt_tip=attempt_tip,
+        item_start_head=item_start_head,
+        attempt_commits=attempt_commits,
+    )
 
 
 async def path_level_item_fix_evidence(
@@ -127,8 +239,8 @@ def correction_self_citation_outcome(
     )
     if has_path_evidence:
         outcome = (
-            f"Accepted as FIXED: the correction verdict cited this item's own "
-            f"commit {short_tip}, which changes the reviewed file. "
+            f"Accepted as FIXED: the correction verdict cited a commit this item "
+            f"made (attempt tip {short_tip}), which changes the reviewed file. "
             f"Agent reason: {reason}"
         )
         return VerdictResult(verdict="fix_committed", reason=_bounded(outcome))

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -937,9 +937,15 @@ async def _run_fix_cycle(
     # outdated at settle: an in-place fix that is later rolled back re-activates
     # it, hygiene never walks it, and its verdict + matching hash suppress
     # AddressComments forever (#925). Adopt those orphans here, and escalate the
-    # ones no owner can be demonstrated for.
+    # ones no owner can be demonstrated for. The sweep covers the whole settle
+    # feed, not just this cycle's deferred ids: a thread stranded that way by an
+    # *earlier* cycle keeps its resolvable verdict and matching hash, so it never
+    # re-enters AddressComments and never becomes a candidate again — only the
+    # feed still shows it (PRRT_kwDOSJAM6s6fmmKc). Threads already on
+    # ``threads_to_resolve`` are excluded: the loop below owns those.
     swept_thread_ids, owner_missing_thread_ids = stranded_resolvable_thread_ids(
         candidate_ids=deferred_resolution_ids,
+        queued_resolution_ids=set(threads_to_resolve),
         state_map=state.threads_addressed_ids,
         settle_threads=(
             canonical_unresolved_inline_threads(

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -231,6 +231,14 @@ async def _run_fix_cycle(
     # Last settle-poll status; used after the loop to skip resolving threads that
     # gained fresh feedback we couldn't re-address (e.g. at the pass limit).
     status: PRStatus | None = None
+    # Whether the *most recent* settle poll succeeded. A later poll can fail
+    # transiently after an earlier one passed, leaving ``status`` holding the
+    # earlier feed. That feed is still valid *positive* evidence (a thread that
+    # needed attention then still does), but it cannot prove the absence of a
+    # reviewer reply that landed during the failed poll window — so the stranded
+    # sweep must treat it as "no settle evidence" and escalate rather than
+    # resolve (PRRT_kwDOSJAM6s6fm4VR).
+    settle_status_is_fresh = False
     fixed_review_comments: list[tuple[ReviewComment, VerdictResult]] = []
     fixed_review_contexts: dict[str, tuple[ReviewComment, VerdictResult]] = {}
     threads = list(initial_threads)
@@ -711,8 +719,12 @@ async def _run_fix_cycle(
                 state=state,
                 monitor_log=monitor_log,
             ):
+                # ``status`` still holds the previous pass's feed; mark it stale so
+                # the stranded sweep below does not mistake it for the final one.
+                settle_status_is_fresh = False
                 break
             raise
+        settle_status_is_fresh = True
         # The settle re-poll succeeded: clear any stale retry count for this context
         # so a recovered blip never accumulates toward the budget across fix cycles.
         await self._clear_forge_transient_retry_state_on_success(
@@ -947,13 +959,18 @@ async def _run_fix_cycle(
         candidate_ids=deferred_resolution_ids,
         queued_resolution_ids=set(threads_to_resolve),
         state_map=state.threads_addressed_ids,
+        # Only a *fresh* settle feed can prove a thread has no pending reply. A
+        # feed left over from an earlier pass whose successor poll failed is
+        # passed as ``None`` so unownable threads escalate to ``needs_human``
+        # instead of being resolved past feedback we never saw
+        # (PRRT_kwDOSJAM6s6fm4VR).
         settle_threads=(
             canonical_unresolved_inline_threads(
                 status.unresolved_inline_threads,
                 status.outdated_unresolved_inline_threads,
                 state.threads_addressed_ids,
             )
-            if status is not None
+            if status is not None and settle_status_is_fresh
             else None
         ),
         stale_thread_ids=stale_thread_ids,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -955,6 +955,15 @@ async def _run_fix_cycle(
     # re-enters AddressComments and never becomes a candidate again — only the
     # feed still shows it (PRRT_kwDOSJAM6s6fmmKc). Threads already on
     # ``threads_to_resolve`` are excluded: the loop below owns those.
+    settle_feed = (
+        canonical_unresolved_inline_threads(
+            status.unresolved_inline_threads,
+            status.outdated_unresolved_inline_threads,
+            state.threads_addressed_ids,
+        )
+        if status is not None
+        else None
+    )
     swept_thread_ids, owner_missing_thread_ids = stranded_resolvable_thread_ids(
         candidate_ids=deferred_resolution_ids,
         queued_resolution_ids=set(threads_to_resolve),
@@ -964,14 +973,16 @@ async def _run_fix_cycle(
         # passed as ``None`` so unownable threads escalate to ``needs_human``
         # instead of being resolved past feedback we never saw
         # (PRRT_kwDOSJAM6s6fm4VR).
-        settle_threads=(
-            canonical_unresolved_inline_threads(
-                status.unresolved_inline_threads,
-                status.outdated_unresolved_inline_threads,
-                state.threads_addressed_ids,
-            )
-            if status is not None and settle_status_is_fresh
-            else None
+        settle_threads=settle_feed if settle_status_is_fresh else None,
+        # ...but that superseded feed still proves those conversations were open,
+        # so hand over its ids. Dropping them entirely would let an orphan
+        # stranded by an earlier cycle — absent from ``candidate_ids`` because its
+        # matching hash keeps it out of AddressComments — slip through a transient
+        # poll blip unresolved AND unescalated (PRRT_kwDOSJAM6s6fm7wj).
+        prior_feed_thread_ids=(
+            frozenset()
+            if settle_status_is_fresh or settle_feed is None
+            else frozenset(thread.thread_id for thread in settle_feed)
         ),
         stale_thread_ids=stale_thread_ids,
         outdated_only_thread_ids=outdated_only_thread_ids,

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle.py
@@ -25,6 +25,7 @@ from awf.common.github_client import (
 from awf.db.enums import FailureReason
 from awf.node.git_manager import git_env_without_object_lookup_overrides
 from awf.runtime.feedback_policy import (
+    RESOLVABLE_THREAD_VERDICTS,
     canonical_unresolved_inline_threads,
     review_thread_body_hashes,
 )
@@ -55,6 +56,10 @@ from awf.runtime.pr_monitor_runner.constants import (
     _GITHUB_WORKFLOW_SCOPE_REQUIRED_REASON,
     _HEAD_OBJECT_MISSING_UNRECOVERABLE_REASON,
 )
+from awf.runtime.pr_monitor_runner.fix_cycle_resolution_invariant import (
+    escalate_owner_missing_threads,
+    stranded_resolvable_thread_ids,
+)
 from awf.runtime.pr_monitor_runner.git_utils import git_worktree_command
 from awf.runtime.pr_monitor_runner.helpers import (
     _clear_addressed_state_by_id,
@@ -81,8 +86,9 @@ from awf.runtime.pr_monitor_runner.types import (
 # Verdicts whose threads may be resolved on GitHub. ``needs_human`` and
 # ``agent_failed`` must keep the thread open, so a thread re-addressed to one of
 # them in a later fix-cycle pass is never resolved even if an earlier pass
-# queued it for resolution.
-_RESOLVABLE_THREAD_VERDICTS = frozenset({"defer", "false_positive", "fix_committed"})
+# queued it for resolution. Aliases the shared taxonomy so the in-cycle resolve
+# loop and the stranded-thread invariant (#925) cannot drift apart.
+_RESOLVABLE_THREAD_VERDICTS = RESOLVABLE_THREAD_VERDICTS
 
 
 def _agent_verdict_protocol_failure_result(
@@ -215,6 +221,10 @@ async def _run_fix_cycle(
     quiet, push everything and resolve the threads we addressed.
     """
     threads_to_resolve: list[str] = []
+    # Threads whose in-cycle resolution was deferred to outdated hygiene because
+    # they were already outdated at batch entry. Re-checked against the final
+    # settle feed so a thread hygiene cannot own is not stranded (#925).
+    deferred_resolution_ids: list[str] = []
     publish_dependent_ids: list[str] = []
     workflow_scope_publish_dependent_ids: list[str] = []
     workflow_scope_resolution_dependent_ids: list[str] = []
@@ -296,6 +306,9 @@ async def _run_fix_cycle(
         ]
         threads_to_resolve[:] = [
             queued_id for queued_id in threads_to_resolve if queued_id != item_id
+        ]
+        deferred_resolution_ids[:] = [
+            queued_id for queued_id in deferred_resolution_ids if queued_id != item_id
         ]
 
     async def _current_item_operation_start_head() -> str:
@@ -457,7 +470,9 @@ async def _run_fix_cycle(
                     monitor_log=monitor_log,
                 )
                 if captured:
-                    if t.thread_id not in already_outdated_at_batch_entry:
+                    if t.thread_id in already_outdated_at_batch_entry:
+                        deferred_resolution_ids.append(t.thread_id)
+                    else:
                         threads_to_resolve.append(t.thread_id)
                     # Roll back with the generic publish-dependent set: if a
                     # non-workflow push later fails, the "defer" addressed
@@ -489,7 +504,9 @@ async def _run_fix_cycle(
                 # resolved on the now-superseded defer.
                 _drop_pending_publish_state(t.thread_id)
             else:
-                if t.thread_id not in already_outdated_at_batch_entry:
+                if t.thread_id in already_outdated_at_batch_entry:
+                    deferred_resolution_ids.append(t.thread_id)
+                else:
                     threads_to_resolve.append(t.thread_id)
                 publish_dependent_ids.append(t.thread_id)
                 if verdict == "fix_committed":
@@ -916,7 +933,40 @@ async def _run_fix_cycle(
     outdated_only_thread_ids = outdated_thread_ids - active_thread_ids
     # ``already_outdated_at_batch_entry`` threads are excluded when enqueueing
     # ``threads_to_resolve`` (single resolution owner: outdated hygiene on the
-    # next outer poll). Do not re-check here — that arm is unreachable.
+    # next outer poll). That hand-off only holds while the thread is still
+    # outdated at settle: an in-place fix that is later rolled back re-activates
+    # it, hygiene never walks it, and its verdict + matching hash suppress
+    # AddressComments forever (#925). Adopt those orphans here, and escalate the
+    # ones no owner can be demonstrated for.
+    swept_thread_ids, owner_missing_thread_ids = stranded_resolvable_thread_ids(
+        candidate_ids=deferred_resolution_ids,
+        state_map=state.threads_addressed_ids,
+        settle_threads=(
+            canonical_unresolved_inline_threads(
+                status.unresolved_inline_threads,
+                status.outdated_unresolved_inline_threads,
+                state.threads_addressed_ids,
+            )
+            if status is not None
+            else None
+        ),
+        stale_thread_ids=stale_thread_ids,
+        outdated_only_thread_ids=outdated_only_thread_ids,
+    )
+    if swept_thread_ids:
+        _log.info(
+            "monitor.thread_resolution_adopted_in_cycle",
+            workspace_id=workspace_id,
+            pr_number=pr_number,
+            thread_ids=list(swept_thread_ids),
+        )
+        threads_to_resolve.extend(swept_thread_ids)
+    escalate_owner_missing_threads(
+        state,
+        owner_missing_thread_ids,
+        workspace_id=workspace_id,
+        pr_number=pr_number,
+    )
     for tid in threads_to_resolve:
         if tid in stale_thread_ids:
             continue

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
@@ -1,0 +1,125 @@
+"""Stranded-thread invariant for the fix cycle's in-cycle resolve step (#925).
+
+Kept separate so ``fix_cycle`` stays under the first-party line budget.
+
+The fix cycle deliberately does not enqueue threads that were already
+``isOutdated`` when the AddressComments batch began: outdated hygiene on the next
+outer poll owns their resolution (#484). That hand-off only holds while the
+thread is *still* outdated. When the outdatedness came from the item's own commit
+and that commit is later rolled back (or the forge simply re-activates the
+thread), hygiene never sees it, the recorded verdict plus matching body hash keep
+``thread_needs_attention`` False, and the conversation stays unresolved forever —
+a silent merge blocker with no escalation (issue #925, PR #922).
+
+This module answers one question over the *final settle* feed: for each thread
+whose in-cycle resolution was deferred, does another owner demonstrably have it?
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from collections.abc import Set as AbstractSet
+from typing import TYPE_CHECKING
+
+from awf.common.logging import get_logger
+from awf.runtime.feedback_policy import (
+    RESOLVABLE_THREAD_VERDICTS,
+    thread_resolution_pending,
+)
+from awf.runtime.pr_monitor_models import ReviewThread
+
+if TYPE_CHECKING:
+    from awf.runtime.pr_monitor import MonitorState
+
+_log = get_logger(__name__)
+
+# A thread ended the cycle dispositioned and unresolved with no demonstrable
+# owner (no settle status to attribute it to). Escalates to ``needs_human`` so
+# the merge gate keeps blocking *visibly* instead of stranding the thread.
+RESOLUTION_OWNER_MISSING_REASON = "THREAD_RESOLUTION_OWNER_MISSING"
+
+
+def stranded_resolvable_thread_ids(
+    *,
+    candidate_ids: Sequence[str],
+    state_map: Mapping[str, str],
+    settle_threads: Sequence[ReviewThread] | None,
+    stale_thread_ids: AbstractSet[str],
+    outdated_only_thread_ids: AbstractSet[str],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Split deferred candidates into (resolve in this cycle, owner missing).
+
+    ``candidate_ids`` are the threads whose in-cycle resolution the caller
+    deferred; they are disjoint from the caller's own resolve queue.
+    ``settle_threads`` is the canonical unresolved view from the last settle
+    poll, or ``None`` when that poll never succeeded. A candidate is left alone
+    when another owner is demonstrable: it needs attention (AddressComments
+    re-enters it), it is outdated-only (hygiene owns it), or it no longer
+    appears in the unresolved feeds at all (already resolved on the forge).
+    """
+    resolve_now: list[str] = []
+    owner_missing: list[str] = []
+    live_by_id = (
+        None if settle_threads is None else {thread.thread_id: thread for thread in settle_threads}
+    )
+    for thread_id in dict.fromkeys(candidate_ids):
+        if thread_id in stale_thread_ids or thread_id in outdated_only_thread_ids:
+            continue
+        if live_by_id is None:
+            # No settle evidence (the settle re-poll never succeeded): the body
+            # hash cannot be re-checked and outdatedness cannot be confirmed, so
+            # fall back to the recorded verdict alone. Deliberately conservative
+            # — outdated hygiene would probably still own these, but "probably"
+            # is what stranded PR #922. A visible ``needs_human`` on a thread
+            # that is unresolved anyway costs an operator glance; a wrong guess
+            # costs a permanently blocked PR with no signal at all.
+            if state_map.get(thread_id) in RESOLVABLE_THREAD_VERDICTS:
+                owner_missing.append(thread_id)
+            continue
+        thread = live_by_id.get(thread_id)
+        if thread is None:
+            continue
+        if thread_resolution_pending(state_map, thread):
+            resolve_now.append(thread_id)
+    return tuple(resolve_now), tuple(owner_missing)
+
+
+def escalate_owner_missing_threads(
+    state: MonitorState,
+    thread_ids: Sequence[str],
+    *,
+    workspace_id: str,
+    pr_number: int,
+) -> None:
+    """Downgrade unownable dispositioned threads to ``needs_human`` (#925).
+
+    The thread is unresolved either way, so this does not block anything that
+    was not already blocked; it converts a silent block into a ``NotifyHuman``
+    carrying ``THREAD_RESOLUTION_OWNER_MISSING``. The recorded body hash is
+    left in place so a later reviewer reply still re-enters AddressComments.
+    """
+    from awf.runtime.pr_monitor_runner.comments import VerdictResult
+    from awf.runtime.pr_monitor_runner.helpers import _sync_needs_human_reason
+
+    for thread_id in thread_ids:
+        _log.warning(
+            "monitor.thread_resolution_owner_missing",
+            workspace_id=workspace_id,
+            pr_number=pr_number,
+            thread_id=thread_id,
+            reason_code=RESOLUTION_OWNER_MISSING_REASON,
+            verdict=state.threads_addressed_ids.get(thread_id),
+        )
+        _sync_needs_human_reason(
+            state,
+            thread_id,
+            VerdictResult(
+                verdict="needs_human",
+                reason=(
+                    f"{RESOLUTION_OWNER_MISSING_REASON}: the fix cycle could not confirm "
+                    "who resolves this dispositioned thread; resolve it manually or "
+                    "re-run the monitor."
+                ),
+            ),
+        )
+        state.mark_addressed(thread_id, "needs_human")

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
@@ -12,7 +12,8 @@ thread), hygiene never sees it, the recorded verdict plus matching body hash kee
 a silent merge blocker with no escalation (issue #925, PR #922).
 
 This module answers one question over the *final settle* feed: for each thread
-whose in-cycle resolution was deferred, does another owner demonstrably have it?
+still awaiting resolution — deferred in this cycle, or stranded the same way by
+an earlier one — does another owner demonstrably have it?
 """
 
 from __future__ import annotations
@@ -46,23 +47,36 @@ def stranded_resolvable_thread_ids(
     settle_threads: Sequence[ReviewThread] | None,
     stale_thread_ids: AbstractSet[str],
     outdated_only_thread_ids: AbstractSet[str],
+    queued_resolution_ids: AbstractSet[str] = frozenset(),
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
-    """Split deferred candidates into (resolve in this cycle, owner missing).
+    """Split resolution-pending threads into (resolve in this cycle, owner missing).
 
     ``candidate_ids`` are the threads whose in-cycle resolution the caller
-    deferred; they are disjoint from the caller's own resolve queue.
-    ``settle_threads`` is the canonical unresolved view from the last settle
-    poll, or ``None`` when that poll never succeeded. A candidate is left alone
-    when another owner is demonstrable: it needs attention (AddressComments
-    re-enters it), it is outdated-only (hygiene owns it), or it no longer
-    appears in the unresolved feeds at all (already resolved on the forge).
+    deferred. ``settle_threads`` is the canonical unresolved view from the last
+    settle poll, or ``None`` when that poll never succeeded; every thread in it
+    is a candidate too. A candidate is left alone when another owner is
+    demonstrable: it is on the caller's own resolve queue
+    (``queued_resolution_ids``), it needs attention (AddressComments re-enters
+    it), it is outdated-only (hygiene owns it), or it no longer appears in the
+    unresolved feeds at all (already resolved on the forge).
+
+    Sweeping the whole settle feed — not just this cycle's deferred candidates —
+    is what catches a thread stranded by an *earlier* cycle: its resolvable
+    verdict plus still-matching body hash keep it out of AddressComments, so it
+    never becomes a deferred candidate again, yet nobody resolves it either
+    (PRRT_kwDOSJAM6s6fmmKc).
     """
     resolve_now: list[str] = []
     owner_missing: list[str] = []
     live_by_id = (
         None if settle_threads is None else {thread.thread_id: thread for thread in settle_threads}
     )
-    for thread_id in dict.fromkeys(candidate_ids):
+    sweep_ids = dict.fromkeys(
+        (*candidate_ids, *(() if live_by_id is None else live_by_id)),
+    )
+    for thread_id in sweep_ids:
+        if thread_id in queued_resolution_ids:
+            continue
         if thread_id in stale_thread_ids or thread_id in outdated_only_thread_ids:
             continue
         if live_by_id is None:

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from awf.common.logging import get_logger
 from awf.runtime.feedback_policy import (
     RESOLVABLE_THREAD_VERDICTS,
+    review_thread_body_hashes,
     thread_resolution_pending,
 )
 from awf.runtime.pr_monitor_models import ReviewThread
@@ -38,6 +39,20 @@ _log = get_logger(__name__)
 # owner (no settle status to attribute it to). Escalates to ``needs_human`` so
 # the merge gate keeps blocking *visibly* instead of stranding the thread.
 RESOLUTION_OWNER_MISSING_REASON = "THREAD_RESOLUTION_OWNER_MISSING"
+
+
+def _deferred_capture_recorded(state_map: Mapping[str, str], thread: ReviewThread) -> bool:
+    """True when a tracking issue is recorded for this ``defer``'s conversation.
+
+    The ``state_map`` view of ``_deferred_issue_already_filed``. Imported lazily
+    because ``fix_cycle`` imports this module.
+    """
+    from awf.runtime.pr_monitor_runner.fix_cycle import _deferred_issue_filed_marker
+
+    return any(
+        state_map.get(_deferred_issue_filed_marker(thread.thread_id, body_hash))
+        for body_hash in review_thread_body_hashes(thread)
+    )
 
 
 def stranded_resolvable_thread_ids(
@@ -64,7 +79,9 @@ def stranded_resolvable_thread_ids(
     is what catches a thread stranded by an *earlier* cycle: its resolvable
     verdict plus still-matching body hash keep it out of AddressComments, so it
     never becomes a deferred candidate again, yet nobody resolves it either
-    (PRRT_kwDOSJAM6s6fmmKc).
+    (PRRT_kwDOSJAM6s6fmmKc). A swept ``defer`` additionally requires its durable
+    capture marker: uncaptured defer state is escalated, never resolved
+    (PRRT_kwDOSJAM6s6fmywf).
     """
     resolve_now: list[str] = []
     owner_missing: list[str] = []
@@ -93,8 +110,20 @@ def stranded_resolvable_thread_ids(
         thread = live_by_id.get(thread_id)
         if thread is None:
             continue
-        if thread_resolution_pending(state_map, thread):
-            resolve_now.append(thread_id)
+        if not thread_resolution_pending(state_map, thread):
+            continue
+        if state_map.get(thread_id) == "defer" and not _deferred_capture_recorded(
+            state_map, thread
+        ):
+            # Incomplete or legacy ``defer`` state: no ``__deferred_issue_filed__``
+            # marker for this conversation, so the deferred work was never durably
+            # captured. In-cycle defers only reach ``candidate_ids`` after capture
+            # succeeded, and outdated hygiene gates on the same marker; resolving
+            # here would be the one path that merges the PR with the follow-up
+            # lost (PRRT_kwDOSJAM6s6fmywf). Escalate instead — no capture, no owner.
+            owner_missing.append(thread_id)
+            continue
+        resolve_now.append(thread_id)
     return tuple(resolve_now), tuple(owner_missing)
 
 

--- a/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
+++ b/src/awf/runtime/pr_monitor_runner/fix_cycle_resolution_invariant.py
@@ -63,6 +63,7 @@ def stranded_resolvable_thread_ids(
     stale_thread_ids: AbstractSet[str],
     outdated_only_thread_ids: AbstractSet[str],
     queued_resolution_ids: AbstractSet[str] = frozenset(),
+    prior_feed_thread_ids: AbstractSet[str] = frozenset(),
 ) -> tuple[tuple[str, ...], tuple[str, ...]]:
     """Split resolution-pending threads into (resolve in this cycle, owner missing).
 
@@ -82,6 +83,13 @@ def stranded_resolvable_thread_ids(
     (PRRT_kwDOSJAM6s6fmmKc). A swept ``defer`` additionally requires its durable
     capture marker: uncaptured defer state is escalated, never resolved
     (PRRT_kwDOSJAM6s6fmywf).
+
+    ``prior_feed_thread_ids`` carries the IDs an *earlier*, superseded settle poll
+    reported unresolved when the final poll failed. That feed cannot license a
+    resolve (``settle_threads`` is ``None`` then), but it is still positive
+    evidence those conversations exist and are open, so its orphans stay in the
+    sweep and escalate instead of vanishing with the discarded feed
+    (PRRT_kwDOSJAM6s6fm7wj).
     """
     resolve_now: list[str] = []
     owner_missing: list[str] = []
@@ -89,7 +97,7 @@ def stranded_resolvable_thread_ids(
         None if settle_threads is None else {thread.thread_id: thread for thread in settle_threads}
     )
     sweep_ids = dict.fromkeys(
-        (*candidate_ids, *(() if live_by_id is None else live_by_id)),
+        (*candidate_ids, *prior_feed_thread_ids, *(() if live_by_id is None else live_by_id)),
     )
     for thread_id in sweep_ids:
         if thread_id in queued_resolution_ids:
@@ -97,9 +105,11 @@ def stranded_resolvable_thread_ids(
         if thread_id in stale_thread_ids or thread_id in outdated_only_thread_ids:
             continue
         if live_by_id is None:
-            # No settle evidence (the settle re-poll never succeeded): the body
-            # hash cannot be re-checked and outdatedness cannot be confirmed, so
-            # fall back to the recorded verdict alone. Deliberately conservative
+            # No final settle evidence (the re-poll never succeeded, or only a
+            # superseded pass did): the body hash cannot be re-checked and
+            # outdatedness cannot be confirmed, so fall back to the recorded
+            # verdict alone — for this cycle's candidates and for the earlier
+            # feed's orphans alike. Deliberately conservative
             # — outdated hygiene would probably still own these, but "probably"
             # is what stranded PR #922. A visible ``needs_human`` on a thread
             # that is unresolved anyway costs an operator glance; a wrong guess

--- a/tests/unit/runtime/test_feedback_policy.py
+++ b/tests/unit/runtime/test_feedback_policy.py
@@ -6,6 +6,8 @@ import pytest
 
 from awf.runtime.feedback_policy import (
     CLOSED_OUTDATED_THREAD_VERDICTS,
+    RESOLVABLE_THREAD_VERDICTS,
+    _legacy_review_thread_body_hash,
     canonical_unresolved_inline_threads,
     needs_comment_attention,
     outdated_thread_has_fresh_feedback,
@@ -15,6 +17,7 @@ from awf.runtime.feedback_policy import (
     review_thread_body_state_key,
     thread_enters_address_comments,
     thread_needs_attention,
+    thread_resolution_pending,
     unresolved_active_count,
     unresolved_canonical_count,
     unresolved_outdated_unique_count,
@@ -768,3 +771,39 @@ def test_preferred_duplicate_review_thread_requires_at_least_one_copy() -> None:
     """Empty transport groups are a caller bug — refuse rather than invent a thread."""
     with pytest.raises(ValueError, match="at least one copy"):
         preferred_duplicate_review_thread(())
+
+
+@pytest.mark.unit
+def test_thread_resolution_pending_requires_resolvable_verdict_and_matching_hash() -> None:
+    """#925: only a resolvable verdict on an unchanged conversation awaits resolve."""
+    thread = _thread("PRRT_pending")
+    body_key = review_thread_body_state_key("PRRT_pending")
+    matching = {
+        "PRRT_pending": "fix_committed",
+        body_key: review_thread_body_hash(thread),
+    }
+    assert thread_resolution_pending(matching, thread)
+    for verdict in RESOLVABLE_THREAD_VERDICTS:
+        assert thread_resolution_pending({**matching, "PRRT_pending": verdict}, thread)
+    # Verdicts that must keep the thread open.
+    assert not thread_resolution_pending({**matching, "PRRT_pending": "needs_human"}, thread)
+    assert not thread_resolution_pending({**matching, "PRRT_pending": "agent_failed"}, thread)
+    # Never addressed.
+    assert not thread_resolution_pending({body_key: review_thread_body_hash(thread)}, thread)
+    # No recorded body snapshot / a stale one: the conversation may have moved on.
+    assert not thread_resolution_pending({"PRRT_pending": "fix_committed"}, thread)
+    assert not thread_resolution_pending(
+        {"PRRT_pending": "fix_committed", body_key: "deadbeef"}, thread
+    )
+
+
+@pytest.mark.unit
+def test_thread_resolution_pending_accepts_legacy_body_hash() -> None:
+    """A pre-normalize hash still means "this conversation is unchanged"."""
+    thread = _thread("PRRT_legacy")
+    legacy = _legacy_review_thread_body_hash(thread)
+    state_map = {
+        "PRRT_legacy": "false_positive",
+        review_thread_body_state_key("PRRT_legacy"): legacy,
+    }
+    assert thread_resolution_pending(state_map, thread)

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -634,8 +634,11 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     """Line coords relative to a newer remote head must map and accept a real FIXED.
 
     When the remote PR head advances (or coords are already for a later commit),
-    anchoring evidence at that head accepts a line-scoped fix. Anchoring at an
-    older SHA maps that line to failure and rejects a real fix.
+    anchoring evidence at that head accepts a line-scoped fix on the first
+    attempt. Anchoring at an older SHA maps that line to the wrong place, so the
+    same real fix fails the line-anchored gate and is sent to the protocol
+    correction — where evidence escalates to the anchored path and the fix is
+    accepted rather than discarded (#925).
     """
     worktree = tmp_path / "worktrees" / "ws_protocol"
     worktree.mkdir(parents=True)
@@ -681,7 +684,10 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     monkeypatch.setattr(comment_verdict, "repair_agent_runtime_ownership", _ok)
     monkeypatch.setattr(comment_verdict, "mirror_path_for_worktree", lambda _path: None)
 
-    async def _fixed_agent(**_kwargs: object) -> AgentRunResult:
+    prompts: list[str] = []
+
+    async def _fixed_agent(**kwargs: object) -> AgentRunResult:
+        prompts.append(str(kwargs["prompt"]))
         return AgentRunResult(
             returncode=0,
             stdout="AWF-VERDICT: FIXED: updated reviewed line",
@@ -706,23 +712,28 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     )
     assert result.verdict == "fix_committed"
     assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == fixed_tip
+    assert len(prompts) == 1
 
-    # Stale operation-open anchor must fail-closed for this settle-thread line.
-    with pytest.raises(AgentVerdictProtocolError) as stale:
-        await comment_verdict._invoke_cli_for_verdict_result(
-            runner,
-            workspace_id="ws_protocol",
-            prompt="fix the reviewed line",
-            commit_message="fix: review item",
-            compose_project="awf_ws_protocol",
-            compose_file=Path("compose.yml"),
-            operation_start_head=pass_head,
-            evidence_item_path="src/mod.py",
-            evidence_item_line=7,
-            evidence_anchor_head=operation_open,
-            commit_dirty_changes=False,
-        )
-    assert stale.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+    # A stale operation-open anchor maps the line elsewhere, so the line gate
+    # still rejects the first attempt (the correction prompt is emitted); the
+    # correction then accepts the same real fix at path level (#925).
+    prompts.clear()
+    stale_result = await comment_verdict._invoke_cli_for_verdict_result(
+        runner,
+        workspace_id="ws_protocol",
+        prompt="fix the reviewed line",
+        commit_message="fix: review item",
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=pass_head,
+        evidence_item_path="src/mod.py",
+        evidence_item_line=7,
+        evidence_anchor_head=operation_open,
+        commit_dirty_changes=False,
+    )
+    assert stale_result.verdict == "fix_committed"
+    assert len(prompts) == 2
+    assert "no new item-scoped Git change" in prompts[1]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
@@ -40,6 +40,7 @@ from awf.runtime.pr_monitor import (
     PRStatus,
     ReviewThread,
 )
+from awf.runtime.pr_monitor_runner.fix_cycle import _deferred_issue_filed_marker
 from awf.runtime.pr_monitor_runner.fix_cycle_resolution_invariant import (
     RESOLUTION_OWNER_MISSING_REASON,
     stranded_resolvable_thread_ids,
@@ -363,6 +364,61 @@ async def test_thread_stranded_by_an_earlier_cycle_is_left_to_hygiene_while_outd
     assert gh.resolved == [_THREAD_ID]
 
 
+@pytest.mark.unit
+async def test_swept_defer_without_capture_marker_is_escalated_not_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fmywf: never resolve a defer whose follow-up was not captured.
+
+    Incomplete or legacy ``defer`` state (no ``__deferred_issue_filed__`` marker
+    for the current conversation) has no durable tracking issue. Resolving it
+    from the whole-feed sweep would let the PR merge with the deferred work lost,
+    so it stays on the ``NotifyHuman`` gate like every other unownable thread.
+    """
+    prior = _thread(thread_id=_PRIOR_THREAD_ID, body="earlier cycle defer")
+    state = MonitorState()
+    state.threads_addressed_ids.update(_state_map("defer", prior))
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread(), prior])],
+        initial_threads=[_thread()],
+        state=state,
+    )
+
+    assert gh.resolved == [_THREAD_ID]
+    assert state.threads_addressed_ids[_PRIOR_THREAD_ID] == "needs_human"
+    reason = state.threads_addressed_ids["__needs_human_reason__:" + _PRIOR_THREAD_ID]
+    assert RESOLUTION_OWNER_MISSING_REASON in reason
+
+
+@pytest.mark.unit
+async def test_swept_defer_with_capture_marker_is_resolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """The captured counterpart still resolves: a tracking issue already holds the work."""
+    prior = _thread(thread_id=_PRIOR_THREAD_ID, body="earlier cycle defer")
+    state = MonitorState()
+    state.threads_addressed_ids.update(_state_map("defer", prior))
+    state.threads_addressed_ids[
+        _deferred_issue_filed_marker(prior.thread_id, review_thread_body_hash(prior))
+    ] = "dimileeh/aira-web#7"
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread(), prior])],
+        initial_threads=[_thread()],
+        state=state,
+    )
+
+    assert gh.resolved == [_THREAD_ID, _PRIOR_THREAD_ID]
+    assert state.threads_addressed_ids[_PRIOR_THREAD_ID] == "defer"
+
+
 def _state_map(verdict: str, thread: ReviewThread) -> dict[str, str]:
     return {
         thread.thread_id: verdict,
@@ -434,3 +490,19 @@ def test_stranded_resolvable_thread_ids_owner_matrix() -> None:
     assert stranded_resolvable_thread_ids(
         settle_threads=None, **{**common, "candidate_ids": []}
     ) == ((), ())
+    # A ``defer`` with no durable capture marker escalates instead of resolving
+    # (PRRT_kwDOSJAM6s6fmywf) — resolving it would lose the deferred follow-up.
+    defer_map = _state_map("defer", thread)
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread], **{**common, "state_map": defer_map}
+    ) == ((), (_THREAD_ID,))
+    # ...and resolves once the tracking issue is recorded for this conversation.
+    captured_map = {
+        **defer_map,
+        _deferred_issue_filed_marker(thread.thread_id, review_thread_body_hash(thread)): (
+            "dimileeh/aira-web#7"
+        ),
+    }
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread], **{**common, "state_map": captured_map}
+    ) == ((_THREAD_ID,), ())

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
@@ -73,10 +73,12 @@ class _ScriptedSettleClient(DefaultMergeMethodGitHubClient):
         *,
         statuses: Sequence[PRStatus] = (),
         status_error: Exception | None = None,
+        status_error_on_call: int | None = None,
     ) -> None:
         super().__init__(runner)
         self._statuses = list(statuses)
         self._status_error = status_error
+        self._status_error_on_call = status_error_on_call
         self.resolved: list[str] = []
         self.status_calls = 0
 
@@ -85,7 +87,10 @@ class _ScriptedSettleClient(DefaultMergeMethodGitHubClient):
     ) -> PRStatus:
         del repo, pr_number, base_behind_count, retry
         self.status_calls += 1
-        if self._status_error is not None:
+        if self._status_error is not None and self._status_error_on_call in (
+            None,
+            self.status_calls,
+        ):
             raise self._status_error
         index = min(self.status_calls - 1, len(self._statuses) - 1)
         return self._statuses[index]
@@ -134,6 +139,7 @@ async def _run_cycle(
     *,
     gh_statuses: Sequence[PRStatus] = (),
     status_error: Exception | None = None,
+    status_error_on_call: int | None = None,
     verdicts: Sequence[str] = ("AWF-VERDICT: FIXED: committed locally",),
     initial_threads: Sequence[ReviewThread],
     state: MonitorState | None = None,
@@ -145,7 +151,12 @@ async def _run_cycle(
     adapter = FakeAdapter()
     for verdict in verdicts:
         adapter.queue(stdout=verdict)
-    gh = _ScriptedSettleClient(cmd, statuses=gh_statuses, status_error=status_error)
+    gh = _ScriptedSettleClient(
+        cmd,
+        statuses=gh_statuses,
+        status_error=status_error,
+        status_error_on_call=status_error_on_call,
+    )
     runner = make_runner(
         factory=factory,
         cmd=cmd,
@@ -257,6 +268,43 @@ async def test_unownable_resolvable_thread_is_escalated_to_needs_human_with_reas
         initial_threads=[entry_thread],
     )
 
+    assert gh.resolved == []
+    assert state.threads_addressed_ids[_THREAD_ID] == "needs_human"
+    reason = state.threads_addressed_ids["__needs_human_reason__:" + _THREAD_ID]
+    assert RESOLUTION_OWNER_MISSING_REASON in reason
+
+
+@pytest.mark.unit
+async def test_failed_later_settle_poll_escalates_instead_of_resolving_on_stale_feed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fm4VR: a stale settle feed is not proof of no fresh reply.
+
+    Pass 1's settle poll succeeds and shows a reviewer reply, so pass 2 re-addresses
+    the thread; pass 2's settle poll then fails transiently and breaks the loop. The
+    surviving ``status`` is pass 1's feed, in which the thread is active with a body
+    hash that now matches the recorded verdict — enough to look sweepable. A reply
+    may have landed during the failed poll window, so the sweep must treat the feed
+    as missing and escalate rather than resolve past feedback it never saw.
+    """
+    entry_thread = _thread(is_outdated=True)
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread(body="reviewer reply 1")])],
+        status_error=GitHubClientError(
+            operation="fetch_pr_status",
+            returncode=1,
+            stderr="HTTP 503: service unavailable",
+        ),
+        status_error_on_call=2,
+        verdicts=["AWF-VERDICT: FIXED: committed locally"] * 2,
+        initial_threads=[entry_thread],
+    )
+
+    assert gh.status_calls == 2
     assert gh.resolved == []
     assert state.threads_addressed_ids[_THREAD_ID] == "needs_human"
     reason = state.threads_addressed_ids["__needs_human_reason__:" + _THREAD_ID]

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
@@ -312,6 +312,47 @@ async def test_failed_later_settle_poll_escalates_instead_of_resolving_on_stale_
 
 
 @pytest.mark.unit
+async def test_failed_later_settle_poll_escalates_prior_cycle_orphan_from_stale_feed(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fm7wj: a discarded feed must not take its orphans with it.
+
+    Pass 1's settle poll exposes a thread stranded by an EARLIER cycle (resolvable
+    verdict + matching hash, so it never re-enters AddressComments and is absent
+    from this cycle's deferred candidates). Pass 2's poll then fails transiently,
+    so the feed is no longer fresh enough to license a resolve. It is still proof
+    the conversation is open, so the orphan must escalate to ``needs_human``
+    rather than end the cycle unresolved *and* unescalated — the silent permanent
+    merge blocker of #925.
+    """
+    prior = _thread(thread_id=_PRIOR_THREAD_ID, body="earlier cycle feedback")
+    state = MonitorState()
+    state.threads_addressed_ids.update(_state_map("fix_committed", prior))
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread(body="reviewer reply 1"), prior])],
+        status_error=GitHubClientError(
+            operation="fetch_pr_status",
+            returncode=1,
+            stderr="HTTP 503: service unavailable",
+        ),
+        status_error_on_call=2,
+        verdicts=["AWF-VERDICT: FIXED: committed locally"] * 2,
+        initial_threads=[_thread(is_outdated=True)],
+        state=state,
+    )
+
+    assert gh.status_calls == 2
+    assert gh.resolved == []
+    assert state.threads_addressed_ids[_PRIOR_THREAD_ID] == "needs_human"
+    reason = state.threads_addressed_ids["__needs_human_reason__:" + _PRIOR_THREAD_ID]
+    assert RESOLUTION_OWNER_MISSING_REASON in reason
+
+
+@pytest.mark.unit
 @pytest.mark.parametrize(
     ("entry_outdated", "settle"),
     [
@@ -537,6 +578,24 @@ def test_stranded_resolvable_thread_ids_owner_matrix() -> None:
     # Without settle evidence there is no feed to sweep: only candidates escalate.
     assert stranded_resolvable_thread_ids(
         settle_threads=None, **{**common, "candidate_ids": []}
+    ) == ((), ())
+    # A superseded feed cannot license a resolve, but the ids it reported open are
+    # still swept, so an earlier cycle's orphan escalates instead of being dropped
+    # with the discarded feed (PRRT_kwDOSJAM6s6fm7wj).
+    assert stranded_resolvable_thread_ids(
+        settle_threads=None,
+        prior_feed_thread_ids=frozenset({_THREAD_ID}),
+        **{**common, "candidate_ids": []},
+    ) == ((), (_THREAD_ID,))
+    # ...and the other owners still win over that escalation.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=None,
+        prior_feed_thread_ids=frozenset({_THREAD_ID}),
+        **{
+            **common,
+            "candidate_ids": [],
+            "outdated_only_thread_ids": frozenset({_THREAD_ID}),
+        },
     ) == ((), ())
     # A ``defer`` with no durable capture marker escalates instead of resolving
     # (PRRT_kwDOSJAM6s6fmywf) — resolving it would lose the deferred follow-up.

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
@@ -1,0 +1,363 @@
+"""#925: a fix cycle must never end with a dispositioned thread nobody owns.
+
+A thread that ends the cycle with a resolvable verdict (``fix_committed`` /
+``false_positive`` / ``defer``) whose recorded body hash still matches the live
+conversation is not waiting on more agent work — it is waiting on
+``resolve_thread``. On PR #922 such threads were excluded from in-cycle
+resolution by ``already_outdated_at_batch_entry`` (their outdatedness came from
+the item's own, subsequently rolled-back commit), and the next poll's
+outdated-hygiene path never saw them because they were active again. The verdict
+plus matching hash then made ``thread_needs_attention`` False forever: a silent
+merge blocker with no ``NotifyHuman`` and no reason code.
+
+These tests pin the invariant: resolved in this cycle, demonstrably owned by
+another path (outdated hygiene / AddressComments), or escalated to
+``needs_human`` with ``THREAD_RESOLUTION_OWNER_MISSING``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Sequence
+from pathlib import Path
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from awf.common.commands import FakeCommandRunner
+from awf.common.github_client import GitHubClientError, RepoRef
+from awf.db.session import make_session_factory
+from awf.runtime.feedback_policy import (
+    review_thread_body_hash,
+    review_thread_body_state_key,
+    thread_enters_address_comments,
+    thread_resolution_pending,
+)
+from awf.runtime.pr_monitor import (
+    CheckState,
+    MergeableState,
+    MergeStateStatus,
+    MonitorState,
+    PRStatus,
+    ReviewThread,
+)
+from awf.runtime.pr_monitor_runner.fix_cycle_resolution_invariant import (
+    RESOLUTION_OWNER_MISSING_REASON,
+    stranded_resolvable_thread_ids,
+)
+from tests.postgres import postgres_test_engine
+from tests.shared.monitor_runner import DefaultMergeMethodGitHubClient
+from tests.unit.runtime._monitor_runner_fixtures import (
+    FakeAdapter,
+    RecordedSleep,
+    make_runner,
+    seed_monitoring_workspace,
+)
+
+_THREAD_ID = "PRRT_stranded"
+
+
+@pytest.fixture
+async def factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    async with postgres_test_engine() as engine:
+        yield make_session_factory(engine)
+
+
+class _ScriptedSettleClient(DefaultMergeMethodGitHubClient):
+    """gh double with scripted settle statuses and a recording ``resolve_thread``."""
+
+    def __init__(
+        self,
+        runner: FakeCommandRunner,
+        *,
+        statuses: Sequence[PRStatus] = (),
+        status_error: Exception | None = None,
+    ) -> None:
+        super().__init__(runner)
+        self._statuses = list(statuses)
+        self._status_error = status_error
+        self.resolved: list[str] = []
+        self.status_calls = 0
+
+    async def fetch_pr_status(
+        self, *, repo: RepoRef, pr_number: int, base_behind_count: int, retry: bool = True
+    ) -> PRStatus:
+        del repo, pr_number, base_behind_count, retry
+        self.status_calls += 1
+        if self._status_error is not None:
+            raise self._status_error
+        index = min(self.status_calls - 1, len(self._statuses) - 1)
+        return self._statuses[index]
+
+    async def resolve_thread(self, *, thread_id: str) -> None:
+        self.resolved.append(thread_id)
+
+
+def _thread(*, body: str = "please adjust this", is_outdated: bool = False) -> ReviewThread:
+    return ReviewThread(
+        thread_id=_THREAD_ID,
+        path="src/foo.py",
+        line=12,
+        body_excerpt=body,
+        author="review-bot",
+        is_outdated=is_outdated,
+    )
+
+
+def _status(
+    *,
+    active: Sequence[ReviewThread] = (),
+    outdated: Sequence[ReviewThread] = (),
+) -> PRStatus:
+    return PRStatus(
+        number=42,
+        head_sha="abc1234567890def",
+        mergeable=MergeableState.MERGEABLE,
+        check_state=CheckState.SUCCESS,
+        unresolved_inline_threads=tuple(active),
+        unresolved_review_comments=(),
+        base_behind_count=0,
+        merge_state_status=MergeStateStatus.CLEAN,
+        outdated_unresolved_inline_threads=tuple(outdated),
+    )
+
+
+async def _run_cycle(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    *,
+    gh_statuses: Sequence[PRStatus] = (),
+    status_error: Exception | None = None,
+    verdicts: Sequence[str] = ("AWF-VERDICT: FIXED: committed locally",),
+    initial_threads: Sequence[ReviewThread],
+) -> tuple[_ScriptedSettleClient, MonitorState]:
+    workspace_id = await seed_monitoring_workspace(factory)
+    cmd = FakeCommandRunner()
+    cmd.queue_result(returncode=0)  # push
+    cmd.queue_result(returncode=0, stdout="newsha\n")  # rev-parse HEAD
+    adapter = FakeAdapter()
+    for verdict in verdicts:
+        adapter.queue(stdout=verdict)
+    gh = _ScriptedSettleClient(cmd, statuses=gh_statuses, status_error=status_error)
+    runner = make_runner(
+        factory=factory,
+        cmd=cmd,
+        adapter=adapter,
+        sleep_fn=RecordedSleep(),
+        worktrees_root=tmp_path / "worktrees",
+        gh=gh,
+    )
+
+    async def _commit_dirty(**_kwargs: object) -> bool:
+        return True
+
+    runner._commit_dirty_worktree = _commit_dirty  # type: ignore[method-assign]
+    state = MonitorState()
+
+    await runner._run_fix_cycle(
+        workspace_id=workspace_id,
+        repo=RepoRef(owner="dimileeh", name="aira-web"),
+        pr_number=42,
+        pr_head_sha="abc1234567890def",
+        initial_threads=tuple(initial_threads),
+        initial_reviews=(),
+        state=state,
+        remote_branch=f"awf/{workspace_id}",
+        compose_project="proj",
+        compose_file=tmp_path / "compose.yml",
+    )
+    return gh, state
+
+
+@pytest.mark.unit
+async def test_thread_outdated_at_batch_entry_but_active_at_settle_is_resolved_in_cycle(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """#925 D3: a rolled-back commit un-outdates the thread — nobody else owns it."""
+    entry_thread = _thread(is_outdated=True)
+    settle_thread = _thread(is_outdated=False)
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[settle_thread])],
+        initial_threads=[entry_thread],
+    )
+
+    assert gh.resolved == [_THREAD_ID]
+    assert state.threads_addressed_ids[_THREAD_ID] == "fix_committed"
+
+
+@pytest.mark.unit
+async def test_thread_still_outdated_at_settle_is_left_to_outdated_hygiene(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Guard (#484): outdated hygiene on the next poll keeps owning resolution."""
+    entry_thread = _thread(is_outdated=True)
+    settle_thread = _thread(is_outdated=True)
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(outdated=[settle_thread])],
+        initial_threads=[entry_thread],
+    )
+
+    assert gh.resolved == []
+    assert state.threads_addressed_ids[_THREAD_ID] == "fix_committed"
+
+
+@pytest.mark.unit
+async def test_thread_with_changed_body_at_settle_is_not_resolved_and_re_enters_repair(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Guard: fresh reviewer feedback keeps the thread in AddressComments."""
+    entry_thread = _thread(is_outdated=True)
+    replies = [_status(active=[_thread(body=f"reviewer reply {index}")]) for index in range(1, 5)]
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=replies,
+        verdicts=["AWF-VERDICT: FIXED: committed locally"] * 4,
+        initial_threads=[entry_thread],
+    )
+
+    assert gh.resolved == []
+    latest = _thread(body="reviewer reply 4")
+    assert thread_enters_address_comments(state.threads_addressed_ids, latest)
+
+
+@pytest.mark.unit
+async def test_unownable_resolvable_thread_is_escalated_to_needs_human_with_reason_code(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """No settle evidence at all: escalate rather than silently strand (#925)."""
+    entry_thread = _thread(is_outdated=True)
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        status_error=GitHubClientError(
+            operation="fetch_pr_status",
+            returncode=1,
+            stderr="HTTP 503: service unavailable",
+        ),
+        initial_threads=[entry_thread],
+    )
+
+    assert gh.resolved == []
+    assert state.threads_addressed_ids[_THREAD_ID] == "needs_human"
+    reason = state.threads_addressed_ids["__needs_human_reason__:" + _THREAD_ID]
+    assert RESOLUTION_OWNER_MISSING_REASON in reason
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("entry_outdated", "settle"),
+    [
+        (True, "active"),
+        (True, "outdated"),
+        (True, "changed_body"),
+        (False, "active"),
+        (False, "outdated"),
+    ],
+)
+async def test_no_thread_left_with_resolvable_verdict_and_matching_hash_unresolved(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+    entry_outdated: bool,
+    settle: str,
+) -> None:
+    """The #925 invariant across the batch-entry / settle matrix."""
+    entry_thread = _thread(is_outdated=entry_outdated)
+    if settle == "active":
+        statuses = [_status(active=[_thread()])]
+    elif settle == "outdated":
+        statuses = [_status(outdated=[_thread(is_outdated=True)])]
+    else:
+        statuses = [
+            _status(active=[_thread(body=f"reviewer reply {index}")]) for index in range(1, 5)
+        ]
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=statuses,
+        verdicts=["AWF-VERDICT: FIXED: committed locally"] * 4,
+        initial_threads=[entry_thread],
+    )
+
+    final_status = statuses[-1]
+    live_threads = (
+        final_status.unresolved_inline_threads + final_status.outdated_unresolved_inline_threads
+    )
+    for thread in live_threads:
+        if thread.thread_id in gh.resolved:
+            continue
+        if not thread_resolution_pending(state.threads_addressed_ids, thread):
+            continue
+        # Still pending resolution and not resolved in-cycle: an owner must exist.
+        assert thread_enters_address_comments(state.threads_addressed_ids, thread) or (
+            thread.is_outdated
+        ), f"thread {thread.thread_id} left stranded for settle={settle}"
+
+
+def _state_map(verdict: str, thread: ReviewThread) -> dict[str, str]:
+    return {
+        thread.thread_id: verdict,
+        review_thread_body_state_key(thread.thread_id): review_thread_body_hash(thread),
+    }
+
+
+@pytest.mark.unit
+def test_stranded_resolvable_thread_ids_owner_matrix() -> None:
+    """Every owner branch of the pure helper, including the unreachable-by-cycle ones."""
+    thread = _thread()
+    state_map = _state_map("fix_committed", thread)
+    common = {
+        "candidate_ids": [_THREAD_ID],
+        "state_map": state_map,
+        "stale_thread_ids": frozenset[str](),
+        "outdated_only_thread_ids": frozenset[str](),
+    }
+
+    # Active at settle with a current disposition: nobody else owns it.
+    assert stranded_resolvable_thread_ids(settle_threads=[thread], **common) == (
+        (_THREAD_ID,),
+        (),
+    )
+    # AddressComments owns a thread that needs attention.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread],
+        **{**common, "stale_thread_ids": frozenset({_THREAD_ID})},
+    ) == ((), ())
+    # Outdated hygiene owns an outdated-only thread.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread],
+        **{**common, "outdated_only_thread_ids": frozenset({_THREAD_ID})},
+    ) == ((), ())
+    # Gone from both unresolved feeds: the forge already resolved it.
+    assert stranded_resolvable_thread_ids(settle_threads=[], **common) == ((), ())
+    # Present but with a changed body: not this cycle's business.
+    assert stranded_resolvable_thread_ids(settle_threads=[_thread(body="new reply")], **common) == (
+        (),
+        (),
+    )
+    # No settle status at all: escalate a resolvable verdict, ignore the rest.
+    assert stranded_resolvable_thread_ids(settle_threads=None, **common) == (
+        (),
+        (_THREAD_ID,),
+    )
+    assert stranded_resolvable_thread_ids(
+        settle_threads=None,
+        **{**common, "state_map": _state_map("needs_human", thread)},
+    ) == ((), ())
+    # Duplicate candidate ids collapse to one decision.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread],
+        **{**common, "candidate_ids": [_THREAD_ID, _THREAD_ID]},
+    ) == ((_THREAD_ID,), ())

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_resolution_invariant.py
@@ -54,6 +54,7 @@ from tests.unit.runtime._monitor_runner_fixtures import (
 )
 
 _THREAD_ID = "PRRT_stranded"
+_PRIOR_THREAD_ID = "PRRT_stranded_by_earlier_cycle"
 
 
 @pytest.fixture
@@ -92,9 +93,14 @@ class _ScriptedSettleClient(DefaultMergeMethodGitHubClient):
         self.resolved.append(thread_id)
 
 
-def _thread(*, body: str = "please adjust this", is_outdated: bool = False) -> ReviewThread:
+def _thread(
+    *,
+    thread_id: str = _THREAD_ID,
+    body: str = "please adjust this",
+    is_outdated: bool = False,
+) -> ReviewThread:
     return ReviewThread(
-        thread_id=_THREAD_ID,
+        thread_id=thread_id,
         path="src/foo.py",
         line=12,
         body_excerpt=body,
@@ -129,6 +135,7 @@ async def _run_cycle(
     status_error: Exception | None = None,
     verdicts: Sequence[str] = ("AWF-VERDICT: FIXED: committed locally",),
     initial_threads: Sequence[ReviewThread],
+    state: MonitorState | None = None,
 ) -> tuple[_ScriptedSettleClient, MonitorState]:
     workspace_id = await seed_monitoring_workspace(factory)
     cmd = FakeCommandRunner()
@@ -151,7 +158,7 @@ async def _run_cycle(
         return True
 
     runner._commit_dirty_worktree = _commit_dirty  # type: ignore[method-assign]
-    state = MonitorState()
+    state = MonitorState() if state is None else state
 
     await runner._run_fix_cycle(
         workspace_id=workspace_id,
@@ -306,6 +313,56 @@ async def test_no_thread_left_with_resolvable_verdict_and_matching_hash_unresolv
         ), f"thread {thread.thread_id} left stranded for settle={settle}"
 
 
+@pytest.mark.unit
+async def test_thread_stranded_by_an_earlier_cycle_is_swept_when_another_comment_runs(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fmmKc: the sweep must cover the whole settle feed.
+
+    A thread stranded by an EARLIER cycle carries a resolvable verdict and a
+    matching body hash, so it never re-enters AddressComments and is absent from
+    this cycle's deferred candidates. It is still unresolved in the settle feed
+    with no other owner — hygiene skips it (it is active again), so the fix cycle
+    must adopt it rather than leave it stranded for another cycle.
+    """
+    prior = _thread(thread_id=_PRIOR_THREAD_ID, body="earlier cycle feedback")
+    state = MonitorState()
+    state.threads_addressed_ids.update(_state_map("fix_committed", prior))
+
+    gh, state = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread(), prior])],
+        initial_threads=[_thread()],
+        state=state,
+    )
+
+    assert gh.resolved == [_THREAD_ID, _PRIOR_THREAD_ID]
+    assert state.threads_addressed_ids[_PRIOR_THREAD_ID] == "fix_committed"
+
+
+@pytest.mark.unit
+async def test_thread_stranded_by_an_earlier_cycle_is_left_to_hygiene_while_outdated(
+    factory: async_sessionmaker[AsyncSession],
+    tmp_path: Path,
+) -> None:
+    """Guard (#484): the broadened sweep must not steal hygiene's outdated-only threads."""
+    prior = _thread(thread_id=_PRIOR_THREAD_ID, body="earlier cycle feedback", is_outdated=True)
+    state = MonitorState()
+    state.threads_addressed_ids.update(_state_map("fix_committed", prior))
+
+    gh, _ = await _run_cycle(
+        factory,
+        tmp_path,
+        gh_statuses=[_status(active=[_thread()], outdated=[prior])],
+        initial_threads=[_thread()],
+        state=state,
+    )
+
+    assert gh.resolved == [_THREAD_ID]
+
+
 def _state_map(verdict: str, thread: ReviewThread) -> dict[str, str]:
     return {
         thread.thread_id: verdict,
@@ -361,3 +418,19 @@ def test_stranded_resolvable_thread_ids_owner_matrix() -> None:
         settle_threads=[thread],
         **{**common, "candidate_ids": [_THREAD_ID, _THREAD_ID]},
     ) == ((_THREAD_ID,), ())
+    # A resolution-pending settle thread that is not a candidate id is swept too
+    # (stranded by an earlier cycle — PRRT_kwDOSJAM6s6fmmKc).
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread],
+        **{**common, "candidate_ids": []},
+    ) == ((_THREAD_ID,), ())
+    # ...unless this cycle's own resolve queue already owns it.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=[thread],
+        queued_resolution_ids=frozenset({_THREAD_ID}),
+        **{**common, "candidate_ids": []},
+    ) == ((), ())
+    # Without settle evidence there is no feed to sweep: only candidates escalate.
+    assert stranded_resolvable_thread_ids(
+        settle_threads=None, **{**common, "candidate_ids": []}
+    ) == ((), ())

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_001.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_001.py
@@ -255,7 +255,8 @@ async def test_fixed_without_evidence_correction_explains_duplicate_path(
     assert result.verdict == "false_positive"
     assert len(runner.prompts) == 2
     assert "no new item-scoped Git change" in runner.prompts[1]
-    assert "duplicate or was already addressed" in runner.prompts[1]
+    assert "duplicate of a different review item" in runner.prompts[1]
+    assert "already addressed by a commit made before this item started" in runner.prompts[1]
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
@@ -547,11 +547,18 @@ async def test_fixed_rejected_when_only_same_directory_sibling_changed(
 
 
 @pytest.mark.unit
-async def test_fixed_rejected_when_same_file_unrelated_line_changed(
+async def test_fixed_rejected_on_first_attempt_when_same_file_unrelated_line_changed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """issue:5381831025: same-file edits away from the review line must not count."""
+    """issue:5381831025 + #925: same-file off-anchor edits fail the *first* gate.
+
+    Attempt 0 keeps the strict line-anchored evidence rule (the correction
+    prompt is emitted). Only after that explicit rejection does evidence
+    escalate to the anchored path, so a legitimate off-anchor fix is accepted on
+    the correction attempt instead of being discarded (#925). Cross-file cases
+    below still reject on both attempts.
+    """
     reviewed_path = "src/awf/reviewed.py"
     worktree = tmp_path / "ws_protocol"
     worktree.mkdir()
@@ -579,20 +586,23 @@ async def test_fixed_rejected_when_same_file_unrelated_line_changed(
         body_excerpt="fix the null check here",
     )
 
-    with pytest.raises(AgentVerdictProtocolError) as caught:
-        await _address_thread(
-            runner,
-            workspace_id="ws_protocol",
-            repo=RepoRef(owner="o", name="r"),
-            pr_number=1,
-            thread=thread,
-            compose_project="awf_ws_protocol",
-            compose_file=Path("compose.yml"),
-            operation_start_head="a" * 40,
-        )
+    verdict = await _address_thread(
+        runner,
+        workspace_id="ws_protocol",
+        repo=RepoRef(owner="o", name="r"),
+        pr_number=1,
+        thread=thread,
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head="a" * 40,
+    )
 
-    assert caught.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+    # Attempt 0 was rejected for missing line-anchored evidence — the correction
+    # prompt proves it — and attempt 1 is accepted at path level.
     assert len(runner.prompts) == 2
+    assert "no new item-scoped Git change" in runner.prompts[1]
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
@@ -1,0 +1,349 @@
+"""#925: the FIXED-without-evidence correction path must not discard real fixes.
+
+Attempt 0 commits a real off-anchor fix in the reviewed file, the line-anchored
+evidence gate rejects it (``AGENT_FIXED_WITHOUT_EVIDENCE``), and the correction
+prompt used to steer the agent into ``FALSE POSITIVE — already addressed by
+commit <its own attempt-0 sha>``. The protocol then accepted that verdict and
+rolled the fix back, leaving the thread dispositioned but unresolved.
+
+These tests pin the corrected policy: inside that correction path evidence
+escalates to the anchored *path*, and a non-FIXED correction verdict that cites
+this item's own attempt-0 commit never causes a rollback.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+
+from awf.common.github_client import RepoRef
+from awf.runtime.pr_monitor import ReviewThread
+from awf.runtime.pr_monitor_runner import (
+    comment_verdict,
+    comments,
+)
+from awf.runtime.pr_monitor_runner import (
+    pre_push_validation_fix_pass_ancestry as ancestry,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT,
+    AGENT_FIXED_WITHOUT_EVIDENCE,
+    AGENT_NON_FIXED_WITH_MUTATION,
+    AgentVerdictProtocolError,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    AGENT_NON_FIX_CITES_OWN_COMMIT,
+    correction_self_citation_outcome,
+    verdict_reason_cites_own_commit,
+)
+from awf.runtime.pr_monitor_runner.comments import _address_thread
+from tests.unit.runtime._verdict_retry_fixtures import _VerdictRunner
+
+pytest_plugins = ["tests.unit.runtime._verdict_retry_fixtures"]
+
+_ITEM_START_HEAD = "a" * 40
+_ATTEMPT0_HEAD = "b" * 40
+_REVIEWED_PATH = "src/awf/reviewed.py"
+
+
+@pytest.fixture(autouse=True)
+def _no_owned_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _empty_owned_paths(_runner: object, _workspace_id: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(comments, "_owned_paths_for_prompt", _empty_owned_paths)
+
+
+def _thread(thread_id: str) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path=_REVIEWED_PATH,
+        line=42,
+        body_excerpt="notification uses stale status",
+    )
+
+
+async def _address(runner: _VerdictRunner, thread: ReviewThread) -> str:
+    return await _address_thread(
+        runner,  # type: ignore[arg-type]
+        workspace_id="ws_protocol",
+        repo=RepoRef(owner="o", name="r"),
+        pr_number=1,
+        thread=thread,
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=_ITEM_START_HEAD,
+    )
+
+
+@pytest.mark.unit
+async def test_off_anchor_fix_accepted_at_path_level_after_evidence_correction(
+    tmp_path: Path,
+) -> None:
+    """#925 D1: a real fix elsewhere in the anchored file survives the correction."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: added a re-read helper above the caller",
+            "AWF-VERDICT: FIXED: the helper is the fix for this item",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_off_anchor"))
+
+    assert verdict == "fix_committed"
+    # Attempt 0 was still rejected at the anchored line (strict first pass).
+    assert len(runner.prompts) == 2
+    assert _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT in runner.prompts[1]
+    # The fix is kept: no rollback to the item-start head.
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+
+
+@pytest.mark.unit
+async def test_correction_false_positive_citing_own_commit_keeps_fix_and_returns_fixed(
+    tmp_path: Path,
+) -> None:
+    """#925 D2: the exact incident shape — self-citing FALSE POSITIVE keeps the fix."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: re-read the status before notifying",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_ATTEMPT0_HEAD} at HEAD",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("PRRT_self_cite"))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    events = [entry.get("event") for entry in captured]
+    assert "monitor.agent_verdict_protocol_retry_rollback" not in events
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
+    assert self_citation[0]["verdict"] == "false_positive"
+
+
+@pytest.mark.unit
+async def test_correction_defer_citing_own_commit_without_path_evidence_escalates(
+    tmp_path: Path,
+) -> None:
+    """#925 D2: no path-level evidence → needs_human, commit still preserved."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: adjusted the caller in a sibling module",
+            f"AWF-VERDICT: DEFER: superseded by {_ATTEMPT0_HEAD[:12]}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("PRRT_self_cite_no_evidence"))
+
+    assert verdict == "needs_human"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    warnings = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(warnings) == 1
+    assert warnings[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
+    assert warnings[0]["verdict"] == "defer"
+
+
+@pytest.mark.unit
+async def test_correction_false_positive_citing_item_start_commit_still_rolls_back(
+    tmp_path: Path,
+) -> None:
+    """Guard: citing a genuinely earlier commit is not self-citation."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: touched the file away from the anchor",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_ITEM_START_HEAD}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_earlier_commit"))
+
+    assert verdict == "false_positive"
+    assert runner.reset_targets == [_ITEM_START_HEAD]
+
+
+@pytest.mark.unit
+async def test_correction_that_mutates_and_cites_own_commit_still_rejected(
+    tmp_path: Path,
+) -> None:
+    """Guard: ``AGENT_NON_FIXED_WITH_MUTATION`` keeps precedence over self-citation."""
+    (tmp_path / "ws_protocol").mkdir()
+    correction_head = "c" * 40
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: touched the file away from the anchor",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_ATTEMPT0_HEAD}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, correction_head],
+        dirty_after_attempt=[True, True],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with pytest.raises(AgentVerdictProtocolError) as caught:
+        await _address(runner, _thread("thread_mutating_correction"))
+
+    assert caught.value.reason_code == AGENT_NON_FIXED_WITH_MUTATION
+    assert runner.reset_targets == [_ITEM_START_HEAD]
+
+
+@pytest.mark.unit
+async def test_fixed_without_evidence_correction_context_excludes_own_item_commit() -> None:
+    """#925 D2: the prompt must not invite citing this item's own retry commit."""
+    context = _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT
+    assert "earlier review item or commit" not in context
+    assert "made for this review item" in context
+    assert "does not count" in context
+
+
+@pytest.mark.unit
+def test_verdict_reason_cites_own_commit_matrix() -> None:
+    """Only ≥7-hex tokens naming the attempt-0 tip count as self-citation."""
+    tip = _ATTEMPT0_HEAD
+    assert verdict_reason_cites_own_commit(
+        f"already addressed by {tip}", attempt_tip=tip, item_start_head=_ITEM_START_HEAD
+    )
+    assert verdict_reason_cites_own_commit(
+        f"superseded by {tip[:8]}", attempt_tip=tip, item_start_head=_ITEM_START_HEAD
+    )
+    # Too short to be a sha reference.
+    assert not verdict_reason_cites_own_commit(
+        f"see {tip[:6]}", attempt_tip=tip, item_start_head=_ITEM_START_HEAD
+    )
+    # A genuinely earlier commit.
+    assert not verdict_reason_cites_own_commit(
+        f"already fixed in {_ITEM_START_HEAD}", attempt_tip=tip, item_start_head=_ITEM_START_HEAD
+    )
+    # No verified attempt-0 tip → today's behaviour stands.
+    assert not verdict_reason_cites_own_commit(
+        f"already addressed by {tip}", attempt_tip=None, item_start_head=_ITEM_START_HEAD
+    )
+    # Attempt 0 never advanced HEAD, so there is no own commit to cite.
+    assert not verdict_reason_cites_own_commit(
+        f"already addressed by {_ITEM_START_HEAD}",
+        attempt_tip=_ITEM_START_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+    )
+    assert not verdict_reason_cites_own_commit(
+        None, attempt_tip=tip, item_start_head=_ITEM_START_HEAD
+    )
+
+
+@pytest.mark.unit
+def test_correction_self_citation_outcome_bounds_the_stored_reason() -> None:
+    """A maximal agent reason must not produce an unbounded persisted reason."""
+    long_reason = "x" * 500
+    fixed = correction_self_citation_outcome(
+        workspace_id="ws_protocol",
+        verdict="false_positive",
+        reason=long_reason,
+        attempt_tip=_ATTEMPT0_HEAD,
+        has_path_evidence=True,
+    )
+    assert fixed.verdict == "fix_committed"
+    assert fixed.reason is not None
+    assert len(fixed.reason) == 500
+    assert fixed.reason.endswith("…")
+
+    escalated = correction_self_citation_outcome(
+        workspace_id="ws_protocol",
+        verdict="defer",
+        reason="short",
+        attempt_tip=_ATTEMPT0_HEAD,
+        has_path_evidence=False,
+    )
+    assert escalated.verdict == "needs_human"
+    assert escalated.reason is not None
+    assert escalated.reason.endswith("Agent reason: short")
+
+
+@pytest.mark.unit
+async def test_unmappable_anchor_line_stays_fail_closed_on_the_correction(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#925 D1 boundary: an unverifiable anchor never escalates to path level.
+
+    When the review line cannot be mapped from the anchor head onto item-start
+    history the remap records the ``-1`` sentinel (PRRT_kwDOSJAM6s6dFLGV). That
+    is "we cannot tell where this item lives", not "the fix is off-anchor", so
+    both attempts stay strict.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+
+    async def _no_line(*_args: object, **_kwargs: object) -> int | None:
+        return None
+
+    async def _same_path(*_args: object, **kwargs: object) -> str | None:
+        return str(kwargs["path"])
+
+    monkeypatch.setattr(ancestry, "_map_review_line_through_commits", _no_line)
+    monkeypatch.setattr(ancestry, "_map_review_path_through_commits", _same_path)
+
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: changed the reviewed file",
+            "AWF-VERDICT: FIXED: still the same change",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with pytest.raises(AgentVerdictProtocolError) as caught:
+        await comment_verdict._invoke_cli_for_verdict_result(
+            runner,  # type: ignore[arg-type]
+            workspace_id="ws_protocol",
+            prompt="ORIGINAL REVIEW PROMPT",
+            commit_message="fix: review item",
+            compose_project="awf_ws_protocol",
+            compose_file=Path("compose.yml"),
+            operation_start_head=_ITEM_START_HEAD,
+            evidence_item_path=_REVIEWED_PATH,
+            evidence_item_line=42,
+            evidence_anchor_head="c" * 40,
+        )
+
+    assert caught.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
+    assert len(runner.prompts) == 2

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
@@ -18,10 +18,12 @@ from pathlib import Path
 import pytest
 import structlog
 
+from awf.common.commands import CommandResult
 from awf.common.github_client import RepoRef
 from awf.runtime.pr_monitor import ReviewThread
 from awf.runtime.pr_monitor_runner import (
     comment_verdict,
+    comment_verdict_correction,
     comments,
 )
 from awf.runtime.pr_monitor_runner import (
@@ -45,7 +47,27 @@ pytest_plugins = ["tests.unit.runtime._verdict_retry_fixtures"]
 
 _ITEM_START_HEAD = "a" * 40
 _ATTEMPT0_HEAD = "b" * 40
+_AGENT_FIX_COMMIT = "d" * 40
 _REVIEWED_PATH = "src/awf/reviewed.py"
+
+
+class _RangeAwareVerdictRunner(_VerdictRunner):
+    """Runner whose attempt-0 range holds a fix commit under the sink tip."""
+
+    def __init__(self, *, attempt_commits: list[str], **kwargs: object) -> None:
+        self._attempt_commits = attempt_commits
+        super().__init__(**kwargs)  # type: ignore[arg-type]
+        self.rev_list_ranges: list[str] = []
+
+    async def _run_git(self, cmd: list[str], **kwargs: object) -> CommandResult:
+        if "rev-list" in cmd:
+            self.rev_list_ranges.append(cmd[-1])
+            return CommandResult(
+                returncode=0,
+                stdout="".join(f"{sha}\n" for sha in self._attempt_commits),
+                stderr="",
+            )
+        return await super()._run_git(cmd, **kwargs)
 
 
 @pytest.fixture(autouse=True)
@@ -347,3 +369,180 @@ async def test_unmappable_anchor_line_stays_fail_closed_on_the_correction(
 
     assert caught.value.reason_code == AGENT_FIXED_WITHOUT_EVIDENCE
     assert len(runner.prompts) == 2
+
+
+@pytest.mark.unit
+def test_verdict_reason_cites_own_commit_covers_the_whole_attempt_range() -> None:
+    """PRRT_kwDOSJAM6s6fmmKY: a non-tip commit from this attempt is self-citation."""
+    attempt_commits = [_ATTEMPT0_HEAD, _AGENT_FIX_COMMIT]
+    # The agent commit sits under the dirty-worktree sink tip.
+    assert not verdict_reason_cites_own_commit(
+        f"already addressed by {_AGENT_FIX_COMMIT}",
+        attempt_tip=_ATTEMPT0_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+    )
+    assert verdict_reason_cites_own_commit(
+        f"already addressed by {_AGENT_FIX_COMMIT}",
+        attempt_tip=_ATTEMPT0_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+        attempt_commits=attempt_commits,
+    )
+    # Abbreviated references still match a non-tip attempt commit.
+    assert verdict_reason_cites_own_commit(
+        f"superseded by {_AGENT_FIX_COMMIT[:8]}",
+        attempt_tip=_ATTEMPT0_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+        attempt_commits=attempt_commits,
+    )
+    # The item-start commit is still a genuinely earlier commit, even if a
+    # malformed range listing includes it.
+    assert not verdict_reason_cites_own_commit(
+        f"already fixed in {_ITEM_START_HEAD}",
+        attempt_tip=_ATTEMPT0_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+        attempt_commits=[_ITEM_START_HEAD, _ATTEMPT0_HEAD],
+    )
+    # Blank/short entries never widen the comparison.
+    assert not verdict_reason_cites_own_commit(
+        f"see {_AGENT_FIX_COMMIT}",
+        attempt_tip=_ATTEMPT0_HEAD,
+        item_start_head=_ITEM_START_HEAD,
+        attempt_commits=["   "],
+    )
+
+
+@pytest.mark.unit
+async def test_correction_citing_non_tip_attempt_commit_keeps_the_fix(
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fmmKY: citing the agent commit under the sink tip is self-citation.
+
+    Attempt 0 lands the real fix as its own commit and the dirty-worktree sink
+    commits the leftovers on top, so the verified tip is the sink commit. A
+    correction verdict that cites the *fix* commit used to miss the tip-only
+    comparison, roll the attempt back to item start, and discard both commits.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _RangeAwareVerdictRunner(
+        attempt_commits=[_ATTEMPT0_HEAD, _AGENT_FIX_COMMIT],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: re-read the status before notifying",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_AGENT_FIX_COMMIT}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("PRRT_self_cite_non_tip"))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    assert runner.rev_list_ranges == [f"{_ITEM_START_HEAD}..{_ATTEMPT0_HEAD}"]
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
+
+
+@pytest.mark.unit
+async def test_correction_citing_foreign_commit_still_rolls_back(
+    tmp_path: Path,
+) -> None:
+    """Guard: a commit outside the attempt range keeps the rollback path."""
+    (tmp_path / "ws_protocol").mkdir()
+    foreign_commit = "e" * 40
+    runner = _RangeAwareVerdictRunner(
+        attempt_commits=[_ATTEMPT0_HEAD, _AGENT_FIX_COMMIT],
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: touched the file away from the anchor",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {foreign_commit}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_foreign_commit"))
+
+    assert verdict == "false_positive"
+    assert runner.reset_targets == [_ITEM_START_HEAD]
+
+
+@pytest.mark.unit
+async def test_attempt_commit_shas_returns_empty_when_git_cannot_list_the_range(
+    tmp_path: Path,
+) -> None:
+    """A failed/unspawnable range listing falls back to the tip-only comparison."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+
+    class _FailingRunner(_VerdictRunner):
+        async def _run_git(self, cmd: list[str], **kwargs: object) -> CommandResult:
+            if "rev-list" in cmd:
+                return CommandResult(returncode=128, stdout="", stderr="bad revision")
+            return await super()._run_git(cmd, **kwargs)
+
+    class _RaisingRunner(_VerdictRunner):
+        async def _run_git(self, cmd: list[str], **kwargs: object) -> CommandResult:
+            if "rev-list" in cmd:
+                raise OSError("git spawn failed")
+            return await super()._run_git(cmd, **kwargs)
+
+    kwargs: dict[str, object] = {
+        "worktrees_root": tmp_path,
+        "outputs": ["AWF-VERDICT: FIXED: change"],
+        "heads_after_attempt": [_ATTEMPT0_HEAD],
+    }
+    for runner_cls in (_FailingRunner, _RaisingRunner):
+        runner = runner_cls(**kwargs)  # type: ignore[arg-type]
+        assert (
+            await comment_verdict_correction.attempt_commit_shas(
+                runner,  # type: ignore[arg-type]
+                worktree_path=worktree,
+                item_start_head=_ITEM_START_HEAD,
+                attempt_tip=_ATTEMPT0_HEAD,
+            )
+            == []
+        )
+        assert not await comment_verdict_correction.correction_reason_cites_own_item_commit(
+            runner,  # type: ignore[arg-type]
+            reason=f"already addressed by {_AGENT_FIX_COMMIT}",
+            worktree_path=worktree,
+            item_start_head=_ITEM_START_HEAD,
+            attempt_tip=_ATTEMPT0_HEAD,
+        )
+
+    # Unknown tip, an unadvanced attempt, and a missing worktree skip Git entirely.
+    unused = _RaisingRunner(**kwargs)  # type: ignore[arg-type]
+    for item_start, tip, path in (
+        (_ITEM_START_HEAD, None, worktree),
+        (None, _ATTEMPT0_HEAD, worktree),
+        (_ITEM_START_HEAD, _ITEM_START_HEAD, worktree),
+        (_ITEM_START_HEAD, _ATTEMPT0_HEAD, tmp_path / "missing"),
+    ):
+        assert (
+            await comment_verdict_correction.attempt_commit_shas(
+                unused,  # type: ignore[arg-type]
+                worktree_path=path,
+                item_start_head=item_start,
+                attempt_tip=tip,
+            )
+            == []
+        )
+    assert not await comment_verdict_correction.correction_reason_cites_own_item_commit(
+        unused,  # type: ignore[arg-type]
+        reason=None,
+        worktree_path=worktree,
+        item_start_head=_ITEM_START_HEAD,
+        attempt_tip=_ATTEMPT0_HEAD,
+    )

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
@@ -453,6 +453,50 @@ async def test_correction_citing_non_tip_attempt_commit_keeps_the_fix(
 
 
 @pytest.mark.unit
+async def test_correction_citing_own_commit_recovered_at_correction_start_keeps_the_fix(
+    tmp_path: Path,
+) -> None:
+    """PRRT_kwDOSJAM6s6fmmha: an unreadable post-attempt tip must not strand the fix.
+
+    The post-attempt-0 tip probe returns None, so ``verified_attempt_tip`` stays
+    unset, but the correction-start probe recovers the very same attempt-0 commit.
+    Comparing the citation against the unset tip alone made self-citation invisible
+    and rolled the legitimate fix back — the #925 defect in a different disguise.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: re-read the status before notifying",
+            f"AWF-VERDICT: FALSE POSITIVE: already addressed by commit {_ATTEMPT0_HEAD}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+        # attempt-0 start, attempt-0 evidence, post-attempt tip probe (None);
+        # every later probe falls through to the live head (_ATTEMPT0_HEAD),
+        # including the correction-start read that recovers the tip.
+        rev_parse_sequence=[_ITEM_START_HEAD, _ATTEMPT0_HEAD, None],
+    )
+    runner.current_head = _ITEM_START_HEAD
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("PRRT_self_cite_recovered_start"))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["attempt_tip"] == _ATTEMPT0_HEAD
+
+
+@pytest.mark.unit
 async def test_correction_citing_foreign_commit_still_rolls_back(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_98485db2b6fa4a1fb63e9876` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Fix GitHub issue #925 in this repo (read it first with: gh issue view 925). Scope is narrow: the PR-monitor comment-repair verdict protocol in src/awf/runtime/pr_monitor_runner/ (comment_verdict.py, comment_verdict_rollback.py, fix_cycle.py) and the resolution bookkeeping in src/awf/runtime/feedback_policy.py. Three defects to fix, TDD (failing test first, then the smallest green change): (1) in the AGENT_FIXED_WITHOUT_EVIDENCE correction path, a non-empty attempt-0 commit that touches the anchored file must count as evidence (path-level) so a legitimate off-anchor fix is accepted as FIXED instead of rejected; (2) never accept a corrected FALSE POSITIVE / DEFER whose stated reason cites the item's own attempt-0 commit and then roll that commit back - keep the fix and accept FIXED (or escalate needs_human with the commit preserved), and reword _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT so 'already addressed by an earlier commit' explicitly excludes this item's own protocol-retry commit; (3) a thread that ends a fix cycle with a resolvable verdict (fix_committed/false_positive/defer) and a matching body hash must be resolved in that cycle or explicitly re-enter repair / escalate with a reason code - in particular the already_outdated_at_batch_entry exclusion in fix_cycle.py must not strand a thread whose outdatedness came from this item's own rolled-back commit; add an invariant test for 'no thread left with resolvable verdict + matching hash + unresolved + not re-queued'. Regression tests go in tests/unit/runtime/test_pr_monitor_verdict_retry_parts/ (ls the dir first and add a NEW part file, never overwrite an existing one) and the fix_cycle test parts. Constraints: keep files under 1500 lines (comment_verdict.py is near the limit - put new logic in a sibling module and re-export with 'X as X'); coverage gate is 99% line+branch; run the full local gate before pushing: ruff check, ruff format --check, mypy, and 'pytest tests -q -n 20' (use -n 20 always). Do not change bot-review policy, release-monitor behaviour, or decide() action semantics. Reference #925 in the PR body with 'Closes #925'.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core monitor verdict acceptance, rollback, and fix-cycle thread resolution with many edge cases (settle poll freshness, defer capture, outdated hygiene hand-offs); mistakes could block merges or accept bad verdicts, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **#925** in the PR-monitor comment-repair path so legitimate agent work is not rolled back and dispositioned threads cannot silently block merge.
> 
> **Verdict protocol (`comment_verdict` + new `comment_verdict_correction`)** — After `AGENT_FIXED_WITHOUT_EVIDENCE`, evidence can escalate from line-anchored to **path-level** on the correction attempt. Corrected **FALSE POSITIVE** / **DEFER** reasons that cite this item’s own attempt-0 commit(s) no longer trigger rollback: the commit stays and the outcome becomes **`fix_committed`** when path evidence exists, otherwise **`needs_human`**. The correction prompt now states that citing this item’s own retry commit is not a valid “already addressed” excuse.
> 
> **Fix-cycle resolution (`fix_cycle` + `fix_cycle_resolution_invariant`)** — Shared **`RESOLVABLE_THREAD_VERDICTS`** and **`thread_resolution_pending`** centralize “awaiting `resolve_thread`”. Threads deferred because they were outdated at batch entry are re-checked on the **fresh** settle feed; orphans (e.g. re-activated after rollback, or stranded from an earlier cycle) are **resolved in-cycle**, left to outdated hygiene / AddressComments when another owner is clear, or escalated with **`THREAD_RESOLUTION_OWNER_MISSING`**. Stale or failed settle polls fail closed (escalate rather than resolve on outdated evidence). Swept **`defer`** threads require a durable capture marker before in-cycle resolve.
> 
> **Tests** — New/updated unit coverage for correction self-citation, path evidence, resolution invariant, and feedback-policy helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62e2a6d0416d4fe81f62ab40364d228bd4defe25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->