### PR TITLE
Accept path-level FIXED evidence on the correction attempt (restore #926 D1 on top of #928)

### DIFF
--- a/src/awf/runtime/pr_monitor_runner/comment_verdict.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict.py
@@ -39,6 +39,9 @@ from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     correction_unscoped_fix_outcome as correction_unscoped_fix_outcome,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
+    path_level_item_fix_evidence as path_level_item_fix_evidence,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
     preserved_correction_tip as preserved_correction_tip,
 )
 from awf.runtime.pr_monitor_runner.comment_verdict_correction import (
@@ -253,20 +256,23 @@ async def _invoke_cli_for_verdict_result(
     Both protocol attempts share the item-start HEAD. FIXED evidence is
     recomputed from the final candidate HEAD after each attempt, not OR-
     accumulated across attempts, so a correction retry that reverts an
-    unaccepted first-attempt commit cannot inherit stale evidence. Related
-    off-anchor fixes (near-anchor inserts, call-site→definition changes) are
-    accepted by the line-scoped evidence gate; path membership alone is never
-    enough for ``fix_committed`` (issue:5558086911). On the correction attempt —
-    whatever rejected attempt 0 — a FIXED whose contentful commit carries no
-    item-scoped evidence is preserved and escalated to ``needs_human`` instead
-    of terminating the protocol, and a corrected ``FALSE POSITIVE`` / ``DEFER``
-    / ``NEEDS_HUMAN`` whose reason cites this item's own attempt-0 commit is
-    never accepted as a non-fix — the commit is kept. ``FALSE POSITIVE`` /
-    ``DEFER`` return ``fix_committed`` when related-line evidence already
-    exists, otherwise ``needs_human``; an explicit corrected ``NEEDS_HUMAN``
-    always stays ``needs_human`` so evidence cannot override a requested human
-    gate (#925, issue:5558086911). A FIXED with no contentful change at all
-    still terminates after its one correction. A corrected
+    unaccepted first-attempt commit cannot inherit stale evidence. Attempt 0 is
+    strictly line-anchored, so a misplaced or absent FIXED still earns its
+    correction round. On the correction attempt — whatever rejected attempt 0 —
+    evidence is re-checked at *path* level over the item's own
+    ``item_start_head``..HEAD range: the agent has been told its FIXED lacked
+    line evidence and re-affirmed it, and the range cannot hold a stale or
+    foreign commit, so a contentful change to the reviewed file is an honest
+    off-anchor fix and is accepted as ``fix_committed`` (#925 D1). A FIXED whose
+    commit touches none of the reviewed paths is preserved and escalated to
+    ``needs_human`` instead of terminating the protocol, and a corrected
+    ``FALSE POSITIVE`` / ``DEFER`` / ``NEEDS_HUMAN`` whose reason cites this
+    item's own attempt-0 commit is never accepted as a non-fix — the commit is
+    kept. ``FALSE POSITIVE`` / ``DEFER`` return ``fix_committed`` when
+    item-scoped evidence exists, otherwise ``needs_human``; an explicit
+    corrected ``NEEDS_HUMAN`` always stays ``needs_human`` so evidence cannot
+    override a requested human gate (#925, issue:5558086911). A FIXED with no
+    contentful change at all still terminates after its one correction. A corrected
     non-FIXED verdict is accepted only when the correction attempt itself did
     not advance HEAD, commit dirty changes it authored, leave new PR-worthy
     uncommitted residue after a False commit sink, or otherwise mutate relative
@@ -383,8 +389,8 @@ async def _invoke_cli_for_verdict_result(
     correction_authored_mutation = False
     # True once attempt 0 has been rejected specifically for missing line-anchored
     # FIXED evidence. It selects the extra correction prompt context only: every
-    # correction attempt refuses to roll back a self-citing non-fix (#925), and
-    # none of them widen FIXED evidence to path membership alone.
+    # correction attempt refuses to roll back a self-citing non-fix and re-checks
+    # evidence at path level (#925), whatever rejected attempt 0.
     fixed_without_evidence_correction = False
 
     for protocol_attempt in range(2):
@@ -842,6 +848,36 @@ async def _invoke_cli_for_verdict_result(
                     state=state,
                     dirty_changes_committed=dirty_changes_committed,
                 )
+                if (
+                    not logical_fix_evidence
+                    and protocol_attempt == 1
+                    and item_path is not None
+                    and item_line is not None
+                    and item_line > 0
+                ):
+                    # Path-level evidence on the correction (#925 D1, restored on
+                    # top of #928). Attempt 0 already failed the strict
+                    # line-anchored gate and the agent was told so; a re-affirmed
+                    # FIXED whose contentful commit changes the anchored *path*
+                    # is an honest off-anchor fix (helper above the caller, guard
+                    # at the call site), not an unsupported claim, and escalating
+                    # it to a human is the unnecessary escalation. Safe because
+                    # this is never the first gate and the probe runs over the
+                    # item's own ``item_start_head``..HEAD range, so the commit
+                    # cannot be stale or foreign. ``item_line <= 0`` is the
+                    # unmappable-anchor sentinel from the path/line remap above:
+                    # those stay fail-closed on both attempts
+                    # (PRRT_kwDOSJAM6s6dFLGV); ``item_line is None`` means the
+                    # check above was already path-level. Inside the commit-sink
+                    # ``try`` so it shares the rollback / reason-code handlers.
+                    logical_fix_evidence = await path_level_item_fix_evidence(
+                        runner,
+                        worktree_path=worktree_path,
+                        item_start_head=item_start_head,
+                        item_path=item_path,
+                        state=state,
+                        dirty_changes_committed=dirty_changes_committed,
+                    )
             except (
                 ProviderRecoveryRetryError,
                 ProviderRecoveryFallbackError,
@@ -1285,8 +1321,10 @@ async def _invoke_cli_for_verdict_result(
                                 # answer "already addressed by <that sha>". Never
                                 # roll a fix back on the strength of a verdict
                                 # that cites it — keep the commit. FALSE POSITIVE /
-                                # DEFER become FIXED when related-line evidence
-                                # exists; an explicit NEEDS_HUMAN stays escalated.
+                                # DEFER become FIXED when item-scoped evidence
+                                # exists — line-anchored, or the correction-time
+                                # path-level re-check above; an explicit
+                                # NEEDS_HUMAN stays escalated.
                                 return correction_self_citation_outcome(
                                     workspace_id=workspace_id,
                                     verdict=parsed.verdict,

--- a/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
+++ b/src/awf/runtime/pr_monitor_runner/comment_verdict_correction.py
@@ -3,21 +3,29 @@
 Kept separate so ``comment_verdict`` stays under the first-party line budget;
 re-exported from ``comment_verdict`` for callers and tests.
 
-Two policies live here, both scoped to the correction retry. Neither ever
-loosens the evidence gate: path membership alone is not item-scoped FIXED
-evidence (issue:5558086911). What they change is the *disposition* of a commit
-the gate rejected — preserved and escalated, never rolled back and terminal.
+Three policies live here, all scoped to the correction retry — the attempt that
+runs only after AWF told the agent, explicitly, why attempt 0 was rejected.
 
+* **Path-level evidence on the correction** — attempt 0 keeps the strict
+  line-anchored gate, so a misplaced or absent fix still earns its correction
+  round. Once the agent has been told its FIXED carried no line evidence and
+  re-affirms FIXED, a contentful commit in the item's *own* range
+  (``item_start_head``..HEAD) that changes the reviewed *file* is accepted as
+  evidence. Real fixes routinely land off the anchor (a helper above the
+  caller, a guard at the call site); escalating those to a human is the
+  unnecessary escalation #925 set out to remove. This is never the first gate,
+  and the range is the item's own, so the commit cannot be a stale, foreign, or
+  pre-existing change. Restores the PR #926 D1 behaviour on top of #928.
 * **No rollback on a self-citing non-fix** — the correction prompt puts the
   item's own attempt-0 commit at HEAD, so an agent can answer ``FALSE POSITIVE:
   already addressed by commit <its own sha>``. Accepting that as a non-fix and
   rolling the commit back discards the change and strands the review thread
   (issue #925, observed six times on PR #922). Keep the commit; for
-  ``false_positive`` / ``defer``, accept ``fix_committed`` only when
-  item-scoped related-line evidence already exists (near-anchor / callee),
-  otherwise escalate to ``needs_human``. An explicit corrected ``needs_human``
-  always stays ``needs_human`` (commit still preserved) so related-line
-  evidence cannot override a requested human gate (issue:5558086911).
+  ``false_positive`` / ``defer``, accept ``fix_committed`` when item-scoped
+  evidence exists (related-line, or correction-time path-level), otherwise
+  escalate to ``needs_human``. An explicit corrected ``needs_human`` always
+  stays ``needs_human`` (commit still preserved) so evidence cannot override a
+  requested human gate (issue:5558086911).
 * **No monitor failure on an unsubstantiated correction fix** — a correction
   FIXED whose contentful commit carries no item-scoped evidence used to roll
   back and terminate with ``AGENT_FIXED_WITHOUT_EVIDENCE``, failing the whole
@@ -40,6 +48,7 @@ from awf.runtime.pr_monitor_runner.comment_verdict_residue_fingerprint import (
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
+    from awf.runtime.pr_monitor import MonitorState
     from awf.runtime.pr_monitor_runner import PullRequestMonitorRunner
     from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
 
@@ -47,8 +56,9 @@ _log = get_logger(__name__)
 
 # A non-FIXED correction verdict whose reason cites the commit this item just
 # made. Never a rollback trigger. ``false_positive`` / ``defer`` may become
-# FIXED when item-scoped related-line evidence exists; an explicit
-# ``needs_human`` stays escalated with the commit preserved.
+# FIXED when item-scoped evidence exists (related-line, or correction-time
+# path-level); an explicit ``needs_human`` stays escalated with the commit
+# preserved.
 AGENT_NON_FIX_CITES_OWN_COMMIT = "AGENT_NON_FIX_CITES_OWN_COMMIT"
 
 # Abbreviated-or-full commit references. Seven hex chars is Git's own minimum
@@ -195,6 +205,40 @@ async def correction_reason_cites_own_item_commit(
     )
 
 
+async def path_level_item_fix_evidence(
+    runner: PullRequestMonitorRunner,
+    *,
+    worktree_path: Path,
+    item_start_head: str | None,
+    item_path: str | None,
+    state: MonitorState | None,
+    dirty_changes_committed: bool,
+) -> bool:
+    """Re-run the FIXED evidence check without the line anchor (#925 D1).
+
+    Same probe, same ``item_start_head``..HEAD range, only the line constraint
+    dropped: the range must still be a contentful descendant of the item's own
+    start that changes the reviewed path. Callers must gate this on the
+    correction attempt — it is the answer to "the agent was told its FIXED had
+    no line evidence and re-affirmed FIXED", never the first evidence check.
+
+    Resolved through ``comment_verdict`` at call time, like the rest of the
+    split-out verdict helpers, so monkeypatches on that module still reach the
+    escalated check as well as the line-anchored one.
+    """
+    from awf.runtime.pr_monitor_runner import comment_verdict
+
+    return await comment_verdict._item_fix_evidence(
+        runner,
+        worktree_path=worktree_path,
+        item_start_head=item_start_head,
+        item_path=item_path,
+        item_line=None,
+        state=state,
+        dirty_changes_committed=dirty_changes_committed,
+    )
+
+
 def correction_self_citation_outcome(
     *,
     workspace_id: str,
@@ -205,18 +249,21 @@ def correction_self_citation_outcome(
 ) -> VerdictResult:
     """Disposition for a self-citing non-FIXED correction verdict (#925 D2).
 
-    An explicit corrected ``needs_human`` always stays ``needs_human``: related-
-    line evidence must not convert a requested human gate into a resolvable
-    ``fix_committed`` (issue:5558086911). For ``false_positive`` / ``defer``,
-    item-scoped related-line FIXED evidence means the item is what the agent
-    said on its first attempt — FIXED — so the commit stays and the thread can
-    be resolved. Without that evidence, the commit is still preserved (rolling
-    back a change the agent points at as the fix is exactly the #925 defect)
-    and the item escalates to ``needs_human`` so the merge gate keeps blocking
-    with a reason code. Path membership alone is not enough for
-    ``fix_committed``. The preserved commit travels with the cycle's ordinary
-    push; on a push failure it follows the ordinary unpublished-repair path
-    while the recorded ``needs_human`` reason keeps describing the change.
+    ``has_path_evidence`` is the caller's item-scoped FIXED evidence: the
+    line-anchored check, **or** — because this only ever runs on the correction
+    attempt — the path-level re-check of the item's own commit range
+    (``path_level_item_fix_evidence``). An explicit corrected ``needs_human``
+    always stays ``needs_human``: no evidence converts a requested human gate
+    into a resolvable ``fix_committed`` (issue:5558086911). For
+    ``false_positive`` / ``defer``, item-scoped evidence means the item is what
+    the agent said on its first attempt — FIXED — so the commit stays and the
+    thread can be resolved. Without that evidence, the commit is still
+    preserved (rolling back a change the agent points at as the fix is exactly
+    the #925 defect) and the item escalates to ``needs_human`` so the merge gate
+    keeps blocking with a reason code. The preserved commit travels with the
+    cycle's ordinary push; on a push failure it follows the ordinary
+    unpublished-repair path while the recorded ``needs_human`` reason keeps
+    describing the change.
     """
     from awf.runtime.pr_monitor_runner.comment_verdict import VerdictResult
 
@@ -232,8 +279,8 @@ def correction_self_citation_outcome(
     if has_path_evidence and verdict != "needs_human":
         outcome = (
             f"Accepted as FIXED: the correction verdict cited a commit this item "
-            f"made (attempt tip {short_tip}), with item-scoped related-line "
-            f"evidence. Agent reason: {reason}"
+            f"made (attempt tip {short_tip}), with item-scoped fix evidence. "
+            f"Agent reason: {reason}"
         )
         return VerdictResult(verdict="fix_committed", reason=_bounded(outcome))
     if verdict == "needs_human":
@@ -303,11 +350,13 @@ def correction_unscoped_fix_outcome(
 ) -> VerdictResult:
     """Disposition for a correction-attempt FIXED with no item-scoped evidence.
 
-    The agent made a contentful change and calls it the fix, but nothing in it
-    is item-scoped — it misses the reviewed file, or touches that file away from
-    the anchored line, and same-file membership alone is not FIXED evidence
-    (issue:5558086911) — so AWF cannot accept FIXED. The protocol used to
-    roll that commit back and terminate with ``AGENT_FIXED_WITHOUT_EVIDENCE``,
+    The agent made a contentful change and calls it the fix, but the commit
+    touches none of the reviewed paths, so AWF cannot accept FIXED. The
+    same-file off-anchor case no longer reaches here: on the correction attempt
+    ``path_level_item_fix_evidence`` accepts a commit that changes the reviewed
+    file, so what is left is a commit in the wrong file (or, with an unmappable
+    anchor, one AWF cannot place at all — that stays fail-closed). The protocol
+    used to roll that commit back and terminate with ``AGENT_FIXED_WITHOUT_EVIDENCE``,
     which failed the whole monitor — the shape that killed ws_46bc0f45 on PR
     #922 after a protocol-violation correction, where attempt 1's off-anchor
     FIXED met the strict gate again. The commit is preserved for human review

--- a/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
+++ b/tests/unit/runtime/test_pr_monitor_fix_cycle_pass_anchor.py
@@ -636,8 +636,10 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     When the remote PR head advances (or coords are already for a later commit),
     anchoring evidence at that head accepts a line-scoped fix on the first
     attempt. Anchoring at an older SHA maps that line elsewhere, so the same
-    contentful change fails the line-anchored gate on both attempts — path
-    membership alone must not produce ``fix_committed`` (issue:5558086911).
+    contentful change fails the line-anchored gate on attempt 0 and earns the
+    correction prompt; the correction's path-level re-check then accepts the
+    change, because it is in the item's own range and touches the reviewed file
+    (#925 D1).
     """
     worktree = tmp_path / "worktrees" / "ws_protocol"
     worktree.mkdir(parents=True)
@@ -714,8 +716,9 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
     assert len(prompts) == 1
 
     # A stale operation-open anchor maps the line elsewhere, so the line gate
-    # rejects both attempts. Path membership alone must not accept FIXED; the
-    # commit is preserved and escalated instead of failing the monitor.
+    # rejects attempt 0 and the agent is told so. The re-affirmed FIXED is then
+    # accepted at path level: the commit is in the item's own range and changes
+    # the reviewed file, so it is kept rather than escalated to a human.
     prompts.clear()
     stale = await comment_verdict._invoke_cli_for_verdict_result(
         runner,
@@ -730,7 +733,7 @@ async def test_later_pass_anchor_accepts_real_item_line_fix(
         evidence_anchor_head=operation_open,
         commit_dirty_changes=False,
     )
-    assert stale.verdict == "needs_human"
+    assert stale.verdict == "fix_committed"
     assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == fixed_tip
     assert len(prompts) == 2
     assert "no new item-scoped Git change" in prompts[1]

--- a/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_011.py
+++ b/tests/unit/runtime/test_pr_monitor_pre_push_validation_fix_pass_parts/test_pr_monitor_pre_push_validation_fix_pass_part_011.py
@@ -710,18 +710,18 @@ async def test_first_attempt_false_positive_still_rolls_back_related_commit(
 
 
 @pytest.mark.unit
-async def test_malformed_first_attempt_with_off_anchor_commit_is_preserved_not_accepted(
+async def test_malformed_first_attempt_with_off_anchor_commit_is_accepted_at_path_level(
     factory: async_sessionmaker[AsyncSession],
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Malformed then FIXED with an off-anchor same-file commit is kept (#925 follow-up).
+    """Malformed then FIXED with an off-anchor same-file commit is FIXED (#925 D1).
 
-    The commit in the item range misses the anchored line, and same-file
-    membership alone is not item-scoped evidence (issue:5558086911), so FIXED is
-    not accepted. The correction still must not roll the commit back and fail
-    the monitor — the ws_46bc0f45 shape on PR #922 — so the commit is preserved
-    and the item escalates to ``needs_human``.
+    The commit in the item's own range misses the anchored line but does change
+    the reviewed file. On the correction attempt — after the agent has been told
+    attempt 0 was rejected — that is accepted as evidence: the ws_46bc0f45 shape
+    on PR #922 neither fails the monitor nor escalates to a human, and the
+    commit is never rolled back.
     """
     worktree = tmp_path / "worktrees" / "ws_protocol"
     worktree.mkdir(parents=True)
@@ -782,5 +782,5 @@ async def test_malformed_first_attempt_with_off_anchor_commit_is_preserved_not_a
         commit_dirty_changes=False,
     )
 
-    assert result.verdict == "needs_human"
+    assert result.verdict == "fix_committed"
     assert _git(worktree, "rev-parse", "HEAD").stdout.strip() == edited_head

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_005.py
@@ -549,22 +549,17 @@ async def test_fixed_rejected_when_only_same_directory_sibling_changed(
 
 
 @pytest.mark.unit
-async def test_fixed_rejected_on_both_attempts_when_same_file_unrelated_line_changed(
+async def test_same_file_off_anchor_fix_accepted_on_the_correction(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """issue:5381831025 + issue:5558086911: unrelated same-file edits never FIXED.
+    """issue:5381831025 + #925 D1: attempt 0 strict, correction path-level.
 
-    Attempt 0 keeps the strict line-anchored evidence rule (the correction
-    prompt is emitted). The correction must not discard the line constraint and
-    accept path membership alone — that would resolve a still-valid finding.
-    Related off-anchor fixes (near-anchor / callee) pass the line-scoped gate
-    without a path-only fallback. Cross-file cases below still reject on both
-    attempts.
-
-    The rejected commit is preserved and escalated to ``needs_human`` rather
-    than rolled back — failing the whole monitor over it is the #925 defect
-    (ws_46bc0f45) — but it is never accepted as ``fix_committed``.
+    Attempt 0 keeps the strict line-anchored evidence rule, so the misplaced
+    FIXED still earns its correction prompt. Having been told its FIXED carried
+    no line evidence, the agent re-affirms it — and the item's own commit range
+    does change the reviewed file, so the off-anchor fix is accepted rather than
+    escalated to a human. Cross-file cases below still reject on both attempts.
     """
     reviewed_path = "src/awf/reviewed.py"
     worktree = tmp_path / "ws_protocol"
@@ -604,8 +599,9 @@ async def test_fixed_rejected_on_both_attempts_when_same_file_unrelated_line_cha
         operation_start_head="a" * 40,
     )
 
-    # Never FIXED: the still-valid finding keeps blocking the merge gate.
-    assert verdict == "needs_human"
+    # Accepted only on the correction, and only because the commit changes the
+    # reviewed file: the fix is kept, not rolled back and not escalated.
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert len(runner.prompts) == 2
     assert "no new item-scoped Git change" in runner.prompts[1]

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_008.py
@@ -9,10 +9,12 @@ the thread dispositioned but unresolved.
 These tests pin the corrected policy: a non-FIXED correction verdict
 (``false_positive``, ``defer``, or ``needs_human``) that cites this item's own
 attempt-0 commit never causes a rollback (commit preserved; ``needs_human``
-without item-scoped related-line evidence, ``fix_committed`` when related-line
-evidence is present). Path membership alone must not escalate to
-``fix_committed`` — related off-anchor fixes are accepted by the line-scoped
-gate (near-anchor / callee), not by discarding the line constraint.
+without item-scoped evidence, ``fix_committed`` when evidence is present). On
+the correction attempt that evidence is re-checked at path level over the
+item's own commit range (#925 D1): the agent has already been told its FIXED
+lacked line evidence, so a re-affirmed change to the reviewed file is an honest
+off-anchor fix. A commit that misses the reviewed path — or an anchor AWF
+cannot map at all — still escalates with the commit preserved.
 """
 
 from __future__ import annotations
@@ -162,25 +164,23 @@ async def _address(runner: _VerdictRunner, thread: ReviewThread) -> str:
 
 
 @pytest.mark.unit
-async def test_unrelated_same_file_edit_not_accepted_as_fix_after_evidence_correction(
+async def test_off_anchor_fix_accepted_at_path_level_after_evidence_correction(
     tmp_path: Path,
 ) -> None:
-    """Path membership alone must not produce ``fix_committed`` (issue:5558086911).
+    """#925 D1: a re-affirmed same-file fix is accepted on the correction.
 
-    After the line-anchored gate rejects FIXED, a contentful edit elsewhere in
-    the reviewed file is not item-scoped evidence. Related off-anchor fixes
-    (near-anchor / callee) already pass the line-scoped gate; discarding the
-    line constraint would let an unrelated same-file edit resolve the thread.
-
-    The commit is preserved and the item escalates to ``needs_human`` instead of
-    terminating the monitor (#925 follow-up), but the thread stays unresolved.
+    The line-anchored gate rejects attempt 0 and the correction prompt says so
+    explicitly. When the agent re-affirms FIXED and the item's own commit range
+    changes the reviewed file, that is an honest off-anchor fix (a helper above
+    the caller, a guard at the call site) — resolving the thread beats sending a
+    human after a change AWF can see.
     """
     (tmp_path / "ws_protocol").mkdir()
     runner = _VerdictRunner(
         worktrees_root=tmp_path,
         outputs=[
-            "AWF-VERDICT: FIXED: renamed an unrelated helper in the same file",
-            "AWF-VERDICT: FIXED: still only the unrelated helper",
+            "AWF-VERDICT: FIXED: fixed the helper above the anchored call",
+            "AWF-VERDICT: FIXED: same change, the fix belongs above the anchor",
         ],
         heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
         dirty_after_attempt=[True, False],
@@ -188,9 +188,9 @@ async def test_unrelated_same_file_edit_not_accepted_as_fix_after_evidence_corre
         line_touched=False,
     )
 
-    verdict = await _address(runner, _thread("thread_unrelated_same_file"))
+    verdict = await _address(runner, _thread("thread_off_anchor_same_file"))
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == _ATTEMPT0_HEAD
     assert len(runner.prompts) == 2
@@ -198,10 +198,10 @@ async def test_unrelated_same_file_edit_not_accepted_as_fix_after_evidence_corre
 
 
 @pytest.mark.unit
-async def test_correction_false_positive_citing_own_commit_keeps_fix_and_escalates(
+async def test_correction_false_positive_citing_own_commit_returns_fixed(
     tmp_path: Path,
 ) -> None:
-    """#925 D2: self-citing FALSE POSITIVE keeps the commit; path-only ≠ FIXED."""
+    """#925 D2 + D1: a self-citing FALSE POSITIVE with path evidence is the fix."""
     (tmp_path / "ws_protocol").mkdir()
     runner = _VerdictRunner(
         worktrees_root=tmp_path,
@@ -218,7 +218,7 @@ async def test_correction_false_positive_citing_own_commit_keeps_fix_and_escalat
     with structlog.testing.capture_logs() as captured:
         verdict = await _address(runner, _thread("PRRT_self_cite"))
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == _ATTEMPT0_HEAD
     events = [entry.get("event") for entry in captured]
@@ -231,7 +231,7 @@ async def test_correction_false_positive_citing_own_commit_keeps_fix_and_escalat
     assert len(self_citation) == 1
     assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
     assert self_citation[0]["verdict"] == "false_positive"
-    assert self_citation[0]["has_path_evidence"] is False
+    assert self_citation[0]["has_path_evidence"] is True
 
 
 @pytest.mark.unit
@@ -502,8 +502,9 @@ async def test_unmappable_anchor_line_stays_fail_closed_on_the_correction(
 
     When the review line cannot be mapped from the anchor head onto item-start
     history the remap records the ``-1`` sentinel. That is "we cannot tell where
-    this item lives", not related-line evidence, so neither attempt accepts
-    FIXED; the correction escalates with the commit kept.
+    this item lives", so neither attempt accepts FIXED — the correction's
+    path-level re-check is skipped too, and the item escalates with the commit
+    kept.
     """
     (tmp_path / "ws_protocol").mkdir()
 
@@ -598,7 +599,7 @@ async def test_correction_citing_non_tip_attempt_commit_keeps_the_fix(
     commits the leftovers on top, so the verified tip is the sink commit. A
     correction verdict that cites the *fix* commit used to miss the tip-only
     comparison, roll the attempt back to item start, and discard both commits.
-    Path-only touch is not item-scoped FIXED evidence; escalate to needs_human.
+    The range changes the reviewed file, so the correction accepts it as FIXED.
     """
     (tmp_path / "ws_protocol").mkdir()
     runner = _RangeAwareVerdictRunner(
@@ -617,7 +618,7 @@ async def test_correction_citing_non_tip_attempt_commit_keeps_the_fix(
     with structlog.testing.capture_logs() as captured:
         verdict = await _address(runner, _thread("PRRT_self_cite_non_tip"))
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == _ATTEMPT0_HEAD
     assert runner.rev_list_ranges == [f"{_ITEM_START_HEAD}..{_ATTEMPT0_HEAD}"]
@@ -641,7 +642,7 @@ async def test_correction_citing_own_commit_recovered_at_correction_start_keeps_
     unset, but the correction-start probe recovers the very same attempt-0 commit.
     Comparing the citation against the unset tip alone made self-citation invisible
     and rolled the legitimate change back — the #925 defect in a different disguise.
-    Without related-line evidence the commit is preserved as ``needs_human``.
+    The correction's path-level evidence accepts the recovered commit as the fix.
     """
     (tmp_path / "ws_protocol").mkdir()
     runner = _VerdictRunner(
@@ -664,7 +665,7 @@ async def test_correction_citing_own_commit_recovered_at_correction_start_keeps_
     with structlog.testing.capture_logs() as captured:
         verdict = await _address(runner, _thread("PRRT_self_cite_recovered_start"))
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == _ATTEMPT0_HEAD
     self_citation = [
@@ -840,7 +841,7 @@ async def test_correction_citing_second_parent_fix_preserves_commit_no_rollback(
             operation_start_head=item_start,
         )
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == merge_tip
     assert all("--first-parent" not in cmd for cmd in runner.rev_list_cmds)

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_009.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_009.py
@@ -7,11 +7,12 @@ whose hunks sat ~100 lines from the anchor in the anchored file. PR #926 only
 escalated *after* an evidence rejection, so that path still rolled the commit
 back and failed the whole monitor.
 
-The evidence gate itself stays strict — same-file membership is not item-scoped
-evidence (issue:5558086911). What changed is the disposition: on any correction
-attempt, a FIXED whose contentful commit carries no item-scoped evidence
-escalates to ``needs_human`` with the commit preserved instead of terminating
-the protocol.
+Attempt 0's gate stays strict and line-anchored. What changed is what the
+*correction* attempt does, and both halves are pinned here: evidence is
+re-checked at path level over the item's own commit range, so a re-affirmed
+off-anchor fix in the reviewed file resolves the thread (#925 D1); and a FIXED
+whose commit misses the reviewed paths escalates to ``needs_human`` with the
+commit preserved instead of terminating the protocol (#928).
 """
 
 from __future__ import annotations
@@ -99,14 +100,14 @@ async def _address(
 
 
 @pytest.mark.unit
-async def test_off_anchor_fix_after_protocol_violation_escalates_with_commit_kept(
+async def test_off_anchor_fix_after_protocol_violation_is_accepted_at_path_level(
     tmp_path: Path,
 ) -> None:
     """The ws_46bc0f45 shape: protocol violation, then an off-anchor FIXED.
 
-    Same-file membership is not item-scoped evidence (issue:5558086911), so the
-    claim is not accepted as FIXED — but the monitor must not die on it either.
-    The commit is preserved and the item escalates to ``needs_human``.
+    The path-level re-check is gated on the correction attempt, not on what
+    rejected attempt 0, so this shape resolves too: the fix commit is in the
+    item's own range and changes the reviewed file.
     """
     (tmp_path / "ws_protocol").mkdir()
     runner = _VerdictRunner(
@@ -125,7 +126,7 @@ async def test_off_anchor_fix_after_protocol_violation_escalates_with_commit_kep
     with structlog.testing.capture_logs() as captured:
         verdict = await _address(runner, _thread("PRRT_protocol_violation_then_fixed"), state)
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert len(runner.prompts) == 2
     # The correction was for the missing verdict line, not for evidence.
     assert _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT not in runner.prompts[1]
@@ -134,7 +135,7 @@ async def test_off_anchor_fix_after_protocol_violation_escalates_with_commit_kep
     assert runner.current_head == _ATTEMPT0_HEAD
     events = [entry.get("event") for entry in captured]
     assert "monitor.agent_verdict_protocol_retry_rollback" not in events
-    assert "monitor.agent_verdict_correction_fixed_outside_item_scope" in events
+    assert "monitor.agent_verdict_correction_fixed_outside_item_scope" not in events
 
 
 @pytest.mark.unit
@@ -283,13 +284,14 @@ async def test_preserved_correction_tip_falls_back_when_head_probe_fails(
 
 
 @pytest.mark.unit
-async def test_self_citing_false_positive_after_protocol_violation_keeps_commit(
+async def test_self_citing_false_positive_after_protocol_violation_returns_fixed(
     tmp_path: Path,
 ) -> None:
     """#925 D2 applies to every correction, not only the evidence-rejection one.
 
-    Without item-scoped related-line evidence the self-cited commit is preserved
-    and the item escalates rather than resolving the thread (issue:5558086911).
+    The self-cited commit is in the item's own range and changes the reviewed
+    file, so the correction's path-level evidence resolves the thread as FIXED
+    rather than sending a human after a change AWF can see.
     """
     (tmp_path / "ws_protocol").mkdir()
     runner = _VerdictRunner(
@@ -308,7 +310,7 @@ async def test_self_citing_false_positive_after_protocol_violation_keeps_commit(
     with structlog.testing.capture_logs() as captured:
         verdict = await _address(runner, _thread("PRRT_self_cite_after_violation"), state)
 
-    assert verdict == "needs_human"
+    assert verdict == "fix_committed"
     assert runner.reset_targets == []
     assert runner.current_head == _ATTEMPT0_HEAD
     self_citation = [
@@ -318,7 +320,7 @@ async def test_self_citing_false_positive_after_protocol_violation_keeps_commit(
     ]
     assert len(self_citation) == 1
     assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
-    assert self_citation[0]["has_path_evidence"] is False
+    assert self_citation[0]["has_path_evidence"] is True
 
 
 @pytest.mark.unit

--- a/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_010.py
+++ b/tests/unit/runtime/test_pr_monitor_verdict_retry_parts/test_pr_monitor_verdict_retry_part_010.py
@@ -1,0 +1,290 @@
+"""Correction-attempt path-level FIXED acceptance (#925 D1 restored on top of #928).
+
+Attempt 0 keeps the strict line-anchored evidence gate, so a FIXED whose hunks
+land away from the anchored line still earns its correction round. On the
+correction attempt the agent has been told, explicitly, that its FIXED carried
+no line evidence — if it re-affirms FIXED and the item's *own* commit range
+(``item_start_head..HEAD``) is a contentful descendant that changes the reviewed
+file, that is an honest off-anchor fix, not an unsupported claim. Accept it as
+``fix_committed`` instead of escalating an honest fix to a human.
+
+The narrowing conditions are what make this safe and are pinned below: it is
+never the first gate (attempt 0 stays strict), the probe runs over the item's
+own commit range so the commit cannot be stale or foreign, a commit that touches
+none of the reviewed paths keeps #928's ``needs_human``-with-commit-preserved
+disposition, the unmappable-anchor sentinel stays fail-closed, and an explicit
+corrected ``NEEDS_HUMAN`` stays escalated (issue:5558086911).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import structlog
+
+from awf.common.github_client import RepoRef
+from awf.runtime.pr_monitor import ReviewThread
+from awf.runtime.pr_monitor_runner import (
+    comment_verdict,
+    comment_verdict_correction,
+    comments,
+)
+from awf.runtime.pr_monitor_runner.comment_verdict import (
+    _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT,
+    AGENT_NON_FIX_CITES_OWN_COMMIT,
+)
+from awf.runtime.pr_monitor_runner.comments import _address_thread
+from tests.unit.runtime._verdict_retry_fixtures import _VerdictRunner
+
+pytest_plugins = ["tests.unit.runtime._verdict_retry_fixtures"]
+
+_ITEM_START_HEAD = "a" * 40
+_ATTEMPT0_HEAD = "b" * 40
+_REVIEWED_PATH = "src/awf/reviewed.py"
+
+
+@pytest.fixture(autouse=True)
+def _no_owned_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _empty_owned_paths(_runner: object, _workspace_id: str) -> list[str]:
+        return []
+
+    monkeypatch.setattr(comments, "_owned_paths_for_prompt", _empty_owned_paths)
+
+
+def _thread(thread_id: str) -> ReviewThread:
+    return ReviewThread(
+        thread_id=thread_id,
+        path=_REVIEWED_PATH,
+        line=42,
+        body_excerpt="notification uses stale status",
+    )
+
+
+async def _address(runner: _VerdictRunner, thread: ReviewThread) -> str:
+    return await _address_thread(
+        runner,  # type: ignore[arg-type]
+        workspace_id="ws_protocol",
+        repo=RepoRef(owner="o", name="r"),
+        pr_number=1,
+        thread=thread,
+        compose_project="awf_ws_protocol",
+        compose_file=Path("compose.yml"),
+        operation_start_head=_ITEM_START_HEAD,
+    )
+
+
+@pytest.mark.unit
+async def test_attempt_zero_never_accepts_path_level_evidence(tmp_path: Path) -> None:
+    """Attempt 0 stays line-anchored: an off-anchor FIXED earns its correction.
+
+    Path-level evidence is only ever consulted after the agent has been told its
+    FIXED lacked line evidence, so the first attempt must still emit the
+    correction prompt rather than resolving on path membership.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: fixed the reviewed file above the anchor",
+            "AWF-VERDICT: FIXED: same change, the fix belongs above the anchor",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    verdict = await _address(runner, _thread("thread_attempt_zero_strict"))
+
+    # Only the correction attempt resolves; attempt 0 was rejected first.
+    assert verdict == "fix_committed"
+    assert len(runner.prompts) == 2
+    assert _FIXED_WITHOUT_EVIDENCE_CORRECTION_CONTEXT in runner.prompts[1]
+    assert "no new item-scoped Git change" in runner.prompts[1]
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+
+
+@pytest.mark.unit
+async def test_correction_path_level_acceptance_needs_the_anchored_path(
+    tmp_path: Path,
+) -> None:
+    """A commit touching none of the reviewed paths keeps the #928 disposition."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: fixed the helper in a sibling module",
+            "AWF-VERDICT: FIXED: still only the sibling module",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("thread_off_path_correction"))
+
+    assert verdict == "needs_human"
+    # Never fatal, never rolled back: the commit is preserved for the human.
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    events = [entry.get("event") for entry in captured]
+    assert "monitor.agent_verdict_correction_fixed_outside_item_scope" in events
+
+
+@pytest.mark.unit
+async def test_self_citing_defer_with_path_level_evidence_returns_fixed(
+    tmp_path: Path,
+) -> None:
+    """A self-citing DEFER on the correction resolves when path evidence holds.
+
+    The correction prompt puts this item's own attempt-0 commit at HEAD, so the
+    agent can answer ``DEFER: superseded by <its own sha>``. With correction-time
+    path-level evidence for the reviewed file that commit *is* the fix.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: re-read the status before notifying",
+            f"AWF-VERDICT: DEFER: superseded by commit {_ATTEMPT0_HEAD}",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("thread_self_citing_defer"))
+
+    assert verdict == "fix_committed"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["reason_code"] == AGENT_NON_FIX_CITES_OWN_COMMIT
+    assert self_citation[0]["verdict"] == "defer"
+    assert self_citation[0]["has_path_evidence"] is True
+
+
+@pytest.mark.unit
+async def test_correction_needs_human_with_path_level_evidence_stays_needs_human(
+    tmp_path: Path,
+) -> None:
+    """issue:5558086911: evidence must not override a requested human gate."""
+    (tmp_path / "ws_protocol").mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: re-read the status before notifying",
+            f"AWF-VERDICT: NEEDS_HUMAN: addressed by {_ATTEMPT0_HEAD}, policy call needed",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with structlog.testing.capture_logs() as captured:
+        verdict = await _address(runner, _thread("thread_corrected_needs_human"))
+
+    assert verdict == "needs_human"
+    assert runner.reset_targets == []
+    assert runner.current_head == _ATTEMPT0_HEAD
+    self_citation = [
+        entry
+        for entry in captured
+        if entry.get("event") == "monitor.agent_verdict_correction_cites_own_commit"
+    ]
+    assert len(self_citation) == 1
+    assert self_citation[0]["verdict"] == "needs_human"
+    assert self_citation[0]["has_path_evidence"] is True
+
+
+@pytest.mark.unit
+async def test_path_level_probe_failure_rolls_back_under_the_sink_handler(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The path-level probe shares the commit sink's rollback handling.
+
+    It runs inside the same ``try`` as the line-anchored check, so an ordinary
+    Git failure rolls the unaccepted correction commit back to item start and
+    propagates unmasked instead of stranding it in the worktree.
+    """
+    (tmp_path / "ws_protocol").mkdir()
+    real_evidence = comment_verdict._item_fix_evidence
+
+    async def _probe(runner: object, **kwargs: object) -> bool:
+        if kwargs.get("item_path") is not None and kwargs.get("item_line") is None:
+            raise OSError("git rev-parse spawn failed")
+        return await real_evidence(runner, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(comment_verdict, "_item_fix_evidence", _probe)
+
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=[
+            "AWF-VERDICT: FIXED: fixed the reviewed file above the anchor",
+            "AWF-VERDICT: FIXED: same change, the fix belongs above the anchor",
+        ],
+        heads_after_attempt=[_ATTEMPT0_HEAD, _ATTEMPT0_HEAD],
+        dirty_after_attempt=[True, False],
+        path_touched=True,
+        line_touched=False,
+    )
+
+    with pytest.raises(OSError, match="git rev-parse spawn failed"):
+        await _address(runner, _thread("thread_path_level_probe_raises"))
+
+    assert runner.reset_targets == [_ITEM_START_HEAD]
+    assert runner.current_head == _ITEM_START_HEAD
+
+
+@pytest.mark.unit
+async def test_path_level_item_fix_evidence_delegates_with_no_line(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The helper drops only the line anchor and resolves through ``comment_verdict``."""
+    worktree = tmp_path / "ws_protocol"
+    worktree.mkdir()
+    runner = _VerdictRunner(
+        worktrees_root=tmp_path,
+        outputs=["AWF-VERDICT: FIXED: unused"],
+        heads_after_attempt=[_ATTEMPT0_HEAD],
+    )
+    seen: list[dict[str, object]] = []
+
+    async def _probe(_runner: object, **kwargs: object) -> bool:
+        seen.append(dict(kwargs))
+        return True
+
+    monkeypatch.setattr(comment_verdict, "_item_fix_evidence", _probe)
+
+    assert await comment_verdict_correction.path_level_item_fix_evidence(
+        runner,  # type: ignore[arg-type]
+        worktree_path=worktree,
+        item_start_head=_ITEM_START_HEAD,
+        item_path=_REVIEWED_PATH,
+        state=None,
+        dirty_changes_committed=True,
+    )
+
+    assert seen == [
+        {
+            "worktree_path": worktree,
+            "item_start_head": _ITEM_START_HEAD,
+            "item_path": _REVIEWED_PATH,
+            "item_line": None,
+            "state": None,
+            "dirty_changes_committed": True,
+        }
+    ]


### PR DESCRIPTION
Automatically opened by AWF workspace `ws_95d0600f9b0849f9b6743895` (agent: `claude_code`, model: `claude-opus-5`, effort: `high`).


### Task
Context: issue #925, PR #926 (path-level FIXED evidence on the correction attempt), PR #929 whose release monitor removed that acceptance (commit 6d7e0e0f9, Greptile comment issue:5558086911), and PR #928 which made a correction-attempt FIXED without evidence non-fatal (needs_human with the commit preserved). Result today: an agent that fixes the reviewed file in the wrong line region gets a correction prompt, re-affirms FIXED, and is escalated to a human. That is an unnecessary human escalation for an honest fix. Change (narrow, TDD, in src/awf/runtime/pr_monitor_runner/comment_verdict.py and comment_verdict_correction.py only): on the correction attempt (protocol_attempt == 1), when the line-anchored evidence check fails, re-run the evidence check at path level for the anchored path (the item's own commit range item_start_head..HEAD must be a contentful descendant that changes the reviewed file; use _item_fix_evidence with item_line=None, keep the unmappable-anchor sentinel item_line <= 0 fail-closed and keep the probe under the same rollback handling as the other probes). If path-level evidence holds, accept FIXED (fix_committed) and, for a self-citing FALSE POSITIVE / DEFER on the correction, return fix_committed as well; keep an explicit corrected NEEDS_HUMAN as needs_human. If the commit touches none of the reviewed paths, keep the #928 outcome: needs_human with the commit preserved (never fatal). Attempt 0 stays strict (line-anchored) so a no-op FIXED still gets its correction round. Rationale to document in the docstrings and in the PR body: path-level evidence is only consulted after the agent was explicitly told its FIXED lacked line evidence and re-affirmed it; the commit is in the item's own range, so it cannot be a stale or foreign change; this is the #926 D1 behaviour restored on top of #928. Update tests to the new dispositions: tests/unit/runtime/test_pr_monitor_verdict_retry_parts/ (part_005, part_008, part_009 - ls the directory and add a NEW part file for new tests, never overwrite), test_pr_monitor_fix_cycle_pass_anchor.py and test_pr_monitor_pre_push_validation_fix_pass_parts/part_011: same-file off-anchor FIXED on the correction -> fix_committed with no rollback; other-file FIXED on the correction -> needs_human with the commit preserved; no-change FIXED -> still terminates after one correction. Keep comment_verdict.py under 1500 lines (put helpers in comment_verdict_correction.py). Run ruff check, ruff format --check, mypy and 'pytest tests -q -n 20' before pushing; coverage gate 99 percent line+branch. For every review item on your PR: put the fix hunk in the reviewed file at or next to the reviewed line, always end with the AWF-VERDICT line, never answer FALSE POSITIVE or DEFER by citing your own commit. If a reviewer asks to remove path-level acceptance again, answer DEFER: this is an explicit operator decision.

---
Validation: 4 profile command(s) passed inside the workspace container.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PR monitor merge-gate verdict logic for when agent fixes auto-resolve vs escalate; mis-tuning path-level acceptance could close threads incorrectly, though it is gated to the correction attempt and the item's own commit range.
> 
> **Overview**
> Restores **#925 D1** on top of **#928**: after attempt 0 still requires **line-anchored** FIXED evidence, the **correction attempt** can accept an honest same-file fix that missed the anchor.
> 
> On `protocol_attempt == 1`, when the strict line check fails (and the anchor is mappable, `item_line > 0`), `comment_verdict` re-runs evidence via new **`path_level_item_fix_evidence`** — same `item_start_head..HEAD` probe with **`item_line=None`**. That yields **`fix_committed`** instead of unnecessary **`needs_human`** for off-anchor edits in the reviewed file. Commits that touch **no reviewed path** still escalate with the commit preserved; unmappable anchors stay fail-closed; explicit corrected **`NEEDS_HUMAN`** is unchanged.
> 
> Self-citing **FALSE POSITIVE** / **DEFER** on the correction now resolves to **`fix_committed`** when that path-level (or line) evidence exists. Docstrings and unit tests across verdict-retry, fix-cycle anchor, and pre-push parts reflect the new dispositions, plus a dedicated **`test_pr_monitor_verdict_retry_part_010.py`** for the narrowing rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b9dc06c1531f94ec34792840644b98bbb6fb7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->